### PR TITLE
Update MPI tools and tests

### DIFF
--- a/HeterogeneousCore/CUDACore/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/test/BuildFile.xml
@@ -25,8 +25,7 @@
     <use name="openmpi"/>
     <use name="cuda"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
-    <flags TEST_RUNNER_CMD="cmsenv_mpirun  -np 2 mpiCudaGeneric -t100 -a10 -s200000 -p123"/>
+    <flags TEST_RUNNER_CMD="cudaIsEnabled &amp;&amp; cmsenv_mpirun -np 2 mpiCudaGeneric -t100 -a10 -s200000 -p123 || echo 'Failed to initialise the CUDA runtime, the test will be skipped.'"/>
 </bin>
 
 </iftool>
-

--- a/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
+++ b/HeterogeneousCore/CUDACore/test/mpiCudaGeneric.cu
@@ -137,7 +137,6 @@ bool saveToFile(const std::string &name, const Timing &timing);
 
 void printHelp(void);
 int main(int argc, char *argv[]) {
-  cms::cudatest::requireDevices();
   int c;  //to get parameters from user.
 
   UserChoises user;  //Setup Uuser's input variables

--- a/HeterogeneousCore/MPICore/scripts/cmsenv_mpirun
+++ b/HeterogeneousCore/MPICore/scripts/cmsenv_mpirun
@@ -2,25 +2,42 @@
 
 VERBOSE=false
 RELEASE=false
+MCA_PREFIX=cmsenv
 
 for ARG in "$@"; do
   case "$ARG" in
     -v|--verbose)
       VERBOSE=true
       ;;
-    cmsenv_release)
+    ${MCA_PREFIX}_release)
       RELEASE=true
       ;;
   esac
 done
 
-# additional options oassed to cmsenv_orted
+# full path to cmsenv_orted
+RELEASE_BASE=
+for VAR in CMSSW_BASE CMSSW_RELEASE_BASE CMSSW_FULL_RELEASE_BASE; do
+  TEST_PATH=${!VAR}
+  if [ -x $TEST_PATH/bin/$SCRAM_ARCH/cmsenv_orted ]; then
+    RELEASE_BASE=$TEST_PATH
+    break
+  fi
+done
+if [ -z "$RELEASE_BASE" ]; then
+  echo "Error: cannot find cmsenv_orted in the \$PATH."
+  exit 1
+fi
+
+# additional options passed to cmsenv_orted
 EXTRA_OPTIONS=""
 
 # if "-v" or "--verbose" are specified, add "-mca cmsenv_verbose true"
-$VERBOSE && EXTRA_OPTIONS="$EXTRA_OPTIONS -mca cmsenv_verbose true"
+$VERBOSE && EXTRA_OPTIONS="$EXTRA_OPTIONS -mca ${MCA_PREFIX}_verbose true"
 
 # if "-mca cmsenv_release" is not specified, add "-mca cmsenv_release $CMSSW_BASE"
-$RELEASE || EXTRA_OPTIONS="$EXTRA_OPTIONS -mca cmsenv_release $CMSSW_BASE"
+$RELEASE || EXTRA_OPTIONS="$EXTRA_OPTIONS -mca ${MCA_PREFIX}_release $CMSSW_BASE"
 
-exec mpirun --launch-agent $CMSSW_BASE/bin/$SCRAM_ARCH/cmsenv_orted $EXTRA_OPTIONS "$@"
+# if "-v" or "--verbose" are specified, print the command that will be executed
+$VERBOSE && echo mpirun --launch-agent $RELEASE_BASE/bin/$SCRAM_ARCH/cmsenv_orted $EXTRA_OPTIONS "$@"
+exec mpirun --launch-agent $RELEASE_BASE/bin/$SCRAM_ARCH/cmsenv_orted $EXTRA_OPTIONS "$@"


### PR DESCRIPTION
#### PR description:

Update `cmsenv_mpirun` to look for `cmsenv_orted` also under the base releases.

Move the test for CUDA availability from `mpiCudaGeneric` binary to the BuildFile.xml.

#### PR validation:

Tested using a CMSSW area with `cmsenv_orted` under `$CMSSW_RELEASE_BASE/bin/` and not under `$CMSSW_BASE/bin`.

#### If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW 12.4.x for ongoing DAQ tests (not used for data taking): see #39037.