### PR TITLE
ECAL - Implement follow up issues for Phase 2 GPU reconstruction

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -61,7 +61,8 @@ The offsets currently in use are:
 * 0.21: Production-like sequence
 * 0.24: 0 Tesla (Run-2, Run-3)
 * 0.31: Photon energy corrections with DRN architecture
-* 0.61: `phase2_ecal_devel` era
+* 0.61: ECAL `phase2_ecal_devel` era, on CPU
+* 0.612: ECAL `phase2_ecal_devel` era, with automatic offload to GPU if available
 * 0.75: Phase-2 HLT
 * 0.91: Track DNN modifier
 * 0.97: Premixing stage1

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1388,34 +1388,56 @@ upgradeWFs['heCollapse'] = UpgradeWorkflow_heCollapse(
     offset = 0.6,
 )
 
+# ECAL Phase 2 development WF
 class UpgradeWorkflow_ecalDevel(UpgradeWorkflow):
+    def __init__(self, digi = {}, reco = {}, harvest = {}, **kwargs):
+        # adapt the parameters for the UpgradeWorkflow init method
+        super(UpgradeWorkflow_ecalDevel, self).__init__(
+            steps = [
+                'DigiTrigger',
+                'RecoGlobal',
+                'HARVESTGlobal',
+            ],
+            PU = [
+                'DigiTrigger',
+                'RecoGlobal',
+                'HARVESTGlobal',
+            ],
+            **kwargs)
+        self.__digi = digi
+        self.__reco = reco
+        self.__harvest = harvest
+
     def setup_(self, step, stepName, stepDict, k, properties):
         # temporarily remove trigger & downstream steps
         mods = {'--era': stepDict[step][k]['--era']+',phase2_ecal_devel'}
         if 'Digi' in step:
             mods['-s'] = 'DIGI:pdigi_valid,DIGI2RAW'
+            mods |= self.__digi
         elif 'Reco' in step:
             mods['-s'] = 'RAW2DIGI,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly'
             mods['--datatier'] = 'GEN-SIM-RECO,DQMIO'
             mods['--eventcontent'] = 'FEVTDEBUGHLT,DQM'
+            mods |= self.__reco
         elif 'HARVEST' in step:
             mods['-s'] = 'HARVESTING:@ecalOnlyValidation+@ecal'
+            mods |= self.__harvest
         stepDict[stepName][k] = merge([mods, stepDict[step][k]])
+
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and '2026' in key
+
+# ECAL Phase 2 workflow running on CPU
 upgradeWFs['ecalDevel'] = UpgradeWorkflow_ecalDevel(
-    steps = [
-        'DigiTrigger',
-        'RecoGlobal',
-        'HARVESTGlobal',
-    ],
-    PU = [
-        'DigiTrigger',
-        'RecoGlobal',
-        'HARVESTGlobal',
-    ],
     suffix = '_ecalDevel',
     offset = 0.61,
+)
+
+# ECAL Phase 2 workflow running on CPU or GPU (if available)
+upgradeWFs['ecalDevelGPU'] = UpgradeWorkflow_ecalDevel(
+    reco = {'--procModifiers': 'gpu'},
+    suffix = '_ecalDevelGPU',
+    offset = 0.612,
 )
 
 class UpgradeWorkflow_0T(UpgradeWorkflow):

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalPhase2DigiToGPUProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalPhase2DigiToGPUProducer.cc
@@ -12,24 +12,18 @@
 
 #include "DeclsForKernelsPhase2.h"
 
