### PR TITLE
miscellaneous updates to SiPixel Lorentz Angle Calibration harvesting

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -81,6 +81,9 @@ public:
   dqm::reco::MonitorElement* h_bySectLA_;
   dqm::reco::MonitorElement* h_bySectDeltaLA_;
   dqm::reco::MonitorElement* h_bySectChi2_;
+  dqm::reco::MonitorElement* h_bySectFitStatus_;
+  dqm::reco::MonitorElement* h_bySectCovMatrixStatus_;
+  dqm::reco::MonitorElement* h_bySectDriftError_;
 
   // ouput LA maps
   std::vector<dqm::reco::MonitorElement*> h2_byLayerLA_;

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -4,6 +4,42 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include <unordered_map>
 
+namespace siPixelLACalibration {
+  static constexpr float cmToum = 10000.f;
+
+  class Chebyshev {
+  public:
+    Chebyshev(int n, double xmin, double xmax) : fA(xmin), fB(xmax), fT(std::vector<double>(n + 1)) {}
+
+    double operator()(const double* xx, const double* p) {
+      double x = (2.0 * xx[0] - fA - fB) / (fB - fA);
+      int npar = fT.size();
+
+      if (npar == 1)
+        return p[0];
+      if (npar == 2)
+        return p[0] + x * p[1];
+      // build the polynomials
+      fT[0] = 1;
+      fT[1] = x;
+      for (int i = 2; i < npar; ++i) {
+        fT[i] = 2 * x * fT[i - 1] - fT[i - 2];
+      }
+      double sum = p[0] * fT[0];
+      for (int i = 1; i < npar; ++i) {
+        sum += p[i] * fT[i];
+      }
+      return sum;
+    }
+
+  private:
+    double fA;
+    double fB;
+    std::vector<double> fT;  // polynomial
+    std::vector<double> fC;  // coefficients
+  };
+}  // namespace siPixelLACalibration
+
 struct SiPixelLorentzAngleCalibrationHistograms {
 public:
   SiPixelLorentzAngleCalibrationHistograms() = default;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -39,35 +39,38 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
+// for ROOT fits
+#include "TFitResult.h"
+
 /* 
  * Auxilliary struct to store fit results
  */
 namespace SiPixelLAHarvest {
+
+  enum covStatus { kNotCalculated = 0, kApproximated = 1, kMadePosDef = 2, kAccurate = 3 };
+
   struct fitResults {
   public:
     fitResults() {
       // set all parameters to default
       p0 = p1 = p2 = p3 = p4 = p5 = 0.;
       e0 = e1 = e2 = e3 = e4 = e5 = 0.;
-      chi2 = prob = redChi2 = tan_LA = error_LA = -9999.;
-      ndf = -999;
+      chi2 = prob = dSq = redChi2 = -9999.;
+      tan_LA = error_LA = -9999.;
+      fitStatus = covMatrixStatus = ndf = -999;
     };
 
-    double p0;
-    double e0;
-    double p1;
-    double e1;
-    double p2;
-    double e2;
-    double p3;
-    double e3;
-    double p4;
-    double e4;
-    double p5;
-    double e5;
+    double p0, e0;
+    double p1, e1;
+    double p2, e2;
+    double p3, e3;
+    double p4, e4;
+    double p5, e5;
     double chi2;
     int ndf;
     double prob;
+    int fitStatus, covMatrixStatus;
+    double dSq;
     double redChi2;
     double tan_LA;
     double error_LA;
@@ -207,7 +210,7 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
 
   std::vector<uint32_t> treatedIndices;
 
-  for (auto det : geom->detsPXB()) {
+  for (const auto& det : geom->detsPXB()) {
     const PixelGeomDetUnit* pixelDet = dynamic_cast<const PixelGeomDetUnit*>(det);
     width_ = pixelDet->surface().bounds().thickness();
     const auto& layer = tTopo->pxbLayer(pixelDet->geographicalId());
@@ -361,6 +364,18 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   hists_.h_bySectChi2_ =
       iBooker.book1D("h_bySectorChi2", "Fit #chi^{2}/ndf by sector;pixel sector; fit #chi^{2}/ndf", maxSect, lo, hi);
 
+  hists_.h_bySectFitStatus_ =
+      iBooker.book1D("h_bySectFitStatus_", "Fit Status by sector;pixel sector; fit status", maxSect, lo, hi);
+
+  hists_.h_bySectCovMatrixStatus_ = iBooker.book1D(
+      "h_bySectorCovMatrixStatus", "Fit Covariance Matrix Status by sector;pixel sector; fit status", maxSect, lo, hi);
+  hists_.h_bySectDriftError_ =
+      iBooker.book1D("h_bySectorDriftError",
+                     "square error on the measured drift at half-width by sector;pixel sector;#Delta d^{2}(t/2)",
+                     maxSect,
+                     lo,
+                     hi);
+
   // copy the bin labels from the occupancy histogram
   for (int bin = 1; bin <= maxSect; bin++) {
     const auto& binName = hists_.h_bySectOccupancy_->getTH1()->GetXaxis()->GetBinLabel(bin);
@@ -370,6 +385,9 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     hists_.h_bySectLA_->setBinLabel(bin, binName);
     hists_.h_bySectDeltaLA_->setBinLabel(bin, binName);
     hists_.h_bySectChi2_->setBinLabel(bin, binName);
+    hists_.h_bySectFitStatus_->setBinLabel(bin, binName);
+    hists_.h_bySectCovMatrixStatus_->setBinLabel(bin, binName);
+    hists_.h_bySectDriftError_->setBinLabel(bin, binName);
   }
 
   // this will be booked in the Harvesting folder
@@ -611,9 +629,10 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   if (doChebyshevFit_) {
     const int npar = order_ + 1;
     auto cheb = std::make_unique<siPixelLACalibration::Chebyshev>(order_, theFitRange_.first, theFitRange_.second);
-    f1_ = std::make_unique<TF1>("ff", cheb.release(), 5., 280., npar, "Chebyshev");
+    f1_ =
+        std::make_unique<TF1>("fChebyshev", cheb.release(), theFitRange_.first, theFitRange_.second, npar, "Chebyshev");
   } else {
-    f1_ = std::make_unique<TF1>("f1",
+    f1_ = std::make_unique<TF1>("fPolynomial",
                                 "[0] + [1]*x + [2]*x*x + [3]*x*x*x + [4]*x*x*x*x + [5]*x*x*x*x*x",
                                 theFitRange_.first,
                                 theFitRange_.second);
@@ -640,7 +659,34 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   f1_->SetParError(5, 0);
   f1_->SetChisquare(0);
 
-  hists_.h_mean_[i_index]->getTH1()->Fit(f1_.get(), "ERQ");
+  TFitResultPtr result = hists_.h_mean_[i_index]->getTH1()->Fit(f1_.get(), "ERQS");
+  if (result.Get()) {
+    res.fitStatus = result->Status();
+    edm::LogInfo("SiPixelLorentzAnglePCLHarvester") << "Fit status: " << res.fitStatus;
+  } else {
+    edm::LogError("SiPixelLorentzAnglePCLHarvester") << "Could not retrieve the fit status! Setting it to 0 by default";
+    res.fitStatus = 0;
+  }
+
+  if (res.fitStatus != 0) {
+    res.covMatrixStatus = result->CovMatrixStatus();
+  } else {
+    res.covMatrixStatus = SiPixelLAHarvest::kNotCalculated;
+  }
+
+  // compute the error on the drift-at-half-width parameter (d^2)
+  float dSq{0.};
+  if (!doChebyshevFit_) {
+    if (res.covMatrixStatus != SiPixelLAHarvest::kNotCalculated) {
+      for (int k = 0; k < order_; k++) {
+        for (int l = 0; l < order_; l++) {
+          dSq += (std::pow(half_width, k) * std::pow(half_width, l) * result->CovMatrix(k, l));
+        }
+      }
+    }
+  }  // compute the error on the drift-at-half width only for the regular polynomial fit
+
+  res.dSq = dSq;
 
   res.p0 = f1_->GetParameter(0);
   res.e0 = f1_->GetParError(0);
@@ -670,12 +716,20 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
       (pow(res.e1, 2) + pow((half_width * res.e2), 2) + pow((half_width * half_width * res.e3), 2) +
        pow((half_width * half_width * half_width * res.e4), 2) +
        pow((half_width * half_width * half_width * half_width * res.e5), 2));  // Propagation of uncertainty
-  res.error_LA = sqrt(errsq_LA);
+
+  res.error_LA = doChebyshevFit_ ? sqrt(errsq_LA) : sqrt(res.dSq + result->CovMatrix(0, 0)) / half_width;
 
   hists_.h_bySectMeasLA_->setBinContent(i_index, (res.tan_LA / theMagField_));
   hists_.h_bySectMeasLA_->setBinError(i_index, (res.error_LA / theMagField_));
   hists_.h_bySectChi2_->setBinContent(i_index, res.redChi2);
   hists_.h_bySectChi2_->setBinError(i_index, 0.);  // no errors
+
+  hists_.h_bySectFitStatus_->setBinContent(i_index, res.fitStatus);
+  hists_.h_bySectFitStatus_->setBinError(i_index, 0.);  // no errors
+  hists_.h_bySectCovMatrixStatus_->setBinContent(i_index, res.covMatrixStatus);
+  hists_.h_bySectCovMatrixStatus_->setBinError(i_index, 0.);  // no errors
+  hists_.h_bySectDriftError_->setBinContent(i_index, res.dSq);
+  hists_.h_bySectDriftError_->setBinError(i_index, 0.);
 
   int nentries = hists_.h_bySectOccupancy_->getBinContent(i_index);  // number of on track hits in that sector
 
@@ -703,9 +757,13 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   float LorentzAnglePerTesla_;
   float currentLA = currentLorentzAngle_->getLorentzAngle(detIdsToFill.front());
   // if the fit quality is OK
+
   // check the result of the chi2 only if doing the chebyshev fit
   const bool chi2Cut = doChebyshevFit_ ? (res.redChi2 < fitChi2Cut_) : true;
-  if ((res.redChi2 != 0.) && chi2Cut && (nentries > minHitsCut_)) {
+  // check the covariance matrix status
+  const bool covMatrixStatusCut = (res.covMatrixStatus == SiPixelLAHarvest::kAccurate);
+
+  if ((res.redChi2 != 0.) && covMatrixStatusCut && chi2Cut && (nentries > minHitsCut_)) {
     LorentzAnglePerTesla_ = res.tan_LA / theMagField_;
     // fill the LA actually written to payload
     hists_.h_bySectSetLA_->setBinContent(i_index, LorentzAnglePerTesla_);

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -309,8 +309,6 @@ SiPixelLorentzAnglePCLWorker::SiPixelLorentzAnglePCLWorker(const edm::ParameterS
 // ------------ method called for each event  ------------
 
 void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
-  static constexpr float cmToum = 10000.;
-
   // Retrieve tracker topology from geometry
   const TrackerTopology* const tTopo = &iSetup.getData(topoPerEventEsToken_);
 
@@ -525,8 +523,8 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
               }
               float ypixavg = 0.5f * (ypixlow + ypixhigh);
 
-              float dx = (pixinfo_.x[j] - xlim1) * cmToum;  // dx: in the unit of micrometer
-              float dy = (ypixavg - ylim1) * cmToum;        // dy: in the unit of micrometer
+              float dx = (pixinfo_.x[j] - xlim1) * siPixelLACalibration::cmToum;  // dx: in the unit of micrometer
+              float dy = (ypixavg - ylim1) * siPixelLACalibration::cmToum;        // dy: in the unit of micrometer
               float depth = dy * tan(trackhit_.beta);
               float drift = dx - dy * tan(trackhit_.gamma);
 


### PR DESCRIPTION
#### PR description:

Miscellaneous updates to SiPixel Lorentz Angle Calibration harvesting:
   * introduce a single `siPixelLACalibration::cmToum` constant and use it everywhere where relevant;
   * address the comment at https://github.com/cms-sw/cmssw/pull/38700#discussion_r930864200
   * provide the code for running the LA fit using Chebyshev polynomials instead of regular ones (currently switched off by default)
   * make the fitting range of the drift vs depth profile configurable;
   * add more fit diagnostic histograms (covariance matrix status and propagated error from the covariance matrix on the drift at half-width).

#### PR validation:

`cmssw` compiles, needs more private testing.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Perhaps to be backported to the production release (12.4.X)