### PR TITLE
Fix nanoAOD trigger bits for e+tau overlap filter

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -107,7 +107,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "32*filter('*Hps*') + " \
                             "64*filter('hlt*DoublePFTau*TrackPt1*ChargedIsolation*Dz02*') + " \
                             "128*filter('hlt*DoublePFTau*DeepTau*L1HLTMatched') + " \
-                            "256*filter('hlt*OverlapFilterIsoEle*WPTightGsf*PFTau') + " \
+                            "256*filter('hlt*OverlapFilterIsoEle*WPTightGsf*PFTau*') + " \
                             "512*filter('hlt*OverlapFilterIsoMu*PFTau*') + " \
                             "1024*filter('hlt*SelectedPFTau*L1HLTMatched') + " \
                             "2048*filter('hlt*DoublePFTau*TrackPt1*ChargedIso*') + " \


### PR DESCRIPTION
#### PR description:

Tau trigger bits for nanoAOD do not correctly store the e+tau cross trigger overlap filter, as this filter ends, e.g. in 2018, with `PFTau30` rather than `PFTau`. In the past the filter matching string correctly had `*` at the end but in this update: https://github.com/cms-sw/cmssw/pull/38472/files it was removed. Adding it back here. 

FYI @mbluj @lwezenbe @kandrosov @danielwinterbottom (I don't have Anne-Catherine's github handle, can someone please tag her). Since nano v10 will close very soon I think we should try to get this fix in urgently which is why I went straight for the PR. 

Spotted thanks to investigation by @PascalBaertschi.

#### PR validation:

Observed incorrect behaviour without the `*` at the end, previous runs with it included produced the correct results.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 

