### PR TITLE
Do NaN-check before accepting a PF candidate for computing photon's isolation

### DIFF
--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -262,6 +262,10 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
       //     continue;
       // }
 
+      // If PF candidate pT is nan, leave it out
+      if (edm::isNotFinite(iCand->pt()))
+        continue;
+
       // Check if this candidate is within the isolation cone
       float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
       if (dR2 > coneSizeDR2)
@@ -396,6 +400,11 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
     // Loop over the PFCandidates
     for (auto const& aCCand : chargedCands) {
       auto iCand = aCCand.candidate;
+
+      //Leave out bizzare PF candidates with nan pT
+      if (edm::isNotFinite(iCand->pt()))
+        continue;
+
       float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
       if (dR2 > coneSizeDR2 || (options & DR_VETO && dR2 < dRveto2))
         continue;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -263,8 +263,10 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
       // }
 
       // If PF candidate pT is nan, leave it out
-      if (edm::isNotFinite(iCand->pt()))
+      if (edm::isNotFinite(iCand->pt())) {
+	edm::LogWarning("PhotonIDValueMapProducer") << "PF candidate pT is NAN, ignoring this candidate from PF isolation computation" << std::endl;
         continue;
+      }
 
       // Check if this candidate is within the isolation cone
       float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
@@ -401,8 +403,8 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
     for (auto const& aCCand : chargedCands) {
       auto iCand = aCCand.candidate;
 
-      //Leave out bizzare PF candidates with nan pT
-      if (edm::isNotFinite(iCand->pt()))
+      //Leave out bizarre PF candidates with nan pT
+      if (edm::isNotFinite(iCand->pt())) 
         continue;
 
       float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -96,7 +96,7 @@ private:
   // HiggsTo2photons anaysis code. Template is introduced to handle reco/pat
   // photons and aod/miniAOD PF candidates collections
   float computeWorstPFChargedIsolation(const reco::Photon& photon,
-                                       const edm::View<reco::Candidate>& pfCands,
+				       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
                                        const reco::VertexCollection& vertices,
                                        const reco::Vertex& pv,
                                        unsigned char options,
@@ -205,6 +205,16 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
   std::vector<float> vars[nVars_];
 
+  std::vector<edm::Ptr<reco::Candidate>> pfCandNoNaN;
+  for (auto pf : pfCandsHandle->ptrs()) {
+    if (edm::isNotFinite(pf->pt())) {
+      edm::LogWarning("PhotonIDValueMapProducer") 
+	<< "PF candidate pT is NaN, skipping, see issue #39110" << std::endl;
+    } else {
+      pfCandNoNaN.push_back(pf);
+    }
+  }
+
   // reco::Photon::superCluster() is virtual so we can exploit polymorphism
   for (auto const& iPho : src->ptrs()) {
     //
@@ -241,8 +251,8 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
     float neutralHadronIsoSum = 0.;
     float photonIsoSum = 0.;
 
-    // Loop over all PF candidates
-    for (auto const& iCand : pfCandsHandle->ptrs()) {
+    // Loop over nan-free PF candidates
+    for (auto const& iCand : pfCandNoNaN) {
       // Here, the type will be a simple reco::Candidate. We cast it
       // for full PFCandidate or PackedCandidate below as necessary
 
@@ -261,13 +271,6 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
       //     if( ((const edm::Ptr<reco::PFCandidate>)iCand)->superClusterRef() == iPho->superCluster() )
       //     continue;
       // }
-
-      // If PF candidate pT is nan, leave it out
-      if (edm::isNotFinite(iCand->pt())) {
-        edm::LogWarning("PhotonIDValueMapProducer")
-            << "PF candidate pT is NAN, ignoring this candidate from PF isolation computation" << std::endl;
-        continue;
-      }
 
       // Check if this candidate is within the isolation cone
       float dR2 = deltaR2(phoWrtVtx.Eta(), phoWrtVtx.Phi(), iCand->eta(), iCand->phi());
@@ -316,15 +319,15 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
     // Worst isolation computed with no vetos or ptMin cut, as in Run 1 Hgg code.
     unsigned char options = 0;
-    vars[13].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
+    vars[13].push_back(computeWorstPFChargedIsolation(*iPho, pfCandNoNaN, *vertices, pv, options, isAOD_));
 
     // Worst isolation computed with cone vetos and a ptMin cut, as in Run 2 Hgg code.
     options |= PT_MIN_THRESH | DR_VETO;
-    vars[14].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
+    vars[14].push_back(computeWorstPFChargedIsolation(*iPho, pfCandNoNaN, *vertices, pv, options, isAOD_));
 
     // Like before, but adding primary vertex constraint
     options |= PV_CONSTRAINT;
-    vars[15].push_back(computeWorstPFChargedIsolation(*iPho, *pfCandsHandle, *vertices, pv, options, isAOD_));
+    vars[15].push_back(computeWorstPFChargedIsolation(*iPho, pfCandNoNaN, *vertices, pv, options, isAOD_));
 
     // PFCluster Isolations
     vars[16].push_back(iPho->trkSumPtSolidConeDR04());
@@ -365,7 +368,7 @@ void PhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 // Charged isolation with respect to the worst vertex. See more
 // comments above at the function declaration.
 float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photon& photon,
-                                                               const edm::View<reco::Candidate>& pfCands,
+							       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
                                                                const reco::VertexCollection& vertices,
                                                                const reco::Vertex& pv,
                                                                unsigned char options,
@@ -378,14 +381,14 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
   chargedCands.reserve(pfCands.size());
   for (auto const& aCand : pfCands) {
     // require that PFCandidate is a charged hadron
-    reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&aCand, isAOD);
+    reco::PFCandidate::ParticleType thisCandidateType = getCandidatePdgId(&*aCand, isAOD);
     if (thisCandidateType != reco::PFCandidate::h)
       continue;
 
-    if ((options & PT_MIN_THRESH) && aCand.pt() < ptMin)
+    if ((options & PT_MIN_THRESH) && aCand.get()->pt() < ptMin)
       continue;
 
-    chargedCands.emplace_back(&aCand, isAOD);
+    chargedCands.emplace_back(&*aCand, isAOD);
   }
 
   // Calculate isolation sum separately for each vertex
@@ -403,10 +406,6 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
     // Loop over the PFCandidates
     for (auto const& aCCand : chargedCands) {
       auto iCand = aCCand.candidate;
-
-      //Leave out bizarre PF candidates with nan pT
-      if (edm::isNotFinite(iCand->pt()))
-        continue;
 
       float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());
       if (dR2 > coneSizeDR2 || (options & DR_VETO && dR2 < dRveto2))

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -96,7 +96,7 @@ private:
   // HiggsTo2photons anaysis code. Template is introduced to handle reco/pat
   // photons and aod/miniAOD PF candidates collections
   float computeWorstPFChargedIsolation(const reco::Photon& photon,
-				       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
+                                       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
                                        const reco::VertexCollection& vertices,
                                        const reco::Vertex& pv,
                                        unsigned char options,
@@ -206,10 +206,9 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
   std::vector<float> vars[nVars_];
 
   std::vector<edm::Ptr<reco::Candidate>> pfCandNoNaN;
-  for (auto pf : pfCandsHandle->ptrs()) {
+  for (const auto& pf : pfCandsHandle->ptrs()) {
     if (edm::isNotFinite(pf->pt())) {
-      edm::LogWarning("PhotonIDValueMapProducer") 
-	<< "PF candidate pT is NaN, skipping, see issue #39110" << std::endl;
+      edm::LogWarning("PhotonIDValueMapProducer") << "PF candidate pT is NaN, skipping, see issue #39110" << std::endl;
     } else {
       pfCandNoNaN.push_back(pf);
     }
@@ -368,7 +367,7 @@ void PhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 // Charged isolation with respect to the worst vertex. See more
 // comments above at the function declaration.
 float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photon& photon,
-							       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
+                                                               const std::vector<edm::Ptr<reco::Candidate>> pfCands,
                                                                const reco::VertexCollection& vertices,
                                                                const reco::Vertex& pv,
                                                                unsigned char options,

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -96,7 +96,7 @@ private:
   // HiggsTo2photons anaysis code. Template is introduced to handle reco/pat
   // photons and aod/miniAOD PF candidates collections
   float computeWorstPFChargedIsolation(const reco::Photon& photon,
-                                       const std::vector<edm::Ptr<reco::Candidate>> pfCands,
+                                       const std::vector<edm::Ptr<reco::Candidate>>& pfCands,
                                        const reco::VertexCollection& vertices,
                                        const reco::Vertex& pv,
                                        unsigned char options,
@@ -367,7 +367,7 @@ void PhotonIDValueMapProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 // Charged isolation with respect to the worst vertex. See more
 // comments above at the function declaration.
 float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photon& photon,
-                                                               const std::vector<edm::Ptr<reco::Candidate>> pfCands,
+                                                               const std::vector<edm::Ptr<reco::Candidate>>& pfCands,
                                                                const reco::VertexCollection& vertices,
                                                                const reco::Vertex& pv,
                                                                unsigned char options,

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc
@@ -264,7 +264,8 @@ void PhotonIDValueMapProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
       // If PF candidate pT is nan, leave it out
       if (edm::isNotFinite(iCand->pt())) {
-	edm::LogWarning("PhotonIDValueMapProducer") << "PF candidate pT is NAN, ignoring this candidate from PF isolation computation" << std::endl;
+        edm::LogWarning("PhotonIDValueMapProducer")
+            << "PF candidate pT is NAN, ignoring this candidate from PF isolation computation" << std::endl;
         continue;
       }
 
@@ -404,7 +405,7 @@ float PhotonIDValueMapProducer::computeWorstPFChargedIsolation(const reco::Photo
       auto iCand = aCCand.candidate;
 
       //Leave out bizarre PF candidates with nan pT
-      if (edm::isNotFinite(iCand->pt())) 
+      if (edm::isNotFinite(iCand->pt()))
         continue;
 
       float dR2 = deltaR2(phoWrtVtxEta, phoWrtVtxPhi, iCand->eta(), iCand->phi());


### PR DESCRIPTION
#### PR description:

This PR proposes to add a NaN-check on PF candidate's pT, before accepting that candidate for photon's isolation calculation. 

It was found, as discussed in this github issue (https://github.com/cms-sw/cmssw/issues/39110), that in some rare cases, PF candidate's pT/eta/phi is `-nan`, and this leads to photon's PF-based isolation to be `-nan` as well. The patch provided in this PR will bypass that problem for photons, and photon's isolation sum will return a meaningful value. 

In recent data (`2022C`, `EGamma` dataset) in Run `355872`, Event `546279379`, LumiSection `508`, 
without this PR: photon's `chargedHadronIso=-nan`
with this PR: photon's `chargedHadronIso=0.683148`
This is checked with these files:
miniAOD: `/store/data/Run2022C/EGamma/MINIAOD/PromptReco-v1/000/355/872/00000/035b7e72-7f0d-42c8-98c7-d0a5100211fe.root`
RAW: `/store/data/Run2022C/EGamma/RAW/v1/000/355/872/00000/3b478527-d206-4b8e-8004-08e9aff7758b.root`
and, `eventsToProcess = cms.untracked.VEventRange('355872:546279379-355872:546279379')`

It was checked that similar `nan` issues in MC, discussed in the github issue (https://github.com/cms-sw/cmssw/issues/39110), are also fixed with this patch, as expected.

Note: we have not found any instance of electron's PFChargedHadIso being nan. Until now, the issue happened only for photons.

#### PR validation:
`runTheMatrix.py -l 11834.0`

This PR is not a backport.
Since the issue seem to be happening also in prompt reco data, a backport to current data-taking release cycle (12_4_X) might be helpful, to have meaningful PF isolation values of reconstructed photons, in all events. 
