### PR TITLE
Introduce `DiMuonMassBiasMonitor` for Tk Alignment ALCARECO monitoring purposes

### DIFF
--- a/DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h
+++ b/DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h
@@ -1,0 +1,238 @@
+#ifndef Alignment_OfflineValidation_DiLeptonVertexHelpers_h
+#define Alignment_OfflineValidation_DiLeptonVertexHelpers_h
+
+#include <vector>
+#include <string>
+#include <fmt/printf.h>
+#include "TH2F.h"
+#include "TLorentzVector.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace DiLepPlotHelp {
+
+  enum flavour { MM = 0, EE = 1, UNDEF = -1 };
+
+  //
+  // Ancillary class for plotting
+  //
+  class PlotsVsKinematics {
+  public:
+    PlotsVsKinematics(flavour FLAV) : m_name(""), m_title(""), m_ytitle(""), m_isBooked(false), m_flav(FLAV) {}
+
+    //________________________________________________________________________________//
+    // overloaded constructor
+    PlotsVsKinematics(flavour FLAV, const std::string& name, const std::string& tt, const std::string& ytt)
+        : m_name(name), m_title(tt), m_ytitle(ytt), m_isBooked(false), m_flav(FLAV) {
+      if (m_flav < 0) {
+        edm::LogError("PlotsVsKinematics") << "The initialization flavour is not correct!" << std::endl;
+      }
+    }
+
+    ~PlotsVsKinematics() = default;
+
+    //________________________________________________________________________________//
+    inline void bookFromPSet(dqm::reco::DQMStore::IBooker& iBooker, const edm::ParameterSet& hpar) {
+      std::string namePostfix;
+      std::string titlePostfix;
+      float xmin, xmax;
+
+      std::string sed = (m_flav ? "e" : "#mu");
+
+      for (const auto& xAx : axisChoices) {
+        switch (xAx) {
+          case xAxis::Z_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EEPhi" : "MuMuPhi";
+            titlePostfix = fmt::sprintf("%s%s pair #phi;%s^{+}%s^{-} #phi", sed, sed, sed, sed);
+            break;
+          case xAxis::Z_ETA:
+            xmin = -3.5;
+            xmax = 3.5;
+            namePostfix = m_flav ? "EEEta" : "MuMuEta";
+            titlePostfix = fmt::sprintf("%s%s pair #eta;%s^{+}%s^{-} #eta", sed, sed, sed, sed);
+            break;
+          case xAxis::LP_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EPlusPhi" : "MuPlusPhi";
+            titlePostfix = fmt::sprintf("%s^{+} #phi;%s^{+} #phi [rad]", sed, sed);
+            break;
+          case xAxis::LP_ETA:
+            xmin = -2.4;
+            xmax = 2.4;
+            namePostfix = m_flav ? "EPlusEta" : "MuPlusEta";
+            titlePostfix = fmt::sprintf("%s^{+} #eta;%s^{+} #eta", sed, sed);
+            break;
+          case xAxis::LM_PHI:
+            xmin = -M_PI;
+            xmax = M_PI;
+            namePostfix = m_flav ? "EMinusPhi" : "MuMinusPhi";
+            titlePostfix = fmt::sprintf("%s^{-} #phi;%s^{-} #phi [rad]", sed, sed);
+            break;
+          case xAxis::LM_ETA:
+            xmin = -2.4;
+            xmax = 2.4;
+            namePostfix = m_flav ? "EMinusEta" : "MuMinusEta";
+            titlePostfix = fmt::sprintf("%s^{-} #eta;%s^{+} #eta", sed, sed);
+            break;
+          case xAxis::DELTA_ETA:
+            xmin = -4.;
+            xmax = 4.;
+            namePostfix = m_flav ? "EEDeltEta" : "MuMuDeltaEta";
+            titlePostfix = fmt::sprintf("%s^{-}%s^{+} #Delta#eta;%s^{+}%s^{-} #Delta#eta", sed, sed, sed, sed);
+            break;
+          case xAxis::COSTHETACS:
+            xmin = -1.;
+            xmax = 1.;
+            namePostfix = "CosThetaCS";
+            titlePostfix =
+                fmt::sprintf("%s^{+}%s^{-} cos(#theta_{CS});%s^{+}%s^{-} cos(#theta_{CS})", sed, sed, sed, sed);
+            break;
+          default:
+            throw cms::Exception("LogicalError") << " there is not such Axis choice as " << xAx;
+        }
+
+        const auto& h2name = fmt::sprintf("%sVs%s", hpar.getParameter<std::string>("name"), namePostfix);
+        const auto& h2title = fmt::sprintf("%s vs %s;%s% s",
+                                           hpar.getParameter<std::string>("title"),
+                                           titlePostfix,
+                                           hpar.getParameter<std::string>("title"),
+                                           hpar.getParameter<std::string>("yUnits"));
+
+        m_h2_map[xAx] = iBooker.book2D(h2name.c_str(),
+                                       h2title.c_str(),
+                                       hpar.getParameter<int32_t>("NxBins"),
+                                       xmin,
+                                       xmax,
+                                       hpar.getParameter<int32_t>("NyBins"),
+                                       hpar.getParameter<double>("ymin"),
+                                       hpar.getParameter<double>("ymax"));
+      }
+
+      // flip the is booked bit
+      m_isBooked = true;
+    }
+
+    //________________________________________________________________________________//
+    inline void bookPlots(dqm::reco::DQMStore::IBooker& iBooker,
+                          const float valmin,
+                          const float valmax,
+                          const int nxbins,
+                          const int nybins) {
+      if (m_name.empty() && m_title.empty() && m_ytitle.empty()) {
+        edm::LogError("PlotsVsKinematics")
+            << "In" << __FUNCTION__ << "," << __LINE__
+            << "trying to book plots without the right constructor being called!" << std::endl;
+        return;
+      }
+
+      std::string dilep = (m_flav ? "e^{+}e^{-}" : "#mu^{+}#mu^{-}");
+      std::string lep = (m_flav ? "e^{+}" : "#mu^{+}");
+      std::string lem = (m_flav ? "e^{-}" : "#mu^{-}");
+
+      static constexpr float maxMuEta = 2.4;
+      static constexpr float maxMuMuEta = 3.5;
+      TH1F::SetDefaultSumw2(kTRUE);
+
+      // clang-format off
+      m_h2_map[xAxis::Z_ETA] = iBooker.book2D(fmt::sprintf("%sVsMuMuEta", m_name).c_str(),
+					      fmt::sprintf("%s vs %s pair #eta;%s #eta;%s", m_title, dilep, dilep, m_ytitle).c_str(),
+					      nxbins, -M_PI, M_PI,
+					      nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::Z_PHI] = iBooker.book2D(fmt::sprintf("%sVsMuMuPhi", m_name).c_str(),
+					      fmt::sprintf("%s vs %s pair #phi;%s #phi [rad];%s", m_title, dilep, dilep, m_ytitle).c_str(),
+					      nxbins, -maxMuMuEta, maxMuMuEta,
+					      nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::LP_ETA] = iBooker.book2D(fmt::sprintf("%sVsMuPlusEta", m_name).c_str(),
+					       fmt::sprintf("%s vs %s #eta;%s #eta;%s", m_title, lep, lep, m_ytitle).c_str(),
+					       nxbins, -maxMuEta, maxMuEta,
+					       nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::LP_PHI] = iBooker.book2D(fmt::sprintf("%sVsMuPlusPhi", m_name).c_str(),
+					       fmt::sprintf("%s vs %s #phi;%s #phi [rad];%s", m_title, lep, lep, m_ytitle).c_str(),
+					       nxbins, -M_PI, M_PI,
+					       nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::LM_ETA] = iBooker.book2D(fmt::sprintf("%sVsMuMinusEta", m_name).c_str(),
+					       fmt::sprintf("%s vs %s #eta;%s #eta;%s", m_title, lem, lem, m_ytitle).c_str(),
+					       nxbins, -maxMuEta, maxMuEta,
+					       nybins, valmin, valmax);
+      
+      m_h2_map[xAxis::LM_PHI] = iBooker.book2D(fmt::sprintf("%sVsMuMinusPhi", m_name).c_str(),
+					       fmt::sprintf("%s vs %s #phi;%s #phi [rad];%s", m_title, lem, lem,  m_ytitle).c_str(),
+					       nxbins, -M_PI, M_PI,
+					       nybins, valmin, valmax);
+
+      m_h2_map[xAxis::DELTA_ETA] = iBooker.book2D(fmt::sprintf("%sVsMuMuDeltaEta", m_name).c_str(),
+						  fmt::sprintf("%s vs %s #Delta#eta;%s #Delta#eta;%s", m_title, dilep, dilep,  m_ytitle).c_str(),
+						  nxbins, -4., 4.,
+						  nybins, valmin, valmax);
+
+      m_h2_map[xAxis::COSTHETACS] = iBooker.book2D(fmt::sprintf("%sVsCosThetaCS", m_name).c_str(),
+						   fmt::sprintf("%s vs %s cos(#theta_{CS});%s cos(#theta_{CS});%s", m_title, dilep, dilep,  m_ytitle).c_str(),
+						   nxbins, -1., 1.,
+						   nybins, valmin, valmax);
+      // clang-format on
+
+      // flip the is booked bit
+      m_isBooked = true;
+    }
+
+    //________________________________________________________________________________//
+    inline void fillPlots(const float val, const std::pair<TLorentzVector, TLorentzVector>& momenta) {
+      if (!m_isBooked) {
+        edm::LogError("PlotsVsKinematics")
+            << "In" << __FUNCTION__ << "," << __LINE__ << "trying to fill a plot not booked!" << std::endl;
+        return;
+      }
+
+      m_h2_map[xAxis::Z_ETA]->Fill((momenta.first + momenta.second).Eta(), val);
+      m_h2_map[xAxis::Z_PHI]->Fill((momenta.first + momenta.second).Phi(), val);
+      m_h2_map[xAxis::LP_ETA]->Fill((momenta.first).Eta(), val);
+      m_h2_map[xAxis::LP_PHI]->Fill((momenta.first).Phi(), val);
+      m_h2_map[xAxis::LM_ETA]->Fill((momenta.second).Eta(), val);
+      m_h2_map[xAxis::LM_PHI]->Fill((momenta.second).Phi(), val);
+
+      // follows here kinematics
+      double deltaEta = (momenta.first).Eta() - (momenta.second).Eta();
+
+      double muplus = 1. / sqrt(2.) * (momenta.first.E() + momenta.first.Z());
+      double muminus = 1. / sqrt(2.) * (momenta.first.E() - momenta.first.Z());
+      double mubarplus = 1. / sqrt(2.) * (momenta.second.E() + momenta.second.Z());
+      double mubarminus = 1. / sqrt(2.) * (momenta.second.E() - momenta.second.Z());
+
+      const auto& mother = momenta.first + momenta.second;
+      double cosThetaCS = 2. / mother.Mag() / sqrt(pow(mother.Mag(), 2) + pow(mother.Pt(), 2)) *
+                          (muplus * mubarminus - muminus * mubarplus);
+
+      m_h2_map[xAxis::DELTA_ETA]->Fill(deltaEta, val);
+      m_h2_map[xAxis::COSTHETACS]->Fill(cosThetaCS, val);
+    }
+
+  private:
+    enum xAxis { Z_PHI, Z_ETA, LP_PHI, LP_ETA, LM_PHI, LM_ETA, DELTA_ETA, COSTHETACS };
+    const std::vector<xAxis> axisChoices = {xAxis::Z_PHI,
+                                            xAxis::Z_ETA,
+                                            xAxis::LP_PHI,
+                                            xAxis::LP_ETA,
+                                            xAxis::LM_PHI,
+                                            xAxis::LM_ETA,
+                                            xAxis::DELTA_ETA,
+                                            xAxis::COSTHETACS};
+
+    const std::string m_name;
+    const std::string m_title;
+    const std::string m_ytitle;
+
+    bool m_isBooked;
+    flavour m_flav;
+
+    std::map<xAxis, dqm::reco::MonitorElement*> m_h2_map;
+  };
+}  // namespace DiLepPlotHelp
+#endif

