### PR TITLE
Cleanup of totemTriggerRawToDigi sequence remnants

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -26,7 +26,7 @@ else:
 # process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 # Required to load Global Tag
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi") 
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 # # Condition for lxplus: change and possibly customise the GT
 # from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
@@ -51,7 +51,7 @@ process.dqmEndPath = cms.EndPath(process.dqmEnv * process.dqmSaver * process.dqm
 #--------------------------------------------------
 # Standard Unpacking Path
 
-process.load("Configuration.StandardSequences.RawToDigi_Data_cff")    
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
 # remove unneeded unpackers
 process.RawToDigi.remove(process.ecalPreshowerDigis)
@@ -63,7 +63,6 @@ process.RawToDigi.remove(process.siStripDigis)
 process.RawToDigi.remove(process.castorDigis)
 process.RawToDigi.remove(process.scalersRawToDigi)
 process.RawToDigi.remove(process.tcdsDigis)
-process.RawToDigi.remove(process.totemTriggerRawToDigi)
 process.RawToDigi.remove(process.totemRPRawToDigi)
 process.RawToDigi.remove(process.ctppsDiamondRawToDigi)
 process.RawToDigi.remove(process.ctppsPixelDigis)
@@ -144,7 +143,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.tcdsDigis.InputLabel = "rawDataRepacker"
     process.tcdsRawToDigi.InputLabel = "rawDataRepacker"
     process.totemRPRawToDigi.rawDataTag = "rawDataRepacker"
-    process.totemTriggerRawToDigi.rawDataTag = "rawDataRepacker"
     process.totemTimingRawToDigi.rawDataTag = "rawDataRepacker"
     process.csctfDigis.producer = "rawDataRepacker"
     process.dttfDigis.DTTF_FED_Source = "rawDataRepacker"

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -63,7 +63,6 @@ process.RawToDigi.remove(process.siStripDigis)
 process.RawToDigi.remove(process.castorDigis)
 process.RawToDigi.remove(process.scalersRawToDigi)
 process.RawToDigi.remove(process.tcdsDigis)
-process.RawToDigi.remove(process.totemTriggerRawToDigi)
 process.RawToDigi.remove(process.totemRPRawToDigi)
 process.RawToDigi.remove(process.ctppsDiamondRawToDigi)
 process.RawToDigi.remove(process.ctppsPixelDigis)
@@ -142,7 +141,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.tcdsDigis.InputLabel = "rawDataRepacker"
     process.tcdsRawToDigi.InputLabel = "rawDataRepacker"
     process.totemRPRawToDigi.rawDataTag = "rawDataRepacker"
-    process.totemTriggerRawToDigi.rawDataTag = "rawDataRepacker"
     process.totemTimingRawToDigi.rawDataTag = "rawDataRepacker"
     process.csctfDigis.producer = "rawDataRepacker"
     process.dttfDigis.DTTF_FED_Source = "rawDataRepacker"


### PR DESCRIPTION
#### PR description:

Following the merge of #38886 and the replacement of FED 577 from a Totem trigger to the new Totem T2 readout component, making the `totemTriggerRawToDigi` sequence obsolete, a few leftover modifications were found in L1T stage 2 emulator DQM sequence. This yielded a `TestDQMOnlineClient` unit test failure reported in #38987.
These leftovers are dropped in this PR. This fixes #38987.

#### PR validation:

`scram b unittests` raises no failure in `TestDQMOnlineClient` unit test.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: N/A
