### PR TITLE
fix for process-name check in `TriggerSummaryProducerAOD`

### DIFF
--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -262,8 +262,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
   /// Record the InputTags of those L3 filters and L3 collections
   std::vector<bool> maskFilters;
   maskFilters.resize(nfob);
-  InputTagSet filterTagsEvent(pn_ != "*");
-  InputTagSet collectionTagsEvent(pn_ != "*");
+  InputTagSet filterTagsEvent(pn_ == "*");
+  InputTagSet collectionTagsEvent(pn_ == "*");
 
   unsigned int nf(0);
   for (unsigned int ifob = 0; ifob != nfob; ++ifob) {


### PR DESCRIPTION
#### PR description:

The boolean used to initialise `InputTagSet`s inside `TriggerSummaryProducerAOD` controls whether or not process names are ignored when comparing `InputTag`s.
https://github.com/cms-sw/cmssw/blob/0c04ca4982d250097f685bffe480187b2dd2444f/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc#L265-L266
https://github.com/cms-sw/cmssw/blob/0c04ca4982d250097f685bffe480187b2dd2444f/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h#L116
https://github.com/cms-sw/cmssw/blob/0c04ca4982d250097f685bffe480187b2dd2444f/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h#L99
If the keyword `"*"` is used, the flag `ignoreProcess` should be `true`, not the other way around.

#### PR validation:

Manual tests, see https://github.com/cms-sw/cmssw/pull/38442#discussion_r951662966.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_12_4_X`