### PR TITLE
[12.4.X]  Enable veto logic for HG PCL Tracker alignment

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -263,12 +263,9 @@ void MillePedeFileReader ::readMillePedeResultFile() {
             << "=============" << std::endl;
 
         if (std::abs(ObsMove) > thresholds_[detLabel][alignableIndex]) {
-          if (!isHG_) {
-            edm::LogWarning("MillePedeFileReader")
-                << "Aborting payload creation."
-                << " Exceeding maximum thresholds for movement: " << std::abs(ObsMove) << " for" << detLabel << "("
-                << coord << ")";
-          }
+          edm::LogWarning("MillePedeFileReader") << "Aborting payload creation."
+                                                 << " Exceeding maximum thresholds for movement: " << std::abs(ObsMove)
+                                                 << " for" << detLabel << "(" << coord << ")";
           updateBits_.set(0);
           vetoUpdateDB_ = true;
           continue;
@@ -277,11 +274,9 @@ void MillePedeFileReader ::readMillePedeResultFile() {
           updateBits_.set(1);
 
           if (std::abs(ObsErr) > errors_[detLabel][alignableIndex]) {
-            if (!isHG_) {
-              edm::LogWarning("MillePedeFileReader") << "Aborting payload creation."
-                                                     << " Exceeding maximum thresholds for error: " << std::abs(ObsErr)
-                                                     << " for" << detLabel << "(" << coord << ")";
-            }
+            edm::LogWarning("MillePedeFileReader") << "Aborting payload creation."
+                                                   << " Exceeding maximum thresholds for error: " << std::abs(ObsErr)
+                                                   << " for" << detLabel << "(" << coord << ")";
             updateBits_.set(2);
             vetoUpdateDB_ = true;
             continue;
@@ -309,8 +304,7 @@ void MillePedeFileReader ::readMillePedeResultFile() {
   }
 
   if (isHG_) {          // check fractionCut
-    updateDB_ = false;  // reset both booleans since only fractionCut is considered for HG
-    vetoUpdateDB_ = false;
+    updateDB_ = false;  // reset booleans since fractionCut is considered for HG
     std::stringstream ss;
     for (auto& ali : alignables_) {
       ss << ali << std::endl;
@@ -332,7 +326,7 @@ void MillePedeFileReader ::readMillePedeResultFile() {
       }
       ss << "===================" << std::endl;
     }
-    if (updateDB_) {
+    if (updateDB_ && !vetoUpdateDB_) {
       ss << "Alignment will be updated" << std::endl;
     } else {
       ss << "Alignment will NOT be updated" << std::endl;


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/39189

#### PR description:

In this PR the veto logic for the HG PCL Tracker alignment is enabled. The same veto logic as used for the old LG PCL alignment is employed, which vetoes the update of the alignment as soon as the movement or the uncertainty an a movement for a alignable exceeds a given thresholds. The thresholds are defined in payloads, which were modified for the HG PCL alingment in https://github.com/cms-sw/cmssw/pull/38195.

#### PR validation:

The PR can be tested using `runTheMatrix.py -l 1001.2`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport of https://github.com/cms-sw/cmssw/pull/39189 which is needed for the HG PCL alignment running on Tier-0.

@mmusich, @connorpa, @antoniovagnerini, @consuegs