### PR TITLE
Implement the alpaka-based accelerator framework for CMSSW

### DIFF
--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -1,16 +1,18 @@
 #ifndef DataFormats_Portable_interface_PortableCollection_h
 #define DataFormats_Portable_interface_PortableCollection_h
 
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
 namespace traits {
 
   // trait for a generic SoA-based product
-  template <typename T, typename TDev>
+  template <typename T, typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
   class PortableCollectionTrait;
 
 }  // namespace traits
 
 // type alias for a generic SoA-based product
-template <typename T, typename TDev>
+template <typename T, typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
 using PortableCollection = typename traits::PortableCollectionTrait<T, TDev>::CollectionType;
 
 #endif  // DataFormats_Portable_interface_PortableCollection_h

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -4,9 +4,8 @@
 #include <optional>
 #include <type_traits>
 
-#include <alpaka/alpaka.hpp>
-
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
 // generic SoA-based product in device memory
@@ -19,14 +18,22 @@ public:
   using Layout = T;
   using View = typename Layout::View;
   using ConstView = typename Layout::ConstView;
-  using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
-  using ConstBuffer = alpaka::ViewConst<Buffer>;
+  using Buffer = cms::alpakatools::device_buffer<TDev, std::byte[]>;
+  using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, std::byte[]>;
 
   PortableDeviceCollection() = default;
 
   PortableDeviceCollection(int32_t elements, TDev const &device)
