### PR TITLE
Use GEM Rechits (not segments) for GEMMuon

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -191,7 +191,8 @@ namespace reco {
       SegmentAndTrackArbitrationCleaned,
       RPCHitAndTrackArbitration,
       GEMSegmentAndTrackArbitration,
-      ME0SegmentAndTrackArbitration
+      ME0SegmentAndTrackArbitration,
+      GEMHitAndTrackArbitration
     };
 
     ///

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -4,6 +4,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonReco/interface/MuonSegmentMatch.h"
 #include "DataFormats/MuonReco/interface/MuonRPCHitMatch.h"
+#include "DataFormats/MuonReco/interface/MuonGEMHitMatch.h"
 #include <vector>
 
 namespace reco {
@@ -11,6 +12,7 @@ namespace reco {
   public:
     std::vector<reco::MuonSegmentMatch> segmentMatches;  // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> gemMatches;      // segments matching propagated track trajectory
+    std::vector<reco::MuonGEMHitMatch> gemHitMatches;      // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> me0Matches;      // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> truthMatches;    // SimHit projection matching propagated track trajectory
     std::vector<reco::MuonRPCHitMatch> rpcMatches;       // rpc hits matching propagated track trajectory

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -12,7 +12,7 @@ namespace reco {
   public:
     std::vector<reco::MuonSegmentMatch> segmentMatches;  // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> gemMatches;      // segments matching propagated track trajectory
-    std::vector<reco::MuonGEMHitMatch> gemHitMatches;      // segments matching propagated track trajectory
+    std::vector<reco::MuonGEMHitMatch> gemHitMatches;    // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> me0Matches;      // segments matching propagated track trajectory
     std::vector<reco::MuonSegmentMatch> truthMatches;    // SimHit projection matching propagated track trajectory
     std::vector<reco::MuonRPCHitMatch> rpcMatches;       // rpc hits matching propagated track trajectory

--- a/DataFormats/MuonReco/interface/MuonGEMHitMatch.h
+++ b/DataFormats/MuonReco/interface/MuonGEMHitMatch.h
@@ -1,0 +1,17 @@
+#ifndef MuonReco_MuonGEMHitMatch_h
+#define MuonReco_MuonGEMHitMatch_h
+
+#include <cmath>
+
+namespace reco {
+  class MuonGEMHitMatch {
+  public:
+    float x;            // X position of the matched segment
+    unsigned int mask;  // arbitration mask
+    int bx;             // bunch crossing
+
+    MuonGEMHitMatch() : x(0), mask(0), bx(0) {}
+  };
+}  // namespace reco
+
+#endif

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -68,9 +68,10 @@ int Muon::numberOfMatches(ArbitrationType type) const {
       continue;
     }
     if (type == GEMSegmentAndTrackArbitration) {
-      if (chamberMatch.gemMatches.empty())
+      if (chamberMatch.gemMatches.empty() && chamberMatch.gemHitMatches.empty())
         continue;
       matches += chamberMatch.gemMatches.size();
+      matches += chamberMatch.gemHitMatches.size();
       continue;
     }
 

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -68,9 +68,15 @@ int Muon::numberOfMatches(ArbitrationType type) const {
       continue;
     }
     if (type == GEMSegmentAndTrackArbitration) {
-      if (chamberMatch.gemMatches.empty() && chamberMatch.gemHitMatches.empty())
+      if (chamberMatch.gemMatches.empty())
         continue;
       matches += chamberMatch.gemMatches.size();
+      continue;
+    }
+
+    if (type == GEMHitAndTrackArbitration) {
+      if (chamberMatch.gemHitMatches.empty())
+        continue;
       matches += chamberMatch.gemHitMatches.size();
       continue;
     }

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -58,7 +58,8 @@ initial version number of a class which has never been stored before.
   <class name="reco::HcalMuonRecHit" ClassVersion="3">
    <version ClassVersion="3" checksum="2031556424"/>
   </class>
-  <class name="reco::MuonChamberMatch" ClassVersion="13">
+  <class name="reco::MuonChamberMatch" ClassVersion="14">
+   <version ClassVersion="14" checksum="3579435038"/>
    <version ClassVersion="13" checksum="2674954213"/>
    <version ClassVersion="12" checksum="2575855272"/>
    <version ClassVersion="11" checksum="541727491"/>
@@ -74,7 +75,12 @@ initial version number of a class which has never been stored before.
   <class name="std::vector<reco::MuonChamberMatch>"/>
   <class name="std::vector<reco::MuonSegmentMatch>"/>
   <class name="std::vector<reco::MuonRPCHitMatch>"/>
+  <class name="reco::MuonGEMHitMatch" ClassVersion="3">
+   <version ClassVersion="3" checksum="2026566570"/>
+  </class>
+  <class name="std::vector<reco::MuonGEMHitMatch>"/>
 
+  
   <class name="reco::MuonIsolation" ClassVersion="10">
    <version ClassVersion="10" checksum="2078425999"/>
   </class>

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -796,7 +796,8 @@ bool MuonIdProducer::isGoodGEMMuon(const reco::Muon& muon) {
     return false;
   if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
     return false;
-  return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) >= 1);
+  return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) +
+          muon.numberOfMatches(reco::Muon::GEMHitAndTrackArbitration)) >= 1;
 }
 
 bool MuonIdProducer::isGoodME0Muon(const reco::Muon& muon) {

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -791,6 +791,9 @@ bool MuonIdProducer::isGoodRPCMuon(const reco::Muon& muon) {
 }
 
 bool MuonIdProducer::isGoodGEMMuon(const reco::Muon& muon) {
+  // require GEMMuon to be a TrackerMuon
+  if (!isGoodTrackerMuon(muon))
+    return false;
   if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
     return false;
   return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) >= 1);
