### PR TITLE
Fix OOT plot in PPS Diamond DQM

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -921,7 +921,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         }
       }
 
-      if (rechit.toT() != 0) {
+      if (rechit.toT() > 0) {
         // Both
         potPlots_[detId_pot].leadingEdgeCumulative_both->Fill(rechit.time() + 25 * rechit.ootIndex());
         potPlots_[detId_pot].timeOverThresholdCumulativePot->Fill(rechit.toT());
@@ -931,7 +931,7 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         int startBin = hitHistoOOTTmpYAxis->FindBin(rechit.x() - x_shift.global - 0.5 * rechit.xWidth());
         int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
         for (int i = 0; i < numOfBins; ++i)
-          hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
+          hitHistoOOTTmp->Fill(detId.plane() + 1. / windowsNum_ * rechit.ootIndex(),
                                hitHistoOOTTmpYAxis->GetBinCenter(startBin + i));
 
       } else if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING && plotOnline_) {
@@ -940,10 +940,9 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
         TAxis* hitHistoOOTTmpYAxis = hitHistoOOTTmp->GetYaxis();
         int startBin = hitHistoOOTTmpYAxis->FindBin(rechit.x() - x_shift.global - 0.5 * rechit.xWidth());
         int numOfBins = rechit.xWidth() * INV_DISPLAY_RESOLUTION_FOR_HITS_MM;
-        for (int i = 0; i < numOfBins; ++i) {
-          hitHistoOOTTmp->Fill(detId.plane() + 0.25 * rechit.ootIndex(),
+        for (int i = 0; i < numOfBins; ++i)
+          hitHistoOOTTmp->Fill(detId.plane() + 1. / windowsNum_ * rechit.ootIndex(),
                                hitHistoOOTTmpYAxis->GetBinCenter(startBin + i));
-        }
       }
       if (rechit.ootIndex() != CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING &&
           potPlots_[detId_pot].activity_per_bx.count(rechit.ootIndex()) > 0)


### PR DESCRIPTION
#### PR description:

This PR aims to fix the incorrect filling of the OOT histogram in the PPS Diamond DQM. It is correcting two issues:

- by default no_TOT = -1 so it should be filtered out by condition TOT!=-1 or, as recommended by expert, TOT>0
- x coordinate has to take into account number of windows, the shift was hardcoded to 0.25 which is only correct for windowsNum=4

#### PR validation:

standard tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport to 12_4_X will follow
