### PR TITLE
[nT2] rechits reconstruction from digis

### DIFF
--- a/DataFormats/TotemReco/BuildFile.xml
+++ b/DataFormats/TotemReco/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Common"/>
-<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TotemReco/BuildFile.xml
+++ b/DataFormats/TotemReco/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/Common"/>
+<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TotemReco/interface/TotemT2RecHit.h
+++ b/DataFormats/TotemReco/interface/TotemT2RecHit.h
@@ -9,32 +9,28 @@
 #ifndef DataFormats_TotemReco_TotemT2RecHit_h
 #define DataFormats_TotemReco_TotemT2RecHit_h
 
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+
 class TotemT2RecHit {
 public:
-  explicit TotemT2RecHit() = default;
+  TotemT2RecHit() = default;
+  explicit TotemT2RecHit(const GlobalPoint&, float, float);
 
-  void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
-  unsigned short leadingEdge() const { return lead_edge_; }
-  void setTrailingEdge(unsigned short te) { trail_edge_ = te; }
-  unsigned short trailingEdge() const { return trail_edge_; }
+  const GlobalPoint centre() const { return centre_; }
+  void setTime(float time) { time_ = time; }
+  float time() const { return time_; }
+  void setTimeUnc(float time_unc) { time_unc_ = time_unc; }
+  float timeUnc() const { return time_unc_; }
 
 private:
+  /// Tile centre position
+  GlobalPoint centre_;
   /// Leading edge time
-  unsigned short lead_edge_;
-  /// Trailing edge time
-  unsigned short trail_edge_;
+  float time_;
+  /// Time over threshold/pulse width
+  float time_unc_;
 };
 
-bool operator<(const TotemT2RecHit& lhs, const TotemT2RecHit& rhs) {
-  if (lhs.leadingEdge() < rhs.leadingEdge())
-    return true;
-  if (lhs.leadingEdge() > rhs.leadingEdge())
-    return false;
-  if (lhs.trailingEdge() < rhs.trailingEdge())
-    return true;
-  if (lhs.trailingEdge() > rhs.trailingEdge())
-    return false;
-  return false;
-}
+bool operator<(const TotemT2RecHit&, const TotemT2RecHit&);
 
 #endif

--- a/DataFormats/TotemReco/interface/TotemT2RecHit.h
+++ b/DataFormats/TotemReco/interface/TotemT2RecHit.h
@@ -14,21 +14,25 @@
 class TotemT2RecHit {
 public:
   TotemT2RecHit() = default;
-  explicit TotemT2RecHit(const GlobalPoint&, float, float);
+  explicit TotemT2RecHit(const GlobalPoint&, float, float, float);
 
   const GlobalPoint centre() const { return centre_; }
   void setTime(float time) { time_ = time; }
   float time() const { return time_; }
   void setTimeUnc(float time_unc) { time_unc_ = time_unc; }
   float timeUnc() const { return time_unc_; }
+  void setToT(float tot) { tot_ = tot; }
+  float toT() const { return tot_; }
 
 private:
   /// Tile centre position
   GlobalPoint centre_;
   /// Leading edge time
   float time_;
-  /// Time over threshold/pulse width
+  /// Uncertainty on leading edge time
   float time_unc_;
+  /// Time over threshold/pulse width
+  float tot_;
 };
 
 bool operator<(const TotemT2RecHit&, const TotemT2RecHit&);

--- a/DataFormats/TotemReco/interface/TotemT2RecHit.h
+++ b/DataFormats/TotemReco/interface/TotemT2RecHit.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_TotemReco_TotemT2RecHit_h
+#define DataFormats_TotemReco_TotemT2RecHit_h
+
+class TotemT2RecHit {
+public:
+  explicit TotemT2RecHit() = default;
+
+  void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
+  unsigned short leadingEdge() const { return lead_edge_; }
+  void setTrailingEdge(unsigned short te) { trail_edge_ = te; }
+  unsigned short trailingEdge() const { return trail_edge_; }
+
+private:
+  /// Leading edge time
+  unsigned short lead_edge_;
+  /// Trailing edge time
+  unsigned short trail_edge_;
+};
+
+bool operator<(const TotemT2RecHit& lhs, const TotemT2RecHit& rhs) {
+  if (lhs.leadingEdge() < rhs.leadingEdge())
+    return true;
+  if (lhs.leadingEdge() > rhs.leadingEdge())
+    return false;
+  if (lhs.trailingEdge() < rhs.trailingEdge())
+    return true;
+  if (lhs.trailingEdge() > rhs.trailingEdge())
+    return false;
+  return false;
+}
+
+#endif

--- a/DataFormats/TotemReco/interface/TotemT2RecHit.h
+++ b/DataFormats/TotemReco/interface/TotemT2RecHit.h
@@ -28,11 +28,11 @@ private:
   /// Tile centre position
   GlobalPoint centre_;
   /// Leading edge time
-  float time_;
+  float time_{0.f};
   /// Uncertainty on leading edge time
-  float time_unc_;
+  float time_unc_{0.f};
   /// Time over threshold/pulse width
-  float tot_;
+  float tot_{0.f};
 };
 
 bool operator<(const TotemT2RecHit&, const TotemT2RecHit&);

--- a/DataFormats/TotemReco/src/TotemT2RecHit.cc
+++ b/DataFormats/TotemReco/src/TotemT2RecHit.cc
@@ -8,13 +8,17 @@
 
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
 
