### PR TITLE
Avoid creation of invalid RooFit proxies in RooFitFunction

### DIFF
--- a/PhysicsTools/Utilities/interface/RooFitFunction.h
+++ b/PhysicsTools/Utilities/interface/RooFitFunction.h
@@ -1,9 +1,11 @@
 #ifndef PhysicsTools_Utilities_RooFitFunction_h
 #define PhysicsTools_Utilities_RooFitFunction_h
+
 #include "PhysicsTools/Utilities/interface/Parameter.h"
 #include "RooAbsReal.h"
+#include "RooListProxy.h"
 #include "RooRealProxy.h"
-#include "RooAbsReal.h"
+
 #include <iostream>
 #include <vector>
 
@@ -14,21 +16,20 @@ namespace root {
   class RooFitFunction : public RooAbsReal {
   public:
     RooFitFunction(const RooFitFunction<X, Expr>& other, const char* name = nullptr)
-        : RooAbsReal(other, name), e_(other.e_), x_(X::name(), this, other.x_) {
-      std::cout << ">>> making new RooFitFunction" << std::endl;
-      std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = other.pars_.begin(),
-                                                                                     end = other.pars_.end();
-      for (; i != end; ++i) {
-        std::cout << ">>> adding par to RooFitFunction" << std::endl;
-        pars_.push_back(std::make_pair(i->first, RooRealProxy(i->second.GetName(), this, i->second)));
-      }
-    }
+        : RooAbsReal(other, name),
+          e_(other.e_),
+          x_(X::name(), this, other.x_),
+          parsPtrs_{other.parsPtrs_},
+          parsArgs_{"!pars", this, other.parsArgs_} {}
     RooFitFunction(const char* name, const char* title, const Expr& e, RooAbsReal& x)
-        : RooAbsReal(name, title), e_(e), x_(X::name(), X::name(), this, x) {}
+        : RooAbsReal(name, title),
+          e_(e),
+          x_(X::name(), X::name(), this, x),
+          parsArgs_("!pars", "List of parameters", this) {}
     RooFitFunction(
         const char* name, const char* title, const Expr& e, RooAbsReal& x, RooAbsReal& rA, funct::Parameter& a)
-        : RooAbsReal(name, title), e_(e), x_(X::name(), X::name(), this, x) {
-      pars_.push_back(std::make_pair(a.ptr(), RooRealProxy(a.name().c_str(), a.name().c_str(), this, rA)));
+        : RooFitFunction{name, title, e, x} {
+      add(rA, a);
     }
     RooFitFunction(const char* name,
                    const char* title,
@@ -38,9 +39,8 @@ namespace root {
                    funct::Parameter& a,
                    RooAbsReal& rB,
                    funct::Parameter& b)
-        : RooAbsReal(name, title), e_(e), x_(X::name(), X::name(), this, x) {
-      pars_.push_back(std::make_pair(a.ptr(), RooRealProxy(a.name().c_str(), a.name().c_str(), this, rA)));
-      pars_.push_back(std::make_pair(b.ptr(), RooRealProxy(b.name().c_str(), b.name().c_str(), this, rB)));
+        : RooFitFunction{name, title, e, x, rA, a} {
+      add(rB, b);
     }
     RooFitFunction(const char* name,
                    const char* title,
@@ -52,27 +52,25 @@ namespace root {
                    funct::Parameter& b,
                    RooAbsReal& rC,
                    funct::Parameter& c)
-        : RooAbsReal(name, title), e_(e), x_(X::name(), X::name(), this, x) {
-      pars_.push_back(std::make_pair(a.ptr(), RooRealProxy(a.name().c_str(), a.name().c_str(), this, rA)));
-      pars_.push_back(std::make_pair(b.ptr(), RooRealProxy(b.name().c_str(), b.name().c_str(), this, rB)));
-      pars_.push_back(std::make_pair(c.ptr(), RooRealProxy(c.name().c_str(), c.name().c_str(), this, rC)));
+        : RooFitFunction{name, title, e, x, rA, a, rB, b} {
+      add(rC, c);
     }
-    ~RooFitFunction() override {}
     void add(RooAbsReal& rA, funct::Parameter& a) {
-      pars_.push_back(std::make_pair(a.ptr(), RooRealProxy(a.name().c_str(), a.name().c_str(), this, rA)));
+      parsPtrs_.emplace_back(a.ptr());
+      parsArgs_.add(rA);
     }
     TObject* clone(const char* newName) const override { return new RooFitFunction<X, Expr>(*this, newName); }
 
   private:
     Expr e_;
     RooRealProxy x_;
-    std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> > pars_;
+    std::vector<std::shared_ptr<double>> parsPtrs_;
+    RooListProxy parsArgs_;
     Double_t evaluate() const override {
       X::set(x_);
-      std::vector<std::pair<std::shared_ptr<double>, RooRealProxy> >::const_iterator i = pars_.begin(),
-                                                                                     end = pars_.end();
-      for (; i != end; ++i)
-        *(i->first) = i->second;
+      for (std::size_t i = 0; i < parsPtrs_.size(); ++i) {
+        *(parsPtrs_[i]) = static_cast<RooAbsReal const&>(parsArgs_[i]).getVal(parsArgs_.nset());
+      }
       return e_();
     }
   };


### PR DESCRIPTION
#### PR description:

The `RooFitFunction` class uses the move constructor of the
`RooRealProxy` class. However, this results in invalid proxy object
because the copy and move constructors were never correctly  implemented
in RooFit. This right alternative is to use a `RooListProxy`, which this
commit suggests to implement.

This makes CMSSW compile again with ROOT master, where the `RooRealProxy`
move constructor was deleted to avoid the creation of invalid RooFit objects.

Addresses https://github.com/root-project/root/issues/11188.

#### PR validation:

CMSSW compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport intended.