### PR TITLE
Utilities/StaticAnalyzers: only report the use of TFileService functions if the parent function does not override a edm::one function

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -72,10 +72,11 @@ for tfunc in sorted(toplevelfuncs):
                         print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
                               re.sub(farg, "()", key)+"'", end=' ')
                         print()
+
             else:
                 for key in G[tfunc].keys():
                     if 'kind' in G[tfunc][key] and G[tfunc][key]['kind'] == ' overrides function ' and not (key.startswith('edm::one') and 'TFileService::' in static):
-                        print("Known thread unsafe function \'"+re.sub(farg, "()",
+                        print("Known thread unsafe function '"+re.sub(farg, "()",
                                                                        static)+"' is called in call stack '", end=' ')
                         for i in range(0, len(path)-1):
                             print(re.sub(farg, "()", path[i]) +
@@ -89,7 +90,7 @@ for tfunc in sorted(toplevelfuncs):
                         for i in range(0, len(path)-1):
                             print(re.sub(farg, "()", path[i]) +
                                   G[path[i]][path[i+1]]['kind'], end=' ')
-                        print(G[path[len(path)-2]][path[len(path)-1]]['kind']+" "+re.sub(farg, "()", static)+"' is called ,", end=' ')
+                        print(re.sub(farg, "()", path[i+1])+"' known thread unsafe function '"+re.sub(farg, "()", static)+"' is called, ", end=' ')
                         print("'"+re.sub(farg, "()", tfunc)+"' overrides '" +
                                       re.sub(farg, "()", key)+"'", end=' ')
                         print()

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -207,7 +207,6 @@ bool clangcms::support::isKnownThrUnsafeFunc(const std::string &fname) {
                                                  "TTable::Fit(const char *,",
                                                  "TTree::Fit(const char *,",
                                                  "TTreePlayer::Fit(const char *,",
-                                                 "TFileService::",
                                                  "CLHEP::HepMatrix::determinant("};
   for (auto &name : names)
     if (fname.substr(0, name.length()) == name)

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -42,7 +42,26 @@ namespace clangcms {
     std::string pname = support::getQualifiedName(*PD);
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
-    if (support::isKnownThrUnsafeFunc(mname)) {
+    const std::string tfname = "TFileService::";
+    const std::string eoname = "edm::one";
+    if (mname.substr(0, tfname.length()) == tfname) {
+      for (auto I = PD->begin_overridden_methods(), E = PD->end_overridden_methods(); I != E; ++I) {
+        std::string oname = support::getQualifiedName(*(*I));
+        if (oname.substr(0, eoname.length()) != eoname) {
+          os << "TFileService function " << mname << " is called in function " << pname;
+          PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
+          BugType *BT = new BugType(Checker, "TFileService function called ", "ThreadSafety");
+          std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
+          R->setDeclWithIssue(AC->getDecl());
+          R->addRange(CE->getSourceRange());
+          BR.emitReport(std::move(R));
+          std::string tname = "function-checker.txt.unsorted";
+          std::string ostring = "function '" + pname + "' known thread unsafe function '" + mname + "'.\n";
+          support::writeLog(ostring, tname);
+        }
+      }
+    }
+    else if (support::isKnownThrUnsafeFunc(mname)) {
       os << "Known thread unsafe function " << mname << " is called in function " << pname;
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BugType *BT = new BugType(Checker, "known thread unsafe function called", "ThreadSafety");

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -60,8 +60,7 @@ namespace clangcms {
           support::writeLog(ostring, tname);
         }
       }
-    }
-    else if (support::isKnownThrUnsafeFunc(mname)) {
+    } else if (support::isKnownThrUnsafeFunc(mname)) {
       os << "Known thread unsafe function " << mname << " is called in function " << pname;
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
       BugType *BT = new BugType(Checker, "known thread unsafe function called", "ThreadSafety");


### PR DESCRIPTION
Tested locally.