### PR TITLE
Phase2-hgx321 Make some fixes to the issues in storing hits for the scintillator part of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixLayer.cc
@@ -448,8 +448,8 @@ void DDHGCalMixLayer::positionMix(const DDLogicalPart& glog,
       double phi2 = dphi * (fimax - fimin + 1);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "DDHGCalMixLayer: Layer " << copy << " iR "
-                                    << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << ":"
-                                    << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << " R " << r1 << ":"
+                                    << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
+                                    << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R " << r1 << ":"
                                     << r2 << " Thick " << (2.0 * hthickl) << " phi " << fimin << ":" << fimax << ":"
                                     << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2);
       ;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
@@ -470,8 +470,8 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
       auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << " iR "
-                                    << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << ":"
-                                    << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << " R " << r1 << ":"
+                                    << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
+                                    << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R " << r1 << ":"
                                     << r2 << " Thick " << (2.0 * hthickl) << " phi " << fimin << ":" << fimax << ":"
                                     << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette " << cassette
                                     << " Shift " << cshift.first << ":" << cshift.second;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixLayer.cc
@@ -377,8 +377,8 @@ struct HGCalMixLayer {
         double phi2 = (forFireworks_ == 1) ? (dphi * (fimax - fimin + 1)) : (dphi * fimax);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixLayer: Layer " << copy << " iR "
-                                      << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << ":"
-                                      << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << " R "
+                                      << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
+                                      << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R "
                                       << cms::convert2mm(r1) << ":" << cms::convert2mm(r2) << " Thick "
                                       << cms::convert2mm((2.0 * hthickl)) << " phi " << fimin << ":" << fimax << ":"
                                       << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
@@ -397,8 +397,8 @@ struct HGCalMixRotatedLayer {
         auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << " iR "
-                                      << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << ":"
-                                      << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ly])) << " R "
+                                      << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
+                                      << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R "
                                       << cms::convert2mm(r1) << ":" << cms::convert2mm(r2) << " Thick "
                                       << cms::convert2mm((2.0 * hthickl)) << " phi " << fimin << ":" << fimax << ":"
                                       << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette "

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -183,35 +183,32 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   const auto& indx = getIndex(layer, reco);
   if (indx.first < 0)
     return std::array<int, 3>{{irad, iphi, type}};
-  double xx = (z > 0) ? x : -x;
-  double phi = (((y == 0.0) && (x == 0.0)) ? 0. : std::atan2(y, xx));
-  if (phi < 0)
-    phi += (2.0 * M_PI);
-  if (indx.second != 0)
-    iphi = 1 + static_cast<int>(phi / indx.second);
+  double xx = (reco) ? ((z > 0) ? x : -x) : ((z > 0) ? (HGCalParameters::k_ScaleFromDDD * x) : -(HGCalParameters::k_ScaleFromDDD * x));
+  double yy = (reco) ? y : HGCalParameters::k_ScaleFromDDD * y;
+  int ll = layer - hgpar_->firstLayer_;
+  xx -= hgpar_->xLayerHex_[ll];
+  yy -= hgpar_->yLayerHex_[ll];
   if (mode_ == HGCalGeometryMode::TrapezoidCassette) {
     int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, hgpar_->nphiCassette_, hgpar_->cassettes_);
     auto cshift = hgcassette_.getShift(layer, 1, cassette);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second;
 #endif
-    if (reco) {
-      x -= cshift.first;
-      y -= cshift.second;
-    } else {
-      x = HGCalParameters::k_ScaleFromDDD * x - cshift.first;
-      y = HGCalParameters::k_ScaleFromDDD * y - cshift.second;
-    }
+    xx -= cshift.first;
+    yy -= cshift.second;
   }
+  double phi = (((yy == 0.0) && (xx == 0.0)) ? 0. : std::atan2(yy, xx));
+  if (phi < 0)
+    phi += (2.0 * M_PI);
+  if (indx.second != 0)
+    iphi = 1 + static_cast<int>(phi / indx.second);
   type = hgpar_->scintType(layer);
-  double r = std::sqrt(x * x + y * y);
+  double r = std::sqrt(xx * xx + yy * yy);
   auto ir = std::lower_bound(hgpar_->radiusLayer_[type].begin(), hgpar_->radiusLayer_[type].end(), r);
   irad = static_cast<int>(ir - hgpar_->radiusLayer_[type].begin());
   irad = std::clamp(irad, hgpar_->iradMinBH_[indx.first], hgpar_->iradMaxBH_[indx.first]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "assignCellTrap Input " << x << ":" << y << ":" << z << ":" << layer << ":" << reco
-                                << " x|r " << xx << ":" << r << " phi " << phi << " o/p " << irad << ":" << iphi << ":"
-                                << type;
+  edm::LogVerbatim("HGCalGeom") << "assignCellTrap Input " << x << ":" << y << ":" << z << ":" << layer << ":" << reco << " x|y|r " << xx << ":" << yy << ":" << r << " phi " << phi << ":" << convertRadToDeg(phi) << " o/p " << irad << ":" << iphi << ":" << type;
 #endif
   return std::array<int, 3>{{irad, iphi, type}};
 }
