### PR TITLE
add states to `GsfMultiStateUpdator` MultiState only if the localError matrix is valid

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -30,7 +30,7 @@ TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSur
   int i = 0;
   for (auto const& tsosI : predictedComponents) {
     TrajectoryStateOnSurface updatedTSOS = KFUpdator().update(tsosI, aRecHit);
-    if (updatedTSOS.isValid()) {
+    if (updatedTSOS.isValid() && updatedTSOS.localError().valid()) {
       result.addState(TrajectoryStateOnSurface(weights[i],
                                                updatedTSOS.localParameters(),
                                                updatedTSOS.localError(),


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/39026

#### PR description:

Title says it all, in order to avoid multi-states during electron tracking that lead to exceptions in `BasicMultiTrajectoryState` when mixing states with valid and invalid local errors.

#### PR validation:

Run successfully the configuration posted at https://github.com/cms-sw/cmssw/issues/39026#issuecomment-1211715967. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but if accepted, it needs to be backported to 12_4_X for data-taking