### PR TITLE
Utilities/StaticAnalyzers: fix errors found in IB static analyzer jobs

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/class-composition.py
+++ b/Utilities/StaticAnalyzers/scripts/class-composition.py
@@ -86,6 +86,7 @@ for node in nodes:
     if node in visited:
         continue
     visited.add(node)
+    stack = []
     if node in Hdg:
         stack = [(node, iter(Hdg[node]))]
     if node in Idg:

--- a/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
+++ b/Utilities/StaticAnalyzers/scripts/run_class_dumper.sh
@@ -32,7 +32,6 @@ sort -u < function-dumper.txt.unsorted > function-calls-db.txt
 class-composition.py >classes.txt.inherits.unsorted
 sort -u classes.txt.inherits.unsorted | grep -e"^class" | grep -v \'\' >classes.txt.inherits
 sort -u classes.txt.inherits.unsorted | grep -v -e"^class" >classes.txt.inherits.extra
-sort -u getparam-dumper.txt.unsorted | awk '{print $0"\n"}' >getparam-dumper.txt
 cat classes.txt.inherits classes.txt.dumperft classes.txt.dumperct | grep -e"^class" | grep -v \'\' | sort -u >classes.txt
 rm *.txt.*unsorted
 classnames-extract.py


### PR DESCRIPTION
Fixes two errors I noticed in IB static analyzer jobs
```
Traceback (most recent call last):
  File "/pool/condor/dir_31792/jenkins/workspace/ib-run-static-checks/CMSSW_12_5_X_2022-08-11-1100/bin/el8_amd64_gcc10/class-composition.py", line 97, in <module>
    while stack:
NameError: name 'stack' is not defined
sort: cannot read: getparam-dumper.txt.unsorted: No such file or directory
```