-TotemT2RecHit::TotemT2RecHit(const GlobalPoint& centre, float time, float time_unc)
-    : centre_(centre), time_(time), time_unc_(time_unc) {}
+TotemT2RecHit::TotemT2RecHit(const GlobalPoint& centre, float time, float time_unc, float tot)
+    : centre_(centre), time_(time), time_unc_(time_unc), tot_(tot) {}
 
 bool operator<(const TotemT2RecHit& lhs, const TotemT2RecHit& rhs) {
   if (lhs.time() < rhs.time())
     return true;
   if (lhs.time() > rhs.time())
+    return false;
+  if (lhs.toT() < rhs.toT())
+    return true;
+  if (lhs.toT() > rhs.toT())
     return false;
   if (lhs.timeUnc() < rhs.timeUnc())
     return true;

--- a/DataFormats/TotemReco/src/TotemT2RecHit.cc
+++ b/DataFormats/TotemReco/src/TotemT2RecHit.cc
@@ -1,0 +1,24 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
+
+TotemT2RecHit::TotemT2RecHit(const GlobalPoint& centre, float time, float time_unc)
+    : centre_(centre), time_(time), time_unc_(time_unc) {}
+
+bool operator<(const TotemT2RecHit& lhs, const TotemT2RecHit& rhs) {
+  if (lhs.time() < rhs.time())
+    return true;
+  if (lhs.time() > rhs.time())
+    return false;
+  if (lhs.timeUnc() < rhs.timeUnc())
+    return true;
+  if (lhs.timeUnc() > rhs.timeUnc())
+    return false;
+  return false;
+}

--- a/DataFormats/TotemReco/src/classes.h
+++ b/DataFormats/TotemReco/src/classes.h
@@ -1,6 +1,8 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"

--- a/DataFormats/TotemReco/src/classes.h
+++ b/DataFormats/TotemReco/src/classes.h
@@ -3,5 +3,6 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+#include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
 
 #include <vector>

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -7,8 +7,8 @@
   <class name="edm::Wrapper<edm::DetSetVector<TotemT2Digi> >"/>
   <class name="std::vector<TotemT2Digi>"/>
   <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
-  <class name="TotemT2RecHit" ClassVersion="2"> <!--FIXME bump class version-->
-    <version ClassVersion="2" checksum="3345666528"/>
+  <class name="TotemT2RecHit" ClassVersion="2">
+    <version ClassVersion="2" checksum="2546742462"/>
   </class>
   <class name="edm::DetSet<TotemT2RecHit>"/>
   <class name="edm::DetSetVector<TotemT2RecHit>"/>

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -1,18 +1,18 @@
 <lcgdict>
-  <class name="TotemT2Digi" ClassVersion="10">
-    <version ClassVersion="10" checksum="4024006040"/>
+  <class name="TotemT2Digi" ClassVersion="3">
+    <version ClassVersion="3" checksum="4024006040"/>
   </class>
   <class name="edm::DetSet<TotemT2Digi>"/>
   <class name="edm::DetSetVector<TotemT2Digi>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemT2Digi> >"/>
   <class name="std::vector<TotemT2Digi>"/>
   <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
-  <class name="TotemT2RecHit" ClassVersion="2">
-    <version ClassVersion="2" checksum="969691996"/>
+  <class name="TotemT2RecHit" ClassVersion="3">
+    <version ClassVersion="3" checksum="969691996"/>
   </class>
-  <class name="edm::DetSet<TotemT2RecHit>"/>
-  <class name="edm::DetSetVector<TotemT2RecHit>"/>
-  <class name="edm::Wrapper<edm::DetSetVector<TotemT2RecHit> >"/>
+  <class name="edmNew::DetSet<TotemT2RecHit>"/>
+  <class name="edmNew::DetSetVector<TotemT2RecHit>"/>
+  <class name="edm::Wrapper<edmNew::DetSetVector<TotemT2RecHit> >"/>
   <class name="std::vector<TotemT2RecHit>"/>
-  <class name="std::vector<edm::DetSet<TotemT2RecHit> >"/>
+  <class name="std::vector<edmNew::DetSet<TotemT2RecHit> >"/>
 </lcgdict>

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -8,7 +8,7 @@
   <class name="std::vector<TotemT2Digi>"/>
   <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
   <class name="TotemT2RecHit" ClassVersion="2">
-    <version ClassVersion="2" checksum="2546742462"/>
+    <version ClassVersion="2" checksum="969691996"/>
   </class>
   <class name="edm::DetSet<TotemT2RecHit>"/>
   <class name="edm::DetSetVector<TotemT2RecHit>"/>

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -7,4 +7,12 @@
   <class name="edm::Wrapper<edm::DetSetVector<TotemT2Digi> >"/>
   <class name="std::vector<TotemT2Digi>"/>
   <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
+  <class name="TotemT2RecHit" ClassVersion="2"> <!--FIXME bump class version-->
+    <version ClassVersion="2" checksum="3345666528"/>
+  </class>
+  <class name="edm::DetSet<TotemT2RecHit>"/>
+  <class name="edm::DetSetVector<TotemT2RecHit>"/>
+  <class name="edm::Wrapper<edm::DetSetVector<TotemT2RecHit> >"/>
+  <class name="std::vector<TotemT2RecHit>"/>
+  <class name="std::vector<edm::DetSet<TotemT2RecHit> >"/>
 </lcgdict>

--- a/Geometry/ForwardGeometry/BuildFile.xml
+++ b/Geometry/ForwardGeometry/BuildFile.xml
@@ -3,6 +3,7 @@
 </export>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>
+<use name="Geometry/VeryForwardGeometryBuilder"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="clhep"/>

--- a/Geometry/ForwardGeometry/BuildFile.xml
+++ b/Geometry/ForwardGeometry/BuildFile.xml
@@ -7,4 +7,3 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="clhep"/>
-<use name="Geom"/>

--- a/Geometry/ForwardGeometry/BuildFile.xml
+++ b/Geometry/ForwardGeometry/BuildFile.xml
@@ -7,3 +7,7 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="clhep"/>
+<use name="DetectorDescription/DDCMS"/>
+<use name="FWCore/Utilities"/>
+<use name="Geom"/>
+<use name="dd4hep"/>

--- a/Geometry/ForwardGeometry/BuildFile.xml
+++ b/Geometry/ForwardGeometry/BuildFile.xml
@@ -7,7 +7,4 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="clhep"/>
-<use name="DetectorDescription/DDCMS"/>
-<use name="FWCore/Utilities"/>
 <use name="Geom"/>
-<use name="dd4hep"/>

--- a/Geometry/ForwardGeometry/interface/TotemGeometry.h
+++ b/Geometry/ForwardGeometry/interface/TotemGeometry.h
@@ -25,7 +25,7 @@ public:
   const TotemT2Tile& tile(const TotemT2DetId&) const;
 
 private:
-  void browse(const DetGeomDesc*&, bool in_t2);
+  void browse(const DetGeomDesc*, bool in_t2);
   void browseT2(const DetGeomDesc*&);
 
   std::map<TotemT2DetId, const DetGeomDesc*> nt2_planes_;

--- a/Geometry/ForwardGeometry/interface/TotemGeometry.h
+++ b/Geometry/ForwardGeometry/interface/TotemGeometry.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Author:
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#ifndef Geometry_ForwardGeometry_TotemGeometry_h
+#define Geometry_ForwardGeometry_TotemGeometry_h
+
+#include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h"
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+
+class TotemGeometry {
+public:
+  TotemGeometry(const DetGeomDesc*);
+
+  bool addT2Sector(const TotemT2DetId&, const DetGeomDesc*&);
+  bool addT2Plane(const TotemT2DetId&, const DetGeomDesc*&);
+  bool addT2Tile(const TotemT2DetId&, const DetGeomDesc*&);
+
+  const DetGeomDesc*& tile(const TotemT2DetId&) const;
+
+private:
+  std::map<CTPPSDetId, const DetGeomDesc*&> nt2_tiles_;
+};
+
+#endif

--- a/Geometry/ForwardGeometry/interface/TotemGeometry.h
+++ b/Geometry/ForwardGeometry/interface/TotemGeometry.h
@@ -9,6 +9,7 @@
 #ifndef Geometry_ForwardGeometry_TotemGeometry_h
 #define Geometry_ForwardGeometry_TotemGeometry_h
 
+#include "Geometry/ForwardGeometry/interface/TotemT2Tile.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h"
 
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
@@ -17,14 +18,18 @@ class TotemGeometry {
 public:
   TotemGeometry(const DetGeomDesc*);
 
-  bool addT2Sector(const TotemT2DetId&, const DetGeomDesc*&);
   bool addT2Plane(const TotemT2DetId&, const DetGeomDesc*&);
   bool addT2Tile(const TotemT2DetId&, const DetGeomDesc*&);
 
-  const DetGeomDesc*& tile(const TotemT2DetId&) const;
+  const DetGeomDesc* plane(const TotemT2DetId&) const;
+  const TotemT2Tile& tile(const TotemT2DetId&) const;
 
 private:
-  std::map<CTPPSDetId, const DetGeomDesc*&> nt2_tiles_;
+  void browse(const DetGeomDesc*&, bool in_t2);
+  void browseT2(const DetGeomDesc*&);
+
+  std::map<TotemT2DetId, const DetGeomDesc*> nt2_planes_;
+  std::map<TotemT2DetId, TotemT2Tile> nt2_tiles_;
 };
 
 #endif

--- a/Geometry/ForwardGeometry/interface/TotemT2Tile.h
+++ b/Geometry/ForwardGeometry/interface/TotemT2Tile.h
@@ -12,8 +12,6 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h"
 
-#include <DD4hep/DD4hepUnits.h>
-
 class TotemT2Tile {
 public:
   TotemT2Tile();
@@ -23,7 +21,6 @@ public:
   const GlobalPoint& centre() const { return centre_; }
 
 private:
-  dd4hep::PlacedVolume vol_;
   GlobalPoint centre_;
 };
 

--- a/Geometry/ForwardGeometry/interface/TotemT2Tile.h
+++ b/Geometry/ForwardGeometry/interface/TotemT2Tile.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Author:
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#ifndef Geometry_ForwardGeometry_TotemT2Tile_h
+#define Geometry_ForwardGeometry_TotemT2Tile_h
+
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h"
+
+#include <DD4hep/DD4hepUnits.h>
+
+class TotemT2Tile {
+public:
+  TotemT2Tile();
+  explicit TotemT2Tile(const DetGeomDesc*);
+  ~TotemT2Tile();
+
+  const GlobalPoint& centre() const { return centre_; }
+
+private:
+  dd4hep::PlacedVolume vol_;
+  GlobalPoint centre_;
+};
+
+#endif

--- a/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
+++ b/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
@@ -15,7 +15,7 @@
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/Records/interface/TotemGeometryRcd.h"
 #include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDescBuilder.h"
 
@@ -24,12 +24,12 @@ public:
   TotemGeometryESModule(const edm::ParameterSet&);
 
   std::unique_ptr<DetGeomDesc> produceGeomDesc(const IdealGeometryRecord&);
-  std::unique_ptr<TotemGeometry> produceGeometry(const VeryForwardRealGeometryRecord&);
+  std::unique_ptr<TotemGeometry> produceGeometry(const TotemGeometryRcd&);
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  const edm::ESGetToken<DetGeomDesc, VeryForwardRealGeometryRecord> detGeomDescToken_;
+  const edm::ESGetToken<DetGeomDesc, TotemGeometryRcd> detGeomDescToken_;
   edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4hepToken_;
 };
 