@@ -803,12 +800,15 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(int lay, int irad, int
       edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << reco
                                     << " IR " << ir << ":" << hgpar_->iradMinBH_[indx.first] << ":"
                                     << hgpar_->iradMaxBH_[indx.first] << " Type " << type << " Z " << indx.first << ":"
-                                    << z << " phi " << phi << " R " << r << ":" << range.first << ":" << range.second;
+                                    << z << " phi " << phi << ":" << convertRadToDeg(phi) << " R " << r << ":" << range.first << ":" << range.second;
     if ((mode_ != HGCalGeometryMode::TrapezoidFile) && (mode_ != HGCalGeometryMode::TrapezoidModule) &&
         (mode_ != HGCalGeometryMode::TrapezoidCassette))
       r = std::max(range.first, std::min(r, range.second));
     x = r * std::cos(phi);
     y = r * std::sin(phi);
+    int ll = lay - hgpar_->firstLayer_;
+    x += hgpar_->xLayerHex_[ll];
+    y += hgpar_->yLayerHex_[ll];
     if (mode_ == HGCalGeometryMode::TrapezoidCassette) {
       int cassette = HGCalTileIndex::tileCassette(iphi, hgpar_->phiOffset_, hgpar_->nphiCassette_, hgpar_->cassettes_);
       auto cshift = hgcassette_.getShift(lay, 1, cassette);

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -183,7 +183,8 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   const auto& indx = getIndex(layer, reco);
   if (indx.first < 0)
     return std::array<int, 3>{{irad, iphi, type}};
-  double xx = (reco) ? ((z > 0) ? x : -x) : ((z > 0) ? (HGCalParameters::k_ScaleFromDDD * x) : -(HGCalParameters::k_ScaleFromDDD * x));
+  double xx = (reco) ? ((z > 0) ? x : -x)
+                     : ((z > 0) ? (HGCalParameters::k_ScaleFromDDD * x) : -(HGCalParameters::k_ScaleFromDDD * x));
   double yy = (reco) ? y : HGCalParameters::k_ScaleFromDDD * y;
   int ll = layer - hgpar_->firstLayer_;
   xx -= hgpar_->xLayerHex_[ll];
@@ -208,7 +209,9 @@ std::array<int, 3> HGCalDDDConstants::assignCellTrap(float x, float y, float z, 
   irad = static_cast<int>(ir - hgpar_->radiusLayer_[type].begin());
   irad = std::clamp(irad, hgpar_->iradMinBH_[indx.first], hgpar_->iradMaxBH_[indx.first]);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "assignCellTrap Input " << x << ":" << y << ":" << z << ":" << layer << ":" << reco << " x|y|r " << xx << ":" << yy << ":" << r << " phi " << phi << ":" << convertRadToDeg(phi) << " o/p " << irad << ":" << iphi << ":" << type;
+  edm::LogVerbatim("HGCalGeom") << "assignCellTrap Input " << x << ":" << y << ":" << z << ":" << layer << ":" << reco
+                                << " x|y|r " << xx << ":" << yy << ":" << r << " phi " << phi << ":"
+                                << convertRadToDeg(phi) << " o/p " << irad << ":" << iphi << ":" << type;
 #endif
   return std::array<int, 3>{{irad, iphi, type}};
 }
@@ -800,7 +803,8 @@ std::pair<float, float> HGCalDDDConstants::locateCellTrap(int lay, int irad, int
       edm::LogVerbatim("HGCalGeom") << "locateCellTrap:: Input " << lay << ":" << irad << ":" << iphi << ":" << reco
                                     << " IR " << ir << ":" << hgpar_->iradMinBH_[indx.first] << ":"
                                     << hgpar_->iradMaxBH_[indx.first] << " Type " << type << " Z " << indx.first << ":"
-                                    << z << " phi " << phi << ":" << convertRadToDeg(phi) << " R " << r << ":" << range.first << ":" << range.second;
+                                    << z << " phi " << phi << ":" << convertRadToDeg(phi) << " R " << r << ":"
+                                    << range.first << ":" << range.second;
     if ((mode_ != HGCalGeometryMode::TrapezoidFile) && (mode_ != HGCalGeometryMode::TrapezoidModule) &&
         (mode_ != HGCalGeometryMode::TrapezoidCassette))
       r = std::max(range.first, std::min(r, range.second));

--- a/Geometry/HGCalCommonData/test/python/testHGCalParametersDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalParametersDDD_cfg.py
@@ -3,7 +3,7 @@ from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
 
 process = cms.Process("HGCalParametersTest",Phase2C11)
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
-process.load("Configuration.Geometry.GeometryExtended2026D82Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D88Reco_cff")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -232,7 +232,8 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                       << id.iCell1 << ":" << id.iCell2 << " Global " << glob;
     }
   } else {
-    edm::LogVerbatim("HGCalGeom") << "Cannot recognize " << std::hex << detid.rawId() << " cellIndex " << cellIndex << ":" << maxSize << " Type " << m_topology.tileTrapezoid();
+    edm::LogVerbatim("HGCalGeom") << "Cannot recognize " << std::hex << detid.rawId() << " cellIndex " << cellIndex
+                                  << ":" << maxSize << " Type " << m_topology.tileTrapezoid();
   }
   return glob;
 }

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -231,6 +231,8 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                       << xy.second << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iSec2 << ":"
                                       << id.iCell1 << ":" << id.iCell2 << " Global " << glob;
     }
+  } else {
+    edm::LogVerbatim("HGCalGeom") << "Cannot recognize " << std::hex << detid.rawId() << " cellIndex " << cellIndex << ":" << maxSize << " Type " << m_topology.tileTrapezoid();
   }
   return glob;
 }

--- a/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
@@ -107,7 +107,7 @@ HGCalGeometry* HGCalGeometryLoader::build(const HGCalTopology& topology) {
 #endif
           if (ok) {
             DetId detId = static_cast<DetId>(id);
-            const auto& w = topology.dddConstants().locateCellTrap(layer, ring, iphi, true);
+            const auto& w = topology.dddConstants().locateCellTrap(layer, ring, iphi, true, false);
             double xx = (zside > 0) ? w.first : -w.first;
             CLHEP::Hep3Vector h3v(xx, w.second, mytr.h3v.z());
             const HepGeom::Transform3D ht3d(mytr.hr, h3v);

--- a/SimG4CMS/Calo/interface/HGCScintSD.h
+++ b/SimG4CMS/Calo/interface/HGCScintSD.h
@@ -44,10 +44,12 @@ private:
   std::string nameX_;
   HGCalGeometryMode::GeometryMode geom_mode_;
   double eminHit_, slopeMin_, distanceFromEdge_;
-  int levelT1_, levelT2_;
+  int levelT1_, levelT2_, firstLayer_;
   bool storeAllG4Hits_, fiducialCut_;
   bool useBirk_;
   double birk1_, birk2_, birk3_, weight_;
+  std::string fileName_;
+  std::vector<int> tiles_;
 };
 
 #endif  // HGCScintSD_h

--- a/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
@@ -38,7 +38,7 @@ private:
   const DetId::Detector det_;
   const std::string name_;
   int firstLayer_;
-  std::vector<int> wafers_;
+  std::vector<int> indices_;
 };
 
 #endif

