### PR TITLE
`DiMuonMassBiasClient`: add protection for empty input histogram in the fitting function

### DIFF
--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -48,6 +48,9 @@ namespace diMuonMassBias {
     assert(v.size() == 3);
     std::copy(std::begin(v), std::end(v), x);
   }
+
+  static constexpr int minimumHits = 10;
+
 }  // namespace diMuonMassBias
 
 class DiMuonMassBiasClient : public DQMEDHarvester {
@@ -83,7 +86,7 @@ private:
 
   float meanConfig_[3];  /* parmaeters for the fit: mean */
   float widthConfig_[3]; /* parameters for the fit: width */
-  float sigmaConfig_[3]; /* parmaeters for the fit: sigma */
+  float sigmaConfig_[3]; /* parameters for the fit: sigma */
 
   // list of histograms to harvest
   std::vector<std::string> MEtoHarvest_;

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -91,7 +91,8 @@ ALCARECOTkAlDiMuonMassBiasClient = DQMOffline.Alignment.DiMuonMassBiasClient_cfi
     FolderName = "AlCaReco/"+__selectionName
 )
 
-ALCARECOTkAlDiMuonAndVertexDQM = cms.Sequence(ALCARECOTkAlDiMuonAndVertexTkAlDQM + ALCARECOTkAlDiMuonAndVertexVtxDQM + ALCARECOTkAlDiMuonMassBiasDQM + ALCARECOTkAlDiMuonMassBiasClient)
+ALCARECOTkAlDiMuonAndVertexDQM = cms.Sequence(ALCARECOTkAlDiMuonAndVertexTkAlDQM + ALCARECOTkAlDiMuonAndVertexVtxDQM + ALCARECOTkAlDiMuonMassBiasDQM)
+# comment for now, doesn't support concurrent lumis + ALCARECOTkAlDiMuonMassBiasClient)
 
 #########################################################
 #############---  TkAlZMuMuHI ---########################

--- a/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
@@ -146,6 +146,14 @@ void DiMuonMassBiasClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGett
 diMuonMassBias::fitOutputs DiMuonMassBiasClient::fitVoigt(TH1* hist, const bool& fitBackground) const
 //-----------------------------------------------------------------------------------
 {
+  if (hist->GetEntries() < diMuonMassBias::minimumHits) {
+    edm::LogWarning("DiMuonMassBiasClient") << " Input histogram:" << hist->GetName() << " has not enough entries ("
+                                            << hist->GetEntries() << ") for a meaningful Voigtian fit!\n"
+                                            << "Skipping!";
+
+    return diMuonMassBias::fitOutputs(Measurement1D(0., 0.), Measurement1D(0., 0.));
+  }
+
   TCanvas* c1 = new TCanvas();
   if (debugMode_) {
     c1->Clear();
@@ -168,9 +176,9 @@ diMuonMassBias::fitOutputs DiMuonMassBiasClient::fitVoigt(TH1* hist, const bool&
   RooDataHist datahist("datahist", "datahist", InvMass, RooFit::Import(*hist));
   datahist.plotOn(frame);
 
-  RooRealVar mean("#mu", "mean", meanConfig_[0], meanConfig_[1], meanConfig_[2]);          //90.0, 60.0, 120.0
-  RooRealVar width("width", "width", widthConfig_[0], widthConfig_[1], widthConfig_[2]);   // 5.0,  0.0, 120.0
-  RooRealVar sigma("#sigma", "sigma", sigmaConfig_[0], sigmaConfig_[1], sigmaConfig_[2]);  // 5.0,  0.0, 120.0
+  RooRealVar mean("#mu", "mean", meanConfig_[0], meanConfig_[1], meanConfig_[2]);          //90.0, 60.0, 120.0 (for Z)
+  RooRealVar width("width", "width", widthConfig_[0], widthConfig_[1], widthConfig_[2]);   // 5.0,  0.0, 120.0 (for Z)
+  RooRealVar sigma("#sigma", "sigma", sigmaConfig_[0], sigmaConfig_[1], sigmaConfig_[2]);  // 5.0,  0.0, 120.0 (for Z)
   RooVoigtian voigt("voigt", "voigt", InvMass, mean, width, sigma);
 
   RooRealVar lambda("#lambda", "slope", -0.01, -100., 1.);


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/39180

#### PR description:

Title says it all, forward-port of commit e03333cdd9bf894c4eca9b348e2538d6c195c89d from PR https://github.com/cms-sw/cmssw/pull/39166, needed to avoid getting stuck with the Voigtian fit on empty input histograms.
Also it removes from the path being run `DiMuonMassBiasClient` as it doesn't support (yet) concurrent lumis, see https://github.com/cms-sw/cmssw/issues/39180#issuecomment-1225931956

#### PR validation:

The unit test in the backport PR https://github.com/cms-sw/cmssw/pull/39166 with this commit now runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Forward-port from https://github.com/cms-sw/cmssw/pull/39166