@@ -43,14 +43,14 @@ std::unique_ptr<DetGeomDesc> TotemGeometryESModule::produceGeomDesc(const IdealG
   return detgeomdescbuilder::buildDetGeomDescFromCompactView(dd4hep, false);
 }
 
-std::unique_ptr<TotemGeometry> TotemGeometryESModule::produceGeometry(const VeryForwardRealGeometryRecord& iRecord) {
+std::unique_ptr<TotemGeometry> TotemGeometryESModule::produceGeometry(const TotemGeometryRcd& iRecord) {
   const auto& geom_desc = iRecord.get(detGeomDescToken_);
   return std::make_unique<TotemGeometry>(&geom_desc);
 }
 
 void TotemGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("compactViewTag", std::string());
+  desc.add<std::string>("compactViewTag", std::string("XMLIdealGeometryESSource"));
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
+++ b/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
@@ -1,0 +1,58 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Author:
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#include <memory>
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+#include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDescBuilder.h"
+
+class TotemGeometryESModule : public edm::ESProducer {
+public:
+  TotemGeometryESModule(const edm::ParameterSet&);
+
+  std::unique_ptr<DetGeomDesc> produceGeomDesc(const IdealGeometryRecord&);
+  std::unique_ptr<TotemGeometry> produceGeometry(const VeryForwardRealGeometryRecord&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  const edm::ESGetToken<DetGeomDesc, VeryForwardRealGeometryRecord> detGeomDescToken_;
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4hepToken_;
+};
+
+TotemGeometryESModule::TotemGeometryESModule(const edm::ParameterSet& iConfig)
+    : detGeomDescToken_{setWhatProduced(this, &TotemGeometryESModule::produceGeometry).consumes<DetGeomDesc>(edm::ESInputTag())},
+      dd4hepToken_{setWhatProduced(this, &TotemGeometryESModule::produceGeomDesc).consumes<cms::DDCompactView>(edm::ESInputTag("", iConfig.getParameter<std::string>("compactViewTag")))} {
+}
+
+std::unique_ptr<DetGeomDesc> TotemGeometryESModule::produceGeomDesc(const IdealGeometryRecord& iRecord) {
+  const auto& dd4hep = iRecord.get(dd4hepToken_);
+  return detgeomdescbuilder::buildDetGeomDescFromCompactView(dd4hep, false);
+}
+
+std::unique_ptr<TotemGeometry> TotemGeometryESModule::produceGeometry(const VeryForwardRealGeometryRecord& iRecord) {
+  const auto& geom_desc = iRecord.get(detGeomDescToken_);
+  return std::make_unique<TotemGeometry>(&geom_desc);
+}
+
+void TotemGeometryESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("compactViewTag", std::string());
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(TotemGeometryESModule);

--- a/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
+++ b/Geometry/ForwardGeometry/plugins/TotemGeometryESModule.cc
@@ -29,7 +29,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  const edm::ESGetToken<DetGeomDesc, TotemGeometryRcd> detGeomDescToken_;
   edm::ESGetToken<DDCompactView, IdealGeometryRecord> ddlToken_;
   edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> dd4hepToken_;
 

--- a/Geometry/ForwardGeometry/src/ES_TotemGeometry.cc
+++ b/Geometry/ForwardGeometry/src/ES_TotemGeometry.cc
@@ -1,0 +1,4 @@
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(TotemGeometry);

--- a/Geometry/ForwardGeometry/src/TotemGeometry.cc
+++ b/Geometry/ForwardGeometry/src/TotemGeometry.cc
@@ -8,25 +8,16 @@
 
 #include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
 
-TotemGeometry::TotemGeometry(const DetGeomDesc* dgd) {
-  std::deque<const DetGeomDesc*> buffer;
-  buffer.emplace_back(dgd);
-  while (!buffer.empty()) {
-    // get the next item
-    const auto* desc = buffer.front();
-    buffer.pop_front();
-    browse(desc, false);
-  }
-}
+TotemGeometry::TotemGeometry(const DetGeomDesc* dgd) { browse(dgd, false); }
 
-void TotemGeometry::browse(const DetGeomDesc*& parent, bool in_t2) {
+void TotemGeometry::browse(const DetGeomDesc* parent, bool in_t2) {
   if (parent->name() == "TotemT2")
     in_t2 = true;  // define the mother volume for all children
   if (in_t2)
     browseT2(parent);
   // start the recursive browsing
   for (const auto& child : parent->components())
-    browse(const_cast<const DetGeomDesc*&>(child), in_t2);
+    browse(child, in_t2);
 }
 
 void TotemGeometry::browseT2(const DetGeomDesc*& parent) {

--- a/Geometry/ForwardGeometry/src/TotemGeometry.cc
+++ b/Geometry/ForwardGeometry/src/TotemGeometry.cc
@@ -1,0 +1,38 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Author:
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+
+TotemGeometry::TotemGeometry(const DetGeomDesc* dgd) {
+  std::deque<const DetGeomDesc*> buffer;
+  buffer.emplace_back(dgd);
+  while (!buffer.empty()) {
+    // get the next item
+    const auto* desc = buffer.front();
+    buffer.pop_front();
+
+    desc->print();
+  }
+}
+
+bool TotemGeometry::addT2Sector(const TotemT2DetId&, const DetGeomDesc*&) {
+  return true;
+}
+
+bool TotemGeometry::addT2Plane(const TotemT2DetId&, const DetGeomDesc*&) {
+  return true;
+}
+
+bool TotemGeometry::addT2Tile(const TotemT2DetId&, const DetGeomDesc*&) {
+  return true;
+}
+
+const DetGeomDesc*& TotemGeometry::tile(const TotemT2DetId& detid) const {
+  return nt2_tiles_.at(detid);
+}
+

--- a/Geometry/ForwardGeometry/src/TotemGeometry.cc
+++ b/Geometry/ForwardGeometry/src/TotemGeometry.cc
@@ -20,19 +20,10 @@ TotemGeometry::TotemGeometry(const DetGeomDesc* dgd) {
   }
 }
 
-bool TotemGeometry::addT2Sector(const TotemT2DetId&, const DetGeomDesc*&) {
-  return true;
-}
+bool TotemGeometry::addT2Sector(const TotemT2DetId&, const DetGeomDesc*&) { return true; }
 
-bool TotemGeometry::addT2Plane(const TotemT2DetId&, const DetGeomDesc*&) {
-  return true;
-}
+bool TotemGeometry::addT2Plane(const TotemT2DetId&, const DetGeomDesc*&) { return true; }
 
-bool TotemGeometry::addT2Tile(const TotemT2DetId&, const DetGeomDesc*&) {
-  return true;
-}
+bool TotemGeometry::addT2Tile(const TotemT2DetId&, const DetGeomDesc*&) { return true; }
 
-const DetGeomDesc*& TotemGeometry::tile(const TotemT2DetId& detid) const {
-  return nt2_tiles_.at(detid);
-}
-
+const DetGeomDesc*& TotemGeometry::tile(const TotemT2DetId& detid) const { return nt2_tiles_.at(detid); }

--- a/Geometry/ForwardGeometry/src/TotemT2Tile.cc
+++ b/Geometry/ForwardGeometry/src/TotemT2Tile.cc
@@ -8,6 +8,7 @@
 
 #include "Geometry/ForwardGeometry/interface/TotemT2Tile.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+#include <TGeoManager.h>
 
 TotemT2Tile::TotemT2Tile() {}
 
@@ -15,10 +16,18 @@ TotemT2Tile::TotemT2Tile(const DetGeomDesc* dgd) {
   centre_ = GlobalPoint{(float)dgd->translation().x(),
                         (float)dgd->translation().y(),
                         (float)dgd->parentZPosition()};  // retrieve the plane position for z coordinate
-  const dd4hep::Volume box;                              //(0, 0, 0);
-  const dd4hep::Trapezoid trap(
-      dgd->params()[4], dgd->params()[8], dgd->params()[3], dgd->params()[3], dgd->params()[0]);
-  const dd4hep::Transform3D tile_transform(dgd->rotation(), dgd->translation());
+  double angle = 0.;
+  {  // get azimutal component of tile rotation
+    AlgebraicMatrix33 mat;
+    dgd->rotation().GetRotationMatrix(mat);
+    angle = acos(mat[0][0]);
+  }
+  TGeoCombiTrans place(centre_.x(), centre_.y(), centre_.z(), new TGeoRotation("tile_rot", angle, 0., 0.));
+  TGeoManager mgr;
+  auto* box = mgr.MakeBox("top", nullptr, 0., 0., 0.);
+  mgr.SetTopVolume(box);
+  auto* vol = mgr.MakeTrd1("tile", nullptr, dgd->params()[4], dgd->params()[8], dgd->params()[3], dgd->params()[0]);
+  box->AddNode(vol, 1, &place);
 }
 
 TotemT2Tile::~TotemT2Tile() {}

--- a/Geometry/ForwardGeometry/src/TotemT2Tile.cc
+++ b/Geometry/ForwardGeometry/src/TotemT2Tile.cc
@@ -1,0 +1,24 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Author:
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#include "Geometry/ForwardGeometry/interface/TotemT2Tile.h"
+#include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+
+TotemT2Tile::TotemT2Tile() {}
+
+TotemT2Tile::TotemT2Tile(const DetGeomDesc* dgd) {
+  centre_ = GlobalPoint{(float)dgd->translation().x(),
+                        (float)dgd->translation().y(),
+                        (float)dgd->parentZPosition()};  // retrieve the plane position for z coordinate
+  const dd4hep::Volume box;                              //(0, 0, 0);
+  const dd4hep::Trapezoid trap(
+      dgd->params()[4], dgd->params()[8], dgd->params()[3], dgd->params()[3], dgd->params()[0]);
+  const dd4hep::Transform3D tile_transform(dgd->rotation(), dgd->translation());
+}
+
+TotemT2Tile::~TotemT2Tile() {}

--- a/Geometry/Records/interface/PTotemRcd.h
+++ b/Geometry/Records/interface/PTotemRcd.h
@@ -1,0 +1,6 @@
+#ifndef Geometry_Records_PTotemRcd_h
+#define Geometry_Records_PTotemRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class PTotemRcd : public edm::eventsetup::EventSetupRecordImplementation<PTotemRcd> {};
+#endif

--- a/Geometry/Records/interface/TotemGeometryRcd.h
+++ b/Geometry/Records/interface/TotemGeometryRcd.h
@@ -1,0 +1,26 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*	  Laurent Forthomme
+*
+****************************************************************************/
+
+#ifndef Geometry_Records_TotemGeometryRcd_h
+#define Geometry_Records_TotemGeometryRcd_h
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Utilities/interface/mplVector.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/PTotemRcd.h"
+
+#include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
+
+/**
+ * \ingroup TotemGeometry
+ * \brief Event setup record containing the real (actual) geometry information.
+ **/
+class TotemGeometryRcd : public edm::eventsetup::DependentRecordImplementation<TotemGeometryRcd, edm::mpl::Vector<IdealGeometryRecord, PTotemRcd> > {};
+
+#endif

--- a/Geometry/Records/interface/TotemGeometryRcd.h
+++ b/Geometry/Records/interface/TotemGeometryRcd.h
@@ -15,8 +15,6 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PTotemRcd.h"
 
-#include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
-
 /**
  * \ingroup TotemGeometry
  * \brief Event setup record containing the real (actual) geometry information.

--- a/Geometry/Records/interface/TotemGeometryRcd.h
+++ b/Geometry/Records/interface/TotemGeometryRcd.h
@@ -21,6 +21,8 @@
  * \ingroup TotemGeometry
  * \brief Event setup record containing the real (actual) geometry information.
  **/
-class TotemGeometryRcd : public edm::eventsetup::DependentRecordImplementation<TotemGeometryRcd, edm::mpl::Vector<IdealGeometryRecord, PTotemRcd> > {};
+class TotemGeometryRcd
+    : public edm::eventsetup::DependentRecordImplementation<TotemGeometryRcd,
+                                                            edm::mpl::Vector<IdealGeometryRecord, PTotemRcd> > {};
 
 #endif

--- a/Geometry/Records/src/PTotemRcd.cc
+++ b/Geometry/Records/src/PTotemRcd.cc
@@ -1,0 +1,4 @@
+#include "Geometry/Records/interface/PTotemRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(PTotemRcd);

--- a/Geometry/Records/src/TotemGeometryRcd.cc
+++ b/Geometry/Records/src/TotemGeometryRcd.cc
@@ -1,0 +1,4 @@
+#include "Geometry/Records/interface/TotemGeometryRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(TotemGeometryRcd);

--- a/RecoPPS/Local/BuildFile.xml
+++ b/RecoPPS/Local/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/CTPPSReco"/>
+<use name="Geometry/ForwardGeometry"/>
 <use name="Geometry/VeryForwardGeometryBuilder"/>
 <use name="Geometry/VeryForwardGeometry" source_only="1"/>
 <use name="Geometry/VeryForwardRPTopology"/>

--- a/RecoPPS/Local/BuildFile.xml
+++ b/RecoPPS/Local/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/CTPPSReco"/>
+<use name="DataFormats/TotemReco"/>
 <use name="Geometry/ForwardGeometry"/>
 <use name="Geometry/VeryForwardGeometryBuilder"/>
 <use name="Geometry/VeryForwardGeometry" source_only="1"/>

--- a/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -11,13 +11,16 @@
 
 #include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
-#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
-
+#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+
 class CTPPSDiamondRecHitProducerAlgorithm
-    : public TimingRecHitProducerAlgorithm<CTPPSGeometry, CTPPSDiamondDigi, CTPPSDiamondRecHit> {
+    : public TimingRecHitProducerAlgorithm<CTPPSGeometry,
+                                           edm::DetSetVector<CTPPSDiamondDigi>,
+                                           edm::DetSetVector<CTPPSDiamondRecHit> > {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
   void build(const CTPPSGeometry&,

--- a/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -16,7 +16,8 @@
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 
-class CTPPSDiamondRecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<CTPPSGeometry, CTPPSDiamondDigi, CTPPSDiamondRecHit> {
+class CTPPSDiamondRecHitProducerAlgorithm
+    : public TimingRecHitProducerAlgorithm<CTPPSGeometry, CTPPSDiamondDigi, CTPPSDiamondRecHit> {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
   void build(const CTPPSGeometry&,

--- a/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -11,10 +11,12 @@
 
 #include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 
-class CTPPSDiamondRecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<CTPPSDiamondDigi, CTPPSDiamondRecHit> {
+class CTPPSDiamondRecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<CTPPSGeometry, CTPPSDiamondDigi, CTPPSDiamondRecHit> {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
   void build(const CTPPSGeometry&,

--- a/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -9,37 +9,20 @@
 #ifndef RecoPPS_Local_CTPPSDiamondRecHitProducerAlgorithm
 #define RecoPPS_Local_CTPPSDiamondRecHitProducerAlgorithm
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-
-#include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSDiamondRecHit.h"
 
-#include "Geometry/VeryForwardRPTopology/interface/RPTopology.h"
-#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
-
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
-
-class CTPPSDiamondRecHitProducerAlgorithm {
+class CTPPSDiamondRecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<CTPPSDiamondDigi, CTPPSDiamondRecHit> {
 public:
-  CTPPSDiamondRecHitProducerAlgorithm(const edm::ParameterSet& conf);
-
-  void setCalibration(const PPSTimingCalibration&, const PPSTimingCalibrationLUT&);
-  void build(const CTPPSGeometry&, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>&);
+  using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
+  void build(const CTPPSGeometry&,
+             const edm::DetSetVector<CTPPSDiamondDigi>&,
+             edm::DetSetVector<CTPPSDiamondRecHit>&) override;
 
 private:
   static constexpr unsigned short MAX_CHANNEL = 20;
-  /// Conversion constant between HPTDC time slice and absolute time (in ns)
-  double ts_to_ns_;
-  /// Switch on/off the timing calibration
-  bool apply_calib_;
-  PPSTimingCalibration calib_;
-  PPSTimingCalibrationLUT calibLUT_;
-  std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
 };
 
 #endif

--- a/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
@@ -11,11 +11,13 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/FormulaEvaluator.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
 
+/// \tparam G Geometry condition format definition
+/// \tparam D Digis input collection type
+/// \tparam R RecHits output collection type
 template <typename G, typename D, typename R>
 class TimingRecHitProducerAlgorithm {
 public:
@@ -25,11 +27,11 @@ public:
   virtual ~TimingRecHitProducerAlgorithm() = default;
 
   void setCalibration(const PPSTimingCalibration& calib, const PPSTimingCalibrationLUT& calibLUT) {
-    calib_ = calib;
-    calibLUT_ = calibLUT;
-    calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_.formula());
+    calib_ = &calib;
+    calibLUT_ = &calibLUT;
+    calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_->formula());
   }
-  virtual void build(const G&, const edm::DetSetVector<D>&, edm::DetSetVector<R>&) = 0;
+  virtual void build(const G&, const D&, R&) = 0;
 
 protected:
   /// Conversion constant between time slice and absolute time (in ns)
@@ -37,8 +39,8 @@ protected:
   /// Switch on/off the timing calibration
   bool apply_calib_;
   /// DB-loaded calibration object
-  PPSTimingCalibration calib_;
-  PPSTimingCalibrationLUT calibLUT_;
+  const PPSTimingCalibration* calib_{nullptr};
+  const PPSTimingCalibrationLUT* calibLUT_{nullptr};
   /// Timing correction formula
   std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
 };

--- a/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
@@ -13,11 +13,10 @@
 #include "CommonTools/Utils/interface/FormulaEvaluator.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 
-#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
 
-template <typename D, typename R>
+template <typename G, typename D, typename R>
 class TimingRecHitProducerAlgorithm {
 public:
   explicit TimingRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
@@ -30,7 +29,7 @@ public:
     calibLUT_ = calibLUT;
     calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_.formula());
   }
-  virtual void build(const CTPPSGeometry&, const edm::DetSetVector<D>&, edm::DetSetVector<R>&) = 0;
+  virtual void build(const G&, const edm::DetSetVector<D>&, edm::DetSetVector<R>&) = 0;
 
 protected:
   /// Conversion constant between time slice and absolute time (in ns)

--- a/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+*
+* This is a part of PPS-TOTEM offline software.
+* Authors:
+*   Laurent Forthomme (laurent.forthomme@cern.ch)
+*
+****************************************************************************/
+
+#ifndef RecoPPS_Local_TimingRecHitProducerAlgorithm
+#define RecoPPS_Local_TimingRecHitProducerAlgorithm
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
+
+template <typename D, typename R>
+class TimingRecHitProducerAlgorithm {
+public:
+  explicit TimingRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
+      : ts_to_ns_(iConfig.getParameter<double>("timeSliceNs")),
+        apply_calib_(iConfig.getParameter<bool>("applyCalibration")) {}
+  virtual ~TimingRecHitProducerAlgorithm() = default;
+
+  void setCalibration(const PPSTimingCalibration& calib, const PPSTimingCalibrationLUT& calibLUT) {
+    calib_ = calib;
+    calibLUT_ = calibLUT;
+    calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_.formula());
+  }
+  virtual void build(const CTPPSGeometry&, const edm::DetSetVector<D>&, edm::DetSetVector<R>&) = 0;
+
+protected:
+  /// Conversion constant between time slice and absolute time (in ns)
+  double ts_to_ns_;
+  /// Switch on/off the timing calibration
+  bool apply_calib_;
+  /// DB-loaded calibration object
+  PPSTimingCalibration calib_;
+  PPSTimingCalibrationLUT calibLUT_;
+  /// Timing correction formula
+  std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
+};
+
+#endif

--- a/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+*
+* This is a part of TOTEM offline software.
+* Authors:
+*   Laurent Forthomme (laurent.forthomme@cern.ch)
+*
+****************************************************************************/
+
+#ifndef RecoPPS_Local_TotemT2RecHitProducerAlgorithm
+#define RecoPPS_Local_TotemT2RecHitProducerAlgorithm
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+#include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
+
+#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
+
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+
+class TotemT2RecHitProducerAlgorithm {
+public:
+  TotemT2RecHitProducerAlgorithm(const edm::ParameterSet& conf);
+
+  void setCalibration(const PPSTimingCalibration&);
+  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&);
+
+private:
+  /// Conversion constant between HPTDC time slice and absolute time (in ns)
+  double ts_to_ns_;
+  /// Switch on/off the timing calibration
+  bool apply_calib_;
+  PPSTimingCalibration calib_;
+  std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
+};
+
+#endif

--- a/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
@@ -11,15 +11,21 @@
 
 #include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
-#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
-
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
 
-class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemGeometry, TotemT2Digi, TotemT2RecHit> {
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+
+class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemGeometry,
+                                                                            edm::DetSetVector<TotemT2Digi>,
+                                                                            edmNew::DetSetVector<TotemT2RecHit> > {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
-  void build(const TotemGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&) override;
+  void build(const TotemGeometry&,
+             const edm::DetSetVector<TotemT2Digi>&,
+             edmNew::DetSetVector<TotemT2RecHit>&) override;
 };
 
 #endif

--- a/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
@@ -9,33 +9,15 @@
 #ifndef RecoPPS_Local_TotemT2RecHitProducerAlgorithm
 #define RecoPPS_Local_TotemT2RecHitProducerAlgorithm
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "CommonTools/Utils/interface/FormulaEvaluator.h"
+#include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-
-#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
 
-#include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
-
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-
-class TotemT2RecHitProducerAlgorithm {
+class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemT2Digi, TotemT2RecHit> {
 public:
-  TotemT2RecHitProducerAlgorithm(const edm::ParameterSet& conf);
-
-  void setCalibration(const PPSTimingCalibration&);
-  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&);
-
-private:
-  /// Conversion constant between HPTDC time slice and absolute time (in ns)
-  double ts_to_ns_;
-  /// Switch on/off the timing calibration
-  bool apply_calib_;
-  PPSTimingCalibration calib_;
-  std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
+  using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
+  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&) override;
 };
 
 #endif

--- a/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
@@ -11,13 +11,15 @@
 
 #include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
 
-class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemT2Digi, TotemT2RecHit> {
+class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemGeometry, TotemT2Digi, TotemT2RecHit> {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
-  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&) override;
+  void build(const TotemGeometry&, const edm::DetSetVector<TotemT2Digi>&, edm::DetSetVector<TotemT2RecHit>&) override;
 };
 
 #endif

--- a/RecoPPS/Local/interface/TotemTimingRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemTimingRecHitProducerAlgorithm.h
@@ -11,27 +11,27 @@
 #ifndef RecoPPS_Local_TotemTimingRecHitProducerAlgorithm
 #define RecoPPS_Local_TotemTimingRecHitProducerAlgorithm
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
-
-#include "DataFormats/CTPPSDetId/interface/TotemTimingDetId.h"
 #include "DataFormats/CTPPSDigi/interface/TotemTimingDigi.h"
 #include "DataFormats/CTPPSReco/interface/TotemTimingRecHit.h"
 
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-
-#include "RecoPPS/Local/interface/TotemTimingConversions.h"
 
 #include <memory>
 
-class TotemTimingRecHitProducerAlgorithm {
+class TotemTimingConversions;
+class TotemTimingRecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<CTPPSGeometry,
+                                                                                edm::DetSetVector<TotemTimingDigi>,
+                                                                                edm::DetSetVector<TotemTimingRecHit> > {
 public:
-  TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet& conf);
+  explicit TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet&);
 
   void setCalibration(const PPSTimingCalibration&);
-  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemTimingDigi>&, edm::DetSetVector<TotemTimingRecHit>&);
+  void build(const CTPPSGeometry&,
+             const edm::DetSetVector<TotemTimingDigi>&,
+             edm::DetSetVector<TotemTimingRecHit>&) override;
 
 private:
   struct RegressionResults {

--- a/RecoPPS/Local/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSDiamondRecHitProducer.cc
@@ -71,20 +71,14 @@ void CTPPSDiamondRecHitProducer::produce(edm::Event& iEvent, const edm::EventSet
   auto pOut = std::make_unique<edm::DetSetVector<CTPPSDiamondRecHit> >();
 
   // get the digi collection
-  edm::Handle<edm::DetSetVector<CTPPSDiamondDigi> > digis;
-  iEvent.getByToken(digiToken_, digis);
+  const auto& digis = iEvent.get(digiToken_);
 
-  if (!digis->empty()) {
-    if (applyCalib_ && calibWatcher_.check(iSetup)) {
-      edm::ESHandle<PPSTimingCalibration> hTimingCalib = iSetup.getHandle(timingCalibrationToken_);
-      edm::ESHandle<PPSTimingCalibrationLUT> hTimingCalibLUT = iSetup.getHandle(timingCalibrationLUTToken_);
-      algo_.setCalibration(*hTimingCalib, *hTimingCalibLUT);
-    }
-    // get the geometry
-    edm::ESHandle<CTPPSGeometry> geometry = iSetup.getHandle(geometryToken_);
+  if (!digis.empty()) {
+    if (applyCalib_ && calibWatcher_.check(iSetup))
+      algo_.setCalibration(iSetup.getData(timingCalibrationToken_), iSetup.getData(timingCalibrationLUTToken_));
 
     // produce the rechits collection
-    algo_.build(*geometry, *digis, *pOut);
+    algo_.build(iSetup.getData(geometryToken_), digis, *pOut);
   }
 
   iEvent.put(std::move(pOut));

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -30,6 +30,7 @@
 #include "Geometry/Records/interface/TotemGeometryRcd.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 #include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationLUTRcd.h"
 
 class TotemT2RecHitProducer : public edm::stream::EDProducer<> {
 public:
@@ -42,6 +43,7 @@ private:
 
   edm::EDGetTokenT<edm::DetSetVector<TotemT2Digi> > digiToken_;
   edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> timingCalibrationToken_;
+  edm::ESGetToken<PPSTimingCalibrationLUT, PPSTimingCalibrationLUTRcd> timingCalibrationLUTToken_;
   edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
   /// A watcher to detect timing calibration changes.
   edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
@@ -71,7 +73,8 @@ void TotemT2RecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   if (!digis->empty()) {
     if (applyCalib_ && calibWatcher_.check(iSetup)) {
       edm::ESHandle<PPSTimingCalibration> hTimingCalib = iSetup.getHandle(timingCalibrationToken_);
-      algo_.setCalibration(*hTimingCalib);
+      edm::ESHandle<PPSTimingCalibrationLUT> hTimingCalibLUT = iSetup.getHandle(timingCalibrationLUTToken_);
+      algo_.setCalibration(*hTimingCalib, *hTimingCalibLUT);
     }
     // get the geometry
     edm::ESHandle<TotemGeometry> geometry = iSetup.getHandle(geometryToken_);

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -92,7 +92,7 @@ void TotemT2RecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& des
       ->setComment("input tag for timing calibrations retrieval");
   desc.add<double>("timeSliceNs", 25.0 / 1024.0)
       ->setComment("conversion constant between timing bin size and nanoseconds");
-  desc.add<bool>("applyCalibration", true)->setComment("switch on/off the timing calibration");
+  desc.add<bool>("applyCalibration", false)->setComment("switch on/off the timing calibration");
 
   descr.add("totemT2RecHits", desc);
 }

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -27,7 +27,7 @@
 
 #include "RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h"
 
-#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/Records/interface/TotemGeometryRcd.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
 #include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
 
@@ -42,7 +42,7 @@ private:
 
   edm::EDGetTokenT<edm::DetSetVector<TotemT2Digi> > digiToken_;
   edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> timingCalibrationToken_;
-  edm::ESGetToken<TotemGeometry, VeryForwardRealGeometryRecord> geometryToken_;
+  edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
   /// A watcher to detect timing calibration changes.
   edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
@@ -52,7 +52,7 @@ private:
 
 TotemT2RecHitProducer::TotemT2RecHitProducer(const edm::ParameterSet& iConfig)
     : digiToken_(consumes<edm::DetSetVector<TotemT2Digi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
-      geometryToken_(esConsumes<TotemGeometry, VeryForwardRealGeometryRecord>()),
+      geometryToken_(esConsumes<TotemGeometry, TotemGeometryRcd>()),
       applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
       algo_(iConfig) {
   if (applyCalib_)

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -42,7 +42,7 @@ private:
 
   edm::EDGetTokenT<edm::DetSetVector<TotemT2Digi> > digiToken_;
   edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> timingCalibrationToken_;
-  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geometryToken_;
+  edm::ESGetToken<TotemGeometry, VeryForwardRealGeometryRecord> geometryToken_;
   /// A watcher to detect timing calibration changes.
   edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
@@ -52,7 +52,7 @@ private:
 
 TotemT2RecHitProducer::TotemT2RecHitProducer(const edm::ParameterSet& iConfig)
     : digiToken_(consumes<edm::DetSetVector<TotemT2Digi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
-      geometryToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>()),
+      geometryToken_(esConsumes<TotemGeometry, VeryForwardRealGeometryRecord>()),
       applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
       algo_(iConfig) {
   if (applyCalib_)
@@ -74,7 +74,7 @@ void TotemT2RecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
       algo_.setCalibration(*hTimingCalib);
     }
     // get the geometry
-    edm::ESHandle<CTPPSGeometry> geometry = iSetup.getHandle(geometryToken_);
+    edm::ESHandle<TotemGeometry> geometry = iSetup.getHandle(geometryToken_);
 
     // produce the rechits collection
     algo_.build(*geometry, *digis, *pOut);

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -1,0 +1,100 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Authors:
+ *   Laurent Forthomme (laurent.forthomme@cern.ch)
+ *
+ ****************************************************************************/
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSet.h"
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+#include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
+
+#include "RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h"
+
+#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
+#include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+
+class TotemT2RecHitProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TotemT2RecHitProducer(const edm::ParameterSet&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  edm::EDGetTokenT<edm::DetSetVector<TotemT2Digi> > digiToken_;
+
+  /// Label to timing calibration tag
+  edm::ESInputTag timingCalibrationTag_;
+  /// A watcher to detect timing calibration changes.
+  edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
+
+  bool applyCalib_;
+  TotemT2RecHitProducerAlgorithm algo_;
+};
+
+TotemT2RecHitProducer::TotemT2RecHitProducer(const edm::ParameterSet& iConfig)
+    : digiToken_(consumes<edm::DetSetVector<TotemT2Digi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
+      timingCalibrationTag_(iConfig.getParameter<std::string>("timingCalibrationTag")),
+      applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
+      algo_(iConfig) {
+  produces<edm::DetSetVector<TotemT2RecHit> >();
+}
+
+void TotemT2RecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto pOut = std::make_unique<edm::DetSetVector<TotemT2RecHit> >();
+
+  // get the digi collection
+  edm::Handle<edm::DetSetVector<TotemT2Digi> > digis;
+  iEvent.getByToken(digiToken_, digis);
+
+  if (!digis->empty()) {
+    if (applyCalib_ && calibWatcher_.check(iSetup)) {
+      edm::ESHandle<PPSTimingCalibration> hTimingCalib;
+      iSetup.get<PPSTimingCalibrationRcd>().get(timingCalibrationTag_, hTimingCalib);
+      algo_.setCalibration(*hTimingCalib);
+    }
+    // get the geometry
+    edm::ESHandle<CTPPSGeometry> geometry;
+    iSetup.get<VeryForwardRealGeometryRecord>().get(geometry);
+
+    // produce the rechits collection
+    algo_.build(*geometry, *digis, *pOut);
+  }
+
+  iEvent.put(std::move(pOut));
+}
+
+void TotemT2RecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("digiTag", edm::InputTag("totemT2Digis", "TotemT2"))
+      ->setComment("input digis collection to retrieve");
+  desc.add<std::string>("timingCalibrationTag", "GlobalTag:TotemT2TimingCalibration")
+      ->setComment("input tag for timing calibrations retrieval");
+  desc.add<double>("timeSliceNs", 25.0 / 1024.0)
+      ->setComment("conversion constant between timing bin size and nanoseconds");
+  desc.add<bool>("applyCalibration", true)->setComment("switch on/off the timing calibration");
+
+  descr.add("totemT2RecHits", desc);
+}
+
+DEFINE_FWK_MODULE(TotemT2RecHitProducer);

--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -38,18 +38,17 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     const int sector = detid.arm(), station = detid.station(), plane = detid.plane(), channel = detid.channel();
     //LUT calibration
     std::vector<double> lut;
-    if (apply_calib_) {
-      lut = calibLUT_.bins(sector, station, plane, channel);
-      if (lut.size() != 1024)
-        lut = std::vector<double>(1024, 0.0);
-    } else
+    if (apply_calib_)
+      lut = calibLUT_->bins(sector, station, plane, channel);
+    if (lut.size() != 1024)
       lut = std::vector<double>(1024, 0.0);
 
     // retrieve the timing calibration part for this channel
-    const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, station, plane, channel) : std::vector<double>{};
+    const auto& ch_params =
+        (apply_calib_) ? calib_->parameters(sector, station, plane, channel) : std::vector<double>{};
     // default values for offset + time precision if calibration object not found
-    const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, station, plane, channel) : 0.;
-    const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, station, plane, channel) : 0.;
+    const double ch_t_offset = (apply_calib_) ? calib_->timeOffset(sector, station, plane, channel) : 0.;
+    const double ch_t_precis = (apply_calib_) ? calib_->timePrecision(sector, station, plane, channel) : 0.;
 
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert(detid);
 

--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -6,22 +6,12 @@
 *
 ****************************************************************************/
 
-#include <memory>
 #include "FWCore/Utilities/interface/isFinite.h"
+
 #include "RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 
 //----------------------------------------------------------------------------------------------------
-
-CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
-    : ts_to_ns_(iConfig.getParameter<double>("timeSliceNs")),
-      apply_calib_(iConfig.getParameter<bool>("applyCalibration")) {}
-
-void CTPPSDiamondRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib,
-                                                         const PPSTimingCalibrationLUT& calibLUT) {
-  calib_ = calib;
-  calibLUT_ = calibLUT;
-  calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_.formula());
-}
 
 void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
                                                 const edm::DetSetVector<CTPPSDiamondDigi>& input,

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -27,9 +27,8 @@ void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
     edm::DetSet<TotemT2RecHit>& rec_hits = output.find_or_insert(detid);
 
     // retrieve the geometry element associated to this DetID
-    const DetGeomDesc* det = geom.tile(detid);
+    const auto& tile = geom.tile(detid);
 
-    const float x_pos = det->translation().x(), y_pos = det->translation().y();
-    float z_pos = det->parentZPosition();  // retrieve the plane position;
+    rec_hits.emplace_back(tile.centre(), ch_t_offset, ch_t_precis);
   }
 }

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -10,7 +10,7 @@
 
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
 
-void TotemT2RecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
+void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
                                            const edm::DetSetVector<TotemT2Digi>& input,
                                            edm::DetSetVector<TotemT2RecHit>& output) {
   for (const auto& vec : input) {
@@ -27,7 +27,7 @@ void TotemT2RecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     edm::DetSet<TotemT2RecHit>& rec_hits = output.find_or_insert(detid);
 
     // retrieve the geometry element associated to this DetID
-    const DetGeomDesc* det = geom.sensor(detid);
+    const DetGeomDesc* det = geom.tile(detid);
 
     const float x_pos = det->translation().x(), y_pos = det->translation().y();
     float z_pos = det->parentZPosition();  // retrieve the plane position;

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -9,23 +9,24 @@
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h"
 
+#include "DataFormats/Common/interface/DetSetNew.h"
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
 
 void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
                                            const edm::DetSetVector<TotemT2Digi>& input,
-                                           edm::DetSetVector<TotemT2RecHit>& output) {
+                                           edmNew::DetSetVector<TotemT2RecHit>& output) {
   for (const auto& vec : input) {
     const TotemT2DetId detid(vec.detId());
     const int sector = detid.arm(), plane = detid.plane(), channel = detid.channel();
 
     // retrieve the timing calibration part for this channel
-    const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, 0, plane, channel) : std::vector<double>{};
+    const auto& ch_params = (apply_calib_) ? calib_->parameters(sector, 0, plane, channel) : std::vector<double>{};
     // default values for offset + time precision if calibration object not found
-    const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, 0, plane, channel) : 0.;
-    const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, 0, plane, channel) : 0.;
+    const double ch_t_offset = (apply_calib_) ? calib_->timeOffset(sector, 0, plane, channel) : 0.;
+    const double ch_t_precis = (apply_calib_) ? calib_->timePrecision(sector, 0, plane, channel) : 0.;
 
-    // prepare the output collection
-    edm::DetSet<TotemT2RecHit>& rec_hits = output.find_or_insert(detid);
+    // prepare the output collection filler
+    edmNew::DetSetVector<TotemT2RecHit>::FastFiller filler(output, detid);
 
     for (const auto& digi : vec) {
       const int t_lead = digi.leadingEdge(), t_trail = digi.trailingEdge();
@@ -44,7 +45,8 @@ void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
       // retrieve the geometry element associated to this DetID
       const auto& tile = geom.tile(detid);
 
-      rec_hits.emplace_back(tile.centre(), t_lead * ts_to_ns_ - ch_t_offset - ch_t_twc, ch_t_precis, tot);
+      // store to the output collection
+      filler.emplace_back(tile.centre(), t_lead * ts_to_ns_ - ch_t_offset - ch_t_twc, ch_t_precis, tot);
     }
   }
 }

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -1,0 +1,35 @@
+/****************************************************************************
+*
+* This is a part of PPS offline software.
+* Authors:
+*   Laurent Forthomme (laurent.forthomme@cern.ch)
+*
+****************************************************************************/
+
+#include "RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h"
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+
+void TotemT2RecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
+                                           const edm::DetSetVector<TotemT2Digi>& input,
+                                           edm::DetSetVector<TotemT2RecHit>& output) {
+  for (const auto& vec : input) {
+    const TotemT2DetId detid(vec.detId());
+    const int sector = detid.arm(), plane = detid.plane(), channel = detid.channel();
+
+    // retrieve the timing calibration part for this channel
+    const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, 0, plane, channel) : std::vector<double>{};
+    // default values for offset + time precision if calibration object not found
+    const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, 0, plane, channel) : 0.;
+    const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, 0, plane, channel) : 0.;
+
+    // prepare the output collection
+    edm::DetSet<TotemT2RecHit>& rec_hits = output.find_or_insert(detid);
+
+    // retrieve the geometry element associated to this DetID
+    const DetGeomDesc* det = geom.sensor(detid);
+
+    const float x_pos = det->translation().x(), y_pos = det->translation().y();
+    float z_pos = det->parentZPosition();  // retrieve the plane position;
+  }
+}

