### PR TITLE
[12_4_X] Reduced length of Geant4 warning printout in production runs

### DIFF
--- a/SimG4Core/Application/interface/ExceptionHandler.h
+++ b/SimG4Core/Application/interface/ExceptionHandler.h
@@ -34,6 +34,7 @@ public:
 
 private:
   double m_eth;
+  int m_number{0};
   bool m_trace;
 };
 

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -65,6 +65,7 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
   if (ekin < m_eth && (code == "GeomNav0003" || code == "GeomField0003")) {
     localSeverity = JustWarning;
     track->SetTrackStatus(fStopAndKill);
+    ++m_number;
   }
 
   bool res = false;
@@ -79,8 +80,9 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
       break;
 
     case JustWarning:
-      edm::LogWarning("SimG4CoreApplication")
-          << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
+      if (m_number < 20)
+        edm::LogWarning("SimG4CoreApplication")
+            << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
       break;
   }
   return res;


### PR DESCRIPTION
#### PR description:
This PR provides suppression of number of Geant4 repeated warning messages on tracking in field or geometry by limit 20.
This is a partial backport of #39052 and assume to be used on top of #39033 


#### PR validation:
private


