### PR TITLE
[nT2] DQM for the TOTEM nT2 detector

### DIFF
--- a/DQM/CTPPS/BuildFile.xml
+++ b/DQM/CTPPS/BuildFile.xml
@@ -1,3 +1,8 @@
+<use name="DataFormats/CTPPSDetId"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/ForwardGeometry"/>
+<use name="dd4hep"/>
+<use name="root"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DQM/CTPPS/BuildFile.xml
+++ b/DQM/CTPPS/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/CTPPSDetId"/>
+<use name="DataFormats/TotemReco"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/ForwardGeometry"/>
 <use name="dd4hep"/>

--- a/DQM/CTPPS/interface/TotemT2Segmentation.h
+++ b/DQM/CTPPS/interface/TotemT2Segmentation.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DQM_CTPPS_TotemT2Segmentation_h
+#define DQM_CTPPS_TotemT2Segmentation_h
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
+
+#include <unordered_map>
+#include <vector>
+
+class TotemGeometry;
+class TH2D;
+
+class TotemT2Segmentation {
+public:
+  explicit TotemT2Segmentation(const TotemGeometry&, size_t, size_t);
+
+  void fill(TH2D*, const TotemT2DetId&, double value = 1.);
+
+private:
+  std::vector<std::pair<short, short> > computeBins(const TotemT2DetId& detid) const;
+
+  const TotemGeometry geom_;
+  const size_t nbinsx_;
+  const size_t nbinsy_;
+
+  std::unordered_map<TotemT2DetId, std::vector<std::pair<short, short> > > bins_map_;
+};
+
+#endif

--- a/DQM/CTPPS/plugins/BuildFile.xml
+++ b/DQM/CTPPS/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="DQMServices/Core"/>
+  <use name="DQM/CTPPS"/>
   <use name="DataFormats/OnlineMetaData"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/CTPPSDetId"/>
@@ -11,6 +12,7 @@
   <use name="DataFormats/CTPPSReco"/>
   <use name="DataFormats/ProtonReco"/>
   <use name="Geometry/Records"/>
