### PR TITLE
Backport option to override GEN decays with FastSim decays 

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/Decayer.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/Decayer.h
@@ -50,11 +50,9 @@ namespace fastsim
             \param engine The Random Engine.
         */
         void decay(const Particle & particle, std::vector<std::unique_ptr<Particle> > & secondaries, CLHEP::HepRandomEngine & engine) const;
-        void setfixLongLivedBug(bool disable){ fixLongLivedBug_ = disable; };            
         private:    
         std::unique_ptr<Pythia8::Pythia> pythia_;  //!< Instance of pythia
         std::unique_ptr<gen::P8RndmEngine> pythiaRandomEngine_;  //!< Instance of pythia Random Engine
-        bool fixLongLivedBug_;
     };
 }
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -9,38 +9,34 @@
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 
-
 ///////////////////////////////////////////////
 // Author: L. Vanelderen, S. Kurz
 // Date: 29 May 2017
 //////////////////////////////////////////////////////////
 
-
-namespace HepPDT
-{
-    class ParticleDataTable;
+namespace HepPDT {
+  class ParticleDataTable;
 }
 
 class RandomEngineAndDistribution;
 
 namespace fastsim {
-    class Particle;
-    class ParticleFilter;
-    class SimplifiedGeometry;
+  class Particle;
+  class ParticleFilter;
+  class SimplifiedGeometry;
 
-    //! Manages GenParticles and Secondaries from interactions.
-    /*!
+  //! Manages GenParticles and Secondaries from interactions.
+  /*!
         Manages which particle has to be propagated next, this includes GenParticles and secondaries from the interactions.
         Furthermore, checks if all necessary information is included with the GenParticles (charge, lifetime), otherwise 
         reads information from HepPDT::ParticleDataTable.
         Also handles secondaries, including closestChargedDaughter algorithm which is used for FastSim (cheat) tracking: a charged daughter can
         continue the track of a charged mother, see addSecondaries(...).
     */
-    class ParticleManager
-    {
-        public:
-        //! Constructor.
-        /*!
+  class ParticleManager {
+  public:
+    //! Constructor.
+    /*!
             \param genEvent Get the GenEvent.
             \param particleDataTable Get information about particles, e.g. charge, lifetime.
             \param beamPipeRadius Radius of the beampipe.
@@ -49,113 +45,111 @@ namespace fastsim {
             \param simTracks The SimTracks.
             \param simVertices The SimVertices.
         */
-        ParticleManager(
-            const HepMC::GenEvent & genEvent,
-            const HepPDT::ParticleDataTable & particleDataTable,
-            double beamPipeRadius,
-            double deltaRchargedMother,
-            const ParticleFilter & particleFilter,
-            std::vector<SimTrack> & simTracks,
-            std::vector<SimVertex> & simVertices,
-            bool fixLongLivedBug);
-        
-        //! Default destructor.
-        ~ParticleManager();
+    ParticleManager(const HepMC::GenEvent& genEvent,
+                    const HepPDT::ParticleDataTable& particleDataTable,
+                    double beamPipeRadius,
+                    double deltaRchargedMother,
+                    const ParticleFilter& particleFilter,
+                    std::vector<SimTrack>& simTracks,
+                    std::vector<SimVertex>& simVertices,
+                    bool useFastSimsDecayer);
 
-        //! Returns the next particle that has to be propagated (secondary or genParticle).
-        /*!
+    //! Default destructor.
+    ~ParticleManager();
+
+    //! Returns the next particle that has to be propagated (secondary or genParticle).
+    /*!
             Main method of this class. At first consideres particles from the buffer (secondaries) if there are none, then the
             next GenParticle is considered. Only returns particles that pass the (kinetic) cuts of the ParticleFilter.
             Furthermore, uses the ParticleDataTable to ensure all necessary information about the particle is stored (lifetime, charge).
             \return The next particle that has to be propagated.
             \sa ParticleFilter
         */
-        std::unique_ptr<Particle> nextParticle(const RandomEngineAndDistribution & random);
-        
-        //! Adds secondaries that are produced by any of the interactions (or particle decay) to the buffer.
-        /*!
+    std::unique_ptr<Particle> nextParticle(const RandomEngineAndDistribution& random);
+
+    //! Adds secondaries that are produced by any of the interactions (or particle decay) to the buffer.
+    /*!
             Also checks which charged daughter is closest to a charged mother (in deltaR) and assigns the same SimTrack ID.
             \param vertexPosition The origin vertex (interaction or particle decay took place here).
             \param motherSimTrackId SimTrack ID of the mother particle, necessary for FastSim (cheat) tracking.
             \param secondaries All secondaries that where produced in a single particle decay or interaction.
         */
-        void addSecondaries(
-            const math::XYZTLorentzVector & vertexPosition,
-            int motherSimTrackId,
-            std::vector<std::unique_ptr<Particle> > & secondaries,
-            const SimplifiedGeometry * layer = nullptr);
+    void addSecondaries(const math::XYZTLorentzVector& vertexPosition,
+                        int motherSimTrackId,
+                        std::vector<std::unique_ptr<Particle> >& secondaries,
+                        const SimplifiedGeometry* layer = nullptr);
 
-        //! Returns the position of a given SimVertex. Needed for interfacing the code with the old calorimetry.
-        const SimVertex getSimVertex(unsigned i) { return simVertices_->at(i); }
+    //! Returns the position of a given SimVertex. Needed for interfacing the code with the old calorimetry.
+    const SimVertex getSimVertex(unsigned i) { return simVertices_->at(i); }
 
-        //! Returns a given SimTrack. Needed for interfacing the code with the old calorimetry.
-        const SimTrack getSimTrack(unsigned i) { return simTracks_->at(i); }
+    //! Returns a given SimTrack. Needed for interfacing the code with the old calorimetry.
+    const SimTrack getSimTrack(unsigned i) { return simTracks_->at(i); }
 
-        //! Necessary to add an end vertex to a particle.
-        /*!
+    //! Necessary to add an end vertex to a particle.
+    /*!
             Needed if particle is no longer propagated for some reason (e.g. remaining energy below threshold) and no
             secondaries where produced at that point.
             \return Index of that vertex.
         */
-        unsigned addEndVertex(const Particle * particle);
+    unsigned addEndVertex(const Particle* particle);
 
-        private:
-        //! Add a simVertex (simVertex contains information about the track it was produced).
-        /*!
+  private:
+    //! Add a simVertex (simVertex contains information about the track it was produced).
+    /*!
             Add a origin vertex for any particle.
             \param position Position of the vertex.
             \param motherIndex Index of the parent's simTrack.
             \return Index of that simVertex.
         */
-        unsigned addSimVertex(
-            const math::XYZTLorentzVector & position,
-            int motherIndex);
-        
-        //! Add a simTrack (simTrack contains some basic info about the particle, e.g. pdgId).
-        /*!
+    unsigned addSimVertex(const math::XYZTLorentzVector& position, int motherIndex);
+
+    //! Add a simTrack (simTrack contains some basic info about the particle, e.g. pdgId).
+    /*!
             Add a simTrack for a given particle and assign an index for that track. This might also be the index of the track
             of the mother particle (FastSim cheat tracking).
             \param particle Particle that produces that simTrack.
             \return Index of that simTrack.
         */
+    unsigned addSimTrack(const Particle* particle);
+    void exoticRelativesChecker(const HepMC::GenVertex* originVertex, int& hasExoticAssociation, int ngendepth);
 
-        unsigned addSimTrack(const Particle * particle);
-        void exoticRelativesChecker(const HepMC::GenVertex* originVertex, int& hasExoticAssociation, int ngendepth);
-
-        //! Returns next particle from the GenEvent that has to be propagated.
-        /*!
+    //! Returns next particle from the GenEvent that has to be propagated.
+    /*!
             Tries to get some basic information about the status of the particle from the GenEvent and does some first rejection cuts based on them.
         */
-        std::unique_ptr<Particle> nextGenParticle();
+    std::unique_ptr<Particle> nextGenParticle();
 
-        // data members
-        const HepMC::GenEvent * const genEvent_;  //!< The GenEvent 
-        HepMC::GenEvent::particle_const_iterator genParticleIterator_;  //!< Iterator to keep track on which GenParticles where already considered.
-        const HepMC::GenEvent::particle_const_iterator genParticleEnd_;  //!< The last particle of the GenEvent.
-        int genParticleIndex_;  //!< Index of particle in the GenEvent (if it is a GenParticle)
-        const HepPDT::ParticleDataTable * const particleDataTable_;  //!< Necessary to get information like lifetime and charge of a particle if unknown.
-        const double beamPipeRadius2_;  //!< (Radius of the beampipe)^2
-        const double deltaRchargedMother_;  //!< For FastSim (cheat) tracking: cut on the angle between a charged mother and charged daughter.
-        const ParticleFilter * const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
-        std::vector<SimTrack> * simTracks_;  //!< The generated SimTrack of this event.
-        std::vector<SimVertex> * simVertices_;  //!< The generated SimVertices of this event.
-        double momentumUnitConversionFactor_;  //!< Convert pythia units to GeV (FastSim standard)
-        double lengthUnitConversionFactor_;  //!< Convert pythia unis to cm (FastSim standard)
-        double lengthUnitConversionFactor2_;  //!< Convert pythia unis to cm^2 (FastSim standard)
-        double timeUnitConversionFactor_;  //!< Convert pythia unis to ns (FastSim standard)
-        std::vector<std::unique_ptr<Particle> > particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
-        bool fixLongLivedBug_;
-    };
-}
+    // data members
+    const HepMC::GenEvent* const genEvent_;  //!< The GenEvent
+    HepMC::GenEvent::particle_const_iterator
+        genParticleIterator_;  //!< Iterator to keep track on which GenParticles where already considered.
+    const HepMC::GenEvent::particle_const_iterator genParticleEnd_;  //!< The last particle of the GenEvent.
+    int genParticleIndex_;  //!< Index of particle in the GenEvent (if it is a GenParticle)
+    const HepPDT::ParticleDataTable* const
+        particleDataTable_;         //!< Necessary to get information like lifetime and charge of a particle if unknown.
+    const double beamPipeRadius2_;  //!< (Radius of the beampipe)^2
+    const double
+        deltaRchargedMother_;  //!< For FastSim (cheat) tracking: cut on the angle between a charged mother and charged daughter.
+    const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
+    std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
+    std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
+    bool useFastSimsDecayer_;
+    double momentumUnitConversionFactor_;  //!< Convert pythia units to GeV (FastSim standard)
+    double lengthUnitConversionFactor_;    //!< Convert pythia unis to cm (FastSim standard)
+    double lengthUnitConversionFactor2_;   //!< Convert pythia unis to cm^2 (FastSim standard)
+    double timeUnitConversionFactor_;      //!< Convert pythia unis to ns (FastSim standard)
+    std::vector<std::unique_ptr<Particle> >
+        particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
+  };
+}  // namespace fastsim
 