--- a/SimG4CMS/Calo/plugins/HGCalHitScint.cc
+++ b/SimG4CMS/Calo/plugins/HGCalHitScint.cc
@@ -1,0 +1,137 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+
+#include "SimDataFormats/CaloHit/interface/PCaloHit.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+#include "SimG4CMS/Calo/interface/CaloSimUtils.h"
+
+#include "Geometry/CaloTopology/interface/HGCalTopology.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+class HGCalHitScint : public edm::one::EDAnalyzer<> {
+public:
+  HGCalHitScint(const edm::ParameterSet& ps);
+  ~HGCalHitScint() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  void beginJob() override {}
+  void endJob() override {}
+
+private:
+  const std::string g4Label_, caloHitSource_, nameSense_, tileFileName_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_calo_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
+  std::vector<int> tiles_;
+};
+
+HGCalHitScint::HGCalHitScint(const edm::ParameterSet& ps)
+    : g4Label_(ps.getParameter<std::string>("moduleLabel")),
+      caloHitSource_(ps.getParameter<std::string>("caloHitSource")),
+      nameSense_(ps.getParameter<std::string>("nameSense")),
+      tileFileName_(ps.getParameter<std::string>("tileFileName")),
+      tok_calo_(consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, caloHitSource_))),
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
+  edm::LogVerbatim("HGCalSim") << "Test Hit ID using SimHits for " << nameSense_ << " with module Label: " << g4Label_
+                               << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
+  if (!tileFileName_.empty()) {
+    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + tileFileName_);
+    std::string fileName = filetmp.fullPath();
+    std::ifstream fInput(fileName.c_str());
+    if (!fInput.good()) {
+      edm::LogVerbatim("HGCalSim") << "Cannot open file " << fileName;
+    } else {
+      char buffer[80];
+      while (fInput.getline(buffer, 80)) {
+        std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
+        if (items.size() > 2) {
+          int layer = std::atoi(items[0].c_str());
+          int ring = std::atoi(items[1].c_str());
+          int phi = std::atoi(items[2].c_str());
+          tiles_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, phi));
+        }
+      }
+      edm::LogVerbatim("HGCalSim") << "Reads in " << tiles_.size() << " tile information from " << fileName;
+      fInput.close();
+    }
+  }
+}
+
+void HGCalHitScint::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("moduleLabel", "g4SimHits");
+  desc.add<std::string>("caloHitSource", "HGCHitsHEback");
+  desc.add<std::string>("nameSense", "HGCalHEScintillatorSensitive");
+  desc.add<std::string>("tileFileName", "");
+  descriptions.add("hgcalHitScintillator", desc);
+}
+
+void HGCalHitScint::analyze(const edm::Event& e, const edm::EventSetup& iS) {
+  // get hcalGeometry
+  const HGCalGeometry* geom = &iS.getData(geomToken_);
+  const HGCalDDDConstants& hgc = geom->topology().dddConstants();
+  int firstLayer = hgc.firstLayer() - 1;
+  // get the hit collection
+  const edm::Handle<edm::PCaloHitContainer>& hitsCalo = e.getHandle(tok_calo_);
+  bool getHits = (hitsCalo.isValid());
+  uint32_t nhits = (getHits) ? hitsCalo->size() : 0;
+  uint32_t good(0), all(0);
+  edm::LogVerbatim("HGCalSim") << "HGCalHitScint: Input flags Hits " << getHits << " with " << nhits
+                               << " hits first Layer " << firstLayer;
+
+  if (getHits) {
+    std::vector<PCaloHit> hits;
+    hits.insert(hits.end(), hitsCalo->begin(), hitsCalo->end());
+    if (!hits.empty()) {
+      // Loop over all hits
+      for (auto hit : hits) {
+        ++all;
+        DetId id(hit.id());
+	HGCScintillatorDetId hid(id);
+	std::pair<int, int> typm = hgc.tileType(hid.layer(), hid.ring(), 0);
+	if (typm.first >= 0) {
+	  hid.setType(typm.first);
+	  hid.setSiPM(typm.second);
+	  id = static_cast<DetId>(hid);
+	}
+	bool toCheck(true);
+	if (!tiles_.empty()) {
+	  int indx = HGCalTileIndex::tileIndex(firstLayer + hid.layer(), hid.ring(), hid.iphi());
+	  if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
+	    toCheck = true;
+	}
+	if (toCheck) {
+	  ++good;
+	  GlobalPoint pos = geom->getPosition(id);
+	  bool valid1 = geom->topology().valid(id);
+	  bool valid2 = hgc.isValidTrap(hid.layer(), hid.ring(), hid.iphi());
+	  edm::LogVerbatim("HGCalSim") << "Hit[" << all <<  ":" << good << "]" << hid << " at (" << pos.x() << ", " << pos.y() << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2 << " Energy " << hit.energy() << " Time " << hit.time();
+	}
+      }
+    }
+  }
+  edm::LogVerbatim("HGCalSim") << "Total hits = " << all << ":" << nhits << " Good DetIds = " << good;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HGCalHitScint);

