### PR TITLE
[nT2] storing digis collection as edmNew::DetSetVector

### DIFF
--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -2,11 +2,11 @@
   <class name="TotemT2Digi" ClassVersion="3">
     <version ClassVersion="3" checksum="4024006040"/>
   </class>
-  <class name="edm::DetSet<TotemT2Digi>"/>
-  <class name="edm::DetSetVector<TotemT2Digi>"/>
-  <class name="edm::Wrapper<edm::DetSetVector<TotemT2Digi> >"/>
+  <class name="edmNew::DetSet<TotemT2Digi>"/>
+  <class name="edmNew::DetSetVector<TotemT2Digi>"/>
+  <class name="edm::Wrapper<edmNew::DetSetVector<TotemT2Digi> >"/>
   <class name="std::vector<TotemT2Digi>"/>
-  <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
+  <class name="std::vector<edmNew::DetSet<TotemT2Digi> >"/>
   <class name="TotemT2RecHit" ClassVersion="3">
     <version ClassVersion="3" checksum="969691996"/>
   </class>

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -13,6 +13,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h"
 
@@ -55,7 +56,7 @@ public:
   void run(const VFATFrameCollection &coll,
            const TotemDAQMapping &mapping,
            const TotemAnalysisMask &mask,
-           edm::DetSetVector<TotemT2Digi> &digi,
+           edmNew::DetSetVector<TotemT2Digi> &digi,
            edm::DetSetVector<TotemVFATStatus> &status);
 
   /// Print error summaries.

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -20,8 +20,6 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-
 #include "DataFormats/CTPPSDigi/interface/TotemRPDigi.h"
 #include "DataFormats/CTPPSDigi/interface/TotemVFATStatus.h"
 #include "DataFormats/CTPPSDigi/interface/TotemFEDInfo.h"
@@ -104,7 +102,7 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
     produces<DetSetVector<TotemTimingDigi>>(subSystemName);
 
   else if (subSystem == ssTotemT2)
-    produces<DetSetVector<TotemT2Digi>>(subSystemName);
+    produces<edmNew::DetSetVector<TotemT2Digi>>(subSystemName);
 
   // set default IDs
   if (fedIds.empty()) {
@@ -153,7 +151,7 @@ void TotemVFATRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
     run<DetSetVector<TotemTimingDigi>>(event, es);
 
   else if (subSystem == ssTotemT2)
-    run<DetSetVector<TotemT2Digi>>(event, es);
+    run<edmNew::DetSetVector<TotemT2Digi>>(event, es);
 }
 
 template <typename DigiType>

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -382,7 +382,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
 void RawToDigiConverter::run(const VFATFrameCollection &coll,
                              const TotemDAQMapping &mapping,
                              const TotemAnalysisMask &mask,
-                             edm::DetSetVector<TotemT2Digi> &digi,
+                             edmNew::DetSetVector<TotemT2Digi> &digi,
                              edm::DetSetVector<TotemVFATStatus> &status) {
   // structure merging vfat frame data with the mapping
   map<TotemFramePosition, Record> records;
@@ -402,12 +402,12 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
       record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
-      DetSet<TotemT2Digi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.emplace_back(totem::nt2::vfat::geoId(*record.frame),
-                              totem::nt2::vfat::channelId(*record.frame),
-                              totem::nt2::vfat::channelMarker(*record.frame),
-                              totem::nt2::vfat::leadingEdgeTime(*record.frame),
-                              totem::nt2::vfat::trailingEdgeTime(*record.frame));
+      edmNew::DetSetVector<TotemT2Digi>::FastFiller(digi, detId)
+          .emplace_back(totem::nt2::vfat::geoId(*record.frame),
+                        totem::nt2::vfat::channelId(*record.frame),
+                        totem::nt2::vfat::channelMarker(*record.frame),
+                        totem::nt2::vfat::leadingEdgeTime(*record.frame),
+                        totem::nt2::vfat::trailingEdgeTime(*record.frame));
     }
 
     // save status

--- a/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h
@@ -11,7 +11,6 @@
 
 #include "RecoPPS/Local/interface/TimingRecHitProducerAlgorithm.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 #include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
@@ -19,12 +18,12 @@
 #include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
 
 class TotemT2RecHitProducerAlgorithm : public TimingRecHitProducerAlgorithm<TotemGeometry,
-                                                                            edm::DetSetVector<TotemT2Digi>,
+                                                                            edmNew::DetSetVector<TotemT2Digi>,
                                                                             edmNew::DetSetVector<TotemT2RecHit> > {
 public:
   using TimingRecHitProducerAlgorithm::TimingRecHitProducerAlgorithm;
   void build(const TotemGeometry&,
-             const edm::DetSetVector<TotemT2Digi>&,
+             const edmNew::DetSetVector<TotemT2Digi>&,
              edmNew::DetSetVector<TotemT2RecHit>&) override;
 };
 

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -18,7 +18,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
@@ -42,7 +41,7 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  edm::EDGetTokenT<edm::DetSetVector<TotemT2Digi> > digiToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TotemT2Digi> > digiToken_;
   edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> timingCalibrationToken_;
   edm::ESGetToken<PPSTimingCalibrationLUT, PPSTimingCalibrationLUTRcd> timingCalibrationLUTToken_;
   edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
@@ -54,7 +53,7 @@ private:
 };
 
 TotemT2RecHitProducer::TotemT2RecHitProducer(const edm::ParameterSet& iConfig)
-    : digiToken_(consumes<edm::DetSetVector<TotemT2Digi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
+    : digiToken_(consumes<edmNew::DetSetVector<TotemT2Digi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
       geometryToken_(esConsumes<TotemGeometry, TotemGeometryRcd>()),
       applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
       algo_(iConfig) {

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
 
 void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
-                                           const edm::DetSetVector<TotemT2Digi>& input,
+                                           const edmNew::DetSetVector<TotemT2Digi>& input,
                                            edmNew::DetSetVector<TotemT2RecHit>& output) {
   for (const auto& vec : input) {
     const TotemT2DetId detid(vec.detId());


### PR DESCRIPTION
#### PR description:

As discussed in https://github.com/cms-sw/cmssw/pull/38986#discussion_r940257317 the usage of `edm::DetSetVector<T>` tends to be deprecated in favour of `edmNew::DetSetVector<T>`. This PR allows to store TOTEM's T2 digis as the latter, to make it compatible with the rechits storage. As no dataset has been produced with the earlier data format, no conversion rule is required.

#### PR validation:

Code compiles, and runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: N/A