--- a/DQMOffline/Alignment/interface/DiMuonMassBiasMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasMonitor.h
@@ -1,0 +1,123 @@
+#ifndef DQMOffline_Alignment_DiMuonMassBiasMonitor_H
+#define DQMOffline_Alignment_DiMuonMassBiasMonitor_H
+
+// -*- C++ -*-
+//
+// Package:    DiMuonMassBiasMonitor
+// Class:      DiMuonMassBiasMonitor
+//
+/**\class DiMuonMassBiasMonitor DiMuonMassBiasMonitor.cc
+   DQM/TrackerMonitorTrack/src/DiMuonMassBiasMonitor.cc
+   Monitoring DiMuon mass bias 
+*/
+
+// system includes
+#include <string>
+
+// user includes
+#include "DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+struct ComponentHists {
+  dqm::reco::MonitorElement* h_pt;
+  dqm::reco::MonitorElement* h_eta;
+  dqm::reco::MonitorElement* h_phi;
+
+  dqm::reco::MonitorElement* h_dxy;
+  dqm::reco::MonitorElement* h_exy;
+  dqm::reco::MonitorElement* h_dz;
+  dqm::reco::MonitorElement* h_ez;
+
+  dqm::reco::MonitorElement* h_chi2;
+};
+
+struct DecayHists {
+  // kinematics
+  dqm::reco::MonitorElement* h_mass;
+  dqm::reco::MonitorElement* h_pt;
+  dqm::reco::MonitorElement* h_eta;
+  dqm::reco::MonitorElement* h_phi;
+
+  // position
+  dqm::reco::MonitorElement* h_displ2D;
+  dqm::reco::MonitorElement* h_displ3D;
+  dqm::reco::MonitorElement* h_sign2D;
+  dqm::reco::MonitorElement* h_sign3D;
+
+  // ct and pointing angle
+  dqm::reco::MonitorElement* h_ct;
+  dqm::reco::MonitorElement* h_pointing;
+
+  // quality
+  dqm::reco::MonitorElement* h_vertNormChi2;
+  dqm::reco::MonitorElement* h_vertProb;
+
+  std::vector<ComponentHists> decayComponents;
+};
+
+class DiMuonMassBiasMonitor : public DQMEDAnalyzer {
+public:
+  explicit DiMuonMassBiasMonitor(const edm::ParameterSet&);
+  ~DiMuonMassBiasMonitor() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  void bookDecayHists(DQMStore::IBooker&,
+                      DecayHists&,
+                      std::string const&,
+                      std::string const&,
+                      int,
+                      float,
+                      float,
+                      float distanceScaleFactor = 1.) const;
+
+  void bookDecayComponentHistograms(DQMStore::IBooker& ibook, DecayHists& histos) const;
+
+  void bookComponentHists(DQMStore::IBooker&,
+                          DecayHists&,
+                          TString const&,  // TString for the IBooker interface
+                          float distanceScaleFactor = 1.) const;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  reco::Vertex const* fillDecayHistograms(DecayHists const&,
+                                          std::vector<const reco::Track*> const& tracks,
+                                          const reco::VertexCollection* const& pvs,
+                                          const edm::EventSetup&) const;
+
+  void fillComponentHistograms(ComponentHists const& histos,
+                               const reco::Track* const& component,
+                               reco::BeamSpot const* bs,
+                               reco::Vertex const* pv) const;
+
+private:
+  // ----------member data ---------------------------
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbESToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+
+  const std::string MEFolderName_;  // Top-level folder name
+  const std::string decayMotherName_;
+  const double distanceScaleFactor_;
+  edm::ParameterSet DiMuMassConfiguration_;
+
+  // 2D histograms of bias vs variable
+  DiLepPlotHelp::PlotsVsKinematics ZMassPlots = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
+  // Decay histograms
+  DecayHists histosZmm;
+};
+#endif

