### PR TITLE
Add support for lambda ESProducer produce functions

### DIFF
--- a/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
+++ b/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
@@ -1,0 +1,45 @@
+#ifndef FWCore_Framework_interface_es_impl_ReturnArgumentTypes_h
+#define FWCore_Framework_interface_es_impl_ReturnArgumentTypes_h
+
+namespace edm::eventsetup::impl {
+  template <typename F>
+  struct ReturnArgumentTypesImpl;
+
+  // function pointer
+  template <typename R, typename T>
+  struct ReturnArgumentTypesImpl<R (*)(T const&)> {
+    using argument_type = T;
+    using return_type = R;
+  };
+
+  // mutable functor/lambda
+  template <typename R, typename T, typename O>
+  struct ReturnArgumentTypesImpl<R (O::*)(T const&)> {
+    using argument_type = T;
+    using return_type = R;
+  };
+
+  // const functor/lambda
+  template <typename R, typename T, typename O>
+  struct ReturnArgumentTypesImpl<R (O::*)(T const&) const> {
+    using argument_type = T;
+    using return_type = R;
+  };
+
+  template <typename F, typename = void>
+  struct ReturnArgumentTypes;
+
+  template <typename F>
+  struct ReturnArgumentTypes<F, std::enable_if_t<std::is_class_v<F>>> {
+    using argument_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::argument_type;
+    using return_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::return_type;
+  };
+
+  template <typename F>
+  struct ReturnArgumentTypes<F, std::enable_if_t<std::is_pointer_v<F>>> {
+    using argument_type = typename ReturnArgumentTypesImpl<F>::argument_type;
+    using return_type = typename ReturnArgumentTypesImpl<F>::return_type;
+  };
+}  // namespace edm::eventsetup::impl
+
+#endif


### PR DESCRIPTION
#### PR description:

This PR adds support for lambda functions as an ESProducer produce function. Such a feature would be useful e.g. for an evolution of Alpaka ESProducer API. The user-facing API in this PR is along
```cpp
FooESProducer::FooESProducer(edm::ParameterSet const&) {
  auto cc = setWhatProduced([&token_](FooRecord const& iRecord) {
    auto const& input = iRecord.get(token_);
    ...
    return std::make_unique<Foo>(...);
  });
  token_ = cc.consumes();
}
```
There are several ways how the API could be improved, but those are left for future PRs (this functionality alone is sufficient for the Alpaka-related work, where this form of `setWhatProduced()` is not (necessarily) exposed to users).

As one would expect, any object with appropriate `operator()` can be used (which implies that standalone functions work too when wrapped into `std:function`).

~~I'm opening this as a draft PR because this is my first attempt, and I'm unsure of some of the implementation details for which I need feedback.~~

#### PR validation:

Framework unit tests run.