--- a/SimG4CMS/Calo/plugins/HGCalHitScint.cc
+++ b/SimG4CMS/Calo/plugins/HGCalHitScint.cc
@@ -107,26 +107,28 @@ void HGCalHitScint::analyze(const edm::Event& e, const edm::EventSetup& iS) {
       for (auto hit : hits) {
         ++all;
         DetId id(hit.id());
-	HGCScintillatorDetId hid(id);
-	std::pair<int, int> typm = hgc.tileType(hid.layer(), hid.ring(), 0);
-	if (typm.first >= 0) {
-	  hid.setType(typm.first);
-	  hid.setSiPM(typm.second);
-	  id = static_cast<DetId>(hid);
-	}
-	bool toCheck(true);
-	if (!tiles_.empty()) {
-	  int indx = HGCalTileIndex::tileIndex(firstLayer + hid.layer(), hid.ring(), hid.iphi());
-	  if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
-	    toCheck = true;
-	}
-	if (toCheck) {
-	  ++good;
-	  GlobalPoint pos = geom->getPosition(id);
-	  bool valid1 = geom->topology().valid(id);
-	  bool valid2 = hgc.isValidTrap(hid.layer(), hid.ring(), hid.iphi());
-	  edm::LogVerbatim("HGCalSim") << "Hit[" << all <<  ":" << good << "]" << hid << " at (" << pos.x() << ", " << pos.y() << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2 << " Energy " << hit.energy() << " Time " << hit.time();
-	}
+        HGCScintillatorDetId hid(id);
+        std::pair<int, int> typm = hgc.tileType(hid.layer(), hid.ring(), 0);
+        if (typm.first >= 0) {
+          hid.setType(typm.first);
+          hid.setSiPM(typm.second);
+          id = static_cast<DetId>(hid);
+        }
+        bool toCheck(true);
+        if (!tiles_.empty()) {
+          int indx = HGCalTileIndex::tileIndex(firstLayer + hid.layer(), hid.ring(), hid.iphi());
+          if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
+            toCheck = true;
+        }
+        if (toCheck) {
+          ++good;
+          GlobalPoint pos = geom->getPosition(id);
+          bool valid1 = geom->topology().valid(id);
+          bool valid2 = hgc.isValidTrap(hid.layer(), hid.ring(), hid.iphi());
+          edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << good << "]" << hid << " at (" << pos.x() << ", "
+                                       << pos.y() << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2
+                                       << " Energy " << hit.energy() << " Time " << hit.time();
+        }
       }
     }
   }

--- a/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
@@ -12,7 +12,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
@@ -21,16 +21,17 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include <fstream>
 #include <string>
 #include <vector>
 
-class HGCalHitScint : public edm::one::EDAnalyzer<> {
+class HGCalTestPartialWaferHits : public edm::one::EDAnalyzer<> {
 public:
-  HGCalHitScint(const edm::ParameterSet& ps);
-  ~HGCalHitScint() override = default;
+  HGCalTestPartialWaferHits(const edm::ParameterSet& ps);
+  ~HGCalTestPartialWaferHits() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
@@ -39,23 +40,23 @@ protected:
   void endJob() override {}
 
 private:
-  const std::string g4Label_, caloHitSource_, nameSense_, tileFileName_;
+  const std::string g4Label_, caloHitSource_, nameSense_, missingFile_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_calo_;
   const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
-  std::vector<int> tiles_;
+  std::vector<int> wafers_;
 };
 
-HGCalHitScint::HGCalHitScint(const edm::ParameterSet& ps)
+HGCalTestPartialWaferHits::HGCalTestPartialWaferHits(const edm::ParameterSet& ps)
     : g4Label_(ps.getParameter<std::string>("moduleLabel")),
       caloHitSource_(ps.getParameter<std::string>("caloHitSource")),
       nameSense_(ps.getParameter<std::string>("nameSense")),
-      tileFileName_(ps.getParameter<std::string>("tileFileName")),
+      missingFile_(ps.getParameter<std::string>("missingFile")),
       tok_calo_(consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, caloHitSource_))),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
   edm::LogVerbatim("HGCalSim") << "Test Hit ID using SimHits for " << nameSense_ << " with module Label: " << g4Label_
-                               << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
-  if (!tileFileName_.empty()) {
-    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + tileFileName_);
+                               << "   Hits: " << caloHitSource_ << " Missing Wafer file " << missingFile_;
+  if (!missingFile_.empty()) {
+    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + missingFile_);
     std::string fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
@@ -66,27 +67,27 @@ HGCalHitScint::HGCalHitScint(const edm::ParameterSet& ps)
         std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
         if (items.size() > 2) {
           int layer = std::atoi(items[0].c_str());
-          int ring = std::atoi(items[1].c_str());
-          int phi = std::atoi(items[2].c_str());
-          tiles_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, phi));
+          int waferU = std::atoi(items[1].c_str());
+          int waferV = std::atoi(items[2].c_str());
+          wafers_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
         }
       }
-      edm::LogVerbatim("HGCalSim") << "Reads in " << tiles_.size() << " tile information from " << fileName;
+      edm::LogVerbatim("HGCalSim") << "Reads in " << wafers_.size() << " wafer information from " << fileName;
       fInput.close();
     }
   }
 }
 
-void HGCalHitScint::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalTestPartialWaferHits::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("moduleLabel", "g4SimHits");
-  desc.add<std::string>("caloHitSource", "HGCHitsHEback");
-  desc.add<std::string>("nameSense", "HGCalHEScintillatorSensitive");
-  desc.add<std::string>("tileFileName", "");
-  descriptions.add("hgcalHitScintillator", desc);
+  desc.add<std::string>("caloHitSource", "HGCHitsEE");
+  desc.add<std::string>("nameSense", "HGCalEESensitive");
+  desc.add<std::string>("missingFile", "");
+  descriptions.add("hgcalHitPartialEE", desc);
 }
 