--- a/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
@@ -25,6 +25,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
@@ -39,23 +40,35 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
+  const reco::Vertex *findClosestVertex(const TransientVertex aTransVtx, const reco::VertexCollection *vertices) const;
+
   // ----------member data ---------------------------
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttbESToken_;
-  const edm::EDGetTokenT<reco::TrackCollection>
-      tracksToken_;  //used to select what tracks to read from configuration file
-  const edm::EDGetTokenT<reco::VertexCollection>
-      vertexToken_;                 //used to select what vertices to read from configuration file
+
+  //used to select what tracks to read from configuration file
+  const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  //used to select what vertices to read from configuration file
+  const edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+
   const std::string MEFolderName_;  // Top-level folder name
+  const bool useClosestVertex_;
   const float maxSVdist_;
 
   // vertex quantities
   MonitorElement *hSVProb_;
+  MonitorElement *hSVChi2_;
+  MonitorElement *hSVNormChi2_;
+
   MonitorElement *hSVDist_;
   MonitorElement *hSVDistErr_;
   MonitorElement *hSVDistSig_;
+  MonitorElement *hSVCompatibility_;
+
   MonitorElement *hSVDist3D_;
   MonitorElement *hSVDist3DErr_;
   MonitorElement *hSVDist3DSig_;
