### PR TITLE
Fix configuration  for BPHMonitor

### DIFF
--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -1242,7 +1242,8 @@ void BPHMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<double>("minprob", 0.005);
   desc.add<double>("mincos", 0.95);
   desc.add<double>("minDS", 3.);
-  desc.add<unsigned int>("stageL1Trigger", 1);
+  HLTPrescaleProvider::fillPSetDescription(
+      desc, 1, edm::InputTag("gtStage2Digis"), edm::InputTag("gtStage2Digis"), false);
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   GenericTriggerEventFlag::fillPSetDescription(genericTriggerEventPSet);

--- a/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
@@ -33,6 +33,7 @@ namespace edm {
   class EventSetup;
   class ParameterSet;
   class Run;
+  class ParameterSetDescription;
 }  // namespace edm
 
 class HLTPrescaleProvider {
@@ -92,6 +93,12 @@ public:
   // Event rejected by HLTPrescaler on ith HLT path?
   bool rejectedByHLTPrescaler(const edm::TriggerResults& triggerResults, unsigned int i) const;
   static int l1PrescaleDenominator() { return kL1PrescaleDenominator_; }
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc,
+                                  unsigned int stageL1Trigger,
+                                  edm::InputTag const& l1tAlgBlkInputTag,
+                                  edm::InputTag const& l1tExtBlkInputTag,
+                                  bool readPrescalesFromFile);
 
 private:
   void checkL1GtUtils() const;

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -10,6 +10,7 @@
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include <cassert>
 #include <sstream>
@@ -367,4 +368,14 @@ unsigned int HLTPrescaleProvider::prescaleValue<unsigned int>(const edm::Event& 
                                                               const std::string& trigger) {
   const int set(prescaleSet(iEvent, iSetup));
   return set < 0 ? 1 : hltConfigProvider_.prescaleValue<unsigned int>(static_cast<unsigned int>(set), trigger);
+}
+
+void HLTPrescaleProvider::fillPSetDescription(edm::ParameterSetDescription& desc,
+                                              unsigned int stageL1Trigger,
+                                              edm::InputTag const& l1tAlgBlkInputTag,
+                                              edm::InputTag const& l1tExtBlkInputTag,
+                                              bool readPrescalesFromFile) {
+  desc.add<unsigned int>("stageL1Trigger", stageL1Trigger);
+  L1GtUtils::fillDescription(desc);
+  l1t::L1TGlobalUtil::fillDescription(desc, l1tAlgBlkInputTag, l1tExtBlkInputTag, readPrescalesFromFile);
 }

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
@@ -97,7 +97,12 @@ namespace l1t {
     /// check that the L1TGlobalUtil has been properly initialised
     bool valid() const;
 
-    static void fillDescription(edm::ParameterSetDescription& desc) { L1TGlobalUtilHelper::fillDescription(desc); }
+    static void fillDescription(edm::ParameterSetDescription& desc,
+                                edm::InputTag const& iAlg,
+                                edm::InputTag const& iExt,
+                                bool readPrescalesFromFile) {
+      L1TGlobalUtilHelper::fillDescription(desc, iAlg, iExt, readPrescalesFromFile);
+    }
 
     // OverridePrescalesAndMasks
     // The ability to override the prescale/mask file will not be part of the permanent interface of this class.

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
@@ -62,7 +62,10 @@ namespace l1t {
                         edm::InputTag const& l1tExtBlkInputTag);
 
     // A module defining its fillDescriptions function might want to use this
-    static void fillDescription(edm::ParameterSetDescription& desc);
+    static void fillDescription(edm::ParameterSetDescription& desc,
+                                edm::InputTag const& iAlg,
+                                edm::InputTag const& iExt,
+                                bool readPrescalesFromFile);
 
     edm::InputTag const& l1tAlgBlkInputTag() const { return m_l1tAlgBlkInputTag; }
     edm::InputTag const& l1tExtBlkInputTag() const { return m_l1tExtBlkInputTag; }
@@ -120,6 +123,7 @@ namespace l1t {
     if (!m_l1tAlgBlkInputTag.label().empty()) {
       m_l1tAlgBlkToken = iC.consumes<GlobalAlgBlkBxCollection>(m_l1tAlgBlkInputTag);
     }
+
     if (!m_l1tExtBlkInputTag.label().empty()) {
       m_l1tExtBlkToken = iC.consumes<GlobalExtBlkBxCollection>(m_l1tExtBlkInputTag);
     }
@@ -131,8 +135,16 @@ namespace l1t {
     // Register the callback function with the Framework
     // if any InputTags still need to be found.
     if (findL1TAlgBlk || findL1TExtBlk) {
-      module.callWhenNewProductsRegistered([this, findL1TAlgBlk, findL1TExtBlk, iC](auto iBranch) {
-        checkToUpdateTags(iBranch, iC, findL1TAlgBlk, findL1TExtBlk);
+      assert(false);
+      auto const* pModule = &module;
+      module.callWhenNewProductsRegistered([this, findL1TAlgBlk, findL1TExtBlk, iC, pModule](auto iBranch) {
+        try {
+          checkToUpdateTags(iBranch, iC, findL1TAlgBlk, findL1TExtBlk);
+        } catch (cms::Exception& iExcept) {
+          auto const& label = pModule->moduleDescription().moduleLabel();
+          iExcept.addContext(std::string("Running 'callWhenNewProductRegistered' for module ") + label);
+          throw;
+        }
       });
     }
   }

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h
@@ -135,7 +135,6 @@ namespace l1t {
     // Register the callback function with the Framework
     // if any InputTags still need to be found.
     if (findL1TAlgBlk || findL1TExtBlk) {
-      assert(false);
       auto const* pModule = &module;
       module.callWhenNewProductsRegistered([this, findL1TAlgBlk, findL1TExtBlk, iC, pModule](auto iBranch) {
         try {


### PR DESCRIPTION
#### PR description:

The recent change to BPHMonitor exposed a configuration problem with workflows in the integration builds. This change avoids having the code do an auto determination of data to get (which can fail when multiple 'preferred' data are available) and instead specifies which data to get via fillDescriptions.

#### PR validation:

The code compiles and workflow 11634.911 no longer complains about the configuration for BPHMonitor instances.

fixes #39017