### PR TITLE
Add missing includes from the standard library

### DIFF
--- a/FWCore/MessageLogger/src/ELmap.cc
+++ b/FWCore/MessageLogger/src/ELmap.cc
@@ -18,6 +18,8 @@
 
 #include "FWCore/MessageLogger/interface/ELmap.h"
 
+#include <ctime>
+
 // Possible traces
 //#include <iostream>
 //#define ELcountTRACE

--- a/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
+++ b/PhysicsTools/MVAComputer/plugins/ProcTMVA.cc
@@ -15,7 +15,7 @@
 //
 
 #include <memory>
-
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
#### PR description:

* the usage of `std::ofstream` in MVAComputer requires the include of `fstream`
* the `time` function in `ELmap.cc` requires the inclusion of `ctime`

These changes are necessary to make CMSSW compile again on my laptop with Arch Linux and the newest gcc.