+  <use name="Geometry/ForwardGeometry"/>
   <use name="Geometry/VeryForwardGeometryBuilder"/>
   <use name="Geometry/VeryForwardRPTopology"/>
   <use name="CondFormats/DataRecord"/>

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+#include "DataFormats/TotemReco/interface/TotemT2RecHit.h"
+
+#include "Geometry/Records/interface/TotemGeometryRcd.h"
+#include "DQM/CTPPS/interface/TotemT2Segmentation.h"
+
+#include <string>
+
+class TotemT2DQMSource : public DQMEDAnalyzer {
+public:
+  TotemT2DQMSource(const edm::ParameterSet&);
+  ~TotemT2DQMSource() override;
+
+protected:
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TotemT2Digi>> digiToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TotemT2RecHit>> rechitToken_;
+
+  std::unique_ptr<TotemT2Segmentation> segm_;
+  MonitorElement* m_digis_mult_[2][TotemT2DetId::maxPlane + 1];
+  MonitorElement* m_rechits_mult_[2][TotemT2DetId::maxPlane + 1];
+};
+
+TotemT2DQMSource::TotemT2DQMSource(const edm::ParameterSet& iConfig)
+    : geometryToken_(esConsumes<TotemGeometry, TotemGeometryRcd, edm::Transition::BeginRun>()),
+      digiToken_(consumes<edmNew::DetSetVector<TotemT2Digi>>(iConfig.getParameter<edm::InputTag>("digisTag"))),
+      rechitToken_(consumes<edmNew::DetSetVector<TotemT2RecHit>>(iConfig.getParameter<edm::InputTag>("rechitsTag"))) {}
+
+TotemT2DQMSource::~TotemT2DQMSource() {}
+
+void TotemT2DQMSource::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {}
+
+void TotemT2DQMSource::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup& iSetup) {
+  ibooker.cd();
+  ibooker.setCurrentFolder("CTPPS/TotemT2");
+
+  const size_t summary_nbinsx = 25, summary_nbinsy = 25;
+
+  for (unsigned int arm = 0; arm <= CTPPSDetId::maxArm; ++arm)
+    for (unsigned int pl = 0; pl <= TotemT2DetId::maxPlane; ++pl) {
+      std::string title, path;
+      const TotemT2DetId detid(arm, pl, 0);
+      detid.planeName(title, TotemT2DetId::nFull);
+      detid.planeName(path, TotemT2DetId::nPath);
+      ibooker.setCurrentFolder(path);
+      m_digis_mult_[arm][pl] = ibooker.book2DD("digis multiplicity",
+                                               title + " digis multiplicity;x;y",
+                                               summary_nbinsx,
+                                               0.,
+                                               summary_nbinsx,
+                                               summary_nbinsy,
+                                               0.,
+                                               summary_nbinsy);
+      m_rechits_mult_[arm][pl] = ibooker.book2DD("rechits multiplicity",
+                                                 title + " rechits multiplicity;x;y",
+                                                 summary_nbinsx,
+                                                 0.,
+                                                 summary_nbinsx,
+                                                 summary_nbinsy,
+                                                 0.,
+                                                 summary_nbinsy);
+    }
+
+  // build a segmentation helper for the size of histograms previously booked
+  segm_ = std::make_unique<TotemT2Segmentation>(iSetup.getData(geometryToken_), summary_nbinsx, summary_nbinsy);
+}
+
+void TotemT2DQMSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // fill digis information
+  for (const auto& ds_digis : iEvent.get(digiToken_)) {
+    const TotemT2DetId detid(ds_digis.detId());
+    for (const auto& digi : ds_digis) {
+      segm_->fill(m_digis_mult_[detid.arm()][detid.plane()]->getTH2D(), detid);
+      (void)digi;  //FIXME make use of them
+    }
+  }
+  // fill rechits information
+  for (const auto& ds_rechits : iEvent.get(rechitToken_)) {
+    const TotemT2DetId detid(ds_rechits.detId());
+    for (const auto& rechit : ds_rechits) {
+      segm_->fill(m_rechits_mult_[detid.arm()][detid.plane()]->getTH2D(), detid);
+      (void)rechit;  //FIXME make use of them
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(TotemT2DQMSource);

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -3,6 +3,7 @@
  * This is a part of TOTEM offline software.
  * Author:
  *   Laurent Forthomme
+ *   Arkadiusz Cwikla
  *
  ****************************************************************************/
 
@@ -30,7 +31,7 @@
 class TotemT2DQMSource : public DQMEDAnalyzer {
 public:
   TotemT2DQMSource(const edm::ParameterSet&);
-  ~TotemT2DQMSource() override;
+  ~TotemT2DQMSource() override = default;
 
 protected:
   void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
@@ -38,76 +39,247 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
-  edm::EDGetTokenT<edmNew::DetSetVector<TotemT2Digi>> digiToken_;
-  edm::EDGetTokenT<edmNew::DetSetVector<TotemT2RecHit>> rechitToken_;
+  void fillActivePlanes(std::unordered_map<unsigned int, std::set<unsigned int>>&, const TotemT2DetId&);
+  void fillTriggerBitset(const TotemT2DetId&);
+  void clearTriggerBitset();
+  bool areChannelsTriggered(const TotemT2DetId&);
+  void bookErrorFlagsHistogram(DQMStore::IBooker&);
+  void fillErrorFlagsHistogram(const TotemT2Digi&);
+  void fillEdges(const TotemT2Digi&, const TotemT2DetId&);
+  void fillToT(const TotemT2RecHit&, const TotemT2DetId&);
+
+  const edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<TotemT2Digi>> digiToken_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<TotemT2RecHit>> rechitToken_;
 
   std::unique_ptr<TotemT2Segmentation> segm_;
-  MonitorElement* m_digis_mult_[2][TotemT2DetId::maxPlane + 1];
-  MonitorElement* m_rechits_mult_[2][TotemT2DetId::maxPlane + 1];
+
+  static constexpr double HPTDC_BIN_WIDTH_NS_ = 25. / 1024;
+  MonitorElement* HPTDCErrorFlags_2D_ = nullptr;
+
+  const unsigned int nbinsx_, nbinsy_;
+  const unsigned int windowsNum_;
+
+  struct SectorPlots {
+    MonitorElement* activePlanes = nullptr;
+    MonitorElement* activePlanesCount = nullptr;
+
+    MonitorElement* triggerEmulator = nullptr;
+    std::bitset<(TotemT2DetId::maxPlane + 1) * (TotemT2DetId::maxChannel + 1)> hitTilesArray;
+    static const unsigned int MINIMAL_TRIGGER = 3;
+
+    MonitorElement *leadingEdge = nullptr, *trailingEdge = nullptr, *timeOverTreshold = nullptr;
+
+    SectorPlots() = default;
+    SectorPlots(
+        DQMStore::IBooker& ibooker, unsigned int id, unsigned int nbinsx, unsigned int nbinsy, unsigned int windowsNum);
+  };
+
+  struct PlanePlots {
+    MonitorElement* digisMultiplicity = nullptr;
+    MonitorElement* rechitMultiplicity = nullptr;
+
+    PlanePlots() = default;
+    PlanePlots(DQMStore::IBooker& ibooker, unsigned int id, unsigned int nbinsx, unsigned int nbinsy);
+  };
+
+  std::unordered_map<unsigned int, SectorPlots> sectorPlots_;
+  std::unordered_map<unsigned int, PlanePlots> planePlots_;
 };
+
+TotemT2DQMSource::SectorPlots::SectorPlots(
+    DQMStore::IBooker& ibooker, unsigned int id, unsigned int nbinsx, unsigned int nbinsy, unsigned int windowsNum) {
+  std::string title, path;
+
+  TotemT2DetId(id).armName(path, TotemT2DetId::nPath);
+  ibooker.setCurrentFolder(path);
+
+  TotemT2DetId(id).armName(title, TotemT2DetId::nFull);
+
+  activePlanes = ibooker.book1D("active planes", title + " which planes are active;plane number", 8, -0.5, 7.5);
+
+  activePlanesCount = ibooker.book1D(
+      "number of active planes", title + " how many planes are active;number of active planes", 9, -0.5, 8.5);
+
+  triggerEmulator = ibooker.book2DD("trigger emulator",
+                                    title + " trigger emulator;arbitrary unit;arbitrary unit",
+                                    nbinsx,
+                                    -0.5,
+                                    double(nbinsx) - 0.5,
+                                    nbinsy,
+                                    -0.5,
+                                    double(nbinsy) - 0.5);
+  leadingEdge = ibooker.book1D(
+      "leading edge", title + " leading edge (DIGIs); leading edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+  trailingEdge = ibooker.book1D(
+      "trailing edge", title + " trailing edge (DIGIs); trailing edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+
+  timeOverTreshold = ibooker.book1D(
+      "time over threshold", title + " time over threshold (rechit);time over threshold (ns)", 250, -25, 100);
+}
+
+TotemT2DQMSource::PlanePlots::PlanePlots(DQMStore::IBooker& ibooker,
+                                         unsigned int id,
+                                         unsigned int nbinsx,
+                                         unsigned int nbinsy) {
+  std::string title, path;
+  TotemT2DetId(id).planeName(title, TotemT2DetId::nFull);
+  TotemT2DetId(id).planeName(path, TotemT2DetId::nPath);
+  ibooker.setCurrentFolder(path);
+
+  digisMultiplicity = ibooker.book2DD("digis multiplicity",
+                                      title + " digis multiplicity;arbitrary unit;arbitrary unit",
+                                      nbinsx,
+                                      -0.5,
+                                      double(nbinsx) - 0.5,
+                                      nbinsy,
+                                      -0.5,
+                                      double(nbinsy) - 0.5);
+  rechitMultiplicity = ibooker.book2DD("rechits multiplicity",
+                                       title + " rechits multiplicity;x;y",
+                                       nbinsx,
+                                       -0.5,
+                                       double(nbinsx) - 0.5,
+                                       nbinsy,
+                                       -0.5,
+                                       double(nbinsy) - 0.5);
+}
 
 TotemT2DQMSource::TotemT2DQMSource(const edm::ParameterSet& iConfig)
     : geometryToken_(esConsumes<TotemGeometry, TotemGeometryRcd, edm::Transition::BeginRun>()),
       digiToken_(consumes<edmNew::DetSetVector<TotemT2Digi>>(iConfig.getParameter<edm::InputTag>("digisTag"))),
-      rechitToken_(consumes<edmNew::DetSetVector<TotemT2RecHit>>(iConfig.getParameter<edm::InputTag>("rechitsTag"))) {}
-
-TotemT2DQMSource::~TotemT2DQMSource() {}
+      rechitToken_(consumes<edmNew::DetSetVector<TotemT2RecHit>>(iConfig.getParameter<edm::InputTag>("rechitsTag"))),
+      nbinsx_(iConfig.getParameter<unsigned int>("nbinsx")),
+      nbinsy_(iConfig.getParameter<unsigned int>("nbinsy")),
+      windowsNum_(iConfig.getParameter<unsigned int>("windowsNum")) {}
 
 void TotemT2DQMSource::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {}
 
 void TotemT2DQMSource::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup& iSetup) {
   ibooker.cd();
-  ibooker.setCurrentFolder("CTPPS/TotemT2");
+  ibooker.setCurrentFolder("TotemT2");
 
-  const size_t summary_nbinsx = 25, summary_nbinsy = 25;
+  bookErrorFlagsHistogram(ibooker);
 
-  for (unsigned int arm = 0; arm <= CTPPSDetId::maxArm; ++arm)
+  for (unsigned int arm = 0; arm <= CTPPSDetId::maxArm; ++arm) {
     for (unsigned int pl = 0; pl <= TotemT2DetId::maxPlane; ++pl) {
-      std::string title, path;
       const TotemT2DetId detid(arm, pl, 0);
-      detid.planeName(title, TotemT2DetId::nFull);
-      detid.planeName(path, TotemT2DetId::nPath);
-      ibooker.setCurrentFolder(path);
-      m_digis_mult_[arm][pl] = ibooker.book2DD("digis multiplicity",
-                                               title + " digis multiplicity;x;y",
-                                               summary_nbinsx,
-                                               0.,
-                                               summary_nbinsx,
-                                               summary_nbinsy,
-                                               0.,
-                                               summary_nbinsy);
-      m_rechits_mult_[arm][pl] = ibooker.book2DD("rechits multiplicity",
-                                                 title + " rechits multiplicity;x;y",
-                                                 summary_nbinsx,
-                                                 0.,
-                                                 summary_nbinsx,
-                                                 summary_nbinsy,
-                                                 0.,
-                                                 summary_nbinsy);
+      const TotemT2DetId planeId(detid.planeId());
+      planePlots_[planeId] = PlanePlots(ibooker, planeId, nbinsx_, nbinsy_);
     }
+    const TotemT2DetId detid(arm, 0, 0);
+    const TotemT2DetId secId(detid.armId());
+    sectorPlots_[secId] = SectorPlots(ibooker, secId, nbinsx_, nbinsy_, windowsNum_);
+  }
 
   // build a segmentation helper for the size of histograms previously booked
-  segm_ = std::make_unique<TotemT2Segmentation>(iSetup.getData(geometryToken_), summary_nbinsx, summary_nbinsy);
+  segm_ = std::make_unique<TotemT2Segmentation>(iSetup.getData(geometryToken_), nbinsx_, nbinsy_);
 }
 
 void TotemT2DQMSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // fill digis information
   for (const auto& ds_digis : iEvent.get(digiToken_)) {
     const TotemT2DetId detid(ds_digis.detId());
+    const TotemT2DetId planeId(detid.planeId());
     for (const auto& digi : ds_digis) {
-      segm_->fill(m_digis_mult_[detid.arm()][detid.plane()]->getTH2D(), detid);
-      (void)digi;  //FIXME make use of them
+      segm_->fill(planePlots_[planeId].digisMultiplicity->getTH2D(), detid);
+      fillTriggerBitset(detid);
+      fillErrorFlagsHistogram(digi);
+      fillEdges(digi, detid);
     }
   }
+
   // fill rechits information
+  std::unordered_map<unsigned int, std::set<unsigned int>> planes;
   for (const auto& ds_rechits : iEvent.get(rechitToken_)) {
     const TotemT2DetId detid(ds_rechits.detId());
+    const TotemT2DetId planeId(detid.planeId());
     for (const auto& rechit : ds_rechits) {
-      segm_->fill(m_rechits_mult_[detid.arm()][detid.plane()]->getTH2D(), detid);
-      (void)rechit;  //FIXME make use of them
+      segm_->fill(planePlots_[planeId].rechitMultiplicity->getTH2D(), detid);
+      fillToT(rechit, detid);
+      fillActivePlanes(planes, detid);
     }
   }
+
+  for (const auto& plt : sectorPlots_)
+    plt.second.activePlanesCount->Fill(planes[plt.first].size());
+
+  for (unsigned short arm = 0; arm <= CTPPSDetId::maxArm; ++arm)
+    for (unsigned short plane = 0; plane <= 1; ++plane)
+      for (unsigned short id = 0; id <= TotemT2DetId::maxChannel; ++id) {
+        const TotemT2DetId detid(arm, plane, id);
+        if (areChannelsTriggered(detid)) {
+          const TotemT2DetId secId(detid.armId());
+          segm_->fill(sectorPlots_[secId].triggerEmulator->getTH2D(), detid);
+        }
+      }
+
+  clearTriggerBitset();
+}
+
+void TotemT2DQMSource::fillActivePlanes(std::unordered_map<unsigned int, std::set<unsigned int>>& planes,
+                                        const TotemT2DetId& detid) {
+  const TotemT2DetId secId(detid.armId());
+  unsigned short pl = detid.plane();
+
+  planes[secId].insert(pl);
+
+  sectorPlots_[secId].activePlanes->Fill(pl);
+}
+
+void TotemT2DQMSource::fillTriggerBitset(const TotemT2DetId& detid) {
+  const TotemT2DetId secId(detid.armId());
+  unsigned short pl = detid.plane();
+  unsigned short ch = detid.channel();
+  sectorPlots_[secId].hitTilesArray[4 * pl + ch] = true;
+}
+
+void TotemT2DQMSource::clearTriggerBitset() {
+  for (auto& sectorPlot : sectorPlots_)
+    sectorPlot.second.hitTilesArray.reset();
+}
+
+bool TotemT2DQMSource::areChannelsTriggered(const TotemT2DetId& detid) {
+  unsigned int channel = detid.channel();
+
+  // prepare mask
+  std::bitset<(TotemT2DetId::maxPlane + 1) * (TotemT2DetId::maxChannel + 1)> mask;
+  // check if plane is even or not
+  unsigned int pl = detid.plane() % 2 == 0 ? 0 : 1;
+  // set only even or only odd plane bits for this channel
+  for (; pl <= TotemT2DetId::maxPlane; pl += 2)
+    mask[4 * pl + channel] = true;
+  const TotemT2DetId secId(detid.armId());
+  // check how many masked channels were hit
+  unsigned int triggeredChannelsNumber = (mask & sectorPlots_[secId].hitTilesArray).count();
+
+  return triggeredChannelsNumber >= SectorPlots::MINIMAL_TRIGGER;
+}
+
+void TotemT2DQMSource::bookErrorFlagsHistogram(DQMStore::IBooker& ibooker) {
+  HPTDCErrorFlags_2D_ = ibooker.book2D("HPTDC Errors", " HPTDC Errors?", 8, -0.5, 7.5, 2, -0.5, 1.5);
+  for (unsigned short error_index = 1; error_index <= 8; ++error_index)
+    HPTDCErrorFlags_2D_->setBinLabel(error_index, "Flag " + std::to_string(error_index));
+
+  int tmpIndex = 0;
+  HPTDCErrorFlags_2D_->setBinLabel(++tmpIndex, "some id 0", /* axis */ 2);
+  HPTDCErrorFlags_2D_->setBinLabel(++tmpIndex, "some id 1", /* axis */ 2);
+}
+
+void TotemT2DQMSource::fillErrorFlagsHistogram(const TotemT2Digi& digi) {
+  // placeholder for error hitogram filling
+  (void)digi;
+}
+
+void TotemT2DQMSource::fillEdges(const TotemT2Digi& digi, const TotemT2DetId& detid) {
+  const TotemT2DetId secId(detid.armId());
+  sectorPlots_[secId].leadingEdge->Fill(HPTDC_BIN_WIDTH_NS_ * digi.leadingEdge());
+  sectorPlots_[secId].trailingEdge->Fill(HPTDC_BIN_WIDTH_NS_ * digi.trailingEdge());
+}
+
+void TotemT2DQMSource::fillToT(const TotemT2RecHit& rechit, const TotemT2DetId& detid) {
+  const TotemT2DetId secId(detid.armId());
+  sectorPlots_[secId].timeOverTreshold->Fill(rechit.toT());
 }
 
 DEFINE_FWK_MODULE(TotemT2DQMSource);

--- a/DQM/CTPPS/python/totemT2DQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemT2DQMSource_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+totemT2DQMSource = DQMEDAnalyzer('TotemT2DQMSource',
+    digisTag = cms.InputTag('totemT2Digis', 'TotemT2'),
+    rechitsTag = cms.InputTag('totemT2RecHits'),
+
+    perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
+)

--- a/DQM/CTPPS/python/totemT2DQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemT2DQMSource_cfi.py
@@ -4,6 +4,9 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 totemT2DQMSource = DQMEDAnalyzer('TotemT2DQMSource',
     digisTag = cms.InputTag('totemT2Digis', 'TotemT2'),
     rechitsTag = cms.InputTag('totemT2RecHits'),
+    nbinsx = cms.uint32(25),
+    nbinsy = cms.uint32(25),
+    windowsNum = cms.uint32(4),
 
     perLSsaving = cms.untracked.bool(False), #driven by DQMServices/Core/python/DQMStore_cfi.py
 )

--- a/DQM/CTPPS/src/TotemT2Segmentation.cc
+++ b/DQM/CTPPS/src/TotemT2Segmentation.cc
@@ -43,12 +43,10 @@ std::vector<std::pair<short, short> > TotemT2Segmentation::computeBins(const Tot
   // compute the ellipse parameters
   const auto ax = ceil(nbinsx_ * 0.5), by = ceil(nbinsy_ * 0.5);
 
-  const float max_half_angle_rad = 0.4;
+  const float max_half_angle_rad = 0.3;
   // find the coordinates of the tile centre to extract its angle
   const auto tile_centre = geom_.tile(detid).centre();
-  const auto tile_angle_rad = std::atan2(tile_centre.y(), tile_centre.x()) *
-                              (detid.arm() == 1 ? 1. : -1.);  //FIXME ensure convention is correct
-
+  const auto tile_angle_rad = std::atan2(tile_centre.y(), tile_centre.x());
   // Geometric way of associating a DetId to a vector<ix, iy> of bins given the size (nx_, ny_) of
   // the TH2D('s) to be filled
   for (size_t ix = 0; ix < nbinsx_; ++ix)

--- a/DQM/CTPPS/src/TotemT2Segmentation.cc
+++ b/DQM/CTPPS/src/TotemT2Segmentation.cc
@@ -1,0 +1,63 @@
+
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *   Arkadiusz Cwikla
+ *
+ ****************************************************************************/
+
+#include "DQM/CTPPS/interface/TotemT2Segmentation.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TH2D.h"
+
+TotemT2Segmentation::TotemT2Segmentation(const TotemGeometry& geom, size_t nbinsx, size_t nbinsy)
+    : geom_(geom), nbinsx_(nbinsx), nbinsy_(nbinsy) {
+  for (unsigned short arm = 0; arm <= CTPPSDetId::maxArm; ++arm)
+    for (unsigned short plane = 0; plane <= TotemT2DetId::maxPlane; ++plane)
+      for (unsigned short id = 0; id <= TotemT2DetId::maxChannel; ++id) {
+        const TotemT2DetId detid(arm, plane, id);
+        bins_map_[detid] = computeBins(detid);
+      }
+}
+
+void TotemT2Segmentation::fill(TH2D* hist, const TotemT2DetId& detid, double value) {
+  if (bins_map_.count(detid) == 0)
+    throw cms::Exception("TotemT2Segmentation") << "Failed to retrieve list of bins for TotemT2DetId " << detid << ".";
+  if (static_cast<size_t>(hist->GetXaxis()->GetNbins()) != nbinsx_ ||
+      static_cast<size_t>(hist->GetYaxis()->GetNbins()) != nbinsy_)
+    throw cms::Exception("TotemT2Segmentation")
+        << "Trying to fill a summary plot with invalid number of bins. "
+        << "Should be of dimension (" << nbinsx_ << ", " << nbinsy_ << "), but has dimension ("
+        << hist->GetXaxis()->GetNbins() << ", " << hist->GetYaxis()->GetNbins() << ").";
+  for (const auto& bin : bins_map_.at(detid))
+    hist->Fill(bin.first, bin.second, value);
+}
+
+std::vector<std::pair<short, short> > TotemT2Segmentation::computeBins(const TotemT2DetId& detid) const {
+  std::vector<std::pair<short, short> > bins;
+  // find the histogram centre
+  const auto ox = floor(nbinsx_ * 0.5), oy = floor(nbinsy_ * 0.5);
+  // compute the ellipse parameters
+  const auto ax = ceil(nbinsx_ * 0.5), by = ceil(nbinsy_ * 0.5);
+
+  const float max_half_angle_rad = 0.4;
+  // find the coordinates of the tile centre to extract its angle
+  const auto tile_centre = geom_.tile(detid).centre();
+  const auto tile_angle_rad = std::atan2(tile_centre.y(), tile_centre.x()) *
+                              (detid.arm() == 1 ? 1. : -1.);  //FIXME ensure convention is correct
+
+  // Geometric way of associating a DetId to a vector<ix, iy> of bins given the size (nx_, ny_) of
+  // the TH2D('s) to be filled
+  for (size_t ix = 0; ix < nbinsx_; ++ix)
+    for (size_t iy = 0; iy < nbinsy_; ++iy) {
+      const auto ell_rad_norm = std::pow((ix - ox) / ax, 2) + std::pow((iy - oy) / by, 2);
+      if (ell_rad_norm < 1. && ell_rad_norm >= 0.1 &&
+          fabs(std::atan2(iy - oy, ix - ox) - tile_angle_rad) < max_half_angle_rad)
+        bins.emplace_back(ix, iy);
+    }
+
+  return bins;
+}

--- a/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
@@ -3,7 +3,7 @@ import string
 
 process = cms.Process('RECODQM')
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(6000) )
 process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 # minimum of logs

--- a/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+import string
+
+process = cms.Process('RECODQM')
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    statistics = cms.untracked.vstring(),
+    destinations = cms.untracked.vstring('cerr'),
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM framework
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = "CTPPS"
+process.dqmEnv.eventInfoFolder = "EventInfo"
+process.dqmSaver.path = ""
+process.dqmSaver.tag = "CTPPS"
+
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(
+        '/store/data/Run2018D/ZeroBias/RAW/v1/000/324/747/00000/97A72F4B-786F-5A48-B97E-C596DD73BD77.root',
+    ),
+)
+
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
+
+process.load('CalibPPS.ESProducers.totemT2DAQMapping_cff')
+process.load('EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff')
+process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')
+process.load('Geometry.ForwardGeometry.totemGeometryESModule_cfi')
+process.load('RecoPPS.Local.totemT2RecHits_cfi')
+process.load('DQM.CTPPS.totemT2DQMSource_cfi')
+
+process.path = cms.Path(
+    process.totemT2Digis *
+    process.totemT2RecHits *
+    process.totemT2DQMSource
+)
+
+process.end_path = cms.EndPath(
+    process.dqmEnv +
+    process.dqmSaver
+)
+
+process.schedule = cms.Schedule(
+    process.path,
+    process.end_path
+)

