### PR TITLE
Clean unused dependencies from BuildFiles

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -2,9 +2,7 @@
   <use name="CondFormats/AlignmentRecord"/>
   <use name="DataFormats/DetId"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/ParameterSet"/>
   <use name="CondFormats/Alignment"/>
-  <use name="Alignment/CommonAlignment"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>

--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -39,13 +39,12 @@
 <use name="Geometry/TrackerNumberingBuilder"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="MagneticField/Records"/>
+<use name="RecoEcal/EgammaCoreTools"/>
 <use name="RecoMuon/TrackingTools"/>
 <use name="RecoVertex/PrimaryVertexProducer"/>
-<use name="RecoEcal/EgammaClusterAlgos"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimTracker/TrackerHitAssociation"/>
-<use name="SimTracker/TrackAssociation"/>
 <use name="TrackPropagation/SteppingHelixPropagator"/>
 <use name="TrackingTools/IPTools"/>
 <use name="TrackingTools/TrackAssociator"/>

--- a/CommonTools/ConditionDBWriter/plugins/BuildFile.xml
+++ b/CommonTools/ConditionDBWriter/plugins/BuildFile.xml
@@ -1,9 +1,9 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="CondCore/Utilities"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="CondCore/DBOutputService"/>
+<use name="CondFormats/DataRecord"/>
 <library file="PCLMetadataWriter.cc" name="PCLMetadataWriter">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DQMOffline/Alignment/BuildFile.xml
+++ b/DQMOffline/Alignment/BuildFile.xml
@@ -10,8 +10,5 @@
 <use name="RecoVertex/VertexTools"/>
 <use name="TrackingTools/IPTools"/>
 <use name="TrackingTools/Records"/>
-<use name="TrackingTools/TrackAssociator"/>
-<use name="TrackingTools/TrackFitters"/>
-<use name="TrackingTools/TrajectoryState"/>
 <use name="TrackingTools/TransientTrack"/>
 <flags EDM_PLUGIN="1"/>

--- a/HeavyFlavorAnalysis/SpecificDecay/BuildFile.xml
+++ b/HeavyFlavorAnalysis/SpecificDecay/BuildFile.xml
@@ -4,8 +4,6 @@
 <use name="FWCore/Framework"/>
 <use name="RecoVertex/KinematicFit"/>
 <use name="RecoVertex/KinematicFitPrimitives"/>
-<use name="TrackingTools/Records"/>
-<use name="TrackingTools/TransientTrack"/>
 <export>
   <flags SEAL_PLUGIN="1"/>
   <use name="DataFormats/PatCandidates"/>

--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BuildFile.xml
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BuildFile.xml
@@ -9,6 +9,8 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="CommonTools/UtilAlgos"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TransientTrack"/>
 <library file="*.cc" name="HeavyFlavorSpecificDecaysPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HeavyFlavorAnalysis/SpecificDecay/test/BuildFile.xml
+++ b/HeavyFlavorAnalysis/SpecificDecay/test/BuildFile.xml
@@ -6,6 +6,8 @@
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TransientTrack"/>
 <library file="stubs/*.cc" name="HeavyFlavorAnalysisSpecificDecayTest">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -1,13 +1,11 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
+<use name="DataFormats/L1THGCal"/>
 <use name="DataFormats/L1TParticleFlow"/>
 <use name="DataFormats/L1TCorrelator"/>
 <use name="CommonTools/BaseParticlePropagator"/>
-<use name="FastSimulation/Particle"/>
 <use name="DataFormats/ParticleFlowReco"/>
-<use name="L1Trigger/L1THGCal"/>
-<use name="L1Trigger/DemonstratorTools"/>
 <use name="CommonTools/Utils"/>
 <use name="CommonTools/MVAUtils"/>
 <use name="PhysicsTools/TensorFlow"/>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/HcalDigi"/>
 <use name="DataFormats/JetReco"/>
-<use name="FWCore/PluginManager"/>
+<use name="L1Trigger/DemonstratorTools"/>
 <use name="L1Trigger/L1TCalorimeter"/>
 <use name="L1Trigger/Phase2L1ParticleFlow"/>
 <use name="MagneticField/Engine"/>

--- a/PhysicsTools/TensorFlow/plugins/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/plugins/BuildFile.xml
@@ -1,9 +1,6 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/MessageLogger"/>
-<use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="PhysicsTools/TensorFlow"/>
-<use name="TrackingTools/Records"/>
 <library file="*.cc" name="PhysicsToolsTensorFlowPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -24,7 +24,6 @@
 <use name="RecoLocalCalo/HGCalRecProducers"/>
 <use name="RecoHGCal/TICL"/>
 <use name="RecoParticleFlow/PFProducer"/>
-<use name="RecoTracker/FinalTrackSelectors"/>
 <use name="SimDataFormats/Associations"/>
 <use name="SimDataFormats/CaloAnalysis"/>
 <use name="TrackingTools/GeomPropagators"/>

--- a/RecoTracker/FinalTrackSelectors/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="CondFormats/GBRForest"/>
-<use name="PhysicsTools/TensorFlow"/>
 <use name="TrackingTools/PatternTools"/>
 <use name="roottmva"/>
 <use name="lwtnn"/>

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -30,9 +30,7 @@
   <use name="TrackingTools/TrajectoryState"/>
   <use name="TrackingTools/TransientTrackingRecHit"/>
   <use name="rootmath"/>
-  <use name="CondFormats/GBRForest"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="TrackingTools/PatternTools"/>
-  <use name="RecoTracker/FinalTrackSelectors"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/SimG4Core/CustomPhysics/BuildFile.xml
+++ b/SimG4Core/CustomPhysics/BuildFile.xml
@@ -1,10 +1,8 @@
 <export>
   <lib name="1"/>
 </export>
-<use name="DataFormats/GeometryVector" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/PluginManager"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Physics"/>
 <use name="SimG4Core/PhysicsLists"/>

--- a/SimG4Core/CustomPhysics/plugins/BuildFile.xml
+++ b/SimG4Core/CustomPhysics/plugins/BuildFile.xml
@@ -1,6 +1,8 @@
+<use name="DataFormats/GeometryVector" source_only="1"/>
 <use name="SimG4Core/Watcher"/>
 <use name="SimG4Core/Notification"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
 <use name="geant4core"/>
 <use name="clhep"/>
 <use name="boost"/>

--- a/Validation/CTPPS/plugins/BuildFile.xml
+++ b/Validation/CTPPS/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="DataFormats/CTPPSDetId"/>
 <use name="rootcore"/>
 <use name="Geometry/VeryForwardGeometryBuilder"/>
-<use name="Geometry/VeryForwardRPTopology"/>
 <use name="DataFormats/ProtonReco"/>
 <library name="ValidationCTPPSPlugins" file="*.cc">
   <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/37915).

In many cases, the dependencies had to be moved to the appropriate BuildFile, for example from a plugins directory to the library directory or vice versa.

This PR cleans unnecessary includes from CMSSW BuildFiles that were added in the last months.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.