### PR TITLE
Fixes for DeepDoubleX

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -646,6 +646,9 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
                 
             if btagInfo == 'pfDeepDoubleXTagInfos':
+                # can only run on PAT jets, so the updater needs to be used
+                if 'updated' not in jetSource.value().lower():
+                    raise ValueError("Invalid jet collection: %s. pfDeepDoubleXTagInfos only supports running via updateJetCollection." % jetSource.value())
                 addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
                                     btag.pfDeepDoubleXTagInfos.clone(
                                       jets = jetSource,

--- a/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
@@ -123,8 +123,9 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
 
     // reco jet reference (use as much as possible)
     const auto& jet = jets->at(jet_n);
-    const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
     const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
+    if (!pat_jet)
+      throw edm::Exception(edm::errors::InvalidReference) << "Input is not a pat::Jet.";
 
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
     if (jet.pt() > min_jet_pt_) {

--- a/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepDoubleXTagInfoProducer.cc
@@ -261,14 +261,6 @@ void DeepDoubleXTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
           auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
           auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
 
-          // need some edm::Ptr or edm::Ref if reco candidates
-          reco::PFCandidatePtr reco_ptr;
-          if (pf_jet) {
-            reco_ptr = pf_jet->getPFConstituent(i);
-          } else if (pat_jet && reco_cand) {
-            reco_ptr = pat_jet->getPFConstituent(i);
-          }
-
           float puppiw = 1.0;  // fallback value
 
           float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand, jet_radius_);


### PR DESCRIPTION
#### PR description:

This PR cleans up a few issues from #30016:
* removes an unnecessary `edm::Ptr` that caused an exception when running on `packedCandidate`: `PFJet constituent is not of PFCandidate type` (reported on Mattermost)
* the new dependency on `pat::Jet` in the DeepDoubleX code was not handled properly: when running on `reco::Jet`, the `dynamic_cast` to `pat::Jet` would fail, creating a `nullptr`, which would then be passed to `commonCandidateToFeatures()`/`getDRSubjetFeatures()` for another `dynamic_cast`, leading to a segfault.
* the requirement to run only on `pat::Jet` should be reflected in `jetTools` as it is for other discriminators. I added a simple check; not sure if it's optimal or comprehensive in this case.

#### PR validation:

Ran jetToolbox several times and observed correct behavior (either runs to completion or throws `"Input is not a pat::Jet."` when expected), rather than unexpected exceptions or segfaults.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 10_6_X for those running on UL samples. Other backports can be made upon request.

attn: @andrzejnovak 