### PR TITLE
Re-add class version SiStripApproximateCluster

### DIFF
--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -26,6 +26,7 @@
 
  <class name="SiStripApproximateCluster" ClassVersion="4">
   <version ClassVersion="4" checksum="2854791577"/>
+  <version ClassVersion="3" checksum="2041370183"/>
  </class>
 
  <class name="edmNew::DetSetVector<SiStripApproximateCluster>"/>


### PR DESCRIPTION
As pointed out by @makortel https://github.com/cms-sw/cmssw/pull/38870#discussion_r938814564, we forgot to keep the old class version in https://github.com/cms-sw/cmssw/pull/38870.