### PR TITLE
modernize configuration of SiPixelGainCalibration DB manipulation code and add unit tests

### DIFF
--- a/CondTools/SiPixel/plugins/SiPixelCondObjAllPayloadsReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjAllPayloadsReader.cc
@@ -52,6 +52,7 @@ namespace cms {
   public:
     explicit SiPixelCondObjAllPayloadsReader(const edm::ParameterSet& iConfig);
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void analyze(const edm::Event&, const edm::EventSetup&) override;
     void endJob() override;
 
@@ -69,6 +70,14 @@ namespace cms {
 }  // namespace cms
 
 namespace cms {
+
+  void SiPixelCondObjAllPayloadsReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("EDAnalyzer to read per-module SiPixelGainCalibration payloads in the EventSetup, for any type");
+    desc.add<std::string>("payloadType", "HLT");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
   SiPixelCondObjAllPayloadsReader::SiPixelCondObjAllPayloadsReader(const edm::ParameterSet& conf)
       : tkGeomToken_(esConsumes()) {
     usesResource(TFileService::kSharedResource);

--- a/CondTools/SiPixel/plugins/SiPixelCondObjForHLTReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjForHLTReader.cc
@@ -51,6 +51,9 @@ namespace cms {
   public:
     explicit SiPixelCondObjForHLTReader(const edm::ParameterSet &iConfig);
 
+    ~SiPixelCondObjForHLTReader() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
     void analyze(const edm::Event &, const edm::EventSetup &) override;
     void endJob() override;
 
@@ -271,6 +274,15 @@ namespace cms {
   void SiPixelCondObjForHLTReader::endJob() {
     edm::LogPrint("SiPixelCondObjForHLTReader") << " ---> End job " << std::endl;
   }
+
+  void SiPixelCondObjForHLTReader::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("EDAnalyzer to read per-module SiPixelGainCalibrationForHLT payloads in the EventSetup");
+    desc.add<bool>("useSimRcd", false);
+    desc.addUntracked<double>("maxRangeDeadPixHist", 0.001);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
 }  // namespace cms
 
 using namespace cms;

--- a/CondTools/SiPixel/plugins/SiPixelCondObjOfflineReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjOfflineReader.cc
@@ -49,6 +49,9 @@ namespace cms {
   class SiPixelCondObjOfflineReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
   public:
     explicit SiPixelCondObjOfflineReader(const edm::ParameterSet &iConfig);
+    ~SiPixelCondObjOfflineReader() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
     void analyze(const edm::Event &, const edm::EventSetup &) override;
     void endJob() override;
 
@@ -275,6 +278,15 @@ namespace cms {
   void SiPixelCondObjOfflineReader::endJob() {
     edm::LogPrint("SiPixelCondObjOfflineReader") << " ---> End job " << std::endl;
   }
+
+  void SiPixelCondObjOfflineReader::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("EDAnalyzer to read per-module SiPixelGainCalibrationForOffline payloads in the EventSetup");
+    desc.add<bool>("useSimRcd", false);
+    desc.addUntracked<double>("maxRangeDeadPixHist", 0.001);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
 }  // namespace cms
 using namespace cms;
 DEFINE_FWK_MODULE(SiPixelCondObjOfflineReader);

--- a/CondTools/SiPixel/plugins/SiPixelCondObjReader.cc
+++ b/CondTools/SiPixel/plugins/SiPixelCondObjReader.cc
@@ -50,6 +50,8 @@ namespace cms {
     explicit SiPixelCondObjReader(const edm::ParameterSet &iConfig);
 
     ~SiPixelCondObjReader() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
     void analyze(const edm::Event &, const edm::EventSetup &) override;
     void endJob() override;
 
@@ -262,6 +264,14 @@ namespace cms {
 
   // ------------ method called once each job just after ending the event loop  ------------
   void SiPixelCondObjReader::endJob() { edm::LogPrint("SiPixelCondObjReader") << " ---> End job " << std::endl; }
+
+  void SiPixelCondObjReader::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.setComment("EDAnalyzer to read per-module SiPixelGainCalibration payloads in the EventSetup");
+    desc.addUntracked<double>("maxRangeDeadPixHist", 0.001);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
 }  // namespace cms
 using namespace cms;
 DEFINE_FWK_MODULE(SiPixelCondObjReader);

--- a/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.cc
+++ b/CondTools/SiPixel/plugins/SiPixelGainCalibrationRejectNoisyAndDead.cc
@@ -59,6 +59,8 @@ public:
   explicit SiPixelGainCalibrationRejectNoisyAndDead(const edm::ParameterSet&);
   ~SiPixelGainCalibrationRejectNoisyAndDead() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
   SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
@@ -89,6 +91,16 @@ private:
 
 using namespace edm;
 using namespace std;
+
+void SiPixelGainCalibrationRejectNoisyAndDead::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("EDAnalyzer to create SiPixelGainCalibration payloads by rejecting noisy and dead ones");
+  desc.addUntracked<bool>("debug", false);
+  desc.addUntracked<int>("insertNoisyPixelsInDB", 1);
+  desc.addUntracked<std::string>("record", "SiPixelGainCalibrationOfflineRcd");
+  desc.addUntracked<std::string>("noisyPixelList", "noisypixel.txt");
+  descriptions.addWithDefaultLabel(desc);
+}
 
 SiPixelGainCalibrationRejectNoisyAndDead::SiPixelGainCalibrationRejectNoisyAndDead(const edm::ParameterSet& iConfig)
     : pddToken_(esConsumes()),

--- a/CondTools/SiPixel/test/BuildFile.xml
+++ b/CondTools/SiPixel/test/BuildFile.xml
@@ -1,6 +1,10 @@
 <environment>
-  <bin file="testPixelDBs.cpp">
+  <bin file="testPixelDBs.cpp" name="createDBObjecs">
     <flags TEST_RUNNER_ARGS="/bin/bash CondTools/SiPixel/test createTestDBObjects.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+  <bin file="testPixelDBs.cpp" name="SiPixelGainCalibrationTests">
+    <flags TEST_RUNNER_ARGS="/bin/bash CondTools/SiPixel/test testSiPixelGainCalibrationHandlers.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
 </environment>

--- a/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader_cfg.py
@@ -1,34 +1,54 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
 
 process = cms.Process("PixelDBReader")
+
+##
+## prepare options
+##
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "auto:run3_data",VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "GlobalTag")
+
+options.register ('payloadType',
+                  "HLT",VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "what payload type should be used")
+
+options.register ('firstRun',
+                  1,VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "first run to be processed")
+
+options.parseArguments()
+
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("histo.root")
+                                   fileName = cms.string("histo_GainsAll.root")
                                    )
 
-process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = 'sqlite_file:prova.db'
-process.CondDB.DBParameters.messageLevel = 2
-process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
-
+# There is no actual payload in DB associated with the SiPixelGainCalibrationRcd record
+# using the fake gain producer instead
 process.load("CalibTracker.SiPixelESProducers.SiPixelFakeGainESSource_cfi")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 process.source = cms.Source("EmptySource",
-    numberEventsInRun = cms.untracked.uint32(10),
-    firstRun = cms.untracked.uint32(1)
-)
+                            numberEventsInRun = cms.untracked.uint32(10),
+                            firstRun = cms.untracked.uint32(options.firstRun)
+                            )
 
 process.Timing = cms.Service("Timing")
 
@@ -36,28 +56,30 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
     ignoreTotal = cms.untracked.int32(0)
 )
 
-process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('SiPixelGainCalibrationRcd'),
-        tag = cms.string('GainCalibTestFull')
-    ), 
-        cms.PSet(
-            record = cms.string('SiPixelGainCalibrationForHLTRcd'),
-            tag = cms.string('GainCalibTestHLT')
-        ), 
-        cms.PSet(
-            record = cms.string('SiPixelGainCalibrationOfflineRcd'),
-            tag = cms.string('GainCalibTestOffline')
-        ))
-)
 
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
+process.CondDB.DBParameters.messageLevel = 2
+process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                      process.CondDB,
+                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                      toGet = cms.VPSet(#cms.PSet(record = cms.string('SiPixelGainCalibrationRcd'),
+                                                        #         tag = cms.string('GainCalibTestFull')
+                                                        #     ), 
+                                                        cms.PSet(record = cms.string('SiPixelGainCalibrationForHLTRcd'),
+                                                                 tag = cms.string('SiPixelGainCalibrationHLT_2009runs_express')
+                                                             ), 
+                                                        cms.PSet(record = cms.string('SiPixelGainCalibrationOfflineRcd'),
+                                                                 tag = cms.string('SiPixelGainCalibration_2009runs_express')
+                                                             ))
+                                       )
 process.prefer("PoolDBESSource")
