### PR TITLE
Fixed initialisation of diamond sensitive detector

### DIFF
--- a/SimG4CMS/PPS/src/PPSDiamondSD.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondSD.cc
@@ -44,9 +44,9 @@ PPSDiamondSD::PPSDiamondSD(const std::string& pname,
 
   slave_ = std::make_unique<TrackingSlaveSD>(pname);
 
-  if (pname == "CTPPSDiamandHits") {
+  if (pname == "CTPPSTimingHits") {
     numberingScheme_ = std::make_unique<PPSDiamondOrganization>();
-    edm::LogVerbatim("PPSSimDiamond") << "Find CTPPSDiamondHits as name";
+    edm::LogVerbatim("PPSSimDiamond") << "Find CTPPSTimingHits as name";
   } else {
     edm::LogError("PPSSimDiamond") << "PPSDiamondSD: ReadoutName " << pname << " not supported";
   }


### PR DESCRIPTION
#### PR description:
This PR fixes issue #38114 - warning at initialisation of numbering scheme for PPS diamond sensitive detector.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: may be backported to 12_4_X
