### PR TITLE
[nT2] zero-initialisation of TotemT2Digi members

### DIFF
--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -11,7 +11,7 @@
 
 class TotemT2Digi {
 public:
-  explicit TotemT2Digi() = default;
+  TotemT2Digi() = default;
   TotemT2Digi(unsigned char geo, unsigned char id, unsigned char marker, unsigned short le, unsigned short te);
 
   void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
@@ -21,15 +21,15 @@ public:
 
 private:
   /// Geo ID
-  unsigned char geo_id_;
+  unsigned char geo_id_{0};
   /// Channel ID
-  unsigned char channel_id_;
+  unsigned char channel_id_{0};
   /// Channel marker
-  unsigned char marker_;
+  unsigned char marker_{0};
   /// Leading edge time
-  unsigned short lead_edge_;
+  unsigned short lead_edge_{0};
   /// Trailing edge time
-  unsigned short trail_edge_;
+  unsigned short trail_edge_{0};
 };
 
 bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs);


### PR DESCRIPTION
#### PR description:

This PR ensures all members of the TotemT2Digi object are zero-initialised, following the discussion in #38986 for equivalent rechits.

#### PR validation:

Code compiles and runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: N/A