--- a/DQM/CTPPS/test/totemt2_dqm_test_fromdigi_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_fromdigi_cfg.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('DQM')
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    statistics = cms.untracked.vstring(),
+    destinations = cms.untracked.vstring('cerr'),
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+
+# load DQM framework
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = "CTPPS"
+process.dqmEnv.eventInfoFolder = "EventInfo"
+process.dqmSaver.path = ""
+process.dqmSaver.tag = "CTPPS"
+
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(
+        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/emulated_digi_test.root',
+    ),
+)
+
+process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')
+process.load('Geometry.ForwardGeometry.totemGeometryESModule_cfi')
+process.load('RecoPPS.Local.totemT2RecHits_cfi')
+process.load('DQM.CTPPS.totemT2DQMSource_cfi')
+
+process.path = cms.Path(
+    process.totemT2RecHits *
+    process.totemT2DQMSource
+)
+
+process.end_path = cms.EndPath(
+    process.dqmEnv +
+    process.dqmSaver
+)
+
+process.schedule = cms.Schedule(
+    process.path,
+    process.end_path
+)


### PR DESCRIPTION
#### PR description:

This PR introduces Data Quality Monitor for T2 telescope.
This code works on top of recently merged PR: https://github.com/cms-sw/cmssw/pull/38986 

#### PR validation:
Code compiles and the `DQM/CTPPS/test/totemt2_dqm_test_fromdigi_cfg.py` test produces DQM root file with plots as expected. Because detector is not yet integrated, test is run on emulated data.`/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/emulated_digi_test.root`.
Sample plot from DQM output file:
![image](https://user-images.githubusercontent.com/44035398/186232409-5b0cc3cb-fbca-49e5-9ab7-ec7d7197a8c0.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This PR is NOT a backport, but it is intented to be integrated into CMSSW_12_5_X.

@forthommel @grzanka @ChrisMisan for your attention.
