### PR TITLE
Fixed codes which causes memory issue by GEM onlineDQM, a backport to 12_4_X

### DIFF
--- a/DQM/GEM/BuildFile.xml
+++ b/DQM/GEM/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="boost"/>
+<use name="CondFormats/GEMObjects"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -468,7 +468,9 @@ public:
                   Int_t nNumChambers,
                   Int_t nNumEtaPartitions,
                   Int_t nMaxVFAT,
-                  Int_t nNumDigi)
+                  Int_t nNumDigi,
+                  Int_t nMinIdxChamber,
+                  Int_t nMaxIdxChamber)
         : nRegion_(nRegion),
           nStation_(nStation),
           nLayer_(nLayer),
@@ -476,6 +478,8 @@ public:
           nNumEtaPartitions_(nNumEtaPartitions),
           nMaxVFAT_(nMaxVFAT),
           nNumDigi_(nNumDigi),
+          nMinIdxChamber_(nMinIdxChamber),
+          nMaxIdxChamber_(nMaxIdxChamber),
           fMinPhi_(0){};
 
     bool operator==(const MEStationInfo &other) const {
@@ -575,7 +579,8 @@ protected:
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
-  std::vector<GEMChamber> gemChambers_;
+  std::vector<GEMDetId> listChamberId_;
+  std::map<GEMDetId, std::vector<const GEMEtaPartition *>> mapEtaPartition_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;

--- a/DQM/GEM/plugins/BuildFile.xml
+++ b/DQM/GEM/plugins/BuildFile.xml
@@ -5,8 +5,6 @@
   <use name="DQMServices/Core"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="CondFormats/DataRecord"/>
-  <use name="CondFormats/GEMObjects"/>
   <use name="RecoMuon/TrackingTools"/>
   <use name="TrackingTools/TransientTrack"/>
   <use name="Validation/MuonHits"/>

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -157,8 +157,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
 
   std::map<ME3IdsKey, Int_t> total_digi_layer;
   std::map<ME3IdsKey, Int_t> total_digi_eta;
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -168,7 +167,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_digi_layer.find(key3) == total_digi_layer.end())
       total_digi_layer[key3] = 0;
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       if (total_digi_eta.find(key3IEta) == total_digi_eta.end())

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -187,13 +187,12 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   std::map<ME3IdsKey, Int_t> total_rechit_iEta;
   std::map<ME4IdsKey, std::map<Int_t, Bool_t>> mapCLSOver5;
 
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     auto chamber = gid.chamber();
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -26,11 +26,9 @@ GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) : geomToken_(esConsumes<edm
 
 int GEMDQMBase::initGeometry(edm::EventSetup const& iSetup) {
   GEMGeometry_ = nullptr;
-  try {
-    //edm::ESHandle<GEMGeometry> hGeom;
-    //iSetup.get<MuonGeometryRecord>().get(hGeom);
-    GEMGeometry_ = &iSetup.getData(geomToken_);
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  if (auto handle = iSetup.getHandle(geomToken_)) {
+    GEMGeometry_ = handle.product();
+  } else {
     edm::LogError(log_category_) << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return -1;
   }
@@ -58,20 +56,19 @@ int GEMDQMBase::getNumEtaPartitions(const GEMStation* station) {
 int GEMDQMBase::loadChambers() {
   if (GEMGeometry_ == nullptr)
     return -1;
-  gemChambers_.clear();
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {  // FIXME: This loop can be merged into the below loop
-    for (auto pch : sch->chambers()) {
-      Bool_t bExist = false;
-      for (const auto& ch : gemChambers_) {
-        if (pch->id() == ch.id()) {
-          bExist = true;
-          break;
+  listChamberId_.clear();
+  mapEtaPartition_.clear();
+  for (const GEMRegion* region : GEMGeometry_->regions()) {
+    for (const GEMStation* station : region->stations()) {
+      for (auto sch : station->superChambers()) {
+        for (auto pchamber : sch->chambers()) {
+          GEMDetId gid = pchamber->id();
+          listChamberId_.push_back(pchamber->id());
+          for (auto iEta : pchamber->etaPartitions()) {
+            mapEtaPartition_[gid].push_back(iEta);
+          }
         }
       }
-      if (bExist)
-        continue;
-      gemChambers_.push_back(*pch);
     }
   }
 
@@ -107,10 +104,15 @@ int GEMDQMBase::loadChambers() {
       for (auto pchamber : chambers) {
         int layer_number = pchamber->id().layer();
         ME3IdsKey key3(region_number, station_number, layer_number);
-        mapStationInfo_[key3] =
-            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
-        mapStationInfo_[key3].nMinIdxChamber_ = nMinIdxChamber;
-        mapStationInfo_[key3].nMaxIdxChamber_ = nMaxIdxChamber;
+        mapStationInfo_[key3] = MEStationInfo(region_number,
+                                              station_number,
+                                              layer_number,
+                                              num_superchambers,
+                                              num_etas,
+                                              num_vfat,
+                                              num_digi,
+                                              nMinIdxChamber,
+                                              nMaxIdxChamber);
         readGeometryRadiusInfoChamber(station, mapStationInfo_[key3]);
         readGeometryPhiInfoChamber(station, mapStationInfo_[key3]);
       }
@@ -178,8 +180,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap3Check_.clear();
   MEMap3WithChCheck_.clear();
   MEMap4Check_.clear();
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key3WithChamber{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -207,7 +208,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;
     }
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), eId.ieta()};
       ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};

--- a/DQM/GEM/test/test.py
+++ b/DQM/GEM/test/test.py
@@ -17,7 +17,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(None, 'auto:phase1_2021_cosmics', '')
+process.GlobalTag = GlobalTag(None, 'auto:phase1_2022_cosmics', '')
 #process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 

--- a/DQM/GEM/test/testGEMEffByGEMCSCSegment.py
+++ b/DQM/GEM/test/testGEMEffByGEMCSCSegment.py
@@ -13,7 +13,7 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(None, 'auto:phase1_2021_cosmics', '')
+process.GlobalTag = GlobalTag(None, 'auto:phase1_2022_cosmics', '')
 
 process.load("DQM.Integration.config.environment_cfi")
 process.dqmEnv.subSystemFolder = "GEM"


### PR DESCRIPTION
#### PR description:
There is an issue with GEM onlineDQM (#38666), which is due to the wrong way to keep the geometry information of GEM chambers. (See [this line](https://github.com/cms-sw/cmssw/pull/38908/files#diff-211b3bdbc65bb043eb340a211fdf6ea24c2e2b17d7cdeb26c535d197be5cee65).) It has been fixed by adapting a safer and lighter method.

#### PR validation:
Test are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True`

@jshlee @watson-ij @seungjin-yang

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of #38908 to CMSSW_12_4_X, which should be propagated to the P5 systems.