-class EcalPhase2DigiToGPUProducer : public edm::stream::EDProducer<edm::ExternalWork> {
+class EcalPhase2DigiToGPUProducer : public edm::stream::EDProducer<> {
 public:
   explicit EcalPhase2DigiToGPUProducer(const edm::ParameterSet& ps);
   ~EcalPhase2DigiToGPUProducer() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  void acquire(edm::Event const& event, edm::EventSetup const& setup, edm::WaitingTaskWithArenaHolder holder) override;
   void produce(edm::Event& evt, edm::EventSetup const& setup) override;
 
 private:
   const edm::EDGetTokenT<EBDigiCollectionPh2> digiCollectionToken_;
   const edm::EDPutTokenT<cms::cuda::Product<ecal::DigisCollection<calo::common::DevStoragePolicy>>>
       digisCollectionToken_;
-  uint32_t size_;
-
-  ecal::DigisCollection<::calo::common::DevStoragePolicy> digis_;
-
-  cms::cuda::ContextState cudaState_;
 };
 
 void EcalPhase2DigiToGPUProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -46,24 +40,24 @@ EcalPhase2DigiToGPUProducer::EcalPhase2DigiToGPUProducer(const edm::ParameterSet
       digisCollectionToken_(produces<cms::cuda::Product<ecal::DigisCollection<calo::common::DevStoragePolicy>>>(
           ps.getParameter<std::string>("digisLabelEB"))) {}
 
-void EcalPhase2DigiToGPUProducer::acquire(edm::Event const& event,
-                                          edm::EventSetup const& setup,
-                                          edm::WaitingTaskWithArenaHolder holder) {
-  cms::cuda::ScopedContextAcquire ctx{event.streamID(), std::move(holder), cudaState_};
+void EcalPhase2DigiToGPUProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
+  cms::cuda::ScopedContextProduce ctx{event.streamID()};
 
   //input data from event
   const auto& pdigis = event.get(digiCollectionToken_);
 
-  size_ = pdigis.size();
+  const uint32_t size = pdigis.size();
 
-  digis_.size = size_;
+  ecal::DigisCollection<::calo::common::DevStoragePolicy> digis;
+  digis.size = size;
+
   //allocate device pointers for output
-  digis_.ids = cms::cuda::make_device_unique<uint32_t[]>(size_, ctx.stream());
-  digis_.data = cms::cuda::make_device_unique<uint16_t[]>(size_ * EcalDataFrame_Ph2::MAXSAMPLES, ctx.stream());
+  digis.ids = cms::cuda::make_device_unique<uint32_t[]>(size, ctx.stream());
+  digis.data = cms::cuda::make_device_unique<uint16_t[]>(size * EcalDataFrame_Ph2::MAXSAMPLES, ctx.stream());
 
   //allocate host pointers for holding product data and id vectors
-  auto idstmp = cms::cuda::make_host_unique<uint32_t[]>(size_, ctx.stream());
-  auto datatmp = cms::cuda::make_host_unique<uint16_t[]>(size_ * EcalDataFrame_Ph2::MAXSAMPLES, ctx.stream());
+  auto idstmp = cms::cuda::make_host_unique<uint32_t[]>(size, ctx.stream());
+  auto datatmp = cms::cuda::make_host_unique<uint16_t[]>(size * EcalDataFrame_Ph2::MAXSAMPLES, ctx.stream());
 
   //iterate over digis
   uint32_t i = 0;
@@ -82,22 +76,16 @@ void EcalPhase2DigiToGPUProducer::acquire(edm::Event const& event,
   }
 
   //copy output vectors into member variable device pointers for the output struct
-
   cudaCheck(
-      cudaMemcpyAsync(digis_.ids.get(), idstmp.get(), size_ * sizeof(uint32_t), cudaMemcpyHostToDevice, ctx.stream()));
-  cudaCheck(cudaMemcpyAsync(digis_.data.get(),
+      cudaMemcpyAsync(digis.ids.get(), idstmp.get(), size * sizeof(uint32_t), cudaMemcpyHostToDevice, ctx.stream()));
+  cudaCheck(cudaMemcpyAsync(digis.data.get(),
                             datatmp.get(),
-                            size_ * EcalDataFrame_Ph2::MAXSAMPLES * sizeof(uint16_t),
+                            size * EcalDataFrame_Ph2::MAXSAMPLES * sizeof(uint16_t),
                             cudaMemcpyHostToDevice,
                             ctx.stream()));
-}
-
-void EcalPhase2DigiToGPUProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
-  //get cuda context state for producer
-  cms::cuda::ScopedContextProduce ctx{cudaState_};
 
   //emplace output in the context
-  ctx.emplace(event, digisCollectionToken_, std::move(digis_));
+  ctx.emplace(event, digisCollectionToken_, std::move(digis));
 }
 
 DEFINE_FWK_MODULE(EcalPhase2DigiToGPUProducer);

--- a/RecoLocalCalo/EcalRecProducers/python/ecalUncalibRecHitPhase2_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalUncalibRecHitPhase2_cff.py
@@ -36,8 +36,8 @@ ecalUncalibRecHitSoA = _ecalCPUUncalibRecHitProducer.clone(
 from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitConvertGPU2CPUFormat_cfi import ecalUncalibRecHitConvertGPU2CPUFormat as _ecalUncalibRecHitConvertGPU2CPUFormat
 gpu.toModify(ecalUncalibRecHitPhase2,
     cuda = _ecalUncalibRecHitConvertGPU2CPUFormat.clone(
-        isPhase2 = cms.bool(True),
-        recHitsLabelGPUEB = cms.InputTag('ecalUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
+        isPhase2 = True,
+        recHitsLabelGPUEB = ('ecalUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
         recHitsLabelGPUEE = None,  # remove unneeded Phase1 parameters
         recHitsLabelCPUEE = None
     )


### PR DESCRIPTION
#### PR description:

This PR addresses the first two items in #38619. The `edm::ExternalWork` is removed from modules that do not need it and the kernel is modified to be able t run with any number of threads and blocks.
The PR also adds new matrix workflows for Phase 2 ECAL developments with GPUs (*.612). The existing *.61 workflows remain CPU only.

No changes to the output are expected.

#### PR validation:

No changes observed.
Tested also with WF 28234.61 by manually adding the gpu modifier to the reconstruction step of the WF.
Passes 32234.61 and the new 32234.612.