-void HGCalHitScint::analyze(const edm::Event& e, const edm::EventSetup& iS) {
+void HGCalTestPartialWaferHits::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   // get hcalGeometry
   const HGCalGeometry* geom = &iS.getData(geomToken_);
   const HGCalDDDConstants& hgc = geom->topology().dddConstants();
@@ -95,8 +96,8 @@ void HGCalHitScint::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   const edm::Handle<edm::PCaloHitContainer>& hitsCalo = e.getHandle(tok_calo_);
   bool getHits = (hitsCalo.isValid());
   uint32_t nhits = (getHits) ? hitsCalo->size() : 0;
-  uint32_t good(0), all(0);
-  edm::LogVerbatim("HGCalSim") << "HGCalHitScint: Input flags Hits " << getHits << " with " << nhits
+  uint32_t good(0), allSi(0), all(0);
+  edm::LogVerbatim("HGCalSim") << "HGCalTestPartialWaferHits: Input flags Hits " << getHits << " with " << nhits
                                << " hits first Layer " << firstLayer;
 
   if (getHits) {
@@ -107,33 +108,35 @@ void HGCalHitScint::analyze(const edm::Event& e, const edm::EventSetup& iS) {
       for (auto hit : hits) {
         ++all;
         DetId id(hit.id());
-        HGCScintillatorDetId hid(id);
-        std::pair<int, int> typm = hgc.tileType(hid.layer(), hid.ring(), 0);
-        if (typm.first >= 0) {
-          hid.setType(typm.first);
-          hid.setSiPM(typm.second);
-          id = static_cast<DetId>(hid);
-        }
-        bool toCheck(true);
-        if (!tiles_.empty()) {
-          int indx = HGCalTileIndex::tileIndex(firstLayer + hid.layer(), hid.ring(), hid.iphi());
-          if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
-            toCheck = true;
-        }
-        if (toCheck) {
-          ++good;
-          GlobalPoint pos = geom->getPosition(id);
-          bool valid1 = geom->topology().valid(id);
-          bool valid2 = hgc.isValidTrap(hid.layer(), hid.ring(), hid.iphi());
-          edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << good << "]" << hid << " at (" << pos.x() << ", "
-                                       << pos.y() << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2
-                                       << " Energy " << hit.energy() << " Time " << hit.time();
+        if ((id.det() == DetId::HGCalEE) || (id.det() == DetId::HGCalHSi)) {
+          ++allSi;
+          HGCSiliconDetId hid(id);
+          const auto& info = hgc.waferInfo(hid.layer(), hid.waferU(), hid.waferV());
+          bool toCheck(false);
+          if (!wafers_.empty()) {
+            int indx = HGCalWaferIndex::waferIndex(firstLayer + hid.layer(), hid.waferU(), hid.waferV(), false);
+            if (std::find(wafers_.begin(), wafers_.end(), indx) != wafers_.end())
+              toCheck = true;
+          } else {
+            // Only partial wafers
+            toCheck = (info.part != HGCalTypes::WaferFull);
+          }
+          if (toCheck) {
+            ++good;
+            GlobalPoint pos = geom->getPosition(id);
+            bool valid1 = geom->topology().valid(id);
+            bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV());
+            edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << allSi << ":" << good << "]" << HGCSiliconDetId(id)
+                                         << " Wafer Type:Part:Orient:Cassette " << info.type << ":" << info.part << ":"
+                                         << info.orient << ":" << info.cassette << " at (" << pos.x() << ", " << pos.y()
+                                         << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2;
+          }
         }
       }
     }
   }
-  edm::LogVerbatim("HGCalSim") << "Total hits = " << all << ":" << nhits << " Good DetIds = " << good;
+  edm::LogVerbatim("HGCalSim") << "Total hits = " << all << ":" << nhits << " Good DetIds = " << allSi << ":" << good;
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(HGCalHitScint);
+DEFINE_FWK_MODULE(HGCalTestPartialWaferHits);

--- a/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestScintHits.cc
@@ -12,7 +12,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
@@ -21,17 +21,16 @@
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
-#include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include <fstream>
 #include <string>
 #include <vector>
 
-class HGCalHitPartial : public edm::one::EDAnalyzer<> {
+class HGCalTestScintHits : public edm::one::EDAnalyzer<> {
 public:
-  HGCalHitPartial(const edm::ParameterSet& ps);
-  ~HGCalHitPartial() override = default;
+  HGCalTestScintHits(const edm::ParameterSet& ps);
+  ~HGCalTestScintHits() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
@@ -40,23 +39,23 @@ protected:
   void endJob() override {}
 
 private:
-  const std::string g4Label_, caloHitSource_, nameSense_, missingFile_;
+  const std::string g4Label_, caloHitSource_, nameSense_, tileFileName_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_calo_;
   const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
-  std::vector<int> wafers_;
+  std::vector<int> tiles_;
 };
 
-HGCalHitPartial::HGCalHitPartial(const edm::ParameterSet& ps)
+HGCalTestScintHits::HGCalTestScintHits(const edm::ParameterSet& ps)
     : g4Label_(ps.getParameter<std::string>("moduleLabel")),
       caloHitSource_(ps.getParameter<std::string>("caloHitSource")),
       nameSense_(ps.getParameter<std::string>("nameSense")),
-      missingFile_(ps.getParameter<std::string>("missingFile")),
+      tileFileName_(ps.getParameter<std::string>("tileFileName")),
       tok_calo_(consumes<edm::PCaloHitContainer>(edm::InputTag(g4Label_, caloHitSource_))),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
   edm::LogVerbatim("HGCalSim") << "Test Hit ID using SimHits for " << nameSense_ << " with module Label: " << g4Label_
-                               << "   Hits: " << caloHitSource_ << " Missing Wafer file " << missingFile_;
-  if (!missingFile_.empty()) {
-    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + missingFile_);
+                               << "   Hits: " << caloHitSource_ << " Tile file " << tileFileName_;
+  if (!tileFileName_.empty()) {
+    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + tileFileName_);
     std::string fileName = filetmp.fullPath();
     std::ifstream fInput(fileName.c_str());
     if (!fInput.good()) {
@@ -67,27 +66,27 @@ HGCalHitPartial::HGCalHitPartial(const edm::ParameterSet& ps)
         std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
         if (items.size() > 2) {
           int layer = std::atoi(items[0].c_str());
-          int waferU = std::atoi(items[1].c_str());
-          int waferV = std::atoi(items[2].c_str());
-          wafers_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
+          int ring = std::atoi(items[1].c_str());
+          int phi = std::atoi(items[2].c_str());
+          tiles_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, phi));
         }
       }
-      edm::LogVerbatim("HGCalSim") << "Reads in " << wafers_.size() << " wafer information from " << fileName;
+      edm::LogVerbatim("HGCalSim") << "Reads in " << tiles_.size() << " tile information from " << fileName;
       fInput.close();
     }
   }
 }
 
-void HGCalHitPartial::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HGCalTestScintHits::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("moduleLabel", "g4SimHits");
-  desc.add<std::string>("caloHitSource", "HGCHitsEE");
-  desc.add<std::string>("nameSense", "HGCalEESensitive");
-  desc.add<std::string>("missingFile", "");
-  descriptions.add("hgcalHitPartialEE", desc);
+  desc.add<std::string>("caloHitSource", "HGCHitsHEback");
+  desc.add<std::string>("nameSense", "HGCalHEScintillatorSensitive");
+  desc.add<std::string>("tileFileName", "");
+  descriptions.add("hgcalHitScintillator", desc);
 }
 