-inline bool isExotic(bool fixLongLivedBug, int pdgid_) {
+inline bool isExotic(int pdgid_) {
   unsigned int pdgid = std::abs(pdgid_);
   return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
           pdgid == 17 ||                                                // 4th generation lepton
           pdgid == 34 ||                                                // W-prime
-          pdgid == 37 ||                                                // charged Higgs  
-          (pdgid == 39 && fixLongLivedBug));                           // bulk graviton
- 
+          pdgid == 37 ||                                                // charged Higgs
+          pdgid == 39);                                                 // bulk graviton
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -34,24 +34,21 @@
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/InteractionModel.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/InteractionModelFactory.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h"
-#include "FastSimulation/Particle/interface/makeParticle.h" 
+#include "FastSimulation/Particle/interface/makeParticle.h"
 
 // Hack for calorimetry
 #include "FastSimulation/Event/interface/FSimTrack.h"
 #include "FastSimulation/Calorimetry/interface/CalorimetryManager.h"
-#include "FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h"  
+#include "FastSimulation/CaloGeometryTools/interface/CaloGeometryHelper.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "FastSimulation/ShowerDevelopment/interface/FastHFShowerLibrary.h"
 
-
-
 ///////////////////////////////////////////////
 // Author: L. Vanelderen, S. Kurz
 // Date: 29 May 2017
 //////////////////////////////////////////////////////////
-
 
 //! The core class of the new SimplifiedGeometryPropagator.
 /*!
@@ -65,506 +62,449 @@
     7) If last particle was propagated add SimTracks, SimVertices, SimHits,... to the event
 */
 class FastSimProducer : public edm::stream::EDProducer<> {
-    public:
-    explicit FastSimProducer(const edm::ParameterSet&);
-    ~FastSimProducer() override{;}
+public:
+  explicit FastSimProducer(const edm::ParameterSet&);
+  ~FastSimProducer() override { ; }
 
-    private:
-    void beginStream(edm::StreamID id) override;
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override;
-    virtual FSimTrack createFSimTrack(fastsim::Particle* particle, fastsim::ParticleManager* particleManager, HepPDT::ParticleDataTable const& particleTable);
+private:
+  void beginStream(edm::StreamID id) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
+  virtual FSimTrack createFSimTrack(fastsim::Particle* particle,
+                                    fastsim::ParticleManager* particleManager,
+                                    HepPDT::ParticleDataTable const& particleTable);
 
-    edm::EDGetTokenT<edm::HepMCProduct> genParticlesToken_; //!< Token to get the genParticles
-    fastsim::Geometry geometry_; //!< The definition of the tracker according to python config
-    fastsim::Geometry caloGeometry_; //!< Hack to interface "old" calo to "new" tracking
-    double beamPipeRadius_; //!< The radius of the beampipe
-    double deltaRchargedMother_;  //!< Cut on deltaR for ClosestChargedDaughter algorithm (FastSim tracking)
-    fastsim::ParticleFilter particleFilter_;  //!< Decides which particles have to be propagated
-    std::unique_ptr<RandomEngineAndDistribution> _randomEngine;  //!< The random engine
+  edm::EDGetTokenT<edm::HepMCProduct> genParticlesToken_;  //!< Token to get the genParticles
+  fastsim::Geometry geometry_;                             //!< The definition of the tracker according to python config
+  fastsim::Geometry caloGeometry_;                         //!< Hack to interface "old" calo to "new" tracking
+  double beamPipeRadius_;                                  //!< The radius of the beampipe
+  double deltaRchargedMother_;              //!< Cut on deltaR for ClosestChargedDaughter algorithm (FastSim tracking)
+  fastsim::ParticleFilter particleFilter_;  //!< Decides which particles have to be propagated
+  std::unique_ptr<RandomEngineAndDistribution> _randomEngine;  //!< The random engine
 
-    bool simulateCalorimetry;
-    edm::ESWatcher<CaloGeometryRecord> watchCaloGeometry_;  
-    edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;  
-    std::unique_ptr<CalorimetryManager> myCalorimetry; // unfortunately, default constructor cannot be called 
-    bool simulateMuons;    
+  bool simulateCalorimetry;
+  edm::ESWatcher<CaloGeometryRecord> watchCaloGeometry_;
+  edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;
+  std::unique_ptr<CalorimetryManager> myCalorimetry;  // unfortunately, default constructor cannot be called
+  bool simulateMuons;
+  bool useFastSimsDecayer;
 
-    fastsim::Decayer decayer_;  //!< Handles decays of non-stable particles using pythia
-    std::vector<std::unique_ptr<fastsim::InteractionModel> > interactionModels_;  //!< All defined interaction models
-    std::map<std::string, fastsim::InteractionModel *> interactionModelMap_;  //!< Each interaction model has a unique name
-    static const std::string MESSAGECATEGORY;  //!< Category of debugging messages ("FastSimulation")
-    
-    bool fixLongLivedBug_;
+  fastsim::Decayer decayer_;  //!< Handles decays of non-stable particles using pythia
+  std::vector<std::unique_ptr<fastsim::InteractionModel> > interactionModels_;  //!< All defined interaction models
+  std::map<std::string, fastsim::InteractionModel*> interactionModelMap_;  //!< Each interaction model has a unique name
+  static const std::string MESSAGECATEGORY;  //!< Category of debugging messages ("FastSimulation")
 };
 
 const std::string FastSimProducer::MESSAGECATEGORY = "FastSimulation";
 
 FastSimProducer::FastSimProducer(const edm::ParameterSet& iConfig)
