### PR TITLE
Adds FED ID 1405 for uGT Testcrate for L1T Ntuples

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -31,7 +31,7 @@ namespace l1t {
     PackerMap GTSetup::getPackers(int fed, unsigned int fw) {
       PackerMap res;
 
-      if (fed == 1404) {
+      if ((fed == 1404) || (fed == 1405)) {
         // Use board id 1 for packing
         auto gt_muon_packer =
             static_pointer_cast<l1t::stage2::GTMuonPacker>(PackerFactory::get()->make("stage2::GTMuonPacker"));
@@ -101,7 +101,7 @@ namespace l1t {
 
       UnpackerMap res;
 
-      if (fed == 1404) {
+      if ((fed == 1404) || (fed == 1405)) {
         // From the rx buffers
         res[0] = muon_unp;
         res[2] = muon_unp;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -33,6 +33,7 @@ namespace l1t {
 
       if ((fed == 1404) || (fed == 1405)) {
         // Use board id 1 for packing
+        //fed id 1404 corresponds to the production crate, 1405 to the test crate
         auto gt_muon_packer =
             static_pointer_cast<l1t::stage2::GTMuonPacker>(PackerFactory::get()->make("stage2::GTMuonPacker"));
         gt_muon_packer->setFed(fed);
@@ -103,6 +104,7 @@ namespace l1t {
 
       if ((fed == 1404) || (fed == 1405)) {
         // From the rx buffers
+        // fed id 1404 corresponds to the production crate, 1405 to the test crate
         res[0] = muon_unp;
         res[2] = muon_unp;
         res[4] = muon_unp;

--- a/EventFilter/L1TRawToDigi/python/gtTestcrateStage2Digis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtTestcrateStage2Digis_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+gtTestcrateStage2Digis = cms.EDProducer(
+    "L1TRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector"),
+    Setup           = cms.string("stage2::GTSetup"),
+    FedIds          = cms.vint32( 1405 ),
+)

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -52,12 +52,13 @@ from EventFilter.L1TRawToDigi.caloLayer1Digis_cfi import caloLayer1Digis
 from EventFilter.L1TRawToDigi.caloStage2Digis_cfi import caloStage2Digis
 from EventFilter.L1TRawToDigi.gmtStage2Digis_cfi import gmtStage2Digis
 from EventFilter.L1TRawToDigi.gtStage2Digis_cfi import gtStage2Digis
+from EventFilter.L1TRawToDigi.gtTestcrateStage2Digis_cfi import gtTestcrateStage2Digis
 from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
 # we only warn if it is stage-2 era and it is an essential, always present, stage-2 payload:
 stage2L1Trigger.toModify(caloStage2Digis, MinFeds = cms.uint32(1))
 stage2L1Trigger.toModify(gmtStage2Digis, MinFeds = cms.uint32(1))
 stage2L1Trigger.toModify(gtStage2Digis, MinFeds = cms.uint32(1))
-L1TRawToDigi_Stage2 = cms.Task(rpcunpacker, rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
+L1TRawToDigi_Stage2 = cms.Task(rpcunpacker,rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis, gtTestcrateStage2Digis)
 stage2L1Trigger.toReplaceWith(L1TRawToDigiTask, cms.Task(L1TRawToDigi_Stage1,L1TRawToDigi_Stage2))
 
 L1TRawToDigi = cms.Sequence(L1TRawToDigiTask)

--- a/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleRAW_cff.py
@@ -7,6 +7,7 @@ from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonShowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
 from L1Trigger.L1TNtuples.l1uGTTree_cfi import *
+from L1Trigger.L1TNtuples.l1uGTTestcrateTree_cfi import *
 from L1Trigger.L1TNtuples.l1HOTree_cfi import *
 
 # we don't have omtfDigis yet, use unpacked input payloads of GMT
@@ -22,6 +23,7 @@ L1NtupleRAW = cms.Sequence(
   +l1UpgradeTfMuonShowerTree
   +l1UpgradeTree
   +l1uGTTree
+  +l1uGTTestcrateTree
   +l1HOTree
 )
 

--- a/L1Trigger/L1TNtuples/python/l1uGTTestcrateTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1uGTTestcrateTree_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+l1uGTTestcrateTree = cms.EDAnalyzer( "L1uGTTreeProducer",
+    ugtToken = cms.InputTag( "gtTestcrateStage2Digis" )
+)


### PR DESCRIPTION
#### PR description:

New code and edits to existing code allow for access to the uGT Testcrate, FedId = 1405:
 - changes to output: no changes to ouput,
 - dependencies: there are no additional PR or external dependencies,
 - additional useful material: see Indico L1 Menu Working meeting https://indico.cern.ch/event/1191249/

#### PR validation:

This PR has been validated by

1.     verifying that it compiles correctly,
2.     verifying that the results were checked with L1TNtuple and were as expected,
3.     verifying that the runTheMatrix test runs successfully,
4.     verifying that it passes the scram build code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.
