### PR TITLE
fix for `NOT` operator in `triggerExpression::Parser` [`12_4_X`]

### DIFF
--- a/HLTrigger/HLTcore/bin/BuildFile.xml
+++ b/HLTrigger/HLTcore/bin/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin name="hltParseTriggerExpressions" file="hltParseTriggerExpressions.cpp">
+  <use name="HLTrigger/HLTcore"/>
+</bin>

--- a/HLTrigger/HLTcore/bin/hltParseTriggerExpressions.cpp
+++ b/HLTrigger/HLTcore/bin/hltParseTriggerExpressions.cpp
@@ -1,0 +1,65 @@
+#include <string>
+
+#include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
+
+int parseExpression(std::string const& expression) {
+  std::cout << "Input expression: \"" << expression << "\"\n";
+
+  auto const* eval = triggerExpression::parse(expression);
+
+  auto ret = 0;
+  if (not eval) {
+    std::cout << "Parsing failed.\n";
+    ++ret;
+  } else {
+    std::cout << "Parsing output:   \"" << *eval << "\"\n";
+  }
+
+  std::cout << "--------------------------------------------------------\n";
+
+  return ret;
+}
+
+void showHelpMessage() {
+  std::cout << "\n"
+            << "Purpose:\n"
+            << "  test parsing of N expressions with the triggerExpression::Parser\n\n"
+            << "Input:\n"
+            << "  N command-line arguments, each parsed as a separate expression\n"
+            << "  (if no arguments are given, or \"-h\" or \"--help\" is specified,"
+            << " this help message is shown)\n\n"
+            << "Exit code:\n"
+            << "  number of expressions for which parsing failed\n\n"
+            << "Example:\n"
+            << "  > hltParseTriggerExpressions \"EXPR1\" \"EXPR2\" [..]\n\n";
+}
+
+int main(int argc, char** argv) {
+  std::cout << "===             hltParseTriggerExpressions           ===\n";
+  std::cout << "=== parse expressions with triggerExpression::Parser ===\n";
+  std::cout << "--------------------------------------------------------\n";
+
+  if (argc < 2) {
+    std::cout << "No expressions specified for parsing. See help message below.\n";
+    showHelpMessage();
+    return 0;
+  }
+
+  std::vector<std::string> v_exprs;
+  v_exprs.reserve(argc - 1);
+  for (auto idx = 1; idx < argc; ++idx) {
+    v_exprs.emplace_back(argv[idx]);
+    if (v_exprs.back() == "-h" or v_exprs.back() == "--help") {
+      showHelpMessage();
+      v_exprs.clear();
+      break;
+    }
+  }
+
+  auto ret = 0;
+  for (auto const& expr : v_exprs) {
+    ret += parseExpression(expr);
+  }
+
+  return ret;
+}

--- a/HLTrigger/HLTcore/interface/TriggerExpressionL1uGTReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionL1uGTReader.h
@@ -10,7 +10,7 @@ namespace triggerExpression {
 
   class L1uGTReader : public Evaluator {
   public:
-    L1uGTReader(const std::string& pattern) : m_pattern(pattern), m_triggers() {}
+    L1uGTReader(const std::string& pattern) : m_pattern{pattern}, m_triggers{}, m_initialised{false} {}
 
     bool operator()(const Data& data) const override;
 
@@ -20,7 +20,8 @@ namespace triggerExpression {
 
   private:
     std::string m_pattern;
-    std::vector<std::pair<std::string, unsigned int> > m_triggers;
+    std::vector<std::pair<std::string, unsigned int>> m_triggers;
+    bool m_initialised;
   };
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
@@ -55,8 +55,10 @@ namespace triggerExpression {
     bool operator()(const Data& data) const override { return not(*m_arg)(data); }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       out << "NOT ";
       m_arg->dump(out);
+      out << ')';
     }
   };
 
@@ -72,9 +74,11 @@ namespace triggerExpression {
     }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       m_arg1->dump(out);
       out << " AND ";
       m_arg2->dump(out);
+      out << ')';
     }
   };
 
@@ -90,9 +94,11 @@ namespace triggerExpression {
     }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       m_arg1->dump(out);
       out << " OR ";
       m_arg2->dump(out);
+      out << ')';
     }
   };
 

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -2,7 +2,7 @@
 #define HLTrigger_HLTfilters_TriggerExpressionParser_h
 
 // Note: this requires Boost 1.41 or higher, for Spirit 2.1 or higher
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 
 #include "HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h"