-void HGCalHitPartial::analyze(const edm::Event& e, const edm::EventSetup& iS) {
+void HGCalTestScintHits::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   // get hcalGeometry
   const HGCalGeometry* geom = &iS.getData(geomToken_);
   const HGCalDDDConstants& hgc = geom->topology().dddConstants();
@@ -96,8 +95,8 @@ void HGCalHitPartial::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   const edm::Handle<edm::PCaloHitContainer>& hitsCalo = e.getHandle(tok_calo_);
   bool getHits = (hitsCalo.isValid());
   uint32_t nhits = (getHits) ? hitsCalo->size() : 0;
-  uint32_t good(0), allSi(0), all(0);
-  edm::LogVerbatim("HGCalSim") << "HGCalHitPartial: Input flags Hits " << getHits << " with " << nhits
+  uint32_t good(0), all(0);
+  edm::LogVerbatim("HGCalSim") << "HGCalTestScintHits: Input flags Hits " << getHits << " with " << nhits
                                << " hits first Layer " << firstLayer;
 
   if (getHits) {
@@ -108,35 +107,33 @@ void HGCalHitPartial::analyze(const edm::Event& e, const edm::EventSetup& iS) {
       for (auto hit : hits) {
         ++all;
         DetId id(hit.id());
-        if ((id.det() == DetId::HGCalEE) || (id.det() == DetId::HGCalHSi)) {
-          ++allSi;
-          HGCSiliconDetId hid(id);
-          const auto& info = hgc.waferInfo(hid.layer(), hid.waferU(), hid.waferV());
-          bool toCheck(false);
-          if (!wafers_.empty()) {
-            int indx = HGCalWaferIndex::waferIndex(firstLayer + hid.layer(), hid.waferU(), hid.waferV(), false);
-            if (std::find(wafers_.begin(), wafers_.end(), indx) != wafers_.end())
-              toCheck = true;
-          } else {
-            // Only partial wafers
-            toCheck = (info.part != HGCalTypes::WaferFull);
-          }
-          if (toCheck) {
-            ++good;
-            GlobalPoint pos = geom->getPosition(id);
-            bool valid1 = geom->topology().valid(id);
-            bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV());
-            edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << allSi << ":" << good << "]" << HGCSiliconDetId(id)
-                                         << " Wafer Type:Part:Orient:Cassette " << info.type << ":" << info.part << ":"
-                                         << info.orient << ":" << info.cassette << " at (" << pos.x() << ", " << pos.y()
-                                         << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2;
-          }
+        HGCScintillatorDetId hid(id);
+        std::pair<int, int> typm = hgc.tileType(hid.layer(), hid.ring(), 0);
+        if (typm.first >= 0) {
+          hid.setType(typm.first);
+          hid.setSiPM(typm.second);
+          id = static_cast<DetId>(hid);
+        }
+        bool toCheck(true);
+        if (!tiles_.empty()) {
+          int indx = HGCalTileIndex::tileIndex(firstLayer + hid.layer(), hid.ring(), hid.iphi());
+          if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
+            toCheck = true;
+        }
+        if (toCheck) {
+          ++good;
+          GlobalPoint pos = geom->getPosition(id);
+          bool valid1 = geom->topology().valid(id);
+          bool valid2 = hgc.isValidTrap(hid.layer(), hid.ring(), hid.iphi());
+          edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << good << "]" << hid << " at (" << pos.x() << ", "
+                                       << pos.y() << ", " << pos.z() << ") Validity " << valid1 << ":" << valid2
+                                       << " Energy " << hit.energy() << " Time " << hit.time();
         }
       }
     }
   }
-  edm::LogVerbatim("HGCalSim") << "Total hits = " << all << ":" << nhits << " Good DetIds = " << allSi << ":" << good;
+  edm::LogVerbatim("HGCalSim") << "Total hits = " << all << ":" << nhits << " Good DetIds = " << good;
 }
 
 //define this as a plug-in
-DEFINE_FWK_MODULE(HGCalHitPartial);
+DEFINE_FWK_MODULE(HGCalTestScintHits);

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -203,7 +203,9 @@ uint32_t HGCScintSD::setDetUnitId(const G4Step* aStep) {
       debug = true;
   }
   if (debug)
