### PR TITLE
Extend CMS protections in Geant4 exception handling

### DIFF
--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -62,7 +62,7 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
   mescode >> code;
 
   // track is killed
-  if (ekin < m_eth && code == "GeomNav0003") {
+  if (ekin < m_eth && (code == "GeomNav0003" || code == "GeomField0003")) {
     localSeverity = JustWarning;
     track->SetTrackStatus(fStopAndKill);
   }


### PR DESCRIPTION
#### PR description:
In MinBias production for Run3 a visible % of jobs crash due to Geant4 problem of tracking of low energy (~5 keV) electrons. It is clear that the problem is numerical - for small steps of electrons of low energy numerical precsion is lost in Geant4 computations. This PR provide work around this rare problem. No change in SIM hits for low statistic run is expected.

#### PR validation:
Locally the problem was not yet reproduced but this approach was validated previously in similar circonstances with more frequent problems.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Will be backported to 12_4