+  MonitorElement *hSVCompatibility3D_;
+
   MonitorElement *hCosPhi_;
   MonitorElement *hCosPhi3D_;
   MonitorElement *hCosPhiInv_;

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 import DQM.TrackingMonitor.TrackingMonitor_cfi
 import DQMOffline.Alignment.TkAlCaRecoMonitor_cfi
 import DQMOffline.Alignment.DiMuonVertexMonitor_cfi
+import DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi
 
 #Below all DQM modules for TrackerAlignment AlCaRecos are instantiated.
 ######################################################
@@ -80,7 +81,12 @@ ALCARECOTkAlDiMuonAndVertexVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi
     maxSVdist = 50
 )
 
-ALCARECOTkAlDiMuonAndVertexDQM = cms.Sequence(ALCARECOTkAlDiMuonAndVertexTkAlDQM + ALCARECOTkAlDiMuonAndVertexVtxDQM)
+ALCARECOTkAlDiMuonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
+    muonTracks = 'ALCARECO'+__trackCollName,
+    FolderName = "AlCaReco/"+__selectionName
+)
+
+ALCARECOTkAlDiMuonAndVertexDQM = cms.Sequence(ALCARECOTkAlDiMuonAndVertexTkAlDQM + ALCARECOTkAlDiMuonAndVertexVtxDQM + ALCARECOTkAlDiMuonMassBiasDQM )
 
 #########################################################
 #############---  TkAlZMuMuHI ---########################

