### PR TITLE
HcalDQM: Revert timing bit to old default, backport of #39058

### DIFF
--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -1130,7 +1130,10 @@ TPTask::TPTask(edm::ParameterSet const& ps)
       HcalElectronicsId const& eid(rawid);
 
       const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
-      const bool Hfb1Agreement = sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain();
+      const bool Hfb1Agreement =
+          (abs(ieta) < 29)
+              ? true
+              : (recdTp.SOI_compressedEt() == 0 || (sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain()) || ignoreHFfbs_);
       // Ignore minBias (FB2) bit if we receieve 0 ET, which means it is likely zero-suppressed on HCal readout side
       const bool Hfb2Agreement =
           (abs(ieta) < 29) ? true

--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -1131,9 +1131,8 @@ TPTask::TPTask(edm::ParameterSet const& ps)
 
       const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
       const bool Hfb1Agreement =
-          (abs(ieta) < 29)
-              ? true
-              : (recdTp.SOI_compressedEt() == 0 || (sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain()) || ignoreHFfbs_);
+          (abs(ieta) < 29) ? true
+                           : (recdTp.SOI_compressedEt() == 0 || (sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain()));
       // Ignore minBias (FB2) bit if we receieve 0 ET, which means it is likely zero-suppressed on HCal readout side
       const bool Hfb2Agreement =
           (abs(ieta) < 29) ? true


### PR DESCRIPTION
#### PR description:
Corrects the uHTR&L1T HCAL TP mismatch discrepancy seen between L1 and HCAL subdetector. Now the finegrain bit definition in both are the same old default. Can be updated when the HCAL LLP trigger commissioning work completes. 

Request to be integrated in the Online DQM Production release at P5.

#### PR validation:
`runTheMatrix.py -l limited -i all --ibeos` test okay
