### PR TITLE
Add remaining plots for PPSTimingCalibration for Payload Inspector

### DIFF
--- a/CondCore/CTPPSPlugins/plugins/PPSTimingCalibration_PayloadInspector.cc
+++ b/CondCore/CTPPSPlugins/plugins/PPSTimingCalibration_PayloadInspector.cc
@@ -17,101 +17,3521 @@ namespace {
   /************************************************
     History plots
   *************************************************/
+
+  //db=0, plane=0, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param3;
+
+  //db=0, plane=0, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param3;
+
+  //db=0, plane=0, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param3;
+
+  //db=0, plane=0, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param3;
+
+  //db=0, plane=0, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param3;
+
+  //db=0, plane=0, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param3;
+
+  //db=0, plane=0, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param3;
+
+  //db=0, plane=0, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param3;
+
+  //db=0, plane=0, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param3;
+
+  //db=0, plane=0, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param3;
+
+  //db=0, plane=0, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param3;
+
+  //db=0, plane=0, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param3;
+
+  //db=0, plane=1, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param3;
+
+  //db=0, plane=1, channel=1
+
   typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
                            PPSTimingCalibrationPI::plane1,
                            PPSTimingCalibrationPI::channel1,
                            PPSTimingCalibrationPI::parameter0,
                            PPSTimingCalibration>
-      PPSTimingCalibration_history_htdc_calibration_param0;
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param0;
+
   typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
                            PPSTimingCalibrationPI::plane1,
                            PPSTimingCalibrationPI::channel1,
                            PPSTimingCalibrationPI::parameter1,
                            PPSTimingCalibration>
-      PPSTimingCalibration_history_htdc_calibration_param1;
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param1;
+
   typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
                            PPSTimingCalibrationPI::plane1,
                            PPSTimingCalibrationPI::channel1,
                            PPSTimingCalibrationPI::parameter2,
                            PPSTimingCalibration>
-      PPSTimingCalibration_history_htdc_calibration_param2;
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param2;
+
   typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
                            PPSTimingCalibrationPI::plane1,
                            PPSTimingCalibrationPI::channel1,
                            PPSTimingCalibrationPI::parameter3,
                            PPSTimingCalibration>
-      PPSTimingCalibration_history_htdc_calibration_param3;
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param3;
+
+  //db=0, plane=1, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param3;
+
+  //db=0, plane=1, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param3;
+
+  //db=0, plane=1, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param3;
+
+  //db=0, plane=1, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param3;
+
+  //db=0, plane=1, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param3;
+
+  //db=0, plane=1, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param3;
+
+  //db=0, plane=1, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param3;
+
+  //db=0, plane=1, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param3;
+
+  //db=0, plane=1, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param3;
+
+  //db=0, plane=1, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param3;
+
+  //db=0, plane=2, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param3;
+
+  //db=0, plane=2, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param3;
+
+  //db=0, plane=2, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param3;
+
+  //db=0, plane=2, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param3;
+
+  //db=0, plane=2, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param3;
+
+  //db=0, plane=2, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param3;
+
+  //db=0, plane=2, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param3;
+
+  //db=0, plane=2, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param3;
+
+  //db=0, plane=2, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param3;
+
+  //db=0, plane=2, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param3;
+
+  //db=0, plane=2, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param3;
+
+  //db=0, plane=2, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param3;
+
+  //db=0, plane=3, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param3;
+
+  //db=0, plane=3, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param3;
+
+  //db=0, plane=3, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param3;
+
+  //db=0, plane=3, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param3;
+
+  //db=0, plane=3, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param3;
+
+  //db=0, plane=3, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param3;
+
+  //db=0, plane=3, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param3;
+
+  //db=0, plane=3, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param3;
+
+  //db=0, plane=3, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param3;
+
+  //db=0, plane=3, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param3;
+
+  //db=0, plane=3, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param3;
+
+  //db=0, plane=3, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param3;
+
+  //db=1, plane=0, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param3;
+
+  //db=1, plane=0, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param3;
+
+  //db=1, plane=0, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param3;
+
+  //db=1, plane=0, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param3;
+
+  //db=1, plane=0, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param3;
+
+  //db=1, plane=0, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param3;
+
+  //db=1, plane=0, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param3;
+
+  //db=1, plane=0, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param3;
+
+  //db=1, plane=0, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param3;
+
+  //db=1, plane=0, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param3;
+
+  //db=1, plane=0, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param3;
+
+  //db=1, plane=0, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane0,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param3;
+
+  //db=1, plane=1, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param3;
+
+  //db=1, plane=1, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param3;
+
+  //db=1, plane=1, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param3;
+
+  //db=1, plane=1, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param3;
+
+  //db=1, plane=1, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param3;
+
+  //db=1, plane=1, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param3;
+
+  //db=1, plane=1, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param3;
+
+  //db=1, plane=1, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param3;
+
+  //db=1, plane=1, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param3;
+
+  //db=1, plane=1, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param3;
+
+  //db=1, plane=1, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param3;
+
+  //db=1, plane=1, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param3;
+
+  //db=1, plane=2, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param3;
+
+  //db=1, plane=2, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param3;
+
+  //db=1, plane=2, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param3;
+
+  //db=1, plane=2, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param3;
+
+  //db=1, plane=2, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param3;
+
+  //db=1, plane=2, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param3;
+
+  //db=1, plane=2, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param3;
+
+  //db=1, plane=2, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param3;
+
+  //db=1, plane=2, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param3;
+
+  //db=1, plane=2, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param3;
+
+  //db=1, plane=2, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param3;
+
+  //db=1, plane=2, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane2,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param3;
+
+  //db=1, plane=3, channel=0
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel0,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param3;
+
+  //db=1, plane=3, channel=1
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param3;
+
+  //db=1, plane=3, channel=2
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel2,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param3;
+
+  //db=1, plane=3, channel=3
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel3,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param3;
+
+  //db=1, plane=3, channel=4
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel4,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param3;
+
+  //db=1, plane=3, channel=5
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel5,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param3;
+
+  //db=1, plane=3, channel=6
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel6,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param3;
+
+  //db=1, plane=3, channel=7
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel7,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param3;
+
+  //db=1, plane=3, channel=8
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel8,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param3;
+
+  //db=1, plane=3, channel=9
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel9,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param3;
+
+  //db=1, plane=3, channel=10
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel10,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param3;
+
+  //db=1, plane=3, channel=11
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param0;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param1;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param2;
+
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db1,
+                           PPSTimingCalibrationPI::plane3,
+                           PPSTimingCalibrationPI::channel11,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param3;
 
   /************************************************
     X-Y correlation plots
   *************************************************/
 
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter0,
-                         PPSTimingCalibrationPI::parameter1,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params01;
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter0,
-                         PPSTimingCalibrationPI::parameter2,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params02;
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter0,
-                         PPSTimingCalibrationPI::parameter3,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params03;
-
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter1,
-                         PPSTimingCalibrationPI::parameter2,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params12;
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter1,
-                         PPSTimingCalibrationPI::parameter3,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params13;
-
-  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
-                         PPSTimingCalibrationPI::plane1,
-                         PPSTimingCalibrationPI::channel1,
-                         PPSTimingCalibrationPI::parameter2,
-                         PPSTimingCalibrationPI::parameter3,
-                         PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_params23;
-
   /************************************************
     Image plots
   *************************************************/
+
+  //db=0, plane=0
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl0param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl0param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl0param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl0param3_per_channels;
+
+  //db=0, plane=1
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl1param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl1param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl1param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl1param3_per_channels;
+
+  //db=0, plane=2
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl2param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl2param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl2param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl2param3_per_channels;
+
+  //db=0, plane=3
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl3param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl3param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db0pl3param2_per_channels;
 
   typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
                                PPSTimingCalibrationPI::plane3,
                                PPSTimingCalibrationPI::parameter3,
                                PPSTimingCalibration>
-      PPSTimingCalibration_htdc_calibration_param3;
+      PPSTimingCalibration_htdc_calibration_db0pl3param3_per_channels;
+
+  //db=1, plane=0
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl0param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl0param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl0param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane0,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl0param3_per_channels;
+
+  //db=1, plane=1
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl1param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl1param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl1param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane1,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl1param3_per_channels;
+
+  //db=1, plane=2
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl2param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl2param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl2param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane2,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl2param3_per_channels;
+
+  //db=1, plane=3
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter0,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl3param0_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter1,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl3param1_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter2,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl3param2_per_channels;
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db1,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_db1pl3param3_per_channels;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(PPSTimingCalibration) {
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param0);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param1);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param2);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param3);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params01);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params02);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params03);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params12);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params13);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params23);
-  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl0ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl1ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl2ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db0pl3ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl0ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl1ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl2ch11_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch0_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch1_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch2_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch3_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch4_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch5_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch6_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch7_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch8_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch9_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch10_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_db1pl3ch11_param3);
+
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl0param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl0param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl0param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl0param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl1param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl1param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl1param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl1param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl2param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl2param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl2param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl2param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl3param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl3param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl3param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db0pl3param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl0param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl0param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl0param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl0param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl1param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl1param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl1param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl1param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl2param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl2param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl2param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl2param3_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl3param0_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl3param1_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl3param2_per_channels);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_db1pl3param3_per_channels);
 }