--- a/DQMOffline/Alignment/python/DiMuonMassBiasMonitor_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasMonitor_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+DiMuonMassBiasMonitor = DQMEDAnalyzer('DiMuonMassBiasMonitor',
+                                      muonTracks = cms.InputTag('ALCARECOTkAlDiMuon'),
+                                      vertices = cms.InputTag('offlinePrimaryVertices'),
+                                      FolderName = cms.string('DiMuonMassBiasMonitor'),
+                                      decayMotherName = cms.string('Z'),
+                                      distanceScaleFactor = cms.double(0.1), # for the Z->mm
+                                      DiMuMassConfig = cms.PSet(
+                                          name = cms.string('DiMuMass'),
+                                          title = cms.string('M(#mu#mu)'),
+                                          yUnits = cms.string('[GeV]'),
+                                          NxBins = cms.int32(24),
+                                          NyBins = cms.int32(50),
+                                          ymin = cms.double(65.),
+                                          ymax = cms.double(115.)
+                                      ))

--- a/DQMOffline/Alignment/src/DiMuonMassBiasMonitor.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasMonitor.cc
@@ -1,0 +1,306 @@
+/*
+ *  See header file for a description of this class.
+ *
+ */
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "DQMOffline/Alignment/interface/DiMuonMassBiasMonitor.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
+#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+
+#include "TLorentzVector.h"
+
+namespace {
+  //constexpr float cmToum = 10e4; /* unused for now */
+  constexpr float mumass2 = 0.105658367 * 0.105658367;  //mu mass squared (GeV^2/c^4)
+}  // namespace
+
+DiMuonMassBiasMonitor::DiMuonMassBiasMonitor(const edm::ParameterSet& iConfig)
+    : ttbESToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+      tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("muonTracks"))),
+      vertexToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
+      beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      MEFolderName_(iConfig.getParameter<std::string>("FolderName")),
+      decayMotherName_(iConfig.getParameter<std::string>("decayMotherName")),
+      distanceScaleFactor_(iConfig.getParameter<double>("distanceScaleFactor")),
+      DiMuMassConfiguration_(iConfig.getParameter<edm::ParameterSet>("DiMuMassConfig")) {}
+
+void DiMuonMassBiasMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, edm::EventSetup const&) {
+  iBooker.setCurrentFolder(MEFolderName_ + "/DiMuonMassBiasMonitor/MassBias");
+  ZMassPlots.bookFromPSet(iBooker, DiMuMassConfiguration_);
+
+  iBooker.setCurrentFolder(MEFolderName_ + "/DiMuonMassBiasMonitor");
+
+  // retrieve the mass bins
+  const auto& mass_bins = DiMuMassConfiguration_.getParameter<int32_t>("NyBins");
+  const auto& mass_min = DiMuMassConfiguration_.getParameter<double>("ymin");
+  const auto& mass_max = DiMuMassConfiguration_.getParameter<double>("ymax");
+
+  bookDecayHists(
+      iBooker, histosZmm, decayMotherName_, "#mu^{+}#mu^{-}", mass_bins, mass_min, mass_max, distanceScaleFactor_);
+
+  iBooker.setCurrentFolder(MEFolderName_ + "/DiMuonMassBiasMonitor/components");
+  bookDecayComponentHistograms(iBooker, histosZmm);
+}
+
+void DiMuonMassBiasMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::vector<const reco::Track*> myTracks;
+  const auto trackHandle = iEvent.getHandle(tracksToken_);
+  if (!trackHandle.isValid()) {
+    edm::LogError("DiMuonMassBiasMonitor") << "invalid track collection encountered!";
+    return;
+  }
+
+  for (const auto& muonTrk : *trackHandle) {
+    myTracks.emplace_back(&muonTrk);
+  }
+
+  if (myTracks.size() != 2) {
+    edm::LogWarning("DiMuonMassBiasMonitor") << "There are not enough tracks to monitor!";
+    return;
+  }
+
+  const auto& t1 = myTracks[1]->momentum();
+  const auto& t0 = myTracks[0]->momentum();
+  const auto& ditrack = t1 + t0;
+
+  const auto& tplus = myTracks[0]->charge() > 0 ? myTracks[0] : myTracks[1];
+  const auto& tminus = myTracks[0]->charge() < 0 ? myTracks[0] : myTracks[1];
+
+  TLorentzVector p4_tplus(tplus->px(), tplus->py(), tplus->pz(), sqrt((tplus->p() * tplus->p()) + mumass2));
+  TLorentzVector p4_tminus(tminus->px(), tminus->py(), tminus->pz(), sqrt((tminus->p() * tminus->p()) + mumass2));
+
+  const auto& Zp4 = p4_tplus + p4_tminus;
+  float track_invMass = Zp4.M();
+
+  // creat the pair of TLorentVectors used to make the plos
+  std::pair<TLorentzVector, TLorentzVector> tktk_p4 = std::make_pair(p4_tplus, p4_tminus);
+
+  // fill the z->mm mass plots
+  ZMassPlots.fillPlots(track_invMass, tktk_p4);
+
+  math::XYZPoint ZpT(ditrack.x(), ditrack.y(), 0);
+  math::XYZPoint Zp(ditrack.x(), ditrack.y(), ditrack.z());
+
+  // get collection of reconstructed vertices from event
+  const auto& vertexHandle = iEvent.getHandle(vertexToken_);
+  if (!vertexHandle.isValid()) {
+    edm::LogError("DiMuonMassBiasMonitor") << "invalid vertex collection encountered!";
+    return;
+  }
+
+  // get the vertices from the event
+  const auto& vertices = vertexHandle.product();
+
+  // fill the decay vertex plots
+  auto decayVertex = fillDecayHistograms(histosZmm, myTracks, vertices, iSetup);
+
+  // get the beamspot from the event
+  const reco::BeamSpot* bs;
+  const auto& beamSpotHandle = iEvent.getHandle(beamSpotToken_);
+  if (!beamSpotHandle.isValid()) {
+    bs = nullptr;
+  } else {
+    bs = beamSpotHandle.product();
+  }
+
+  // fill the components plots
+  fillComponentHistograms(histosZmm.decayComponents[0], tplus, bs, decayVertex);
+  fillComponentHistograms(histosZmm.decayComponents[1], tminus, bs, decayVertex);
+}
+
+void DiMuonMassBiasMonitor::bookDecayComponentHistograms(DQMStore::IBooker& ibook, DecayHists& histos) const {
+  bookComponentHists(ibook, histos, "mu_plus", 0.1);
+  bookComponentHists(ibook, histos, "mu_minus", 0.1);
+}
+
+void DiMuonMassBiasMonitor::bookComponentHists(DQMStore::IBooker& ibook,
+                                               DecayHists& histos,
+                                               TString const& componentName,
+                                               float distanceScaleFactor) const {
+  ComponentHists comp;
+
+  comp.h_pt = ibook.book1D(componentName + "_pt", "track momentum ;p_{T} [GeV]", 100, 0., 100.);
+  comp.h_eta = ibook.book1D(componentName + "_eta", "track rapidity;#eta", 100, -2.5, 2.5);
+  comp.h_phi = ibook.book1D(componentName + "_phi", "track azimuth;#phi", 100, -M_PI, M_PI);
+  comp.h_dxy = ibook.book1D(componentName + "_dxyBS",
+                            "TIP w.r.t BS;d_{xy}(BS) [cm]",
+                            100,
+                            -0.5 * distanceScaleFactor,
+                            0.5 * distanceScaleFactor);
+  comp.h_exy =
+      ibook.book1D(componentName + "_exy", "Error on TIP ;#sigma(d_{xy}(BS)) [cm]", 100, 0, 0.05 * distanceScaleFactor);
+  comp.h_dz = ibook.book1D(componentName + "_dzPV",
+                           "LIP w.r.t PV;d_{z}(PV) [cm]",
+                           100,
+                           -0.5 * distanceScaleFactor,
+                           0.5 * distanceScaleFactor);
+  comp.h_ez =
+      ibook.book1D(componentName + "_ez", "Error on LIP;#sigma(d_{z}(PV)) [cm]", 100, 0, 0.5 * distanceScaleFactor);
+  comp.h_chi2 = ibook.book1D(componentName + "_chi2", ";#chi^{2}", 100, 0, 20);
+
+  histos.decayComponents.push_back(comp);
+}
+
+void DiMuonMassBiasMonitor::bookDecayHists(DQMStore::IBooker& ibook,
+                                           DecayHists& decayHists,
+                                           std::string const& name,
+                                           std::string const& products,
+                                           int nMassBins,
+                                           float massMin,
+                                           float massMax,
+                                           float distanceScaleFactor) const {
+  std::string histTitle = name + " #rightarrow " + products + ";";
+
+  decayHists.h_mass = ibook.book1D("h_mass", histTitle + "M(" + products + ") [GeV]", nMassBins, massMin, massMax);
+  decayHists.h_pt = ibook.book1D("h_pt", histTitle + "p_{T} [GeV]", 100, 0.00, 200.0);
+  decayHists.h_eta = ibook.book1D("h_eta", histTitle + "#eta", 100, -5., 5.);
+  decayHists.h_phi = ibook.book1D("h_phi", histTitle + "#varphi [rad]", 100, -M_PI, M_PI);
+  decayHists.h_displ2D =
+      ibook.book1D("h_displ2D", histTitle + "vertex 2D displacement [cm]", 100, 0.00, 0.1 * distanceScaleFactor);
+  decayHists.h_sign2D =
+      ibook.book1D("h_sign2D", histTitle + "vertex 2D displ. significance", 100, 0.00, 100.0 * distanceScaleFactor);
+  decayHists.h_ct = ibook.book1D("h_ct", histTitle + "c#tau [cm]", 100, 0.00, 0.4 * distanceScaleFactor);
+  decayHists.h_pointing = ibook.book1D("h_pointing", histTitle + "cos( 2D pointing angle )", 100, -1, 1);
+  decayHists.h_vertNormChi2 = ibook.book1D("h_vertNormChi2", histTitle + "vertex #chi^{2}/ndof", 100, 0.00, 10);
+  decayHists.h_vertProb = ibook.book1D("h_vertProb", histTitle + "vertex prob.", 100, 0.00, 1.0);
+}
+
+reco::Vertex const* DiMuonMassBiasMonitor::fillDecayHistograms(DecayHists const& histos,
+                                                               std::vector<const reco::Track*> const& tracks,
+                                                               const reco::VertexCollection* const& pvs,
+                                                               const edm::EventSetup& iSetup) const {
+  if (tracks.size() != 2) {
+    edm::LogWarning("DiMuonVertexMonitor") << "There are not enough tracks to construct a vertex!";
+    return nullptr;
+  }
+
+  const TransientTrackBuilder* theB = &iSetup.getData(ttbESToken_);
+  TransientVertex mumuTransientVtx;
+  std::vector<reco::TransientTrack> tks;
+
+  for (const auto& track : tracks) {
+    reco::TransientTrack trajectory = theB->build(track);
+    tks.push_back(trajectory);
+  }
+
+  KalmanVertexFitter kalman(true);
+  mumuTransientVtx = kalman.vertex(tks);
+
+  auto svtx = reco::Vertex(mumuTransientVtx);
+  if (not svtx.isValid()) {
+    return nullptr;
+  }
+
+  const auto& mom_t1 = tracks[1]->momentum();
+  const auto& mom_t0 = tracks[0]->momentum();
+  const auto& momentum = mom_t1 + mom_t0;
+
+  TLorentzVector p4_t0(mom_t0.x(), mom_t0.y(), mom_t0.z(), sqrt(mom_t0.mag2() + mumass2));
+  TLorentzVector p4_t1(mom_t1.x(), mom_t1.y(), mom_t1.z(), sqrt(mom_t1.mag2() + mumass2));
+
+  const auto& p4 = p4_t0 + p4_t1;
+  float mass = p4.M();
+
+  auto pvtx = std::min_element(pvs->begin(), pvs->end(), [svtx](reco::Vertex const& pv1, reco::Vertex const& pv2) {
+    return abs(pv1.z() - svtx.z()) < abs(pv2.z() - svtx.z());
+  });
+
+  if (pvtx == pvs->end()) {
+    return nullptr;
+  }
+
+  VertexDistanceXY vdistXY;
+  Measurement1D distXY = vdistXY.distance(svtx, *pvtx);
+
+  auto pvtPos = pvtx->position();
+  const auto& svtPos = svtx.position();
+
+  math::XYZVector displVect2D(svtPos.x() - pvtPos.x(), svtPos.y() - pvtPos.y(), 0);
+  auto cosAlpha = displVect2D.Dot(momentum) / (displVect2D.Rho() * momentum.rho());
+
+  auto ct = distXY.value() * cosAlpha * mass / momentum.rho();
+
+  histos.h_pointing->Fill(cosAlpha);
+
+  histos.h_mass->Fill(mass);
+
+  histos.h_pt->Fill(momentum.rho());
+  histos.h_eta->Fill(momentum.eta());
+  histos.h_phi->Fill(momentum.phi());
+
+  histos.h_ct->Fill(ct);
+
+  histos.h_displ2D->Fill(distXY.value());
+  histos.h_sign2D->Fill(distXY.significance());
+
+  if (svtx.chi2() >= 0) {
+    histos.h_vertNormChi2->Fill(svtx.chi2() / svtx.ndof());
+    histos.h_vertProb->Fill(ChiSquaredProbability(svtx.chi2(), svtx.ndof()));
+  }
+
+  return &*pvtx;
+}
+
+void DiMuonMassBiasMonitor::fillComponentHistograms(ComponentHists const& histos,
+                                                    const reco::Track* const& component,
+                                                    reco::BeamSpot const* bs,
+                                                    reco::Vertex const* pv) const {
+  histos.h_pt->Fill(component->pt());
+  histos.h_eta->Fill(component->eta());
+  histos.h_phi->Fill(component->phi());
+
+  math::XYZPoint zero(0, 0, 0);
+  math::Error<3>::type zeroCov;  // needed for dxyError
+  if (bs) {
+    histos.h_dxy->Fill(component->dxy(*bs));
+    histos.h_exy->Fill(component->dxyError(*bs));
+  } else {
+    histos.h_dxy->Fill(component->dxy(zero));
+    histos.h_exy->Fill(component->dxyError(zero, zeroCov));
+  }
+  if (pv) {
+    histos.h_dz->Fill(component->dz(pv->position()));
+  } else {
+    histos.h_dz->Fill(component->dz(zero));
+  }
+  histos.h_ez->Fill(component->dzError());
+
+  histos.h_chi2->Fill(component->chi2() / component->ndof());
+}
+
+void DiMuonMassBiasMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muonTracks", edm::InputTag("ALCARECOTkAlDiMuon"));
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<std::string>("FolderName", "DiMuonMassBiasMonitor");
+  desc.add<std::string>("decayMotherName", "Z");
+  desc.add<double>("distanceScaleFactor", 0.1);
+
+  {
+    edm::ParameterSetDescription psDiMuMass;
+    psDiMuMass.add<std::string>("name", "DiMuMass");
+    psDiMuMass.add<std::string>("title", "M(#mu#mu)");
+    psDiMuMass.add<std::string>("yUnits", "[GeV]");
+    psDiMuMass.add<int>("NxBins", 24);
+    psDiMuMass.add<int>("NyBins", 50);
+    psDiMuMass.add<double>("ymin", 65.);
+    psDiMuMass.add<double>("ymax", 115.);
+    desc.add<edm::ParameterSetDescription>("DiMuMassConfig", psDiMuMass);
+  }
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(DiMuonMassBiasMonitor);

--- a/DQMOffline/Alignment/test/DiMuonVertexValidator_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonVertexValidator_cfg.py
@@ -88,7 +88,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
 
 process.load("DQMOffline.Configuration.AlCaRecoDQM_cff")
-process.seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(process.ALCARECOTkAlDiMuonAndVertexVtxDQM)
+process.seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(process.ALCARECOTkAlDiMuonAndVertexVtxDQM + process.ALCARECOTkAlDiMuonMassBiasDQM)
 
 process.dqmoffline_step = cms.EndPath(process.seqALCARECOTkAlDiMuonAndVertex)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to expand on the concept introduced at https://github.com/cms-sw/cmssw/pull/38378, about adding the DQM monitoring for the `ALCARECOTkAlDiMuonAndVertex` stream and adds a new DQM Analyzer (`DiMuonMassBiasMonitor`) to monitor the bias of the di-muon mass system as a function of the component track kinematics.

#### PR validation:

Relies on the existing unit tests. 
The output of it has been uploaded to a test GUI for convenience of inspection and it's available by connecting to:
```console
 ssh -NL 8060:localhost:8060 <USER>@lxplus724.cern.ch
````
and visiting https://tinyurl.com/2gapbtzy.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_12_4_X for data-taking operations.