-    : genParticlesToken_(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("src"))) 
-    , geometry_(iConfig.getParameter<edm::ParameterSet>("trackerDefinition"))
-    , caloGeometry_(iConfig.getParameter<edm::ParameterSet>("caloDefinition"))
-    , beamPipeRadius_(iConfig.getParameter<double>("beamPipeRadius"))
-    , deltaRchargedMother_(iConfig.getParameter<double>("deltaRchargedMother"))
-    , particleFilter_(iConfig.getParameter<edm::ParameterSet>("particleFilter"))
-    , _randomEngine(nullptr)
-    , simulateCalorimetry(iConfig.getParameter<bool>("simulateCalorimetry"))
-    , simulateMuons(iConfig.getParameter<bool>("simulateMuons"))
-    , fixLongLivedBug_(iConfig.getParameter<bool>("fixLongLivedBug"))
-{
-    // Fix the decayer for the long lived stuff
-    decayer_.setfixLongLivedBug(fixLongLivedBug_);
-    //----------------
-    // define interaction models
-    //---------------
+    : genParticlesToken_(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("src"))),
+      geometry_(iConfig.getParameter<edm::ParameterSet>("trackerDefinition")),
+      caloGeometry_(iConfig.getParameter<edm::ParameterSet>("caloDefinition")),
+      beamPipeRadius_(iConfig.getParameter<double>("beamPipeRadius")),
+      deltaRchargedMother_(iConfig.getParameter<double>("deltaRchargedMother")),
+      particleFilter_(iConfig.getParameter<edm::ParameterSet>("particleFilter")),
+      _randomEngine(nullptr),
+      simulateCalorimetry(iConfig.getParameter<bool>("simulateCalorimetry")),
+      simulateMuons(iConfig.getParameter<bool>("simulateMuons")),
+      useFastSimsDecayer(iConfig.getParameter<bool>("useFastSimsDecayer")) {
+  //----------------
+  // define interaction models
+  //---------------
 
-    const edm::ParameterSet & modelCfgs = iConfig.getParameter<edm::ParameterSet>("interactionModels");
-    for(const std::string & modelName : modelCfgs.getParameterNames())
-    {
-        const edm::ParameterSet & modelCfg = modelCfgs.getParameter<edm::ParameterSet>(modelName);
-        std::string modelClassName(modelCfg.getParameter<std::string>("className"));
-        // Use plugin-factory to create model
-        std::unique_ptr<fastsim::InteractionModel> interactionModel(fastsim::InteractionModelFactory::get()->create(modelClassName, modelName, modelCfg));
-        if(!interactionModel.get()){
-            throw cms::Exception("FastSimProducer") << "InteractionModel " << modelName << " could not be created";
-        }
-        // Add model to list
-        interactionModels_.push_back(std::move(interactionModel));
-        // and create the map
-        interactionModelMap_[modelName] = interactionModels_.back().get();
+  const edm::ParameterSet& modelCfgs = iConfig.getParameter<edm::ParameterSet>("interactionModels");
+  for (const std::string& modelName : modelCfgs.getParameterNames()) {
+    const edm::ParameterSet& modelCfg = modelCfgs.getParameter<edm::ParameterSet>(modelName);
+    std::string modelClassName(modelCfg.getParameter<std::string>("className"));
+    // Use plugin-factory to create model
+    std::unique_ptr<fastsim::InteractionModel> interactionModel(
+        fastsim::InteractionModelFactory::get()->create(modelClassName, modelName, modelCfg));
+    if (!interactionModel.get()) {
+      throw cms::Exception("FastSimProducer") << "InteractionModel " << modelName << " could not be created";
     }
+    // Add model to list
+    interactionModels_.push_back(std::move(interactionModel));
+    // and create the map
+    interactionModelMap_[modelName] = interactionModels_.back().get();
+  }
 
-    //----------------
-    // calorimetry
-    //---------------
+  //----------------
+  // calorimetry
+  //---------------
 
-    if(simulateCalorimetry){
-        myCalorimetry.reset(new CalorimetryManager(nullptr,
-                            iConfig.getParameter<edm::ParameterSet>("Calorimetry"),              
-                            iConfig.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInECAL"),
-                            iConfig.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInHCAL"),
-                            iConfig.getParameter<edm::ParameterSet>("GFlash")));
-    }    
+  if (simulateCalorimetry) {
+    myCalorimetry.reset(new CalorimetryManager(nullptr,
+                                               iConfig.getParameter<edm::ParameterSet>("Calorimetry"),
+                                               iConfig.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInECAL"),
+                                               iConfig.getParameter<edm::ParameterSet>("MaterialEffectsForMuonsInHCAL"),
+                                               iConfig.getParameter<edm::ParameterSet>("GFlash")));
+  }
 
-    //----------------
-    // register products
-    //----------------
+  //----------------
+  // register products
+  //----------------
 
-    // SimTracks and SimVertices
-    produces<edm::SimTrackContainer>();
-    produces<edm::SimVertexContainer>();
-    // products of interaction models, i.e. simHits
-    for(auto & interactionModel : interactionModels_)
-    {
-        interactionModel->registerProducts(*this);
-    }
-    produces<edm::PCaloHitContainer>("EcalHitsEB");
-    produces<edm::PCaloHitContainer>("EcalHitsEE");
-    produces<edm::PCaloHitContainer>("EcalHitsES");
-    produces<edm::PCaloHitContainer>("HcalHits");
-    produces<edm::SimTrackContainer>("MuonSimTracks");
+  // SimTracks and SimVertices
+  produces<edm::SimTrackContainer>();
+  produces<edm::SimVertexContainer>();
+  // products of interaction models, i.e. simHits
+  for (auto& interactionModel : interactionModels_) {
+    interactionModel->registerProducts(*this);
+  }
+  produces<edm::PCaloHitContainer>("EcalHitsEB");
+  produces<edm::PCaloHitContainer>("EcalHitsEE");
+  produces<edm::PCaloHitContainer>("EcalHitsES");
+  produces<edm::PCaloHitContainer>("HcalHits");
+  produces<edm::SimTrackContainer>("MuonSimTracks");
 }
 
-void
-FastSimProducer::beginStream(const edm::StreamID id)
-{
-    _randomEngine = std::make_unique<RandomEngineAndDistribution>(id);
+void FastSimProducer::beginStream(const edm::StreamID id) {
+  _randomEngine = std::make_unique<RandomEngineAndDistribution>(id);
 }
 
-void
-FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    LogDebug(MESSAGECATEGORY) << "   produce";
+void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  LogDebug(MESSAGECATEGORY) << "   produce";
 
-    geometry_.update(iSetup, interactionModelMap_);
-    caloGeometry_.update(iSetup, interactionModelMap_);
+  geometry_.update(iSetup, interactionModelMap_);
+  caloGeometry_.update(iSetup, interactionModelMap_);
 
-    // Define containers for SimTracks, SimVertices
-    std::unique_ptr<edm::SimTrackContainer> simTracks_(new edm::SimTrackContainer);
-    std::unique_ptr<edm::SimVertexContainer> simVertices_(new edm::SimVertexContainer);
+  // Define containers for SimTracks, SimVertices
+  std::unique_ptr<edm::SimTrackContainer> simTracks_(new edm::SimTrackContainer);
+  std::unique_ptr<edm::SimVertexContainer> simVertices_(new edm::SimVertexContainer);
 
-    // Get the particle data table (in case lifetime or charge of GenParticles not set)
-    edm::ESHandle <HepPDT::ParticleDataTable> pdt;
-    iSetup.getData(pdt);
+  // Get the particle data table (in case lifetime or charge of GenParticles not set)
+  edm::ESHandle<HepPDT::ParticleDataTable> pdt;
+  iSetup.getData(pdt);
 
-    // Get the GenParticle collection
-    edm::Handle<edm::HepMCProduct> genParticles;
-    iEvent.getByToken(genParticlesToken_, genParticles);
+  // Get the GenParticle collection
+  edm::Handle<edm::HepMCProduct> genParticles;
+  iEvent.getByToken(genParticlesToken_, genParticles);
 
-    // Load the ParticleManager which returns the particles that have to be propagated
-    // Creates a fastsim::Particle out of a GenParticle/secondary
-    fastsim::ParticleManager particleManager(*genParticles->GetEvent()
-                                            ,*pdt
-                                            ,beamPipeRadius_
-                                            ,deltaRchargedMother_
-                                            ,particleFilter_
-                                            ,*simTracks_
-                                            ,*simVertices_
-                                            ,fixLongLivedBug_);
+  // Load the ParticleManager which returns the particles that have to be propagated
+  // Creates a fastsim::Particle out of a GenParticle/secondary
+  fastsim::ParticleManager particleManager(*genParticles->GetEvent(),
+                                           *pdt,
+                                           beamPipeRadius_,
+                                           deltaRchargedMother_,
+                                           particleFilter_,
+                                           *simTracks_,
+                                           *simVertices_,
+                                           useFastSimsDecayer);
 
-    //  Initialize the calorimeter geometry
-    if(simulateCalorimetry)
-    {
-        if(watchCaloGeometry_.check(iSetup) || watchCaloTopology_.check(iSetup)){
-            edm::ESHandle<CaloGeometry> pG;
-            iSetup.get<CaloGeometryRecord>().get(pG);   
-            myCalorimetry->getCalorimeter()->setupGeometry(*pG); 
-                
-            edm::ESHandle<CaloTopology> theCaloTopology;
-            iSetup.get<CaloTopologyRecord>().get(theCaloTopology);     
-            myCalorimetry->getCalorimeter()->setupTopology(*theCaloTopology);
-            myCalorimetry->getCalorimeter()->initialize(geometry_.getMagneticFieldZ(math::XYZTLorentzVector(0., 0., 0., 0.)));
+  //  Initialize the calorimeter geometry
+  if (simulateCalorimetry) {
+    if (watchCaloGeometry_.check(iSetup) || watchCaloTopology_.check(iSetup)) {
+      edm::ESHandle<CaloGeometry> pG;
+      iSetup.get<CaloGeometryRecord>().get(pG);
+      myCalorimetry->getCalorimeter()->setupGeometry(*pG);
 
-            myCalorimetry->getHFShowerLibrary()->initHFShowerLibrary(iSetup);
-        }
+      edm::ESHandle<CaloTopology> theCaloTopology;
+      iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
+      myCalorimetry->getCalorimeter()->setupTopology(*theCaloTopology);
+      myCalorimetry->getCalorimeter()->initialize(geometry_.getMagneticFieldZ(math::XYZTLorentzVector(0., 0., 0., 0.)));
 
-        // Important: this also cleans the calorimetry information from the last event
-        myCalorimetry->initialize(_randomEngine.get());
+      myCalorimetry->getHFShowerLibrary()->initHFShowerLibrary(iSetup);
     }
 
-    // The vector of SimTracks needed for the CalorimetryManager
-    std::vector<FSimTrack> myFSimTracks;
+    // Important: this also cleans the calorimetry information from the last event
+    myCalorimetry->initialize(_randomEngine.get());
+  }
 
-    
-    LogDebug(MESSAGECATEGORY) << "################################"
-                  << "\n###############################";    
+  // The vector of SimTracks needed for the CalorimetryManager
+  std::vector<FSimTrack> myFSimTracks;
 
-    // loop over particles
-    for(std::unique_ptr<fastsim::Particle> particle = particleManager.nextParticle(*_randomEngine); particle != nullptr; particle=particleManager.nextParticle(*_randomEngine)) 
-    {
-        LogDebug(MESSAGECATEGORY) << "\n   moving NEXT particle: " << *particle;
+  LogDebug(MESSAGECATEGORY) << "################################"
+                            << "\n###############################";
 
-        // -----------------------------
-        // This condition is necessary because of hack for calorimetry
-        // -> The CalorimetryManager should also be implemented based on this new FastSim classes (Particle.h) in a future project.
-        // A second loop (below) loops over all parts of the calorimetry in order to create a track of the old FastSim class FSimTrack.
-        // The condition below (R<128, z<302) makes sure that the particle geometrically is outside the tracker boundaries
-        // -----------------------------
-
-        if(particle->position().Perp2() < 128.*128. && std::abs(particle->position().Z()) < 302.){ 
-            // move the particle through the layers
-            fastsim::LayerNavigator layerNavigator(geometry_);
-            const fastsim::SimplifiedGeometry * layer = nullptr;
-
-            // moveParticleToNextLayer(..) returns 0 in case that particle decays
-            // in this case particle is propagated up to its decay vertex
-            while(layerNavigator.moveParticleToNextLayer(*particle,layer))
-            {
-                LogDebug(MESSAGECATEGORY) << "   moved to next layer: " << *layer;
-                LogDebug(MESSAGECATEGORY) << "   new state: " << *particle;
-
-                // Hack to interface "old" calo to "new" tracking
-                // Particle reached calorimetry so stop further propagation
-                if(layer->getCaloType() == fastsim::SimplifiedGeometry::TRACKERBOUNDARY)
-                {
-                    layer = nullptr;
-                    // particle no longer is on a layer
-                    particle->resetOnLayer();
-                    break;
-                }
-
-                // break after 25 ns: only happens for particles stuck in loops
-                if(particle->position().T() > 25)
-                {
-                    layer = nullptr;
-                    // particle no longer is on a layer
-                    particle->resetOnLayer();
-                    break;
-                }
-
-                // perform interaction between layer and particle
-                // do only if there is actual material
-                if(layer->getThickness(particle->position(), particle->momentum()) > 1E-10){
-                    int nSecondaries = 0;
-                    // loop on interaction models
-                    for(fastsim::InteractionModel * interactionModel : layer->getInteractionModels())
-                    {
-                        LogDebug(MESSAGECATEGORY) << "   interact with " << *interactionModel;
-                        std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-                        interactionModel->interact(*particle,*layer,secondaries,*_randomEngine);
-                        nSecondaries += secondaries.size();
-                        particleManager.addSecondaries(particle->position(),particle->simTrackIndex(),secondaries,layer);
-                    }
-
-                    // kinematic cuts: particle might e.g. lost all its energy
-                    if(!particleFilter_.acceptsEn(*particle))
-                    {   
-                        // Add endvertex if particle did not create any secondaries
-                        if(nSecondaries==0) particleManager.addEndVertex(particle.get());
-                        layer = nullptr;
-                        break;
-                    }
-                }
-                
-                LogDebug(MESSAGECATEGORY) << "--------------------------------"
-                              << "\n-------------------------------";
-            }
-
-            // do decays
-            if(!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10)
-            {
-                LogDebug(MESSAGECATEGORY) << "Decaying particle...";
-                std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-                decayer_.decay(*particle,secondaries, _randomEngine->theEngine());
-                LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
-                particleManager.addSecondaries(particle->position(), particle->simTrackIndex(),secondaries);
-                continue;
-            }
-            
-            LogDebug(MESSAGECATEGORY) << "################################"
-                          << "\n###############################";
-        }
-
-
-        // -----------------------------
-        // Hack to interface "old" calorimetry with "new" propagation in tracker
-        // The CalorimetryManager has to know which particle could in principle hit which parts of the calorimeter
-        // I think it's a bit strange to propagate the particle even further (and even decay it) if it already hits
-        // some part of the calorimetry but this is how the code works...
-        // -----------------------------
-
-        if(particle->position().Perp2() >= 128.*128. || std::abs(particle->position().Z()) >= 302.){
-
-            LogDebug(MESSAGECATEGORY) << "\n   moving particle to calorimetry: " << *particle;
-
-            // create FSimTrack (this is the object the old propagation uses)
-            myFSimTracks.push_back(createFSimTrack(particle.get(), &particleManager, *pdt));
-            // particle was decayed
-            if(!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10)
-            {
-                continue;
-            }
-
-            LogDebug(MESSAGECATEGORY) << "################################"
-                          << "\n###############################";
-        }
-
-        // -----------------------------
-        // End Hack
-        // -----------------------------
-
-
-        LogDebug(MESSAGECATEGORY) << "################################"
-                      << "\n###############################";
-
-    }
-
-    // store simTracks and simVertices
-    iEvent.put(std::move(simTracks_));
-    iEvent.put(std::move(simVertices_));
-    // store products of interaction models, i.e. simHits
-    for(auto & interactionModel : interactionModels_)
-    {
-        interactionModel->storeProducts(iEvent);
-    }
-
+  // loop over particles
+  for (std::unique_ptr<fastsim::Particle> particle = particleManager.nextParticle(*_randomEngine); particle != nullptr;
+       particle = particleManager.nextParticle(*_randomEngine)) {
+    LogDebug(MESSAGECATEGORY) << "\n   moving NEXT particle: " << *particle;
 
     // -----------------------------
-    // Calorimetry Manager
+    // This condition is necessary because of hack for calorimetry
+    // -> The CalorimetryManager should also be implemented based on this new FastSim classes (Particle.h) in a future project.
+    // A second loop (below) loops over all parts of the calorimetry in order to create a track of the old FastSim class FSimTrack.
+    // The condition below (R<128, z<302) makes sure that the particle geometrically is outside the tracker boundaries
     // -----------------------------
-    if(simulateCalorimetry)
-    {
-        for(auto myFSimTrack : myFSimTracks)
-        {
-            myCalorimetry->reconstructTrack(myFSimTrack, _randomEngine.get());
-        }
-    }
 
+    if (particle->position().Perp2() < 128. * 128. && std::abs(particle->position().Z()) < 302.) {
+      // move the particle through the layers
+      fastsim::LayerNavigator layerNavigator(geometry_);
+      const fastsim::SimplifiedGeometry* layer = nullptr;
 
-    // -----------------------------
-    // Store Hits
-    // -----------------------------
-    std::unique_ptr<edm::PCaloHitContainer> p4(new edm::PCaloHitContainer);
-    std::unique_ptr<edm::PCaloHitContainer> p5(new edm::PCaloHitContainer);
-    std::unique_ptr<edm::PCaloHitContainer> p6(new edm::PCaloHitContainer); 
-    std::unique_ptr<edm::PCaloHitContainer> p7(new edm::PCaloHitContainer);
-
-    std::unique_ptr<edm::SimTrackContainer> m1(new edm::SimTrackContainer);
-
-    if(simulateCalorimetry)
-    {
-        myCalorimetry->loadFromEcalBarrel(*p4);
-        myCalorimetry->loadFromEcalEndcap(*p5);
-        myCalorimetry->loadFromPreshower(*p6);
-        myCalorimetry->loadFromHcal(*p7);
-        if(simulateMuons){
-            myCalorimetry->harvestMuonSimTracks(*m1);
-        }
-    }   
-    iEvent.put(std::move(p4),"EcalHitsEB");
-    iEvent.put(std::move(p5),"EcalHitsEE");
-    iEvent.put(std::move(p6),"EcalHitsES");
-    iEvent.put(std::move(p7),"HcalHits");
-    iEvent.put(std::move(m1),"MuonSimTracks");
-}
-
-void
-FastSimProducer::endStream()
-{
-    _randomEngine.reset();
-}
-
-FSimTrack
-FastSimProducer::createFSimTrack(fastsim::Particle* particle, fastsim::ParticleManager* particleManager, HepPDT::ParticleDataTable const& particleTable)
-{
-    FSimTrack myFSimTrack(particle->pdgId(),
-        particleManager->getSimTrack(particle->simTrackIndex()).momentum(),
-        particle->simVertexIndex(),
-        particle->genParticleIndex(),
-        particle->simTrackIndex(),
-        particle->charge(),
-        particle->position(),
-        particle->momentum(),
-        particleManager->getSimVertex(particle->simVertexIndex()));
-
-    // move the particle through the caloLayers
-    fastsim::LayerNavigator caloLayerNavigator(caloGeometry_);
-    const fastsim::SimplifiedGeometry * caloLayer = nullptr;
-
-    // moveParticleToNextLayer(..) returns 0 in case that particle decays
-    // in this case particle is propagated up to its decay vertex
-    while(caloLayerNavigator.moveParticleToNextLayer(*particle,caloLayer))
-    {
-        LogDebug(MESSAGECATEGORY) << "   moved to next caloLayer: " << *caloLayer;
+      // moveParticleToNextLayer(..) returns 0 in case that particle decays
+      // in this case particle is propagated up to its decay vertex
+      while (layerNavigator.moveParticleToNextLayer(*particle, layer)) {
+        LogDebug(MESSAGECATEGORY) << "   moved to next layer: " << *layer;
         LogDebug(MESSAGECATEGORY) << "   new state: " << *particle;
 
+        // Hack to interface "old" calo to "new" tracking
+        // Particle reached calorimetry so stop further propagation
+        if (layer->getCaloType() == fastsim::SimplifiedGeometry::TRACKERBOUNDARY) {
+          layer = nullptr;
+          // particle no longer is on a layer
+          particle->resetOnLayer();
+          break;
+        }
+
         // break after 25 ns: only happens for particles stuck in loops
-        if(particle->position().T() > 50)
-        {
-            caloLayer = nullptr;
+        if (particle->position().T() > 25) {
+          layer = nullptr;
+          // particle no longer is on a layer
+          particle->resetOnLayer();
+          break;
+        }
+
+        // perform interaction between layer and particle
+        // do only if there is actual material
+        if (layer->getThickness(particle->position(), particle->momentum()) > 1E-10) {
+          int nSecondaries = 0;
+          // loop on interaction models
+          for (fastsim::InteractionModel* interactionModel : layer->getInteractionModels()) {
+            LogDebug(MESSAGECATEGORY) << "   interact with " << *interactionModel;
+            std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
+            interactionModel->interact(*particle, *layer, secondaries, *_randomEngine);
+            nSecondaries += secondaries.size();
+            particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries, layer);
+          }
+
+          // kinematic cuts: particle might e.g. lost all its energy
+          if (!particleFilter_.acceptsEn(*particle)) {
+            // Add endvertex if particle did not create any secondaries
+            if (nSecondaries == 0)
+              particleManager.addEndVertex(particle.get());
+            layer = nullptr;
             break;
+          }
         }
 
-        //////////
-        // Define ParticlePropagators (RawParticle) needed for CalorimetryManager and save them
-        //////////
-
-        RawParticle PP = makeParticle(&particleTable,
-                                      particle->pdgId(), 
-                                      particle->momentum(),
-                                      particle->position());
-
-        // no material
-        if(caloLayer->getThickness(particle->position(), particle->momentum()) < 1E-10)
-        {
-            // unfortunately needed for CalorimetryManager
-            if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::ECAL){
-                if(!myFSimTrack.onEcal())
-                {
-                    myFSimTrack.setEcal(PP, 0);
-                }
-            }
-            else if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::HCAL){
-                if(!myFSimTrack.onHcal())
-                {
-                    myFSimTrack.setHcal(PP, 0);
-                }
-            }
-            else if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL){
-                if(!myFSimTrack.onVFcal())
-                {
-                    myFSimTrack.setVFcal(PP, 0);
-                }
-            }
-
-            // not necessary to continue propagation
-            if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL)
-            {
-                myFSimTrack.setGlobal();
-                caloLayer = nullptr;
-                break;
-            }
-
-            continue;
-        }
-
-        // Stupid variable used by the old propagator
-        // For details check BaseParticlePropagator.h
-        int success = 0;
-        if(caloLayer->isForward())
-        {
-            success = 2;
-            // particle moves inwards
-            if(particle->position().Z() * particle->momentum().Z() < 0)
-            {
-                success *= -1;
-            }
-        }
-        else
-        {
-            success = 1;
-            // particle moves inwards
-            if(particle->momentum().X() * particle->position().X() + particle->momentum().Y() * particle->position().Y() < 0)
-            {
-                success *= -1;
-            }
-        }
-
-        // Save the hit
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER1)
-        {   
-            if(!myFSimTrack.onLayer1())
-            {
-                myFSimTrack.setLayer1(PP, success);
-            }
-        }
-
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER2)
-        {                   
-            if(!myFSimTrack.onLayer2())
-            {
-                myFSimTrack.setLayer2(PP, success);
-            }
-        }
-
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::ECAL)
-        {                   
-            if(!myFSimTrack.onEcal())
-            {
-                myFSimTrack.setEcal(PP, success);
-            }
-        }
-
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::HCAL)
-        {                   
-            if(!myFSimTrack.onHcal())
-            {
-                myFSimTrack.setHcal(PP, success);
-            }
-        }
-
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL)
-        {                   
-            if(!myFSimTrack.onVFcal())
-            {
-                myFSimTrack.setVFcal(PP, success);
-            }
-        }
-
-        // Particle reached end of detector
-        if(caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL)
-        {
-            myFSimTrack.setGlobal();
-            caloLayer = nullptr;
-            break;
-        }
-        
         LogDebug(MESSAGECATEGORY) << "--------------------------------"