--- a/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.sh
+++ b/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.sh
@@ -10,16 +10,25 @@ then
 
     echo "Testing history plots"
 
-    for param in 0 1 2 3
+    for db in 0 1
     do
-        getPayloadData.py \
-            --plugin pluginPPSTimingCalibration_PayloadInspector \
-            --plot plot_PPSTimingCalibration_history_htdc_calibration_param$param \
-            --tag PPSDiamondTimingCalibration_v1 \
-            --time_type Run \
-            --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
-            --db Prod \
-            --test 2> CondCore/CTPPSPlugins/test/results/data_history_$param.json
+        for pl in 0 1 2 3
+        do
+            for ch in 0 1 2 3 4 5 6 7 8 9 10 11
+            do
+                for param in 0 1 2 3
+                do
+                    python3 CondCore/Utilities/scripts/getPayloadData.py \
+                            --plugin pluginPPSTimingCalibration_PayloadInspector \
+                            --plot plot_PPSTimingCalibration_history_htdc_calibration_db${db}pl${pl}ch${ch}_param${param} \
+                            --tag CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt \
+                            --time_type Run \
+                            --iovs '{"start_iov": "355892", "end_iov": "357079"}' \
+                            --db Prod \
+                            --test 2> CondCore/CTPPSPlugins/test/results/data_history__db${db}pl${pl}ch${ch}_param${param}.json
+                done
+            done
+        done                    
     done 
 
 
