### PR TITLE
[12_4_X] Declare production of Track collection after TrackExtra collection in modules run at HLT

### DIFF
--- a/RecoMuon/L2MuonProducer/plugins/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/plugins/L2MuonProducer.cc
@@ -111,10 +111,13 @@ L2MuonProducer::L2MuonProducer(const edm::ParameterSet& parameterSet) {
                                         std::make_unique<MuonTrajectoryCleaner>(true),
                                         iC);
 
-  produces<reco::TrackCollection>();
-  produces<reco::TrackCollection>("UpdatedAtVtx");
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>();
+  produces<reco::TrackCollection>("UpdatedAtVtx");
   produces<reco::TrackToTrackMap>();
 
   produces<std::vector<Trajectory>>();

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -63,15 +63,21 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
   theL2SeededTkLabel =
       trackLoaderParameters.getUntrackedParameter<std::string>("MuonSeededTracksInstance", std::string());
 
-  produces<reco::TrackCollection>(theL2SeededTkLabel);
   produces<TrackingRecHitCollection>(theL2SeededTkLabel);
   produces<reco::TrackExtraCollection>(theL2SeededTkLabel);
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>(theL2SeededTkLabel);
   produces<vector<Trajectory>>(theL2SeededTkLabel);
   produces<TrajTrackAssociationCollection>(theL2SeededTkLabel);
 
-  produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>();
   produces<vector<Trajectory>>();
   produces<TrajTrackAssociationCollection>();
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -38,9 +38,12 @@ public:
   explicit PixelTrackProducer(const edm::ParameterSet& cfg)
       : theReconstruction(cfg, consumesCollector()), htTopoToken_(esConsumes()) {
     edm::LogInfo("PixelTrackProducer") << " construction...";
-    produces<reco::TrackCollection>();
     produces<TrackingRecHitCollection>();
     produces<reco::TrackExtraCollection>();
+    // TrackCollection refers to TrackingRechit and TrackExtra
+    // collections, need to declare its production after them to work
+    // around a rare race condition in framework scheduling
+    produces<reco::TrackCollection>();
   }
 
   ~PixelTrackProducer() override = default;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -82,9 +82,12 @@ PixelTrackProducerFromSoA::PixelTrackProducerFromSoA(const edm::ParameterSet &iC
     throw cms::Exception("PixelTrackConfiguration")
         << iConfig.getParameter<std::string>("minQuality") + " not supported";
   }
-  produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>();
   produces<IndToEdm>();
 }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -217,7 +217,6 @@ AnalyticalTrackSelector::AnalyticalTrackSelector(const edm::ParameterSet& cfg) :
   }
 
   std::string alias(cfg.getParameter<std::string>("@module_label"));
-  produces<reco::TrackCollection>().setBranchAlias(alias + "Tracks");
   if (copyExtras_) {
     produces<reco::TrackExtraCollection>().setBranchAlias(alias + "TrackExtras");
     produces<TrackingRecHitCollection>().setBranchAlias(alias + "RecHits");
@@ -226,6 +225,10 @@ AnalyticalTrackSelector::AnalyticalTrackSelector(const edm::ParameterSet& cfg) :
     produces<std::vector<Trajectory>>().setBranchAlias(alias + "Trajectories");
     produces<TrajTrackAssociationCollection>().setBranchAlias(alias + "TrajectoryTrackAssociations");
   }
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>().setBranchAlias(alias + "Tracks");
 }
 
 AnalyticalTrackSelector::~AnalyticalTrackSelector() {}

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -276,8 +276,6 @@ TrackListMerger::TrackListMerger(edm::ParameterSet const& conf) {
     produces<edm::ValueMap<int>>();
     produces<QualityMaskCollection>("QualityMasks");
   } else {
-    produces<reco::TrackCollection>();
-
     makeReKeyedSeeds_ = conf.getUntrackedParameter<bool>("makeReKeyedSeeds", false);
     if (makeReKeyedSeeds_) {
       copyExtras_ = true;
@@ -288,6 +286,12 @@ TrackListMerger::TrackListMerger(edm::ParameterSet const& conf) {
       produces<reco::TrackExtraCollection>();
       produces<TrackingRecHitCollection>();
     }
+
+    // TrackCollection refers to TrackingRechit and TrackExtra
+    // collections, need to declare its production after them to work
+    // around a rare race condition in framework scheduling
+    produces<reco::TrackCollection>();
+
     produces<std::vector<Trajectory>>();
     produces<TrajTrackAssociationCollection>();
   }

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -36,10 +36,13 @@ GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig)
   //   string a = alias_;
   //   a.erase(a.size()-6,a.size());
   //register your products
-  produces<reco::GsfTrackCollection>().setBranchAlias(alias_ + "GsfTracks");
   produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
   produces<reco::GsfTrackExtraCollection>().setBranchAlias(alias_ + "GsfTrackExtras");
   produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
+  // GsfTrackCollection refers to TrackingRechit, TrackExtra, and
+  // GsfTrackExtra collections, need to declare its production after
+  // them to work around a rare race condition in framework scheduling
+  produces<reco::GsfTrackCollection>().setBranchAlias(alias_ + "GsfTracks");
   produces<std::vector<Trajectory> >();
   produces<TrajGsfTrackAssociationCollection>();
 }

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -32,9 +32,12 @@ TrackProducer::TrackProducer(const edm::ParameterSet& iConfig)
   }
 
   //register your products
-  produces<reco::TrackCollection>().setBranchAlias(alias_ + "Tracks");
   produces<reco::TrackExtraCollection>().setBranchAlias(alias_ + "TrackExtras");
   produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
+  // TrackCollection refers to TrackingRechit and TrackExtra
+  // collections, need to declare its production after them to work
+  // around a rare race condition in framework scheduling
+  produces<reco::TrackCollection>().setBranchAlias(alias_ + "Tracks");
   produces<std::vector<Trajectory> >();
   produces<std::vector<int> >();
   produces<TrajTrackAssociationCollection>();


### PR DESCRIPTION
backport of #39201

#### PR description:

Verbatim backport of #39201 by @makortel.

From the description of #39201:

> This PR proposes to declare the production of `Track` collection after `TrackExtra` and `TrackingRecHit` collections to work around a rare scheduling bug in the framework that might have caused three failures in the HLT that were reporter in #39064 (see [#39064 (comment)](https://github.com/cms-sw/cmssw/issues/39064#issuecomment-1227671651) for the details). The problem should be specific modules run in scheduled mode (i.e. modules are in Path or Sequence). Given that in all offline workflows the reconstruction code is run unscheduled, I limited to modules that I saw were in `HLT_GRun_cff`. I might have missed some, but I hope these changes would reduce the rate of the failures.

#### PR validation:

None

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#39201

Potentially relevant to current HLT online operations, see #39064.