### PR TITLE
Run3-gex138A Replace access by label with access using token in CalibCalorimetry/EcalPedestalOffsets

### DIFF
--- a/CalibCalorimetry/EcalPedestalOffsets/interface/testChannel.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/testChannel.h
@@ -58,18 +58,17 @@ public:
 private:
   int getHeaderSMId(const int headerId);
 
-  std::string m_digiCollection;  //! secondary name given to collection of digis
-  std::string m_digiProducer;    //! name of module/plugin/producer making digis
-  std::string m_headerProducer;  //! name of module/plugin/producer making headers
+  const edm::EDGetTokenT<EBDigiCollection> m_digiProducerToken;         //! Token to access digis
+  const edm::EDGetTokenT<EcalRawDataCollection> m_headerProducerToken;  //! Token to access headers
 
-  std::string m_xmlFile;  //! name of the xml file to be saved
+  const std::string m_xmlFile;  //! name of the xml file to be saved
 
-  int m_DACmin;
-  int m_DACmax;
-  double m_RMSmax;
-  int m_bestPed;
+  const int m_DACmin;
+  const int m_DACmax;
+  const double m_RMSmax;
+  const int m_bestPed;
 
-  int m_xtal;
+  const int m_xtal;
 
   TH2F m_pedVSDAC;
   TH2F m_singlePedVSDAC_1;

--- a/CalibCalorimetry/EcalPedestalOffsets/src/testChannel.cc
+++ b/CalibCalorimetry/EcalPedestalOffsets/src/testChannel.cc
@@ -15,9 +15,10 @@
 
 //! ctor
 testChannel::testChannel(const edm::ParameterSet &paramSet)
-    : m_digiCollection(paramSet.getParameter<std::string>("digiCollection")),
-      m_digiProducer(paramSet.getParameter<std::string>("digiProducer")),
-      m_headerProducer(paramSet.getParameter<std::string>("headerProducer")),
+    : m_digiProducerToken(
+          consumes<EBDigiCollection>(edm::InputTag(paramSet.getParameter<std::string>("digiProducer")))),
+      m_headerProducerToken(
+          consumes<EcalRawDataCollection>(edm::InputTag(paramSet.getParameter<std::string>("headerProducer")))),
       m_xmlFile(paramSet.getParameter<std::string>("xmlFile")),
       m_DACmin(paramSet.getParameter<int>("DACmin")),
       m_DACmax(paramSet.getParameter<int>("DACmax")),
@@ -66,10 +67,9 @@ void testChannel::analyze(edm::Event const &event, edm::EventSetup const &eventS
 
   // get the headers
   // (one header for each supermodule)
-  edm::Handle<EcalRawDataCollection> DCCHeaders;
-  event.getByLabel(m_headerProducer, DCCHeaders);
+  const edm::Handle<EcalRawDataCollection> &DCCHeaders = event.getHandle(m_headerProducerToken);
   if (!DCCHeaders.isValid()) {
-    edm::LogError("testChannel") << "Error! can't get the product " << m_headerProducer.c_str();
+    edm::LogError("testChannel") << "Error! can't get the product for EcalRawDataCollection";
   }
 
   std::map<int, int> DACvalues;
@@ -85,10 +85,9 @@ void testChannel::analyze(edm::Event const &event, edm::EventSetup const &eventS
 
   // get the digis
   // (one digi for each crystal)
-  edm::Handle<EBDigiCollection> pDigis;
-  event.getByLabel(m_digiProducer, pDigis);
+  const edm::Handle<EBDigiCollection> &pDigis = event.getHandle(m_digiProducerToken);
   if (!pDigis.isValid()) {
-    edm::LogError("testChannel") << "Error! can't get the product " << m_digiCollection.c_str();
+    edm::LogError("testChannel") << "Error! can't get the product for EBDigiCollection";
   }
 
   // loop over the digis


### PR DESCRIPTION
#### PR description:

Replace access by label with access using token in CalibCalorimetry/EcalPedestalOffsets

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special