### PR TITLE
Utilities/StaticAnalyzer: Add TFileServer:: functions to list of known thread unsafe functions.

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -35,6 +35,7 @@ fi
 sort -u < statics-report.txt.unsorted > statics-report.txt
 grep -e "^In call stack " statics-report.txt | awk '{print $0"\n"}' > modules2statics.txt
 grep -e "^Non-const static variable " statics-report.txt | awk '{print $0"\n"}' > statics2modules.txt
+grep -e "^Known thread unsafe function " statics-report.txt | awk '{print $0"\n"}' >> statics2modules.txt
 
 if [ ! -f ./edm-global-class.py ]
 	then

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -51,25 +51,45 @@ for tfunc in sorted(toplevelfuncs):
         if G.has_node(tfunc) and G.has_node(static) and nx.has_path(G, tfunc, static):
             path = nx.shortest_path(G, tfunc, static)
 
-            print("Non-const static variable \'"+re.sub(farg, "()",
-                                                        static)+"' is accessed in call stack '", end=' ')
-            for i in range(0, len(path)-1):
-                print(re.sub(farg, "()", path[i]) +
-                      G[path[i]][path[i+1]]['kind'], end=' ')
-            print(re.sub(farg, "()", path[i+1])+"' ,", end=' ')
-            for key in G[tfunc].keys():
-                if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ':
-                    print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
-                          re.sub(farg, "()", key)+"'", end=' ')
-            print()
+            if 'kind' in G[path[len(path)-2]][path[len(path)-1]] and G[path[len(path)-2]][path[len(path)-1]]['kind'] == ' static variable ':
+                for key in G[tfunc].keys():
+                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not (key.startswith('edm::one') or key.startswith('edm::global')):
+                        print("Non-const static variable \'"+re.sub(farg, "()",
+                                                                    static)+"' is accessed in call stack '", end=' ')
+                        for i in range(0, len(path)-1):
+                            print(re.sub(farg, "()", path[i]) +
+                                  G[path[i]][path[i+1]]['kind'], end=' ')
+                        print(re.sub(farg, "()", path[i+1])+"' ,", end=' ')
+                        print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
+                              re.sub(farg, "()", key)+"'", end=' ')
+                        print()
 
-            print("In call stack ' ", end=' ')
-            for i in range(0, len(path)-1):
-                print(re.sub(farg, "()", path[i]) +
-                      G[path[i]][path[i+1]]['kind'], end=' ')
-            print(re.sub(farg, "()", path[i+1])+"' is accessed ,", end=' ')
-            for key in G[tfunc].keys():
-                if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ':
-                    print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
-                          re.sub(farg, "()", key)+"'", end=' ')
-            print()
+                        print("In call stack ' ", end=' ')
+                        for i in range(0, len(path)-1):
+                            print(re.sub(farg, "()", path[i]) +
+                                  G[path[i]][path[i+1]]['kind'], end=' ')
+                        print(re.sub(farg, "()", path[i+1])+"' is accessed ,", end=' ')
+                        print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
+                              re.sub(farg, "()", key)+"'", end=' ')
+                        print()
+            else:
+                for key in G[tfunc].keys():
+                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not (key.startswith('edm::one') or key.startswith('edm::global')):
+                        print("Known thread unsafe function \'"+re.sub(farg, "()",
+                                                                       static)+"' is called in call stack '", end=' ')
+                        for i in range(0, len(path)-1):
+                            print(re.sub(farg, "()", path[i]) +
+                                  G[path[i]][path[i+1]]['kind'], end=' ')
+                        print(re.sub(farg, "()", path[i+1])+"' ,", end=' ')
+                        print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
+                                  re.sub(farg, "()", key)+"'", end=' ')
+                        print()
+
+                        print("In call stack ' ", end=' ')
+                        for i in range(0, len(path)-1):
+                            print(re.sub(farg, "()", path[i]) +
+                                  G[path[i]][path[i+1]]['kind'], end=' ')
+                        print(G[path[len(path)-2]][path[len(path)-1]]['kind']+" "+re.sub(farg, "()", static)+"' is called ,", end=' ')
+                        print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
+                                      re.sub(farg, "()", key)+"'", end=' ')
+                        print()

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -53,7 +53,7 @@ for tfunc in sorted(toplevelfuncs):
 
             if 'kind' in G[path[len(path)-2]][path[len(path)-1]] and G[path[len(path)-2]][path[len(path)-1]]['kind'] == ' static variable ':
                 for key in G[tfunc].keys():
-                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not (key.startswith('edm::one') or key.startswith('edm::global')):
+                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not key.startswith('edm::one'):
                         print("Non-const static variable \'"+re.sub(farg, "()",
                                                                     static)+"' is accessed in call stack '", end=' ')
                         for i in range(0, len(path)-1):
@@ -74,7 +74,7 @@ for tfunc in sorted(toplevelfuncs):
                         print()
             else:
                 for key in G[tfunc].keys():
-                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not (key.startswith('edm::one') or key.startswith('edm::global')):
+                    if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not key.startswith('edm::one'):
                         print("Known thread unsafe function \'"+re.sub(farg, "()",
                                                                        static)+"' is called in call stack '", end=' ')
                         for i in range(0, len(path)-1):

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -207,6 +207,7 @@ bool clangcms::support::isKnownThrUnsafeFunc(const std::string &fname) {
                                                  "TTable::Fit(const char *,",
                                                  "TTree::Fit(const char *,",
                                                  "TTreePlayer::Fit(const char *,",
+                                                 "TFileService::",
                                                  "CLHEP::HepMatrix::determinant("};
   for (auto &name : names)
     if (fname.substr(0, name.length()) == name)


### PR DESCRIPTION
Utilities/StaticAnalyzer: Add TFileServer:: functions to list of known thread unsafe functions.
    Update statics.py to only report non-const static access for non edm::one modules.
    Update statics.py to report calls to TFileServer:: functions from non edm::one modules

Tested locally.