### PR TITLE
fixup reading histograms in TrackTimingTable in trackingPlots

### DIFF
--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -1810,7 +1810,7 @@ class TrackingTimingTable:
         return self._section
 
     def _getValues(self, tdirectory, histo):
-        h = tdirectory.Get(histo)
+        h = tdirectory.Get(histo._timeHisto)
         totalReco = None
         if h:
             totalReco = "%.1f" % h.Integral()


### PR DESCRIPTION
I came across an error in parsing the timing results using `makeTrackValidationPlots.py`

```
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_0_pre4/src/Validation/RecoTrack/python/plotting/trackingPlots.py", line 1837, in create
    cpuValues = self._getValues(tdirectory, _time_per_event_cpu)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_0_pre4/src/Validation/RecoTrack/python/plotting/trackingPlots.py", line 1813, in _getValues
    h = tdirectory.Get(histo)
TypeError: bad argument type for built-in operation

```

the proposed fix lets the job run to completion

@elusian 