### PR TITLE
Add new tag for PPS PCL, move SiStrips tags to Prod in DropBoxMetadata

### DIFF
--- a/CondFormats/Common/data/PPSTimingCalibrationRcd_prep.json
+++ b/CondFormats/Common/data/PPSTimingCalibrationRcd_prep.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt": {}
+        "CTPPPSTimingCalibration_HPTDC_byPCL_v1_prompt": {}
     }, 
     "inputTag": "PPSDiamondTimingCalibration_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/PPSTimingCalibrationRcd_prod.json
+++ b/CondFormats/Common/data/PPSTimingCalibrationRcd_prod.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt": {}
+        "CTPPPSTimingCalibration_HPTDC_byPCL_v1_prompt": {}
     }, 
     "inputTag": "PPSDiamondTimingCalibration_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/SiStripApvGainRcdAAG_multirun_prod.json
+++ b/CondFormats/Common/data/SiStripApvGainRcdAAG_multirun_prod.json
@@ -1,5 +1,5 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripApvGainAfterAbortGap_PCL_multirun_v0_prompt": {}
     }, 

--- a/CondFormats/Common/data/SiStripApvGainRcdAAG_prod.json
+++ b/CondFormats/Common/data/SiStripApvGainRcdAAG_prod.json
@@ -1,5 +1,5 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}

--- a/CondFormats/Common/data/SiStripApvGainRcdAfterAbortGap_prod.json
+++ b/CondFormats/Common/data/SiStripApvGainRcdAfterAbortGap_prod.json
@@ -1,5 +1,5 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripApvGainAfterAbortGap_PCL_v0_hlt": {}, 
         "SiStripApvGainAfterAbortGap_PCL_v0_prompt": {}

--- a/CondFormats/Common/data/SiStripApvGainRcd_multirun_prod.json
+++ b/CondFormats/Common/data/SiStripApvGainRcd_multirun_prod.json
@@ -1,5 +1,5 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripApvGain_PCL_multirun_v0_prompt": {},
         "SiStripApvGain_PCL_multirun_v0_hlt": {}

--- a/CondFormats/Common/data/SiStripApvGainRcd_prod.json
+++ b/CondFormats/Common/data/SiStripApvGainRcd_prod.json
@@ -1,5 +1,5 @@
 {
-    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripApvGain_PCL_v0_hlt": {}, 
         "SiStripApvGain_PCL_v0_prompt": {}


### PR DESCRIPTION
#### PR description:

As requested in https://cms-talk.web.cern.ch/t/new-tag-for-pcl-for-pps-timingcalibration/14245 we moved the PPS Timing PCL tag to v1

I took the opp to fix some other metadatas for the strips (in agreement with the strips convenors)

#### PR validation:

The produced payload differs only in the keys where it should:
https://cern.ch/go/z8gx

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not really needed, but I think we should have it in 12_4_X, that's where it's really used