@@ -1078,7 +1081,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
 
         const double absDx = std::abs(gemRecHit.localPosition().x() - chamber.tState.localPosition().x());
         //std::cout << " absdx " << absDx << "  :";
-        if (absDx <= 20 or absDx * absDx <= 16 * localError.xx())
+        if (absDx <= 5 or absDx * absDx <= 16 * localError.xx())
           matchedChamber.gemHitMatches.push_back(gemHitMatch);
       }
       //std::cout << ":" << std::endl;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -882,7 +882,8 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
   for (const auto& chamber : info.chambers) {
     if (chamber.id.subdetId() == MuonSubdetId::RPC && rpcHitHandle_.isValid())
       continue;  // Skip RPC chambers, they are taken care of below)
-    if (chamber.id.subdetId() == MuonSubdetId::GEM && gemHitHandle_.isValid() && GEMDetId(chamber.id.rawId()).station() != 0)
+    if (chamber.id.subdetId() == MuonSubdetId::GEM && gemHitHandle_.isValid() &&
+        GEMDetId(chamber.id.rawId()).station() != 0)
       continue;  // Skip GE1/1 and 2/1 chambers, they are taken care of below)
     reco::MuonChamberMatch matchedChamber;
 
@@ -1038,7 +1039,8 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
   if (gemHitHandle_.isValid()) {
     for (const auto& chamber : info.chambers) {
       // only GE1/1 and 2/1 are for rechits, reject station 0 and segments (layer==0 for GEMSegment)
-      if (chamber.id.subdetId() != MuonSubdetId::GEM || GEMDetId(chamber.id.rawId()).station() == 0 || GEMDetId(chamber.id.rawId()).layer() == 0)
+      if (chamber.id.subdetId() != MuonSubdetId::GEM || GEMDetId(chamber.id.rawId()).station() == 0 ||
+          GEMDetId(chamber.id.rawId()).layer() == 0)
         continue;  // Consider RPC chambers only
       const auto& lErr = chamber.tState.localError();
       const auto& lPos = chamber.tState.localPosition();
@@ -1072,7 +1074,13 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
 
         // std::cout << " h:" << gemRecHit.gemId();
         //  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int ieta)
-        if (GEMDetId(gemRecHit.gemId().region(),gemRecHit.gemId().ring(),gemRecHit.gemId().station(),gemRecHit.gemId().layer(),gemRecHit.gemId().chamber(),0).rawId() != chamber.id.rawId())
+        if (GEMDetId(gemRecHit.gemId().region(),
+                     gemRecHit.gemId().ring(),
+                     gemRecHit.gemId().station(),
+                     gemRecHit.gemId().layer(),
+                     gemRecHit.gemId().chamber(),
+                     0)
+                .rawId() != chamber.id.rawId())
           continue;
 
         gemHitMatch.x = gemRecHit.localPosition().x();

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1111,7 +1111,8 @@ void MuonIdProducer::arbitrateMuons(reco::MuonCollection* muons, reco::CaloMuonC
         // TrackerMuon failed arbitration
         // If not any other base type - erase the element
         // (PFMuon is not a base type)
-        unsigned int mask = reco::Muon::TrackerMuon | reco::Muon::PFMuon;
+        // GEMMuon should be a subset of TrackerMuon, so don't count it either
+        unsigned int mask = reco::Muon::TrackerMuon | reco::Muon::PFMuon | reco::Muon::GEMMuon;
         if ((muon->type() & (~mask)) == 0) {
           const reco::CaloMuon& caloMuon = makeCaloMuon(*muon);
           if (isGoodCaloMuon(caloMuon))
@@ -1119,7 +1120,7 @@ void MuonIdProducer::arbitrateMuons(reco::MuonCollection* muons, reco::CaloMuonC
           muon = muons->erase(muon);
           continue;
         } else {
-          muon->setType(muon->type() & (~reco::Muon::TrackerMuon));
+          muon->setType(muon->type() & (~(reco::Muon::TrackerMuon | reco::Muon::GEMMuon)));
         }
       }
     }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -797,7 +797,6 @@ bool MuonIdProducer::isGoodGEMMuon(const reco::Muon& muon) {
   if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
     return false;
   return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) >= 1);
-  //return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) >= 1);
 }
 
 bool MuonIdProducer::isGoodME0Muon(const reco::Muon& muon) {
@@ -1041,7 +1040,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
       // only GE1/1 and 2/1 are for rechits, reject station 0 and segments (layer==0 for GEMSegment)
       if (chamber.id.subdetId() != MuonSubdetId::GEM || GEMDetId(chamber.id.rawId()).station() == 0 ||
           GEMDetId(chamber.id.rawId()).layer() == 0)
-        continue;  // Consider RPC chambers only
+        continue;  // Consider GEM chambers only
       const auto& lErr = chamber.tState.localError();
       const auto& lPos = chamber.tState.localPosition();
       const auto& lDir = chamber.tState.localDirection();
@@ -1068,12 +1067,9 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
 
       matchedChamber.id = chamber.id;
 
-      //std::cout << "In GEM Hit Matching info s" << GEMDetId(chamber.id.rawId()) << " ngs:" << gemHitHandle_->size() << " :: ";
       for (const auto& gemRecHit : *gemHitHandle_) {
         reco::MuonGEMHitMatch gemHitMatch;
 
-        // std::cout << " h:" << gemRecHit.gemId();
-        //  constexpr GEMDetId(int region, int ring, int station, int layer, int chamber, int ieta)
         if (GEMDetId(gemRecHit.gemId().region(),
                      gemRecHit.gemId().ring(),
                      gemRecHit.gemId().station(),
@@ -1088,11 +1084,9 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent,
         gemHitMatch.bx = gemRecHit.BunchX();
 
         const double absDx = std::abs(gemRecHit.localPosition().x() - chamber.tState.localPosition().x());
-        //std::cout << " absdx " << absDx << "  :";
         if (absDx <= 5 or absDx * absDx <= 16 * localError.xx())
           matchedChamber.gemHitMatches.push_back(gemHitMatch);
       }
-      //std::cout << ":" << std::endl;
 
       muonChamberMatches.push_back(matchedChamber);
     }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -52,6 +52,7 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/MuonReco/interface/MuonRPCHitMatch.h"
+#include "DataFormats/MuonReco/interface/MuonGEMHitMatch.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/CaloMuon.h"
@@ -241,9 +242,11 @@ private:
   edm::EDGetTokenT<reco::TrackToTrackMap> dytCollectionToken_;
 
   edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
+  edm::EDGetTokenT<GEMRecHitCollection> gemHitToken_;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
 
   edm::Handle<RPCRecHitCollection> rpcHitHandle_;
+  edm::Handle<GEMRecHitCollection> gemHitHandle_;
   edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
 
   const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomTokenRun_;

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
@@ -95,7 +95,11 @@ void MuonDetIdAssociator::getValidDetIds(unsigned int subDectorIndex, std::vecto
     auto const& geomDetsGEM = geometry_->slaveGeometry(GEMDetId())->dets();
     for (auto it = geomDetsGEM.begin(); it != geomDetsGEM.end(); ++it) {
       if (auto gem = dynamic_cast<const GEMSuperChamber*>(*it)) {
-        validIds.push_back(gem->id());
+        if (gem->id().station() == 0)
+          validIds.push_back(gem->id());
+        else
+          for (auto ch : gem->chambers())
+            validIds.push_back(ch->id());
       }
     }
   }


### PR DESCRIPTION
#### PR description:

Changes definition of GEMMuon to match to GEM RecHits, rather than GEM Segments. This change will enable us to use GEMMuon for GEM efficiency measurements with the common muon POG tag and probe code in the DQM. We also require that a GEMMuon be a good TrackerMuon, as there is no use case for a separate GEMMuon which is not also a TrackerMuon, and we want to keep the fake rate low. The code to change to rechits was copied from the RPC code and adjusted to GEM.

These changes were originally proposed to the muon POG in April [1], and it was agreed the changes would be okay, assuming the fake rate wouldn't increase. We found that segments to rechits would increase the fake rate [2], so we proposed by mail to require that GEMMuon be a subset of TrackerMuon, which still allows our TnP measurement, which is the use case of GEMMuon from the GEM side.

@jshlee

[1] https://indico.cern.ch/event/1153168/
[2] https://indico.cern.ch/event/1171113/contributions/4918837/attachments/2462011/4221295/Fake-rate-study_counting.pdf

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Ran a ttbar workflow with the changes. Checked that we keep all GEMMuon that are also TrackerMuon. Checked efficiency measurements look okay.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
