### PR TITLE
[12_4_X] Extend CMS protections in Geant4 exception handling

### DIFF
--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -62,7 +62,7 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
   mescode >> code;
 
   // track is killed
-  if (ekin < m_eth && code == "GeomNav0003") {
+  if (ekin < m_eth && (code == "GeomNav0003" || code == "GeomField0003")) {
     localSeverity = JustWarning;
     track->SetTrackStatus(fStopAndKill);
   }


### PR DESCRIPTION
#### PR description:
It is a backport of #39032 for MC production. This PR should reduce rare crashes due to numerical problem in Geant4 tracking in field of low-energy e-.

#### PR validation:
the method itself is used for the long time in CMSSW.