@@ -33,12 +42,12 @@ then
             then
                 getPayloadData.py \
                     --plugin pluginPPSTimingCalibration_PayloadInspector \
-                    --plot  plot_PPSTimingCalibration_htdc_calibration_params$param1$param2 \
-                    --tag PPSDiamondTimingCalibration_v1 \
+                    --plot  plot_PPSTimingCalibration_htdc_calibration_params${param1}${param2} \
+                    --tag CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt \
                     --time_type Run \
-                    --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
+                    --iovs '{"start_iov": "355892", "end_iov": "357079"}' \
                     --db Prod \
-                    --test 2> CondCore/CTPPSPlugins/test/results/data_params_$param1$param2.json 
+                    --test 2> CondCore/CTPPSPlugins/test/results/data_params_${param1}${param2}.json 
             fi  
         done
     done    
@@ -47,16 +56,26 @@ then
 
     echo "Testing channel plots"
 
-    getPayloadData.py \
-        --plugin pluginPPSTimingCalibration_PayloadInspector \
-        --plot plot_PPSTimingCalibration_htdc_calibration_param3 \
-        --tag PPSDiamondTimingCalibration_v1 \
-        --time_type Run \
-        --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
-        --db Prod \
-        --test
 
-    mv *.png CondCore/CTPPSPlugins/test/results/plot_PPSTimingCalibration_ppc.png
+    for db in 0 1
+    do
+        for pl in 0 1 2 3
+        do
+            for param in 0 1 2 3
+            do
+                getPayloadData.py \
+                    --plugin pluginPPSTimingCalibration_PayloadInspector \
+                    --plot plot_PPSTimingCalibration_htdc_calibration_db${db}pl${pl}param${param}_per_channels \
+                    --tag CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt \
+                    --time_type Run \
+                    --iovs '{"start_iov": "356489", "end_iov": "356489"}' \
+                    --db Prod \
+                    --test
+                mv *.png CondCore/CTPPSPlugins/test/results/plot_PPSTimingCalibration_db${db}pl${pl}param${param}_per_channels.png    
+            done
+        done                    
+    done 
+
 
 elif [ "$1" == "clear" ]
 then


### PR DESCRIPTION
#### PR description:
The main aim of this PR is to add remaining plots for PPSTimingCalibration class to Payload Inspector software so to be able to visualize it on the website.

#### PR validation:
The code was tested by a script testPPSTimingCalibration.sh (which is mostly based on getPayloadData.py from CondCore/Utilities) just to check whether the code is properly added to PI software and generate some proper data in JSON files produced by PI.
In case of testing - testPPSTimingCalibration.sh script should be run with 'run' argument.

####PR backport:

No backport.
