### PR TITLE
 HCAL: Modifications to the LUT and trigger key generation script

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -1703,8 +1703,6 @@ int HcalLutManager::createLutXmlFiles_HBEFFromCoder_HOFromAscii_ZDC(std::string 
     addLutMap(xml, masks);
   }
   //
-  const std::map<int, std::shared_ptr<LutXml>> _zdc_lut_xml = getZdcLutXml(_tag, split_by_crate);
-  addLutMap(xml, _zdc_lut_xml);
 
   writeLutXmlFiles(xml, _tag, split_by_crate);
 


### PR DESCRIPTION
#### PR description:

Modifications to the HCAL LUTs and trigger key generation script, with the changes that are described in slide 3 [here](https://indico.cern.ch/event/1182049/contributions/4965979/attachments/2480788/4258655/O2OStatusUpdate_71522.pdf). This is needed for the new o2o system for updating online conditions in the HCAL. Also, removed ZDC from the LUT generation as there is an issue with the LUT generation of the ZDC that causes the scripts to fail and at the moment ZDC does not need LUTs.

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport. This PR updates the "service" scripts for LUTs and Trigger key generation, so the changes do not need to be backported to 12_4_X