-                      << "\n-------------------------------";
-    }
+                                  << "\n-------------------------------";
+      }
 
-    // do decays
-    // don't have to worry about daughters if particle already within the calorimetry
-    // since they will be rejected by the vertex cut of the ParticleFilter
-    if(!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10)
-    {
+      // do decays
+      if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
         LogDebug(MESSAGECATEGORY) << "Decaying particle...";
         std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-        decayer_.decay(*particle,secondaries, _randomEngine->theEngine());
+        decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
         LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
-        particleManager->addSecondaries(particle->position(), particle->simTrackIndex(),secondaries);
+        particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
+        continue;
+      }
+
+      LogDebug(MESSAGECATEGORY) << "################################"
+                                << "\n###############################";
     }
 
-    return myFSimTrack;
+    // -----------------------------
+    // Hack to interface "old" calorimetry with "new" propagation in tracker
+    // The CalorimetryManager has to know which particle could in principle hit which parts of the calorimeter
+    // I think it's a bit strange to propagate the particle even further (and even decay it) if it already hits
+    // some part of the calorimetry but this is how the code works...
+    // -----------------------------
+
+    if (particle->position().Perp2() >= 128. * 128. || std::abs(particle->position().Z()) >= 302.) {
+      LogDebug(MESSAGECATEGORY) << "\n   moving particle to calorimetry: " << *particle;
+
+      // create FSimTrack (this is the object the old propagation uses)
+      myFSimTracks.push_back(createFSimTrack(particle.get(), &particleManager, *pdt));
+      // particle was decayed
+      if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
+        continue;
+      }
+
+      LogDebug(MESSAGECATEGORY) << "################################"
+                                << "\n###############################";
+    }
+
+    // -----------------------------
+    // End Hack
+    // -----------------------------
+
+    LogDebug(MESSAGECATEGORY) << "################################"
+                              << "\n###############################";
+  }
+
+  // store simTracks and simVertices
+  iEvent.put(std::move(simTracks_));
+  iEvent.put(std::move(simVertices_));
+  // store products of interaction models, i.e. simHits
+  for (auto& interactionModel : interactionModels_) {
+    interactionModel->storeProducts(iEvent);
+  }
+
+  // -----------------------------
+  // Calorimetry Manager
+  // -----------------------------
+  if (simulateCalorimetry) {
+    for (auto myFSimTrack : myFSimTracks) {
+      myCalorimetry->reconstructTrack(myFSimTrack, _randomEngine.get());
+    }
+  }
+
+  // -----------------------------
+  // Store Hits
+  // -----------------------------
+  std::unique_ptr<edm::PCaloHitContainer> p4(new edm::PCaloHitContainer);
+  std::unique_ptr<edm::PCaloHitContainer> p5(new edm::PCaloHitContainer);
+  std::unique_ptr<edm::PCaloHitContainer> p6(new edm::PCaloHitContainer);
+  std::unique_ptr<edm::PCaloHitContainer> p7(new edm::PCaloHitContainer);
+
+  std::unique_ptr<edm::SimTrackContainer> m1(new edm::SimTrackContainer);
+
+  if (simulateCalorimetry) {
+    myCalorimetry->loadFromEcalBarrel(*p4);
+    myCalorimetry->loadFromEcalEndcap(*p5);
+    myCalorimetry->loadFromPreshower(*p6);
+    myCalorimetry->loadFromHcal(*p7);
+    if (simulateMuons) {
+      myCalorimetry->harvestMuonSimTracks(*m1);
+    }
+  }
+  iEvent.put(std::move(p4), "EcalHitsEB");
+  iEvent.put(std::move(p5), "EcalHitsEE");
+  iEvent.put(std::move(p6), "EcalHitsES");
+  iEvent.put(std::move(p7), "HcalHits");
+  iEvent.put(std::move(m1), "MuonSimTracks");
+}
+
+void FastSimProducer::endStream() { _randomEngine.reset(); }
+
+FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
+                                           fastsim::ParticleManager* particleManager,
+                                           HepPDT::ParticleDataTable const& particleTable) {
+  FSimTrack myFSimTrack(particle->pdgId(),
+                        particleManager->getSimTrack(particle->simTrackIndex()).momentum(),
+                        particle->simVertexIndex(),
+                        particle->genParticleIndex(),
+                        particle->simTrackIndex(),
+                        particle->charge(),
+                        particle->position(),
+                        particle->momentum(),
+                        particleManager->getSimVertex(particle->simVertexIndex()));
+
+  // move the particle through the caloLayers
+  fastsim::LayerNavigator caloLayerNavigator(caloGeometry_);
+  const fastsim::SimplifiedGeometry* caloLayer = nullptr;
+
+  // moveParticleToNextLayer(..) returns 0 in case that particle decays
+  // in this case particle is propagated up to its decay vertex
+  while (caloLayerNavigator.moveParticleToNextLayer(*particle, caloLayer)) {
+    LogDebug(MESSAGECATEGORY) << "   moved to next caloLayer: " << *caloLayer;
+    LogDebug(MESSAGECATEGORY) << "   new state: " << *particle;
+
+    // break after 25 ns: only happens for particles stuck in loops
+    if (particle->position().T() > 50) {
+      caloLayer = nullptr;
+      break;
+    }
+
+    //////////
+    // Define ParticlePropagators (RawParticle) needed for CalorimetryManager and save them
+    //////////
+
+    RawParticle PP = makeParticle(&particleTable, particle->pdgId(), particle->momentum(), particle->position());
+
+    // no material
+    if (caloLayer->getThickness(particle->position(), particle->momentum()) < 1E-10) {
+      // unfortunately needed for CalorimetryManager
+      if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::ECAL) {
+        if (!myFSimTrack.onEcal()) {
+          myFSimTrack.setEcal(PP, 0);
+        }
+      } else if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::HCAL) {
+        if (!myFSimTrack.onHcal()) {
+          myFSimTrack.setHcal(PP, 0);
+        }
+      } else if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL) {
+        if (!myFSimTrack.onVFcal()) {
+          myFSimTrack.setVFcal(PP, 0);
+        }
+      }
+
+      // not necessary to continue propagation
+      if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL) {
+        myFSimTrack.setGlobal();
+        caloLayer = nullptr;
+        break;
+      }
+
+      continue;
+    }
+
+    // Stupid variable used by the old propagator
+    // For details check BaseParticlePropagator.h
+    int success = 0;
+    if (caloLayer->isForward()) {
+      success = 2;
+      // particle moves inwards
+      if (particle->position().Z() * particle->momentum().Z() < 0) {
+        success *= -1;
+      }
+    } else {
+      success = 1;
+      // particle moves inwards
+      if (particle->momentum().X() * particle->position().X() + particle->momentum().Y() * particle->position().Y() <
+          0) {
+        success *= -1;
+      }
+    }
+
+    // Save the hit
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER1) {
+      if (!myFSimTrack.onLayer1()) {
+        myFSimTrack.setLayer1(PP, success);
+      }
+    }
+
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::PRESHOWER2) {
+      if (!myFSimTrack.onLayer2()) {
+        myFSimTrack.setLayer2(PP, success);
+      }
+    }
+
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::ECAL) {
+      if (!myFSimTrack.onEcal()) {
+        myFSimTrack.setEcal(PP, success);
+      }
+    }
+
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::HCAL) {
+      if (!myFSimTrack.onHcal()) {
+        myFSimTrack.setHcal(PP, success);
+      }
+    }
+
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL) {
+      if (!myFSimTrack.onVFcal()) {
+        myFSimTrack.setVFcal(PP, success);
+      }
+    }
+
+    // Particle reached end of detector
+    if (caloLayer->getCaloType() == fastsim::SimplifiedGeometry::VFCAL) {
+      myFSimTrack.setGlobal();
+      caloLayer = nullptr;
+      break;
+    }
+
+    LogDebug(MESSAGECATEGORY) << "--------------------------------"
+                              << "\n-------------------------------";
+  }
+
+  // do decays
+  // don't have to worry about daughters if particle already within the calorimetry
+  // since they will be rejected by the vertex cut of the ParticleFilter
+  if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
+    LogDebug(MESSAGECATEGORY) << "Decaying particle...";
+    std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
+    decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+    LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
+    particleManager->addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
+  }
+
+  return myFSimTrack;
 }
 
 DEFINE_FWK_MODULE(FastSimProducer);

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -13,6 +13,7 @@ fastSimProducer = cms.EDProducer(
     trackerDefinition = TrackerMaterialBlock.TrackerMaterial,
     simulateCalorimetry = cms.bool(True),
     simulateMuons = cms.bool(True),
+    useFastSimsDecayer = cms.bool(False),
     caloDefinition = CaloMaterialBlock.CaloMaterial, #  Hack to interface "old" calorimetry with "new" propagation in tracker
     beamPipeRadius = cms.double(3.),
     deltaRchargedMother = cms.double(0.02), # Maximum angle to associate a charged daughter to a charged mother (mostly done to associate muons to decaying pions)
@@ -77,9 +78,4 @@ fastSimProducer = cms.EDProducer(
     MaterialEffectsForMuonsInECAL = MaterialEffectsForMuonsInECALBlock.MaterialEffectsForMuonsInECAL,
     MaterialEffectsForMuonsInHCAL = MaterialEffectsForMuonsInHCALBlock.MaterialEffectsForMuonsInHCAL,
     GFlash = FamosCalorimetryBlock.GFlash,
-    fixLongLivedBug = cms.bool(False),
 )
-
-from Configuration.ProcessModifiers.fastSimFixLongLivedBug_cff import fastSimFixLongLivedBug
-
-fastSimFixLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -7,83 +7,89 @@
 #include <Pythia8/Pythia.h>
 #include "Pythia8Plugins/HepMC2.h"
 
-fastsim::Decayer::~Decayer(){;}
+fastsim::Decayer::~Decayer() { ; }
 
-fastsim::Decayer::Decayer()
-    : pythia_(new Pythia8::Pythia())
-    , pythiaRandomEngine_(new gen::P8RndmEngine())
-{
-    pythia_->setRndmEnginePtr(pythiaRandomEngine_.get());
-    pythia_->settings.flag("ProcessLevel:all",false);
-    pythia_->settings.flag("PartonLevel:FSRinResonances",false);
-    pythia_->settings.flag("ProcessLevel:resonanceDecays",false);
-    pythia_->init();
-    fixLongLivedBug_ = false;
-    // forbid all decays
-    // (decays are allowed selectively in the decay function)
-    Pythia8::ParticleData & pdt = pythia_->particleData;
-    int pid = 0;
-    while(pdt.nextId(pid) > pid)
-    {
-        pid = pdt.nextId(pid);
-        pdt.mayDecay(pid,false);
-    }
+fastsim::Decayer::Decayer() : pythia_(new Pythia8::Pythia()), pythiaRandomEngine_(new gen::P8RndmEngine()) {
+  pythia_->setRndmEnginePtr(pythiaRandomEngine_.get());
+  pythia_->settings.flag("ProcessLevel:all", false);
+  pythia_->settings.flag("PartonLevel:FSRinResonances", false);
+  pythia_->settings.flag("ProcessLevel:resonanceDecays", false);
+  pythia_->init();
+
+  // forbid all decays
+  // (decays are allowed selectively in the decay function)
+  Pythia8::ParticleData& pdt = pythia_->particleData;
+  int pid = 0;
+  while (pdt.nextId(pid) > pid) {
+    pid = pdt.nextId(pid);
+    pdt.mayDecay(pid, false);
+  }
 }
 
-void
-fastsim::Decayer::decay(const Particle & particle,std::vector<std::unique_ptr<fastsim::Particle> > & secondaries,CLHEP::HepRandomEngine & engine) const
-{
-    // make sure pythia takes random numbers from the engine past through via the function arguments
-    edm::RandomEngineSentry<gen::P8RndmEngine> sentry(pythiaRandomEngine_.get(), &engine);
-    
-    // inspired by method Pythia8Hadronizer::residualDecay() in GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
-    int pid = particle.pdgId();
-    // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
-    // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.    
-    if (isExotic(fixLongLivedBug_, pid) || isExotic(fixLongLivedBug_, particle.getMotherPdgId())) {
-        return;
+void fastsim::Decayer::decay(const Particle& particle,
+                             std::vector<std::unique_ptr<fastsim::Particle> >& secondaries,
+                             CLHEP::HepRandomEngine& engine) const {
+  // make sure pythia takes random numbers from the engine past through via the function arguments
+  edm::RandomEngineSentry<gen::P8RndmEngine> sentry(pythiaRandomEngine_.get(), &engine);
+
+  // inspired by method Pythia8Hadronizer::residualDecay() in GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
+  int pid = particle.pdgId();
+  // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
+  // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
+
+  if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
+    return;
+  }
+
+  pythia_->event.reset();
+
+  // create a pythia particle which has the same properties as the FastSim particle
+  Pythia8::Particle pythiaParticle(pid,
+                                   93,
+                                   0,
+                                   0,
+                                   0,
+                                   0,
+                                   0,
+                                   0,
+                                   particle.momentum().X(),
+                                   particle.momentum().Y(),
+                                   particle.momentum().Z(),
+                                   particle.momentum().E(),
+                                   particle.momentum().M());
+  pythiaParticle.vProd(
+      particle.position().X(), particle.position().Y(), particle.position().Z(), particle.position().T());
+  pythia_->event.append(pythiaParticle);
+
+  int nentries_before = pythia_->event.size();
+  // switch on the decay of this and only this particle (avoid double decays)
+  pythia_->particleData.mayDecay(pid, true);
+  // do the decay
+  pythia_->next();
+  // switch it off again
+  pythia_->particleData.mayDecay(pid, false);
+  int nentries_after = pythia_->event.size();
+
+  if (nentries_after <= nentries_before)
+    return;
+
+  // add decay products back to the event
+  for (int ipart = nentries_before; ipart < nentries_after; ipart++) {
+    Pythia8::Particle& daughter = pythia_->event[ipart];
+
+    secondaries.emplace_back(new fastsim::Particle(
+        daughter.id(),
+        math::XYZTLorentzVector(daughter.xProd(), daughter.yProd(), daughter.zProd(), daughter.tProd()),
+        math::XYZTLorentzVector(daughter.px(), daughter.py(), daughter.pz(), daughter.e())));
+
+    // daughter can inherit the SimTrackIndex of mother (if both charged): necessary for FastSim (cheat) tracking
+    if (particle.charge() != 0 && std::abs(particle.charge() - daughter.charge()) < 1E-10) {
+      secondaries.back()->setMotherDeltaR(particle.momentum());
+      secondaries.back()->setMotherPdgId(particle.getMotherDeltaR() == -1 ? particle.pdgId()
+                                                                          : particle.getMotherPdgId());
+      secondaries.back()->setMotherSimTrackIndex(particle.simTrackIndex());
     }
-      
-    pythia_->event.reset();
-    
-    // create a pythia particle which has the same properties as the FastSim particle
-    Pythia8::Particle pythiaParticle( pid , 93, 0, 0, 0, 0, 0, 0,
-                      particle.momentum().X(),
-                      particle.momentum().Y(),
-                      particle.momentum().Z(),
-                      particle.momentum().E(),
-                      particle.momentum().M() );
-    pythiaParticle.vProd(particle.position().X(), particle.position().Y(), particle.position().Z(), particle.position().T());
-    pythia_->event.append(pythiaParticle);
+  }
 
-
-    int nentries_before = pythia_->event.size();
-    // switch on the decay of this and only this particle (avoid double decays)
-    pythia_->particleData.mayDecay(pid,true);   
-    // do the decay
-    pythia_->next();
-    // switch it off again                            
-    pythia_->particleData.mayDecay(pid,false);  
-    int nentries_after = pythia_->event.size();
-
-    if(nentries_after <= nentries_before)return;
-
-    // add decay products back to the event
-    for(int ipart=nentries_before; ipart<nentries_after; ipart++) 
-    {
-        Pythia8::Particle& daughter = pythia_->event[ipart];
-        
-        secondaries.emplace_back(new fastsim::Particle(daughter.id()
-                                   ,math::XYZTLorentzVector(daughter.xProd(),daughter.yProd(),daughter.zProd(),daughter.tProd())
-                                   ,math::XYZTLorentzVector(daughter.px(), daughter.py(), daughter.pz(), daughter.e())));
-
-        // daughter can inherit the SimTrackIndex of mother (if both charged): necessary for FastSim (cheat) tracking
-        if(particle.charge() != 0 && std::abs(particle.charge()-daughter.charge()) < 1E-10){
-            secondaries.back()->setMotherDeltaR(particle.momentum());
-            secondaries.back()->setMotherPdgId(particle.getMotherDeltaR() == -1 ? particle.pdgId() : particle.getMotherPdgId());
-            secondaries.back()->setMotherSimTrackIndex(particle.simTrackIndex());
-        }
-    }
-    
   return;
 }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -14,318 +14,291 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
 
-fastsim::ParticleManager::ParticleManager(
-    const HepMC::GenEvent & genEvent,
-    const HepPDT::ParticleDataTable & particleDataTable,
-    double beamPipeRadius,
-    double deltaRchargedMother,
-    const fastsim::ParticleFilter & particleFilter,
-    std::vector<SimTrack> & simTracks,
-    std::vector<SimVertex> & simVertices,
-    bool fixLongLivedBug)
-    : genEvent_(&genEvent)
-    , genParticleIterator_(genEvent_->particles_begin())
-    , genParticleEnd_(genEvent_->particles_end())
-    , genParticleIndex_(1)
-    , particleDataTable_(&particleDataTable)
-    , beamPipeRadius2_(beamPipeRadius*beamPipeRadius)
-    , deltaRchargedMother_(deltaRchargedMother)
-    , particleFilter_(&particleFilter)
-    , simTracks_(&simTracks)
-    , simVertices_(&simVertices)
-    // prepare unit convsersions
-    //  --------------------------------------------
-    // |          |      hepmc               |  cms |
-    //  --------------------------------------------
-    // | length   | genEvent_->length_unit   |  cm  |
-    // | momentum | genEvent_->momentum_unit |  GeV |
-    // | time     | length unit (t*c)        |  ns  |
-    //  --------------------------------------------
-    , momentumUnitConversionFactor_(conversion_factor( genEvent_->momentum_unit(), HepMC::Units::GEV ))
-    , lengthUnitConversionFactor_(conversion_factor(genEvent_->length_unit(),HepMC::Units::LengthUnit::CM))
-    , lengthUnitConversionFactor2_(lengthUnitConversionFactor_*lengthUnitConversionFactor_)
-    , timeUnitConversionFactor_(lengthUnitConversionFactor_/fastsim::Constants::speedOfLight)
-    , fixLongLivedBug_(fixLongLivedBug)
-{
+fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
+                                          const HepPDT::ParticleDataTable& particleDataTable,
+                                          double beamPipeRadius,
+                                          double deltaRchargedMother,
+                                          const fastsim::ParticleFilter& particleFilter,
+                                          std::vector<SimTrack>& simTracks,
+                                          std::vector<SimVertex>& simVertices,
+                                          bool useFastSimsDecayer)
+    : genEvent_(&genEvent),
+      genParticleIterator_(genEvent_->particles_begin()),
+      genParticleEnd_(genEvent_->particles_end()),
+      genParticleIndex_(1),
+      particleDataTable_(&particleDataTable),
+      beamPipeRadius2_(beamPipeRadius * beamPipeRadius),
+      deltaRchargedMother_(deltaRchargedMother),
+      particleFilter_(&particleFilter),
+      simTracks_(&simTracks),
+      simVertices_(&simVertices),
+      useFastSimsDecayer_(useFastSimsDecayer)
+      // prepare unit convsersions
+      //  --------------------------------------------
+      // |          |      hepmc               |  cms |
+      //  --------------------------------------------
+      // | length   | genEvent_->length_unit   |  cm  |
+      // | momentum | genEvent_->momentum_unit |  GeV |
+      // | time     | length unit (t*c)        |  ns  |
+      //  --------------------------------------------
+      ,
+      momentumUnitConversionFactor_(conversion_factor(genEvent_->momentum_unit(), HepMC::Units::GEV)),
+      lengthUnitConversionFactor_(conversion_factor(genEvent_->length_unit(), HepMC::Units::LengthUnit::CM)),
+      lengthUnitConversionFactor2_(lengthUnitConversionFactor_ * lengthUnitConversionFactor_),
+      timeUnitConversionFactor_(lengthUnitConversionFactor_ / fastsim::Constants::speedOfLight)
 
-    // add the main vertex from the signal event to the simvertex collection
-    if(genEvent.vertices_begin() != genEvent_->vertices_end())
-    {
-        const HepMC::FourVector & position = (*genEvent.vertices_begin())->position();
-        addSimVertex(math::XYZTLorentzVector(position.x()*lengthUnitConversionFactor_,
-                             position.y()*lengthUnitConversionFactor_,
-                             position.z()*lengthUnitConversionFactor_,
-                             position.t()*timeUnitConversionFactor_)
-                    ,-1);
-    }
+{
+  // add the main vertex from the signal event to the simvertex collection
+  if (genEvent.vertices_begin() != genEvent_->vertices_end()) {
+    const HepMC::FourVector& position = (*genEvent.vertices_begin())->position();
+    addSimVertex(math::XYZTLorentzVector(position.x() * lengthUnitConversionFactor_,
+                                         position.y() * lengthUnitConversionFactor_,
+                                         position.z() * lengthUnitConversionFactor_,
+                                         position.t() * timeUnitConversionFactor_),
+                 -1);
+  }
 }
 
-fastsim::ParticleManager::~ParticleManager(){}
+fastsim::ParticleManager::~ParticleManager() {}
 
-std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextParticle(const RandomEngineAndDistribution & random)
-{
-    std::unique_ptr<fastsim::Particle> particle;
+std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextParticle(const RandomEngineAndDistribution& random) {
+  std::unique_ptr<fastsim::Particle> particle;
 
-    // retrieve particle from buffer
-    if(!particleBuffer_.empty())
-    {
-        particle = std::move(particleBuffer_.back());
-        particleBuffer_.pop_back();
-    }
-    // or from genParticle list
-    else
-    {
-       particle = nextGenParticle();
-       if(!particle) return nullptr;
-    }
+  // retrieve particle from buffer
+  if (!particleBuffer_.empty()) {
+    particle = std::move(particleBuffer_.back());
+    particleBuffer_.pop_back();
+  }
+  // or from genParticle list
+  else {
+    particle = nextGenParticle();
+    if (!particle)
+      return nullptr;
+  }
 
-    // if filter does not accept, skip particle
-    if(!particleFilter_->accepts(*particle))
-    {
-        return nextParticle(random);
-    }
+  // if filter does not accept, skip particle
+  if (!particleFilter_->accepts(*particle)) {
+    return nextParticle(random);
+  }
 
-    // lifetime or charge of particle are not yet set
-    if(!particle->remainingProperLifeTimeIsSet() || !particle->chargeIsSet())
-    {
-        // retrieve the particle data
-        const HepPDT::ParticleData * particleData = particleDataTable_->particle(HepPDT::ParticleID(particle->pdgId()));
-        if(!particleData)
-        {
-            // in very few events the Decayer (pythia) produces high mass resonances that are for some reason not present in the table (even though they should technically be)
-            // they have short lifetimes, so decay them right away (charge and lifetime cannot be taken from table)
-            particle->setRemainingProperLifeTimeC(0.);
-            particle->setCharge(0.);
-        }
-
-        // set lifetime
-        if(!particle->remainingProperLifeTimeIsSet())
-        {
-            // The lifetime is 0. in the Pythia Particle Data Table! Calculate from width instead (ct=hbar/width).
-            // ct=particleData->lifetime().value();
-            double width = particleData->totalWidth().value();
-            if(width > 1.0e-35)
-            {
-                particle->setRemainingProperLifeTimeC(-log(random.flatShoot())*6.582119e-25/width/10.); // ct in cm
-            }
-            else
-            {
-                particle->setStable();
-            }
-        }
-
-        // set charge
-        if(!particle->chargeIsSet())
-        {
-            particle->setCharge(particleData->charge());
-        }
+  // lifetime or charge of particle are not yet set
+  if (!particle->remainingProperLifeTimeIsSet() || !particle->chargeIsSet()) {
+    // retrieve the particle data
+    const HepPDT::ParticleData* particleData = particleDataTable_->particle(HepPDT::ParticleID(particle->pdgId()));
+    if (!particleData) {
+      // in very few events the Decayer (pythia) produces high mass resonances that are for some reason not present in the table (even though they should technically be)
+      // they have short lifetimes, so decay them right away (charge and lifetime cannot be taken from table)
+      particle->setRemainingProperLifeTimeC(0.);
+      particle->setCharge(0.);
     }
 
-    // add corresponding simTrack to simTrack collection
-    unsigned simTrackIndex = addSimTrack(particle.get());
-    particle->setSimTrackIndex(simTrackIndex);
+    // set lifetime
+    if (!particle->remainingProperLifeTimeIsSet()) {
+      // The lifetime is 0. in the Pythia Particle Data Table! Calculate from width instead (ct=hbar/width).
+      // ct=particleData->lifetime().value();
+      double width = particleData->totalWidth().value();
+      if (width > 1.0e-35) {
+        particle->setRemainingProperLifeTimeC(-log(random.flatShoot()) * 6.582119e-25 / width / 10.);  // ct in cm
+      } else {
+        particle->setStable();
+      }
+    }
 
-    // and return
-    return particle;
+    // set charge
+    if (!particle->chargeIsSet()) {
+      particle->setCharge(particleData->charge());
+    }
+  }
+
+  // add corresponding simTrack to simTrack collection
+  unsigned simTrackIndex = addSimTrack(particle.get());
+  particle->setSimTrackIndex(simTrackIndex);
+
+  // and return
+  return particle;
 }
 
+void fastsim::ParticleManager::addSecondaries(const math::XYZTLorentzVector& vertexPosition,
+                                              int parentSimTrackIndex,
+                                              std::vector<std::unique_ptr<Particle> >& secondaries,
+                                              const SimplifiedGeometry* layer) {
+  // vertex must be within the accepted volume
+  if (!particleFilter_->acceptsVtx(vertexPosition)) {
+    return;
+  }
 
-void fastsim::ParticleManager::addSecondaries(
-    const math::XYZTLorentzVector & vertexPosition,
-    int parentSimTrackIndex,
-    std::vector<std::unique_ptr<Particle> > & secondaries,
-    const SimplifiedGeometry * layer)
-{
+  // no need to create vertex in case no particles are produced
+  if (secondaries.empty()) {
+    return;
+  }
 
-    // vertex must be within the accepted volume
-    if(!particleFilter_->acceptsVtx(vertexPosition))
-    {
-       return;
+  // add simVertex
+  unsigned simVertexIndex = addSimVertex(vertexPosition, parentSimTrackIndex);
+
+  // closest charged daughter continues the track of the mother particle
+  // simplified tracking algorithm for fastSim
+  double distMin = 99999.;
+  int idx = -1;
+  int idxMin = -1;
+  for (auto& secondary : secondaries) {
+    idx++;
+    if (secondary->getMotherDeltaR() != -1) {
+      if (secondary->getMotherDeltaR() > deltaRchargedMother_) {
+        // larger than max requirement on deltaR
+        secondary->resetMother();
+      } else {
+        if (secondary->getMotherDeltaR() < distMin) {
+          distMin = secondary->getMotherDeltaR();
+          idxMin = idx;
+        }
+      }
+    }
+  }
+
+  // add secondaries to buffer
+  idx = -1;
+  for (auto& secondary : secondaries) {
+    idx++;
+    if (idxMin != -1) {
+      // reset all but the particle with the lowest deltaR (which is at idxMin)
+      if (secondary->getMotherDeltaR() != -1 && idx != idxMin) {
+        secondary->resetMother();
+      }
     }
 
-    // no need to create vertex in case no particles are produced
-    if(secondaries.empty()){
-        return;
+    // set origin vertex
+    secondary->setSimVertexIndex(simVertexIndex);
+    //
+    if (layer) {
+      secondary->setOnLayer(layer->isForward(), layer->index());
     }
+    // ...and add particle to buffer
+    particleBuffer_.push_back(std::move(secondary));
+  }
+}
 
-    // add simVertex
-    unsigned simVertexIndex = addSimVertex(vertexPosition,parentSimTrackIndex);
+unsigned fastsim::ParticleManager::addEndVertex(const fastsim::Particle* particle) {
+  return this->addSimVertex(particle->position(), particle->simTrackIndex());
+}
 
-    // closest charged daughter continues the track of the mother particle
-    // simplified tracking algorithm for fastSim
-    double distMin = 99999.;
-    int idx = -1;
-    int idxMin = -1;
-    for(auto & secondary : secondaries)
-    {
-        idx++;
-        if(secondary->getMotherDeltaR() != -1){
-            if(secondary->getMotherDeltaR() > deltaRchargedMother_){
-                // larger than max requirement on deltaR
-                secondary->resetMother();
-            }else{
-                if(secondary->getMotherDeltaR() < distMin){
-                    distMin = secondary->getMotherDeltaR();
-                    idxMin = idx;
-                }
-            }            
-        }
+unsigned fastsim::ParticleManager::addSimVertex(const math::XYZTLorentzVector& position, int parentSimTrackIndex) {
+  int simVertexIndex = simVertices_->size();
+  simVertices_->emplace_back(position.Vect(), position.T(), parentSimTrackIndex, simVertexIndex);
+  return simVertexIndex;
+}
+
+unsigned fastsim::ParticleManager::addSimTrack(const fastsim::Particle* particle) {
+  int simTrackIndex = simTracks_->size();
+  simTracks_->emplace_back(
+      particle->pdgId(), particle->momentum(), particle->simVertexIndex(), particle->genParticleIndex());
+  simTracks_->back().setTrackId(simTrackIndex);
+  return simTrackIndex;
+}
+
+std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
+  // only consider particles that start in the beam pipe and end outside the beam pipe
+  // try to get the decay time from pythia
+  // use hepmc units
+  // make the link simtrack to simvertex
+  // try not to change the simvertex structure
+
+  // loop over gen particles
+  for (; genParticleIterator_ != genParticleEnd_; ++genParticleIterator_, ++genParticleIndex_) {
+    // some handy pointers and references
+    const HepMC::GenParticle& particle = **genParticleIterator_;
+    const HepMC::GenVertex* productionVertex = particle.production_vertex();
+    const HepMC::GenVertex* endVertex = particle.end_vertex();
+
+    // skip incoming particles
+    if (!productionVertex) {
+      continue;
     }
-    
-    // add secondaries to buffer
-    idx = -1;
-    for(auto & secondary : secondaries)
-    {
-        idx++;
-        if(idxMin != -1){
-            // reset all but the particle with the lowest deltaR (which is at idxMin)
-            if(secondary->getMotherDeltaR() != -1 && idx != idxMin){
-                secondary->resetMother();
-            }
-        }
-
-        // set origin vertex
-        secondary->setSimVertexIndex(simVertexIndex);
-        //
-        if(layer)
-        {
-            secondary->setOnLayer(layer->isForward(), layer->index());
-        }
-        // ...and add particle to buffer
-        particleBuffer_.push_back(std::move(secondary));
+    if (std::abs(particle.pdg_id()) < 10 || std::abs(particle.pdg_id()) == 21) {
+      continue;
     }
-
-}
-
-unsigned fastsim::ParticleManager::addEndVertex(const fastsim::Particle * particle)
-{
-    return this->addSimVertex(particle->position(), particle->simTrackIndex());
-}
-
-unsigned fastsim::ParticleManager::addSimVertex(
-    const math::XYZTLorentzVector & position,
-    int parentSimTrackIndex)
-{
-    int simVertexIndex = simVertices_->size();
-    simVertices_->emplace_back(position.Vect(),
-                   position.T(),
-                   parentSimTrackIndex,
-                   simVertexIndex);
-    return simVertexIndex;
-}
-
-
-unsigned fastsim::ParticleManager::addSimTrack(const fastsim::Particle * particle)
-{
-    int simTrackIndex = simTracks_->size();
-    simTracks_->emplace_back(particle->pdgId(),
-                particle->momentum(),
-                particle->simVertexIndex(),
-                particle->genParticleIndex());
-    simTracks_->back().setTrackId(simTrackIndex);
-    return simTrackIndex;
-}
-
-std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
-{
-    // only consider particles that start in the beam pipe and end outside the beam pipe
-    // try to get the decay time from pythia
-    // use hepmc units
-    // make the link simtrack to simvertex
-    // try not to change the simvertex structure
-    
-    // loop over gen particles
-    for ( ; genParticleIterator_ != genParticleEnd_ ; ++genParticleIterator_,++genParticleIndex_ ) 
-    {
-        // some handy pointers and references
-        const HepMC::GenParticle & particle = **genParticleIterator_;
-        const HepMC::GenVertex * productionVertex = particle.production_vertex();
-        const HepMC::GenVertex * endVertex = particle.end_vertex();
-        // skip incoming particles
-        if(!productionVertex){
-            continue;
-        }
-        
-        if (std::abs(particle.pdg_id()) < 10 || std::abs(particle.pdg_id()) == 21) {
+    // particles which do not descend from exotics must be produced within the beampipe
+    int exoticRelativeId = 0;
+    const bool producedWithinBeamPipe =
+        productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    if (!producedWithinBeamPipe && useFastSimsDecayer_) {
+      exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
+      if (!isExotic(exoticRelativeId)) {
         continue;
-        }        
-
-        // particles which do not descend from exotics must be produced within the beampipe
-        int exoticRelativeId = 0;
-        const bool producedWithinBeamPipe = productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-        if (!producedWithinBeamPipe)  //
-        {
-          exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-          if (!isExotic(fixLongLivedBug_, exoticRelativeId)) {
-            continue;
-          }
-        }	
-        const bool decayedWithinBeamPipe = endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-        // FastSim will not make hits out of particles that decay before reaching the beam pipe
-        if(decayedWithinBeamPipe)
-        {
-            continue;
-        }
-
-        // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed, by default it will duplicate FastSim hits for long lived particles and so anything produced without activating fixLongLivedBug_ is physically wrong
-        if (fixLongLivedBug_ && producedWithinBeamPipe && !decayedWithinBeamPipe){
-          exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-        }    
-
-        // make the particle
-        std::unique_ptr<Particle> newParticle(
-            new Particle(particle.pdg_id(),
-                 math::XYZTLorentzVector(productionVertex->position().x()*lengthUnitConversionFactor_,
-                             productionVertex->position().y()*lengthUnitConversionFactor_,
-                             productionVertex->position().z()*lengthUnitConversionFactor_,
-                             productionVertex->position().t()*timeUnitConversionFactor_),
-                 math::XYZTLorentzVector(particle.momentum().x()*momentumUnitConversionFactor_,
-                             particle.momentum().y()*momentumUnitConversionFactor_,
-                             particle.momentum().z()*momentumUnitConversionFactor_,
-                             particle.momentum().e()*momentumUnitConversionFactor_)));
-        newParticle->setGenParticleIndex(genParticleIndex_);
-        if (isExotic(fixLongLivedBug_, exoticRelativeId)) {
-            newParticle->setMotherPdgId(exoticRelativeId);
-        }
-        // try to get the life time of the particle from the genEvent
-        if(endVertex)
-        {
-            double labFrameLifeTime = (endVertex->position().t() - productionVertex->position().t())*timeUnitConversionFactor_;
-            newParticle->setRemainingProperLifeTimeC(labFrameLifeTime / newParticle->gamma() * fastsim::Constants::speedOfLight);
-        }
-
-        // Find production vertex if it already exists. Otherwise create new vertex
-        // Possible to recreate the whole GenEvent using SimTracks/SimVertices (see FBaseSimEvent::fill(..))
-        bool foundVtx = false;
-        for(const auto& simVtx : *simVertices_){
-            if(std::abs(simVtx.position().x() - newParticle->position().x()) < 1E-3 && std::abs(simVtx.position().y() - newParticle->position().y()) < 1E-3 && std::abs(simVtx.position().z() - newParticle->position().z()) < 1E-3){
-                newParticle->setSimVertexIndex(simVtx.vertexId());
-                foundVtx = true;
-                break;
-            }
-        }        
-        if(!foundVtx) newParticle->setSimVertexIndex(addSimVertex(newParticle->position(), -1));
-
-        // iterator/index has to be increased in case of return (is not done by the loop then)
-        ++genParticleIterator_; ++genParticleIndex_;
-        // and return
-        return newParticle;
+      }
     }
 
-    return std::unique_ptr<Particle>();
+    // FastSim will not make hits out of particles that decay before reaching the beam pipe
+    const bool decayedWithinBeamPipe =
+        endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
+    if (decayedWithinBeamPipe) {
+      continue;
+    }
+
+    // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
+    if (producedWithinBeamPipe && !decayedWithinBeamPipe && useFastSimsDecayer_) {
+      exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
+    }
+
+    // make the particle
+    std::unique_ptr<Particle> newParticle(
+        new Particle(particle.pdg_id(),
+                     math::XYZTLorentzVector(productionVertex->position().x() * lengthUnitConversionFactor_,
+                                             productionVertex->position().y() * lengthUnitConversionFactor_,
+                                             productionVertex->position().z() * lengthUnitConversionFactor_,
+                                             productionVertex->position().t() * timeUnitConversionFactor_),
+                     math::XYZTLorentzVector(particle.momentum().x() * momentumUnitConversionFactor_,
+                                             particle.momentum().y() * momentumUnitConversionFactor_,
+                                             particle.momentum().z() * momentumUnitConversionFactor_,
+                                             particle.momentum().e() * momentumUnitConversionFactor_)));
+    newParticle->setGenParticleIndex(genParticleIndex_);
+    if (isExotic(exoticRelativeId)) {
+      newParticle->setMotherPdgId(exoticRelativeId);
+    }
+
+    // try to get the life time of the particle from the genEvent
+    if (endVertex) {
+      double labFrameLifeTime =
+          (endVertex->position().t() - productionVertex->position().t()) * timeUnitConversionFactor_;
+      newParticle->setRemainingProperLifeTimeC(labFrameLifeTime / newParticle->gamma() *
+                                               fastsim::Constants::speedOfLight);
+    }
+
+    // Find production vertex if it already exists. Otherwise create new vertex
+    // Possible to recreate the whole GenEvent using SimTracks/SimVertices (see FBaseSimEvent::fill(..))
+    bool foundVtx = false;
+    for (const auto& simVtx : *simVertices_) {
+      if (std::abs(simVtx.position().x() - newParticle->position().x()) < 1E-3 &&
+          std::abs(simVtx.position().y() - newParticle->position().y()) < 1E-3 &&
+          std::abs(simVtx.position().z() - newParticle->position().z()) < 1E-3) {
+        newParticle->setSimVertexIndex(simVtx.vertexId());
+        foundVtx = true;
+        break;
+      }
+    }
+    if (!foundVtx)
+      newParticle->setSimVertexIndex(addSimVertex(newParticle->position(), -1));
+
+    // iterator/index has to be increased in case of return (is not done by the loop then)
+    ++genParticleIterator_;
+    ++genParticleIndex_;
+    // and return
+    return newParticle;
+  }
+
+  return std::unique_ptr<Particle>();
 }
 
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(fixLongLivedBug_, std::abs(exoticRelativeId_)))
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_)))
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();
   std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = originVertex->particles_in_const_end();
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
-    if (isExotic(fixLongLivedBug_, std::abs(genRelative.pdg_id()))) {
+    if (isExotic(std::abs(genRelative.pdg_id()))) {
       exoticRelativeId_ = genRelative.pdg_id();
       if (ngendepth == 100)
         exoticRelativeId_ = -1;


### PR DESCRIPTION
#### PR description:

This PR backports the option to only use the FastSim decayer when specified by a flag, which is necessary for FastSim to avoid large inaccuracies in the modeling of SM event processes.

This change is needed for the use of FastSim by PAGs other than SUS and EXO, e.g.,. TOP/HIG with Run 2 UL campaigns. The changes replace earlier changes which affect only decay chains of exotic particles, and extends the behavior to cover all decay chains. Future development may include tweaking the FastSim decayer to be as identical to FullSim as possible. 

#### PR validation:

Distributions of all quantities in the NANO were examined for their impact in ttbar events [1]. Almost all changes are desirable, and some are very much needed, e.g., the MET [2]

[1] https://www.desy.de/~beinsam/FastSim/Nano/6July2022/TTbar/
[2] https://www.desy.de/~beinsam/FastSim/Nano/6July2022/TTbar/CaloMET_pt.png

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/38813, which should be merged for all future FastSim productions in CMSSW_10_6_X, e.g., UL requests. 