### PR TITLE
Handle pixel modules with all invalid pixels

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
@@ -39,11 +39,21 @@ namespace gpuClustering {
     auto endModule = moduleStart[0];
     for (auto module = firstModule; module < endModule; module += gridDim.x) {
       auto firstPixel = moduleStart[1 + module];
-      while (id[firstPixel] == invalidModuleId)
-        ++firstPixel;  // could be duplicates!
       auto thisModuleId = id[firstPixel];
+      while (thisModuleId == invalidModuleId and firstPixel < numElements) {
+        // skip invalid or duplicate pixels
+        ++firstPixel;
+        thisModuleId = id[firstPixel];
+      }
+      if (firstPixel >= numElements) {
+        // reached the end of the input while skipping the invalid pixels, nothing left to do
+        break;
+      }
+      if (thisModuleId != moduleId[module]) {
+        // reached the end of the module while skipping the invalid pixels, skip this module
+        continue;
+      }
       assert(thisModuleId < nMaxModules);
-      assert(thisModuleId == moduleId[module]);
 
       auto nclus = nClustersInModule[thisModuleId];
       if (nclus == 0)


### PR DESCRIPTION
#### PR description:

Deal with the the case where all pixels in a module are invalid or duplicate.

#### PR validation:

Testes over data from run 356998: the events which caused crashes with `CMSSW_12_4_5_patch1` are being processed without errors with these changes.

#### If this PR will be backported please specify to which release cycle the backport is meant for:

Backported to CMSSW 12.4.x for data taking: #38989 .