+
 process.SiPixelCondObjAllPayloadsReader = cms.EDAnalyzer("SiPixelCondObjAllPayloadsReader",
-    process.SiPixelGainCalibrationServiceParameters,
-    payloadType = cms.string('HLT')
-)
+                                                         process.SiPixelGainCalibrationServiceParameters,
+                                                         payloadType = cms.string(options.payloadType)
+                                                         )
 
 #process.print = cms.OutputModule("AsciiOutputModule")
 

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader_cfg.py
@@ -3,22 +3,19 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-#process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("histo.root")
+                                   fileName = cms.string("histo_GainsForHLT.root")
                                    )
 
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = 'sqlite_file:prova.db'
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
 process.CondDB.DBParameters.messageLevel = 2
 process.CondDB.DBParameters.authenticationPath = ''
 
@@ -41,16 +38,16 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationForHLTRcd'),
-        tag = cms.string('GainCalib_TEST_hlt')
+        tag = cms.string('SiPixelGainCalibrationHLT_2009runs_express')
     ))
 )
 
 process.prefer("PoolDBESSource")
 process.SiPixelCondObjForHLTReader = cms.EDAnalyzer("SiPixelCondObjForHLTReader",
-    process.SiPixelGainCalibrationServiceParameters,
-    maxRangeDeadPixHist = cms.untracked.double(0.001)
-
-)
+                                                    process.SiPixelGainCalibrationServiceParameters,
+                                                    maxRangeDeadPixHist = cms.untracked.double(0.001),
+                                                    useSimRcd = cms.bool(False)
+                                                    )
 
 #process.print = cms.OutputModule("AsciiOutputModule")
 

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader_cfg.py
@@ -3,22 +3,19 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-#process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
 
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("histo.root")
+                                   fileName = cms.string("histo_GainsForOffline.root")
                                    )
 
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = 'sqlite_file:prova.db'
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
 process.CondDB.DBParameters.authenticationPath = '.' #'/afs/cern.ch/cms/DB/conddb'
 process.CondDB.DBParameters.messageLevel = 10
 
