### PR TITLE
Phase2-hgx320 Try a fix for V17 HGCal geometry to treat orientation index correctly

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1531,7 +1531,7 @@ void HGCalGeomParameters::loadSpecParsHexagon8(HGCalParameters& php,
   }
   for (unsigned int k = 0; k < waferIndex.size(); ++k) {
     int partial = HGCalProperty::waferPartial(waferProperties[k]);
-    int orient = HGCalWaferMask::getRotation(php.waferZSide_, partial, HGCalProperty::waferOrient(waferProperties[k]));
+    int orient = (php.mode_ == HGCalGeometryMode::Hexagon8Cassette) ? HGCalProperty::waferOrient(waferProperties[k]) : HGCalWaferMask::getRotation(php.waferZSide_, partial, HGCalProperty::waferOrient(waferProperties[k]));
     php.waferInfoMap_[waferIndex[k]] = HGCalParameters::waferInfo(HGCalProperty::waferThick(waferProperties[k]),
                                                                   partial,
                                                                   orient,

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -1531,7 +1531,10 @@ void HGCalGeomParameters::loadSpecParsHexagon8(HGCalParameters& php,
   }
   for (unsigned int k = 0; k < waferIndex.size(); ++k) {
     int partial = HGCalProperty::waferPartial(waferProperties[k]);
-    int orient = (php.mode_ == HGCalGeometryMode::Hexagon8Cassette) ? HGCalProperty::waferOrient(waferProperties[k]) : HGCalWaferMask::getRotation(php.waferZSide_, partial, HGCalProperty::waferOrient(waferProperties[k]));
+    int orient =
+        (php.mode_ == HGCalGeometryMode::Hexagon8Cassette)
+            ? HGCalProperty::waferOrient(waferProperties[k])
+            : HGCalWaferMask::getRotation(php.waferZSide_, partial, HGCalProperty::waferOrient(waferProperties[k]));
     php.waferInfoMap_[waferIndex[k]] = HGCalParameters::waferInfo(HGCalProperty::waferThick(waferProperties[k]),
                                                                   partial,
                                                                   orient,


### PR DESCRIPTION
#### PR description:

Try a fix for V17 HGCal geometry to treat orientation index correctly

#### PR validation:

Use test codes in Geometry/HGcalCommonData/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special