### PR TITLE
[12.4.X] Adjustments to `SiPixelCalSingleMuon` producers

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_cff.py
@@ -24,7 +24,7 @@ ALCARECOSiPixelCalSingleMuonLoose.etaMax = 3.5
 # Prescale events
 ##################################################################
 import CalibTracker.SiStripCommon.prescaleEvent_cfi
-scalerForSiPixelCalSingleMuonLoose = CalibTracker.SiStripCommon.prescaleEvent_cfi.prescaleEvent.clone(prescale = 100)
+scalerForSiPixelCalSingleMuonLoose = CalibTracker.SiStripCommon.prescaleEvent_cfi.prescaleEvent.clone(prescale = 10)
 
 ##################################################################
 # Loose Sequence

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -7,8 +7,7 @@ from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 ALCARECOSiPixelCalSingleMuonTightHLTFilter = hltHighLevel.clone()
 ALCARECOSiPixelCalSingleMuonTightHLTFilter.andOr = True ## choose logical OR between Triggerbits
 ALCARECOSiPixelCalSingleMuonTightHLTFilter.throw = False ## dont throw on unknown path names
-ALCARECOSiPixelCalSingleMuonTightHLTFilter.HLTPaths = ["HLT_*"]
-#ALCARECOSiPixelCalSingleMuonTightHLTFilter.eventSetupPathsKey = 'SiPixelCalSingleMuonTight'  ## FIXME: to be changed once trigger bit is updated
+ALCARECOSiPixelCalSingleMuonTightHLTFilter.eventSetupPathsKey = 'SiPixelCalSingleMuon' # share the same trigger bit with the loose one
 
 ##################################################################
 # Filter on the DCS partitions


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39025

#### PR description:

The goal of this PR is two-fold:

   * reduce the event prescale of `ALCARECOSiPixelCalSingleMuonLoose` from 100 to 10, as operational experience has shown that the amount of collected data with the current prescale in 2022 is too low to be useful.
   * use the `SiPixelCalSingleMuon` `eventSetupPathsKey` for `ALCARECOSiPixelCalSingleMuonTight` (as it can be shared among the different flavours of Muon-based pixel AlCaRecos, as discussed at https://github.com/cms-AlCaDB/AlCaTools/issues/70)

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #39025, needed for data-taking operations