### PR TITLE
(DAQ) silence warnings in GlobalEvFOutputModule (12_5_X)

### DIFF
--- a/EventFilter/Utilities/interface/JsonMonitorable.h
+++ b/EventFilter/Utilities/interface/JsonMonitorable.h
@@ -142,6 +142,7 @@ namespace jsoncollector {
   class StringJ : public JsonMonitorable {
   public:
     StringJ() : JsonMonitorable() {}
+    StringJ(StringJ const& sJ) : JsonMonitorable() { theVar_ = sJ.value(); }
 
     ~StringJ() override {}
 


### PR DESCRIPTION
#### PR description:
Avoid initialization of same transfer info values from HLT menu PSet for each lumisection in GlobalEvFOutputModule, instead it can be done per run (i.e. only once in the lifetime of a HLT cmsRun process).

Main reason of doing this was to reduce printing log warnings in online HLT at every lumisection for each module instance.

#### PR validation:

Tested in DAQ F3 test setup (BU-FU VM cluster) with JSON output being valid and gets merged fine at micro and mini-merge levels.