### PR TITLE
Streamer input source prefetching (12_5_X)

### DIFF
--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -54,7 +54,7 @@ namespace edm {
 
   private:
     void openStreamerFile(std::string const& name, std::string const& LFN);
-    storage::IOSize readBytes(char* buf, storage::IOSize nBytes);
+    storage::IOSize readBytes(char** buf, storage::IOSize nBytes, bool zeroCopy=true, unsigned skipped = 0);
     storage::IOOffset skipBytes(storage::IOSize nBytes);
 
     void readStartMessage();

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -87,8 +87,6 @@ namespace edm {
 
     edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
 
-    unsigned int prefetchMBytes_;
-
     uint32 currRun_;
     uint32 currProto_;
 

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -54,7 +54,7 @@ namespace edm {
 
   private:
     void openStreamerFile(std::string const& name, std::string const& LFN);
-    storage::IOSize readBytes(char** buf, storage::IOSize nBytes, bool zeroCopy = true, unsigned skipped = 0);
+    std::pair<storage::IOSize, char*> readBytes(char* buf, storage::IOSize nBytes, bool zeroCopy, unsigned int skippedHdr = 0);
     storage::IOOffset skipBytes(storage::IOSize nBytes);
 
     void readStartMessage();

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -54,7 +54,7 @@ namespace edm {
 
   private:
     void openStreamerFile(std::string const& name, std::string const& LFN);
-    storage::IOSize readBytes(char** buf, storage::IOSize nBytes, bool zeroCopy=true, unsigned skipped = 0);
+    storage::IOSize readBytes(char** buf, storage::IOSize nBytes, bool zeroCopy = true, unsigned skipped = 0);
     storage::IOOffset skipBytes(storage::IOSize nBytes);
 
     void readStartMessage();

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -54,7 +54,10 @@ namespace edm {
 
   private:
     void openStreamerFile(std::string const& name, std::string const& LFN);
-    std::pair<storage::IOSize, char*> readBytes(char* buf, storage::IOSize nBytes, bool zeroCopy, unsigned int skippedHdr = 0);
+    std::pair<storage::IOSize, char*> readBytes(char* buf,
+                                                storage::IOSize nBytes,
+                                                bool zeroCopy,
+                                                unsigned int skippedHdr = 0);
     storage::IOOffset skipBytes(storage::IOSize nBytes);
 
     void readStartMessage();

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -21,13 +21,16 @@ namespace edm {
     /**Reads a Streamer file */
     explicit StreamerInputFile(std::string const& name,
                                std::string const& LFN,
-                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>());
+                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>(),
+                               unsigned int prefetchMBytes = 0);
     explicit StreamerInputFile(std::string const& name,
-                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>());
+                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>(),
+                               unsigned int prefetchMBytes = 0);
 
     /** Multiple Streamer files */
     explicit StreamerInputFile(std::vector<FileCatalogItem> const& names,
-                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>());
+                               std::shared_ptr<EventSkipperByID> eventSkipperByID = std::shared_ptr<EventSkipperByID>(),
+                               unsigned int prefetchMBytes = 0);
 
     ~StreamerInputFile();
 
@@ -69,6 +72,10 @@ namespace edm {
     std::vector<char> headerBuf_; /** Buffer to store file Header */
     std::vector<char> eventBuf_;  /** Buffer to store Event Data */
 
+    std::vector<char> tempBuf_; /** Buffer to store prefetched bytes */
+    unsigned int tempLen_ = 0;
+    unsigned int tempPos_ = 0;
+
     unsigned int currentFile_;                   /** keeps track of which file is in use at the moment*/
     std::vector<FileCatalogItem> streamerNames_; /** names of Streamer files */
     bool multiStreams_;                          /** True if Multiple Streams are Read */
@@ -76,6 +83,8 @@ namespace edm {
     bool currentFileOpen_;
 
     edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
+
+    unsigned int prefetchMBytes_;
 
     uint32 currRun_;
     uint32 currProto_;

--- a/IOPool/Streamer/src/StreamerFileReader.cc
+++ b/IOPool/Streamer/src/StreamerFileReader.cc
@@ -16,7 +16,8 @@ namespace edm {
       : StreamerInputSource(pset, desc),
         streamReader_(),
         eventSkipperByID_(EventSkipperByID::create(pset).release()),
-        initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents")) {
+        initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents")),
+        prefetchMBytes_(pset.getUntrackedParameter<unsigned int>("prefetchMBytes")) {
     InputFileCatalog catalog(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
                              pset.getUntrackedParameter<std::string>("overrideCatalog"));
     streamerNames_ = catalog.fileCatalogItems();
@@ -27,10 +28,10 @@ namespace edm {
 
   void StreamerFileReader::reset_() {
     if (streamerNames_.size() > 1) {
-      streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_, eventSkipperByID());
+      streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_, eventSkipperByID(), prefetchMBytes_);
     } else if (streamerNames_.size() == 1) {
       streamReader_ = std::make_unique<StreamerInputFile>(
-          streamerNames_.at(0).fileNames()[0], streamerNames_.at(0).logicalFileName(), eventSkipperByID());
+          streamerNames_.at(0).fileNames()[0], streamerNames_.at(0).logicalFileName(), eventSkipperByID(), prefetchMBytes_);
     } else {
       throw Exception(errors::FileReadError, "StreamerFileReader::StreamerFileReader")
           << "No fileNames were specified\n";
@@ -116,6 +117,7 @@ namespace edm {
     desc.addUntracked<std::string>("overrideCatalog", std::string());
     //This next parameter is read in the base class, but its default value depends on the derived class, so it is set here.
     desc.addUntracked<bool>("inputFileTransitionsEachEvent", false);
+    desc.addUntracked<unsigned int>("prefetchMBytes", 0);
     StreamerInputSource::fillDescription(desc);
     EventSkipperByID::fillDescription(desc);
     descriptions.add("source", desc);

--- a/IOPool/Streamer/src/StreamerFileReader.cc
+++ b/IOPool/Streamer/src/StreamerFileReader.cc
@@ -30,8 +30,10 @@ namespace edm {
     if (streamerNames_.size() > 1) {
       streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_, eventSkipperByID(), prefetchMBytes_);
     } else if (streamerNames_.size() == 1) {
-      streamReader_ = std::make_unique<StreamerInputFile>(
-          streamerNames_.at(0).fileNames()[0], streamerNames_.at(0).logicalFileName(), eventSkipperByID(), prefetchMBytes_);
+      streamReader_ = std::make_unique<StreamerInputFile>(streamerNames_.at(0).fileNames()[0],
+                                                          streamerNames_.at(0).logicalFileName(),
+                                                          eventSkipperByID(),
+                                                          prefetchMBytes_);
     } else {
       throw Exception(errors::FileReadError, "StreamerFileReader::StreamerFileReader")
           << "No fileNames were specified\n";

--- a/IOPool/Streamer/src/StreamerFileReader.h
+++ b/IOPool/Streamer/src/StreamerFileReader.h
@@ -44,6 +44,7 @@ namespace edm {
     edm::propagate_const<std::unique_ptr<StreamerInputFile>> streamReader_;
     edm::propagate_const<std::shared_ptr<EventSkipperByID>> eventSkipperByID_;
     int initialNumberOfEventsToSkip_;
+    int prefetchMBytes_;
     bool isFirstFile_ = true;
   };
 }  // namespace edm

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -133,7 +133,7 @@ namespace edm {
           tempPos_ = 0;
           tempLen_ = n;
           if (n == 0)
-            return std::make_pair<storage::IOSize, char*>(0, std::move(ptr));
+            return std::pair<storage::IOSize, char*>(0, ptr);
         }
         if (nBytes <= tempLen_ - tempPos_) {
           if (!zeroCopy || skippedHdr > tempPos_) {
@@ -160,7 +160,7 @@ namespace edm {
       ex.addContext("Calling StreamerInputFile::readBytes()");
       throw ex;
     }
-    return std::make_pair<storage::IOSize, char*>(std::move(n), std::move(ptr));
+    return std::pair<storage::IOSize, char*>(n, ptr);
   }
 
   storage::IOOffset StreamerInputFile::skipBytes(storage::IOSize nBytes) {

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -198,6 +198,9 @@ namespace edm {
     if (headerBuf_.size() < headerSize)
       headerBuf_.resize(headerSize);
 
+    //set the pointer again as it can be changed by resize
+    headerPtr = &headerBuf_[0];
+
     if (headerSize > sizeof(HeaderView)) {
       nWant = headerSize - sizeof(HeaderView);
       nGot = readBytes(&headerPtr, nWant, true, sizeof(HeaderView));
@@ -307,6 +310,10 @@ namespace edm {
       if (eventRead) {
         if (eventBuf_.size() < eventSize)
           eventBuf_.resize(eventSize);
+
+        //set the pointer again as it can be changed by resize
+        eventPtr = &eventBuf_[0];
+
         nGot = readBytes(&eventPtr, nWant, true, sizeof(EventHeader));
         if (nGot != nWant) {
           throw Exception(errors::FileReadError, "StreamerInputFile::readEventMessage")

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -43,7 +43,9 @@ namespace edm {
     readStartMessage();
   }
 
-  StreamerInputFile::StreamerInputFile(std::string const& name, std::shared_ptr<EventSkipperByID> eventSkipperByID, unsigned int prefetchMBytes)
+  StreamerInputFile::StreamerInputFile(std::string const& name,
+                                       std::shared_ptr<EventSkipperByID> eventSkipperByID,
+                                       unsigned int prefetchMBytes)
       : StreamerInputFile(name, name, eventSkipperByID, prefetchMBytes) {}
 
   StreamerInputFile::StreamerInputFile(std::vector<FileCatalogItem> const& names,
@@ -117,16 +119,20 @@ namespace edm {
     currentFileOpen_ = false;
   }
 
-  storage::IOSize StreamerInputFile::readBytes(char** buf, storage::IOSize nBytes, bool zeroCopy, unsigned int skippedHdr) {
+  storage::IOSize StreamerInputFile::readBytes(char** buf,
+                                               storage::IOSize nBytes,
+                                               bool zeroCopy,
+                                               unsigned int skippedHdr) {
     storage::IOSize n = 0;
     try {
       if (prefetchMBytes_) {
         //assert(tempPos_ > tempLen_);
         if (tempPos_ == tempLen_) {
-          n = storage_->read(&tempBuf_[0], prefetchMBytes_*1024*1024);
+          n = storage_->read(&tempBuf_[0], prefetchMBytes_ * 1024 * 1024);
           tempPos_ = 0;
           tempLen_ = n;
-          if (n == 0) return 0;
+          if (n == 0)
+            return 0;
         }
         if (nBytes <= tempLen_ - tempPos_) {
           if (!zeroCopy || skippedHdr > tempPos_)
@@ -137,8 +143,7 @@ namespace edm {
           }
           tempPos_ += nBytes;
           return nBytes;
-        }
-        else {
+        } else {
           //crossing buffer boundary
           auto len = tempLen_ - tempPos_;
           memcpy(*buf + skippedHdr, &tempBuf_[0] + tempPos_, len);
@@ -146,8 +151,7 @@ namespace edm {
           char* tmpPtr = *buf + skippedHdr + len;
           return len + readBytes(&tmpPtr, nBytes - len, false);
         }
-      }
-      else
+      } else
         n = storage_->read(*buf + skippedHdr, nBytes);
     } catch (cms::Exception& ce) {
       Exception ex(errors::FileReadError, "", ce);

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -128,7 +128,7 @@ namespace edm {
       if (prefetchMBytes_) {
         //assert(tempPos_ > tempLen_);
         if (tempPos_ == tempLen_) {
-          n = storage_->read(&tempBuf_[0], prefetchMBytes_ * 1024 * 1024);
+          n = storage_->read(&tempBuf_[0], tempBuf_.size());
           tempPos_ = 0;
           tempLen_ = n;
           if (n == 0)

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -126,7 +126,7 @@ namespace edm {
     //even if we read event payload that comes afterwards
     char* ptr = buf - skippedHdr;
     try {
-      if (tempBuf_.size()) {
+      if (!tempBuf_.empty()) {
         if (tempPos_ == tempLen_) {
           n = storage_->read(&tempBuf_[0], tempBuf_.size());
           tempPos_ = 0;

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -124,7 +124,7 @@ namespace edm {
                                                                  bool zeroCopy,
                                                                  unsigned int skippedHdr) {
     storage::IOSize n = 0;
-    char * ptr = buf - skippedHdr;
+    char* ptr = buf - skippedHdr;
     try {
       if (prefetchMBytes_) {
         //assert(tempPos_ > tempLen_);
@@ -214,7 +214,6 @@ namespace edm {
       throw Exception(errors::FileReadError, "StreamerInputFile::readStartMessage")
           << "Failed reading streamer file, init header size from data too small\n";
     }
-
   }
 
   StreamerInputFile::Next StreamerInputFile::next() {
@@ -321,7 +320,8 @@ namespace edm {
               << "Failed reading streamer file, second read in readEventMessage\n"
               << "Requested " << nWant << " bytes, read function returned " << res.first << " bytes\n";
         }
-        currentEvMsg_ = std::make_shared<EventMsgView>((void*)res.second);  // propagate_const<T> has no reset() function
+        currentEvMsg_ =
+            std::make_shared<EventMsgView>((void*)res.second);  // propagate_const<T> has no reset() function
       } else {
         nGot = skipBytes(nWant);
         if (nGot != nWant) {

--- a/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
@@ -8,7 +8,7 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat'),
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat', 'file:teststreamfile_ext2.dat'),
     prefetchMBytes = cms.untracked.uint32(1)
     #firstEvent = cms.untracked.uint64(10123456835)
 )

--- a/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TRANSFER")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat'),
+    prefetchMBytes = cms.untracked.uint32(100)
+    #firstEvent = cms.untracked.uint64(10123456835)
+)
+
+process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
+    product_to_get = cms.string('m1')
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('myout.root')
+)
+
+process.end = cms.EndPath(process.a1*process.out)

--- a/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInExtBuf_cfg.py
@@ -8,8 +8,8 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat'),
-    prefetchMBytes = cms.untracked.uint32(100)
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat'),
+    prefetchMBytes = cms.untracked.uint32(1)
     #firstEvent = cms.untracked.uint64(10123456835)
 )
 

--- a/IOPool/Streamer/test/NewStreamInExt_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInExt_cfg.py
@@ -8,7 +8,7 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat')
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat'),
     #firstEvent = cms.untracked.uint64(10123456835)
 )
 

--- a/IOPool/Streamer/test/NewStreamInExt_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInExt_cfg.py
@@ -8,7 +8,7 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat'),
+    fileNames = cms.untracked.vstring('file:teststreamfile.dat', 'file:teststreamfile_ext.dat', 'file:teststreamfile_ext2.dat', 'file:teststreamfile_ext2.dat'),
     #firstEvent = cms.untracked.uint64(10123456835)
 )
 

--- a/IOPool/Streamer/test/NewStreamOutExt2_cfg.py
+++ b/IOPool/Streamer/test/NewStreamOutExt2_cfg.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('compAlgo',
+                  'ZLIB', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Compression Algorithm")
+
+options.parseArguments()
+
+
+process = cms.Process("HLT")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(5000)
+)
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint64(20123456789)
+)
+
+process.a = cms.EDProducer("StreamThingProducer",
+    instance_count = cms.int32(5),
+    array_size = cms.int32(2)
+)
+
+process.m1 = cms.EDProducer("StreamThingProducer",
+    instance_count = cms.int32(5),
+    array_size = cms.int32(2)
+)
+
+process.z = cms.EDProducer("StreamThingProducer",
+    instance_count = cms.int32(5),
+    array_size = cms.int32(2)
+)
+
+process.m2 = cms.EDProducer("NonProducer")
+
+process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
+    product_to_get = cms.string('m1')
+)
+
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('teststreamfile_ext2.dat'),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    compression_algorithm = cms.untracked.string(options.compAlgo),
+    max_event_size = cms.untracked.int32(7000000),
+    outputCommands = cms.untracked.vstring("drop *", "keep *_m1_*_*")
+)
+
+process.p1 = cms.Path(process.a*process.m1*process.a1*process.m2*process.z)
+process.end = cms.EndPath(process.out)

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -37,6 +37,7 @@ cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStre
 cmsRun --parameter-set NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
 cmsRun --parameter-set NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
 cmsRun --parameter-set NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
+cmsRun --parameter-set NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -31,7 +31,7 @@ cd ${OUTDIR}
 cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
 cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
 cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -31,6 +31,7 @@ cd ${OUTDIR}
 cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
 cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
 cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?


### PR DESCRIPTION
#### PR description:

Adds a preallocated buffer intended to avoid many small reads when reading streamer files. This is aimed at improving EOS reading performance (see https://github.com/cms-sw/cmssw/issues/38997).
A pointer to the big buffer is passed if possible for reading header and even payloads (contiguous), otherwise data is copied to  the intermediate header or event buffer.

New parameter enables and configures size of the large buffer in MBytes (0 to disable), for example:
```
process.source = cms.Source("NewEventStreamFileReader",
    prefetchMBytes = cms.untracked.uint32(100),
```

#### PR validation:

A new unit test in `IOPool/Streamer` specifically checks behavior with this parameter (1 MB with small generated events). A file larger than the buffer was created to test behavior at the buffer boundary.
Internally, source checks adler32 checksum of both the header and event payload (compared to a header field), so corruption of payloads would be caught by unit tests.


Streamer source in `CalibCalorimetry/EcalLaserSorting` uses this code and has a respective unit test in that location.
Similarly, DQM streamer input source is tested as part of DAQ I/O chain in `EventFilter/Utilities` unit test.