### PR TITLE
Fix for `SiPixelLorentzAnglePCLHarvester` after #38996 

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -85,6 +85,9 @@ public:
   dqm::reco::MonitorElement* h_bySectCovMatrixStatus_;
   dqm::reco::MonitorElement* h_bySectDriftError_;
 
+  // for fit quality
+  dqm::reco::MonitorElement* h_bySectFitQuality_;
+
   // ouput LA maps
   std::vector<dqm::reco::MonitorElement*> h2_byLayerLA_;
   std::vector<dqm::reco::MonitorElement*> h2_byLayerDiff_;


### PR DESCRIPTION
#### PR description:

When scrutinizing the output of the [CMSSW_12_4_7](https://github.com/dmwm/T0/pull/4745) replay in the [offline test GUI](https://tinyurl.com/2exrs63w) it was noticed that PR https://github.com/cms-sw/cmssw/pull/38996 introduced a couple of issues:
   * the name of the fit function at https://github.com/cms-sw/cmssw/blob/7c31bc40ae3339fbabfbba037e11aabbb602ca60/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc#L635 was changed going out-of-synch with the one of the render plugin defined at [SiPixelLorentzAnglePCLRenderPlugin.cc#L199](https://github.com/dmwm/deployment/blob/634bb4f46b5b6c989b0817162c29dca050d98104/dqmgui/style/SiPixelLorentzAnglePCLRenderPlugin.cc#L199) and causing the not correct rendering of the fits in the GUI, cf https://tinyurl.com/2qkryzg2;
   * the cut on the covariance matrix status introduced at https://github.com/cms-sw/cmssw/blob/7c31bc40ae3339fbabfbba037e11aabbb602ca60/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc#L766 results too strict for the measurements to pass it, resulting in none of them to be accepted (cf. https://tinyurl.com/2ekl8s7c ).
   
   
This PR fixes both issues, by:
   * restoring the name of the fit function to be synchronized with the render plugin (an assertion statement is also introduced such that it is not changed again by mistake later);
   * the cut on the covariance matrix status is loosened to accept also `kMadePosDef` grade fits;
   
Finally I profit of this PR to improve the diagnostics, by including a dashboard histogram to show what quality cuts fails.

#### PR validation:

Manually re-run the configuration for the multi-run harvesting (MRH ID 325019) from:
 `/eos/cms/store/group/alca_global/multiruns/results/prod//el8_amd64_gcc10/CMSSW_12_4_6/325019/ `
 
and obtained the following file, displayed in a private GUI reachable via:

```
 ssh -NL 8060:localhost:8060 <USER>@lxplus724.cern.ch
```
and visiting https://tinyurl.com/2mo3on59.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but needs to be backported to CMSSW_12_4_X for data-taking operations