### PR TITLE
HcalDQM: Revert timing bit to old default

### DIFF
--- a/DQM/HcalTasks/plugins/TPTask.cc
+++ b/DQM/HcalTasks/plugins/TPTask.cc
@@ -1128,7 +1128,9 @@ TPTask::TPTask(edm::ParameterSet const& ps)
       HcalElectronicsId const& eid(rawid);
 
       const bool HetAgreement = sentTp.SOI_compressedEt() == recdTp.SOI_compressedEt();
-      const bool Hfb1Agreement = sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain();
+      const bool Hfb1Agreement =
+          (abs(ieta) < 29) ? true
+                           : (recdTp.SOI_compressedEt() == 0 || (sentTp.SOI_fineGrain() == recdTp.SOI_fineGrain()));
       // Ignore minBias (FB2) bit if we receieve 0 ET, which means it is likely zero-suppressed on HCal readout side
       const bool Hfb2Agreement =
           (abs(ieta) < 29) ? true


### PR DESCRIPTION
#### PR description:
Corrects the uHTR&L1T HCAL TP mismatch discrepancy seen between L1 and HCAL subdetector. Now the finegrain bit definition in both are the same old default. Can be updated when the HCAL LLP trigger commissioning work completes.

#### PR validation:
runTheMatrix.py -l limited -i all --ibeos test okay