### PR TITLE
allow `TriggerResultsFilter` to throw for invalid `HLTPathStatus` patterns

### DIFF
--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -48,11 +48,16 @@ namespace triggerExpression {
     if (usePathStatus()) {
       m_pathStatus.clear();
       std::vector<std::string> triggerNames;
+      m_pathStatus.reserve(m_pathStatusTokens.size());
+      triggerNames.reserve(m_pathStatusTokens.size());
       for (auto const& p : m_pathStatusTokens) {
         auto const& handle = event.getHandle(p.second);
         if (handle.isValid()) {
           m_pathStatus.push_back(handle->accept());
           triggerNames.push_back(p.first);
+        } else {
+          edm::LogError("MissingHLTPathStatus")
+              << "invalid handle for requested edm::HLTPathStatus with label \"" << p.first << "\"";
         }
       }
       m_hltUpdated = m_triggerNames != triggerNames;

--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.h
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.h
@@ -17,12 +17,12 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <regex>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
 // forward declaration
@@ -45,6 +45,8 @@ public:
   bool filter(edm::Event &, const edm::EventSetup &) override;
 
 private:
+  void beginStream(edm::StreamID) override;
+
   /// parse the logical expression into functionals
   void parse(const std::string &expression);
   void parse(const std::vector<std::string> &expressions);
@@ -54,6 +56,16 @@ private:
 
   /// cache some data from the Event for faster access by the m_expression
   triggerExpression::Data m_eventCache;
+
+  struct PatternData {
+    PatternData(std::string const &aStr, std::regex const &aRegex, bool const hasMatch = false)
+        : str(aStr), regex(aRegex), matched(hasMatch) {}
+    std::string str;
+    std::regex regex;
+    bool matched;
+  };
+
+  std::vector<PatternData> hltPathStatusPatterns_;
 };
 
 #endif  //TriggerResultsFilter_h

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
@@ -2,174 +2,137 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('TEST')
 
-process.options = cms.untracked.PSet(
-    wantSummary = cms.untracked.bool(True)
-)
-process.load('FWCore.MessageService.MessageLogger_cfi')
-#process.MessageLogger.cerr.INFO = cms.untracked.PSet(
-#    reportEvery = cms.untracked.int32(1), # every!
-#    limit = cms.untracked.int32(-1)       # no limit!
-#    )
-#process.MessageLogger.cerr.FwkReport.reportEvery = 10 # only report every 10th event start
-#process.MessageLogger.cerr_stats.threshold = 'INFO' # also info in statistics
+process.options.wantSummary = True
 
-# load conditions from the global tag
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 100 # only report every 100th event start
+process.MessageLogger.cerr.enableStatistics = False # enable "MessageLogger Summary" message
+process.MessageLogger.cerr.threshold = 'INFO' # change to 'WARNING' not to show INFO-level messages
+## enable reporting of INFO-level messages (default is limit=0, i.e. no messages reported)
+#process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+#    reportEvery = cms.untracked.int32(1), # every event!
+#    limit = cms.untracked.int32(-1)       # no limit!
+#)
 
 # read back the trigger decisions
 process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring('file:trigger.root')
 )
 
-from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter as _trigResFilter
+_triggerResultsFilter = _trigResFilter.clone( l1tResults = '' )
 
 # accept if 'Path_1' succeeds
-process.filter_1 = triggerResultsFilter.clone(
-    triggerConditions =  ( 'Path_1', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_1 = _triggerResultsFilter.clone(
+    triggerConditions =  ( 'Path_1', )
+)
 
 # accept if 'Path_2' succeeds
-process.filter_2 = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_2', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_2 = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_2', )
+)
 
 # accept if 'Path_3' succeeds
-process.filter_3 = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_3', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_3 = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_3', )
+)
 
 # accept if any path succeeds (explicit OR)
-process.filter_any_or = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_1', 'Path_2', 'Path_3' ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_or = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1', 'Path_2', 'Path_3' )
+)
 
 # accept if 'Path_1' succeeds, prescaled by 15
