### PR TITLE
PFCandidate no longer inherits from CompositeCandidate

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -14,7 +14,7 @@
 
 #include "DataFormats/Math/interface/Point3D.h"
 
-#include "DataFormats/Candidate/interface/CompositeCandidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -38,7 +38,7 @@ namespace reco {
      \date   February 2007
   */
 
-  class PFCandidate : public CompositeCandidate {
+  class PFCandidate : public LeafCandidate {
   public:
     /// particle types
     enum ParticleType {

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -65,7 +65,7 @@ PFCandidate::PFCandidate(const PFCandidatePtr& sourcePtr) : PFCandidate(*sourceP
 }
 
 PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType partId)
-    : CompositeCandidate(charge, p4),
+    : LeafCandidate(charge, p4),
       elementsInBlocks_(nullptr),
       ecalERatio_(1.),
       hcalERatio_(1.),
@@ -123,7 +123,7 @@ PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType pa
 }
 
 PFCandidate::PFCandidate(PFCandidate const& iOther)
-    : CompositeCandidate(iOther),
+    : LeafCandidate(static_cast<LeafCandidate const&>(iOther)),
       elementsInBlocks_(nullptr),
       blocksStorage_(iOther.blocksStorage_),
       elementsStorage_(iOther.elementsStorage_),
@@ -168,7 +168,7 @@ PFCandidate::PFCandidate(PFCandidate const& iOther)
 }
 
 PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
-  CompositeCandidate::operator=(iOther);
+  LeafCandidate::operator=(iOther);
   auto tmp = iOther.elementsInBlocks_.load(std::memory_order_acquire);
   if (nullptr != tmp) {
     delete elementsInBlocks_.exchange(new ElementsInBlocks{*tmp}, std::memory_order_acq_rel);

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="20">
+   <class name="reco::PFCandidate" ClassVersion="21">
+    <version ClassVersion="21" checksum="1234401465"/>
     <version ClassVersion="20" checksum="2748489940"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
@@ -53,7 +54,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="3450520986"/>
    <version ClassVersion="16" checksum="2274533749"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
@@ -69,7 +71,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="1734959799"/>
    <version ClassVersion="16" checksum="3331568330"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -308,7 +308,8 @@
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="16">
+  <class name="pat::PFParticle"  ClassVersion="17">
+   <version ClassVersion="17" checksum="265229913"/>
    <version ClassVersion="16" checksum="4057492004"/>
    <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>


### PR DESCRIPTION

#### PR description:

The storing of PFCandidates takes 1/3rd of the entire time it takes to write AOD. I have started to look at the class to see if there was a way to make it easier for ROOT to store. The first think I tried to was to remove CompositeCandidate (as that looks hard to store) in order to see what would break and therefore would have to be changed if I removed the inheritance. To my surprise no code in CMSSW made use of the possible compositeness of the class.

#### PR validation:

The Code and all dependent code compiles.