### PR TITLE
[12_4_X] Fix resolution/offset order in the PPS calibration payload

### DIFF
--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
@@ -42,6 +42,8 @@ private:
   const std::string dqmDir_;
   const std::string formula_;
   const unsigned int min_entries_;
+  static constexpr double resolution_ = 0.1;
+  static constexpr double offset_ = 0.;
   TF1 interp_;
 };
 
@@ -96,7 +98,7 @@ void PPSTimingCalibrationPCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQM
         (int)detid.arm(), (int)detid.station(), (int)detid.plane(), (int)detid.channel()};
 
     calib_params[key] = {0, 0, 0, 0};
-    calib_time[key] = std::make_pair(0.1, 0.);
+    calib_time[key] = std::make_pair(offset_, resolution_);
 
     hists.leadingTime[chid] = iGetter.get(dqmDir_ + "/t_" + ch_name);
     if (hists.leadingTime[chid] == nullptr) {
@@ -134,7 +136,8 @@ void PPSTimingCalibrationPCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQM
       if (res == 0) {
         calib_params[key] = {
             interp_.GetParameter(0), interp_.GetParameter(1), interp_.GetParameter(2), interp_.GetParameter(3)};
-        calib_time[key] = std::make_pair(0.1, 0.);  // hardcoded resolution/offset placeholder for the time being
+        calib_time[key] =
+            std::make_pair(offset_, resolution_);  // hardcoded offset/resolution placeholder for the time being
         // can possibly do something with interp_.GetChiSquare() in the near future
       } else
         edm::LogWarning("PPSTimingCalibrationPCLHarvester:dqmEndJob")


### PR DESCRIPTION
#### PR description:

This is a bug-fix for the PPS Diamond PCL. It inverts the resolution/offset so it matches the PPSTimingCalibration description.

#### PR validation:

relvals 1041, 1044

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #39109 
