### PR TITLE
introduce G4e refitter in the tracker alignment machinery

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -2,8 +2,6 @@ from __future__ import print_function
 import sys
 import FWCore.ParameterSet.Config as cms
 
-
-
 def getSequence(process, collection,
                 saveCPU = False,
                 TTRHBuilder = "WithAngleAndTemplate",
@@ -14,7 +12,8 @@ def getSequence(process, collection,
                 momentumConstraint = None,
                 cosmicTrackSplitting = False,
                 isPVValidation = False,
-                use_d0cut = True):
+                use_d0cut = True,
+                g4Refitting = False):
     """This function returns a cms.Sequence containing as last element the
     module 'FinalTrackRefitter', which can be used as cms.InputTag for
     subsequent processing steps.
@@ -53,6 +52,8 @@ def getSequence(process, collection,
     # resolve default values incl. consistency checks #
     ###################################################
 
+    print("g4Refitting=",g4Refitting)
+
     if usePixelQualityFlag is None:
         if "Template" not in TTRHBuilder:
             usePixelQualityFlag = False # not defined without templates
@@ -69,7 +70,8 @@ def getSequence(process, collection,
     options = {"TrackHitFilter": {},
                "TrackFitter": {},
                "TrackRefitter": {},
-               "TrackSelector": {}}
+               "TrackSelector": {},
+               "geopro": {} }
 
     options["TrackSelector"]["HighPurity"] = {
         "trackQualities": ["highPurity"],
@@ -113,7 +115,27 @@ def getSequence(process, collection,
         "NavigationSchool": "",
         "TTRHBuilder": TTRHBuilder,
         }
+    options["geopro"][""] = {
+        }
 
+    if g4Refitting:
+        options["TrackRefitter"]["Second"] = {
+            "AlgorithmName" : cms.string('undefAlgorithm'),
+            "Fitter" : cms.string('G4eFitterSmoother'),
+            "GeometricInnerState" : cms.bool(False),
+            "MeasurementTracker" : cms.string(''),
+            "MeasurementTrackerEvent" : cms.InputTag("MeasurementTrackerEvent"),
+            "NavigationSchool" : cms.string('SimpleNavigationSchool'),  # Correct?
+            "Propagator" : cms.string('Geant4ePropagator'),
+            "TTRHBuilder" : cms.string('WithAngleAndTemplate'),
+            "TrajectoryInEvent" : cms.bool(True),
+            "beamSpot" : cms.InputTag("offlineBeamSpot"),
+            "constraint" : cms.string(''),
+            "src" : cms.InputTag("AlignmentTrackSelector"),
+            "srcConstr" : cms.InputTag(""),
+            "useHitsSplitting" : cms.bool(False),
+            "usePropagatorForPCA" : cms.bool(True)   # not sure whether it is needed
+        }
 
     #########################################
     ## setting collection specific options ##
@@ -131,7 +153,6 @@ def getSequence(process, collection,
                 "minimumHits": 10,
                 })
     elif collection in ("ALCARECOTkAlCosmicsCTF0T",
-                        "ALCARECOTkAlCosmicsCosmicTF0T",
                         "ALCARECOTkAlCosmicsInCollisions"):
         isCosmics = True
         options["TrackSelector"]["HighPurity"] = {} # drop high purity cut
@@ -267,6 +288,17 @@ def getSequence(process, collection,
                 ("TrackFitter", "HitFilteredTracks", {"method": "import"}),
                 ("TrackRefitter", "Second", {"method": "load",
                                              "clone": True})]
+    elif g4Refitting:
+        mods = [("TrackSelector", "HighPurity", {"method": "import"}),
+                ("TrackRefitter", "First", {"method": "load",
+                                            "clone": True}),
+                ("TrackHitFilter", "Tracker", {"method": "load"}),
+                ("TrackFitter", "HitFilteredTracks", {"method": "import"}),
+                ("TrackSelector", "Alignment", {"method": "load"}),
+                #("geopro","", {"method": "load"}),
+                ("TrackRefitter", "Second", {"method": "load",
+                                             "clone": True})]
+        if isCosmics: mods = mods[1:] # skip high purity selector for cosmics
     else:
         mods = [("TrackSelector", "HighPurity", {"method": "import"}),
                 ("TrackRefitter", "First", {"method": "load",
@@ -323,8 +355,6 @@ def getSequence(process, collection,
     #######################################################
     process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 
-
-
     ###############################
     ## put the sequence together ##
     ###############################
@@ -342,12 +372,23 @@ def getSequence(process, collection,
                 not mods[-1][-1].get("clone", False):
             print("Name of the last module needs to be modifiable.")
             sys.exit(1)
+
+        if g4Refitting:
+            print("Here we must include geopro first")
+            process.load('Configuration.StandardSequences.GeometryDB_cff')
+            process.load("TrackPropagation.Geant4e.geantRefit_cff")
+            modules.append(getattr(process,"geopro"))
+
         src = _getModule(process, src, mods[-1][0], "FinalTrackRefitter",
                          options[mods[-1][0]][mods[-1][1]],
                          isCosmics = isCosmics, **(mods[-1][2]))
         modules.append(getattr(process, src))
 
     moduleSum = process.offlineBeamSpot        # first element of the sequence
+    if g4Refitting:
+        # g4Refitter needs measurements
+        moduleSum += getattr(process,"MeasurementTrackerEvent")
+
     for module in modules:
         # Spply srcConstr fix here
         if hasattr(module,"srcConstr"):
@@ -375,10 +416,6 @@ def getSequence(process, collection,
         moduleSum += module # append the other modules
 
     return cms.Sequence(moduleSum)
-
-
-
-
 
 ###############################
 ###############################
@@ -490,6 +527,9 @@ def _TrackRefitter(kwargs):
 def _TrackSplitting(kwargs):
     return ("RecoTracker.FinalTrackSelectors.cosmicTrackSplitter_cfi",
             "cosmicTrackSplitter")
+
+def _geopro(kwargs):
+    return ("TrackPropagation.Geant4e.geantRefit_cff","geopro")
 
 
 def _customSetattr(obj, attr, val):

--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -144,7 +144,7 @@ def getSequence(process, collection,
 
     if collection in ("ALCARECOTkAlMinBias", "generalTracks",
                       "ALCARECOTkAlMinBiasHI", "hiGeneralTracks",
-                      "ALCARECOTkAlJetHT"):
+                      "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,
@@ -195,7 +195,8 @@ def getSequence(process, collection,
                 })
     elif collection in ("ALCARECOTkAlZMuMu",
                         "ALCARECOTkAlZMuMuHI",
-                        "ALCARECOTkAlZMuMuPA"):
+                        "ALCARECOTkAlZMuMuPA",
+                        "ALCARECOTkAlDiMuon"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 15.0,
                 "etaMin": -3.0,

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -7,6 +7,10 @@
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testPVValidation.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
+  <bin file="testAlignmentOfflineValidation.cpp" name="testMiscellanea">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testMiscellanea.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
   <bin file="testAlignmentOfflineValidation.cpp" name="testEoP">
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testEoP.sh"/>
     <use name="FWCore/Utilities"/>

--- a/Alignment/OfflineValidation/test/testEoP.sh
+++ b/Alignment/OfflineValidation/test/testEoP.sh
@@ -1,12 +1,6 @@
 #! /bin/bash
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING DiMuonVertexValidation ..."
-cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidation_cfg.py maxEvents=10 || die "Failure running DiMuonVertexValidation_cfg.py" $?
-
-echo "TESTING inspectData ..."
-cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
-
 echo "TESTING eopTreeWriter (Pion Analysis) ..."
 cmsRun ${LOCAL_TEST_DIR}/eopTreeWriter_cfg.py unitTest=True maxEvents=10 || die "Failure running eopTreeWriter" $?
 

--- a/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
+++ b/Alignment/OfflineValidation/test/testG4Refitter_cfg.py
@@ -1,0 +1,161 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import sys
+from enum import Enum
+import FWCore.ParameterSet.VarParsing as VarParsing
+from Configuration.StandardSequences.Eras import eras
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
+
+process = cms.Process("Demo") 
+
+options = VarParsing.VarParsing ()
+options.register('maxEvents',
+                 -1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "number of events to process (\"-1\" for all)")
+options.parseArguments()
+
+###################################################################
+# Event source and run selection
+###################################################################
+process.source = cms.Source("PoolSource",
+                            fileNames = filesRelValTTbarPileUpGENSIMRECO,
+                            duplicateCheckMode = cms.untracked.string('checkAllFilesOpened')
+                            )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.PrimaryVertexValidation=dict()
+process.MessageLogger.FilterOutLowPt=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    PrimaryVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    FilterOutLowPt          = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+####################################################################
+# Produce the Transient Track Record in the event
+####################################################################
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+
+####################################################################
+# Get the Magnetic Field
+####################################################################
+process.load('Configuration.StandardSequences.MagneticField_cff')
+
+###################################################################
+# Standard loads
+###################################################################
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+
+####################################################################
+# Get the BeamSpot
+####################################################################
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
+
+####################################################################
+# Get the GlogalTag
+####################################################################
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
+
+####################################################################
+# Load and Configure event selection
+####################################################################
+process.primaryVertexFilter = cms.EDFilter("VertexSelector",
+                                           src = cms.InputTag("offlinePrimaryVertices"),
+                                           cut = cms.string("!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2"),
+                                           filter = cms.bool(True))
+
+process.noscraping = cms.EDFilter("FilterOutScraping",
+                                  applyfilter = cms.untracked.bool(True),
+                                  src =  cms.untracked.InputTag("generalTracks"),
+                                  debugOn = cms.untracked.bool(False),
+                                  numtrack = cms.untracked.uint32(10),
+                                  thresh = cms.untracked.double(0.25))
+
+process.noslowpt = cms.EDFilter("FilterOutLowPt",
+                                applyfilter = cms.untracked.bool(True),
+                                src =  cms.untracked.InputTag("generalTracks"),
+                                debugOn = cms.untracked.bool(False),
+                                numtrack = cms.untracked.uint32(0),
+                                thresh = cms.untracked.int32(1),
+                                ptmin  = cms.untracked.double(3.),
+                                runControl = cms.untracked.bool(True),
+                                runControlNumber = cms.untracked.vuint32(1))
+
+process.goodvertexSkim = cms.Sequence(process.primaryVertexFilter + process.noscraping + process.noslowpt)
+     
+import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
+process.seqTrackselRefit = trackselRefit.getSequence(process, 'generalTracks',
+                                                     isPVValidation=True, 
+                                                     TTRHBuilder='WithAngleAndTemplate',
+                                                     usePixelQualityFlag=True,
+                                                     openMassWindow=False,
+                                                     cosmicsDecoMode=True,
+                                                     cosmicsZeroTesla=False,
+                                                     momentumConstraint=None,
+                                                     cosmicTrackSplitting=False,
+                                                     use_d0cut=False,
+                                                     g4Refitting=True) # this activates the G4 refiting
+
+####################################################################
+# Output file
+####################################################################
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string("PVValidation_testG4Refit_0.root"))
+
+####################################################################
+# Imports of parameters
+####################################################################
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
+## modify the parameters which differ
+FilteringParams = offlinePrimaryVertices.TkFilterParameters.clone(
+     maxNormalizedChi2 = 5.0,  # chi2ndof < 5
+     maxD0Significance = 5.0,  # fake cut (requiring 1 PXB hit)
+     maxEta = 5.0,             # as per recommendation in PR #18330
+)
+
+## MM 04.05.2017 (use settings as in: https://github.com/cms-sw/cmssw/pull/18330)
+from RecoVertex.PrimaryVertexProducer.TkClusParameters_cff import DA_vectParameters
+DAClusterizationParams = DA_vectParameters.clone()
+
+####################################################################
+# Configure the PVValidation Analyzer module
+####################################################################
+process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
+                                      TrackCollectionTag = cms.InputTag("FinalTrackRefitter"),
+                                      VertexCollectionTag = cms.InputTag("offlinePrimaryVertices"),
+                                      Debug = cms.bool(False),
+                                      storeNtuple = cms.bool(False),
+                                      useTracksFromRecoVtx = cms.bool(False),
+                                      isLightNtuple = cms.bool(True),
+                                      askFirstLayerHit = cms.bool(False),
+                                      forceBeamSpot = cms.untracked.bool(False),
+                                      probePt = cms.untracked.double(3.),
+                                      minPt   = cms.untracked.double(1.),
+                                      maxPt   = cms.untracked.double(30.),
+                                      runControl = cms.untracked.bool(True),
+                                      runControlNumber = cms.untracked.vuint32(1),
+                                      TkFilterParameters = FilteringParams,
+                                      TkClusParameters = DAClusterizationParams)
+
+####################################################################
+# Path
+####################################################################
+process.p = cms.Path(process.goodvertexSkim*
+                     process.seqTrackselRefit*
+                     process.PVValidation)

--- a/Alignment/OfflineValidation/test/testMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testMiscellanea.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING G4e refitter ..."
+cmsRun ${LOCAL_TEST_DIR}/testG4Refitter_cfg.py maxEvents=50  || die "Failure running testG4Refitter_cfg.py" $?
+
+echo "TESTING DiMuonVertexValidation ..."
+cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidation_cfg.py maxEvents=10 || die "Failure running DiMuonVertexValidation_cfg.py" $?
+
+echo "TESTING inspectData ..."
+cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?


### PR DESCRIPTION
#### PR description:

This PR has 3 commits:
   * 63c2db620d9ae9b1f05bead9a4e85ed7780b9985 introduces the machinery to be able to run the Geant4e refit in the `trackselectionRefitting` code, that is consumed by all the alignment and validation algorithms.
   * 0ea34e981c79f86e775bc0b10821048188a420da adds a dedicated unit test for this feature, now that https://github.com/cms-sw/cmssw/pull/38864 has fixed the core algorithm to be able to run in recent releases.
   * 00190045d3005f83ad0ebd86087b50c6afa9319c is a leftover from https://github.com/cms-sw/cmssw/pull/39013. In this commit I supply coverage for the track collections introduced in PR https://github.com/cms-sw/cmssw/pull/33770.

#### PR validation:

Relies on the augmented unit tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but shall be backported.