@@ -41,15 +38,16 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('SiPixelGainCalibrationOfflineRcd'),
-        tag = cms.string('GainCalib_TEST_offline')
+        tag = cms.string('SiPixelGainCalibration_2009runs_express')
     ))
 )
 
 process.prefer("PoolDBESSource")
 process.SiPixelCondObjOfflineReader = cms.EDAnalyzer("SiPixelCondObjOfflineReader",
-    process.SiPixelGainCalibrationServiceParameters,
-    maxRangeDeadPixHist = cms.untracked.double(0.001)
-)
+                                                     process.SiPixelGainCalibrationServiceParameters,
+                                                     maxRangeDeadPixHist = cms.untracked.double(0.001),
+                                                     useSimRcd = cms.bool(False)
+                                                     )
 
 #process.print = cms.OutputModule("AsciiOutputModule")
 

--- a/CondTools/SiPixel/test/SiPixelCondObjReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCondObjReader_cfg.py
@@ -3,28 +3,19 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PixelDBReader")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-#process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-process.load("Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 process.load("CondTools.SiPixel.SiPixelGainCalibrationService_cfi")
-
-process.load("CondCore.CondDB.CondDB_cfi")
-
-process.load("CalibTracker.SiPixelESProducers.SiPixelFakeGainESSource_cfi")
-
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("histo.root")
+                                   fileName = cms.string("histo_FullGains.root")
                                    )
 
 process.CondDB.connect = 'sqlite_file:prova.db'
 process.CondDB.DBParameters.messageLevel = 2
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
-
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -40,16 +31,21 @@ process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
     ignoreTotal = cms.untracked.int32(0)
 )
 
-process.PoolDBESSource = cms.ESSource("PoolDBESSource",
-    process.CondDB,
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    toGet = cms.VPSet(cms.PSet(
-        record = cms.string('SiPixelGainCalibrationRcd'),
-        tag = cms.string('GainCalib_v2_test')
-    ))
-)
+# There is no actual payload in DB associated with this record
+# using the fake gain producer instead
+process.load("CalibTracker.SiPixelESProducers.SiPixelFakeGainESSource_cfi")
 
-process.prefer("PoolDBESSource")
+#process.load("CondCore.CondDB.CondDB_cfi")
+# process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+#     process.CondDB,
+#     BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+#     toGet = cms.VPSet(cms.PSet(
+#         record = cms.string('SiPixelGainCalibrationRcd'),
+#         tag = cms.string('GainCalib_v2_test')
+#     ))
+# )
+#process.prefer("PoolDBESSource")
+
 process.SiPixelCondObjReader = cms.EDAnalyzer("SiPixelCondObjReader",
     process.SiPixelGainCalibrationServiceParameters,
     maxRangeDeadPixHist = cms.untracked.double(0.001)

--- a/CondTools/SiPixel/test/testSiPixelGainCalibrationHandlers.sh
+++ b/CondTools/SiPixel/test/testSiPixelGainCalibrationHandlers.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo -e "TESTING SiPixelGainCalibration codes ..."
+
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
+
+for entry in "${LOCAL_TEST_DIR}/"SiPixelCondObj*Reader_cfg.py
+do
+  echo "===== Test \"cmsRun $entry \" ===="
+  (cmsRun $entry) || die "Failure using cmsRun $entry" $?
+done
+
+echo -e " Done with the readers \n\n"
+
+echo -e "TESTING Reject Noisy and Dead ...\n\n"
+cmsRun  ${LOCAL_TEST_DIR}/SiPixelGainCalibrationRejectNoisyAndDead_cfg.py || die "Failure running SiPixelGainCalibrationRejectNoisyAndDead_cfg.py" $?
+
+echo -e " Done with the test \n\n"


### PR DESCRIPTION
#### PR description:

In response of https://github.com/cms-sw/cmssw/pull/39012#issuecomment-1225713019.
Modernized the configuration of several configuration files in `CondTools/SiPixel` and added them as test units.
Profited to add `fillDescriptions` methods for modules that were lacking it.

#### PR validation:

Relies on the successful running of the test units:

```console
scram b runtests_SiPixelGainCalibrationTests
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A