### PR TITLE
PPS fixed LHCInfo PopCon 100 lumisections query limit

### DIFF
--- a/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
@@ -18,6 +18,8 @@ public:
   void getNewObjects() override;
   std::string id() const override;
 
+  static constexpr unsigned int kLumisectionsQueryLimit = 4000;  // enough for fills not exceeding 25h
+
 private:
   void addEmptyPayload(cond::Time_t iov);
 

--- a/CondTools/RunInfo/interface/OMSAccess.h
+++ b/CondTools/RunInfo/interface/OMSAccess.h
@@ -185,6 +185,9 @@ namespace cond {
       std::stringstream filter;
       if (m_filter.empty()) {
         filter << "?";
+        if (!m_limit.empty()) {
+          m_limit.front() = '&';
+        }
       } else {
         filter << m_filter << "&";
       }
@@ -212,6 +215,9 @@ namespace cond {
     // not null filter
     inline OMSServiceQuery& filterNotNull(const std::string& varName) { return filterNEQ(varName, SNULL); }
 
+    // limit for the page size, when unspecified OMS's default limit is 100
+    OMSServiceQuery& limit(int value);
+
     // triggers the execution of the query ( calling curl functions )
     bool execute();
 
@@ -230,6 +236,7 @@ namespace cond {
   private:
     std::string m_url;
     std::string m_filter;
+    std::string m_limit;
     std::string m_varList;
     std::unique_ptr<OMSServiceResult> m_result;
     unsigned long m_status = 0;

--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -156,7 +156,9 @@ size_t LHCInfoPopConSourceHandler::getLumiData(const cond::OMSService& oms,
                                                const boost::posix_time::ptime& endFillTime) {
   auto query = oms.query("lumisections");
   query->addOutputVars({"start_time", "delivered_lumi", "recorded_lumi"});
-  query->filterEQ("fill_number", fillId).filterGT("start_time", beginFillTime).filterLT("start_time", endFillTime);
+  query->filterEQ("fill_number", fillId);
+  query->filterGT("start_time", beginFillTime).filterLT("start_time", endFillTime);
+  query->limit(kLumisectionsQueryLimit);
   size_t nlumi = 0;
   if (query->execute()) {
     auto res = query->result();
@@ -239,6 +241,8 @@ void LHCInfoPopConSourceHandler::getDipData(const cond::OMSService& oms,
   // the old implementation is not helping: apparently it is checking only the bunchconfiguration for the first diptime set of values...
   auto query1 = oms.query("diplogger/dip/acc/LHC/RunControl/CirculatingBunchConfig/Beam1");
   query1->filterGT("dip_time", beginFillTime).filterLT("dip_time", endFillTime);
+  //This query is limited to 100 rows, but currently only one is used
+  //If all this data is needed and saved properly the limit has to be set: query1->limit(...)
   if (query1->execute()) {
     auto res = query1->result();
     if (!res.empty()) {
@@ -256,6 +260,7 @@ void LHCInfoPopConSourceHandler::getDipData(const cond::OMSService& oms,
   }
   auto query2 = oms.query("diplogger/dip/acc/LHC/RunControl/CirculatingBunchConfig/Beam2");
   query2->filterGT("dip_time", beginFillTime).filterLT("dip_time", endFillTime);
+  //This query is limited to 100 rows, but currently only one is used
   if (query2->execute()) {
     auto res = query2->result();
     if (!res.empty()) {
@@ -274,6 +279,7 @@ void LHCInfoPopConSourceHandler::getDipData(const cond::OMSService& oms,
 
   auto query3 = oms.query("diplogger/dip/CMS/LHC/LumiPerBunch");
   query3->filterGT("dip_time", beginFillTime).filterLT("dip_time", endFillTime);
+  //This query is limited to 100 rows, but currently only one is used
   if (query3->execute()) {
     auto res = query3->result();
     if (!res.empty()) {

--- a/CondTools/RunInfo/src/OMSAccess.cc
+++ b/CondTools/RunInfo/src/OMSAccess.cc
@@ -83,6 +83,18 @@ namespace cond {
     return *this;
   }
 
+  OMSServiceQuery& OMSServiceQuery::limit(int value) {
+    std::stringstream pageLimit;
+    if (m_filter.empty()) {
+      pageLimit << "?";
+    } else {
+      pageLimit << "&";
+    }
+    pageLimit << "page[limit]=" << value;
+    m_limit = pageLimit.str();
+    return *this;
+  }
+
   bool OMSServiceQuery::execute() {
     bool ret = false;
     std::string out;
@@ -99,7 +111,7 @@ namespace cond {
 
   OMSServiceResult& OMSServiceQuery::result() { return *m_result; }
 
-  std::string OMSServiceQuery::url() { return m_url + m_filter + m_varList; }
+  std::string OMSServiceQuery::url() { return m_url + m_filter + m_limit + m_varList; }
 
   OMSService::OMSService() : m_baseUrl() {}
 


### PR DESCRIPTION
#### PR description:

Fixes a bug in LHCInfo PopCon: before the fix it saved only up to 100 payloads for a fill because it used to get only up to 100 lumisections from a query to OMS which API has default page limit of 100 entries.  
The fix consits of adding functionality to `cond::OMSService` for setting the page limit and using it in `LHCInfoPopConSourceHandler.cc` with limit set to a constant of 4000 which is enough for fills not exceeding 25 hours.

#### PR validation:

Verified retrieval of more than 100LS with local tests running LHCInfoPopConAnalyzerStartFill.py and LHCInfoPopConAnalyzerEndFill.py and checking the logs and payloads written to local sqlite database. In the logs there were lines "Found ... lumisections during the fill ..." with lumisections number higher than 100 confirming the fix.

