### PR TITLE
Add missing include for Alpaka CachingAllocator

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
#### PR description:

GCC 11 IB had a build failure
```
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h:8,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc:13:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h:239:12: error: 'optional' in namespace 'std' does not name a template type
   239 |       std::optional<Buffer> buffer;
      |            ^~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h:8,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc:13:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/b88bf8b0f9bf734c61d48d872f44fda5/opt/cmssw/el9_amd64_gcc11/cms/cmssw/CMSSW_12_5_X_2022-08-14-2300/src/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h:5:1: note: 'std::optional' is defined in header '<optional>'; did you forget to '#include <optional>'?
    4 | #include <cassert>
  +++ |+#include <optional>
    5 | #include <exception>
```
etc https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc11/CMSSW_12_5_X_2022-08-14-2300/HeterogeneousCore/AlpakaServices

This PR adds the missing include.

#### PR validation:

None (edited on the web)