--- a/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -11,15 +11,15 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "RecoPPS/Local/interface/TotemTimingRecHitProducerAlgorithm.h"
-
-#include <memory>
+#include "RecoPPS/Local/interface/TotemTimingConversions.h"
 
 #include <numeric>
 
 //----------------------------------------------------------------------------------------------------
 
 TotemTimingRecHitProducerAlgorithm::TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
-    : mergeTimePeaks_(iConfig.getParameter<bool>("mergeTimePeaks")),
+    : TimingRecHitProducerAlgorithm(iConfig),
+      mergeTimePeaks_(iConfig.getParameter<bool>("mergeTimePeaks")),
       baselinePoints_(iConfig.getParameter<int>("baselinePoints")),
       saturationLimit_(iConfig.getParameter<double>("saturationLimit")),
       cfdFraction_(iConfig.getParameter<double>("cfdFraction")),

--- a/RecoPPS/Local/test/totemT2_rechits_cfg.py
+++ b/RecoPPS/Local/test/totemT2_rechits_cfg.py
@@ -1,0 +1,40 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')
+process.load('Geometry.ForwardGeometry.totemGeometryESModule_cfi')
+process.load('RecoPPS.Local.totemT2RecHits_cfi')
+
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(
+        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/emulated_digi_test.root'
+    ),
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("file:output.root"),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_totemT2*_*_*',
+    ),
+)
+
+# execution configuration
+process.p = cms.Path(
+    process.totemT2RecHits
+)
+
+process.outpath = cms.EndPath(process.output)

