### PR TITLE
[12.4.X] fix run-by-run TkAlignment PV Validation submission script in case of extra conditions

### DIFF
--- a/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
@@ -444,12 +444,10 @@ class Job:
         fout=open(os.path.join(self.cfg_dir,self.outputCfgName),'w')
 
         template_cfg_file = os.path.join(self.the_dir,"PVValidation_T_cfg.py")
-
-        fin = open(template_cfg_file)
+        file = open(template_cfg_file,'r')
 
         config_txt = '\n\n' + CopyRights + '\n\n'
-        config_txt += fin.read()
-
+        config_txt += file.read()
         config_txt=config_txt.replace("ISDATEMPLATE",self.isDA)
         config_txt=config_txt.replace("ISMCTEMPLATE",self.isMC)
         config_txt=config_txt.replace("APPLYBOWSTEMPLATE",self.applyBOWS)
@@ -477,27 +475,36 @@ class Job:
         config_txt=config_txt.replace("FILESOURCETEMPLATE","["+",".join(lfn_with_quotes)+"]")
         config_txt=config_txt.replace("OUTFILETEMPLATE",self.output_full_name+".root")
 
+        ### now for the extra conditions
+        textToWrite=''
+        for element in self.extraCondVect :
+            if("Rcd" in element):
+                params = self.extraCondVect[element].split(',')
+                text = '''\n
+          process.conditionsIn{record} = CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone(
+               connect = cms.string('{database}'),
+               toGet = cms.VPSet(cms.PSet(record = cms.string('{record}'),
+                                          tag = cms.string('{tag}'),
+                                          label = cms.untracked.string('{label}')
+                                         )
+                                )
+          )
+          process.prefer_conditionsIn{record} = cms.ESPrefer("PoolDBESSource", "conditionsIn{record}")
+        '''.format(record = element, database = params[0], tag = params[1], label = (params[2] if len(params)>2 else ''))
+                textToWrite+=text
+
+        if(self.applyEXTRACOND=="True"):
+            if not self.extraCondVect:
+                raise Exception('Requested extra conditions, but none provided')
+
+            config_txt=config_txt.replace("END OF EXTRA CONDITIONS",textToWrite)
+        else:
+            print("INFO: Will not apply any extra conditions")
+            pass
+
         fout.write(config_txt)
 
-        for line in fin.readlines():
-
-            if 'END OF EXTRA CONDITIONS' in line:
-                for element in self.extraCondVect :
-                    if("Rcd" in element):
-                        params = self.extraCondVect[element].split(',')
-
-                        fout.write(" \n")
-                        fout.write("     process.conditionsIn"+element+"= CalibTracker.Configuration.Common.PoolDBESSource_cfi.poolDBESSource.clone( \n")
-                        fout.write("          connect = cms.string('"+params[0]+"'), \n")
-                        fout.write("          toGet = cms.VPSet(cms.PSet(record = cms.string('"+element+"'), \n")
-                        fout.write("                                     tag = cms.string('"+params[1]+"'), \n")
-                        if (len(params)>2):
-                            fout.write("                                     label = cms.untracked.string('"+params[2]+"') \n")
-                        fout.write("                                     ) \n")
-                        fout.write("                            ) \n")
-                        fout.write("          ) \n")
-                        fout.write("     process.prefer_conditionsIn"+element+" = cms.ESPrefer(\"PoolDBESSource\", \"conditionsIn"+element[0]+"\") \n \n") 
-            fout.write(line)
+        file.close()
         fout.close()
                           
     def createTheLSFFile(self):


### PR DESCRIPTION
backport of #39091

#### PR description:

Title says it all, discovered during the 13.6TeV alignment campaign when using updated pixel templates (cf [here](https://cms-talk.web.cern.ch/t/new-1d-and-2d-templates/13982) )

#### PR validation:

Private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #39091