### PR TITLE
Run3-alca226 Update the macros to e used for Run3 analysis of hadron calorimeter calibration data with isolated muons

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/AnalyzeLepTree.C
+++ b/Calibration/HcalCalibAlgos/macros/AnalyzeLepTree.C
@@ -25,11 +25,9 @@
 //                   1 constant p ranges
 //            13-15: 0 no cut on ediff; 1-4 cuts at 5, 10, 15, 20 GeV
 //      modeLHC (integer) specifies the detector condition
-//              0      Run1   detector (till 2016)
-//              1      Plan36 detector (2018)
-//              2      Phase1 detector (Run3)
-//              3      Plan1  detector (2017)
-//              4      Phase2 detector
+//              1 (Run 1; valid till 2016); 2 (Run 2; 2018);
+//              3 (Run 3; post LS2); 4 (2017 Plan 1);
+//              5 (Run 4; post LS3); (default: 3)
 //
 //   AnalyzeLepTree a1(tree, mode, modeLHC);
 //   AnalyzeLepTree a1(fname, mode, modeLHC);
@@ -82,8 +80,8 @@
 
 class AnalyzeLepTree {
 public:
-  AnalyzeLepTree(TChain* tree, int mode = 0, int modeLHC = 1);
-  AnalyzeLepTree(const char* fname, int mode = 0, int modeLHC = 1);
+  AnalyzeLepTree(TChain* tree, int mode = 0, int modeLHC = 3);
+  AnalyzeLepTree(const char* fname, int mode = 0, int modeLHC = 3);
   virtual ~AnalyzeLepTree();
   virtual Int_t Cut(Long64_t entry);
   virtual Int_t GetEntry(Long64_t entry);
@@ -253,13 +251,13 @@ void AnalyzeLepTree::Init(TChain* tree) {
     std::cout << "Make separate plot for each RBX\n";
   else
     std::cout << "Exclude the RBX " << exRBX_ << std::endl;
-  if (modeLHC_ == 0)
+  if (modeLHC_ == 1)
     std::cout << "This is Run1 detector (till 2016)\n";
-  else if (modeLHC_ == 1)
-    std::cout << "This is Plan36 detector (2018)\n";
   else if (modeLHC_ == 2)
-    std::cout << "This is Phase1 detector (after 2021)\n";
+    std::cout << "This is Plan36 detector (2018)\n";
   else if (modeLHC_ == 3)
+    std::cout << "This is Phase1 detector (after 2021)\n";
+  else if (modeLHC_ == 4)
     std::cout << "This is Plan1  detector (2017)\n";
   else
     std::cout << "This is Phase2 detector (after 2026)\n";
@@ -604,7 +602,9 @@ void AnalyzeLepTree::bookHisto() {
         int eta = (ieta > 0) ? ieta : -ieta;
         if (eta != 0) {
           int ndepth = ((kdepth_ == 0) ? nDepthBins(eta, 63, modeLHC_)
-                                       : ((kdepth_ != 1) ? nDepthBins(eta, 63, 0) : (eta == 16) ? 2 : 1));
+                                       : ((kdepth_ != 1) ? nDepthBins(eta, 63, 0)
+                                          : (eta == 16)  ? 2
+                                                         : 1));
           std::cout << "Eta " << ieta << " with " << nPhiBins(eta) << " phi bins " << ndepth << " maximum depths and "
                     << nPBins(eta) << " p bins" << std::endl;
         }
@@ -713,7 +713,9 @@ void AnalyzeLepTree::bookHisto() {
             sprintf(phis, "All i#phi");
           }
           int ndepth = ((kdepth_ == 0) ? nDepthBins(eta, phi0, modeLHC_)
-                                       : ((kdepth_ != 1) ? nDepthBins(eta, phi0, 0) : (eta == 16) ? 2 : 1));
+                                       : ((kdepth_ != 1) ? nDepthBins(eta, phi0, 0)
+                                          : (eta == 16)  ? 2
+                                                         : 1));
           for (int depth = 0; depth < ndepth; ++depth) {
             char deps[20];
             if (kdepth_ == 1) {
@@ -826,7 +828,9 @@ void AnalyzeLepTree::writeHisto(const char* outfile) {
             phi = iphi + 1;
           };
           int ndepth = ((kdepth_ == 0) ? nDepthBins(eta, phi0, modeLHC_)
-                                       : ((kdepth_ != 1) ? nDepthBins(eta, phi0, 0) : (eta == 16) ? 2 : 1));
+                                       : ((kdepth_ != 1) ? nDepthBins(eta, phi0, 0)
+                                          : (eta == 16)  ? 2
+                                                         : 1));
           for (int depth = 0; depth < ndepth; ++depth) {
             for (int pbin = 0; pbin < nPBins(eta); ++pbin) {
               for (int vbin = 0; vbin < nVxBins(); ++vbin) {
@@ -1142,11 +1146,11 @@ void AnalyzeLepTree::makeVxBins(int modeLHC) {
   int npvbin3[nvbin_] = {0, 30, 40, 50, 70, 200};
   npvbin_.clear();
   for (int i = 0; i < nvbin_; ++i) {
-    if (modeLHC <= 0 || modeLHC == 3)
+    if (modeLHC == 3)
       npvbin_.push_back(npvbin0[i]);
     else if (modeLHC == 1)
       npvbin_.push_back(npvbin1[i]);
-    else if (modeLHC == 2)
+    else if ((modeLHC == 2) || (modeLHC == 4))
       npvbin_.push_back(npvbin2[i]);
     else
       npvbin_.push_back(npvbin3[i]);
@@ -1162,19 +1166,19 @@ int AnalyzeLepTree::nDepthBins(int eta, int phi, int modeLHC) {
   int nDepthR3[29] = {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 5, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 3};
   // Run 4 scenario
   int nDepthR4[29] = {4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
-  // modeLHC = 0 -->      corresponds to Run 1 (valid till 2016)
-  //         = 1 -->      corresponds to Run 2 (2018 geometry)
-  //         = 2 -->      corresponds to Run 3 (post LS2)
-  //         = 3 -->      corresponds to 2017  (Plan 1)
-  //         = 4 -->      corresponds to Run4  (post LS3)
+  // modeLHC = 1 -->      corresponds to Run 1 (valid till 2016)
+  //         = 2 -->      corresponds to Run 2 (2018 geometry)
+  //         = 3 -->      corresponds to Run 3 (post LS2)
+  //         = 4 -->      corresponds to 2017  (Plan 1)
+  //         = 5 -->      corresponds to Run4  (post LS3)
   int nbin(0);
-  if (modeLHC == 0) {
+  if (modeLHC == 1) {
     nbin = nDepthR1[eta - 1];
-  } else if (modeLHC == 1) {
-    nbin = nDepthR2[eta - 1];
   } else if (modeLHC == 2) {
-    nbin = nDepthR3[eta - 1];
+    nbin = nDepthR2[eta - 1];
   } else if (modeLHC == 3) {
+    nbin = nDepthR3[eta - 1];
+  } else if (modeLHC == 4) {
     if (phi > 0) {
       if (eta >= 16 && phi >= 63 && phi <= 66) {
         nbin = nDepthR2[eta - 1];
@@ -1200,7 +1204,7 @@ int AnalyzeLepTree::nDepthBins(int eta, int phi, int modeLHC) {
 
 int AnalyzeLepTree::nPhiBins(int eta) {
   int nphi = (eta <= 20) ? 72 : 36;
-  if (modeLHC_ == 4 && eta > 16)
+  if (modeLHC_ == 5 && eta > 16)
     nphi = 360;
   if (kphi_ == 0)
     nphi = 1;
@@ -1247,7 +1251,7 @@ void AnalyzeLepTree::getBins(int type, int ieta, int phi, int depth, int& nbin, 
   nbin = 5000;
   xmax = 10.0;
   if (type >= 4) {
-    if ((modeLHC_ == 0) || (((modeLHC_ == 1) || (modeLHC_ == 3)) && barrel) || ((modeLHC_ == 3) && (!rbx17))) {
+    if ((modeLHC_ == 1) || (((modeLHC_ == 2) || (modeLHC_ == 4)) && barrel) || ((modeLHC_ == 4) && (!rbx17))) {
       // HPD Channels
       xmax = 50.0;
     } else {

--- a/Calibration/HcalCalibAlgos/macros/HBHEMuonHighEta.C
+++ b/Calibration/HcalCalibAlgos/macros/HBHEMuonHighEta.C
@@ -9,7 +9,7 @@
 //   mode       int          Geometry file used 0:(defined by maxDHB/HE);
 //                           1 (Run 1; valid till 2016); 2 (Run 2; 2018);
 //                           3 (Run 3; post LS2); 4 (2017 Plan 1);
-//                           5 (Run 4; post LS3); (default: 0)
+//                           5 (Run 4; post LS3); (default: 3)
 //   debug      bool         Debug flag (default: false)
 //
 ///////////////////////////////////////////////////////////////////////////////
@@ -33,7 +33,7 @@
 
 class HBHEMuonHighEta {
 public:
-  HBHEMuonHighEta(const char *infile, const char *outfile, const int mode = 0, const bool debug = false);
+  HBHEMuonHighEta(const char *infile, const char *outfile, const int mode = 3, const bool debug = false);
   virtual ~HBHEMuonHighEta();
   virtual Int_t Cut(Long64_t entry);
   virtual Int_t GetEntry(Long64_t entry);

--- a/Calibration/HcalCalibAlgos/macros/HBHEMuonOfflineAnalyzer.C
+++ b/Calibration/HcalCalibAlgos/macros/HBHEMuonOfflineAnalyzer.C
@@ -20,7 +20,7 @@
 //   mode       int          Geometry file used 0:(defined by maxDHB/HE);
 //                           1 (Run 1; valid till 2016); 2 (Run 2; 2018);
 //                           3 (Run 3; post LS2); 4 (2017 Plan 1);
-//                           5 (Run 4; post LS3); default (2)
+//                           5 (Run 4; post LS3); default (3)
 //   maxDHB     int          Maximum number of depths for HB (4)
 //   maxDHE     int          Maximum number of depths for HE (7)
 //   runLO      int          Minimum run number (1)
@@ -331,7 +331,7 @@ public:
                           const char *outfile = "dyll_PU20_25_output_10.root",
                           const char *rcorFileName = "",
                           int flag = 0,
-                          int mode = 2,
+                          int mode = 3,
                           int maxDHB = 4,
                           int maxDHE = 7,
                           int runLo = 1,
@@ -343,7 +343,7 @@ public:
                           const char *outfile = "dyll_PU20_25_output_10.root",
                           const char *rcorFileName = "",
                           int flag = 0,
-                          int mode = 2,
+                          int mode = 3,
                           int maxDHB = 4,
                           int maxDHE = 7,
                           int runLo = 1,
@@ -352,7 +352,7 @@ public:
                           int etaMax = 29,
                           bool debug = false);
   // mode of LHC is kept 1 for 2017 scenario as no change in depth segmentation
-  // mode of LHC is 0 for 2021
+  // mode of LHC is 3 for 2021
   virtual ~HBHEMuonOfflineAnalyzer();
 
   virtual Int_t Cut(Long64_t entry);

--- a/Calibration/HcalCalibAlgos/macros/HBHEMuonOfflineSimAnalyzer.C
+++ b/Calibration/HcalCalibAlgos/macros/HBHEMuonOfflineSimAnalyzer.C
@@ -11,7 +11,7 @@
 //   mode       int          Geometry file used 0:(defined by maxDHB/HE);
 //                           1 (Run 1; valid till 2016); 2 (Run 2; 2018);
 //                           3 (Run 3; post LS2); 4 (2017 Plan 1);
-//                           5 (Run 4; post LS3); default (2)
+//                           5 (Run 4; post LS3); default (3)
 //   maxDHB     int          Maximum number of depths for HB (4)
 //   maxDHE     int          Maximum number of depths for HE (7)
 //
@@ -132,7 +132,7 @@ private:
 public:
   HBHEMuonOfflineSimAnalyzer(const char *infile,
                              const char *outfile = "dyll_PU20_25_output.root",
-                             const int mode = 0,
+                             const int mode = 3,
                              const int maxDHB = 4,
                              const int maxDHE = 7);
   virtual ~HBHEMuonOfflineSimAnalyzer();
@@ -203,7 +203,6 @@ HBHEMuonOfflineSimAnalyzer::HBHEMuonOfflineSimAnalyzer(
   maxDepth_ = (maxDepthHB_ > maxDepthHE_) ? maxDepthHB_ : maxDepthHE_;
   // if parameter tree is not specified (or zero), connect the file
   // used to generate this class and read the Tree.
-  // std::cout << "maxDepth_" << maxDepth_ << std::endl;
   TFile *f = new TFile(infile);
   TDirectory *dir = (TDirectory *)f->Get("HcalHBHEMuonAnalyzer");
   TTree *tree(0);
@@ -675,7 +674,6 @@ void HBHEMuonOfflineSimAnalyzer::BookHistograms(const char *fname) {
     h_HotCell[i] = new TH1D(name, title, 100, 0, 2);
 
     std::cout << "problem here" << std::endl;
-    //		output_file->cd();
     for (int eta = 0; eta < 29; ++eta) {
       int nDepth = NDepthBins(eta + 1, -1);
       int nPhi = NPhiBins(eta + 1);
@@ -775,7 +773,6 @@ void HBHEMuonOfflineSimAnalyzer::etaPhiHcal(unsigned int detId, int &eta, int &p
 void HBHEMuonOfflineSimAnalyzer::etaPhiEcal(
     unsigned int detId, int &type, int &zside, int &etaX, int &phiY, int &plane, int &strip) {
   type = ((detId >> 25) & 0x7);
-  // std::cout << "type" << type << std::endl;
   plane = strip = 0;
   if (type == 1) {
     //Ecal Barrel
@@ -814,7 +811,6 @@ void HBHEMuonOfflineSimAnalyzer::close() {
 }
 
 void HBHEMuonOfflineSimAnalyzer::WriteHistograms() {
-  //output_file->cd();
   std::string type[] = {"tight", "soft", "loose"};
   char name[128];
 
@@ -836,7 +832,6 @@ void HBHEMuonOfflineSimAnalyzer::WriteHistograms() {
   }
 
   TDirectory *d_output_file[3][29];
-  //output_file->cd();
   for (int i = 0; i < 3; ++i) {
     h_Pt_Muon[i]->Write();
     h_Eta_Muon[i]->Write();
@@ -895,7 +890,6 @@ void HBHEMuonOfflineSimAnalyzer::WriteHistograms() {
       int nPhi = NPhiBins(eta + 1);
       sprintf(name, "Dir_muon_type_%s_ieta%d", type[i].c_str(), eta + 1);
       d_output_file[i][eta] = output_file->mkdir(name);
-      //output_file->cd(name);
       d_output_file[i][eta]->cd();
       for (int depth = 0; depth < nDepth; ++depth) {
         for (int PHI = 0; PHI < nPhi; ++PHI) {


### PR DESCRIPTION
#### PR description:

Update the macros to e used for Run3 analysis of HCAL calibration data with isolated muons

#### PR validation:

Use the macros to analyze Run3 calibration data

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special