### PR TITLE
`SiPixelLorentzAnglePCLHarvester`: protect the computation of the LA error in case of missing covariance matrix

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -676,6 +676,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
 
   // compute the error on the drift-at-half-width parameter (d^2)
   float dSq{0.};
+  float cov00{0.};  // needed later for the error on the tan(theta_LA)
   if (!doChebyshevFit_) {
     if (res.covMatrixStatus != SiPixelLAHarvest::kNotCalculated) {
       for (int k = 0; k < order_; k++) {
@@ -683,8 +684,9 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
           dSq += (std::pow(half_width, k) * std::pow(half_width, l) * result->CovMatrix(k, l));
         }
       }
-    }
-  }  // compute the error on the drift-at-half width only for the regular polynomial fit
+      cov00 = result->CovMatrix(0, 0);
+    }  // if the covariance matrix is valid
+  }    // compute the error on the drift-at-half width only for the regular polynomial fit
 
   res.dSq = dSq;
 
@@ -717,7 +719,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
        pow((half_width * half_width * half_width * res.e4), 2) +
        pow((half_width * half_width * half_width * half_width * res.e5), 2));  // Propagation of uncertainty
 
-  res.error_LA = doChebyshevFit_ ? sqrt(errsq_LA) : sqrt(res.dSq + result->CovMatrix(0, 0)) / half_width;
+  res.error_LA = doChebyshevFit_ ? sqrt(errsq_LA) : sqrt(res.dSq + cov00) / half_width;
 
   hists_.h_bySectMeasLA_->setBinContent(i_index, (res.tan_LA / theMagField_));
   hists_.h_bySectMeasLA_->setBinError(i_index, (res.error_LA / theMagField_));


### PR DESCRIPTION
#### PR description:

Title says it all, resolves the issue reported at https://github.com/cms-sw/cmssw/pull/38996#issuecomment-1216704561

#### PR validation:

Run successfully with this branch:
```console 
runTheMatrix.py -l 1001.2 -j 8 -t 4
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be included in the backport of https://github.com/cms-sw/cmssw/pull/38996 (https://github.com/cms-sw/cmssw/pull/39075)