-    edm::LogVerbatim("HGCSim") << "Layer:module:cell:iz " << layer << ":" << module << ":" << cell << ":" << iz << "  Point (" << hitPoint.x() << ", " << hitPoint.y() << ", " << hitPoint.z() << ") " << HGCScintillatorDetId(id);
+    edm::LogVerbatim("HGCSim") << "Layer:module:cell:iz " << layer << ":" << module << ":" << cell << ":" << iz
+                               << "  Point (" << hitPoint.x() << ", " << hitPoint.y() << ", " << hitPoint.z() << ") "
+                               << HGCScintillatorDetId(id);
 
   if (!isItinFidVolume(hitPoint)) {
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/Calo/src/HGCScintSD.cc
+++ b/SimG4CMS/Calo/src/HGCScintSD.cc
@@ -7,8 +7,10 @@
 #include "DataFormats/Math/interface/FastMath.h"
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "SimG4CMS/Calo/interface/HGCScintSD.h"
+#include "SimG4CMS/Calo/interface/CaloSimUtils.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimDataFormats/CaloTest/interface/HGCalTestNumbering.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
@@ -41,7 +43,8 @@ HGCScintSD::HGCScintSD(const std::string& name,
       hgcons_(hgc),
       slopeMin_(0),
       levelT1_(99),
-      levelT2_(99) {
+      levelT2_(99),
+      firstLayer_(0) {
   numberingScheme_.reset(nullptr);
 
   edm::ParameterSet m_HGC = p.getParameter<edm::ParameterSet>("HGCScintSD");
@@ -53,6 +56,7 @@ HGCScintSD::HGCScintSD(const std::string& name,
   birk2_ = m_HGC.getParameter<double>("BirkC2");
   birk3_ = m_HGC.getParameter<double>("BirkC3");
   storeAllG4Hits_ = m_HGC.getParameter<bool>("StoreAllG4Hits");
+  fileName_ = m_HGC.getUntrackedParameter<std::string>("TileFileName");
 
   if (storeAllG4Hits_) {
     setUseMap(false);
@@ -79,12 +83,34 @@ HGCScintSD::HGCScintSD(const std::string& name,
                              << "**************************************************";
 #endif
   edm::LogVerbatim("HGCSim") << "HGCScintSD:: Threshold for storing hits: " << eminHit_ << " for " << nameX_
-                             << " detector " << mydet_;
+                             << " detector " << mydet_ << " File " << fileName_;
   edm::LogVerbatim("HGCSim") << "Flag for storing individual Geant4 Hits " << storeAllG4Hits_;
   edm::LogVerbatim("HGCSim") << "Fiducial volume cut with cut from eta/phi "
                              << "boundary " << fiducialCut_ << " at " << distanceFromEdge_;
   edm::LogVerbatim("HGCSim") << "Use of Birks law is set to      " << useBirk_
                              << "  with three constants kB = " << birk1_ << ", C1 = " << birk2_ << ", C2 = " << birk3_;
+
+  if (!fileName_.empty()) {
+    edm::FileInPath filetmp("SimG4CMS/Calo/data/" + fileName_);
+    std::string fileName = filetmp.fullPath();
+    std::ifstream fInput(fileName.c_str());
+    if (!fInput.good()) {
+      edm::LogVerbatim("HGCSim") << "Cannot open file " << fileName;
+    } else {
+      char buffer[80];
+      while (fInput.getline(buffer, 80)) {
+        std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
+        if (items.size() > 2) {
+          int layer = std::atoi(items[0].c_str());
+          int ring = std::atoi(items[1].c_str());
+          int phi = std::atoi(items[2].c_str());
+          tiles_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, phi));
+        }
+      }
+      edm::LogVerbatim("HGCSim") << "Reads in " << tiles_.size() << " tile information from " << fileName_;
+      fInput.close();
+    }
+  }
 }
 
 double HGCScintSD::getEnergyDeposit(const G4Step* aStep) {
@@ -169,6 +195,16 @@ uint32_t HGCScintSD::setDetUnitId(const G4Step* aStep) {
     return 0;
 
   uint32_t id = setDetUnitId(layer, module, cell, iz, hitPoint);
+  bool debug(false);
+  if (!tiles_.empty()) {
+    HGCScintillatorDetId hid(id);
+    int indx = HGCalTileIndex::tileIndex(firstLayer_ + hid.layer(), hid.ring(), hid.iphi());
+    if (std::find(tiles_.begin(), tiles_.end(), indx) != tiles_.end())
+      debug = true;
+  }
+  if (debug)
+    edm::LogVerbatim("HGCSim") << "Layer:module:cell:iz " << layer << ":" << module << ":" << cell << ":" << iz << "  Point (" << hitPoint.x() << ", " << hitPoint.y() << ", " << hitPoint.z() << ") " << HGCScintillatorDetId(id);
+
   if (!isItinFidVolume(hitPoint)) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCSim") << "ID " << std::hex << id << std::dec << " " << HGCScintillatorDetId(id)
@@ -185,12 +221,13 @@ void HGCScintSD::update(const BeginOfJob* job) {
     slopeMin_ = hgcons_->minSlope();
     levelT1_ = hgcons_->levelTop(0);
     levelT2_ = hgcons_->levelTop(1);
+    firstLayer_ = hgcons_->firstLayer() - 1;
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCSim") << "HGCScintSD::Initialized with mode " << geom_mode_ << " Slope cut " << slopeMin_
-                               << " top Level " << levelT1_ << ":" << levelT2_;
+                               << " top Level " << levelT1_ << ":" << levelT2_ << " FirstLayer " << firstLayer_;
 #endif
 
-    numberingScheme_ = std::make_unique<HGCalNumberingScheme>(*hgcons_, mydet_, nameX_, "");
+    numberingScheme_ = std::make_unique<HGCalNumberingScheme>(*hgcons_, mydet_, nameX_, fileName_);
   } else {
     throw cms::Exception("Unknown", "HGCScintSD") << "Cannot find HGCalDDDConstants for " << nameX_ << "\n";
   }

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -40,14 +40,21 @@ HGCalNumberingScheme::HGCalNumberingScheme(const HGCalDDDConstants& hgc,
       char buffer[80];
       while (fInput.getline(buffer, 80)) {
         std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
-        if (items.size() > 2) {
-          int layer = std::atoi(items[0].c_str());
-          int waferU = std::atoi(items[1].c_str());
-          int waferV = std::atoi(items[2].c_str());
-          wafers_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
-        }
+	if (items.size() > 2) {
+	  if (hgcons_.waferHexagon8File()) {
+	    int layer = std::atoi(items[0].c_str());
+	    int waferU = std::atoi(items[1].c_str());
+	    int waferV = std::atoi(items[2].c_str());
+	    indices_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
+	  } else if (hgcons_.tileTrapezoid()) {
+	    int layer = std::atoi(items[0].c_str());
+	    int ring = std::atoi(items[1].c_str());
+	    int iphi = std::atoi(items[2].c_str());
+	    indices_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, iphi));
+	  }
+	}
       }
-      edm::LogVerbatim("HGCalSim") << "Reads in " << wafers_.size() << " wafer information from " << filetmp2;
+      edm::LogVerbatim("HGCalSim") << "Reads in " << indices_.size() << " component information from " << filetmp2;
       fInput.close();
     }
   }
@@ -78,9 +85,9 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
     } else if (mode_ != HGCalGeometryMode::Hexagon8) {
       double xx = (pos.z() > 0) ? pos.x() : -pos.x();
       bool debug(false);
-      if (!wafers_.empty()) {
+      if (!indices_.empty()) {
         int indx = HGCalWaferIndex::waferIndex(firstLayer_ + layer, waferU, waferV, false);
-        if (std::find(wafers_.begin(), wafers_.end(), indx) != wafers_.end())
+        if (std::find(indices_.begin(), indices_.end(), indx) != indices_.end())
           debug = true;
       }
       hgcons_.waferFromPosition(xx, pos.y(), layer, waferU, waferV, cellU, cellV, waferType, wt, false, debug);
@@ -118,11 +125,18 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
         detId.setSiPM(typm.second);
       }
       index = detId.rawId();
-#ifdef EDM_ML_DEBUG
       int lay = layer + hgcons_.getLayerOffset();
-      edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << ":" << typm.first
-                                 << " SiPM " << typm.second << ":" << hgcons_.tileSiPM(typm.second) << " Layer "
-                                 << layer << ":" << lay << " z " << iz << " " << detId;
+      bool debug(false);
+      if (!indices_.empty()) {
+        int indx = HGCalWaferIndex::waferIndex(lay, id[0], id[1], false);
+        if (std::find(indices_.begin(), indices_.end(), indx) != indices_.end())
+          debug = true;
+      }
+      if (debug)
+	edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << ":" << typm.first
+				   << " SiPM " << typm.second << ":" << hgcons_.tileSiPM(typm.second) << " Layer "
+				   << layer << ":" << lay << " z " << iz << " " << detId << " wt " << wt;
+#ifdef EDM_ML_DEBUG
     } else {
       edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << " Layer|iz " << layer
                                  << ":" << iz << " ERROR";

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -40,19 +40,19 @@ HGCalNumberingScheme::HGCalNumberingScheme(const HGCalDDDConstants& hgc,
       char buffer[80];
       while (fInput.getline(buffer, 80)) {
         std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
-	if (items.size() > 2) {
-	  if (hgcons_.waferHexagon8File()) {
-	    int layer = std::atoi(items[0].c_str());
-	    int waferU = std::atoi(items[1].c_str());
-	    int waferV = std::atoi(items[2].c_str());
-	    indices_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
-	  } else if (hgcons_.tileTrapezoid()) {
-	    int layer = std::atoi(items[0].c_str());
-	    int ring = std::atoi(items[1].c_str());
-	    int iphi = std::atoi(items[2].c_str());
-	    indices_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, iphi));
-	  }
-	}
+        if (items.size() > 2) {
+          if (hgcons_.waferHexagon8File()) {
+            int layer = std::atoi(items[0].c_str());
+            int waferU = std::atoi(items[1].c_str());
+            int waferV = std::atoi(items[2].c_str());
+            indices_.emplace_back(HGCalWaferIndex::waferIndex(layer, waferU, waferV, false));
+          } else if (hgcons_.tileTrapezoid()) {
+            int layer = std::atoi(items[0].c_str());
+            int ring = std::atoi(items[1].c_str());
+            int iphi = std::atoi(items[2].c_str());
+            indices_.emplace_back(HGCalTileIndex::tileIndex(layer, ring, iphi));
+          }
+        }
       }
       edm::LogVerbatim("HGCalSim") << "Reads in " << indices_.size() << " component information from " << filetmp2;
       fInput.close();
@@ -133,9 +133,9 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
           debug = true;
       }
       if (debug)
-	edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << ":" << typm.first
-				   << " SiPM " << typm.second << ":" << hgcons_.tileSiPM(typm.second) << " Layer "
-				   << layer << ":" << lay << " z " << iz << " " << detId << " wt " << wt;
+        edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << ":" << typm.first
+                                   << " SiPM " << typm.second << ":" << hgcons_.tileSiPM(typm.second) << " Layer "
+                                   << layer << ":" << lay << " z " << iz << " " << detId << " wt " << wt;
 #ifdef EDM_ML_DEBUG
     } else {
       edm::LogVerbatim("HGCSim") << "Radius/Phi " << id[0] << ":" << id[1] << " Type " << id[2] << " Layer|iz " << layer

--- a/SimG4CMS/Calo/test/python/runHGC8_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC8_cfg.py
@@ -1,0 +1,77 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+
+process = cms.Process("PROD",Phase2C11)
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
+process.load("Configuration.Geometry.GeometryExtended2026D88Reco_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.EventContent.EventContent_cff")
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('SimG4CMS.Calo.hgcalHitScintillator_cfi')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCalSim=dict()
+    process.MessageLogger.HGCSim=dict()
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
+
+process.Timing = cms.Service("Timing")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.source = cms.Source("EmptySource",
+    firstRun        = cms.untracked.uint32(1),
+    firstEvent      = cms.untracked.uint32(1)
+)
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(211),
+        MinEta = cms.double(1.50),
+        MaxEta = cms.double(2.20),
+        MinPhi = cms.double(-3.1415926),
+        MaxPhi = cms.double(-1.5707963),
+        MinE   = cms.double(100.00),
+        MaxE   = cms.double(100.00)
+    ),
+    Verbosity       = cms.untracked.int32(0),
+    AddAntiParticle = cms.bool(True)
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    process.FEVTSIMEventContent,
+    fileName = cms.untracked.string('hgcV16.root')
+)
+
+#process.hgcalHitScintillator.tileFileName = "scintillatorTiles.txt"
+#process.g4SimHits.HGCScintSD.TileFileName = "scintillatorTiles.txt"
+
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.analysis_step = cms.Path(process.hgcalHitScintillator)
+process.out_step = cms.EndPath(process.output)
+
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/FTFP_BERT_EMM'
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,
+                                process.simulation_step,
+                                process.analysis_step,
+                                process.out_step
+                                )
+
+# filter all path with the production filter sequence
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -527,6 +527,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         FiducialCut      = cms.bool(False),
         DistanceFromEdge = cms.double(1.0),
         StoreAllG4Hits   = cms.bool(False),
+        TileFileName     = cms.untracked.string("")
     ),
     HFNoseSD = cms.PSet(
         Verbosity        = cms.untracked.int32(0),


### PR DESCRIPTION
#### PR description:

Make some fixes to the issues in storing hits for the scintillator part of HGCal. 

In the process of debugging the SimHits for scintillators, several hit id's were found to be declared to be invalid. This was traced down to wrong assignment of the ID's from position. Most likely while introducing the cassette concept, the conversion between SIM/RECO unit was disturbed. That led to wrong assignment of DetId's. This is cured by this PR. In the process, possible shifts due to cassette positioning etc are rightly handled now. Most of the codes are used for debugging while a very small fraction is used in the fix.

Since it is a bug fix the comparison plots for many phase2 scenarios will look different

#### PR validation:

Use several phase2 runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Should be backported to 12_4_X if any MC production for Phase2 scenario will be done using that