### PR TITLE
tighter selection in pp_on_AA era for iterations still using pp defaults

### DIFF
--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -259,6 +259,7 @@ jetCoreRegionalStep = TrackCutClassifier.clone(
     ),
     vertices = 'firstStepGoodPrimaryVertices'
 )
+
 jetCoreRegionalStepBarrel = jetCoreRegionalStep.clone(
     src = 'jetCoreRegionalStepBarrelTracks',
     mva = dict(
@@ -277,6 +278,9 @@ trackingPhase1.toReplaceWith(jetCoreRegionalStep, TrackMVAClassifierPrompt.clone
 trackingPhase1.toReplaceWith(jetCoreRegionalStepBarrel, jetCoreRegionalStep.clone(
      src = 'jetCoreRegionalStepBarrelTracks',
 ))
+
+pp_on_AA.toModify(jetCoreRegionalStep, qualityCuts = [-0.2, 0.0, 0.8])
+pp_on_AA.toModify(jetCoreRegionalStepBarrel, qualityCuts = [-0.2, 0.0, 0.8])
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -259,7 +259,6 @@ jetCoreRegionalStep = TrackCutClassifier.clone(
     ),
     vertices = 'firstStepGoodPrimaryVertices'
 )
-
 jetCoreRegionalStepBarrel = jetCoreRegionalStep.clone(
     src = 'jetCoreRegionalStepBarrelTracks',
     mva = dict(

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -152,6 +152,44 @@ muonSeededTracksOutInClassifier = TrackCutClassifier.clone(
     )
 )
 
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(muonSeededTracksOutInClassifier.mva,
+                  dr_par = cms.PSet(
+                      d0err = cms.vdouble(0.003, 0.003, 0.003),
+                      d0err_par = cms.vdouble(0.001, 0.001, 0.001),
+                      dr_exp = cms.vint32(4, 4, 4),
+                      dr_par1 = cms.vdouble(0.4, 0.4, 0.4),
+                      dr_par2 = cms.vdouble(0.3, 0.3, 0.3)
+                  ),
+                  dz_par = cms.PSet(
+                      dz_exp = cms.vint32(4, 4, 4),
+                      dz_par1 = cms.vdouble(0.4, 0.4, 0.4),
+                      dz_par2 = cms.vdouble(0.35, 0.35, 0.35)
+                  ),
+                  maxDr         = [9999.,9999.,0.5],
+                  maxDz         = [9999.,9999.,0.5],
+                  minHits     =   [0,0,10],
+                  minPixelHits  = [0,0,1],
+)
+pp_on_AA.toModify(muonSeededTracksInOutClassifier.mva,
+                  dr_par = cms.PSet(
+                      d0err = cms.vdouble(0.003, 0.003, 0.003),
+                      d0err_par = cms.vdouble(0.001, 0.001, 0.001),
+                      dr_exp = cms.vint32(4, 4, 4),
+                      dr_par1 = cms.vdouble(0.4, 0.4, 0.4),
+                      dr_par2 = cms.vdouble(0.3, 0.3, 0.3)
+                  ),
+                  dz_par = cms.PSet(
+                      dz_exp = cms.vint32(4, 4, 4),
+                      dz_par1 = cms.vdouble(0.4, 0.4, 0.4),
+                      dz_par2 = cms.vdouble(0.35, 0.35, 0.35)
+                  ),
+                  maxDr         = [9999.,9999.,0.5],
+                  maxDz         = [9999.,9999.,0.5],
+                  minHits     =   [0,0,10],
+                  minPixelHits  = [0,0,1],
+)
+
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 muonSeededTracksInOutSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(


### PR DESCRIPTION
In the heavy-ion era (pp_on_AA) each tracking iteration either has a dedicated MVA track selection, trained in heavy ions, or we simply tighten the cut on the pp-trained MVA output.
The exceptions are the jetCore and muon-seeded iterations, which are still using the pp defaults.  The quality selection is far too loose for central PbPb collisions giving rise to fake tracks that can lead to fake hadrons in particle flow. 
In the 2018 data this was dealt with by a post-PF cleaning module [1], which is sub-optimal, as the event interpretation is already done.
This PR tighten the selections that define the highPurity bit, which is required for charged hadrons in PF (at least for PbPb)

For the jetCore iteration we simply tightened the value of the pp-trained MVA cut used in the highPurity bit from 0.4 to 0.8.    This was tested in minbias and QCD events (with a PbPb UE).  There is about a 10% loss of tracks for this iteration, but the fake rate is reduced by a factor of several.  The overall effect on the efficiency and fake rate is small, as this iteration does not contribute much to the overall tracking.

The muon-seeded iterations are still cut based.  We tuned the cuts that define highPurity using a muon-jet and upsilon sample (with PbPb underlying event).  There is no effect on the efficiency of muons passing the standard selection.  This is expected as highPurity is not used in the global muon reconstruction or in the selection.  Matched tracks from these iterations were reduced by about 5%, while fake tracks were reduced by 30%, notably removing a tail of high pT fake/mis-reco'd tracks, which was known to be problematic for jets.  

@denerslemos 
 