-process.filter_1_pre = triggerResultsFilter.clone(
-    triggerConditions =  ( '(Path_1) / 15', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_1_pre = _triggerResultsFilter.clone(
+    triggerConditions =  ( '(Path_1) / 15', )
+)
 
 # accept if 'Path_1' prescaled by 15 does not succeed
-process.filter_not_1_pre = triggerResultsFilter.clone(
-    triggerConditions =  ( 'NOT (Path_1 / 15)', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_not_1_pre = _triggerResultsFilter.clone(
+    triggerConditions =  ( 'NOT (Path_1 / 15)', )
+)
 
 # accept if 'Path_2' succeeds, prescaled by 10
-process.filter_2_pre = triggerResultsFilter.clone(
-    triggerConditions = ( '(Path_2 / 10)', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_2_pre = _triggerResultsFilter.clone(
+    triggerConditions = ( '(Path_2 / 10)', )
+)
 
 # accept if any path succeeds, with different prescales (explicit OR, prescaled)
-process.filter_any_pre = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_pre = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', )
+)
 
 # equivalent of filter_any_pre using NOT operator twice
-process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
-    triggerConditions = ( 'NOT NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6)', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_pre_doubleNOT = _triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6)', )
+)
 
 # opposite of filter_any_pre without whitespaces where possible
-process.filter_not_any_pre = triggerResultsFilter.clone(
-    triggerConditions = ( 'NOT(Path_1/15)AND(NOT Path_2/10)AND(NOT Path_3/6)', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_not_any_pre = _triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT(Path_1/15)AND(NOT Path_2/10)AND(NOT Path_3/6)', )
+)
 
 # accept if any path succeeds (wildcard, '*')
-process.filter_any_star = triggerResultsFilter.clone(
-    triggerConditions = ( '*', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_star = _triggerResultsFilter.clone(
+    triggerConditions = ( '*', )
+)
 
 # accept if any path succeeds (wildcard, twice '*')
-process.filter_any_doublestar = triggerResultsFilter.clone(
-    triggerConditions = ( '*_*', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_doublestar = _triggerResultsFilter.clone(
+    triggerConditions = ( '*_*', )
+)
 
 # accept if any path succeeds (wildcard, '?')
-process.filter_any_question = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_?', ),
-    l1tResults = '',
-    throw = False
-    )
+process.filter_any_question = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_?', )
+)
 
 # accept if all path succeed (explicit AND)
-process.filter_all_explicit = triggerResultsFilter.clone(
-    triggerConditions = ( 'Path_1 AND Path_2 AND Path_3', ),
-    l1tResults = '',
-    throw = False
+process.filter_all_explicit = _triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1 AND Path_2 AND Path_3', )
 )
 
 # wrong path name (explicit)
-process.filter_wrong_name = triggerResultsFilter.clone(
+process.filter_wrong_name = _triggerResultsFilter.clone(
     triggerConditions = ( 'Wrong', ),
-    l1tResults = '',
     throw = False
 )
 
 # wrong path name (wildcard)
-process.filter_wrong_pattern = triggerResultsFilter.clone(
+process.filter_wrong_pattern = _triggerResultsFilter.clone(
     triggerConditions = ( '*_Wrong', ),
-    l1tResults = '',
     throw = False
 )
 
 # empty path list
-process.filter_empty_pattern = triggerResultsFilter.clone(
-    triggerConditions = ( ),
-    l1tResults = '',
-    throw = False
+process.filter_empty_pattern = _triggerResultsFilter.clone(
+    triggerConditions = ( )
 )
 
 # L1-like path name
-process.filter_l1path_pattern = triggerResultsFilter.clone(
-    triggerConditions = ( 'L1_Path', ),
-    l1tResults = '',
-    throw = False
+process.filter_l1path_pattern = _triggerResultsFilter.clone(
+    # this returns False for every event without throwing exceptions,
+    # because here l1tResults is an empty InputTag
+    # (patterns starting with "L1_" are used exclusively to check the L1-Trigger decisions)
+    triggerConditions = ( 'L1_Path', )
 )
 
 # real L1 trigger
-process.filter_l1singlemuopen_pattern = triggerResultsFilter.clone(
-    triggerConditions = ( 'L1_SingleMuOpen', ),
-    l1tResults = '',
-    throw = False
+process.filter_l1singlemuopen_pattern = _triggerResultsFilter.clone(
+    # this returns False for every event without throwing exceptions,
+    # because here l1tResults is an empty InputTag
+    # (patterns starting with "L1_" are used exclusively to check the L1-Trigger decisions)
+    triggerConditions = ( 'L1_SingleMuOpen', )
 )
 
 # TRUE
-process.filter_true_pattern = triggerResultsFilter.clone(
-    triggerConditions = ( 'TRUE', ),
-    l1tResults = '',
-    throw = False
+process.filter_true_pattern = _triggerResultsFilter.clone(
+    triggerConditions = ( 'TRUE', )
 )
 
 # FALSE
-process.filter_false_pattern = triggerResultsFilter.clone(
-    triggerConditions = ( 'FALSE', ),
-    l1tResults = '',
-    throw = False
+process.filter_false_pattern = _triggerResultsFilter.clone(
+    triggerConditions = ( 'FALSE', )
 )
 
 
@@ -202,6 +165,6 @@ process.path_false_pattern       = cms.Path( process.filter_false_pattern )
 
 # define an EndPath to analyze all other path results
 process.hltTrigReport = cms.EDAnalyzer( 'HLTrigReport',
-    HLTriggerResults = cms.InputTag( 'TriggerResults', '', 'TEST' )
+    HLTriggerResults = cms.InputTag( 'TriggerResults', '', '@currentProcess' )
 )
 process.HLTAnalyzerEndpath = cms.EndPath( process.hltTrigReport )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
@@ -2,6 +2,18 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('HLT')
 
+process.options.wantSummary = True
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 100 # only report every 100th event start
+process.MessageLogger.cerr.enableStatistics = False # enable "MessageLogger Summary" message
+process.MessageLogger.cerr.threshold = 'INFO' # change to 'WARNING' not to show INFO-level messages
+## enable reporting of INFO-level messages (default is limit=0, i.e. no messages reported)
+#process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+#    reportEvery = cms.untracked.int32(1), # every event!
+#    limit = cms.untracked.int32(-1)       # no limit!
+#)
+
 # define the Prescaler service, and set the scale factors
 process.PrescaleService = cms.Service('PrescaleService',
     prescaleTable = cms.VPSet(
@@ -22,17 +34,9 @@ process.PrescaleService = cms.Service('PrescaleService',
     lvl1DefaultLabel = cms.string('any')
 )    
 
-# load conditions from the global tag
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
-
-# define an empty source, and ask for 100 events
+# define an empty source, and ask for 1000 events
 process.source = cms.Source('EmptySource')
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
-)
+process.maxEvents.input = 1000
 
 # define 3 prescalers, one per path
 process.scale_1 = cms.EDFilter('HLTPrescaler')


### PR DESCRIPTION
#### PR description:

This PR updates the `TriggerResultsFilter` plugin to spot patterns without any valid matches when `HLTPathStatus` collections are used (i.e. when `usePathStatus=True`).

Up to now `throw=True` had no effect if `usePathStatus=True`, even if `triggerConditions` contained patterns with no valid matches amongst the Paths in the job.

All `TriggerResultsFilter` instances in the central HLT menus use `throw=True`, and since many use `usePathStatus=True`, those could in principle silently return `False` due to invalid patterns (in practise, those patterns are often controlled by the `ConfDB` GUI, so should be correct).

After this PR, invalid patterns for `HLTPathStatus` collections will lead to an exception if `throw=True`.

While testing these changes, small updates were applied to the unit-tests for `TriggerResultsFilter`. In particular, `TriggerResultsFilter` modules with valid patterns now use `throw=True`, while those with invalid patterns are those with `throw=False`.

_Edit_ : in addition, if `throw=True`, the plugin `TriggerResultsFilter` will now throw an exception if the parsing of the trigger-results expression fails (query with invalid syntax); up to now, this was leading only to a warning.

Thanks to @fwyzard for much help with the implementation; I tag him to review these changes.

#### PR validation:

Private tests with the relevant unit-tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

~~A backport to `12_4_X` is not necessary, but might be useful.~~ (see https://github.com/cms-sw/cmssw/pull/39044#issuecomment-1224969438)

`CMSSW_12_4_X`