@@ -37,7 +37,7 @@ namespace triggerExpression {
 
       operand %= (prescale | element);
 
-      unary = (operand[qi::_val = qi::_1] | (qi::lit("NOT") >> operand)[qi::_val = new_<OperatorNot>(qi::_1)]);
+      unary = ((qi::lit("NOT") >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
 
       expression =
           unary[qi::_val = qi::_1] >> *((qi::lit("AND") >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -23,11 +23,22 @@ namespace triggerExpression {
   class Parser : public qi::grammar<Iterator, Evaluator *(), ascii::space_type> {
   public:
     Parser() : Parser::base_type(expression) {
+      auto delimiter = qi::copy(qi::eoi | !qi::char_("a-zA-Z0-9_*?"));
+
+      token_true = qi::lexeme[qi::lit("TRUE") >> delimiter];
+      token_false = qi::lexeme[qi::lit("FALSE") >> delimiter];
+
+      operand_not = qi::lexeme[qi::lit("NOT") >> delimiter];
+      operand_and = qi::lexeme[qi::lit("AND") >> delimiter];
+      operand_or = qi::lexeme[qi::lit("OR") >> delimiter];
+
       token_l1algo %= qi::raw[qi::lexeme["L1_" >> +(qi::char_("a-zA-Z0-9_*?"))]];
       token_path %= qi::raw[qi::lexeme[+(qi::char_("a-zA-Z0-9_*?"))]];
 
-      token = (qi::lit("TRUE")[qi::_val = new_<Constant>(true)] | qi::lit("FALSE")[qi::_val = new_<Constant>(false)] |
-               token_l1algo[qi::_val = new_<L1uGTReader>(qi::_1)] | token_path[qi::_val = new_<PathReader>(qi::_1)]);
+      token = (token_true[qi::_val = new_<Constant>(true)] |         // TRUE
+               token_false[qi::_val = new_<Constant>(false)] |       // FALSE
+               token_l1algo[qi::_val = new_<L1uGTReader>(qi::_1)] |  // L1_*
+               token_path[qi::_val = new_<PathReader>(qi::_1)]);     // *
 
       parenthesis %= ('(' >> expression >> ')');
 
@@ -37,16 +48,24 @@ namespace triggerExpression {
 
       operand %= (prescale | element);
 
-      unary = ((qi::lit("NOT") >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
+      unary = ((operand_not >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
 
       expression =
-          unary[qi::_val = qi::_1] >> *((qi::lit("AND") >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |
-                                        (qi::lit("OR") >> unary)[qi::_val = new_<OperatorOr>(qi::_val, qi::_1)]);
+          unary[qi::_val = qi::_1] >> *((operand_and >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |
+                                        (operand_or >> unary)[qi::_val = new_<OperatorOr>(qi::_val, qi::_1)]);
     }
 
   private:
     typedef qi::rule<Iterator, std::string(), ascii::space_type> name_rule;
     typedef qi::rule<Iterator, Evaluator *(), ascii::space_type> rule;
+    typedef qi::rule<Iterator> terminal_rule;
+
+    terminal_rule token_true;
+    terminal_rule token_false;
+
+    terminal_rule operand_not;
+    terminal_rule operand_and;
+    terminal_rule operand_or;
 
     name_rule token_l1algo;
     name_rule token_path;

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -48,7 +48,7 @@ namespace triggerExpression {
 
       operand %= (prescale | element);
 
-      unary = ((operand_not >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
+      unary = ((operand_not >> unary)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
 
       expression =
           unary[qi::_val = qi::_1] >> *((operand_and >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -33,12 +33,12 @@ namespace triggerExpression {
       operand_or = qi::lexeme[qi::lit("OR") >> delimiter];
 
       token_l1algo %= qi::raw[qi::lexeme["L1_" >> +(qi::char_("a-zA-Z0-9_*?"))]];
-      token_path %= qi::raw[qi::lexeme[+(qi::char_("a-zA-Z0-9_*?"))]];
+      token_path %= qi::raw[qi::lexeme[+(qi::char_("a-zA-Z0-9_*?"))] - operand_not - operand_and - operand_or];
 
       token = (token_true[qi::_val = new_<Constant>(true)] |         // TRUE
                token_false[qi::_val = new_<Constant>(false)] |       // FALSE
                token_l1algo[qi::_val = new_<L1uGTReader>(qi::_1)] |  // L1_*
-               token_path[qi::_val = new_<PathReader>(qi::_1)]);     // *
+               token_path[qi::_val = new_<PathReader>(qi::_1)]);     // * (except "NOT", "AND" and "OR")
 
       parenthesis %= ('(' >> expression >> ')');
 

--- a/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
@@ -10,7 +10,7 @@ namespace triggerExpression {
 
   class PathReader : public Evaluator {
   public:
-    PathReader(const std::string& pattern) : m_pattern(pattern), m_triggers() {}
+    PathReader(const std::string& pattern) : m_pattern{pattern}, m_triggers{}, m_initialised{false} {}
 
     bool operator()(const Data& data) const override;
 
@@ -22,7 +22,8 @@ namespace triggerExpression {
 
   private:
     std::string m_pattern;
-    std::vector<std::pair<std::string, unsigned int> > m_triggers;
+    std::vector<std::pair<std::string, unsigned int>> m_triggers;
+    bool m_initialised;
   };
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
@@ -28,6 +28,10 @@ namespace triggerExpression {
   }
 
   void L1uGTReader::dump(std::ostream& out) const {
+    if (not m_initialised) {
+      out << "Uninitialised_L1_Expression";
+      return;
+    }
     if (m_triggers.empty()) {
       out << "FALSE";
     } else if (m_triggers.size() == 1) {
@@ -85,6 +89,8 @@ namespace triggerExpression {
               << "requested pattern \"" << m_pattern << "\" does not match any L1 trigger in the current menu";
       }
     }
+
+    m_initialised = true;
   }
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
@@ -22,6 +22,10 @@ namespace triggerExpression {
   }
 
   void PathReader::dump(std::ostream& out) const {
+    if (not m_initialised) {
+      out << "Uninitialised_Path_Expression";
+      return;
+    }
     if (m_triggers.empty()) {
       out << "FALSE";
     } else if (m_triggers.size() == 1) {
@@ -84,6 +88,8 @@ namespace triggerExpression {
         }
       }
     }
+
+    m_initialised = true;
   }
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -1,4 +1,11 @@
-<bin file="test_catch2_*.cc" name="testHLTriggerHLTcoreCatch2">
+<bin file="test_catch2_HLTConfigData.cc" name="testHLTriggerHLTcoreHLTConfigDataCatch2">
+  <use name="FWCore/ParameterSet"/>
+  <use name="HLTrigger/HLTcore"/>
+  <use name="catch2"/>
+</bin>
+
+<bin file="test_catch2_TriggerExpressionParser.cc" name="testHLTriggerHLTcoreTriggerExpressionParserCatch2">
+  <use name="FWCore/MessageLogger"/>
   <use name="HLTrigger/HLTcore"/>
   <use name="catch2"/>
 </bin>

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -1,0 +1,52 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <string>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
+
+namespace {
+
+  bool testExpression(std::string const& expression) {
+    auto const* expr = triggerExpression::parse(expression);
+
+    if (not expr) {
+      edm::LogWarning("InvalidInput") << "Couldn't parse trigger results expression \"" << expression << "\"";
+      return false;
+    }
+
+    edm::LogPrint("testExpression") << "Parsed expression: \"" << expression << "\"";
+    return true;
+  }
+
+}  // namespace
+
+TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
+  // examples of expressions supported by the triggerExpression parser
+  SECTION("CorrectExpressions") {
+    REQUIRE(testExpression("TRUE"));
+    REQUIRE(testExpression("FALSE"));
+    REQUIRE(testExpression("NOT (FALSE)"));
+    REQUIRE(testExpression("(NOT FALSE) OR TRUE"));
+    REQUIRE(testExpression("NOTThisHLTPath AND TRUE AND NOT L1_A?_*"));
+    REQUIRE(testExpression("NOT NOTThisHLTPath"));
+    REQUIRE(testExpression("ThisHLTANDNOTThatORTheOther"));
+    REQUIRE(testExpression("NOT L1_SEED1 AND L1_SEED2*"));
+    REQUIRE(testExpression("NOT L1_SEED2 AND (HLT_PATH_? AND NOT HLT_PATH2_??_*)"));
+    REQUIRE(testExpression("NOT (HLT_Path1 AND HLT_Path2)"));
+    REQUIRE(testExpression("NOT (NOTHLT_Path OR HLT_Path2)"));
+    REQUIRE(testExpression("((L1_A AND HLT_B) OR Dataset_C) AND NOT (Status_D OR Name_E OR HLT_F*) AND L1_??_?_?"));
+    REQUIRE(testExpression("NOT (NOT (HLT_Path1 AND HLT_Path_*))"));
+  }
+
+  // examples of expressions not supported by the triggerExpression parser
+  SECTION("IncorrectExpressions") {
+    REQUIRE(not testExpression("A | B"));
+    REQUIRE(not testExpression("A && B"));
+    REQUIRE(not testExpression("NOT L1_SEED1 ANDD L1_SEED2*"));
+    REQUIRE(not testExpression("NOT (NOTHLT_Path OR HLT_Path2))"));
+    REQUIRE(not testExpression("NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)"));
+    REQUIRE(not testExpression("HLT_Path* NOT TRUE"));
+  }
+}

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -72,6 +72,11 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
         " OR Uninitialised_Path_Expression))) AND Uninitialised_L1_Expression)"));
     REQUIRE(testExpression("NOT (NOT (HLT_Path1 AND HLT_Path_*))",  //
                            "(NOT (NOT (Uninitialised_Path_Expression AND Uninitialised_Path_Expression)))"));
+    REQUIRE(testExpression("NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)",  //
+                           "(NOT (NOT ((Uninitialised_Path_Expression AND Uninitialised_L1_Expression) OR "
+                           "Uninitialised_Path_Expression)))"));
+    REQUIRE(testExpression("NOT NOT HLT_Path1 AND L1_Seed_??",  //
+                           "((NOT (NOT Uninitialised_Path_Expression)) AND Uninitialised_L1_Expression)"));
   }
 
   // examples of expressions not supported by the triggerExpression parser
@@ -80,7 +85,6 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(not testExpression("A && B"));
     REQUIRE(not testExpression("NOT L1_SEED1 ANDD L1_SEED2*"));
     REQUIRE(not testExpression("NOT (NOTHLT_Path OR HLT_Path2))"));
-    REQUIRE(not testExpression("NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)"));
     REQUIRE(not testExpression("HLT_Path* NOT TRUE"));
     REQUIRE(not testExpression("ThisPath ANDThatPath"));
   }

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -13,7 +13,7 @@ namespace {
     auto const* expr = triggerExpression::parse(expression);
 
     if (not expr) {
-      edm::LogWarning("InvalidInput") << "Couldn't parse trigger results expression \"" << expression << "\"";
+      edm::LogWarning("InvalidInput") << "Couldn't parse trigger-results expression \"" << expression << "\"";
       return false;
     }
 
@@ -77,6 +77,12 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
                            "Uninitialised_Path_Expression)))"));
     REQUIRE(testExpression("NOT NOT HLT_Path1 AND L1_Seed_??",  //
                            "((NOT (NOT Uninitialised_Path_Expression)) AND Uninitialised_L1_Expression)"));
+    REQUIRE(testExpression("NOT(THIS OR THAT)AND(L1_THEOTHER)OR(NOTFALSE)",  //
+                           "(((NOT (Uninitialised_Path_Expression OR Uninitialised_Path_Expression))"
+                           " AND Uninitialised_L1_Expression) OR Uninitialised_Path_Expression)"));
+    REQUIRE(testExpression("TRUE AND L1_FALSE AND AND OR NOT",  //
+                           "(((TRUE AND Uninitialised_L1_Expression) AND Uninitialised_Path_Expression) OR "
+                           "Uninitialised_Path_Expression)"));
   }
 
   // examples of expressions not supported by the triggerExpression parser

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -80,9 +80,6 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(testExpression("NOT(THIS OR THAT)AND(L1_THEOTHER)OR(NOTFALSE)",  //
                            "(((NOT (Uninitialised_Path_Expression OR Uninitialised_Path_Expression))"
                            " AND Uninitialised_L1_Expression) OR Uninitialised_Path_Expression)"));
-    REQUIRE(testExpression("TRUE AND L1_FALSE AND AND OR NOT",  //
-                           "(((TRUE AND Uninitialised_L1_Expression) AND Uninitialised_Path_Expression) OR "
-                           "Uninitialised_Path_Expression)"));
   }
 
   // examples of expressions not supported by the triggerExpression parser
@@ -93,5 +90,7 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(not testExpression("NOT (NOTHLT_Path OR HLT_Path2))"));
     REQUIRE(not testExpression("HLT_Path* NOT TRUE"));
     REQUIRE(not testExpression("ThisPath ANDThatPath"));
+    REQUIRE(not testExpression("ThisPath AND ThatPath AND OR"));
+    REQUIRE(not testExpression("ThisPath AND ThatPath OR NOT"));
   }
 }

--- a/HLTrigger/HLTfilters/test/BuildFile.xml
+++ b/HLTrigger/HLTfilters/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <!-- test the TriggerResultsFilter reading the CMSSW results from the TriggerResults object of a previous process -->
-<test name="triggerResultsFilter_by_TriggerResults" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py; cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py"/>
+<test name="triggerResultsFilter_by_TriggerResults" command="triggerResultsFilter_by_TriggerResults.sh"/>
 
 <!-- test the TriggerResultsFilter reading the CMSSW results from the HLTPathStatus objects of the current process -->
-<test name="triggerResultsFilter_by_PathStatus" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py"/>
+<test name="triggerResultsFilter_by_PathStatus" command="triggerResultsFilter_by_PathStatus.sh"/>

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
@@ -114,7 +114,7 @@ process.filter_any_pre = triggerResultsFilter.clone(
 
 # equivalent of filter_any_pre using NOT operator twice
 process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
-    triggerConditions = ( 'NOT (NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6))', ),
+    triggerConditions = ( 'NOT NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6)', ),
     l1tResults = '',
     throw = False
 )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('HLT')
 
+process.options.wantSummary = True
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 # define the Prescaler service, and set the scale factors
@@ -82,9 +84,16 @@ process.filter_any_or = triggerResultsFilter.clone(
     throw = False
 )
 
-# accept if 'Path_1' succeeds, prescaled by 2
+# accept if 'Path_1' succeeds, prescaled by 15
 process.filter_1_pre = triggerResultsFilter.clone(
     triggerConditions =  ( '(Path_1) / 15', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if 'Path_1' prescaled by 15 does not succeed
+process.filter_not_1_pre = triggerResultsFilter.clone(
+    triggerConditions =  ( 'NOT (Path_1 / 15)', ),
     l1tResults = '',
     throw = False
 )
@@ -99,6 +108,13 @@ process.filter_2_pre = triggerResultsFilter.clone(
 # accept if any path succeeds, with different prescales (explicit OR, prescaled)
 process.filter_any_pre = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
+    l1tResults = '',
+    throw = False
+)
+
+# equivalent of filter_any_pre using NOT operator twice
+process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT (NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6))', ),
     l1tResults = '',
     throw = False
 )
@@ -190,9 +206,11 @@ process.Check_All_Explicit = cms.Path( process.filter_all_explicit )
 process.Check_Any_Or   = cms.Path( process.filter_any_or )
 process.Check_Any_Star = cms.Path( process.filter_any_star )
 
-process.Check_1_Pre    = cms.Path( process.filter_1_pre )
-process.Check_2_Pre    = cms.Path( process.filter_2_pre )
-process.Check_Any_Pre  = cms.Path( process.filter_any_pre ) 
+process.Check_1_Pre     = cms.Path( process.filter_1_pre )
+process.Check_NOT_1_Pre = cms.Path( process.filter_not_1_pre )
+process.Check_2_Pre     = cms.Path( process.filter_2_pre )
+process.Check_Any_Pre   = cms.Path( process.filter_any_pre )
+process.Check_Any_Pre_DoubleNOT = cms.Path( process.filter_any_pre_doubleNOT )
 
 process.Check_Any_Question        = cms.Path( process.filter_any_question )
 process.Check_Any_StarQuestion    = cms.Path( process.filter_any_starquestion )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
@@ -48,9 +48,10 @@ process.success = cms.EDFilter('HLTBool', result = cms.bool(True))
 process.Path_1  = cms.Path(process.scale_1)
 process.Path_2  = cms.Path(process.scale_2)
 process.Path_3  = cms.Path(process.scale_3)
-process.AlwaysTrue    = cms.Path(process.success)
-process.AlwaysFalse   = cms.Path(process.fail)
 process.L1_Path = cms.Path(process.success)
+# Path names containing a special keyword (TRUE, FALSE, AND, OR, NOT)
+process.AlwaysNOTFalse = cms.Path(process.success)
+process.AlwaysFALSE    = cms.Path(process.fail)
 
 # define the TriggerResultsFilters based on the status of the previous paths
 from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter as _triggerResultsFilter
@@ -203,6 +204,20 @@ process.filter_false_pattern = triggerResultsFilter.clone(
     throw = False
 )
 
+# Path name containing special keyword NOT
+process.filter_AlwaysNOTFalse_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'AlwaysNOTFalse', ),
+    l1tResults = '',
+    throw = False
+)
+
+# Path name containing special keyword FALSE
+process.filter_NOTAlwaysFALSE_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT AlwaysFALSE', ),
+    l1tResults = '',
+    throw = False
+)
+
 
 process.Check_1 = cms.Path( process.filter_1 )
 process.Check_2 = cms.Path( process.filter_2 )
@@ -230,6 +245,8 @@ process.Check_L1Path_Pattern      = cms.Path( process.filter_l1path_pattern )
 process.Check_L1Singlemuopen_Pattern = cms.Path( process.filter_l1singlemuopen_pattern )
 process.Check_True_Pattern        = cms.Path( process.filter_true_pattern )
 process.Check_False_Pattern       = cms.Path( process.filter_false_pattern )
+process.Check_AlwaysNOTFalse_Pattern = cms.Path( process.filter_AlwaysNOTFalse_pattern )
+process.Check_NOTAlwaysFALSE_Pattern = cms.Path( process.filter_NOTAlwaysFALSE_pattern )
 
 # define an EndPath to analyze all other path results
 process.hltTrigReport = cms.EDAnalyzer( 'HLTrigReport',

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
@@ -119,6 +119,13 @@ process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
     throw = False
 )
 
+# opposite of filter_any_pre without whitespaces where possible
+process.filter_not_any_pre = triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT(Path_1/15)AND(NOT Path_2/10)AND(NOT Path_3/6)', ),
+    l1tResults = '',
+    throw = False
+)
+
 # accept if any path succeeds (wildcard, '*')
 process.filter_any_star = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_*', ),
@@ -211,6 +218,7 @@ process.Check_NOT_1_Pre = cms.Path( process.filter_not_1_pre )
 process.Check_2_Pre     = cms.Path( process.filter_2_pre )
 process.Check_Any_Pre   = cms.Path( process.filter_any_pre )
 process.Check_Any_Pre_DoubleNOT = cms.Path( process.filter_any_pre_doubleNOT )
+process.Check_Not_Any_Pre = cms.Path( process.filter_not_any_pre )
 
 process.Check_Any_Question        = cms.Path( process.filter_any_question )
 process.Check_Any_StarQuestion    = cms.Path( process.filter_any_starquestion )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Pass in name and status
+function die {
+  echo $1: status $2
+  echo === Log file ===
+  cat ${3:-/dev/null}
+  echo === End log file ===
+  exit $2
+}
+
+# run test job
+TESTDIR="${LOCALTOP}"/src/HLTrigger/HLTfilters/test
+
+cmsRun "${TESTDIR}"/triggerResultsFilter_by_PathStatus.py &> log_triggerResultsFilter_by_PathStatus \
+ || die "Failure running triggerResultsFilter_by_PathStatus.py" $? log_triggerResultsFilter_by_PathStatus
+
+# expected PathSummary of test job
+cat <<@EOF > log_triggerResultsFilter_by_PathStatus_expected
+TrigReport ---------- Event  Summary ------------
+TrigReport Events total = 1000 passed = 1000 failed = 0
+TrigReport ---------- Path   Summary ------------
+TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
+TrigReport     1    0       1000        500        500          0 Path_1
+TrigReport     1    1       1000        333        667          0 Path_2
+TrigReport     1    2       1000        200        800          0 Path_3
+TrigReport     1    3       1000       1000          0          0 AlwaysTrue
+TrigReport     1    4       1000          0       1000          0 AlwaysFalse
+TrigReport     1    5       1000       1000          0          0 L1_Path
+TrigReport     1    6       1000        500        500          0 Check_1
+TrigReport     1    7       1000        333        667          0 Check_2
+TrigReport     1    8       1000        200        800          0 Check_3
+TrigReport     1    9       1000         33        967          0 Check_All_Explicit
+TrigReport     1   10       1000        733        267          0 Check_Any_Or
+TrigReport     1   11       1000        733        267          0 Check_Any_Star
+TrigReport     1   12       1000         33        967          0 Check_1_Pre
+TrigReport     1   13       1000        967         33          0 Check_NOT_1_Pre
+TrigReport     1   14       1000         33        967          0 Check_2_Pre
+TrigReport     1   15       1000         99        901          0 Check_Any_Pre
+TrigReport     1   16       1000         99        901          0 Check_Any_Pre_DoubleNOT
+TrigReport     1   17       1000        733        267          0 Check_Any_Question
+TrigReport     1   18       1000        733        267          0 Check_Any_StarQuestion
+TrigReport     1   19       1000          0       1000          0 Check_Wrong_Name
+TrigReport     1   20       1000          0       1000          0 Check_Wrong_Pattern
+TrigReport     1   21       1000       1000          0          0 Check_Not_Wrong_Pattern
+TrigReport     1   22       1000          0       1000          0 Check_Empty_Pattern
+TrigReport     1   23       1000          0       1000          0 Check_L1Path_Pattern
+TrigReport     1   24       1000          0       1000          0 Check_L1Singlemuopen_Pattern
+TrigReport     1   25       1000       1000          0          0 Check_True_Pattern
+TrigReport     1   26       1000          0       1000          0 Check_False_Pattern
+@EOF
+
+# compare to expected output of test job
+grep -m$(cat log_triggerResultsFilter_by_PathStatus_expected | wc -l) \
+ 'TrigReport ' log_triggerResultsFilter_by_PathStatus | diff log_triggerResultsFilter_by_PathStatus_expected - \
+ || die "differences in expected log report" $?

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
@@ -24,9 +24,9 @@ TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
 TrigReport     1    0       1000        500        500          0 Path_1
 TrigReport     1    1       1000        333        667          0 Path_2
 TrigReport     1    2       1000        200        800          0 Path_3
-TrigReport     1    3       1000       1000          0          0 AlwaysTrue
-TrigReport     1    4       1000          0       1000          0 AlwaysFalse
-TrigReport     1    5       1000       1000          0          0 L1_Path
+TrigReport     1    3       1000       1000          0          0 L1_Path
+TrigReport     1    4       1000       1000          0          0 AlwaysNOTFalse
+TrigReport     1    5       1000          0       1000          0 AlwaysFALSE
 TrigReport     1    6       1000        500        500          0 Check_1
 TrigReport     1    7       1000        333        667          0 Check_2
 TrigReport     1    8       1000        200        800          0 Check_3
@@ -49,6 +49,8 @@ TrigReport     1   24       1000          0       1000          0 Check_L1Path_P
 TrigReport     1   25       1000          0       1000          0 Check_L1Singlemuopen_Pattern
 TrigReport     1   26       1000       1000          0          0 Check_True_Pattern
 TrigReport     1   27       1000          0       1000          0 Check_False_Pattern
+TrigReport     1   28       1000       1000          0          0 Check_AlwaysNOTFalse_Pattern
+TrigReport     1   29       1000       1000          0          0 Check_NOTAlwaysFALSE_Pattern
 @EOF
 
 # compare to expected output of test job

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.sh
@@ -38,16 +38,17 @@ TrigReport     1   13       1000        967         33          0 Check_NOT_1_Pr
 TrigReport     1   14       1000         33        967          0 Check_2_Pre
 TrigReport     1   15       1000         99        901          0 Check_Any_Pre
 TrigReport     1   16       1000         99        901          0 Check_Any_Pre_DoubleNOT
-TrigReport     1   17       1000        733        267          0 Check_Any_Question
-TrigReport     1   18       1000        733        267          0 Check_Any_StarQuestion
-TrigReport     1   19       1000          0       1000          0 Check_Wrong_Name
-TrigReport     1   20       1000          0       1000          0 Check_Wrong_Pattern
-TrigReport     1   21       1000       1000          0          0 Check_Not_Wrong_Pattern
-TrigReport     1   22       1000          0       1000          0 Check_Empty_Pattern
-TrigReport     1   23       1000          0       1000          0 Check_L1Path_Pattern
-TrigReport     1   24       1000          0       1000          0 Check_L1Singlemuopen_Pattern
-TrigReport     1   25       1000       1000          0          0 Check_True_Pattern
-TrigReport     1   26       1000          0       1000          0 Check_False_Pattern
+TrigReport     1   17       1000        901         99          0 Check_Not_Any_Pre
+TrigReport     1   18       1000        733        267          0 Check_Any_Question
+TrigReport     1   19       1000        733        267          0 Check_Any_StarQuestion
+TrigReport     1   20       1000          0       1000          0 Check_Wrong_Name
+TrigReport     1   21       1000          0       1000          0 Check_Wrong_Pattern
+TrigReport     1   22       1000       1000          0          0 Check_Not_Wrong_Pattern
+TrigReport     1   23       1000          0       1000          0 Check_Empty_Pattern
+TrigReport     1   24       1000          0       1000          0 Check_L1Path_Pattern
+TrigReport     1   25       1000          0       1000          0 Check_L1Singlemuopen_Pattern
+TrigReport     1   26       1000       1000          0          0 Check_True_Pattern
+TrigReport     1   27       1000          0       1000          0 Check_False_Pattern
 @EOF
 
 # compare to expected output of test job

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
@@ -53,9 +53,16 @@ process.filter_any_or = triggerResultsFilter.clone(
     throw = False
     )
 
-# accept if 'Path_1' succeeds, prescaled by 2
+# accept if 'Path_1' succeeds, prescaled by 15
 process.filter_1_pre = triggerResultsFilter.clone(
     triggerConditions =  ( '(Path_1) / 15', ),
+    l1tResults = '',
+    throw = False
+    )
+
+# accept if 'Path_1' prescaled by 15 does not succeed
+process.filter_not_1_pre = triggerResultsFilter.clone(
+    triggerConditions =  ( 'NOT (Path_1 / 15)', ),
     l1tResults = '',
     throw = False
     )
@@ -70,6 +77,13 @@ process.filter_2_pre = triggerResultsFilter.clone(
 # accept if any path succeeds, with different prescales (explicit OR, prescaled)
 process.filter_any_pre = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
+    l1tResults = '',
+    throw = False
+    )
+
+# equivalent of filter_any_pre using NOT operator twice
+process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT (NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6))', ),
     l1tResults = '',
     throw = False
     )
@@ -162,9 +176,11 @@ process.path_all_explicit = cms.Path( process.filter_all_explicit )
 process.path_any_or   = cms.Path( process.filter_any_or )
 process.path_any_star = cms.Path( process.filter_any_star )
 
-process.path_1_pre    = cms.Path( process.filter_1_pre )
-process.path_2_pre    = cms.Path( process.filter_2_pre )
-process.path_any_pre  = cms.Path( process.filter_any_pre ) 
+process.path_1_pre     = cms.Path( process.filter_1_pre )
+process.path_not_1_pre = cms.Path( process.filter_not_1_pre )
+process.path_2_pre     = cms.Path( process.filter_2_pre )
+process.path_any_pre   = cms.Path( process.filter_any_pre )
+process.path_any_pre_doubleNOT = cms.Path( process.filter_any_pre_doubleNOT )
 
 process.path_any_doublestar      = cms.Path( process.filter_any_doublestar )
 process.path_any_question        = cms.Path( process.filter_any_question )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
@@ -83,7 +83,7 @@ process.filter_any_pre = triggerResultsFilter.clone(
 
 # equivalent of filter_any_pre using NOT operator twice
 process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
-    triggerConditions = ( 'NOT (NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6))', ),
+    triggerConditions = ( 'NOT NOT (Path_1 / 15 OR Path_2 / 10 OR Path_3 / 6)', ),
     l1tResults = '',
     throw = False
     )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
@@ -88,6 +88,13 @@ process.filter_any_pre_doubleNOT = triggerResultsFilter.clone(
     throw = False
     )
 
+# opposite of filter_any_pre without whitespaces where possible
+process.filter_not_any_pre = triggerResultsFilter.clone(
+    triggerConditions = ( 'NOT(Path_1/15)AND(NOT Path_2/10)AND(NOT Path_3/6)', ),
+    l1tResults = '',
+    throw = False
+    )
+
 # accept if any path succeeds (wildcard, '*')
 process.filter_any_star = triggerResultsFilter.clone(
     triggerConditions = ( '*', ),
@@ -101,7 +108,6 @@ process.filter_any_doublestar = triggerResultsFilter.clone(
     l1tResults = '',
     throw = False
     )
-
 
 # accept if any path succeeds (wildcard, '?')
 process.filter_any_question = triggerResultsFilter.clone(
@@ -181,6 +187,7 @@ process.path_not_1_pre = cms.Path( process.filter_not_1_pre )
 process.path_2_pre     = cms.Path( process.filter_2_pre )
 process.path_any_pre   = cms.Path( process.filter_any_pre )
 process.path_any_pre_doubleNOT = cms.Path( process.filter_any_pre_doubleNOT )
+process.path_not_any_pre = cms.Path( process.filter_not_any_pre )
 
 process.path_any_doublestar      = cms.Path( process.filter_any_doublestar )
 process.path_any_question        = cms.Path( process.filter_any_question )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.sh
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Pass in name and status
+function die {
+  echo $1: status $2
+  echo === Log file ===
+  cat ${3:-/dev/null}
+  echo === End log file ===
+  exit $2
+}
+
+# run test job
+TESTDIR="${LOCALTOP}"/src/HLTrigger/HLTfilters/test
+
+cmsRun "${TESTDIR}"/triggerResultsFilter_producer.py &> log_triggerResultsFilter_producer \
+  || die "Failure running triggerResultsFilter_producer.py" $? log_triggerResultsFilter_producer
+
+cmsRun "${TESTDIR}"/triggerResultsFilter_by_TriggerResults.py &> log_triggerResultsFilter_by_TriggerResults \
+ || die "Failure running triggerResultsFilter_by_TriggerResults.py" $? log_triggerResultsFilter_by_TriggerResults
+
+# expected PathSummary of test job
+cat <<@EOF > log_triggerResultsFilter_by_TriggerResults_expected
+TrigReport ---------- Event  Summary ------------
+TrigReport Events total = 1000 passed = 1000 failed = 0
+TrigReport ---------- Path   Summary ------------
+TrigReport  Trig Bit#   Executed     Passed     Failed      Error Name
+TrigReport     1    0       1000        500        500          0 path_1
+TrigReport     1    1       1000        333        667          0 path_2
+TrigReport     1    2       1000        200        800          0 path_3
+TrigReport     1    3       1000         33        967          0 path_all_explicit
+TrigReport     1    4       1000        733        267          0 path_any_or
+TrigReport     1    5       1000       1000          0          0 path_any_star
+TrigReport     1    6       1000         33        967          0 path_1_pre
+TrigReport     1    7       1000        967         33          0 path_not_1_pre
+TrigReport     1    8       1000         33        967          0 path_2_pre
+TrigReport     1    9       1000         99        901          0 path_any_pre
+TrigReport     1   10       1000         99        901          0 path_any_pre_doubleNOT
+TrigReport     1   11       1000       1000          0          0 path_any_doublestar
+TrigReport     1   12       1000        733        267          0 path_any_question
+TrigReport     1   13       1000          0       1000          0 path_wrong_name
+TrigReport     1   14       1000          0       1000          0 path_wrong_pattern
+TrigReport     1   15       1000       1000          0          0 path_not_wrong_pattern
+TrigReport     1   16       1000          0       1000          0 path_empty_pattern
+TrigReport     1   17       1000          0       1000          0 path_l1path_pattern
+TrigReport     1   18       1000          0       1000          0 path_l1singlemuopen_pattern
+TrigReport     1   19       1000       1000          0          0 path_true_pattern
+TrigReport     1   20       1000          0       1000          0 path_false_pattern
+@EOF
+
+# compare to expected output of test job
+grep -m$(cat log_triggerResultsFilter_by_TriggerResults_expected | wc -l) \
+ 'TrigReport ' log_triggerResultsFilter_by_TriggerResults | diff log_triggerResultsFilter_by_TriggerResults_expected - \
+ || die "differences in expected log report" $?

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.sh
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.sh
@@ -35,16 +35,17 @@ TrigReport     1    7       1000        967         33          0 path_not_1_pre
 TrigReport     1    8       1000         33        967          0 path_2_pre
 TrigReport     1    9       1000         99        901          0 path_any_pre
 TrigReport     1   10       1000         99        901          0 path_any_pre_doubleNOT
-TrigReport     1   11       1000       1000          0          0 path_any_doublestar
-TrigReport     1   12       1000        733        267          0 path_any_question
-TrigReport     1   13       1000          0       1000          0 path_wrong_name
-TrigReport     1   14       1000          0       1000          0 path_wrong_pattern
-TrigReport     1   15       1000       1000          0          0 path_not_wrong_pattern
-TrigReport     1   16       1000          0       1000          0 path_empty_pattern
-TrigReport     1   17       1000          0       1000          0 path_l1path_pattern
-TrigReport     1   18       1000          0       1000          0 path_l1singlemuopen_pattern
-TrigReport     1   19       1000       1000          0          0 path_true_pattern
-TrigReport     1   20       1000          0       1000          0 path_false_pattern
+TrigReport     1   11       1000        901         99          0 path_not_any_pre
+TrigReport     1   12       1000       1000          0          0 path_any_doublestar
+TrigReport     1   13       1000        733        267          0 path_any_question
+TrigReport     1   14       1000          0       1000          0 path_wrong_name
+TrigReport     1   15       1000          0       1000          0 path_wrong_pattern
+TrigReport     1   16       1000       1000          0          0 path_not_wrong_pattern
+TrigReport     1   17       1000          0       1000          0 path_empty_pattern
+TrigReport     1   18       1000          0       1000          0 path_l1path_pattern
+TrigReport     1   19       1000          0       1000          0 path_l1singlemuopen_pattern
+TrigReport     1   20       1000       1000          0          0 path_true_pattern
+TrigReport     1   21       1000          0       1000          0 path_false_pattern
 @EOF
 
 # compare to expected output of test job


### PR DESCRIPTION
backport of #39108

#### PR description:

From https://github.com/cms-sw/cmssw/pull/39108#issuecomment-1223739821:

 - fixes the `NOT` operator in the parser used by `TriggerResultsFilter`
 - includes further updates to improve the behaviour of the parser (requiring a delimiter for special keywords like `AND/OR/NOT`, allowing for expressions like `NOT NOT`)
 - the parser now does not allow `AND/OR/NOT` as names of HLT paths; the implementation of that requirement is maybe suboptimal, but it passes all the tests and considered use cases
 - added unit test for the parser and cmd-line utility to check its behaviour; unit tests of `TriggerResultsFilter` improved accordingly

Thanks to @fwyzard for finding the solution, and improving the initial version of the PR.

See description and discussions in the original PR for more information.

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#39108

Backport of a bugfix to the release cycle currently used for online operations.