### PR TITLE
[12_4_X] Fixed initialisation of diamond sensitive detector

### DIFF
--- a/SimG4CMS/PPS/src/PPSDiamondSD.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondSD.cc
@@ -44,7 +44,7 @@ PPSDiamondSD::PPSDiamondSD(const std::string& pname,
 
   slave_ = std::make_unique<TrackingSlaveSD>(pname);
 
-  if (pname == "CTPPSDiamandHits") {
+  if (pname == "CTPPSTimingHits") {
     numberingScheme_ = std::make_unique<PPSDiamondOrganization>();
     edm::LogVerbatim("PPSSimDiamond") << "Find CTPPSDiamondHits as name";
   } else {


### PR DESCRIPTION
#### PR description:
This PR is a backport of #39139, it fixes issue https://github.com/cms-sw/cmssw/issues/38114 - warning at initialisation of numbering scheme for PPS diamond sensitive detector. The fix allows to have correct diamond DetId for hits. 

This fix affect only PPS simulation.

#### PR validation:
private

