### PR TITLE
Vertex smearing for 2022 PbPb based on pp centroid and 2018 PbPb width

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -67,6 +67,7 @@ VtxSmeared = {
     'Run3FlatOpticsGaussSigmaZ5p3cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi',
     'Realistic25ns900GeV2021Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns900GeV2021Collision_cfi',
     'Realistic25ns13p6TeVEarly2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi',
+    'Nominal2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2022PbPbCollision_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominal2022PbPbCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominal2022PbPbCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Nominal2022PbPbCollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Nominal2022PbPbCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -970,6 +970,19 @@ Realistic8TeVPACollision2016VtxSmearingParameters = cms.PSet(
     Z0 = cms.double(1.3577)
 )
 
+# Guess for 2022 PbPb beam conditions, which takes the 2018 PbPb beam width parameters from RealisticPbPbCollision2018VtxSmearingParameters with the current pp MC beam centroid from Realistic25ns13p6TeVEarly2022Collision
+Nominal2022PbPbCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(50),
+    Emittance = cms.double(3.36e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(4.97),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.100629),
+    Y0 = cms.double(-0.014995),
+    Z0 = cms.double(1.298155)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),


### PR DESCRIPTION
This PR adds a vertex smearing for 2022 PbPb MC.
The 2022 PbPb relval is currently using pp beam settings for convenience.
Here we add a dedicated vertex smearing using the current pp beam centroid, which is the current best guess for the centroid in the PbPb run.  The width parameters (emittance & sigmaZ) are taken from 2018 PbPb, which should be quite close to what we get this year, and are quite a bit different from the pp defaults. 

This vertex smearing is not yet active in relval, as it needs the matching reco beamspot in the global tag.

@francescobrivio @tvami 
