### PR TITLE
Updates in TOP-HLT DQM : Deepjet HLT path monitoring & flag to enable/disable production of 2d histos

### DIFF
--- a/DQMOffline/Trigger/plugins/TopMonitor.cc
+++ b/DQMOffline/Trigger/plugins/TopMonitor.cc
@@ -235,6 +235,7 @@ private:
 
   bool enablePhotonPlot_;
   bool enableMETPlot_;
+  bool enable2DPlots_;
 };
 
 TopMonitor::TopMonitor(const edm::ParameterSet& iConfig)
@@ -341,7 +342,8 @@ TopMonitor::TopMonitor(const edm::ParameterSet& iConfig)
       MHTcut_(iConfig.getParameter<double>("MHTcut")),
       invMassCutInAllMuPairs_(iConfig.getParameter<bool>("invMassCutInAllMuPairs")),
       enablePhotonPlot_(iConfig.getParameter<bool>("enablePhotonPlot")),
-      enableMETPlot_(iConfig.getParameter<bool>("enableMETPlot")) {
+      enableMETPlot_(iConfig.getParameter<bool>("enableMETPlot")),
+      enable2DPlots_(iConfig.getParameter<bool>("enable2DPlots")) {
   ObjME empty;
 
   muPhi_ = std::vector<ObjME>(nmuons_, empty);
@@ -521,14 +523,14 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, eleMulti_, histname, histtitle, 6, -.5, 5.5);
     setMETitle(eleMulti_, "electron multiplicity", "events");
 
-    if (njets_ > 0) {
+    if (njets_ > 0 && enable2DPlots_) {
       histname = "elePt_jetPt";
       histtitle = "electron pt vs jet pt";
       bookME(ibooker, elePt_jetPt_, histname, histtitle, elePt_variable_binning_2D_, jetPt_variable_binning_2D_);
       setMETitle(elePt_jetPt_, "leading electron pt", "leading jet pt");
     }
 
-    if (nmuons_ > 0) {
+    if (nmuons_ > 0 && enable2DPlots_) {
       histname = "elePt_muPt";
       histtitle = "electron pt vs muon pt";
       bookME(ibooker, elePt_muPt_, histname, histtitle, elePt_variable_binning_2D_, muPt_variable_binning_2D_);
@@ -580,7 +582,7 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     setMETitle(bjetMulti_, "b-jet multiplicity", "events");
   }
 
-  if (nelectrons_ > 1) {
+  if (nelectrons_ > 1 && enable2DPlots_) {
     histname = "ele1Pt_ele2Pt";
     histtitle = "electron-1 pt vs electron-2 pt";
     bookME(ibooker, ele1Pt_ele2Pt_, histname, histtitle, elePt_variable_binning_2D_, elePt_variable_binning_2D_);
@@ -593,15 +595,17 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
   }
 
   if (nmuons_ > 1) {
-    histname = "mu1Pt_mu2Pt";
-    histtitle = "muon-1 pt vs muon-2 pt";
-    bookME(ibooker, mu1Pt_mu2Pt_, histname, histtitle, muPt_variable_binning_2D_, muPt_variable_binning_2D_);
-    setMETitle(mu1Pt_mu2Pt_, "muon-1 pt [GeV]", "muon-2 pt [GeV]");
+    if (enable2DPlots_) {
+      histname = "mu1Pt_mu2Pt";
+      histtitle = "muon-1 pt vs muon-2 pt";
+      bookME(ibooker, mu1Pt_mu2Pt_, histname, histtitle, muPt_variable_binning_2D_, muPt_variable_binning_2D_);
+      setMETitle(mu1Pt_mu2Pt_, "muon-1 pt [GeV]", "muon-2 pt [GeV]");
 
-    histname = "mu1Eta_mu2Eta";
-    histtitle = "muon-1 #eta vs muon-2 #eta";
-    bookME(ibooker, mu1Eta_mu2Eta_, histname, histtitle, muEta_variable_binning_2D_, muEta_variable_binning_2D_);
-    setMETitle(mu1Eta_mu2Eta_, "muon-1 #eta", "muon-2 #eta");
+      histname = "mu1Eta_mu2Eta";
+      histtitle = "muon-1 #eta vs muon-2 #eta";
+      bookME(ibooker, mu1Eta_mu2Eta_, histname, histtitle, muEta_variable_binning_2D_, muEta_variable_binning_2D_);
+      setMETitle(mu1Eta_mu2Eta_, "muon-1 #eta", "muon-2 #eta");
+    }
     //george
     histname = "invMass";
     histtitle = "M mu1 mu2";
@@ -641,7 +645,7 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, eventHT_variableBinning_, histname, histtitle, HT_variable_binning_);
     setMETitle(eventHT_variableBinning_, "event HT [GeV]", "events");
 
-    if (nelectrons_ > 0) {
+    if (nelectrons_ > 0 && enable2DPlots_) {
       histname = "elePt_eventHT";
       histtitle = "electron pt vs event HT";
       bookME(ibooker, elePt_eventHT_, histname, histtitle, elePt_variable_binning_2D_, HT_variable_binning_2D_);
@@ -705,19 +709,21 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, muPhi_.at(iMu), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
     setMETitle(muPhi_.at(iMu), " muon #phi", "events");
 
-    histname = "muPtEta_";
-    histtitle = "muon p_{T} - #eta - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, muPtEta_.at(iMu), histname, histtitle, muPt_variable_binning_2D_, muEta_variable_binning_2D_);
-    setMETitle(muPtEta_.at(iMu), "muon p_{T} [GeV]", "muon #eta");
+    if (enable2DPlots_) {
+      histname = "muPtEta_";
+      histtitle = "muon p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, muPtEta_.at(iMu), histname, histtitle, muPt_variable_binning_2D_, muEta_variable_binning_2D_);
+      setMETitle(muPtEta_.at(iMu), "muon p_{T} [GeV]", "muon #eta");
 
-    histname = "muEtaPhi_";
-    histtitle = "muon #eta - #phi - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, muEtaPhi_.at(iMu), histname, histtitle, muEta_variable_binning_2D_, phi_variable_binning_2D_);
-    setMETitle(muEtaPhi_.at(iMu), "muon #eta", "muon #phi");
+      histname = "muEtaPhi_";
+      histtitle = "muon #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, muEtaPhi_.at(iMu), histname, histtitle, muEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(muEtaPhi_.at(iMu), "muon #eta", "muon #phi");
+    }
   }
 
   for (unsigned int iEle = 0; iEle < nelectrons_; ++iEle) {
@@ -750,19 +756,21 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, elePhi_.at(iEle), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
     setMETitle(elePhi_.at(iEle), " electron #phi", "events");
 
-    histname = "elePtEta_";
-    histtitle = "electron p_{T} - #eta - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, elePtEta_.at(iEle), histname, histtitle, elePt_variable_binning_2D_, eleEta_variable_binning_2D_);
-    setMETitle(elePtEta_.at(iEle), "electron p_{T} [GeV]", "electron #eta");
+    if (enable2DPlots_) {
+      histname = "elePtEta_";
+      histtitle = "electron p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, elePtEta_.at(iEle), histname, histtitle, elePt_variable_binning_2D_, eleEta_variable_binning_2D_);
+      setMETitle(elePtEta_.at(iEle), "electron p_{T} [GeV]", "electron #eta");
 
-    histname = "eleEtaPhi_";
-    histtitle = "electron #eta - #phi - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, eleEtaPhi_.at(iEle), histname, histtitle, eleEta_variable_binning_2D_, phi_variable_binning_2D_);
-    setMETitle(eleEtaPhi_.at(iEle), "electron #eta", "electron #phi");
+      histname = "eleEtaPhi_";
+      histtitle = "electron #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, eleEtaPhi_.at(iEle), histname, histtitle, eleEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(eleEtaPhi_.at(iEle), "electron #eta", "electron #phi");
+    }
   }
 
   //Menglei
@@ -837,19 +845,21 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, jetPhi_.at(iJet), histname, histtitle, phi_binning_.nbins, phi_binning_.xmin, phi_binning_.xmax);
     setMETitle(jetPhi_.at(iJet), "jet #phi", "events");
 
-    histname = "jetPtEta_";
-    histtitle = "jet p_{T} - #eta - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, jetPtEta_.at(iJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
-    setMETitle(jetPtEta_.at(iJet), "jet p_{T} [GeV]", "jet #eta");
+    if (enable2DPlots_) {
+      histname = "jetPtEta_";
+      histtitle = "jet p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, jetPtEta_.at(iJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
+      setMETitle(jetPtEta_.at(iJet), "jet p_{T} [GeV]", "jet #eta");
 
-    histname = "jetEtaPhi_";
-    histtitle = "jet #eta - #phi - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, jetEtaPhi_.at(iJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
-    setMETitle(jetEtaPhi_.at(iJet), "jet #eta", "jet #phi");
+      histname = "jetEtaPhi_";
+      histtitle = "jet #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(ibooker, jetEtaPhi_.at(iJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(jetEtaPhi_.at(iJet), "jet #eta", "jet #phi");
+    }
   }
 
   // Marina
@@ -890,19 +900,23 @@ void TopMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun
     bookME(ibooker, bjetCSV_.at(iBJet), histname, histtitle, csv_binning_.nbins, csv_binning_.xmin, csv_binning_.xmax);
     setMETitle(bjetCSV_.at(iBJet), "b-jet CSV", "events");
 
-    histname = "bjetPtEta_";
-    histtitle = "b-jet p_{T} - #eta - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, bjetPtEta_.at(iBJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
-    setMETitle(bjetPtEta_.at(iBJet), "b-jet p_{T} [GeV]", "b-jet #eta");
+    if (enable2DPlots_) {
+      histname = "bjetPtEta_";
+      histtitle = "b-jet p_{T} - #eta - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(
+          ibooker, bjetPtEta_.at(iBJet), histname, histtitle, jetPt_variable_binning_2D_, jetEta_variable_binning_2D_);
+      setMETitle(bjetPtEta_.at(iBJet), "b-jet p_{T} [GeV]", "b-jet #eta");
 
-    histname = "bjetEtaPhi_";
-    histtitle = "b-jet #eta - #phi - ";
-    histname.append(index);
-    histtitle.append(index);
-    bookME(ibooker, bjetEtaPhi_.at(iBJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
-    setMETitle(bjetEtaPhi_.at(iBJet), "b-jet #eta", "b-jet #phi");
+      histname = "bjetEtaPhi_";
+      histtitle = "b-jet #eta - #phi - ";
+      histname.append(index);
+      histtitle.append(index);
+      bookME(
+          ibooker, bjetEtaPhi_.at(iBJet), histname, histtitle, jetEta_variable_binning_2D_, phi_variable_binning_2D_);
+      setMETitle(bjetEtaPhi_.at(iBJet), "b-jet #eta", "b-jet #phi");
+    }
 
     histname = "bjetCSVHT_";
     histtitle = "HT - b-jet CSV - ";
@@ -1412,6 +1426,7 @@ void TopMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<bool>("invMassCutInAllMuPairs", false);
   desc.add<bool>("enablePhotonPlot", false);
   desc.add<bool>("enableMETPlot", false);
+  desc.add<bool>("enable2DPlots", true);
 
   edm::ParameterSetDescription genericTriggerEventPSet;
   GenericTriggerEventFlag::fillPSetDescription(genericTriggerEventPSet);

--- a/DQMOffline/Trigger/python/TopMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/TopMonitor_cfi.py
@@ -5,7 +5,7 @@ from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 hltTOPmonitoring = topMonitoring.clone()
 
 hltTOPmonitoring.FolderName = 'HLT/TOP/default/'
-hltTOPmonitoring.requireValidHLTPaths = True
+hltTOPmonitoring.requireValidHLTPaths = True 
 
 # histo PSets
 hltTOPmonitoring.histoPSet.lsPSet.nbins =  250
@@ -77,6 +77,7 @@ hltTOPmonitoring.histoPSet.phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849
 
 hltTOPmonitoring.enablePhotonPlot = False
 hltTOPmonitoring.enableMETPlot = False
+hltTOPmonitoring.enable2DPlots = True
 
 hltTOPmonitoring.applyLeptonPVcuts = False
 hltTOPmonitoring.leptonPVcuts.dxy = 9999.

--- a/DQMOffline/Trigger/python/TopMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_Client_cff.py
@@ -317,6 +317,93 @@ topEfficiency_fullyhadronic_DoubleBTag = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
+topEfficiency_fullyhadronic_DoubleBTag_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/TOP/FullyHadronic/DoubleBTagDeepJet/*"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_jetPt_1       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_numerator       jetPt_1_denominator",
+        "effic_jetPt_2       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_numerator       jetPt_2_denominator",
+        "effic_jetPt_3       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_numerator       jetPt_3_denominator",
+        "effic_jetPt_4       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_numerator       jetPt_4_denominator",
+        "effic_jetPt_5       'efficiency vs 5th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_5_numerator       jetPt_5_denominator",
+        "effic_jetPt_6       'efficiency vs 6th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_6_numerator       jetPt_6_denominator",
+
+        "effic_jetEta_1      'efficiency vs 1st jet #eta;jet #eta;efficiency' jetEta_1_numerator     jetEta_1_denominator",
+        "effic_jetEta_2      'efficiency vs 2nd jet #eta;jet #eta;efficiency' jetEta_2_numerator     jetEta_2_denominator",
+        "effic_jetEta_3      'efficiency vs 3rd jet #eta;jet #eta;efficiency' jetEta_3_numerator     jetEta_3_denominator",
+        "effic_jetEta_4      'efficiency vs 4th jet #eta;jet #eta;efficiency' jetEta_4_numerator     jetEta_4_denominator",
+        "effic_jetEta_5      'efficiency vs 5th jet #eta;jet #eta;efficiency' jetEta_5_numerator     jetEta_5_denominator",
+        "effic_jetEta_6      'efficiency vs 6th jet #eta;jet #eta;efficiency' jetEta_6_numerator     jetEta_6_denominator",
+
+        "effic_jetPhi_1      'efficiency vs 1st jet #phi;jet #phi;efficiency'    jetPhi_1_numerator      jetPhi_1_denominator",
+        "effic_jetPhi_2      'efficiency vs 2nd jet #phi;jet #phi;efficiency'    jetPhi_2_numerator      jetPhi_2_denominator",
+        "effic_jetPhi_3      'efficiency vs 3rd jet #phi;jet #phi;efficiency'    jetPhi_3_numerator      jetPhi_3_denominator",
+        "effic_jetPhi_4      'efficiency vs 4th jet #phi;jet #phi;efficiency'    jetPhi_4_numerator      jetPhi_4_denominator",
+        "effic_jetPhi_5      'efficiency vs 5th jet #phi;jet #phi;efficiency'    jetPhi_5_numerator      jetPhi_5_denominator",
+        "effic_jetPhi_6      'efficiency vs 6th jet #phi;jet #phi;efficiency'    jetPhi_6_numerator      jetPhi_6_denominator",
+
+        "effic_bjetPt_1      'efficiency vs 1st b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
+        "effic_bjetPt_2      'efficiency vs 2nd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_2_numerator  bjetPt_2_denominator",
+        "effic_bjetEta_1     'efficiency vs 1st b-jet #eta;bjet #eta;efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
+        "effic_bjetEta_2     'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency'  bjetEta_2_numerator   bjetEta_2_denominator",
+        "effic_bjetPhi_1     'efficiency vs 1st b-jet #phi;bjet #phi;efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
+        "effic_bjetPhi_2     'efficiency vs 2nd b-jet #phi;bjet #phi;efficiency'  bjetPhi_2_numerator   bjetPhi_2_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet Discrim;bjet Discrim;efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_2     'efficiency vs 2nd b-jet Discrim;bjet Discrim;efficiency' bjetCSV_2_numerator  bjetCSV_2_denominator",
+
+        "effic_eventHT       'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_numerator       eventHT_denominator",
+        "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
+
+        "effic_jetPt_1_variableBinning       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
+        "effic_jetPt_2_variableBinning       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_variableBinning_numerator       jetPt_2_variableBinning_denominator",
+        "effic_jetPt_3_variableBinning       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_variableBinning_numerator       jetPt_3_variableBinning_denominator",
+        "effic_jetPt_4_variableBinning       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_variableBinning_numerator       jetPt_4_variableBinning_denominator",
+        "effic_jetPt_5_variableBinning       'efficiency vs 5th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_5_variableBinning_numerator       jetPt_5_variableBinning_denominator",
+        "effic_jetPt_6_variableBinning       'efficiency vs 6th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_6_variableBinning_numerator       jetPt_6_variableBinning_denominator",
+
+        "effic_jetEta_1_variableBinning       'efficiency vs 1st jet #eta;jet #eta;efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
+        "effic_jetEta_2_variableBinning       'efficiency vs 2nd jet #eta;jet #eta;efficiency' jetEta_2_variableBinning_numerator       jetEta_2_variableBinning_denominator",
+        "effic_jetEta_3_variableBinning       'efficiency vs 3rd jet #eta;jet #eta;efficiency' jetEta_3_variableBinning_numerator       jetEta_3_variableBinning_denominator",
+        "effic_jetEta_4_variableBinning       'efficiency vs 4th jet #eta;jet #eta;efficiency' jetEta_4_variableBinning_numerator       jetEta_4_variableBinning_denominator",
+        "effic_jetEta_5_variableBinning       'efficiency vs 5th jet #eta;jet #eta;efficiency' jetEta_5_variableBinning_numerator       jetEta_5_variableBinning_denominator",
+        "effic_jetEta_6_variableBinning       'efficiency vs 6th jet #eta;jet #eta;efficiency' jetEta_6_variableBinning_numerator       jetEta_6_variableBinning_denominator",
+
+        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
+        "effic_bjetPt_2_variableBinning   'efficiency vs 2nd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_2_variableBinning_numerator   bjetPt_2_variableBinning_denominator",
+        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet #eta;bjet #eta;efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetEta_2_variableBinning  'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency' bjetEta_2_variableBinning_numerator     bjetEta_2_variableBinning_denominator",
+
+        "effic_eventHT_variableBinning       'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
+
+        "effic_jetMulti       'efficiency vs jet multiplicity;jet multiplicity;efficiency' jetMulti_numerator       jetMulti_denominator",
+        "effic_bjetMulti      'efficiency vs b-jet multiplicity;bjet multiplicity;efficiency' bjetMulti_numerator   bjetMulti_denominator",
+
+        "effic_jetPtEta_1     'efficiency vs 1st jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_1_numerator       jetPtEta_1_denominator",
+        "effic_jetPtEta_2     'efficiency vs 2nd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_2_numerator       jetPtEta_2_denominator",
+        "effic_jetPtEta_3     'efficiency vs 3rd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_3_numerator       jetPtEta_3_denominator",
+        "effic_jetPtEta_4     'efficiency vs 4th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_4_numerator       jetPtEta_4_denominator",
+        "effic_jetPtEta_5     'efficiency vs 5th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_5_numerator       jetPtEta_5_denominator",
+        "effic_jetPtEta_6     'efficiency vs 6th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_6_numerator       jetPtEta_6_denominator",
+
+        "effic_jetEtaPhi_1    'efficiency vs 1st jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_1_numerator       jetEtaPhi_1_denominator",
+        "effic_jetEtaPhi_2    'efficiency vs 2nd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_2_numerator       jetEtaPhi_2_denominator",
+        "effic_jetEtaPhi_3    'efficiency vs 3rd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_3_numerator       jetEtaPhi_3_denominator",
+        "effic_jetEtaPhi_4    'efficiency vs 4th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_4_numerator       jetEtaPhi_4_denominator",
+        "effic_jetEtaPhi_5    'efficiency vs 5th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_5_numerator       jetEtaPhi_5_denominator",
+        "effic_jetEtaPhi_6    'efficiency vs 6th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_6_numerator       jetEtaPhi_6_denominator",
+
+        "effic_bjetPtEta_1    'efficiency vs 1st b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
+        "effic_bjetPtEta_2    'efficiency vs 2nd b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_2_numerator   bjetPtEta_2_denominator",
+
+        "effic_bjetEtaPhi_1   'efficiency vs 1st b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
+        "effic_bjetEtaPhi_2   'efficiency vs 2nd b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_2_numerator  bjetEtaPhi_2_denominator",
+
+        "effic_bjetCSVHT_1 'efficiency vs 1st b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_1_numerator bjetCSVHT_1_denominator"
+        "effic_bjetCSVHT_2 'efficiency vs 2nd b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_2_numerator bjetCSVHT_2_denominator"
+    ),
+)
+
 topEfficiency_fullyhadronic_SingleBTag = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/TOP/FullyHadronic/SingleBTag/*"),
     verbose        = cms.untracked.uint32(0),
@@ -395,7 +482,93 @@ topEfficiency_fullyhadronic_SingleBTag = DQMEDHarvester("DQMGenericClient",
 
         "effic_bjetPtEta_1    'efficiency vs 1st b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
         "effic_bjetPtEta_2    'efficiency vs 2nd b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_2_numerator   bjetPtEta_2_denominator",
+        "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
+        "effic_bjetEtaPhi_2    'efficiency vs 2nd b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_2_numerator  bjetEtaPhi_2_denominator",
 
+        "effic_bjetCSVHT_1 'efficiency vs 1st b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_1_numerator bjetCSVHT_1_denominator"
+        "effic_bjetCSVHT_2 'efficiency vs 2nd b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_2_numerator bjetCSVHT_2_denominator"
+    ),
+)
+
+
+topEfficiency_fullyhadronic_SingleBTag_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/TOP/FullyHadronic/SingleBTagDeepJet/*"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_jetPt_1       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_numerator       jetPt_1_denominator",
+        "effic_jetPt_2       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_numerator       jetPt_2_denominator",
+        "effic_jetPt_3       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_numerator       jetPt_3_denominator",
+        "effic_jetPt_4       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_numerator       jetPt_4_denominator",
+        "effic_jetPt_5       'efficiency vs 5th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_5_numerator       jetPt_5_denominator",
+        "effic_jetPt_6       'efficiency vs 6th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_6_numerator       jetPt_6_denominator",
+
+        "effic_jetEta_1      'efficiency vs 1st jet #eta;jet #eta;efficiency' jetEta_1_numerator     jetEta_1_denominator",
+        "effic_jetEta_2      'efficiency vs 2nd jet #eta;jet #eta;efficiency' jetEta_2_numerator     jetEta_2_denominator",
+        "effic_jetEta_3      'efficiency vs 3rd jet #eta;jet #eta;efficiency' jetEta_3_numerator     jetEta_3_denominator",
+        "effic_jetEta_4      'efficiency vs 4th jet #eta;jet #eta;efficiency' jetEta_4_numerator     jetEta_4_denominator",
+        "effic_jetEta_5      'efficiency vs 5th jet #eta;jet #eta;efficiency' jetEta_5_numerator     jetEta_5_denominator",
+        "effic_jetEta_6      'efficiency vs 6th jet #eta;jet #eta;efficiency' jetEta_6_numerator     jetEta_6_denominator",
+
+        "effic_jetPhi_1      'efficiency vs 1st jet #phi;jet #phi;efficiency'    jetPhi_1_numerator      jetPhi_1_denominator",
+        "effic_jetPhi_2      'efficiency vs 2nd jet #phi;jet #phi;efficiency'    jetPhi_2_numerator      jetPhi_2_denominator",
+        "effic_jetPhi_3      'efficiency vs 3rd jet #phi;jet #phi;efficiency'    jetPhi_3_numerator      jetPhi_3_denominator",
+        "effic_jetPhi_4      'efficiency vs 4th jet #phi;jet #phi;efficiency'    jetPhi_4_numerator      jetPhi_4_denominator",
+        "effic_jetPhi_5      'efficiency vs 5th jet #phi;jet #phi;efficiency'    jetPhi_5_numerator      jetPhi_5_denominator",
+        "effic_jetPhi_6      'efficiency vs 6th jet #phi;jet #phi;efficiency'    jetPhi_6_numerator      jetPhi_6_denominator",
+
+        "effic_bjetPt_1      'efficiency vs 1st b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
+        "effic_bjetPt_2      'efficiency vs 2nd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_2_numerator  bjetPt_2_denominator",
+        "effic_bjetEta_1     'efficiency vs 1st b-jet #eta;bjet #eta;efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
+        "effic_bjetEta_2     'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency'  bjetEta_2_numerator   bjetEta_2_denominator",
+        "effic_bjetPhi_1     'efficiency vs 1st b-jet #phi;bjet #phi;efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
+        "effic_bjetPhi_2     'efficiency vs 2nd b-jet #phi;bjet #phi;efficiency'  bjetPhi_2_numerator   bjetPhi_2_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet Discrim;bjet Discrim;efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_2     'efficiency vs 2nd b-jet Discrim;bjet Discrim;efficiency' bjetCSV_2_numerator  bjetCSV_2_denominator",
+
+        "effic_eventHT       'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_numerator       eventHT_denominator",
+        "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
+
+        "effic_jetPt_1_variableBinning       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
+        "effic_jetPt_2_variableBinning       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_variableBinning_numerator       jetPt_2_variableBinning_denominator",
+        "effic_jetPt_3_variableBinning       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_variableBinning_numerator       jetPt_3_variableBinning_denominator",
+        "effic_jetPt_4_variableBinning       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_variableBinning_numerator       jetPt_4_variableBinning_denominator",
+        "effic_jetPt_5_variableBinning       'efficiency vs 5th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_5_variableBinning_numerator       jetPt_5_variableBinning_denominator",
+        "effic_jetPt_6_variableBinning       'efficiency vs 6th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_6_variableBinning_numerator       jetPt_6_variableBinning_denominator",
+
+        "effic_jetEta_1_variableBinning       'efficiency vs 1st jet #eta;jet #eta;efficiency' jetEta_1_variableBinning_numerator       jetEta_1_variableBinning_denominator",
+        "effic_jetEta_2_variableBinning       'efficiency vs 2nd jet #eta;jet #eta;efficiency' jetEta_2_variableBinning_numerator       jetEta_2_variableBinning_denominator",
+        "effic_jetEta_3_variableBinning       'efficiency vs 3rd jet #eta;jet #eta;efficiency' jetEta_3_variableBinning_numerator       jetEta_3_variableBinning_denominator",
+        "effic_jetEta_4_variableBinning       'efficiency vs 4th jet #eta;jet #eta;efficiency' jetEta_4_variableBinning_numerator       jetEta_4_variableBinning_denominator",
+        "effic_jetEta_5_variableBinning       'efficiency vs 5th jet #eta;jet #eta;efficiency' jetEta_5_variableBinning_numerator       jetEta_5_variableBinning_denominator",
+        "effic_jetEta_6_variableBinning       'efficiency vs 6th jet #eta;jet #eta;efficiency' jetEta_6_variableBinning_numerator       jetEta_6_variableBinning_denominator",
+
+        "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
+        "effic_bjetPt_2_variableBinning   'efficiency vs 2nd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_2_variableBinning_numerator   bjetPt_2_variableBinning_denominator",
+        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet #eta;bjet #eta;efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetEta_2_variableBinning  'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency' bjetEta_2_variableBinning_numerator     bjetEta_2_variableBinning_denominator",
+
+        "effic_eventHT_variableBinning    'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
+
+        "effic_jetMulti       'efficiency vs jet multiplicity;jet multiplicity;efficiency' jetMulti_numerator       jetMulti_denominator",
+        "effic_bjetMulti      'efficiency vs b-jet multiplicity;bjet multiplicity;efficiency' bjetMulti_numerator   bjetMulti_denominator",
+
+        "effic_jetPtEta_1     'efficiency vs 1st jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_1_numerator       jetPtEta_1_denominator",
+        "effic_jetPtEta_2     'efficiency vs 2nd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_2_numerator       jetPtEta_2_denominator",
+        "effic_jetPtEta_3     'efficiency vs 3rd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_3_numerator       jetPtEta_3_denominator",
+        "effic_jetPtEta_4     'efficiency vs 4th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_4_numerator       jetPtEta_4_denominator",
+        "effic_jetPtEta_5     'efficiency vs 5th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_5_numerator       jetPtEta_5_denominator",
+        "effic_jetPtEta_6     'efficiency vs 6th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_6_numerator       jetPtEta_6_denominator",
+
+        "effic_jetEtaPhi_1    'efficiency vs 1st jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_1_numerator       jetEtaPhi_1_denominator",
+        "effic_jetEtaPhi_2    'efficiency vs 2nd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_2_numerator       jetEtaPhi_2_denominator",
+        "effic_jetEtaPhi_3    'efficiency vs 3rd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_3_numerator       jetEtaPhi_3_denominator",
+        "effic_jetEtaPhi_4    'efficiency vs 4th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_4_numerator       jetEtaPhi_4_denominator",
+        "effic_jetEtaPhi_5    'efficiency vs 5th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_5_numerator       jetEtaPhi_5_denominator",
+        "effic_jetEtaPhi_6    'efficiency vs 6th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_6_numerator       jetEtaPhi_6_denominator",
+
+        "effic_bjetPtEta_1    'efficiency vs 1st b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
+        "effic_bjetPtEta_2    'efficiency vs 2nd b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_2_numerator   bjetPtEta_2_denominator",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_bjetEtaPhi_2    'efficiency vs 2nd b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_2_numerator  bjetEtaPhi_2_denominator",
 
@@ -498,6 +671,8 @@ topClient = cms.Sequence(
   + topEfficiency_ElecMu
   + topEfficiency_fullyhadronic_Reference
   + topEfficiency_fullyhadronic_DoubleBTag
+  + topEfficiency_fullyhadronic_DoubleBTag_DeepJet
   + topEfficiency_fullyhadronic_SingleBTag
+  + topEfficiency_fullyhadronic_SingleBTag_DeepJet
   + topEfficiency_fullyhadronic_TripleBTag
 )

--- a/DQMOffline/Trigger/python/TopMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_cff.py
@@ -12,6 +12,7 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTcond
 
 topEleJet_jet = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleJet/JetMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 1,
@@ -32,6 +33,7 @@ topEleJet_jet = hltTOPmonitoring.clone(
 
 topEleJet_ele = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleJet/ElectronMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 1,
@@ -58,6 +60,7 @@ topEleJet_ele = hltTOPmonitoring.clone(
 ### ---
 topEleJet_all = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleJet/GlobalMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 1,
@@ -78,6 +81,7 @@ topEleJet_all = hltTOPmonitoring.clone(
 
 topEleHT_ht = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleHT/HTMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 2,
@@ -101,6 +105,7 @@ topEleHT_ht = hltTOPmonitoring.clone(
 
 topEleHT_ele = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleHT/ElectronMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 2,
@@ -129,6 +134,7 @@ topEleHT_ele = hltTOPmonitoring.clone(
 
 topEleHT_all = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/EleHT/GlobalMonitor',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 1,
     njets = 2,
@@ -152,6 +158,7 @@ topEleHT_all = hltTOPmonitoring.clone(
 
 topSingleMuonHLTMonitor_Mu24 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu24/',
+    enable2DPlots = False,
     nmuons = 1,
     nelectrons = 0,
     njets = 0,
@@ -164,6 +171,7 @@ topSingleMuonHLTMonitor_Mu24 = hltTOPmonitoring.clone(
 
 topSingleMuonHLTMonitor_Mu27 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu27/',
+    enable2DPlots = False,
     nmuons = 1,
     nelectrons = 0,
     njets = 0,
@@ -176,6 +184,7 @@ topSingleMuonHLTMonitor_Mu27 = hltTOPmonitoring.clone(
 
 topSingleMuonHLTMonitor_Mu50 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu50/',
+    enable2DPlots = False,
     nmuons = 1,
     nelectrons = 0,
     njets = 0,
@@ -190,6 +199,7 @@ topSingleMuonHLTMonitor_Mu50 = hltTOPmonitoring.clone(
 
 topDiElectronHLTMonitor = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/DiElectron/Ele23Ele12/',
+    enable2DPlots = False,
     nmuons = 0,
     nelectrons = 2,
     njets = 0,
@@ -210,6 +220,7 @@ topDiElectronHLTMonitor_Dz = topDiElectronHLTMonitor.clone(
 
 topDiMuonHLTMonitor_noDz = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -222,6 +233,7 @@ topDiMuonHLTMonitor_noDz = hltTOPmonitoring.clone(
 
 topDiMuonHLTMonitor_Dz = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Dz/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -241,6 +253,7 @@ topDiMuonHLTMonitor_Dz_Mu17_Mu8 = topDiMuonHLTMonitor_Dz.clone(
 
 topDiMuonHLTMonitor_Mass8 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mass8/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -253,6 +266,7 @@ topDiMuonHLTMonitor_Mass8 = hltTOPmonitoring.clone(
 
 topDiMuonHLTMonitor_Mass3p8 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mass3p8/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -264,8 +278,8 @@ topDiMuonHLTMonitor_Mass3p8 = hltTOPmonitoring.clone(
 ### ---
 
 topDiMuonHLTMonitor_Mass8Mon = hltTOPmonitoring.clone(
-    #FolderName = 'HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/',
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -278,8 +292,8 @@ topDiMuonHLTMonitor_Mass8Mon = hltTOPmonitoring.clone(
 ### ---
 
 topDiMuonHLTMonitor_Mass3p8Mon = hltTOPmonitoring.clone(
-    #FolderName = 'HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/',
     FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/',
+    enable2DPlots = False,
     nmuons = 2,
     nelectrons = 0,
     njets = 0,
@@ -295,6 +309,7 @@ topDiMuonHLTMonitor_Mass3p8Mon = hltTOPmonitoring.clone(
 
 topElecMuonHLTMonitor = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/DiLepton/ElecMuon/OR/',
+    enable2DPlots = False,
     nmuons = 1,
     nelectrons = 1,
     njets = 0,
@@ -371,6 +386,7 @@ topElecMuonHLTMonitor_Mu23Ele12_ref = topElecMuonHLTMonitor.clone(
 
 fullyhadronic_ref350 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT350Monitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     HTdefinition     = 'pt>30 & abs(eta)<2.4',
@@ -386,6 +402,7 @@ fullyhadronic_ref350 = hltTOPmonitoring.clone(
 
 fullyhadronic_ref370 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT370Monitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     HTdefinition     = 'pt>30 & abs(eta)<2.4',
@@ -401,6 +418,7 @@ fullyhadronic_ref370 = hltTOPmonitoring.clone(
 
 fullyhadronic_ref430 = hltTOPmonitoring.clone(
     FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT430Monitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     HTdefinition     = 'pt>30 & abs(eta)<2.4',
@@ -416,6 +434,7 @@ fullyhadronic_ref430 = hltTOPmonitoring.clone(
 
 fullyhadronic_DoubleBTag_all = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/GlobalMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -448,8 +467,58 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_all, workingpoint = 0.
 run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_all.numGenericTriggerEventPSet, hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*'])
 ### ---
 
+fullyhadronic_DoubleBTag_DeepJet_all = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTagDeepJet/GlobalMonitor/',
+    enable2DPlots = False,
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    #btagAlgos        = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb"],
+    #workingpoint     = 0.2770, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X )
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers 
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepJet_2p94_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
+
+fullyhadronic_DoubleBTag_DeepJet_bjet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTagDeepJet/BJetMonitor/',
+    enable2DPlots = False,
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.1522, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    #btagAlgos        = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb"],
+    #workingpoint     = 0.0494, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X )
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepJet_2p94_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_v*'])
+)
+### ---
+
 fullyhadronic_DoubleBTag_jet = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/JetMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -487,6 +556,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_jet.denGenericTriggerE
 
 fullyhadronic_DoubleBTag_bjet = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/BJetMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -525,6 +595,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_bjet.denGenericTrigger
 
 fullyhadronic_DoubleBTag_ref = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/RefMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -560,6 +631,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_ref.numGenericTriggerE
 
 fullyhadronic_SingleBTag_all = hltTOPmonitoring.clone(
     FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/GlobalMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -593,8 +665,59 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_all.numGenericTriggerE
 
 ### ---
 
+fullyhadronic_SingleBTagDeepJet_all = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTagDeepJet/GlobalMonitor/',
+    enable2DPlots = False,
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    #btagAlgos        = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb"],
+    #workingpoint     = 0.2770, 
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_PFBTagDeepJet_1p59_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*']),
+)
+
+fullyhadronic_SingleBTagDeepJet_bjet = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTagDeepJet/BJetMonitor/',
+    enable2DPlots = False,
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.1522, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    #btagAlgos        = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb", "pfDeepFlavourJetTags:problepb"],
+    #workingpoint     = 0.0494, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X )
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_PFBTagDeepJet_1p59_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_v*'])
+)
+
+### ---
+
 fullyhadronic_SingleBTag_jet = hltTOPmonitoring.clone(
     FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/JetMonitor/',
+    enable2DPlots = False,
     # Selection
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -633,6 +756,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_jet.denGenericTriggerE
 
 fullyhadronic_SingleBTag_bjet = hltTOPmonitoring.clone(
     FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/BJetMonitor/',
+    enable2DPlots = False,
     # Selection
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -651,6 +775,7 @@ fullyhadronic_SingleBTag_bjet = hltTOPmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*']),
     denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_v*'])
 )
+
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_bjet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_bjet, workingpoint = 0.5426)
@@ -671,6 +796,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_bjet.denGenericTrigger
 
 fullyhadronic_SingleBTag_ref = hltTOPmonitoring.clone(
     FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/RefMonitor/',
+    enable2DPlots = False,
     # Selection
     leptJetDeltaRmin = 0.0,
     njets            = 6,
@@ -706,6 +832,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_ref.numGenericTriggerE
 
 fullyhadronic_TripleBTag_all = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/GlobalMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 4,
@@ -736,6 +863,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_TripleBTag_all.numGenericTriggerE
 
 fullyhadronic_TripleBTag_jet = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/JetMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 4,
@@ -767,6 +895,7 @@ run2_HLTconditions_2018.toModify(fullyhadronic_TripleBTag_jet.numGenericTriggerE
 
 fullyhadronic_TripleBTag_bjet = hltTOPmonitoring.clone(
     FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/BJetMonitor/',
+    enable2DPlots = False,
     # Selections
     leptJetDeltaRmin = 0.0,
     njets            = 4,
@@ -840,18 +969,26 @@ topMonitorHLT = cms.Sequence(
     + fullyhadronic_ref350
     + fullyhadronic_ref370
     + fullyhadronic_ref430
-    + fullyhadronic_DoubleBTag_all
+
+    + fullyhadronic_DoubleBTag_all  
     + fullyhadronic_DoubleBTag_jet
     + fullyhadronic_DoubleBTag_bjet
     + fullyhadronic_DoubleBTag_ref
+
+    + fullyhadronic_DoubleBTag_DeepJet_all
+    + fullyhadronic_DoubleBTag_DeepJet_bjet
+
     + fullyhadronic_SingleBTag_all
     + fullyhadronic_SingleBTag_jet
     + fullyhadronic_SingleBTag_bjet
     + fullyhadronic_SingleBTag_ref
+
+    + fullyhadronic_SingleBTagDeepJet_all
+    + fullyhadronic_SingleBTagDeepJet_bjet
+
     + fullyhadronic_TripleBTag_all
     + fullyhadronic_TripleBTag_jet
     + fullyhadronic_TripleBTag_bjet
-
     , cms.Task(egmGsfElectronIDsForDQM) # Use of electron VID requires this module being executed first
 )
 


### PR DESCRIPTION
#### PR description:

This PR implements a cleanup of the Top PAG HLT Offline DQM code. Changes were made in certain files under `DQMOffline/Trigger`:
`plugins/TopMonitor.cc`
`python/TopMonitor_cfi.py`
`python/TopMonitoring_Client_cff.py`
`python/TopMonitoring_cff.py`

**Changes :** 
- A flag to enable and disable the creation of 2D DQM plots was added (enable2DPlots) and was set to True by default. 
  - This flag was set to False in the  TOP HLT DQM module configuration : 
    - 2-d histograms under sub-folders HLT/TOP/* will not be produced. 
- Added monitoring of the following HLT paths : 
  1. HLT_PFHT400_SixPFJet32_DoublePFBTagDeepJet_2p94_v
  2. HLT_PFHT450_SixPFJet36_PFBTagDeepJet_1p59_v
As a result, two additional sub-folders are expected to be produced: 
HLT/TOP/FullyHadronic/DoubleBTagDeepJet
HLT/TOP/FullyHadronic/SingleBTagDeepJet  
Note : The deepCSV tagger is used for the selection of offline b-tagged jets since the deepjet b-tag handle is not available at RECO level. The compatibility of the trigger efficiency derived when selecting offline b-tagged jets with the deepjet vs the deepcsv tagger can be seen in slide 6 of [this](https://indico.cern.ch/event/1191718/#22-top-pag) presentation. In the future we could consider calculating the deep-jet outputs of the offline jets on-the-fly. 

No changes are expected in any of the previously produced histograms in folders other than HLT/TOP
- Performed needed updates with respect to [PR39158](https://github.com/cms-sw/cmssw/pull/39158)

#### PR validation:
Tested with runTheMatrix.py -l 11634.0

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a back-port, and no back-port of this is planned. 