### PR TITLE
Add more profile dump points to IgProfService

### DIFF
--- a/IgTools/IgProf/plugins/IgProfService.cc
+++ b/IgTools/IgProf/plugins/IgProfService.cc
@@ -66,7 +66,13 @@ IgProfService::IgProfService(ParameterSet const &ps, ActivityRegistry &iRegistry
   atPostModuleEvent_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostModuleEvent", atPostModuleEvent_);
 
   atPostEndLumi_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndLumi", atPostEndLumi_);
+  atPreEndRun_ = ps.getUntrackedParameter<std::string>("reportToFileAtPreEndRun", atPreEndRun_);
   atPostEndRun_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndRun", atPostEndRun_);
+  atPreEndProcessBlock_ =
+      ps.getUntrackedParameter<std::string>("reportToFileAtPreEndProcessBlock", atPreEndProcessBlock_);
+  atPostEndProcessBlock_ =
+      ps.getUntrackedParameter<std::string>("reportToFileAtPostEndProcessBlock", atPostEndProcessBlock_);
+  atPreEndJob_ = ps.getUntrackedParameter<std::string>("reportToFileAtPreEndJob", atPreEndJob_);
   atPostEndJob_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndJob", atPostEndJob_);
 
   atPostOpenFile_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostOpenFile", atPostOpenFile_);
@@ -86,7 +92,11 @@ IgProfService::IgProfService(ParameterSet const &ps, ActivityRegistry &iRegistry
   }
 
   iRegistry.watchPostGlobalEndLumi(this, &IgProfService::postEndLumi);
+  iRegistry.watchPreGlobalEndRun(this, &IgProfService::preEndRun);
   iRegistry.watchPostGlobalEndRun(this, &IgProfService::postEndRun);
+  iRegistry.watchPreEndProcessBlock(this, &IgProfService::preEndProcessBlock);
+  iRegistry.watchPostEndProcessBlock(this, &IgProfService::postEndProcessBlock);
+  iRegistry.watchPreEndJob(this, &IgProfService::preEndJob);
   iRegistry.watchPostEndJob(this, &IgProfService::postEndJob);
 
   iRegistry.watchPostOpenFile(this, &IgProfService::postOpenFile);
@@ -147,10 +157,21 @@ void IgProfService::postEndLumi(GlobalContext const &gc) {
   makeDump(atPostEndLumi_);
 }
 
+void IgProfService::preEndRun(GlobalContext const &gc) {
+  nrun_ = gc.luminosityBlockID().run();
+  makeDump(atPreEndRun_);
+}
+
 void IgProfService::postEndRun(GlobalContext const &gc) {
   nrun_ = gc.luminosityBlockID().run();
   makeDump(atPostEndRun_);
 }
+
+void IgProfService::preEndProcessBlock(GlobalContext const &gc) { makeDump(atPreEndProcessBlock_); }
+
+void IgProfService::postEndProcessBlock(GlobalContext const &gc) { makeDump(atPostEndProcessBlock_); }
+
+void IgProfService::preEndJob() { makeDump(atPreEndJob_); }
 
 void IgProfService::postEndJob() { makeDump(atPostEndJob_); }
 

--- a/IgTools/IgProf/plugins/IgProfService.h
+++ b/IgTools/IgProf/plugins/IgProfService.h
@@ -35,8 +35,13 @@ namespace edm {
 
       void postEndLumi(GlobalContext const &gc);
 
+      void preEndRun(GlobalContext const &gc);
       void postEndRun(GlobalContext const &gc);
 
+      void preEndProcessBlock(GlobalContext const &gc);
+      void postEndProcessBlock(GlobalContext const &gc);
+
+      void preEndJob();
       void postEndJob();
 
       void postOpenFile(std::string const &);
@@ -64,7 +69,11 @@ namespace edm {
       std::string atPostModuleEvent_;
 
       std::string atPostEndLumi_;
+      std::string atPreEndRun_;
       std::string atPostEndRun_;
+      std::string atPreEndProcessBlock_;
+      std::string atPostEndProcessBlock_;
+      std::string atPreEndJob_;
       std::string atPostEndJob_;
 
       std::string atPostOpenFile_;


### PR DESCRIPTION
#### PR description:

This PR adds options to `IgProfService` to dump the profile at `preGlobalEndRun`, `{pre,post}EndProcessBlock`, and `preEndJob` signals. I used those to investigate #38976.

#### PR validation:

Got profile dumps at the aforementioned transitions.