### PR TITLE
Move PyBind11 interpreter management into its own sentry class

### DIFF
--- a/FWCore/PythonParameterSet/interface/PyBind11ProcessDesc.h
+++ b/FWCore/PythonParameterSet/interface/PyBind11ProcessDesc.h
@@ -4,7 +4,6 @@
 #include "FWCore/PythonParameterSet/interface/Python11ParameterSet.h"
 
 #include <memory>
-
 #include <string>
 #include <vector>
 
@@ -12,6 +11,17 @@ namespace edm {
   class ParameterSet;
   class ProcessDesc;
 }  // namespace edm
+
+class PyBind11InterpreterSentry {
+public:
+  PyBind11InterpreterSentry(bool ownsInterpreter);
+  ~PyBind11InterpreterSentry();
+
+  pybind11::object mainModule;
+
+private:
+  bool const ownsInterpreter_;
+};
 
 class PyBind11ProcessDesc {
 public:
@@ -49,8 +59,7 @@ private:
   void readString(std::string const& pyConfig);
 
   Python11ParameterSet theProcessPSet;
-  pybind11::object theMainModule;
-  bool theOwnsInterpreter;
+  PyBind11InterpreterSentry theInterpreter;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

The use of a separate class will guarantee that the interpreter will be shut down properly even if the `PyBind11ProcessDesc` constructor would throw an exception. Resolves https://github.com/cms-sw/cmssw/issues/39147.

#### PR validation:

Framework unit tests pass in the LTO build.