### PR TITLE
implement event consumes in `MuScleFit`

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.cc
@@ -87,8 +87,7 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event& event,
                                         std::vector<GenMuonPair>& genPair,
                                         std::vector<std::pair<lorentzVector, lorentzVector> >& simPair,
                                         MuScleFitPlotter* plotter) {
-  edm::Handle<pat::CompositeCandidateCollection> collAll;
-  event.getByLabel("onia2MuMuPatTrkTrk", collAll);
+  edm::Handle<pat::CompositeCandidateCollection> collAll = event.getHandle(onia2MuMuToken_);
   if (!collAll.isValid()) {
     edm::LogWarning("MuScleFitUtils") << "J/psi not present in event!";
   }
@@ -179,8 +178,7 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event& event,
   } else if ((muonType_ < 4 && muonType_ >= 0) || muonType_ >= 10) {  // Muons (glb,sta,trk)
     std::vector<reco::Track> tracks;
     if (PATmuons_ == true) {
-      edm::Handle<pat::MuonCollection> allMuons;
-      event.getByLabel(muonLabel_, allMuons);
+      edm::Handle<pat::MuonCollection> allMuons = event.getHandle(patMuonToken_);
       if (muonType_ == 0) {
         // Take directly the muon
         muons = fillMuonCollection(*allMuons);
@@ -192,8 +190,7 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event& event,
         muons = fillMuonCollection(tracks);
       }
     } else {
-      edm::Handle<reco::MuonCollection> allMuons;
-      event.getByLabel(muonLabel_, allMuons);
+      edm::Handle<reco::MuonCollection> allMuons = event.getHandle(recoMuonToken_);
       if (muonType_ == 0) {
         // Take directly the muon
         muons = fillMuonCollection(*allMuons);
@@ -205,8 +202,7 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event& event,
       }
     }
   } else if (muonType_ == 4) {  //CaloMuons
-    edm::Handle<reco::CaloMuonCollection> caloMuons;
-    event.getByLabel(muonLabel_, caloMuons);
+    edm::Handle<reco::CaloMuonCollection> caloMuons = event.getHandle(caloMuonToken_);
     std::vector<reco::Track> tracks;
     for (std::vector<reco::CaloMuon>::const_iterator muon = caloMuons->begin(); muon != caloMuons->end(); ++muon) {
       tracks.push_back(*(muon->track()));
@@ -215,8 +211,7 @@ void MuScleFitMuonSelector::selectMuons(const edm::Event& event,
   }
 
   else if (muonType_ == 5) {  // Inner tracker tracks
-    edm::Handle<reco::TrackCollection> tracks;
-    event.getByLabel(muonLabel_, tracks);
+    edm::Handle<reco::TrackCollection> tracks = event.getHandle(trackCollectionToken_);
     muons = fillMuonCollection(*tracks);
   }
   plotter->fillRec(muons);
@@ -296,14 +291,11 @@ void MuScleFitMuonSelector::selectGenSimMuons(const edm::Event& event,
                                               MuScleFitPlotter* plotter) {
   // Find and store in histograms the generated and simulated resonance and muons
   // ----------------------------------------------------------------------------
-  edm::Handle<edm::HepMCProduct> evtMC;
-  edm::Handle<reco::GenParticleCollection> genParticles;
+  edm::Handle<edm::HepMCProduct> evtMC = event.getHandle(evtMCToken_);
+  edm::Handle<reco::GenParticleCollection> genParticles = event.getHandle(genParticleToken_);
 
   // Fill gen information only in the first loop
   bool ifHepMC = false;
-
-  event.getByLabel(genParticlesName_, evtMC);
-  event.getByLabel(genParticlesName_, genParticles);
   if (evtMC.isValid()) {
     genPair.push_back(findGenMuFromRes(evtMC.product()));
     plotter->fillGen(*evtMC, sherpa_);
@@ -334,9 +326,8 @@ void MuScleFitMuonSelector::selectSimulatedMuons(const edm::Event& event,
                                                  edm::Handle<edm::HepMCProduct> evtMC,
                                                  std::vector<std::pair<lorentzVector, lorentzVector> >& simPair,
                                                  MuScleFitPlotter* plotter) {
-  edm::Handle<edm::SimTrackContainer> simTracks;
+  edm::Handle<edm::SimTrackContainer> simTracks = event.getHandle(simTrackToken_);
   bool simTracksFound = false;
-  event.getByLabel(simTracksCollectionName_, simTracks);
   if (simTracks.isValid()) {
     plotter->fillSim(simTracks);
     if (ifHepMC) {

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
@@ -28,7 +29,8 @@ typedef reco::Particle::LorentzVector lorentzVector;
 
 class MuScleFitMuonSelector {
 public:
-  MuScleFitMuonSelector(const edm::InputTag& muonLabel,
+  MuScleFitMuonSelector(edm::ConsumesCollector& iC,
+                        const edm::InputTag& muonLabel,
                         const int muonType,
                         const bool PATmuons,
                         const std::vector<int>& resfind,
@@ -47,8 +49,16 @@ public:
         compareToSimTracks_(compareToSimTracks),
         simTracksCollectionName_(simTracksCollectionName),
         sherpa_(sherpa),
-        debug_(debug) {}
-  ~MuScleFitMuonSelector() {}
+        debug_(debug),
+        onia2MuMuToken_(iC.consumes<pat::CompositeCandidateCollection>(edm::InputTag("onia2MuMuPatTrkTrk"))),
+        trackCollectionToken_(iC.consumes<reco::TrackCollection>(muonLabel_)),
+        patMuonToken_(iC.consumes<pat::MuonCollection>(muonLabel_)),
+        recoMuonToken_(iC.consumes<reco::MuonCollection>(muonLabel_)),
+        caloMuonToken_(iC.consumes<reco::CaloMuonCollection>(muonLabel_)),
+        evtMCToken_(iC.consumes<edm::HepMCProduct>(genParticlesName_)),
+        genParticleToken_(iC.consumes<reco::GenParticleCollection>(genParticlesName_)),
+        simTrackToken_(iC.consumes<edm::SimTrackContainer>(simTracksCollectionName_)) {}
+  ~MuScleFitMuonSelector() = default;
 
   //Method to get the muon after FSR (status 1 muon in PYTHIA6) starting from status 3 muon which is daughter of the Z
   const reco::Candidate* getStatus1Muon(const reco::Candidate* status3Muon);
@@ -156,6 +166,16 @@ protected:
   const edm::InputTag simTracksCollectionName_;
   const bool sherpa_;
   const bool debug_;
+
+  const edm::EDGetTokenT<pat::CompositeCandidateCollection> onia2MuMuToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> trackCollectionToken_;
+  const edm::EDGetTokenT<pat::MuonCollection> patMuonToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> recoMuonToken_;
+  const edm::EDGetTokenT<reco::CaloMuonCollection> caloMuonToken_;
+  const edm::EDGetTokenT<edm::HepMCProduct> evtMCToken_;
+  const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
+
   static const double mMu2;
   static const unsigned int motherPdgIdArray[6];
 };


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38958

#### PR description:

Title says it all.

#### PR validation:

Run with this branch the configuration posted at https://github.com/cms-sw/cmssw/issues/38958#issuecomment-1203927278 (for convenience also available [here](https://gist.github.com/mmusich/80fa5cb6e192c9f424f715b598b22604)) successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will need to be backported to CMSSW_12_4_X for tracker alignment validation purposes.
