### PR TITLE
[LTO] Fix ODR warnings for L1Trigger/RPCTrigger

### DIFF
--- a/L1Trigger/RPCTrigger/src/MuonsGrabber.cc
+++ b/L1Trigger/RPCTrigger/src/MuonsGrabber.cc
@@ -23,11 +23,11 @@
 
 XERCES_CPP_NAMESPACE_USE
 
-class XStr {
+class XStrPrivate {
 public:
-  XStr(const char* const toTranscode) { fUnicodeForm = XMLString::transcode(toTranscode); }
+  XStrPrivate(const char* const toTranscode) { fUnicodeForm = XMLString::transcode(toTranscode); }
 
-  ~XStr() { XMLString::release(&fUnicodeForm); }
+  ~XStrPrivate() { XMLString::release(&fUnicodeForm); }
 
   const XMLCh* unicodeForm() const { return fUnicodeForm; }
 
@@ -35,7 +35,7 @@ private:
   XMLCh* fUnicodeForm;
 };
 
-#define X(str) XStr(str).unicodeForm()
+#define X(str) XStrPrivate(str).unicodeForm()
 
 //
 // constants, enums and typedefs


### PR DESCRIPTION
LTO build complains that `class XStr` is defined multiple time in the package

- https://github.com/cms-sw/cmssw/blob/master/L1Trigger/RPCTrigger/src/RPCPatternsParser.cc#L66-L91
- https://github.com/cms-sw/cmssw/blob/master/L1Trigger/RPCTrigger/src/MuonsGrabber.cc#L26-L36

This PR proposes to change the name of one of these.