### PR TITLE
[12.4.X] add support for `ALCARECOTkAlJetHT` to `trackselectionRefitting`

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -121,7 +121,8 @@ def getSequence(process, collection,
     isCosmics = False
 
     if collection in ("ALCARECOTkAlMinBias", "generalTracks",
-                      "ALCARECOTkAlMinBiasHI", "hiGeneralTracks"):
+                      "ALCARECOTkAlMinBiasHI", "hiGeneralTracks",
+                      "ALCARECOTkAlJetHT"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39013

#### PR description:

Title says it all. Needed to make use of the new ALCARECO samples created via PR https://github.com/cms-sw/cmssw/pull/38254 in the alignment workflow.

#### PR validation:

Run the unit tests of `Alignment/OfflineValidation` without problems

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/39013