### PR TITLE
Backport of #39043 and #39099: fixing e+tau cross trigger and photon trigger filters in nanoAOD 

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -49,13 +49,25 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
             qualityBitsDoc = cms.string("1 = CaloIdL_TrackIdL_IsoVL, 2 = 1e (WPTight), 4 = 1e (WPLoose), 8 = OverlapFilter PFTau, 16 = 2e, 32 = 1e-1mu, 64 = 1e-1tau, 128 = 3e, 256 = 2e-1mu, 512 = 1e-2mu, 1024 = 1e (32_L1DoubleEG_AND_L1SingleEGOr), 2048 = 1e (CaloIdVT_GsfTrkIdT), 4096 = 1e (PFJet), 8192 = 1e (Photon175_OR_Photon200)"),
             ),
         cms.PSet(
-            name = cms.string("Photon (PixelMatch-vetoed e/gamma)"), 
+            name = cms.string("Photon"), 
             id = cms.int32(22),
-            sel = cms.string("type(92) && pt > 20 && coll('hltEgammaCandidates') && !filter('*PixelMatchFilter')"), 
+            sel = cms.string("type(92) && pt > 20 && coll('hltEgammaCandidates')"), 
             l1seed = cms.string("type(-98)"),  l1deltaR = cms.double(0.3),
             #l2seed = cms.string("type(92) && coll('')"),  l2deltaR = cms.double(0.5),
             skipObjectsNotPassingQualityBits = cms.bool(True),
-            qualityBits = cms.string("0"), qualityBitsDoc = cms.string(""),
+            qualityBits = cms.string(
+                            "filter('hltEG33L1EG26HEFilter') + " \
+                            "2*filter('hltEG50HEFilter') + " \
+                            "4*filter('hltEG75HEFilter') + " \
+                            "8*filter('hltEG90HEFilter') + " \
+                            "16*filter('hltEG120HEFilter') + " \
+                            "32*filter('hltEG150HEFilter') + " \
+                            "64*filter('hltEG175HEFilter') + " \
+                            "128*filter('hltEG200HEFilter') + " \
+                            "256*filter('hltHtEcal800') + " \
+                            "512*filter('hltEG110EBTightIDTightIsoTrackIsoFilter') + " \
+                            "1024*filter('hltEG120EBTightIDTightIsoTrackIsoFilter')"),
+            qualityBitsDoc = cms.string("Single Photon filters: 1 = hltEG33L1EG26HEFilter, 2 = hltEG50HEFilter, 4 = hltEG75HEFilter, 8 = hltEG90HEFilter, 16 = hltEG120HEFilter, 32 = hltEG150HEFilter, 64 = hltEG175HEFilter, 128 = hltEG200HEFilter, 256 = hltHtEcal800, 512 = hltEG110EBTightIDTightIsoTrackIsoFilter, 1024 = hltEG120EBTightIDTightIsoTrackIsoFilter"),
         ),
         cms.PSet(
             name = cms.string("Muon"),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -95,7 +95,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "32*filter('*Hps*') + " \
                             "64*filter('hlt*DoublePFTau*TrackPt1*ChargedIsolation*Dz02*') + " \
                             "128*filter('hlt*DoublePFTau*DeepTau*L1HLTMatched') + " \
-                            "256*filter('hlt*OverlapFilterIsoEle*WPTightGsf*PFTau') + " \
+                            "256*filter('hlt*OverlapFilterIsoEle*WPTightGsf*PFTau*') + " \
                             "512*filter('hlt*OverlapFilterIsoMu*PFTau*') + " \
                             "1024*filter('hlt*SelectedPFTau*L1HLTMatched') + " \
                             "2048*filter('hlt*DoublePFTau*TrackPt1*ChargedIso*') + " \


### PR DESCRIPTION
#### PR description:

Fixes e+tau cross trigger related filters in nanoAOD, plus the issue reported in https://github.com/cms-nanoAOD/cmssw/issues/592

#### PR validation:

code checks pass; correctness of filter-matching regexps checked

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #39043 and #39099 made at the request of @mariadalfonso (needed for nanoAOD processing)