--- a/RecoPPS/Local/test/totemT2_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2_reco_cfg.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+# raw data source
+#process.source = cms.Source("NewEventStreamFileReader",
+#    fileNames = cms.untracked.vstring(
+#        '/store/t0streamer/Data/Physics/000/286/591/run286591_ls0521_streamPhysics_StorageManager.dat',
+#        '/store/t0streamer/Minidaq/A/000/303/982/run303982_ls0001_streamA_StorageManager.dat',
+#    )
+#)
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(
+        '/store/data/Run2018D/ZeroBias/RAW/v1/000/324/747/00000/97A72F4B-786F-5A48-B97E-C596DD73BD77.root',
+    ),
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# raw-to-digi conversion
+process.load('CalibPPS.ESProducers.totemT2DAQMapping_cff')
+process.load('EventFilter.CTPPSRawToDigi.totemT2Digis_cfi')
+process.totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
+
+# rechits production
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("file:output.root"),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_totemT2*_*_*',
+    ),
+)
+
+# execution configuration
+process.p = cms.Path(
+    process.totemT2Digis
+)
+
+process.outpath = cms.EndPath(process.output)

--- a/RecoPPS/Local/test/totemT2_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2_reco_cfg.py
@@ -34,6 +34,9 @@ process.load('EventFilter.CTPPSRawToDigi.totemT2Digis_cfi')
 process.totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
 
 # rechits production
+process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')
+process.load('Geometry.ForwardGeometry.totemGeometryESModule_cfi')
+process.load('RecoPPS.Local.totemT2RecHits_cfi')
 
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string("file:output.root"),
@@ -46,6 +49,7 @@ process.output = cms.OutputModule("PoolOutputModule",
 # execution configuration
 process.p = cms.Path(
     process.totemT2Digis
+    * process.totemT2RecHits
 )
 
 process.outpath = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

In this PR we introduce the Totem (for now, new T2-only) geometry-DetId mapping condition object, and the construction of a T2 rechits collection from the digis collection recently introduced in #38886.
In order to avoid yet another duplication of pre-existing digi-rechits conversion code, the algorithmic part of this latter was transformed into a `TimingRecHitProducerAlgorithm` base class from which the pre-existing `CTPPSDiamondRecHitProducerAlgorithm`, `TotemTimingRecHitProducerAlgorithm`, and the newly-introduced `TotemT2RecHitProducerAlgorithm` inheritate.
Most of the development history has been stashed in a few minimally-working commits, and follow-up developments were rebased on top of this branch.

#### PR validation:

Code compiles and runs on top of a digi-level sample. Matrix tests succede.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: N/A
