### PR TITLE
[12.4.X] Fix Tracker Alignment overlap validation 

### DIFF
--- a/Alignment/OfflineValidation/python/overlapValidationPlot.py
+++ b/Alignment/OfflineValidation/python/overlapValidationPlot.py
@@ -6,7 +6,7 @@ import math
 
 import ROOT
 
-from .TkAlStyle import TkAlStyle
+from TkAlStyle import TkAlStyle
 
 dirNameList=["z","r","phi"]# in general directions are labeled z=0 r =1 phi =2 throughout this, I should probably think of something more elegant
 detNameList = ("BPIX", "FPIX", "TIB", "TID", "TOB", "TEC")

--- a/Alignment/OfflineValidation/python/overlapValidationPlot.py
+++ b/Alignment/OfflineValidation/python/overlapValidationPlot.py
@@ -26,7 +26,7 @@ def hist(tree_file_name, hist_name,subdet_ids,module_directions,overlap_directio
                         for overlap in range(3):
                                 h[subdet][module].append([])
                                 for profile in range(4):
-                                        if subdetConditon(subdet,module,overlap):
+                                        if subdetCondition(subdet,module,overlap):
                                                 h[subdet][module][overlap].append(0)
                                                 continue
                                         name = hist_name + "{0}_{1}_{2}".format(dirNameList[module],dirNameList[overlap],detNameList[subdet])


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39035

#### PR description:

As per suggestion at https://github.com/cms-sw/cmssw/issues/39031#issuecomment-1211958241

#### PR validation:

script compiles (notice that I need to include https://github.com/cms-sw/cmssw/commit/98d8b945195d22288ca45c1c4ba8ce31f80e1972 in order to make it compile under python3)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/39035 needed for tracker alignment purposed.
