### PR TITLE
Replace Geometry_cff with GeometryDB_cff in DPGAnalysis

### DIFF
--- a/DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_MC_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_MC_ToscaMap090322_cfg.py
@@ -25,20 +25,20 @@ process.maxEvents = cms.untracked.PSet(
 #------------------------------------------
 # Load standard sequences.
 #------------------------------------------
-process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_ALL_V9::All' 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 
 #------------------------------------------
 # parameters for the CSCSkim module
 #------------------------------------------
-process.load("DPGAnalysis/Skims/CSCSkim_cfi")
+process.load("DPGAnalysis.Skims.CSCSkim_cfi")
 process.cscSkim.typeOfSkim = cms.untracked.int32(9)
 
 #### the path

--- a/DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_ToscaMap090322_cfg.py
@@ -25,20 +25,20 @@ process.maxEvents = cms.untracked.PSet(
 #------------------------------------------
 # Load standard sequences.
 #------------------------------------------
-process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_ALL_V9::All' 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 
 #------------------------------------------
 # parameters for the CSCSkim module
 #------------------------------------------
-process.load("DPGAnalysis/Skims/CSCSkim_cfi")
+process.load("DPGAnalysis.Skims.CSCSkim_cfi")
 process.cscSkim.typeOfSkim = cms.untracked.int32(9)
 
 #### the path

--- a/DPGAnalysis/Skims/python/DoubleMuon_cfg.py
+++ b/DPGAnalysis/Skims/python/DoubleMuon_cfg.py
@@ -16,10 +16,10 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRZT210_V1::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/PointingDoubleMultiSkim_cfg.py
+++ b/DPGAnalysis/Skims/python/PointingDoubleMultiSkim_cfg.py
@@ -16,10 +16,10 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRZT210_V1::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/RPCNoise_example.py
+++ b/DPGAnalysis/Skims/python/RPCNoise_example.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("USER")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_38T_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRUZET4_V5P::All'
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(

--- a/DPGAnalysis/Skims/python/SuperPointing_MC_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/SuperPointing_MC_ToscaMap090322_cfg.py
@@ -22,10 +22,10 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_ALL_V4::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/SuperPointing_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/SuperPointing_ToscaMap090322_cfg.py
@@ -22,10 +22,10 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_ALL_V4::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/SuperPointing_and_pixcluster_cfg.py
+++ b/DPGAnalysis/Skims/python/SuperPointing_and_pixcluster_cfg.py
@@ -17,10 +17,10 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(5000))
 process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRZT210_V1::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/TrackerPointing_MC_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/TrackerPointing_MC_ToscaMap090322_cfg.py
@@ -23,10 +23,10 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_V4P::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/TrackerPointing_ToscaMap090322_cfg.py
+++ b/DPGAnalysis/Skims/python/TrackerPointing_ToscaMap090322_cfg.py
@@ -23,10 +23,10 @@ process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRAFT_V4P::All' 
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")

--- a/DPGAnalysis/Skims/python/filterRecHits_cfg.py
+++ b/DPGAnalysis/Skims/python/filterRecHits_cfg.py
@@ -9,7 +9,7 @@ process = cms.Process('FILTER')
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, DPGAnalysis configuration files (11 files) are fixed.

```
        modified:   DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_MC_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/CSCSkim_BFieldStudies_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/DoubleMuon_cfg.py
        modified:   DPGAnalysis/Skims/python/PointingDoubleMultiSkim_cfg.py
        modified:   DPGAnalysis/Skims/python/RPCNoise_example.py
        modified:   DPGAnalysis/Skims/python/SuperPointing_MC_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/SuperPointing_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/SuperPointing_and_pixcluster_cfg.py
        modified:   DPGAnalysis/Skims/python/TrackerPointing_MC_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/TrackerPointing_ToscaMap090322_cfg.py
        modified:   DPGAnalysis/Skims/python/filterRecHits_cfg.py
```

Please inform us if there is any obsolete configurations in this PR. Then I will remove.

#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)