### PR TITLE
[LTO] ODR warning fixed by moving MTDHit struct in to its own header file

### DIFF
--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -39,13 +39,7 @@
 
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
-struct MTDHit {
-  float energy;
-  float time;
-  float x;
-  float y;
-  float z;
-};
+#include "MTDHit.h"
 
 class BtlSimHitsValidation : public DQMEDAnalyzer {
 public:

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -39,13 +39,7 @@
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
-struct MTDHit {
-  float energy;
-  float time;
-  float x_local;
-  float y_local;
-  float z_local;
-};
+#include "MTDHit.h"
 
 class EtlLocalRecoValidation : public DQMEDAnalyzer {
 public:
@@ -246,9 +240,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       (simHitIt->second).time = simHit.tof();
 
       auto hit_pos = simHit.entryPoint();
-      (simHitIt->second).x_local = hit_pos.x();
-      (simHitIt->second).y_local = hit_pos.y();
-      (simHitIt->second).z_local = hit_pos.z();
+      (simHitIt->second).x = hit_pos.x();
+      (simHitIt->second).y = hit_pos.y();
+      (simHitIt->second).z = hit_pos.z();
     }
 
   }  // simHit loop
@@ -450,9 +444,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             continue;
 
           // SIM hit's position in the module reference frame
-          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].x_local),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].y_local),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].z_local));
+          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].x),
+                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].y),
+                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].z));
 
           // Calculate the SIM cluster's position in the module reference frame
           cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][recHit.id().rawId()].energy;

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -34,13 +34,7 @@
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
-struct MTDHit {
-  float energy;
-  float time;
-  float x;
-  float y;
-  float z;
-};
+#include "MTDHit.h"
 
 class EtlSimHitsValidation : public DQMEDAnalyzer {
 public:

--- a/Validation/MtdValidation/plugins/MTDHit.h
+++ b/Validation/MtdValidation/plugins/MTDHit.h
@@ -1,0 +1,12 @@
+#ifndef Validation_MtdValidation_MTDHit_h
+#define Validation_MtdValidation_MTDHit_h
+
+struct MTDHit {
+  float energy;
+  float time;
+  float x;
+  float y;
+  float z;
+};
+
+#endif  //Validation_MtdValidation_MTDHit_h

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -44,18 +44,7 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "HepMC/GenRanges.h"
 #include "CLHEP/Units/PhysicalConstants.h"
-
-namespace {
-
-  struct MTDHit {
-    float energy;
-    float time;
-    float x;
-    float y;
-    float z;
-  };
-
-}  // namespace
+#include "MTDHit.h"
 
 class MtdTracksValidation : public DQMEDAnalyzer {
 public:


### PR DESCRIPTION
This is a follow up of https://github.com/cms-sw/cmssw/pull/39136 PR. Looks like there were multiple `MTDHit` structures with same data members but different names. This PR moves `MTDHit` in to a separate header file.

This shoudl fix the last remaining LTO warnings