### PR TITLE
[12.4.X] fix compilation errors in MomentumScaleCalibration macros

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitSlices.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitSlices.cc
@@ -12,10 +12,8 @@
  * This class can be used to fit the X slices of a TH1 histogram using RooFit.
  * It uses the FitXslices class to do the fitting.
  */
-class FitSlices
-{
+class FitSlices {
 public:
-
   double xMean;
   double xMin;
   double xMax;
@@ -33,26 +31,29 @@ public:
 
   FitXslices fitXslices;
 
-  FitSlices(
-    double xMean_,
-    double xMin_,
-    double xMax_,
-    double sigma_,
-    double sigmaMin_,
-    double sigmaMax_,
-    TString signalType_,
-    TString backgroundType_
-    ) :
-    xMean(xMean_),
-    xMin(xMin_),
-    xMax(xMax_),
-    sigma(sigma_),
-    sigmaMin(sigmaMin_),
-    sigmaMax(sigmaMax_),
-    signalType(signalType_),
-    backgroundType(backgroundType_),
-    rebinX(2), rebinY(2), rebinZ(2), sigma2(0.1), sigma2Min(0.), sigma2Max(10.), useChi2(false)
-  {
+  FitSlices(double xMean_,
+            double xMin_,
+            double xMax_,
+            double sigma_,
+            double sigmaMin_,
+            double sigmaMax_,
+            TString signalType_,
+            TString backgroundType_)
+      : xMean(xMean_),
+        xMin(xMin_),
+        xMax(xMax_),
+        sigma(sigma_),
+        sigmaMin(sigmaMin_),
+        sigmaMax(sigmaMax_),
+        signalType(signalType_),
+        backgroundType(backgroundType_),
+        rebinX(2),
+        rebinY(2),
+        rebinZ(2),
+        sigma2(0.1),
+        sigma2Min(0.),
+        sigma2Max(10.),
+        useChi2(false) {
     // Initialize fitXslices to some defaults, nothing un-overridable
     fitXslices.fitter()->useChi2_ = useChi2;
     fitXslices.fitter()->initMean(xMean, xMin, xMax);
@@ -69,15 +70,10 @@ public:
   // 		   const double & sigma = 0.03, const double & sigmaMin = 0., const double & sigmaMax = 0.1,
   // 		   const TString & histoBaseName = "hRecBestResVSMu", const TString & histoBaseTitle = "MassVs") = 0;
 
-  void fitSlice(
-    const TString & histoName, const TString & dirName,
-    TFile * inputFile, TDirectory * outputFile
-    ){
+  void fitSlice(const TString& histoName, const TString& dirName, TFile* inputFile, TDirectory* outputFile) {
     //r.c. patch --------------
-    if (
-      histoName=="hRecBestResVSMu_MassVSEtaPhiPlus" || histoName=="hRecBestResVSMu_MassVSEtaPhiMinus" ||
-      histoName=="hRecBestResVSMu_MassVSPhiPlusPhiMinus" || histoName=="hRecBestResVSMu_MassVSEtaPlusEtaMinus"
-      ){
+    if (histoName == "hRecBestResVSMu_MassVSEtaPhiPlus" || histoName == "hRecBestResVSMu_MassVSEtaPhiMinus" ||
+        histoName == "hRecBestResVSMu_MassVSPhiPlusPhiMinus" || histoName == "hRecBestResVSMu_MassVSEtaPlusEtaMinus") {
       TH3* histoPt3 = (TH3*)inputFile->FindObjectAny(histoName);
       outputFile->mkdir(dirName);
       outputFile->cd(dirName);
@@ -90,8 +86,7 @@ public:
       //	histoPt3->RebinY(rebinY);
       //	(histoPt3->DoProject2D())->RebinX(rebinX);
       //	(histoPt3->DoProject2D())->RebinY(rebinY);
-    }
-    else{
+    } else {
       TH2* histoPt2 = (TH2*)inputFile->FindObjectAny(histoName);
       histoPt2->RebinX(rebinX);
       histoPt2->RebinY(rebinY);
@@ -103,45 +98,47 @@ public:
     }
   }
 
-  TH3* rebin3D(const TH3* histo3D){
-    unsigned int zbins=histo3D->GetNbinsZ();
+  TH3* rebin3D(const TH3* histo3D) {
+    unsigned int zbins = histo3D->GetNbinsZ();
     // std::cout<< "number of bins in z (and tempHisto) --> "<<zbins<<std::endl;
     std::map<unsigned int, TH2*> twoDprojection;
-    for (unsigned int z=1; z<zbins; ++z) {
-      TAxis* ax_tmp = const_cast<TAxis*>(histo3D->GetZaxis()); ax_tmp->SetRange(z, z);
-      TH2* tempHisto= (TH2*)histo3D->Project3D("xy");
+    for (unsigned int z = 1; z < zbins; ++z) {
+      TAxis* ax_tmp = const_cast<TAxis*>(histo3D->GetZaxis());
+      ax_tmp->SetRange(z, z);
+      TH2* tempHisto = (TH2*)histo3D->Project3D("xy");
       std::stringstream ss;
       ss << z;
-      tempHisto->SetName((std::string{tempHisto->GetName()}+ss.str()).c_str());
+      tempHisto->SetName((std::string{tempHisto->GetName()} + ss.str()).c_str());
       tempHisto->RebinX(rebinX);
       tempHisto->RebinY(rebinY);
       twoDprojection.insert(std::make_pair(z, tempHisto));
     }
     unsigned int xbins, ybins;
-    TH3* rebinned3D = (TH3*) new TH3F(TString(histo3D->GetName())+"_rebinned", histo3D->GetTitle(),
-      xbins, histo3D->GetXaxis()->GetXmin(), histo3D->GetXaxis()->GetXmax(),
-      ybins, histo3D->GetYaxis()->GetXmin(), histo3D->GetYaxis()->GetXmax(),
-      zbins, histo3D->GetZaxis()->GetXmin(), histo3D->GetZaxis()->GetXmax());
-    if (twoDprojection.size()!=0)
-    {
-      xbins=twoDprojection[1]->GetNbinsX();
-      ybins=twoDprojection[1]->GetNbinsY();
+    TH3* rebinned3D = (TH3*)new TH3F(TString(histo3D->GetName()) + "_rebinned",
+                                     histo3D->GetTitle(),
+                                     xbins,
+                                     histo3D->GetXaxis()->GetXmin(),
+                                     histo3D->GetXaxis()->GetXmax(),
+                                     ybins,
+                                     histo3D->GetYaxis()->GetXmin(),
+                                     histo3D->GetYaxis()->GetXmax(),
+                                     zbins,
+                                     histo3D->GetZaxis()->GetXmin(),
+                                     histo3D->GetZaxis()->GetXmax());
+    if (twoDprojection.size() != 0) {
+      xbins = twoDprojection[1]->GetNbinsX();
+      ybins = twoDprojection[1]->GetNbinsY();
       //std::cout<< "number of bins in x --> "<<xbins<<std::endl;
       //std::cout<< "number of bins in y --> "<<ybins<<std::endl;
-      for (unsigned int z=1; z<zbins; ++z)
-      {
-        for (unsigned int y=1; y<ybins; ++y)
-        {
-          for (unsigned int x=1; x<xbins; ++x)
-          {
-            std::cout<< "x/y/z= "<<x<<"/"<<y<<"/"<<z <<std::endl;
-            std::cout<< "number of bins in x --> "<<xbins<<std::endl;
-            std::cout<< "number of bins in y --> "<<ybins<<std::endl;
+      for (unsigned int z = 1; z < zbins; ++z) {
+        for (unsigned int y = 1; y < ybins; ++y) {
+          for (unsigned int x = 1; x < xbins; ++x) {
+            std::cout << "x/y/z= " << x << "/" << y << "/" << z << std::endl;
+            std::cout << "number of bins in x --> " << xbins << std::endl;
+            std::cout << "number of bins in y --> " << ybins << std::endl;
             rebinned3D->Fill(x, y, twoDprojection[z]->GetBinContent(x, y));
           }
-
         }
-
       }
     }
     return rebinned3D;

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitSlices.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitSlices.cc
@@ -112,7 +112,7 @@ public:
       TH2* tempHisto= (TH2*)histo3D->Project3D("xy");
       std::stringstream ss;
       ss << z;
-      tempHisto->SetName(TString(tempHisto->GetName())+ss.str());
+      tempHisto->SetName((std::string{tempHisto->GetName()}+ss.str()).c_str());
       tempHisto->RebinX(rebinX);
       tempHisto->RebinY(rebinY);
       twoDprojection.insert(std::make_pair(z, tempHisto));

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitXslices.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitXslices.cc
@@ -19,11 +19,9 @@
  * It uses RooFit for the fitting.
  */
 
-class FitXslices
-{
+class FitXslices {
 public:
-  FitXslices()
-  {
+  FitXslices() {
     /// Initialize suitable parameter values for Z fitting
     /// N.B.: mean and sigma of gaussian, as well as mean and range of the peak are defined in the CompareBiasZValidation class
 
@@ -31,23 +29,23 @@ public:
     fitter_.initFsig(0.9, 0., 1.);
 
     /// CB
-    fitter_.initMean2( 0., -20., 20. );
+    fitter_.initMean2(0., -20., 20.);
     fitter_.mean2()->setConstant(kTRUE);
-    fitter_.initSigma( 1.5, 0.5, 3. );
-    fitter_.initSigma2(1.2,0.,5.);
+    fitter_.initSigma(1.5, 0.5, 3.);
+    fitter_.initSigma2(1.2, 0., 5.);
     fitter_.initAlpha(1.5, 0.05, 10.);
     fitter_.initN(1, 0.01, 100.);
 
     // BW Fix the gamma for the Z
-    fitter_.initGamma( 2.4952, 0., 10. );
-    fitter_.gamma()->setConstant(kTRUE); // This can be overriden as well.
+    fitter_.initGamma(2.4952, 0., 10.);
+    fitter_.gamma()->setConstant(kTRUE);  // This can be overriden as well.
 
-    fitter_.initGaussFrac( 0.5,  0., 1. );
+    fitter_.initGaussFrac(0.5, 0., 1.);
 
     /// Exponential with pol2 argument
-    fitter_.initExpCoeffA0(-1.,-10.,10.);
-    fitter_.initExpCoeffA1( 0.,-10.,10.);
-    fitter_.initExpCoeffA2( 0., -2., 2.);
+    fitter_.initExpCoeffA0(-1., -10., 10.);
+    fitter_.initExpCoeffA1(0., -10., 10.);
+    fitter_.initExpCoeffA2(0., -2., 2.);
 
     /// Polynomial
     fitter_.initA0(0., -10., 10.);
@@ -58,16 +56,19 @@ public:
     fitter_.initA5(0., -10., 10.);
     fitter_.initA6(0., -10., 10.);
 
-
     fitter_.useChi2_ = false;
   }
 
-  FitWithRooFit * fitter(){ return( &fitter_ ); }
+  FitWithRooFit* fitter() { return (&fitter_); }
 
   //  void fitSlices( std::map<unsigned int, TH1*> & slices, const double & xMin, const double & xMax, const TString & signalType, const TString & backgroundType, const bool twoD ){    }
 
-  void operator()(TH2 * histo, const double & xMin, const double & xMax, const TString & signalType, const TString & backgroundType, unsigned int rebinY)
-  {
+  void operator()(TH2* histo,
+                  const double& xMin,
+                  const double& xMax,
+                  const TString& signalType,
+                  const TString& backgroundType,
+                  unsigned int rebinY) {
     // Create and move in a subdir
     gDirectory->mkdir("allHistos");
     gDirectory->cd("allHistos");
@@ -79,33 +80,39 @@ public:
 
     // The canvas for the results of the fit (the mean values for the gaussians +- errors)
     TCanvas* meanCanvas = new TCanvas("meanCanvas", "meanCanvas", 1000, 800);
-    TH1D* meanHisto = new TH1D("meanHisto", "meanHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* meanHisto =
+        new TH1D("meanHisto", "meanHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* sigmaCanvas = new TCanvas("sigmaCanvas", "sigmaCanvas", 1000, 800);
-    TH1D* sigmaHisto = new TH1D("sigmaHisto", "sigmaHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* sigmaHisto =
+        new TH1D("sigmaHisto", "sigmaHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* backgroundCanvas = new TCanvas("backgroundCanvas", "backgroundCanvas", 1000, 800);
-    TH1D* backgroundHisto = new TH1D("backgroundHisto", "backgroundHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* backgroundHisto = new TH1D(
+        "backgroundHisto", "backgroundHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* backgroundCanvas2 = new TCanvas("backgroundCanvas2", "backgroundCanvas2", 1000, 800);
-    TH1D* backgroundHisto2 = new TH1D("backgroundHisto2", "exp a1", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* backgroundHisto2 =
+        new TH1D("backgroundHisto2", "exp a1", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* backgroundCanvas3 = new TCanvas("backgroundCanvas3", "backgroundCanvas3", 1000, 800);
-    TH1D* backgroundHisto3 = new TH1D("backgroundHisto3", "exp a2", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* backgroundHisto3 =
+        new TH1D("backgroundHisto3", "exp a2", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* signalFractionCanvas = new TCanvas("signalFractionCanvas", "signalFractionCanvas", 1000, 800);
-    TH1D* signalFractionHisto = new TH1D("signalFractionHisto", "signalFractionHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
+    TH1D* signalFractionHisto = new TH1D(
+        "signalFractionHisto", "signalFractionHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     TCanvas* probChi2Canvas = new TCanvas("probChi2Canvas", "probChi2Canvas", 1000, 800);
-    TH1D* probChi2Histo = new TH1D("probChi2Histo", "probChi2Histo", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
-
+    TH1D* probChi2Histo =
+        new TH1D("probChi2Histo", "probChi2Histo", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax());
 
     // Store all the non-empty slices
-    std::map< unsigned int, TH1 *> slices;
-    for (unsigned int x=1; x<=binsX; ++x) {
+    std::map<unsigned int, TH1*> slices;
+    for (unsigned int x = 1; x <= binsX; ++x) {
       std::stringstream ss;
       ss << x;
-      TH1* sliceHisto = histo->ProjectionY((std::string{name.Data()}+ss.str()).c_str(), x, x);
+      TH1* sliceHisto = histo->ProjectionY((std::string{name.Data()} + ss.str()).c_str(), x, x);
       if (sliceHisto->GetEntries() != 0) {
         // std::cout << "filling for x = " << x << endl;
         slices.insert(std::make_pair(x, sliceHisto));
@@ -118,7 +125,7 @@ public:
     // cout << "slices.size = " << slices.size() << endl;
     unsigned int x = sqrt(slices.size());
     unsigned int y = x;
-    if (x*y < slices.size()) {
+    if (x * y < slices.size()) {
       x += 1;
       y += 1;
     }
@@ -126,7 +133,7 @@ public:
 
     // Loop on the saved slices and fit
     std::map<unsigned int, TH1*>::iterator it = slices.begin();
-    unsigned int i=1;
+    unsigned int i = 1;
     for (; it != slices.end(); ++it, ++i) {
       fitsCanvas->cd(i);
       fitter_.fit(it->second, signalType, backgroundType, xMin, xMax);
@@ -148,8 +155,7 @@ public:
         RooRealVar* expCoeff = fitter_.expCoeffa1();
         backgroundHisto->SetBinContent(it->first, expCoeff->getVal());
         backgroundHisto->SetBinError(it->first, expCoeff->getError());
-      }
-      else if (backgroundType == "exponentialpol") {
+      } else if (backgroundType == "exponentialpol") {
         RooRealVar* expCoeffa0 = fitter_.expCoeffa0();
         backgroundHisto->SetBinContent(it->first, expCoeffa0->getVal());
         backgroundHisto->SetBinError(it->first, expCoeffa0->getError());
@@ -219,8 +225,12 @@ public:
     meanCanvas->Close();
   }
 
-  void operator()(TH3 * histo, const double & xMin, const double & xMax, const TString & signalType, const TString & backgroundType, unsigned int rebinZ)
-  {
+  void operator()(TH3* histo,
+                  const double& xMin,
+                  const double& xMax,
+                  const TString& signalType,
+                  const TString& backgroundType,
+                  unsigned int rebinZ) {
     // Create and move in a subdir
     gDirectory->mkdir("allHistos");
     gDirectory->cd("allHistos");
@@ -235,35 +245,84 @@ public:
 
     // The canvas for the results of the fit (the mean values for the gaussians +- errors)
     TCanvas* meanCanvas = new TCanvas("meanCanvas", "meanCanvas", 1000, 800);
-    TH2D * meanHisto = new TH2D("meanHisto", "meanHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* meanHisto = new TH2D("meanHisto",
+                               "meanHisto",
+                               binsX,
+                               histo->GetXaxis()->GetXmin(),
+                               histo->GetXaxis()->GetXmax(),
+                               binsY,
+                               histo->GetYaxis()->GetXmin(),
+                               histo->GetYaxis()->GetXmax());
 
     TCanvas* errorMeanCanvas = new TCanvas("errorMeanCanvas", "errorMeanCanvas", 1000, 800);
-    TH2D * errorMeanHisto = new TH2D("errorMeanHisto", "errorMeanHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* errorMeanHisto = new TH2D("errorMeanHisto",
+                                    "errorMeanHisto",
+                                    binsX,
+                                    histo->GetXaxis()->GetXmin(),
+                                    histo->GetXaxis()->GetXmax(),
+                                    binsY,
+                                    histo->GetYaxis()->GetXmin(),
+                                    histo->GetYaxis()->GetXmax());
 
     TCanvas* sigmaCanvas = new TCanvas("sigmaCanvas", "sigmaCanvas", 1000, 800);
-    TH2D * sigmaHisto = new TH2D("sigmaHisto", "sigmaHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* sigmaHisto = new TH2D("sigmaHisto",
+                                "sigmaHisto",
+                                binsX,
+                                histo->GetXaxis()->GetXmin(),
+                                histo->GetXaxis()->GetXmax(),
+                                binsY,
+                                histo->GetYaxis()->GetXmin(),
+                                histo->GetYaxis()->GetXmax());
 
     TCanvas* backgroundCanvas = new TCanvas("backgroundCanvas", "backgroundCanvas", 1000, 800);
-    TH2D * backgroundHisto = new TH2D("backgroundHisto", "backgroundHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* backgroundHisto = new TH2D("backgroundHisto",
+                                     "backgroundHisto",
+                                     binsX,
+                                     histo->GetXaxis()->GetXmin(),
+                                     histo->GetXaxis()->GetXmax(),
+                                     binsY,
+                                     histo->GetYaxis()->GetXmin(),
+                                     histo->GetYaxis()->GetXmax());
     TCanvas* backgroundCanvas2 = new TCanvas("backgroundCanvas2", "backgroundCanvas2", 1000, 800);
-    TH2D * backgroundHisto2 = new TH2D("backgroundHisto2", "a1", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* backgroundHisto2 = new TH2D("backgroundHisto2",
+                                      "a1",
+                                      binsX,
+                                      histo->GetXaxis()->GetXmin(),
+                                      histo->GetXaxis()->GetXmax(),
+                                      binsY,
+                                      histo->GetYaxis()->GetXmin(),
+                                      histo->GetYaxis()->GetXmax());
     TCanvas* backgroundCanvas3 = new TCanvas("backgroundCanvas3", "backgroundCanvas3", 1000, 800);
-    TH2D * backgroundHisto3 = new TH2D("backgroundHisto3", "a2", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* backgroundHisto3 = new TH2D("backgroundHisto3",
+                                      "a2",
+                                      binsX,
+                                      histo->GetXaxis()->GetXmin(),
+                                      histo->GetXaxis()->GetXmax(),
+                                      binsY,
+                                      histo->GetYaxis()->GetXmin(),
+                                      histo->GetYaxis()->GetXmax());
 
     TCanvas* signalFractionCanvas = new TCanvas("signalFractionCanvas", "signalFractionCanvas", 1000, 800);
-    TH2D * signalFractionHisto = new TH2D("signalFractionHisto", "signalFractionHisto", binsX, histo->GetXaxis()->GetXmin(), histo->GetXaxis()->GetXmax(), binsY, histo->GetYaxis()->GetXmin(), histo->GetYaxis()->GetXmax());
+    TH2D* signalFractionHisto = new TH2D("signalFractionHisto",
+                                         "signalFractionHisto",
+                                         binsX,
+                                         histo->GetXaxis()->GetXmin(),
+                                         histo->GetXaxis()->GetXmax(),
+                                         binsY,
+                                         histo->GetYaxis()->GetXmin(),
+                                         histo->GetYaxis()->GetXmax());
 
     // Store all the non-empty slices
-    std::map<unsigned int, TH1 *> slices;
-    for (unsigned int x=1; x<=binsX; ++x) {
-      for (unsigned int y=1; y<=binsY; ++y) {
+    std::map<unsigned int, TH1*> slices;
+    for (unsigned int x = 1; x <= binsX; ++x) {
+      for (unsigned int y = 1; y <= binsY; ++y) {
         std::stringstream ss;
         ss << x << "_" << y;
-        TH1* sliceHisto = histo->ProjectionZ((std::string{name.Data()}+ss.str()).c_str(), x, x, y, y);
+        TH1* sliceHisto = histo->ProjectionZ((std::string{name.Data()} + ss.str()).c_str(), x, x, y, y);
         if (sliceHisto->GetEntries() != 0) {
           sliceHisto->Rebin(rebinZ);
           // std::cout << "filling for x = " << x << endl;
-          slices.insert(std::make_pair(x+(binsX+1)*y, sliceHisto));
+          slices.insert(std::make_pair(x + (binsX + 1) * y, sliceHisto));
         }
       }
     }
@@ -273,7 +332,7 @@ public:
     // cout << "slices.size = " << slices.size() << endl;
     unsigned int x = sqrt(slices.size());
     unsigned int y = x;
-    if (x*y < slices.size()) {
+    if (x * y < slices.size()) {
       x += 1;
       y += 1;
     }
@@ -281,56 +340,54 @@ public:
 
     // Loop on the saved slices and fit
     std::map<unsigned int, TH1*>::iterator it = slices.begin();
-    unsigned int i=1;
+    unsigned int i = 1;
     for (; it != slices.end(); ++it, ++i) {
       fitsCanvas->cd(i);
 
       fitter_.fit(it->second, signalType, backgroundType, xMin, xMax);
 
       RooRealVar* mean = fitter_.mean();
-      meanHisto->SetBinContent(it->first%(binsX+1), int(it->first/(binsX+1)), mean->getVal());
-      errorMeanHisto->SetBinContent(it->first%(binsX+1), int(it->first/(binsX+1)), mean->getError());
+      meanHisto->SetBinContent(it->first % (binsX + 1), int(it->first / (binsX + 1)), mean->getVal());
+      errorMeanHisto->SetBinContent(it->first % (binsX + 1), int(it->first / (binsX + 1)), mean->getError());
       //      meanHisto->SetBinError(it->first%binsX, int(it->first/binsX), mean->getError());
       //std::cout<<"int i -->"<<i<<std::endl;
       //std::cout<< " it->first%(binsX+1) --> "<<it->first%(binsX+1)<<std::endl;
-      //std::cout<< " it->first/(binsX+1) --> "<<int(it->first/(binsX+1))<<std::endl;    
+      //std::cout<< " it->first/(binsX+1) --> "<<int(it->first/(binsX+1))<<std::endl;
 
       RooRealVar* sigma = fitter_.sigma();
-      sigmaHisto->SetBinContent(it->first%binsX, int(it->first/binsX), sigma->getVal());
-      sigmaHisto->SetBinError(it->first%binsX, int(it->first/binsX), sigma->getError());
+      sigmaHisto->SetBinContent(it->first % binsX, int(it->first / binsX), sigma->getVal());
+      sigmaHisto->SetBinError(it->first % binsX, int(it->first / binsX), sigma->getError());
 
       std::cout << "backgroundType = " << backgroundType << std::endl;
       if (backgroundType == "exponential") {
         RooRealVar* expCoeff = fitter_.expCoeffa1();
-        backgroundHisto->SetBinContent(it->first%binsX, int(it->first/binsX), expCoeff->getVal());
-        backgroundHisto->SetBinError(it->first%binsX, int(it->first/binsX), expCoeff->getError());
-      }
-      else if (backgroundType == "exponentialpol") {
+        backgroundHisto->SetBinContent(it->first % binsX, int(it->first / binsX), expCoeff->getVal());
+        backgroundHisto->SetBinError(it->first % binsX, int(it->first / binsX), expCoeff->getError());
+      } else if (backgroundType == "exponentialpol") {
         RooRealVar* expCoeffa0 = fitter_.expCoeffa0();
-        backgroundHisto->SetBinContent(it->first%binsX, int(it->first/binsX), expCoeffa0->getVal());
-        backgroundHisto->SetBinError(it->first%binsX, int(it->first/binsX), expCoeffa0->getError());
+        backgroundHisto->SetBinContent(it->first % binsX, int(it->first / binsX), expCoeffa0->getVal());
+        backgroundHisto->SetBinError(it->first % binsX, int(it->first / binsX), expCoeffa0->getError());
 
-        RooRealVar* expCoeffa1= fitter_.expCoeffa1();
-        backgroundHisto2->SetBinContent(it->first%binsX, int(it->first/binsX), expCoeffa1->getVal());
-        backgroundHisto2->SetBinError(it->first%binsX, int(it->first/binsX), expCoeffa1->getError());
+        RooRealVar* expCoeffa1 = fitter_.expCoeffa1();
+        backgroundHisto2->SetBinContent(it->first % binsX, int(it->first / binsX), expCoeffa1->getVal());
+        backgroundHisto2->SetBinError(it->first % binsX, int(it->first / binsX), expCoeffa1->getError());
 
-        RooRealVar* expCoeffa2= fitter_.expCoeffa2();
-        backgroundHisto3->SetBinContent(it->first%binsX, int(it->first/binsX), expCoeffa2->getVal());
-        backgroundHisto3->SetBinError(it->first%binsX, int(it->first/binsX), expCoeffa2->getError());
-      }
-      else if (backgroundType == "linear") {
+        RooRealVar* expCoeffa2 = fitter_.expCoeffa2();
+        backgroundHisto3->SetBinContent(it->first % binsX, int(it->first / binsX), expCoeffa2->getVal());
+        backgroundHisto3->SetBinError(it->first % binsX, int(it->first / binsX), expCoeffa2->getError());
+      } else if (backgroundType == "linear") {
         RooRealVar* linearTerm = fitter_.a1();
-        backgroundHisto->SetBinContent(it->first%binsX, int(it->first/binsX), linearTerm->getVal());
-        backgroundHisto->SetBinError(it->first%binsX, int(it->first/binsX), linearTerm->getError());
+        backgroundHisto->SetBinContent(it->first % binsX, int(it->first / binsX), linearTerm->getVal());
+        backgroundHisto->SetBinError(it->first % binsX, int(it->first / binsX), linearTerm->getError());
 
         RooRealVar* constant = fitter_.a0();
-        backgroundHisto2->SetBinContent(it->first%binsX, int(it->first/binsX), constant->getVal());
-        backgroundHisto2->SetBinError(it->first%binsX, int(it->first/binsX), constant->getError());
+        backgroundHisto2->SetBinContent(it->first % binsX, int(it->first / binsX), constant->getVal());
+        backgroundHisto2->SetBinError(it->first % binsX, int(it->first / binsX), constant->getError());
       }
 
       RooRealVar* fsig = fitter_.fsig();
-      signalFractionHisto->SetBinContent(it->first%binsX, int(it->first/binsX), fsig->getVal());
-      signalFractionHisto->SetBinError(it->first%binsX, int(it->first/binsX), fsig->getError());
+      signalFractionHisto->SetBinContent(it->first % binsX, int(it->first / binsX), fsig->getVal());
+      signalFractionHisto->SetBinError(it->first % binsX, int(it->first / binsX), fsig->getError());
     }
     // Go back to the main dir before saving the canvases
     gDirectory->GetMotherDir()->cd();
@@ -378,11 +435,8 @@ public:
   }
 
 protected:
-  struct Parameter
-  {
-    Parameter(const double & inputValue, const double & inputError) :
-      value(inputValue), error(inputError)
-    {}
+  struct Parameter {
+    Parameter(const double& inputValue, const double& inputError) : value(inputValue), error(inputError) {}
 
     double value;
     double error;

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitXslices.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitXslices.cc
@@ -105,7 +105,7 @@ public:
     for (unsigned int x=1; x<=binsX; ++x) {
       std::stringstream ss;
       ss << x;
-      TH1* sliceHisto = histo->ProjectionY(name+ss.str(), x, x);
+      TH1* sliceHisto = histo->ProjectionY((std::string{name.Data()}+ss.str()).c_str(), x, x);
       if (sliceHisto->GetEntries() != 0) {
         // std::cout << "filling for x = " << x << endl;
         slices.insert(std::make_pair(x, sliceHisto));
@@ -259,7 +259,7 @@ public:
       for (unsigned int y=1; y<=binsY; ++y) {
         std::stringstream ss;
         ss << x << "_" << y;
-        TH1* sliceHisto = histo->ProjectionZ(name+ss.str(), x, x, y, y);
+        TH1* sliceHisto = histo->ProjectionZ((std::string{name.Data()}+ss.str()).c_str(), x, x, y, y);
         if (sliceHisto->GetEntries() != 0) {
           sliceHisto->Rebin(rebinZ);
           // std::cout << "filling for x = " << x << endl;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39065

#### PR description:

This PR fixes a couple of compilation errors preventing the Zµµ alignment validation to run, due to failures in the merge step.
The errors spotted are:

```
Info in <TUnixSystem::ACLiC>: creating shared library /pool/condor/dir_18690/TkAllInOneTool/./CompareBiasZValidation_cc.so
In file included from CompareBiasZValidation_cc_ACLiC_dict dictionary payload:8:
In file included from ././CompareBiasZValidation.cc:9:
In file included from /pool/condor/dir_18690/TkAllInOneTool/FitMassSlices.cc:4:
In file included from /pool/condor/dir_18690/TkAllInOneTool/FitSlices.cc:4:
/pool/condor/dir_18690/TkAllInOneTool/FitXslices.cc:108:48: error: use of overloaded operator '+' is ambiguous (with operand types 'TString' and 'std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::__string_type' (aka 'basic_string<char, std::char_traits<char>, std::allocator<char> >'))
      TH1* sliceHisto = histo->ProjectionY(name+ss.str(), x, x);
                                           ~~~~^~~~~~~~~
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:49:9: note: candidate function
TString operator+(const TString &s1, const TString &s2);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:116:15: note: candidate function
TEveException operator+(const TEveException &s1, const std::string  &s2);
              ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:51:9: note: candidate function
TString operator+(const char *cs, const TString &s);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:117:15: note: candidate function
TEveException operator+(const TEveException &s1, const TString &s2);
              ^
In file included from CompareBiasZValidation_cc_ACLiC_dict dictionary payload:8:
In file included from ././CompareBiasZValidation.cc:9:
In file included from /pool/condor/dir_18690/TkAllInOneTool/FitMassSlices.cc:4:
In file included from /pool/condor/dir_18690/TkAllInOneTool/FitSlices.cc:4:
/pool/condor/dir_18690/TkAllInOneTool/FitXslices.cc:262:50: error: use of overloaded operator '+' is ambiguous (with operand types 'TString' and 'std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::__string_type' (aka 'basic_string<char, std::char_traits<char>, std::allocator<char> >'))
        TH1* sliceHisto = histo->ProjectionZ(name+ss.str(), x, x, y, y);
                                             ~~~~^~~~~~~~~
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:49:9: note: candidate function
TString operator+(const TString &s1, const TString &s2);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:116:15: note: candidate function
TEveException operator+(const TEveException &s1, const std::string  &s2);
              ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:51:9: note: candidate function
TString operator+(const char *cs, const TString &s);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:117:15: note: candidate function
TEveException operator+(const TEveException &s1, const TString &s2);
              ^
In file included from CompareBiasZValidation_cc_ACLiC_dict dictionary payload:8:
In file included from ././CompareBiasZValidation.cc:9:
In file included from /pool/condor/dir_18690/TkAllInOneTool/FitMassSlices.cc:4:
/pool/condor/dir_18690/TkAllInOneTool/FitSlices.cc:115:55: error: use of overloaded operator '+' is ambiguous (with operand types 'TString' and 'std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >::__string_type' (aka 'basic_string<char, std::char_traits<char>, std::allocator<char> >'))
      tempHisto->SetName(TString(tempHisto->GetName())+ss.str());
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:49:9: note: candidate function
TString operator+(const TString &s1, const TString &s2);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:116:15: note: candidate function
TEveException operator+(const TEveException &s1, const std::string  &s2);
              ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TString.h:51:9: note: candidate function
TString operator+(const char *cs, const TString &s);
        ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-bf41b0420bc269850b74e23486e2953a/include/TEveUtil.h:117:15: note: candidate function
TEveException operator+(const TEveException &s1, const TString &s2);
              ^
Warning in <TInterpreter::TCling::RegisterModule>: Problems declaring payload for module CompareBiasZValidation_cc_ACLiC_dict.
IncrementalExecutor::executeFunction: symbol '_ZStL19__constant_string_pIcEbPKT_' unresolved while linking [cling interface function]!
You are probably missing the definition of bool std::__constant_string_p<char>(char const*)
Maybe you need to load the corresponding shared library?
```

#### PR validation:

Run successfully with the fix.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/39065, needed for tracker alignment purposes.