### PR TITLE
Reduction of RAW' data size via adjustment of approx. cluster member data types

### DIFF
--- a/DataFormats/SiStripCluster/BuildFile.xml
+++ b/DataFormats/SiStripCluster/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/TrajectoryState"/>
 <use name="DataFormats/SiStripDigi"/>
 <use name="DataFormats/SiStripDetId"/>
+<use name="FWCore/Utilities" source_only="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -1,12 +1,7 @@
-#ifndef DATAFORMATS_SISTRIPAPPROXIMATECLUSTER_H
-#define DATAFORMATS_SISTRIPAPPROXIMATECLUSTER_H
+#ifndef DataFormats_SiStripCluster_SiStripApproximateCluster_h
+#define DataFormats_SiStripCluster_SiStripApproximateCluster_h
 
-#include <numeric>
-#include <cmath>
-#include <iostream>
-#include <iomanip>
-
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "FWCore/Utilities/interface/typedefs.h"
 
 class SiStripCluster;
 class SiStripApproximateCluster {
@@ -33,4 +28,4 @@ private:
   float avgCharge_ = 0;
   bool isSaturated_ = false;
 };
-#endif  // DATAFORMATS_SiStripApproximateCluster_H
+#endif  // DataFormats_SiStripCluster_SiStripApproximateCluster_h

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -8,7 +8,10 @@ class SiStripApproximateCluster {
 public:
   SiStripApproximateCluster() {}
 
-  explicit SiStripApproximateCluster(float barycenter, uint8_t width, float avgCharge, bool isSaturated) {
+  explicit SiStripApproximateCluster(cms_uint16_t barycenter,
+                                     cms_uint8_t width,
+                                     cms_uint8_t avgCharge,
+                                     bool isSaturated) {
     barycenter_ = barycenter;
     width_ = width;
     avgCharge_ = avgCharge;
@@ -17,15 +20,15 @@ public:
 
   explicit SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat);
 
-  float barycenter() const { return barycenter_; }
-  uint8_t width() const { return width_; }
-  float avgCharge() const { return avgCharge_; }
+  cms_uint16_t barycenter() const { return barycenter_; }
+  cms_uint8_t width() const { return width_; }
+  cms_uint8_t avgCharge() const { return avgCharge_; }
   bool isSaturated() const { return isSaturated_; }
 
 private:
-  float barycenter_ = 0;
-  uint8_t width_ = 0;
-  float avgCharge_ = 0;
+  cms_uint16_t barycenter_ = 0;
+  cms_uint8_t width_ = 0;
+  cms_uint8_t avgCharge_ = 0;
   bool isSaturated_ = false;
 };
 #endif  // DataFormats_SiStripCluster_SiStripApproximateCluster_h

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -1,7 +1,10 @@
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include <algorithm>
+#include <cmath>
 
 SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat) {
-  barycenter_ = cluster.barycenter();
+  barycenter_ = std::round(cluster.barycenter() * 10);
   width_ = cluster.size();
   avgCharge_ = cluster.charge() / cluster.size();
   isSaturated_ = false;

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -23,7 +23,7 @@ SiStripCluster::SiStripCluster(const SiStripDigiRange& range) : firstStrip_(rang
 }
 
 SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips) : error_x(-99999.9) {
-  barycenter_ = cluster.barycenter();
+  barycenter_ = cluster.barycenter() / 10.0;
   charge_ = cluster.width() * cluster.avgCharge();
   amplitudes_.resize(cluster.width(), cluster.avgCharge());
 

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -24,7 +24,8 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripCluster>,SiStripCluster,edmNew::DetSetVector<SiStripCluster>::FindForDetSetVector> > >" />
 
 
- <class name="SiStripApproximateCluster" ClassVersion="4">
+ <class name="SiStripApproximateCluster" ClassVersion="5">
+  <version ClassVersion="5" checksum="3495825183"/>
   <version ClassVersion="4" checksum="2854791577"/>
   <version ClassVersion="3" checksum="2041370183"/>
  </class>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
@@ -41,7 +41,7 @@ void SiStripApprox2Clusters::produce(edm::StreamID id, edm::Event& event, const 
   const auto& clusterCollection = event.get(clusterToken_);
 
   const auto& tkGeom = &iSetup.getData(tkGeomToken_);
-  const auto tkDets = tkGeom->dets();
+  const auto& tkDets = tkGeom->dets();
 
   for (const auto& detClusters : clusterCollection) {
     edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};


### PR DESCRIPTION
This PR is aimed at significantly reducing the size of the RAW' data format which uses the Approximated Cluster class, as the current implementation is not fully optimized.  This is the subsequent PR for improving the format which is mentioned at the end of the first paragraph in the description of PR #38423.

The space savings is accomplished by changing the full-precision float class members of SiStripApproximatedCluster to integer data types having limited precision.  In the case of the cluster width and average charge, values are rounded to the nearest whole number.  For the barycenter, rounding to one decimal place was found to give a good tradeoff of tracking performance and space savings .  To avoid using a floating point number, the barycenter is multiplied by 10 and stored as a 16-bit integer, and is converted back when regenerating the cluster collection from approximated clusters.  This reduces the approximated cluster collection size by 37% over the current implementation, and the SiStrip detector payload by 45% compared to the conventional RAW format.  A small loss (~0.5%) of inclusive tracks was observed, but largely disappears when applying analysis-type track selections.  (More info on our tests at [1], which was discussed in our data format working group)

This PR also incorporates two suggestions from @makortel for cleaning up the approximated cluster code [2,3].

[1] https://twiki.cern.ch/twiki/pub/Main/HIDetectorReadout2020/ApproxClusters_integer10th_Aug25.pdf
[2] https://github.com/cms-sw/cmssw/commit/8871eff2433649ccd801afc52edc00bbcf2f54d2
[3] https://github.com/cms-sw/cmssw/commit/0492f1f0803339ca24396a0429fb8b0c51aae72b

#### PR validation:

This PR can be tested using WF 140.58 and checking step2 to verify the smaller approx. cluster size.  Step 3 can be used to check physics performance and tracking differences.

@icali @mandrenguyen 

