### PR TITLE
Added optional Geant4 tracking cut for charged particles

### DIFF
--- a/SimG4Core/Application/interface/ExceptionHandler.h
+++ b/SimG4Core/Application/interface/ExceptionHandler.h
@@ -34,6 +34,7 @@ public:
 
 private:
   double m_eth;
+  int m_number{0};
   bool m_trace;
 };
 

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -160,7 +160,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
                 )
             )
         ),
-        delta = cms.double(1.0)
+        delta = cms.double(1.0) ## in mm
     ),
     Physics = cms.PSet(
         common_maximum_time,
@@ -175,11 +175,12 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         DefaultCutValue = cms.double(1.0), ## cuts in cm
         G4BremsstrahlungThreshold = cms.double(0.5), ## cut in GeV
         G4MuonBremsstrahlungThreshold = cms.double(10000.), ## cut in GeV
+        G4TrackingCut = cms.double(0.001), ## cut in MeV
         G4MscRangeFactor = cms.double(0.04),
         G4MscGeomFactor = cms.double(2.5), 
         G4MscSafetyFactor = cms.double(0.6), 
-        G4MscLambdaLimit = cms.double(1.0), # mm 
-        G4MscStepLimit = cms.string("UseSafety"), 
+        G4MscLambdaLimit = cms.double(1.0), # in mm 
+        G4MscStepLimit = cms.string("UseSafety"),
         G4GeneralProcess = cms.bool(False),
         ReadMuonData = cms.bool(False), 
         Verbosity = cms.untracked.int32(0),

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -80,9 +80,9 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
       break;
 
     case JustWarning:
-      if(m_number < 20) 
-	edm::LogWarning("SimG4CoreApplication")
-          << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
+      if (m_number < 20)
+        edm::LogWarning("SimG4CoreApplication")
+            << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
       break;
   }
   return res;

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -65,6 +65,7 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
   if (ekin < m_eth && (code == "GeomNav0003" || code == "GeomField0003")) {
     localSeverity = JustWarning;
     track->SetTrackStatus(fStopAndKill);
+    ++m_number;
   }
 
   bool res = false;
@@ -79,7 +80,8 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
       break;
 
     case JustWarning:
