### PR TITLE
[LTO] Fix ODR warning for DQM/HLTEvF

### DIFF
--- a/DQM/HLTEvF/plugins/PSMonitorClient.cc
+++ b/DQM/HLTEvF/plugins/PSMonitorClient.cc
@@ -20,7 +20,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
-struct MEPSet {
+struct MEPSetData {
   std::string name;
   std::string folder;
 };
@@ -34,7 +34,7 @@ public:
   static void fillMePSetDescription(edm::ParameterSetDescription &pset);
 
 private:
-  static MEPSet getHistoPSet(edm::ParameterSet pset);
+  static MEPSetData getHistoPSet(edm::ParameterSet pset);
 
   std::string m_dqm_path;
 
@@ -46,15 +46,15 @@ private:
 
   void check(DQMStore::IBooker &booker, DQMStore::IGetter &getter);
 
-  MEPSet psColumnVSlumiPSet;
+  MEPSetData psColumnVSlumiPSet;
 };
 
 PSMonitorClient::PSMonitorClient(edm::ParameterSet const &config)
     : m_dqm_path(config.getUntrackedParameter<std::string>("dqmPath")),
       psColumnVSlumiPSet(getHistoPSet(config.getParameter<edm::ParameterSet>("me"))) {}
 
-MEPSet PSMonitorClient::getHistoPSet(edm::ParameterSet pset) {
-  return MEPSet{
+MEPSetData PSMonitorClient::getHistoPSet(edm::ParameterSet pset) {
+  return MEPSetData{
       pset.getParameter<std::string>("name"),
       pset.getParameter<std::string>("folder"),
   };


### PR DESCRIPTION
LTO build complains that `struct MEPSet` is defined multiple time in the package

- https://github.com/cms-sw/cmssw/blob/master/DQM/HLTEvF/plugins/DQMCorrelationClient.h#L17-L21
- https://github.com/cms-sw/cmssw/blob/master/DQM/HLTEvF/plugins/PSMonitorClient.cc#L23-L26

This PR proposes to change the name of one in the `PSMonitorClient.cc`