-      : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
-            device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+      : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(device, Layout::computeDataSize(elements))},
+        layout_{buffer_->data(), elements},
+        view_{layout_} {
+    // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  PortableDeviceCollection(int32_t elements, TQueue const &queue)
+      : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(queue, Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -7,9 +7,10 @@
 #include <alpaka/alpaka.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
 // generic SoA-based product in device memory
-template <typename T, typename TDev>
+template <typename T, typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
 class PortableDeviceCollection {
   static_assert(not std::is_same_v<TDev, alpaka_common::DevHost>,
                 "Use PortableHostCollection<T> instead of PortableDeviceCollection<T, DevHost>");

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -3,11 +3,10 @@
 
 #include <optional>
 
-#include <alpaka/alpaka.hpp>
-
 #include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
 // generic SoA-based product in host memory
@@ -17,26 +16,24 @@ public:
   using Layout = T;
   using View = typename Layout::View;
   using ConstView = typename Layout::ConstView;
-  using Buffer = alpaka::Buf<alpaka_common::DevHost, std::byte, alpaka::DimInt<1u>, uint32_t>;
-  using ConstBuffer = alpaka::ViewConst<Buffer>;
+  using Buffer = cms::alpakatools::host_buffer<std::byte[]>;
+  using ConstBuffer = cms::alpakatools::const_host_buffer<std::byte[]>;
 
   PortableHostCollection() = default;
 
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host)
       // allocate pageable host memory
-      : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
-            host, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+      : buffer_{cms::alpakatools::make_host_buffer<std::byte[]>(Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
   }
 
-  template <typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
-  PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host, TDev const &device)
-      // allocate pinned host memory, accessible by the given device
-      : buffer_{alpaka::allocMappedBuf<std::byte, uint32_t>(
-            host, device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  PortableHostCollection(int32_t elements, TQueue const &queue)
+      // allocate pinned host memory associated to the given work queue, accessible by the queue's device
+      : buffer_{cms::alpakatools::make_host_buffer<std::byte[]>(queue, Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -70,8 +70,8 @@ public:
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostCollection *newObj, Layout const &layout) {
     newObj->~PortableHostCollection();
-    // use the global "host" object returned by alpaka_common::host()
-    new (newObj) PortableHostCollection(layout.metadata().size(), alpaka_common::host());
+    // use the global "host" object returned by cms::alpakatools::host()
+    new (newObj) PortableHostCollection(layout.metadata().size(), cms::alpakatools::host());
     newObj->layout_.ROOTReadStreamer(layout);
   }
 

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -8,6 +8,7 @@
 #include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
 // generic SoA-based product in host memory
 template <typename T>
@@ -31,7 +32,7 @@ public:
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
   }
 
-  template <typename TDev>
+  template <typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host, TDev const &device)
       // allocate pinned host memory, accessible by the given device
       : buffer_{alpaka::allocMappedBuf<std::byte, uint32_t>(

--- a/DataFormats/Portable/interface/Product.h
+++ b/DataFormats/Portable/interface/Product.h
@@ -1,0 +1,63 @@
+#ifndef DataFormats_Portable_interface_Product_h
+#define DataFormats_Portable_interface_Product_h
+
+#include <memory>
+#include <utility>
+
+#include "DataFormats/Portable/interface/ProductBase.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace edm {
+  template <typename T>
+  class Wrapper;
+}
+
+namespace cms::alpakatools {
+
+  /**
+     * The purpose of this class is to wrap alpaka-based data products for
+     * the edm::Event in a way which forces correct use of various utilities.
+     *
+     * The default constructor is needed only for the ROOT dictionary generation.
+     *
+     * The non-default construction has to be done with ScopedContext
+     * (in order to properly register the alpaka event).
+     *
+     * The alpaka event is in practice needed only for inter-queue
+     * synchronization, but someone with long-enough lifetime has to own
+     * it. Here is a somewhat natural place. If the overhead is too much, we
+     * can use them only where synchronization between queues is needed.
+     */
+  template <typename TQueue, typename T, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class Product : public ProductBase<TQueue> {
+  public:
+    using Queue = TQueue;
+    using Event = alpaka::Event<Queue>;
+
+    Product() = default;  // Needed only for ROOT dictionary generation
+
+    Product(const Product&) = delete;
+    Product& operator=(const Product&) = delete;
+    Product(Product&&) = default;
+    Product& operator=(Product&&) = default;
+
+  private:
+    friend class impl::ScopedContextGetterBase<Queue>;
+    friend class ScopedContextProduce<Queue>;
+    friend class edm::Wrapper<Product<Queue, T>>;
+
+    explicit Product(std::shared_ptr<Queue> queue, std::shared_ptr<Event> event, T data)
+        : ProductBase<Queue>(std::move(queue), std::move(event)), data_(std::move(data)) {}
+
+    template <typename... Args>
+    explicit Product(std::shared_ptr<Queue> queue, std::shared_ptr<Event> event, Args&&... args)
+        : ProductBase<Queue>(std::move(queue), std::move(event)), data_(std::forward<Args>(args)...) {}
+
+    T data_;  //!
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // DataFormats_Portable_interface_Product_h

--- a/DataFormats/Portable/interface/ProductBase.h
+++ b/DataFormats/Portable/interface/ProductBase.h
@@ -1,0 +1,102 @@
+#ifndef DataFormats_Portable_interface_ProductBase_h
+#define DataFormats_Portable_interface_ProductBase_h
+
+#include <atomic>
+#include <memory>
+#include <utility>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  /**
+   * Base class for all instantiations of Product<TQueue, T> to hold the
+   * non-T-dependent members.
+   */
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ProductBase {
+  public:
+    using Queue = TQueue;
+    using Event = alpaka::Event<Queue>;
+    using Device = alpaka::Dev<Queue>;
+
+    ProductBase() = default;  // Needed only for ROOT dictionary generation
+
+    ~ProductBase() {
+      // Make sure that the production of the product in the GPU is
+      // complete before destructing the product. This is to make sure
+      // that the EDM stream does not move to the next event before all
+      // asynchronous processing of the current is complete.
+
+      // TODO: a callback notifying a WaitingTaskHolder (or similar)
+      // would avoid blocking the CPU, but would also require more work.
+
+      // FIXME: this may throw an execption if the underlaying call fails.
+      if (event_) {
+        alpaka::wait(*event_);
+      }
+    }
+
+    ProductBase(const ProductBase&) = delete;
+    ProductBase& operator=(const ProductBase&) = delete;
+    ProductBase(ProductBase&& other)
+        : queue_{std::move(other.queue_)}, event_{std::move(other.event_)}, mayReuseQueue_{other.mayReuseQueue_.load()} {}
+    ProductBase& operator=(ProductBase&& other) {
+      queue_ = std::move(other.queue_);
+      event_ = std::move(other.event_);
+      mayReuseQueue_ = other.mayReuseQueue_.load();
+      return *this;
+    }
+
+    bool isValid() const { return queue_.get() != nullptr; }
+
+    bool isAvailable() const {
+      // if default-constructed, the product is not available
+      if (not event_) {
+        return false;
+      }
+      return alpaka::isComplete(*event_);
+    }
+
+    // returning a const& requires changes in alpaka's getDev() implementations
+    Device device() const { return alpaka::getDev(queue()); }
+
+    Queue const& queue() const { return *queue_; }
+
+    Event const& event() const { return *event_; }
+
+  protected:
+    explicit ProductBase(std::shared_ptr<Queue> queue, std::shared_ptr<Event> event)
+        : queue_{std::move(queue)}, event_{std::move(event)} {}
+
+  private:
+    friend class impl::ScopedContextBase<Queue>;
+    friend class ScopedContextProduce<Queue>;
+
+    // The following function is intended to be used only from ScopedContext
+    const std::shared_ptr<Queue>& queuePtr() const { return queue_; }
+
+    bool mayReuseQueue() const {
+      bool expected = true;
+      bool changed = mayReuseQueue_.compare_exchange_strong(expected, false);
+      // If the current thread is the one flipping the flag, it may
+      // reuse the queue.
+      return changed;
+    }
+
+    // shared_ptr because of caching in QueueCache, and sharing across edm::Event products
+    std::shared_ptr<Queue> queue_;  //!
+    // shared_ptr because of caching in EventCache
+    std::shared_ptr<Event> event_;  //!
+
+    // This flag tells whether the queue may be reused by a consumer or not.
+    // The goal is to have a "chain" of modules to enqueue their work to the same queue.
+    mutable std::atomic<bool> mayReuseQueue_ = true;  //!
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // DataFormats_Portable_interface_ProductBase_h

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
@@ -1,3 +1,4 @@
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
@@ -1,4 +1,7 @@
 <lcgdict>
   <class name="alpaka_cuda_async::portabletest::TestDeviceCollection" persistent="false"/>
   <class name="edm::Wrapper<alpaka_cuda_async::portabletest::TestDeviceCollection>" persistent="false"/>
+
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::Queue, alpaka_cuda_async::portabletest::TestDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::Queue, alpaka_cuda_async::portabletest::TestDeviceCollection>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial.h
@@ -1,3 +1,4 @@
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
@@ -11,6 +11,8 @@
     portabletest::TestHostCollection::ROOTReadStreamer(newObj, onfile.layout_);
   ]]>
   </read>
-
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
+
+  <class name="cms::alpakatools::Product<alpaka_serial_sync::Queue, portabletest::TestHostCollection>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_serial_sync::Queue, portabletest::TestHostCollection>>" persistent="false"/>
 </lcgdict>

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -92,6 +92,23 @@ namespace edm {
     static std::regex const reToRefsAssoc(
         "edm::RefVector< *Association(.*) *, *edm::helper(.*), *Association(.*)::Find>");
 
+    // type aliases for Alpaka internals
+    static std::regex const reAlpakaDevCpu("alpaka::DevCpu");                                     // alpakaDevCpu
+    static std::regex const reAlpakaDevCudaRt("alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>");  // alpakaDevCudaRt
+    static std::regex const reAlpakaDevHipRt("alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>");    // alpakaDevHipRt
+    static std::regex const reAlpakaQueueCpuBlocking(
+        "alpaka::QueueGenericThreadsBlocking<alpaka::DevCpu>");  // alpakaQueueCpuBlocking
+    static std::regex const reAlpakaQueueCpuNonBlocking(
+        "alpaka::QueueGenericThreadsNonBlocking<alpaka::DevCpu>");  // alpakaQueueCpuNonBlocking
+    static std::regex const reAlpakaQueueCudaRtBlocking(
+        "alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt,true>");  // alpakaQueueCudaRtBlocking
+    static std::regex const reAlpakaQueueCudaRtNonBlocking(
+        "alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt,false>");  // alpakaQueueCudaRtNonBlocking
+    static std::regex const reAlpakaQueueHipRtBlocking(
+        "alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiHipRt,true>");  // alpakaQueueHipRtBlocking
+    static std::regex const reAlpakaQueueHipRtNonBlocking(
+        "alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiHipRt,false>");  // alpakaQueueHipRtNonBlocking
+
     std::string standardRenames(std::string const& iIn) {
       using std::regex;
       using std::regex_replace;
@@ -121,7 +138,22 @@ namespace edm {
       name = regex_replace(name, reToRefs1, "Refs<$1<$2>>");
       name = regex_replace(name, reToRefs2, "Refs<$1,$2>");
       name = regex_replace(name, reToRefsAssoc, "Refs<Association$1>");
-      //std::cout <<"standardRenames '"<<name<<"'"<<std::endl;
+
+      // Alpaka types
+      name = regex_replace(name, reAlpakaQueueCpuBlocking, "alpakaQueueCpuBlocking");
+      name = regex_replace(name, reAlpakaQueueCpuNonBlocking, "alpakaQueueCpuNonBlocking");
+      name = regex_replace(name, reAlpakaQueueCudaRtBlocking, "alpakaQueueCudaRtBlocking");
+      name = regex_replace(name, reAlpakaQueueCudaRtNonBlocking, "alpakaQueueCudaRtNonBlocking");
+      name = regex_replace(name, reAlpakaQueueHipRtBlocking, "alpakaQueueHipRtBlocking");
+      name = regex_replace(name, reAlpakaQueueHipRtNonBlocking, "alpakaQueueHipRtNonBlocking");
+      // devices should be last, as they can appear as template arguments in other types
+      name = regex_replace(name, reAlpakaDevCpu, "alpakaDevCpu");
+      name = regex_replace(name, reAlpakaDevCudaRt, "alpakaDevCudaRt");
+      name = regex_replace(name, reAlpakaDevHipRt, "alpakaDevHipRt");
+
+      if constexpr (debug) {
+        std::cout << prefix << "standardRenames iIn " << iIn << " result " << name << std::endl;
+      }
       return name;
     }
 

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -223,6 +223,21 @@ void testfriendlyName::test() {
   classToFriendly.insert(Values("foo<int[]>", "intAsfoo"));
   classToFriendly.insert(Values("bar<foo<int[]>>", "intAsfoobar"));
 
+  // Alpaka types
+  classToFriendly.insert(Values("alpaka::DevCpu", "alpakaDevCpu"));
+  classToFriendly.insert(Values("alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>", "alpakaDevCudaRt"));
+  classToFriendly.insert(Values("alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>", "alpakaDevHipRt"));
+  classToFriendly.insert(Values("alpaka::QueueGenericThreadsBlocking<alpaka::DevCpu>", "alpakaQueueCpuBlocking"));
+  classToFriendly.insert(Values("alpaka::QueueGenericThreadsNonBlocking<alpaka::DevCpu>", "alpakaQueueCpuNonBlocking"));
+  classToFriendly.insert(Values("alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt,true>",
+                                "alpakaQueueCudaRtBlocking"));
+  classToFriendly.insert(Values("alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt,false>",
+                                "alpakaQueueCudaRtNonBlocking"));
+  classToFriendly.insert(Values("alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiHipRt,true>",
+                                "alpakaQueueHipRtBlocking"));
+  classToFriendly.insert(Values("alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiHipRt,false>",
+                                "alpakaQueueHipRtNonBlocking"));
+
   for (std::map<std::string, std::string>::iterator itInfo = classToFriendly.begin(), itInfoEnd = classToFriendly.end();
        itInfo != itInfoEnd;
        ++itInfo) {

--- a/HeterogeneousCore/AlpakaCore/interface/ContextState.h
+++ b/HeterogeneousCore/AlpakaCore/interface/ContextState.h
@@ -1,0 +1,86 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_ContextState_h
+#define HeterogeneousCore_AlpakaCore_interface_ContextState_h
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  /**
+   * The purpose of this class is to deliver the device and queue
+   * information from ExternalWork's acquire() to producer() via a
+   * member/QueueCache variable.
+   */
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ContextState {
+  public:
+    using Queue = TQueue;
+    using Device = alpaka::Dev<Queue>;
+
+    ContextState() = default;
+    ~ContextState() = default;
+
+    ContextState(const ContextState&) = delete;
+    ContextState& operator=(const ContextState&) = delete;
+    ContextState(ContextState&&) = delete;
+    ContextState& operator=(ContextState&& other) = delete;
+
+  private:
+    friend class ScopedContextAcquire<TQueue>;
+    friend class ScopedContextProduce<TQueue>;
+    friend class ScopedContextTask<TQueue>;
+
+    void set(std::shared_ptr<Queue> queue) {
+      throwIfQueue();
+      queue_ = std::move(queue);
+    }
+
+    Device device() const {
+      throwIfNoQueue();
+      return alpaka::getDev(*queue_);
+    }
+
+    Queue queue() const {
+      throwIfNoQueue();
+      return *queue_;
+    }
+
+    std::shared_ptr<Queue> const& queuePtr() const {
+      throwIfNoQueue();
+      return queue_;
+    }
+
+    std::shared_ptr<Queue> releaseQueuePtr() {
+      throwIfNoQueue();
+      // This function needs to effectively reset queue_ (i.e. queue_
+      // must be empty after this function). This behavior ensures that
+      // the std::shared_ptr<Queue> is not hold for inadvertedly long (i.e. to
+      // the next event), and is checked at run time.
+      Queue queue = std::move(queue_);
+      return queue;
+    }
+
+    void throwIfQueue() const {
+      if (queue_) {
+        throw cms::Exception("LogicError") << "Trying to set ContextState, but it already had a valid state";
+      }
+    }
+
+    void throwIfNoQueue() const {
+      if (not queue_) {
+        throw cms::Exception("LogicError") << "Trying to get ContextState, but it did not have a valid state";
+      }
+    }
+
+    std::shared_ptr<Queue> queue_;
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_ContextState_h

--- a/HeterogeneousCore/AlpakaCore/interface/EventCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/EventCache.h
@@ -8,6 +8,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h"
 
@@ -89,7 +90,7 @@ namespace cms::alpakatools {
   template <typename Event>
   EventCache<Event>& getEventCache() {
     // the public interface is thread safe
-    static EventCache<Event> cache;
+    CMS_THREAD_SAFE static EventCache<Event> cache;
     return cache;
   }
 

--- a/HeterogeneousCore/AlpakaCore/interface/EventCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/EventCache.h
@@ -1,0 +1,84 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_EventCache_h
+#define HeterogeneousCore_AlpakaCore_interface_EventCache_h
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace cms::alpakatools {
+
+  template <typename Event>
+  class EventCache {
+  public:
+    using Device = alpaka::Dev<Event>;
+    using Platform = alpaka::Pltf<Device>;
+
+    // EventCache should be constructed by the first call to
+    // getEventCache() only if we have any devices present
+    EventCache() : cache_(alpaka::getDevCount<Platform>()) {}
+
+    // Gets a (cached) event for the current device. The event
+    // will be returned to the cache by the shared_ptr destructor. The
+    // returned event is guaranteed to be in the state where all
+    // captured work has completed.
+    //
+    // This function is thread safe
+    std::shared_ptr<Event> get(Device dev) {
+      auto event = makeOrGet(dev);
+      // captured work has completed, or a just-created event
+      if (alpaka::isComplete(*event)) {
+        return event;
+      }
+
+      // Got an event with incomplete captured work. Try again until we
+      // get a completed (or a just-created) event. Need to keep all
+      // incomplete events until a completed event is found in order to
+      // avoid ping-pong with an incomplete event.
+      std::vector<std::shared_ptr<Event>> ptrs{std::move(event)};
+      bool completed;
+      do {
+        event = makeOrGet(dev);
+        completed = alpaka::isComplete(*event);
+        if (not completed) {
+          ptrs.emplace_back(std::move(event));
+        }
+      } while (not completed);
+      return event;
+    }
+
+  private:
+    std::shared_ptr<Event> makeOrGet(Device dev) {
+      return cache_[alpaka::getNativeHandle(dev)].makeOrGet([dev]() { return std::make_unique<Event>(dev); });
+    }
+
+    // FIXME: not thread safe, intended to be called only from CUDAService destructor ?
+    void clear() {
+      // Reset the contents of the caches, but leave an
+      // edm::ReusableObjectHolder alive for each device. This is needed
+      // mostly for the unit tests, where the function-static
+      // EventCache lives through multiple tests (and go through
+      // multiple shutdowns of the framework).
+      cache_.clear();
+      cache_.resize(alpaka::getDevCount<Platform>());
+    }
+
+    std::vector<edm::ReusableObjectHolder<Event>> cache_;
+  };
+
+  // Gets the global instance of a EventCache
+  // This function is thread safe
+  template <typename Event>
+  EventCache<Event>& getEventCache() {
+    // the public interface is thread safe
+    static EventCache<Event> cache;
+    return cache;
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_EventCache_h

--- a/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
@@ -8,11 +8,25 @@
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h"
 
 namespace cms::alpakatools {
 
   template <typename Queue>
   class QueueCache {
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    friend class alpaka_cuda_async::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+    friend class alpaka_hip_async::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    friend class alpaka_serial_sync::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    friend class alpaka_tbb_async::AlpakaService;
+#endif
+
     using Device = alpaka::Dev<Queue>;
     using Platform = alpaka::Pltf<Device>;
 
@@ -29,7 +43,7 @@ namespace cms::alpakatools {
     }
 
   private:
-    // FIXME: not thread safe, intended to be called only from CUDAService destructor ?
+    // not thread safe, intended to be called only from AlpakaService
     void clear() {
       // Reset the contents of the caches, but leave an
       // edm::ReusableObjectHolder alive for each device. This is needed

--- a/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
@@ -7,6 +7,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h"
 
@@ -62,7 +63,7 @@ namespace cms::alpakatools {
   template <typename Queue>
   QueueCache<Queue>& getQueueCache() {
     // the public interface is thread safe
-    static QueueCache<Queue> cache;
+    CMS_THREAD_SAFE static QueueCache<Queue> cache;
     return cache;
   }
 

--- a/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
@@ -1,0 +1,57 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_QueueCache_h
+#define HeterogeneousCore_AlpakaCore_interface_QueueCache_h
+
+#include <memory>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace cms::alpakatools {
+
+  template <typename Queue>
+  class QueueCache {
+    using Device = alpaka::Dev<Queue>;
+    using Platform = alpaka::Pltf<Device>;
+
+  public:
+    // QueueCache should be constructed by the first call to
+    // getQueueCache() only if we have any devices present
+    QueueCache() : cache_(alpaka::getDevCount<Platform>()) {}
+
+    // Gets a (cached) queue for the current device. The queue
+    // will be returned to the cache by the shared_ptr destructor.
+    // This function is thread safe
+    std::shared_ptr<Queue> get(Device const& dev) {
+      return cache_[alpaka::getNativeHandle(dev)].makeOrGet([dev]() { return std::make_unique<Queue>(dev); });
+    }
+
+  private:
+    // FIXME: not thread safe, intended to be called only from CUDAService destructor ?
+    void clear() {
+      // Reset the contents of the caches, but leave an
+      // edm::ReusableObjectHolder alive for each device. This is needed
+      // mostly for the unit tests, where the function-static
+      // QueueCache lives through multiple tests (and go through
+      // multiple shutdowns of the framework).
+      cache_.clear();
+      cache_.resize(alpaka::getDevCount<Platform>());
+    }
+
+    std::vector<edm::ReusableObjectHolder<Queue>> cache_;
+  };
+
+  // Gets the global instance of a QueueCache
+  // This function is thread safe
+  template <typename Queue>
+  QueueCache<Queue>& getQueueCache() {
+    // the public interface is thread safe
+    static QueueCache<Queue> cache;
+    return cache;
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_QueueCache_h

--- a/HeterogeneousCore/AlpakaCore/interface/ScopedContext.h
+++ b/HeterogeneousCore/AlpakaCore/interface/ScopedContext.h
@@ -1,0 +1,300 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_ScopedContext_h
+#define HeterogeneousCore_AlpakaCore_interface_ScopedContext_h
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+#include "DataFormats/Portable/interface/Product.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/ContextState.h"
+#include "HeterogeneousCore/AlpakaCore/interface/EventCache.h"
+#include "HeterogeneousCore/AlpakaCore/interface/QueueCache.h"
+#include "HeterogeneousCore/AlpakaCore/interface/chooseDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/HostOnlyTask.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatest {
+  class TestScopedContext;
+}
+
+namespace cms::alpakatools {
+
+  namespace impl {
+    // This class is intended to be derived by other ScopedContext*, not for general use
+    template <typename TQueue, typename>
+    class ScopedContextBase {
+    public:
+      using Queue = TQueue;
+      using Device = alpaka::Dev<Queue>;
+      using Platform = alpaka::Pltf<Device>;
+
+      Device device() const { return alpaka::getDev(*queue_); }
+
+      Queue& queue() { return *queue_; }
+      const std::shared_ptr<Queue>& queuePtr() const { return queue_; }
+
+    protected:
+      ScopedContextBase(ProductBase<Queue> const& data)
+          : queue_{data.mayReuseQueue() ? data.queuePtr() : getQueueCache<Queue>().get(data.device())} {}
+
+      explicit ScopedContextBase(std::shared_ptr<Queue> queue) : queue_(std::move(queue)) {}
+
+      explicit ScopedContextBase(edm::StreamID streamID)
+          : queue_{getQueueCache<Queue>().get(cms::alpakatools::chooseDevice<Platform>(streamID))} {}
+
+    private:
+      std::shared_ptr<Queue> queue_;
+    };
+
+    template <typename TQueue, typename>
+    class ScopedContextGetterBase : public ScopedContextBase<TQueue> {
+    public:
+      using Queue = TQueue;
+
+      template <typename T>
+      const T& get(Product<Queue, T> const& data) {
+        synchronizeStreams(data);
+        return data.data_;
+      }
+
+      template <typename T>
+      const T& get(edm::Event const& event, edm::EDGetTokenT<Product<Queue, T>> token) {
+        return get(event.get(token));
+      }
+
+    protected:
+      template <typename... Args>
+      ScopedContextGetterBase(Args&&... args) : ScopedContextBase<Queue>{std::forward<Args>(args)...} {}
+
+      void synchronizeStreams(ProductBase<Queue> const& data) {
+        // If the product has been enqueued to a different queue, make sure that it is available before accessing it
+        if (data.queue() != this->queue()) {
+          // Different queues, check if the underlying device is the same
+          if (data.device() != this->device()) {
+            // Eventually replace with prefetch to current device (assuming unified memory works)
+            // If we won't go to unified memory, need to figure out something else...
+            throw cms::Exception("LogicError") << "Handling data from multiple devices is not yet supported";
+          }
+          // If the data product is not yet available, synchronize the two queues
+          if (not data.isAvailable()) {
+            // Event not yet occurred, so need to add synchronization
+            // here. Sychronization is done by making the current queue
+            // wait for an event, so all subsequent work in the queue
+            // will run only after the event has "occurred" (i.e. data
+            // product became available).
+            alpaka::wait(this->queue(), data.event());
+          }
+        }
+      }
+    };
+
+    class ScopedContextHolderHelper {
+    public:
+      ScopedContextHolderHelper(edm::WaitingTaskWithArenaHolder waitingTaskHolder)
+          : waitingTaskHolder_{std::move(waitingTaskHolder)} {}
+
+      template <typename F, typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+      void pushNextTask(F&& f, ContextState<TQueue> const* state) {
+        replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder{edm::make_waiting_task_with_holder(
+            std::move(waitingTaskHolder_), [state, func = std::forward<F>(f)](edm::WaitingTaskWithArenaHolder h) {
+              func(ScopedContextTask{state, std::move(h)});
+            })});
+      }
+
+      void replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
+        waitingTaskHolder_ = std::move(waitingTaskHolder);
+      }
+
+      template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+      void enqueueCallback(TQueue& queue) {
+        alpaka::enqueue(queue, alpaka::HostOnlyTask([holder = std::move(waitingTaskHolder_)]() {
+                          // The functor is required to be const, but the original waitingTaskHolder_
+                          // needs to be notified...
+                          const_cast<edm::WaitingTaskWithArenaHolder&>(holder).doneWaiting(nullptr);
+                        }));
+      }
+
+    private:
+      edm::WaitingTaskWithArenaHolder waitingTaskHolder_;
+    };
+  }  // namespace impl
+
+  /**
+   * The aim of this class is to do necessary per-event "initialization" in ExternalWork acquire():
+   * - setting the current device
+   * - calling edm::WaitingTaskWithArenaHolder::doneWaiting() when necessary
+   * - synchronizing between queues if necessary
+   * and enforce that those get done in a proper way in RAII fashion.
+   */
+  template <typename TQueue, typename>
+  class ScopedContextAcquire : public impl::ScopedContextGetterBase<TQueue> {
+  public:
+    using Queue = TQueue;
+    using ScopedContextGetterBase = impl::ScopedContextGetterBase<Queue>;
+    using ScopedContextGetterBase::queue;
+    using ScopedContextGetterBase::queuePtr;
+
+    /// Constructor to create a new queue (no need for context beyond acquire())
+    explicit ScopedContextAcquire(edm::StreamID streamID, edm::WaitingTaskWithArenaHolder waitingTaskHolder)
+        : ScopedContextGetterBase(streamID), holderHelper_{std::move(waitingTaskHolder)} {}
+
+    /// Constructor to create a new queue, and the context is needed after acquire()
+    explicit ScopedContextAcquire(edm::StreamID streamID,
+                                  edm::WaitingTaskWithArenaHolder waitingTaskHolder,
+                                  ContextState<Queue>& state)
+        : ScopedContextGetterBase(streamID), holderHelper_{std::move(waitingTaskHolder)}, contextState_{&state} {}
+
+    /// Constructor to (possibly) re-use a queue (no need for context beyond acquire())
+    explicit ScopedContextAcquire(ProductBase<Queue> const& data, edm::WaitingTaskWithArenaHolder waitingTaskHolder)
+        : ScopedContextGetterBase(data), holderHelper_{std::move(waitingTaskHolder)} {}
+
+    /// Constructor to (possibly) re-use a queue, and the context is needed after acquire()
+    explicit ScopedContextAcquire(ProductBase<Queue> const& data,
+                                  edm::WaitingTaskWithArenaHolder waitingTaskHolder,
+                                  ContextState<Queue>& state)
+        : ScopedContextGetterBase(data), holderHelper_{std::move(waitingTaskHolder)}, contextState_{&state} {}
+
+    ~ScopedContextAcquire() {
+      holderHelper_.enqueueCallback(queue());
+      if (contextState_) {
+        contextState_->set(queuePtr());
+      }
+    }
+
+    template <typename F>
+    void pushNextTask(F&& f) {
+      if (contextState_ == nullptr)
+        throwNoState();
+      holderHelper_.pushNextTask(std::forward<F>(f), contextState_);
+    }
+
+    void replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
+      holderHelper_.replaceWaitingTaskHolder(std::move(waitingTaskHolder));
+    }
+
+  private:
+    void throwNoState() {
+      throw cms::Exception("LogicError")
+          << "Calling ScopedContextAcquire::insertNextTask() requires ScopedContextAcquire to be constructed with "
+             "ContextState, but that was not the case";
+    }
+
+    impl::ScopedContextHolderHelper holderHelper_;
+    ContextState<Queue>* contextState_ = nullptr;
+  };
+
+  /**
+   * The aim of this class is to do necessary per-event "initialization" in ExternalWork produce() or normal produce():
+   * - setting the current device
+   * - synchronizing between queues if necessary
+   * and enforce that those get done in a proper way in RAII fashion.
+   */
+  template <typename TQueue, typename>
+  class ScopedContextProduce : public impl::ScopedContextGetterBase<TQueue> {
+  public:
+    using Queue = TQueue;
+    using Event = alpaka::Event<Queue>;
+    using ScopedContextGetterBase = impl::ScopedContextGetterBase<Queue>;
+    using ScopedContextGetterBase::device;
+    using ScopedContextGetterBase::queue;
+    using ScopedContextGetterBase::queuePtr;
+
+    /// Constructor to re-use the queue of acquire() (ExternalWork module)
+    explicit ScopedContextProduce(ContextState<Queue>& state)
+        : ScopedContextGetterBase(state.releaseQueuePtr()), event_{getEventCache<Event>().get(device())} {}
+
+    explicit ScopedContextProduce(ProductBase<Queue> const& data)
+        : ScopedContextGetterBase(data), event_{getEventCache<Event>().get(device())} {}
+
+    explicit ScopedContextProduce(edm::StreamID streamID)
+        : ScopedContextGetterBase(streamID), event_{getEventCache<Event>().get(device())} {}
+
+    /// Record the event, all asynchronous work must have been queued before the destructor
+    ~ScopedContextProduce() {
+      // FIXME: this may throw an execption if the underlaying call fails.
+      alpaka::enqueue(queue(), *event_);
+    }
+
+    template <typename T>
+    std::unique_ptr<Product<Queue, T>> wrap(T data) {
+      // make_unique doesn't work because of private constructor
+      return std::unique_ptr<Product<Queue, T>>(new Product<Queue, T>(queuePtr(), std::move(data)));
+    }
+
+    template <typename T, typename... Args>
+    auto emplace(edm::Event& iEvent, edm::EDPutTokenT<Product<Queue, T>> token, Args&&... args) {
+      return iEvent.emplace(token, queuePtr(), event_, std::forward<Args>(args)...);
+    }
+
+  private:
+    friend class ::cms::alpakatest::TestScopedContext;
+
+    explicit ScopedContextProduce(std::shared_ptr<Queue> queue)
+        : ScopedContextGetterBase(std::move(queue)), event_{getEventCache<Event>().get(device())} {}
+
+    std::shared_ptr<Event> event_;
+  };
+
+  /**
+   * The aim of this class is to do necessary per-task "initialization" tasks created in ExternalWork acquire():
+   * - setting the current device
+   * - calling edm::WaitingTaskWithArenaHolder::doneWaiting() when necessary
+   * and enforce that those get done in a proper way in RAII fashion.
+   */
+  template <typename TQueue, typename>
+  class ScopedContextTask : public impl::ScopedContextBase<TQueue> {
+  public:
+    using Queue = TQueue;
+    using ScopedContextBase = impl::ScopedContextBase<Queue>;
+    using ScopedContextBase::queue;
+    using ScopedContextBase::queuePtr;
+
+    /// Constructor to re-use the queue of acquire() (ExternalWork module)
+    explicit ScopedContextTask(ContextState<Queue> const* state, edm::WaitingTaskWithArenaHolder waitingTaskHolder)
+        : ScopedContextBase(state->queuePtr()),  // don't move, state is re-used afterwards
+          holderHelper_{std::move(waitingTaskHolder)},
+          contextState_{state} {}
+
+    ~ScopedContextTask() { holderHelper_.enqueueCallback(queue()); }
+
+    template <typename F>
+    void pushNextTask(F&& f) {
+      holderHelper_.pushNextTask(std::forward<F>(f), contextState_);
+    }
+
+    void replaceWaitingTaskHolder(edm::WaitingTaskWithArenaHolder waitingTaskHolder) {
+      holderHelper_.replaceWaitingTaskHolder(std::move(waitingTaskHolder));
+    }
+
+  private:
+    impl::ScopedContextHolderHelper holderHelper_;
+    ContextState<Queue> const* contextState_;
+  };
+
+  /**
+   * The aim of this class is to do necessary per-event "initialization" in analyze()
+   * - setting the current device
+   * - synchronizing between queues if necessary
+   * and enforce that those get done in a proper way in RAII fashion.
+   */
+  template <typename TQueue, typename>
+  class ScopedContextAnalyze : public impl::ScopedContextGetterBase<TQueue> {
+  public:
+    using Queue = TQueue;
+    using ScopedContextGetterBase = impl::ScopedContextGetterBase<Queue>;
+    using ScopedContextGetterBase::queue;
+    using ScopedContextGetterBase::queuePtr;
+
+    /// Constructor to (possibly) re-use a queue
+    explicit ScopedContextAnalyze(ProductBase<Queue> const& data) : ScopedContextGetterBase(data) {}
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_ScopedContext_h

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -11,7 +11,7 @@ namespace cms::alpakatools {
   alpaka::Dev<TPlatform> const& chooseDevice(edm::StreamID id) {
     // For startes we "statically" assign the device based on
     // edm::Stream number. This is suboptimal if the number of
-    // edm::Streams is not a multiple of the number of CUDA devices
+    // edm::Streams is not a multiple of the number of devices
     // (and even then there is no load balancing).
 
     // TODO: improve the "assignment" logic

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -1,0 +1,24 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
+#define HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  template <typename TPlatform, typename = std::enable_if_t<is_platform_v<TPlatform>>>
+  alpaka::Dev<TPlatform> const& chooseDevice(edm::StreamID id) {
+    // For startes we "statically" assign the device based on
+    // edm::Stream number. This is suboptimal if the number of
+    // edm::Streams is not a multiple of the number of CUDA devices
+    // (and even then there is no load balancing).
+
+    // TODO: improve the "assignment" logic
+    auto const& devices = cms::alpakatools::devices<TPlatform>();
+    return devices[id % devices.size()];
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_chooseDevice_h

--- a/HeterogeneousCore/AlpakaInterface/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaInterface/BuildFile.xml
@@ -1,2 +1,3 @@
 <use name="alpaka"/>
+<use name="boost_header"/>
 <use name="FWCore/Utilities" source_only="1"/>

--- a/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
@@ -1,0 +1,31 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h
+#define HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h
+
+#include <limits>
+
+namespace cms::alpakatools {
+
+  namespace config {
+
+    // bin growth factor (bin_growth in cub::CachingDeviceAllocator)
+    constexpr unsigned int binGrowth = 2;
+
+    // smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CachingDeviceAllocator
+    constexpr unsigned int minBin = 8;  // 256 bytes
+
+    // largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
+    constexpr unsigned int maxBin = 30;  // 1 GB
+
+    // total storage for the allocator; 0 means no limit.
+    constexpr size_t maxCachedBytes = 0;
+
+    // fraction of total device memory taken for the allocator; 0 means no limit.
+    constexpr double maxCachedFraction = 0.8;
+
+    // if both maxCachedBytes and maxCachedFraction are non-zero, the smallest resulting value is used.
+
+  }  // namespace config
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h

--- a/HeterogeneousCore/AlpakaInterface/interface/AllocatorPolicy.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AllocatorPolicy.h
@@ -1,0 +1,53 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_AllocatorPolicy_h
+#define HeterogeneousCore_AlpakaInterface_interface_AllocatorPolicy_h
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  // Which memory allocator to use
+  //   - Synchronous:   (device and host) cudaMalloc/hipMalloc and cudaMallocHost/hipMallocHost
+  //   - Asynchronous:  (device only)     cudaMallocAsync (requires CUDA >= 11.2)
+  //   - Caching:       (device and host) caching allocator
+  enum class AllocatorPolicy { Synchronous = 0, Asynchronous = 1, Caching = 2 };
+
+  template <typename TDev, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+  constexpr inline AllocatorPolicy allocator_policy = AllocatorPolicy::Synchronous;
+
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+  template <>
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCpu> =
+#if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+      AllocatorPolicy::Caching;
+#else
+      AllocatorPolicy::Synchronous;
+#endif
+#endif  // defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+
+#if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+  template <>
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevCudaRt> =
+#if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+      AllocatorPolicy::Caching;
+#elif CUDA_VERSION >= 11020 && !defined ALPAKA_DISABLE_ASYNC_ALLOCATOR
+      AllocatorPolicy::Asynchronous;
+#else
+          AllocatorPolicy::Synchronous;
+#endif
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#if defined ALPAKA_ACC_GPU_HIP_ENABLED
+  template <>
+  constexpr inline AllocatorPolicy allocator_policy<alpaka::DevHipRt> =
+#if !defined ALPAKA_DISABLE_CACHING_ALLOCATOR
+      AllocatorPolicy::Caching;
+#else
+      AllocatorPolicy::Synchronous;
+#endif
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_AllocatorPolicy_h

--- a/HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h
@@ -1,0 +1,33 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_AlpakaServiceFwd_h
+#define HeterogeneousCore_AlpakaInterface_interface_AlpakaServiceFwd_h
+
+// Forward declaration of the alpaka accelerator namespaces and of the AlpakaService for each of them.
+//
+// This file is under HeterogeneousCore/AlpakaInterface to avoid introducing a dependency on
+// HeterogeneousCore/AlpakaServices and HeterogeneousCore/AlpakaCore.
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+namespace alpaka_cuda_async {
+  class AlpakaService;
+}  // namespace alpaka_cuda_async
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+namespace alpaka_hip_async {
+  class AlpakaService;
+}  // namespace alpaka_hip_async
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+namespace alpaka_serial_sync {
+  class AlpakaService;
+}  // namespace alpaka_serial_sync
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+namespace alpaka_tbb_async {
+  class AlpakaService;
+}  // namespace alpaka_tbb_async
+#endif  // ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_AlpakaServiceFwd_h

--- a/HeterogeneousCore/AlpakaInterface/interface/CachedBufAlloc.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachedBufAlloc.h
@@ -1,0 +1,207 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_CachedBufAlloc_h
+#define HeterogeneousCore_AlpakaInterface_interface_CachedBufAlloc_h
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  namespace traits {
+
+    //! The caching memory allocator trait.
+    template <typename TElem,
+              typename TDim,
+              typename TIdx,
+              typename TDev,
+              typename TQueue,
+              typename = void,
+              typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
+    struct CachedBufAlloc {
+      static_assert(alpaka::meta::DependentFalseType<TDev>::value, "This device does not support a caching allocator");
+    };
+
+    //! The caching memory allocator implementation for the CPU device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        // non-cached, queue-ordered asynchronous host-only memory
+        return alpaka::allocAsyncBuf<TElem, TIdx>(queue, extent);
+      }
+    };
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+
+    //! The caching memory allocator implementation for the pinned host memory, with a blocking queue
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueCudaRtBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueCudaRtBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueCudaRtBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the pinned host memory, with a non-blocking queue
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueCudaRtNonBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueCudaRtNonBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueCudaRtNonBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the CUDA device
+    template <typename TElem, typename TDim, typename TIdx, typename TQueue>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCudaRt, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCudaRt const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufCudaRt<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevCudaRt, TQueue>(dev);
+
+        size_t width = alpaka::getWidth(extent);
+        size_t widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+        // TODO implement pitch for TDim > 1
+        size_t pitchBytes = widthBytes;
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCudaRt<TElem, TDim, TIdx>(
+            dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), pitchBytes, extent);
+      }
+    };
+
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+
+    //! The caching memory allocator implementation for the pinned host memory, with a blocking queue
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueHipRtBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueHipRtBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueHipRtBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the pinned host memory, with a non-blocking queue
+    template <typename TElem, typename TDim, typename TIdx>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevCpu, alpaka::QueueHipRtNonBlocking, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevCpu const& dev,
+                                                alpaka::QueueHipRtNonBlocking queue,
+                                                TExtent const& extent) -> alpaka::BufCpu<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getHostCachingAllocator<alpaka::QueueHipRtNonBlocking>();
+
+        // FIXME the BufCpu does not support a pitch ?
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufCpu<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), extent);
+      }
+    };
+
+    //! The caching memory allocator implementation for the ROCm/HIP device
+    template <typename TElem,
+              typename TDim,
+              typename TIdx,
+              typename TQueue,
+              typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+    struct CachedBufAlloc<TElem, TDim, TIdx, alpaka::DevHipRt, TQueue, void> {
+      template <typename TExtent>
+      ALPAKA_FN_HOST static auto allocCachedBuf(alpaka::DevHipRt const& dev, TQueue queue, TExtent const& extent)
+          -> alpaka::BufHipRt<TElem, TDim, TIdx> {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        auto& allocator = getDeviceCachingAllocator<alpaka::DevHipRt, TQueue>(dev);
+
+        size_t width = alpaka::getWidth(extent);
+        size_t widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+        // TODO implement pitch for TDim > 1
+        size_t pitchBytes = widthBytes;
+        size_t size = alpaka::getExtentProduct(extent);
+        size_t sizeBytes = size * sizeof(TElem);
+        void* memPtr = allocator.allocate(sizeBytes, queue);
+
+        // use a custom deleter to return the buffer to the CachingAllocator
+        auto deleter = [alloc = &allocator](TElem* ptr) { alloc->free(ptr); };
+
+        return alpaka::BufHipRt<TElem, TDim, TIdx>(
+            dev, reinterpret_cast<TElem*>(memPtr), std::move(deleter), pitchBytes, extent);
+      }
+    };
+
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+
+  }  // namespace traits
+
+  template <typename TElem,
+            typename TIdx,
+            typename TExtent,
+            typename TQueue,
+            typename TDev,
+            typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
+  ALPAKA_FN_HOST auto allocCachedBuf(TDev const& dev, TQueue queue, TExtent const& extent = TExtent()) {
+    return traits::CachedBufAlloc<TElem, alpaka::Dim<TExtent>, TIdx, TDev, TQueue>::allocCachedBuf(dev, queue, extent);
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_CachedBufAlloc_h

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -1,0 +1,421 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_CachingAllocator_h
+#define HeterogeneousCore_AlpakaInterface_interface_CachingAllocator_h
+
+#include <cassert>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+// Inspired by cub::CachingDeviceAllocator
+
+namespace cms::alpakatools {
+
+  namespace detail {
+
+    inline constexpr unsigned int power(unsigned int base, unsigned int exponent) {
+      unsigned int power = 1;
+      while (exponent > 0) {
+        if (exponent & 1) {
+          power = power * base;
+        }
+        base = base * base;
+        exponent = exponent >> 1;
+      }
+      return power;
+    }
+
+    // format a memory size in B/kB/MB/GB
+    inline std::string as_bytes(size_t value) {
+      if (value == std::numeric_limits<size_t>::max()) {
+        return "unlimited";
+      } else if (value >= (1 << 30) and value % (1 << 30) == 0) {
+        return std::to_string(value >> 30) + " GB";
+      } else if (value >= (1 << 20) and value % (1 << 20) == 0) {
+        return std::to_string(value >> 20) + " MB";
+      } else if (value >= (1 << 10) and value % (1 << 10) == 0) {
+        return std::to_string(value >> 10) + " kB";
+      } else {
+        return std::to_string(value) + "  B";
+      }
+    }
+
+  }  // namespace detail
+
+  /*
+   * The "memory device" identifies the memory space, i.e. the device where the memory is allocated.
+   * A caching allocator object is associated to a single memory `Device`, set at construction time, and unchanged for
+   * the lifetime of the allocator.
+   *
+   * Each allocation is associated to an event on a queue, that identifies the "synchronisation device" according to
+   * which the synchronisation occurs.
+   * The `Event` type depends only on the synchronisation `Device` type.
+   * The `Queue` type depends on the synchronisation `Device` type and the queue properties, either `Sync` or `Async`.
+   *
+   * **Note**: how to handle different queue and event types in a single allocator ?  store and access type-punned
+   * queues and events ?  or template the internal structures on them, but with a common base class ?
+   * alpaka does rely on the compile-time type for dispatch.
+   *
+   * Common use case #1: accelerator's memory allocations
+   *   - the "memory device" is the accelerator device (e.g. a GPU);
+   *   - the "synchronisation device" is the same accelerator device;
+   *   - the `Queue` type is usually always the same (either `Sync` or `Async`).
+   *
+   * Common use case #2: pinned host memory allocations
+   *    - the "memory device" is the host device (e.g. system memory);
+   *    - the "synchronisation device" is the accelerator device (e.g. a GPU) whose work queue will access the host;
+   *      memory (direct memory access from the accelerator, or scheduling `alpaka::memcpy`/`alpaka::memset`), and can
+   *      be different for each allocation;
+   *    - the synchronisation `Device` _type_ could potentially be different, but memory pinning is currently tied to
+   *      the accelerator's platform (CUDA, HIP, etc.), so the device type needs to be fixed to benefit from caching;
+   *    - the `Queue` type can be either `Sync` _or_ `Async` on any allocation.
+   */
+
+  template <typename TDev,
+            typename TQueue,
+            typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
+  class CachingAllocator {
+  public:
+    using Device = TDev;                 // the "memory device", where the memory will be allocated
+    using Queue = TQueue;                // the queue used to submit the memory operations
+    using Event = alpaka::Event<Queue>;  // the events used to synchronise the operations
+    using Buffer = alpaka::Buf<Device, std::byte, alpaka::DimInt<1u>, size_t>;
+
+    // The "memory device" type can either be the same as the "synchronisation device" type, or be the host CPU.
+    static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,
+                  "The \"memory device\" type can either be the same as the \"synchronisation device\" type, or be the "
+                  "host CPU.");
+
+    struct CachedBytes {
+      size_t free = 0;       // total bytes freed and cached on this device
+      size_t live = 0;       // total bytes currently in use oin this device
+      size_t requested = 0;  // total bytes requested and currently in use on this device
+    };
+
+    explicit CachingAllocator(
+        Device const& device,
+        unsigned int binGrowth,          // bin growth factor;
+        unsigned int minBin,             // smallest bin, corresponds to binGrowth^minBin bytes;
+                                         // smaller allocations are rounded to this value;
+        unsigned int maxBin,             // largest bin, corresponds to binGrowth^maxBin bytes;
+                                         // larger allocations will fail;
+        size_t maxCachedBytes,           // total storage for the allocator (0 means no limit);
+        double maxCachedFraction,        // fraction of total device memory taken for the allocator (0 means no limit);
+                                         // if both maxCachedBytes and maxCachedFraction are non-zero,
+                                         // the smallest resulting value is used.
+        bool reuseSameQueueAllocations,  // reuse non-ready allocations if they are in the same queue as the new one;
+                                         // this is safe only if all memory operations are scheduled in the same queue
+        bool debug)
+        : device_(device),
+          binGrowth_(binGrowth),
+          minBin_(minBin),
+          maxBin_(maxBin),
+          minBinBytes_(detail::power(binGrowth, minBin)),
+          maxBinBytes_(detail::power(binGrowth, maxBin)),
+          maxCachedBytes_(cacheSize(maxCachedBytes, maxCachedFraction)),
+          reuseSameQueueAllocations_(reuseSameQueueAllocations),
+          debug_(debug) {
+      if (debug_) {
+        std::ostringstream out;
+        out << "CachingAllocator settings\n"
+            << "  bin growth " << binGrowth_ << "\n"
+            << "  min bin    " << minBin_ << "\n"
+            << "  max bin    " << maxBin_ << "\n"
+            << "  resulting bins:\n";
+        for (auto bin = minBin_; bin <= maxBin_; ++bin) {
+          auto binSize = detail::power(binGrowth, bin);
+          out << "    " << std::right << std::setw(12) << detail::as_bytes(binSize) << '\n';
+        }
+        out << "  maximum amount of cached memory: " << detail::as_bytes(maxCachedBytes_);
+        std::cout << out.str() << std::endl;
+      }
+    }
+
+    ~CachingAllocator() {
+      {
+        // this should never be called while some memory blocks are still live
+        std::scoped_lock lock(mutex_);
+        assert(liveBlocks_.empty());
+        assert(cachedBytes_.live == 0);
+      }
+
+      freeAllCached();
+    }
+
+    // return a copy of the cache allocation status, for monitoring purposes
+    CachedBytes cacheStatus() const {
+      std::scoped_lock lock(mutex_);
+      return cachedBytes_;
+    }
+
+    // Allocate given number of bytes on the current device associated to given queue
+    void* allocate(size_t bytes, Queue queue) {
+      // create a block descriptor for the requested allocation
+      BlockDescriptor block;
+      block.queue = std::move(queue);
+      block.requested = bytes;
+      std::tie(block.bin, block.bytes) = findBin(bytes);
+
+      // try to re-use a cached block, or allocate a new buffer
+      if (not tryReuseCachedBlock(block)) {
+        allocateNewBlock(block);
+      }
+
+      return block.buffer->data();
+    }
+
+    // frees an allocation
+    void free(void* ptr) {
+      std::scoped_lock lock(mutex_);
+
+      auto iBlock = liveBlocks_.find(ptr);
+      if (iBlock == liveBlocks_.end()) {
+        std::stringstream ss;
+        ss << "Trying to free a non-live block at " << ptr;
+        throw std::runtime_error(ss.str());
+      }
+      // remove the block from the list of live blocks
+      BlockDescriptor block = std::move(iBlock->second);
+      liveBlocks_.erase(iBlock);
+      cachedBytes_.live -= block.bytes;
+      cachedBytes_.requested -= block.requested;
+
+      bool recache = (cachedBytes_.free + block.bytes <= maxCachedBytes_);
+      if (recache) {
+        alpaka::enqueue(*(block.queue), *(block.event));
+        cachedBytes_.free += block.bytes;
+        // after the call to insert(), cachedBlocks_ shares ownership of the buffer
+        // TODO use std::move ?
+        cachedBlocks_.insert(std::make_pair(block.bin, block));
+
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " returned " << block.bytes << " bytes at "
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << " , event "
+              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
+              << " bytes) outstanding." << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+      } else {
+        // if the buffer is not recached, it is automatically freed when block goes out of scope
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << block.bytes << " bytes at "
+              << ptr << " from associated queue " << block.queue->m_spQueueImpl.get() << ", event "
+              << block.event->m_spEventImpl.get() << " .\n\t\t " << cachedBlocks_.size() << " available blocks cached ("
+              << cachedBytes_.free << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live
+              << " bytes) outstanding." << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+      }
+    }
+
+  private:
+    struct BlockDescriptor {
+      std::optional<Buffer> buffer;
+      std::optional<Queue> queue;
+      std::optional<Event> event;
+      size_t bytes = 0;
+      size_t requested = 0;  // for monitoring only
+      unsigned int bin = 0;
+
+      // the "synchronisation device" for this block
+      auto device() { return alpaka::getDev(*queue); }
+    };
+
+  private:
+    // return the maximum amount of memory that should be cached on this device
+    size_t cacheSize(size_t maxCachedBytes, double maxCachedFraction) const {
+      // note that getMemBytes() returns 0 if the platform does not support querying the device memory
+      size_t totalMemory = alpaka::getMemBytes(device_);
+      size_t memoryFraction = static_cast<size_t>(maxCachedFraction * totalMemory);
+      size_t size = std::numeric_limits<size_t>::max();
+      if (maxCachedBytes > 0 and maxCachedBytes < size) {
+        size = maxCachedBytes;
+      }
+      if (memoryFraction > 0 and memoryFraction < size) {
+        size = memoryFraction;
+      }
+      return size;
+    }
+
+    // return (bin, bin size)
+    std::tuple<unsigned int, size_t> findBin(size_t bytes) const {
+      if (bytes < minBinBytes_) {
+        return std::make_tuple(minBin_, minBinBytes_);
+      }
+      if (bytes > maxBinBytes_) {
+        throw std::runtime_error("Requested allocation size " + std::to_string(bytes) +
+                                 " bytes is too large for the caching detail with maximum bin " +
+                                 std::to_string(maxBinBytes_) +
+                                 " bytes. You might want to increase the maximum bin size");
+      }
+      unsigned int bin = minBin_;
+      size_t binBytes = minBinBytes_;
+      while (binBytes < bytes) {
+        ++bin;
+        binBytes *= binGrowth_;
+      }
+      return std::make_tuple(bin, binBytes);
+    }
+
+    bool tryReuseCachedBlock(BlockDescriptor& block) {
+      std::scoped_lock lock(mutex_);
+
+      // iterate through the range of cached blocks in the same bin
+      const auto [begin, end] = cachedBlocks_.equal_range(block.bin);
+      for (auto iBlock = begin; iBlock != end; ++iBlock) {
+        if ((reuseSameQueueAllocations_ and (*block.queue == *(iBlock->second.queue))) or
+            alpaka::isComplete(*(iBlock->second.event))) {
+          // associate the cached buffer to the new queue
+          auto queue = std::move(*(block.queue));
+          // TODO cache (or remove) the debug information and use std::move()
+          block = iBlock->second;
+          block.queue = std::move(queue);
+
+          // if the new queue is on different device than the old event, create a new event
+          if (block.device() != alpaka::getDev(*(block.event))) {
+            block.event = Event{block.device()};
+          }
+
+          // insert the cached block into the live blocks
+          // TODO cache (or remove) the debug information and use std::move()
+          liveBlocks_[block.buffer->data()] = block;
+
+          // update the accounting information
+          cachedBytes_.free -= block.bytes;
+          cachedBytes_.live += block.bytes;
+          cachedBytes_.requested += block.requested;
+
+          if (debug_) {
+            std::ostringstream out;
+            out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " reused cached block at "
+                << block.buffer->data() << " (" << block.bytes << " bytes) for queue "
+                << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get()
+                << " (previously associated with stream " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
+                << iBlock->second.event->m_spEventImpl.get() << ")." << std::endl;
+            std::cout << out.str() << std::endl;
+          }
+
+          // remove the reused block from the list of cached blocks
+          cachedBlocks_.erase(iBlock);
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    Buffer allocateBuffer(size_t bytes, Queue const& queue) {
+      if constexpr (std::is_same_v<Device, alpaka::Dev<Queue>>) {
+        // allocate device memory
+        return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
+      } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+        // allocate pinned host memory
+        return alpaka::allocMappedBuf<std::byte, size_t>(device_, alpaka::getDev(queue), bytes);
+      } else {
+        // unsupported combination
+        static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,
+                      "The \"memory device\" type can either be the same as the \"synchronisation device\" type, or be "
+                      "the host CPU.");
+      }
+    }
+
+    void allocateNewBlock(BlockDescriptor& block) {
+      try {
+        block.buffer = allocateBuffer(block.bytes, *block.queue);
+      } catch (std::runtime_error const& e) {
+        // the allocation attempt failed: free all cached blocks on the device and retry
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " failed to allocate " << block.bytes
+              << " bytes for queue " << block.queue->m_spQueueImpl.get()
+              << ", retrying after freeing cached allocations" << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+        // TODO implement a method that frees only up to block.bytes bytes
+        freeAllCached();
+
+        // throw an exception if it fails again
+        block.buffer = allocateBuffer(block.bytes, *block.queue);
+      }
+
+      // create a new event associated to the "synchronisation device"
+      block.event = Event{block.device()};
+
+      {
+        std::scoped_lock lock(mutex_);
+        cachedBytes_.live += block.bytes;
+        cachedBytes_.requested += block.requested;
+        // TODO use std::move() ?
+        liveBlocks_[block.buffer->data()] = block;
+      }
+
+      if (debug_) {
+        std::ostringstream out;
+        out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " allocated new block at "
+            << block.buffer->data() << " (" << block.bytes << " bytes associated with queue "
+            << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get() << "." << std::endl;
+        std::cout << out.str() << std::endl;
+      }
+    }
+
+    void freeAllCached() {
+      std::scoped_lock lock(mutex_);
+
+      while (not cachedBlocks_.empty()) {
+        auto iBlock = cachedBlocks_.begin();
+        cachedBytes_.free -= iBlock->second.bytes;
+
+        if (debug_) {
+          std::ostringstream out;
+          out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " freed " << iBlock->second.bytes
+              << " bytes.\n\t\t  " << (cachedBlocks_.size() - 1) << " available blocks cached (" << cachedBytes_.free
+              << " bytes), " << liveBlocks_.size() << " live blocks (" << cachedBytes_.live << " bytes) outstanding."
+              << std::endl;
+          std::cout << out.str() << std::endl;
+        }
+
+        cachedBlocks_.erase(iBlock);
+      }
+    }
+
+    // TODO replace with a tbb::concurrent_multimap ?
+    using CachedBlocks = std::multimap<unsigned int, BlockDescriptor>;  // ordered by the allocation bin
+    // TODO replace with a tbb::concurrent_map ?
+    using BusyBlocks = std::map<void*, BlockDescriptor>;  // ordered by the address of the allocated memory
+
+    inline static const std::string deviceType_ = alpaka::core::demangled<Device>;
+
+    mutable std::mutex mutex_;
+    Device device_;  // the device where the memory is allocated
+
+    CachedBytes cachedBytes_;
+    CachedBlocks cachedBlocks_;  // Set of cached device allocations available for reuse
+    BusyBlocks liveBlocks_;      // map of pointers to the live device allocations currently in use
+
+    const unsigned int binGrowth_;  // Geometric growth factor for bin-sizes
+    const unsigned int minBin_;
+    const unsigned int maxBin_;
+
+    const size_t minBinBytes_;
+    const size_t maxBinBytes_;
+    const size_t maxCachedBytes_;  // Maximum aggregate cached bytes per device
+
+    const bool reuseSameQueueAllocations_;
+    const bool debug_;
+  };
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_CachingAllocator_h

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -302,7 +302,7 @@ namespace cms::alpakatools {
             out << "\t" << deviceType_ << " " << alpaka::getName(device_) << " reused cached block at "
                 << block.buffer->data() << " (" << block.bytes << " bytes) for queue "
                 << block.queue->m_spQueueImpl.get() << ", event " << block.event->m_spEventImpl.get()
-                << " (previously associated with stream " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
+                << " (previously associated with queue " << iBlock->second.queue->m_spQueueImpl.get() << " , event "
                 << iBlock->second.event->m_spEventImpl.get() << ")." << std::endl;
             std::cout << out.str() << std::endl;
           }

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -15,6 +15,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h"
 
 // Inspired by cub::CachingDeviceAllocator
 
@@ -85,6 +86,19 @@ namespace cms::alpakatools {
             typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
   class CachingAllocator {
   public:
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    friend class alpaka_cuda_async::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+    friend class alpaka_hip_async::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    friend class alpaka_serial_sync::AlpakaService;
+#endif
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    friend class alpaka_tbb_async::AlpakaService;
+#endif
+
     using Device = TDev;                 // the "memory device", where the memory will be allocated
     using Queue = TQueue;                // the queue used to submit the memory operations
     using Event = alpaka::Event<Queue>;  // the events used to synchronise the operations

--- a/HeterogeneousCore/AlpakaInterface/interface/HostOnlyTask.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/HostOnlyTask.h
@@ -1,0 +1,71 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_HostOnlyTask_h
+#define HeterogeneousCore_AlpakaInterface_interface_HostOnlyTask_h
+
+#include <functional>
+#include <memory>
+
+#include <alpaka/alpaka.hpp>
+
+namespace alpaka {
+
+  //! A task that is guaranted not to call any GPU-ralated APIs
+  //!
+  //! These tasks can be enqueued directly to the native GPU queues, without the use of a
+  //! dedicated host-side worker thread.
+  class HostOnlyTask {
+  public:
+    HostOnlyTask(std::function<void()> task) : task_(std::move(task)) {}
+
+    void operator()() const { task_(); }
+
+  private:
+    std::function<void()> task_;
+  };
+
+  namespace trait {
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    //! The CUDA async queue enqueue trait specialization for "safe tasks"
+    template <>
+    struct Enqueue<QueueCudaRtNonBlocking, HostOnlyTask> {
+      using TApi = ApiCudaRt;
+
+      static void CUDART_CB callback(cudaStream_t /*queue*/, cudaError_t /*status*/, void* arg) {
+        //ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(status);
+        std::unique_ptr<HostOnlyTask> pTask(static_cast<HostOnlyTask*>(arg));
+        (*pTask)();
+      }
+
+      ALPAKA_FN_HOST static auto enqueue(QueueCudaRtNonBlocking& queue, HostOnlyTask task) -> void {
+        auto pTask = std::make_unique<HostOnlyTask>(std::move(task));
+        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+            cudaStreamAddCallback(alpaka::getNativeHandle(queue), callback, static_cast<void*>(pTask.release()), 0u));
+      }
+    };
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+    //! The HIP async queue enqueue trait specialization for "safe tasks"
+    template <>
+    struct Enqueue<QueueHipRtNonBlocking, HostOnlyTask> {
+      using TApi = ApiHipRt;
+
+      static void callback(hipStream_t /*queue*/, hipError_t /*status*/, void* arg) {
+        //ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(status);
+        std::unique_ptr<HostOnlyTask> pTask(static_cast<HostOnlyTask*>(arg));
+        (*pTask)();
+      }
+
+      ALPAKA_FN_HOST static auto enqueue(QueueHipRtNonBlocking& queue, HostOnlyTask task) -> void {
+        auto pTask = std::make_unique<HostOnlyTask>(std::move(task));
+        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+            hipStreamAddCallback(alpaka::getNativeHandle(queue), callback, static_cast<void*>(pTask.release()), 0u));
+      }
+    };
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+
+  }  // namespace trait
+
+}  // namespace alpaka
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_HostOnlyTask_h

--- a/HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h
@@ -1,0 +1,35 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_ScopedContextFwd_h
+#define HeterogeneousCore_AlpakaInterface_interface_ScopedContextFwd_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+// Forward declaration of the alpaka framework Context classes
+//
+// This file is under HeterogeneousCore/AlpakaInterface to avoid introducing a dependency on
+// HeterogeneousCore/AlpakaCore.
+
+namespace cms::alpakatools {
+
+  namespace impl {
+    template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+    class ScopedContextBase;
+
+    template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+    class ScopedContextGetterBase;
+  }  // namespace impl
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ScopedContextAcquire;
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ScopedContextProduce;
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ScopedContextTask;
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  class ScopedContextAnalyze;
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_ScopedContextFwd_h

--- a/HeterogeneousCore/AlpakaInterface/interface/devices.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/devices.h
@@ -1,0 +1,43 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_devices_h
+#define HeterogeneousCore_AlpakaInterface_interface_devices_h
+
+#include <cassert>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  namespace detail {
+
+    template <typename TPlatform, typename = std::enable_if_t<is_platform_v<TPlatform>>>
+    inline std::vector<alpaka::Dev<TPlatform>> enumerate_devices() {
+      using Platform = TPlatform;
+      using Device = alpaka::Dev<Platform>;
+
+      std::vector<Device> devices;
+      uint32_t n = alpaka::getDevCount<Platform>();
+      devices.reserve(n);
+      for (uint32_t i = 0; i < n; ++i) {
+        devices.push_back(alpaka::getDevByIdx<Platform>(i));
+        assert(alpaka::getNativeHandle(devices.back()) == static_cast<int>(i));
+      }
+
+      return devices;
+    }
+
+  }  // namespace detail
+
+  // return the alpaka accelerator devices for the given platform
+  template <typename TPlatform, typename = std::enable_if_t<is_platform_v<TPlatform>>>
+  inline std::vector<alpaka::Dev<TPlatform>> const& devices() {
+    static const auto devices = detail::enumerate_devices<TPlatform>();
+    return devices;
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_devices_h

--- a/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
@@ -73,7 +74,7 @@ namespace cms::alpakatools {
             typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
   inline CachingAllocator<TDev, TQueue>& getDeviceCachingAllocator(TDev const& device) {
     // initialise all allocators, one per device
-    static auto allocators = detail::allocate_device_allocators<TDev, TQueue>();
+    CMS_THREAD_SAFE static auto allocators = detail::allocate_device_allocators<TDev, TQueue>();
 
     size_t const index = alpaka::getNativeHandle(device);
     assert(index < cms::alpakatools::devices<alpaka::Pltf<TDev>>().size());

--- a/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
@@ -1,0 +1,87 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_getDeviceCachingAllocator_h
+#define HeterogeneousCore_AlpakaInterface_interface_getDeviceCachingAllocator_h
+
+#include <memory>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  namespace detail {
+
+    template <typename TDev,
+              typename TQueue,
+              typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
+    auto allocate_device_allocators() {
+      using Allocator = CachingAllocator<TDev, TQueue>;
+      auto const& devices = cms::alpakatools::devices<alpaka::Pltf<TDev>>();
+      ssize_t const size = devices.size();
+
+      // allocate the storage for the objects
+      auto ptr = std::allocator<Allocator>().allocate(size);
+
+      // construct the objects in the storage
+      ptrdiff_t index = 0;
+      try {
+        for (; index < size; ++index) {
+#if __cplusplus >= 202002L
+          std::construct_at(
+#else
+          std::allocator<Allocator>().construct(
+#endif
+              ptr + index,
+              devices[index],
+              config::binGrowth,
+              config::minBin,
+              config::maxBin,
+              config::maxCachedBytes,
+              config::maxCachedFraction,
+              true,    // reuseSameQueueAllocations
+              false);  // debug
+        }
+      } catch (...) {
+        --index;
+        // destroy any object that had been succesfully constructed
+        while (index >= 0) {
+          std::destroy_at(ptr + index);
+          --index;
+        }
+        // deallocate the storage
+        std::allocator<Allocator>().deallocate(ptr, size);
+        // rethrow the exception
+        throw;
+      }
+
+      // use a custom deleter to destroy all objects and deallocate the memory
+      auto deleter = [size](Allocator* ptr) {
+        for (size_t i = size; i > 0; --i) {
+          std::destroy_at(ptr + i - 1);
+        }
+        std::allocator<Allocator>().deallocate(ptr, size);
+      };
+
+      return std::unique_ptr<Allocator[], decltype(deleter)>(ptr, deleter);
+    }
+
+  }  // namespace detail
+
+  template <typename TDev,
+            typename TQueue,
+            typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev> and cms::alpakatools::is_queue_v<TQueue>>>
+  inline CachingAllocator<TDev, TQueue>& getDeviceCachingAllocator(TDev const& device) {
+    // initialise all allocators, one per device
+    static auto allocators = detail::allocate_device_allocators<TDev, TQueue>();
+
+    size_t const index = alpaka::getNativeHandle(device);
+    assert(index < cms::alpakatools::devices<alpaka::Pltf<TDev>>().size());
+
+    // the public interface is thread safe
+    return allocators[index];
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_getDeviceCachingAllocator_h

--- a/HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h
@@ -1,0 +1,30 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_getHostCachingAllocator_h
+#define HeterogeneousCore_AlpakaInterface_interface_getHostCachingAllocator_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
+  inline CachingAllocator<alpaka_common::DevHost, TQueue>& getHostCachingAllocator() {
+    // thread safe initialisation of the host allocator
+    static CachingAllocator<alpaka_common::DevHost, TQueue> allocator(host(),
+                                                                      config::binGrowth,
+                                                                      config::minBin,
+                                                                      config::maxBin,
+                                                                      config::maxCachedBytes,
+                                                                      config::maxCachedFraction,
+                                                                      false,   // reuseSameQueueAllocations
+                                                                      false);  // debug
+
+    // the public interface is thread safe
+    return allocator;
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_getHostCachingAllocator_h

--- a/HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_AlpakaInterface_interface_getHostCachingAllocator_h
 #define HeterogeneousCore_AlpakaInterface_interface_getHostCachingAllocator_h
 
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -12,14 +13,15 @@ namespace cms::alpakatools {
   template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
   inline CachingAllocator<alpaka_common::DevHost, TQueue>& getHostCachingAllocator() {
     // thread safe initialisation of the host allocator
-    static CachingAllocator<alpaka_common::DevHost, TQueue> allocator(host(),
-                                                                      config::binGrowth,
-                                                                      config::minBin,
-                                                                      config::maxBin,
-                                                                      config::maxCachedBytes,
-                                                                      config::maxCachedFraction,
-                                                                      false,   // reuseSameQueueAllocations
-                                                                      false);  // debug
+    CMS_THREAD_SAFE static CachingAllocator<alpaka_common::DevHost, TQueue> allocator(
+        host(),
+        config::binGrowth,
+        config::minBin,
+        config::maxBin,
+        config::maxCachedBytes,
+        config::maxCachedFraction,
+        false,   // reuseSameQueueAllocations
+        false);  // debug
 
     // the public interface is thread safe
     return allocator;

--- a/HeterogeneousCore/AlpakaInterface/interface/host.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/host.h
@@ -1,16 +1,29 @@
 #ifndef HeterogeneousCore_AlpakaInterface_interface_host_h
 #define HeterogeneousCore_AlpakaInterface_interface_host_h
 
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+namespace cms::alpakatools {
 
-namespace alpaka_common {
+  namespace detail {
 
-  // alpaka host device
-  static inline DevHost const& host() {
-    static const auto host = alpaka::getDevByIdx<alpaka_common::PltfHost>(0u);
+    inline alpaka::DevCpu enumerate_host() {
+      using Platform = alpaka::PltfCpu;
+      using Host = alpaka::DevCpu;
+
+      assert(alpaka::getDevCount<Platform>() == 1);
+      Host host = alpaka::getDevByIdx<Platform>(0);
+      assert(alpaka::getNativeHandle(host) == 0);
+
+      return host;
+    }
+
+  }  // namespace detail
+
+  // returns the alpaka host device
+  static inline alpaka::DevCpu const& host() {
+    static const auto host = detail::enumerate_host();
     return host;
   }
 
-}  // namespace alpaka_common
+}  // namespace cms::alpakatools
 
 #endif  // HeterogeneousCore_AlpakaInterface_interface_host_h

--- a/HeterogeneousCore/AlpakaInterface/interface/memory.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/memory.h
@@ -1,0 +1,247 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_memory_h
+#define HeterogeneousCore_AlpakaInterface_interface_memory_h
+
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/AllocatorPolicy.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CachedBufAlloc.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace cms::alpakatools {
+
+  // for Extent, Dim1D, Idx
+  using namespace alpaka_common;
+
+  // type deduction helpers
+  namespace detail {
+
+    template <typename TDev, typename T, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+    struct buffer_type {
+      using type = alpaka::Buf<TDev, T, Dim0D, Idx>;
+    };
+
+    template <typename TDev, typename T>
+    struct buffer_type<TDev, T[]> {
+      using type = alpaka::Buf<TDev, T, Dim1D, Idx>;
+    };
+
+    template <typename TDev, typename T, int N>
+    struct buffer_type<TDev, T[N]> {
+      using type = alpaka::Buf<TDev, T, Dim1D, Idx>;
+    };
+
+    template <typename TDev, typename T, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+    struct view_type {
+      using type = alpaka::ViewPlainPtr<TDev, T, Dim0D, Idx>;
+    };
+
+    template <typename TDev, typename T>
+    struct view_type<TDev, T[]> {
+      using type = alpaka::ViewPlainPtr<TDev, T, Dim1D, Idx>;
+    };
+
+    template <typename TDev, typename T, int N>
+    struct view_type<TDev, T[N]> {
+      using type = alpaka::ViewPlainPtr<TDev, T, Dim1D, Idx>;
+    };
+
+  }  // namespace detail
+
+  // scalar and 1-dimensional host buffers
+
+  template <typename T>
+  using host_buffer = typename detail::buffer_type<DevHost, T>::type;
+
+  template <typename T>
+  using const_host_buffer = alpaka::ViewConst<host_buffer<T>>;
+
+  // non-cached, non-pinned, scalar and 1-dimensional host buffers
+
+  template <typename T>
+  std::enable_if_t<not std::is_array_v<T>, host_buffer<T>> make_host_buffer() {
+    return alpaka::allocBuf<T, Idx>(host(), Scalar{});
+  }
+
+  template <typename T>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer(Extent extent) {
+    return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(host(), Vec1D{extent});
+  }
+
+  template <typename T>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_buffer<T>>
+  make_host_buffer() {
+    return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(host(), Vec1D{std::extent_v<T>});
+  }
+
+  // potentially cached, pinned, scalar and 1-dimensional host buffers, associated to a work queue
+  // the memory is pinned according to the device associated to the queue
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and not std::is_array_v<T>, host_buffer<T>> make_host_buffer(TQueue const& queue) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<T, Idx>(host(), queue, Scalar{});
+    } else {
+      return alpaka::allocMappedBuf<T, Idx>(host(), alpaka::getDev(queue), Scalar{});
+    }
+  }
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   host_buffer<T>>
+  make_host_buffer(TQueue const& queue, Extent extent) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<std::remove_extent_t<T>, Idx>(host(), queue, Vec1D{extent});
+    } else {
+      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(host(), alpaka::getDev(queue), Vec1D{extent});
+    }
+  }
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   host_buffer<T>>
+  make_host_buffer(TQueue const& queue) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<std::remove_extent_t<T>, Idx>(host(), queue, Vec1D{std::extent_v<T>});
+    } else {
+      return alpaka::allocMappedBuf<std::remove_extent_t<T>, Idx>(
+          host(), alpaka::getDev(queue), Vec1D{std::extent_v<T>});
+    }
+  }
+
+  // scalar and 1-dimensional host views
+
+  template <typename T>
+  using host_view = typename detail::view_type<DevHost, T>::type;
+
+  template <typename T>
+  std::enable_if_t<not std::is_array_v<T>, host_view<T>> make_host_view(T& data) {
+    return alpaka::ViewPlainPtr<DevHost, T, Dim0D, Idx>(&data, host(), Scalar{});
+  }
+
+  template <typename T>
+  host_view<T[]> make_host_view(T* data, Extent extent) {
+    return alpaka::ViewPlainPtr<DevHost, T, Dim1D, Idx>(data, host(), Vec1D{extent});
+  }
+
+  template <typename T>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_view<T>>
+  make_host_view(T& data, Extent extent) {
+    return alpaka::ViewPlainPtr<DevHost, std::remove_extent_t<T>, Dim1D, Idx>(data, host(), Vec1D{extent});
+  }
+
+  template <typename T>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, host_view<T>>
+  make_host_view(T& data) {
+    return alpaka::ViewPlainPtr<DevHost, std::remove_extent_t<T>, Dim1D, Idx>(data, host(), Vec1D{std::extent_v<T>});
+  }
+
+  // scalar and 1-dimensional device buffers
+
+  template <typename TDev, typename T, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+  using device_buffer = typename detail::buffer_type<TDev, T>::type;
+
+  template <typename TDev, typename T, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+  using const_device_buffer = alpaka::ViewConst<device_buffer<TDev, T>>;
+
+  // non-cached, scalar and 1-dimensional device buffers
+
+  template <typename T, typename TDev>
+  std::enable_if_t<is_device_v<TDev> and not std::is_array_v<T>, device_buffer<TDev, T>> make_device_buffer(
+      TDev const& device) {
+    return alpaka::allocBuf<T, Idx>(device, Scalar{});
+  }
+
+  template <typename T, typename TDev>
+  std::enable_if_t<is_device_v<TDev> and cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   device_buffer<TDev, T>>
+  make_device_buffer(TDev const& device, Extent extent) {
+    return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(device, Vec1D{extent});
+  }
+
+  template <typename T, typename TDev>
+  std::enable_if_t<is_device_v<TDev> and cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   device_buffer<TDev, T>>
+  make_device_buffer(TDev const& device) {
+    return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(device, Vec1D{std::extent_v<T>});
+  }
+
+  // potentially-cached, scalar and 1-dimensional device buffers with queue-ordered semantic
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and not std::is_array_v<T>, device_buffer<alpaka::Dev<TQueue>, T>>
+  make_device_buffer(TQueue const& queue) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<T, Idx>(alpaka::getDev(queue), queue, Scalar{});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Asynchronous) {
+      return alpaka::allocAsyncBuf<T, Idx>(queue, Scalar{});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Synchronous) {
+      return alpaka::allocBuf<T, Idx>(alpaka::getDev(queue), Scalar{});
+    }
+  }
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   device_buffer<alpaka::Dev<TQueue>, T>>
+  make_device_buffer(TQueue const& queue, Extent extent) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<std::remove_extent_t<T>, Idx>(alpaka::getDev(queue), queue, Vec1D{extent});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Asynchronous) {
+      return alpaka::allocAsyncBuf<std::remove_extent_t<T>, Idx>(queue, Vec1D{extent});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Synchronous) {
+      return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(alpaka::getDev(queue), Vec1D{extent});
+    }
+  }
+
+  template <typename T, typename TQueue>
+  std::enable_if_t<is_queue_v<TQueue> and cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>,
+                   device_buffer<alpaka::Dev<TQueue>, T>>
+  make_device_buffer(TQueue const& queue) {
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Caching) {
+      return allocCachedBuf<std::remove_extent_t<T>, Idx>(alpaka::getDev(queue), queue, Vec1D{std::extent_v<T>});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Asynchronous) {
+      return alpaka::allocAsyncBuf<std::remove_extent_t<T>, Idx>(queue, Vec1D{std::extent_v<T>});
+    }
+    if constexpr (allocator_policy<alpaka::Dev<TQueue>> == AllocatorPolicy::Synchronous) {
+      return alpaka::allocBuf<std::remove_extent_t<T>, Idx>(alpaka::getDev(queue), Vec1D{std::extent_v<T>});
+    }
+  }
+
+  // scalar and 1-dimensional device views
+
+  template <typename TDev, typename T, typename = std::enable_if_t<cms::alpakatools::is_device_v<TDev>>>
+  using device_view = typename detail::view_type<TDev, T>::type;
+
+  template <typename T, typename TDev>
+  std::enable_if_t<not std::is_array_v<T>, device_view<TDev, T>> make_device_view(TDev const& device, T& data) {
+    return alpaka::ViewPlainPtr<TDev, T, Dim0D, Idx>(&data, device, Scalar{});
+  }
+
+  template <typename T, typename TDev>
+  device_view<TDev, T[]> make_device_view(TDev const& device, T* data, Extent extent) {
+    return alpaka::ViewPlainPtr<TDev, T, Dim1D, Idx>(data, device, Vec1D{extent});
+  }
+
+  template <typename T, typename TDev>
+  std::enable_if_t<cms::is_unbounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, device_view<TDev, T>>
+  make_device_view(TDev const& device, T& data, Extent extent) {
+    return alpaka::ViewPlainPtr<TDev, std::remove_extent_t<T>, Dim1D, Idx>(data, device, Vec1D{extent});
+  }
+
+  template <typename T, typename TDev>
+  std::enable_if_t<cms::is_bounded_array_v<T> and not std::is_array_v<std::remove_extent_t<T>>, device_view<TDev, T>>
+  make_device_view(TDev const& device, T& data) {
+    return alpaka::ViewPlainPtr<TDev, std::remove_extent_t<T>, Dim1D, Idx>(data, device, Vec1D{std::extent_v<T>});
+  }
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_memory_h

--- a/HeterogeneousCore/AlpakaInterface/interface/traits.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/traits.h
@@ -1,0 +1,69 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_traits_h
+#define HeterogeneousCore_AlpakaInterface_interface_traits_h
+
+#include <type_traits>
+
+#if __cplusplus >= 202002L
+namespace cms {
+  using std::is_bounded_array;
+  using std::is_unbounded_array;
+}  // namespace cms
+#else
+#include <boost/type_traits/is_bounded_array.hpp>
+#include <boost/type_traits/is_unbounded_array.hpp>
+namespace cms {
+  using boost::is_bounded_array;
+  using boost::is_unbounded_array;
+}  // namespace cms
+#endif
+
+namespace cms {
+  template <typename T>
+  inline constexpr bool is_bounded_array_v = is_bounded_array<T>::value;
+
+  template <typename T>
+  inline constexpr bool is_unbounded_array_v = is_unbounded_array<T>::value;
+}  // namespace cms
+
+#include <alpaka/alpaka.hpp>
+
+namespace cms::alpakatools {
+
+  // is_platform
+
+  template <typename T>
+  struct is_platform
+      : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptPltf, T>::value> {};
+
+  template <typename T>
+  constexpr bool is_platform_v = is_platform<T>::value;
+
+  // is_device
+
+  template <typename T>
+  struct is_device : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptDev, T>::value> {};
+
+  template <typename T>
+  constexpr bool is_device_v = is_device<T>::value;
+
+  // is_accelerator
+
+  template <typename T>
+  struct is_accelerator
+      : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptAcc, T>::value> {};
+
+  template <typename T>
+  constexpr bool is_accelerator_v = is_accelerator<T>::value;
+
+  // is_queue
+
+  template <typename T>
+  struct is_queue : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptQueue, T>::value> {
+  };
+
+  template <typename T>
+  constexpr bool is_queue_v = is_queue<T>::value;
+
+}  // namespace cms::alpakatools
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_traits_h

--- a/HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h
+++ b/HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h
@@ -3,9 +3,8 @@
 
 #include <vector>
 
-#include <alpaka/alpaka.hpp>
-
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h"
 
 namespace edm {
   class ActivityRegistry;
@@ -18,20 +17,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class AlpakaService {
   public:
     AlpakaService(edm::ParameterSet const& config, edm::ActivityRegistry&);
-    ~AlpakaService() = default;
+    ~AlpakaService();
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     bool enabled() const { return enabled_; }
 
-    std::vector<Device> const& devices() const { return devices_; }
-
-    Device const& device(uint32_t index) const { return devices_.at(index); }
-
   private:
     bool enabled_ = false;
     bool verbose_ = false;
-    std::vector<Device> devices_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc
+++ b/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc
@@ -6,6 +6,12 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/AlpakaCore/interface/EventCache.h"
+#include "HeterogeneousCore/AlpakaCore/interface/QueueCache.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/getHostCachingAllocator.h"
 #include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -41,8 +47,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
     // enumerate all devices on this platform
-    uint32_t n = alpaka::getDevCount<Platform>();
-    if (n == 0) {
+    auto const& devices = cms::alpakatools::devices<Platform>();
+    if (devices.empty()) {
       const std::string platform = boost::core::demangle(typeid(Platform).name());
       edm::LogWarning("AlpakaService") << "Could not find any devices on platform " << platform << ".\n"
                                        << "Disabling " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << ".";
@@ -50,21 +56,36 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       return;
     }
 
-    devices_.reserve(n);
-    for (uint32_t i = 0; i < n; ++i) {
-      devices_.push_back(alpaka::getDevByIdx<Platform>(i));
-      //assert(getDeviceIndex(devices_.back()) == static_cast<int>(i));
-    }
-
     {
       const char* suffix[] = {"s.", ":", "s:"};
+      const auto n = devices.size();
       edm::LogInfo out("AlpakaService");
       out << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " succesfully initialised.\n";
       out << "Found " << n << " device" << suffix[n < 2 ? n : 2];
-      for (auto const& device : devices_) {
+      for (auto const& device : devices) {
         out << "\n  - " << alpaka::getName(device);
       }
     }
+
+    // initialise the queue and event caches
+    cms::alpakatools::getQueueCache<Queue>().clear();
+    cms::alpakatools::getEventCache<Event>().clear();
+
+    // initialise the caching memory allocators
+    cms::alpakatools::getHostCachingAllocator<Queue>();
+    for (auto const& device : devices)
+      cms::alpakatools::getDeviceCachingAllocator<Device, Queue>(device);
+  }
+
+  AlpakaService::~AlpakaService() {
+    // clean up the caching memory allocators
+    cms::alpakatools::getHostCachingAllocator<Queue>().freeAllCached();
+    for (auto const& device : cms::alpakatools::devices<Platform>())
+      cms::alpakatools::getDeviceCachingAllocator<Device, Queue>(device).freeAllCached();
+
+    // clean up the queue and event caches
+    cms::alpakatools::getQueueCache<Queue>().clear();
+    cms::alpakatools::getEventCache<Event>().clear();
   }
 
   void AlpakaService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -7,6 +7,7 @@
 
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
 #include "TestAlgo.h"
 
@@ -14,7 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class TestAlgoKernel {
   public:
-    template <typename TAcc>
+    template <typename TAcc, typename = std::enable_if_t<cms::alpakatools::is_accelerator_v<TAcc>>>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::View view, int32_t size) const {
       // this example accepts an arbitrary number of blocks and threads, and always uses 1 element per thread
       const int32_t thread = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -15,6 +15,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/AlpakaCore/interface/chooseDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
@@ -33,9 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (not service->enabled()) {
         throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
       }
-      auto& devices = service->devices();
-      unsigned int index = sid.value() % devices.size();
-      device_ = devices[index];
+      device_ = cms::alpakatools::chooseDevice<Platform>(sid);
     }
 
     void produce(edm::Event& event, edm::EventSetup const&) override {

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -3,6 +3,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -43,10 +44,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       portabletest::TestDeviceCollection deviceProduct{size_, ctx.queue()};
       algo_.fill(ctx.queue(), deviceProduct);
 
-      // wait for any asynchronous work to complete
-      alpaka::wait(ctx.queue());
-
-      event.emplace(deviceToken_, std::move(deviceProduct));
+      // put the asynchronous product into the event without waiting
+      ctx.emplace(event, deviceToken_, std::move(deviceProduct));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -56,7 +55,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
   private:
-    const edm::EDPutTokenT<portabletest::TestDeviceCollection> deviceToken_;
+    const edm::EDPutTokenT<cms::alpakatools::Product<Queue, portabletest::TestDeviceCollection>> deviceToken_;
     const int32_t size_;
 
     // implementation of the algorithm

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -1,11 +1,9 @@
-// The "Transcriber" makes sense only across different memory spaces
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-
 #include <optional>
 #include <string>
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -25,7 +23,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
-  class TestAlpakaTranscriber : public edm::stream::EDProducer<> {
+  class TestAlpakaTranscriber : public edm::stream::EDProducer<edm::ExternalWork> {
   public:
     TestAlpakaTranscriber(edm::ParameterSet const& config)
         : deviceToken_{consumes(config.getParameter<edm::InputTag>("source"))}, hostToken_{produces()} {}
@@ -37,19 +35,27 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     }
 
+    void acquire(edm::Event const& event, edm::EventSetup const& setup, edm::WaitingTaskWithArenaHolder task) override {
+      // create a context reusing the same device and queue as the producer of the input collection
+      auto const& input = event.get(deviceToken_);
+      cms::alpakatools::ScopedContextAcquire ctx{input, std::move(task)};
+
+      portabletest::TestDeviceCollection const& deviceProduct = ctx.get(input);
+
+      // allocate a host product based on the metadata of the device product
+      hostProduct_ = portabletest::TestHostCollection{deviceProduct->metadata().size(), ctx.queue()};
+
+      // FIXME find a way to avoid the copy when the device product is actually a wrapped host prodict
+
+      // copy the content of the device product to the host product
+      alpaka::memcpy(ctx.queue(), hostProduct_.buffer(), deviceProduct.const_buffer());
+
+      // do not wait for the asynchronous operation to complete
+    }
+
     void produce(edm::Event& event, edm::EventSetup const&) override {
-      // create a context based on the EDM stream number
-      cms::alpakatools::ScopedContextProduce<Queue> ctx(event.streamID());
-
-      portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
-
-      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), ctx.queue()};
-      alpaka::memcpy(ctx.queue(), hostProduct.buffer(), deviceProduct.const_buffer());
-
-      // wait for any async work to complete
-      alpaka::wait(ctx.queue());
-
-      event.emplace(hostToken_, std::move(hostProduct));
+      // produce() is called once the asynchronous operation has completed, so there is no need for an explicit wait
+      event.emplace(hostToken_, std::move(hostProduct_));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -59,13 +65,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
   private:
-    const edm::EDGetTokenT<portabletest::TestDeviceCollection> deviceToken_;
+    const edm::EDGetTokenT<cms::alpakatools::Product<Queue, portabletest::TestDeviceCollection>> deviceToken_;
     const edm::EDPutTokenT<portabletest::TestHostCollection> hostToken_;
+
+    // hold the output product between acquire() and produce()
+    portabletest::TestHostCollection hostProduct_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 #include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaTranscriber);
-
-#endif  // defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -46,7 +46,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       Queue queue{*device_};
       portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
 
-      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), alpaka_common::host(), *device_};
+      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), cms::alpakatools::host(), *device_};
       alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.const_buffer());
 
       // wait for any async work to complete

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/AlpakaCore/interface/chooseDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
@@ -36,9 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (not service->enabled()) {
         throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
       }
-      auto& devices = service->devices();
-      unsigned int index = sid.value() % devices.size();
-      device_ = devices[index];
+      device_ = cms::alpakatools::chooseDevice<Platform>(sid);
     }
 
     void produce(edm::Event& event, edm::EventSetup const&) override {

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -21,7 +21,6 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaCore/interface/chooseDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -45,7 +44,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       Queue queue{*device_};
       portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
 
-      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), cms::alpakatools::host(), *device_};
+      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), queue};
       alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.const_buffer());
 
       // wait for any async work to complete

--- a/HeterogeneousCore/AlpakaTest/test/reader.py
+++ b/HeterogeneousCore/AlpakaTest/test/reader.py
@@ -17,7 +17,7 @@ process.testAnalyzer = cms.EDAnalyzer('TestAlpakaAnalyzer',
 
 # analyse the second product
 process.testAnalyzerSerial = cms.EDAnalyzer('TestAlpakaAnalyzer',
-    source = cms.InputTag('testProducerSerial')
+    source = cms.InputTag('testTranscriberSerial')
 )
 
 process.cuda_path = cms.Path(process.testAnalyzer)


### PR DESCRIPTION
#### PR description:

Implement the alpaka-based accelerator framework for CMSSW.

There are a few open issues, that could be addressed by further developments here or in a follow-up PR:
  - the CPU workflow is inefficient with an extra memory copy;
  - the use of `beginStream()` needs to be understood and eventually removed;
  - memory operations should be updated:
    - ~~the versions of `make_host_buffer` that take a queue could add the intermediate case of falling back to `allocAsyncBuf` to provide non-cached, queue-ordered, non-pinned host memory;~~ this is currently not available in alpaka (there is no `allocMappedAsyncBuf` call)
    - ~~the various specialisations of `allocCachedBuf` could support both blocking and non-blocking queues.~~ done

#### PR validation:

The unit tests pass and the test modules seem to behave as expected.