-      edm::LogWarning("SimG4CoreApplication")
+      if(m_number < 20) 
+	edm::LogWarning("SimG4CoreApplication")
           << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
       break;
   }

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMZ.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMZ.h
@@ -16,7 +16,7 @@
 
 class CMSEmStandardPhysicsEMZ : public G4VPhysicsConstructor {
 public:
-  CMSEmStandardPhysicsEMZ(G4int ver,  const edm::ParameterSet& p);
+  CMSEmStandardPhysicsEMZ(G4int ver, const edm::ParameterSet& p);
   ~CMSEmStandardPhysicsEMZ() override;
 
   void ConstructParticle() override;

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMZ.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMZ.h
@@ -12,9 +12,11 @@
 #include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 class CMSEmStandardPhysicsEMZ : public G4VPhysicsConstructor {
 public:
-  CMSEmStandardPhysicsEMZ(G4int ver);
+  CMSEmStandardPhysicsEMZ(G4int ver,  const edm::ParameterSet& p);
   ~CMSEmStandardPhysicsEMZ() override;
 
   void ConstructParticle() override;

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsLPM.h
@@ -12,9 +12,11 @@
 #include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 class CMSEmStandardPhysicsLPM : public G4VPhysicsConstructor {
 public:
-  CMSEmStandardPhysicsLPM(G4int ver);
+  CMSEmStandardPhysicsLPM(G4int ver, const edm::ParameterSet& p);
   ~CMSEmStandardPhysicsLPM() override;
 
   void ConstructParticle() override;

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMZ.cc
@@ -24,7 +24,7 @@ FTFPCMS_BERT_EMZ::FTFPCMS_BERT_EMZ(const edm::ParameterSet& p) : PhysicsList(p) 
 
   if (emPhys) {
     // EM Physics
-    RegisterPhysics(new CMSEmStandardPhysicsEMZ(ver));
+    RegisterPhysics(new CMSEmStandardPhysicsEMZ(ver, p));
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -72,6 +72,9 @@ CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver, const edm::ParameterSet& p
   if (msc == "Minimal") {
     fStepLimitType = fMinimal;
   }
+  double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
+  param->SetLowestElectronEnergy(tcut);
+  param->SetLowestMuHadEnergy(tcut);
 }
 
 CMSEmStandardPhysics::~CMSEmStandardPhysics() {}

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMZ.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMZ.cc
@@ -60,7 +60,8 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsEMZ::CMSEmStandardPhysicsEMZ(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emz") {
+CMSEmStandardPhysicsEMZ::CMSEmStandardPhysicsEMZ(G4int ver, const edm::ParameterSet& p)
+: G4VPhysicsConstructor("CMSEmStandard_emz") {
   SetVerboseLevel(ver);
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
@@ -81,6 +82,9 @@ CMSEmStandardPhysicsEMZ::CMSEmStandardPhysicsEMZ(G4int ver) : G4VPhysicsConstruc
   param->SetFluo(true);
   param->SetUseICRU90Data(true);
   param->SetMaxNIELEnergy(1 * CLHEP::MeV);
+  double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
+  param->SetLowestElectronEnergy(tcut);
+  param->SetLowestMuHadEnergy(tcut);
   SetPhysicsType(bElectromagnetic);
 }
 

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMZ.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMZ.cc
@@ -61,7 +61,7 @@
 #include "G4SystemOfUnits.hh"
 
 CMSEmStandardPhysicsEMZ::CMSEmStandardPhysicsEMZ(G4int ver, const edm::ParameterSet& p)
-: G4VPhysicsConstructor("CMSEmStandard_emz") {
+    : G4VPhysicsConstructor("CMSEmStandard_emz") {
   SetVerboseLevel(ver);
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -57,7 +57,8 @@
 
 #include "G4SystemOfUnits.hh"
 
-CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) : G4VPhysicsConstructor("CMSEmStandard_emm") {
+CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver, const edm::ParameterSet& p)
+: G4VPhysicsConstructor("CMSEmStandard_emm") {
   SetVerboseLevel(ver);
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
@@ -67,6 +68,9 @@ CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver) : G4VPhysicsConstruc
   param->SetMscRangeFactor(0.2);
   param->SetMscStepLimitType(fMinimal);
   SetPhysicsType(bElectromagnetic);
+  double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
+  param->SetLowestElectronEnergy(tcut);
+  param->SetLowestMuHadEnergy(tcut);
 }
 
 CMSEmStandardPhysicsLPM::~CMSEmStandardPhysicsLPM() {}

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsLPM.cc
@@ -58,7 +58,7 @@
 #include "G4SystemOfUnits.hh"
 
 CMSEmStandardPhysicsLPM::CMSEmStandardPhysicsLPM(G4int ver, const edm::ParameterSet& p)
-: G4VPhysicsConstructor("CMSEmStandard_emm") {
+    : G4VPhysicsConstructor("CMSEmStandard_emm") {
   SetVerboseLevel(ver);
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -87,6 +87,9 @@ CMSEmStandardPhysicsXS::CMSEmStandardPhysicsXS(G4int ver, const edm::ParameterSe
   if (msc == "Minimal") {
     fStepLimitType = fMinimal;
   }
+  double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
+  param->SetLowestElectronEnergy(tcut);
+  param->SetLowestMuHadEnergy(tcut);
 }
 
 CMSEmStandardPhysicsXS::~CMSEmStandardPhysicsXS() {}


### PR DESCRIPTION
#### PR description:
This PR is needed in order to reduce effect of the Geant4 problem for tracking of low-energy charged particles in CMS magnetic field. It includes following modifications:
1)   suppressed number of Geant4 repeated warning messages by limit 20
2)   introduced a new parameter G4TrackingCut for all charged particles, Geant4 default 1 keV
3)   it is possible to increase this value inside g4SimHits configuration, for 20 keV SIM step speed-up for ttbar is ~1%, for MinBias events ~10% 

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
feature 1) may be backported to 12_4

