### PR TITLE
RecoLocalTracker/SiPixelRecHits: changes to vectorize loops in VVIObjF::VVIObjF constructor

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
@@ -142,7 +142,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x[k]) - c1_[k - 1];
+    c1[k] = vdt::fast_logf(x[k]) - c1[k - 1];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1[k], c3[k], c4[k]);
@@ -278,7 +278,7 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
     VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x[k]) - c1[k - 1];
+    c1[k] = vdt::fast_logf(x[k]) - c1[k - 1];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1[k], c3[k], c4[k]);

--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
@@ -111,29 +111,29 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
   q_[0] = 1.f;
   q2_[0] = -2.f;
   for (k = 1; k < n; ++k) {
-    q_[k] = -q_[k-1];
-    q2_[k] = -q2_[k-1];
+    q_[k] = -q_[k - 1];
+    q2_[k] = -q2_[k - 1];
   }
   float x_[n];
-  x_[0]=0.f;
+  x_[0] = 0.f;
   float x1_[n];
-  x1_[0]=0.f;
+  x1_[0] = 0.f;
   float c1_[n];
-  c1_[0]=0.f;
+  c1_[0] = 0.f;
   float c2_[n];
-  c2_[0]=0.f;
+  c2_[0] = 0.f;
   float c3_[n];
-  c3_[0]=0.f;
+  c3_[0] = 0.f;
   float c4_[n];
-  c4_[0]=0.f;
+  c4_[0] = 0.f;
   float s_[n];
-  s_[0]=0.f;
+  s_[0] = 0.f;
   float c_[n];
-  c_[0]=0.f;
+  c_[0] = 0.f;
   float xf1_[n];
-  xf1_[0]=0.f;
+  xf1_[0] = 0.f;
   float xf2_[n];
-  xf2_[0]=0.f;
+  xf2_[0] = 0.f;
   for (k = 1; k < n; ++k) {
     x_[k] = omega_ * k;
     x1_[k] = h6 * x_[k];
@@ -142,7 +142,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     VVIObjFDetails::sincosint(x1_[k], c2_[k], c1_[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k-1];
+    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k - 1];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1_[k], c3_[k], c4_[k]);
@@ -153,7 +153,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     vdt::fast_sincosf(xf2_[k], s_[k], c_[k]);
   }
   float d1_[n];
-  d1_[0]=0.f;
+  d1_[0] = 0.f;
   if (mode_ == 0) {
     for (k = 1; k < n; ++k) {
       d1_[k] = q_[k] * d * omega_ * vdt::fast_expf(xf1_[k]);
@@ -247,29 +247,29 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   q_[0] = 1.f;
   q2_[0] = -2.f;
   for (k = 1; k < n; ++k) {
-    q_[k] = -q_[k-1];
-    q2_[k] = -q2_[k-1];
+    q_[k] = -q_[k - 1];
+    q2_[k] = -q2_[k - 1];
   }
   float x_[n];
-  x_[0]=0.f;
+  x_[0] = 0.f;
   float x1_[n];
-  x1_[0]=0.f;
+  x1_[0] = 0.f;
   float c1_[n];
-  c1_[0]=0.f;
+  c1_[0] = 0.f;
   float c2_[n];
-  c2_[0]=0.f;
+  c2_[0] = 0.f;
   float c3_[n];
-  c3_[0]=0.f;
+  c3_[0] = 0.f;
   float c4_[n];
-  c4_[0]=0.f;
+  c4_[0] = 0.f;
   float s_[n];
-  s_[0]=0.f;
+  s_[0] = 0.f;
   float c_[n];
-  c_[0]=0.f;
+  c_[0] = 0.f;
   float xf1_[n];
-  xf1_[0]=0.f;
+  xf1_[0] = 0.f;
   float xf2_[n];
-  xf2_[0]=0.f;
+  xf2_[0] = 0.f;
   for (k = 1; k < n; ++k) {
     x_[k] = omega_ * k;
     x1_[k] = h6 * x_[k];
@@ -278,18 +278,18 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
     VVIObjFDetails::sincosint(x1_[k], c2_[k], c1_[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k-1];
+    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k - 1];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1_[k], c3_[k], c4_[k]);
-    xf1_[k] = kappa * ( c1_[k] - c4_[k]) - x_[k] * c2_[k];
+    xf1_[k] = kappa * (c1_[k] - c4_[k]) - x_[k] * c2_[k];
     xf2_[k] = x_[k] * c1_[k] + kappa * (c3_[k] + c2_[k]) + t0_ * x_[k];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(xf2_[k], s_[k], c_[k]);
   }
   float d1_[n];
-  d1_[0]=0.f;
+  d1_[0] = 0.f;
   for (k = 1; k < n; ++k) {
     d1_[k] = q_[k] * d * vdt::fast_expf(xf1_[k]) / k;
   }

--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
@@ -44,7 +44,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
   const float xp[9] = {9.29, 2.47, .89, .36, .15, .07, .03, .02, 0.0};
   const float xq[7] = {.012, .03, .08, .26, .87, 3.83, 11.0};
   float h_[7];
-  float q, u, d, h4, h5, h6, ll, ul, rv;
+  float q, u, h4, h5, h6, d, ll, ul, rv;
   int lp, lq, k, l, n;
 
   // Make sure that the inputs are reasonable
@@ -106,78 +106,78 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     a_[n - 1] = omega_ * .31830988654751274f;
   }
 
-  float q_[n];
-  float q2_[n];
-  q_[0] = 1.f;
-  q2_[0] = -2.f;
+  float q1[n];
+  float q2[n];
+  q1[0] = 1.f;
+  q2[0] = -2.f;
   for (k = 1; k < n; ++k) {
-    q_[k] = -q_[k - 1];
-    q2_[k] = -q2_[k - 1];
+    q1[k] = -q1[k - 1];
+    q2[k] = -q2[k - 1];
   }
-  float x_[n];
-  x_[0] = 0.f;
-  float x1_[n];
-  x1_[0] = 0.f;
-  float c1_[n];
-  c1_[0] = 0.f;
-  float c2_[n];
-  c2_[0] = 0.f;
-  float c3_[n];
-  c3_[0] = 0.f;
-  float c4_[n];
-  c4_[0] = 0.f;
-  float s_[n];
-  s_[0] = 0.f;
-  float c_[n];
-  c_[0] = 0.f;
-  float xf1_[n];
-  xf1_[0] = 0.f;
-  float xf2_[n];
-  xf2_[0] = 0.f;
+  float x[n];
+  x[0] = 0.f;
+  float x1[n];
+  x1[0] = 0.f;
+  float c1[n];
+  c1[0] = 0.f;
+  float c2[n];
+  c2[0] = 0.f;
+  float c3[n];
+  c3[0] = 0.f;
+  float c4[n];
+  c4[0] = 0.f;
+  float s[n];
+  s[0] = 0.f;
+  float c[n];
+  c[0] = 0.f;
+  float xf1[n];
+  xf1[0] = 0.f;
+  float xf2[n];
+  xf2[0] = 0.f;
   for (k = 1; k < n; ++k) {
-    x_[k] = omega_ * k;
-    x1_[k] = h6 * x_[k];
-  }
-  for (k = 1; k < n; ++k) {
-    VVIObjFDetails::sincosint(x1_[k], c2_[k], c1_[k]);
+    x[k] = omega_ * k;
+    x1[k] = h6 * x[k];
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k - 1];
+    VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    vdt::fast_sincosf(x1_[k], c3_[k], c4_[k]);
-    xf1_[k] = kappa * (beta2 * c1_[k] - c4_[k]) - x_[k] * c2_[k];
-    xf2_[k] = x_[k] * c1_[k] + kappa * (c3_[k] + beta2 * c2_[k]) + t0_ * x_[k];
+    c1_[k] = vdt::fast_logf(x[k]) - c1_[k - 1];
   }
   for (k = 1; k < n; ++k) {
-    vdt::fast_sincosf(xf2_[k], s_[k], c_[k]);
+    vdt::fast_sincosf(x1[k], c3[k], c4[k]);
+    xf1[k] = kappa * (beta2 * c1[k] - c4[k]) - x[k] * c2[k];
+    xf2[k] = x[k] * c1[k] + kappa * (c3[k] + beta2 * c2[k]) + t0_ * x[k];
   }
-  float d1_[n];
-  d1_[0] = 0.f;
+  for (k = 1; k < n; ++k) {
+    vdt::fast_sincosf(xf2[k], s[k], c[k]);
+  }
+  float d1[n];
+  d1[0] = 0.f;
   if (mode_ == 0) {
     for (k = 1; k < n; ++k) {
-      d1_[k] = q_[k] * d * omega_ * vdt::fast_expf(xf1_[k]);
+      d1[k] = q1[k] * d * omega_ * vdt::fast_expf(xf1[k]);
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
-      a_[l - 1] = d1_[k] * c_[k];
-      b_[l - 1] = -d1_[k] * s_[k];
+      a_[l - 1] = d1[k] * c[k];
+      b_[l - 1] = -d1[k] * s[k];
     }
   } else {
     for (k = 1; k < n; ++k) {
-      d1_[k] = q_[k] * d * vdt::fast_expf(xf1_[k]) / k;
+      d1[k] = q1[k] * d * vdt::fast_expf(xf1[k]) / k;
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
-      a_[l - 1] = d1_[k] * s_[k];
+      a_[l - 1] = d1[k] * s[k];
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
-      b_[l - 1] = d1_[k] * c_[k];
+      b_[l - 1] = d1[k] * c[k];
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
-      a_[n - 1] += q2_[k] * a_[l - 1];
+      a_[n - 1] += q2[k] * a_[l - 1];
     }
   }
 }  // VVIObjF
@@ -242,68 +242,68 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   n = x0_ + 1.;
   d = vdt::fast_expf(kappa * ((0.57721566f - h5) + 1.f)) * .31830988654751274f;
   a_[n - 1] = 0.f;
-  float q_[n];
-  float q2_[n];
-  q_[0] = 1.f;
-  q2_[0] = -2.f;
+  float q1[n];
+  float q2[n];
+  q1[0] = 1.f;
+  q2[0] = -2.f;
   for (k = 1; k < n; ++k) {
-    q_[k] = -q_[k - 1];
-    q2_[k] = -q2_[k - 1];
+    q1[k] = -q1[k - 1];
+    q2[k] = -q2[k - 1];
   }
-  float x_[n];
-  x_[0] = 0.f;
-  float x1_[n];
-  x1_[0] = 0.f;
-  float c1_[n];
-  c1_[0] = 0.f;
-  float c2_[n];
-  c2_[0] = 0.f;
-  float c3_[n];
-  c3_[0] = 0.f;
-  float c4_[n];
-  c4_[0] = 0.f;
-  float s_[n];
-  s_[0] = 0.f;
-  float c_[n];
-  c_[0] = 0.f;
-  float xf1_[n];
-  xf1_[0] = 0.f;
-  float xf2_[n];
-  xf2_[0] = 0.f;
+  float x[n];
+  x[0] = 0.f;
+  float x1[n];
+  x1[0] = 0.f;
+  float c1[n];
+  c1[0] = 0.f;
+  float c2[n];
+  c2[0] = 0.f;
+  float c3[n];
+  c3[0] = 0.f;
+  float c4[n];
+  c4[0] = 0.f;
+  float s[n];
+  s[0] = 0.f;
+  float c[n];
+  c[0] = 0.f;
+  float xf1[n];
+  xf1[0] = 0.f;
+  float xf2[n];
+  xf2[0] = 0.f;
   for (k = 1; k < n; ++k) {
-    x_[k] = omega_ * k;
-    x1_[k] = h6 * x_[k];
-  }
-  for (k = 1; k < n; ++k) {
-    VVIObjFDetails::sincosint(x1_[k], c2_[k], c1_[k]);
+    x[k] = omega_ * k;
+    x1[k] = h6 * x[k];
   }
   for (k = 1; k < n; ++k) {
-    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k - 1];
+    VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    vdt::fast_sincosf(x1_[k], c3_[k], c4_[k]);
-    xf1_[k] = kappa * (c1_[k] - c4_[k]) - x_[k] * c2_[k];
-    xf2_[k] = x_[k] * c1_[k] + kappa * (c3_[k] + c2_[k]) + t0_ * x_[k];
+    c1_[k] = vdt::fast_logf(x[k]) - c1[k - 1];
   }
   for (k = 1; k < n; ++k) {
-    vdt::fast_sincosf(xf2_[k], s_[k], c_[k]);
-  }
-  float d1_[n];
-  d1_[0] = 0.f;
-  for (k = 1; k < n; ++k) {
-    d1_[k] = q_[k] * d * vdt::fast_expf(xf1_[k]) / k;
+    vdt::fast_sincosf(x1[k], c3[k], c4[k]);
+    xf1[k] = kappa * (c1[k] - c4[k]) - x[k] * c2[k];
+    xf2[k] = x[k] * c1[k] + kappa * (c3[k] + c2[k]) + t0_ * x[k];
   }
   for (k = 1; k < n; ++k) {
-    l = n - k;
-    a_[l - 1] = d1_[k] * s_[k];
+    vdt::fast_sincosf(xf2[k], s[k], c[k]);
+  }
+  float d1[n];
+  d1[0] = 0.f;
+  for (k = 1; k < n; ++k) {
+    d1[k] = q1[k] * d * vdt::fast_expf(xf1[k]) / k;
   }
   for (k = 1; k < n; ++k) {
     l = n - k;
-    b_[l - 1] = d1_[k] * c_[k];
+    a_[l - 1] = d1[k] * s[k];
   }
   for (k = 1; k < n; ++k) {
     l = n - k;
-    a_[n - 1] += q2_[k] * a_[l - 1];
+    b_[l - 1] = d1[k] * c[k];
+  }
+  for (k = 1; k < n; ++k) {
+    l = n - k;
+    a_[n - 1] += q2[k] * a_[l - 1];
   }
 
 }  // VVIObjF with kappa only

--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
@@ -44,7 +44,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
   const float xp[9] = {9.29, 2.47, .89, .36, .15, .07, .03, .02, 0.0};
   const float xq[7] = {.012, .03, .08, .26, .87, 3.83, 11.0};
   float h_[7];
-  float q, u, h4, h5, h6, d, ll, ul, rv;
+  float q, u, h4, h5, h6, q2, d, ll, ul, rv;
   int lp, lq, k, l, n;
 
   // Make sure that the inputs are reasonable
@@ -105,15 +105,9 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
   if (mode_ == 0) {
     a_[n - 1] = omega_ * .31830988654751274f;
   }
+  q = -1.;
+  q2 = 2.;
 
-  float q1[n];
-  float q2[n];
-  q1[0] = 1.f;
-  q2[0] = -2.f;
-  for (k = 1; k < n; ++k) {
-    q1[k] = -q1[k - 1];
-    q2[k] = -q2[k - 1];
-  }
   float x[n];
   x[0] = 0.f;
   float x1[n];
@@ -142,7 +136,7 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1[k] = vdt::fast_logf(x[k]) - c1[k - 1];
+    c1[k] = vdt::fast_logf(x[k]) - c1[k];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1[k], c3[k], c4[k]);
@@ -156,7 +150,8 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
   d1[0] = 0.f;
   if (mode_ == 0) {
     for (k = 1; k < n; ++k) {
-      d1[k] = q1[k] * d * omega_ * vdt::fast_expf(xf1[k]);
+      d1[k] = q * d * omega_ * vdt::fast_expf(xf1[k]);
+      q = -q;
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
@@ -165,7 +160,8 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     }
   } else {
     for (k = 1; k < n; ++k) {
-      d1[k] = q1[k] * d * vdt::fast_expf(xf1[k]) / k;
+      d1[k] = q * d * vdt::fast_expf(xf1[k]) / k;
+      q = -q;
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
@@ -177,7 +173,8 @@ VVIObjF::VVIObjF(float kappa, float beta2, int mode) : mode_(mode) {
     }
     for (k = 1; k < n; ++k) {
       l = n - k;
-      a_[n - 1] += q2[k] * a_[l - 1];
+      a_[n - 1] += q2 * a_[l - 1];
+      q2 = -q2;
     }
   }
 }  // VVIObjF
@@ -193,7 +190,7 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   const float xp[9] = {9.29, 2.47, .89, .36, .15, .07, .03, .02, 0.0};
   const float xq[7] = {.012, .03, .08, .26, .87, 3.83, 11.0};
   float h_[5];
-  float q, u, h4, h5, h6, d, ll, ul, rv;
+  float q, u, h4, h5, h6, q2, d, ll, ul, rv;
   int lp, lq, k, l, n;
 
   // Make sure that the inputs are reasonable
@@ -242,14 +239,9 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   n = x0_ + 1.;
   d = vdt::fast_expf(kappa * ((0.57721566f - h5) + 1.f)) * .31830988654751274f;
   a_[n - 1] = 0.f;
-  float q1[n];
-  float q2[n];
-  q1[0] = 1.f;
-  q2[0] = -2.f;
-  for (k = 1; k < n; ++k) {
-    q1[k] = -q1[k - 1];
-    q2[k] = -q2[k - 1];
-  }
+  q = -1.;
+  q2 = 2.;
+
   float x[n];
   x[0] = 0.f;
   float x1[n];
@@ -278,7 +270,7 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
     VVIObjFDetails::sincosint(x1[k], c2[k], c1[k]);
   }
   for (k = 1; k < n; ++k) {
-    c1[k] = vdt::fast_logf(x[k]) - c1[k - 1];
+    c1[k] = vdt::fast_logf(x[k]) - c1[k];
   }
   for (k = 1; k < n; ++k) {
     vdt::fast_sincosf(x1[k], c3[k], c4[k]);
@@ -291,7 +283,8 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   float d1[n];
   d1[0] = 0.f;
   for (k = 1; k < n; ++k) {
-    d1[k] = q1[k] * d * vdt::fast_expf(xf1[k]) / k;
+    d1[k] = q * d * vdt::fast_expf(xf1[k]) / k;
+    q = -q;
   }
   for (k = 1; k < n; ++k) {
     l = n - k;
@@ -303,7 +296,8 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   }
   for (k = 1; k < n; ++k) {
     l = n - k;
-    a_[n - 1] += q2[k] * a_[l - 1];
+    a_[n - 1] += q2 * a_[l - 1];
+    q2 = -q2;
   }
 
 }  // VVIObjF with kappa only

--- a/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/VVIObjF.cc
@@ -193,7 +193,7 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   const float xp[9] = {9.29, 2.47, .89, .36, .15, .07, .03, .02, 0.0};
   const float xq[7] = {.012, .03, .08, .26, .87, 3.83, 11.0};
   float h_[5];
-  float q, u, x, c1, c2, c3, c4, d1, h4, h5, h6, q2, x1, d, ll, ul, xf1, xf2, rv;
+  float q, u, h4, h5, h6, d, ll, ul, rv;
   int lp, lq, k, l, n;
 
   // Make sure that the inputs are reasonable
@@ -242,25 +242,68 @@ VVIObjF::VVIObjF(float kappa) : mode_(1) {
   n = x0_ + 1.;
   d = vdt::fast_expf(kappa * ((0.57721566f - h5) + 1.f)) * .31830988654751274f;
   a_[n - 1] = 0.f;
-  q = -1.;
-  q2 = 2.;
+  float q_[n];
+  float q2_[n];
+  q_[0] = 1.f;
+  q2_[0] = -2.f;
+  for (k = 1; k < n; ++k) {
+    q_[k] = -q_[k-1];
+    q2_[k] = -q2_[k-1];
+  }
+  float x_[n];
+  x_[0]=0.f;
+  float x1_[n];
+  x1_[0]=0.f;
+  float c1_[n];
+  c1_[0]=0.f;
+  float c2_[n];
+  c2_[0]=0.f;
+  float c3_[n];
+  c3_[0]=0.f;
+  float c4_[n];
+  c4_[0]=0.f;
+  float s_[n];
+  s_[0]=0.f;
+  float c_[n];
+  c_[0]=0.f;
+  float xf1_[n];
+  xf1_[0]=0.f;
+  float xf2_[n];
+  xf2_[0]=0.f;
+  for (k = 1; k < n; ++k) {
+    x_[k] = omega_ * k;
+    x1_[k] = h6 * x_[k];
+  }
+  for (k = 1; k < n; ++k) {
+    VVIObjFDetails::sincosint(x1_[k], c2_[k], c1_[k]);
+  }
+  for (k = 1; k < n; ++k) {
+    c1_[k] = vdt::fast_logf(x_[k]) - c1_[k-1];
+  }
+  for (k = 1; k < n; ++k) {
+    vdt::fast_sincosf(x1_[k], c3_[k], c4_[k]);
+    xf1_[k] = kappa * ( c1_[k] - c4_[k]) - x_[k] * c2_[k];
+    xf2_[k] = x_[k] * c1_[k] + kappa * (c3_[k] + c2_[k]) + t0_ * x_[k];
+  }
+  for (k = 1; k < n; ++k) {
+    vdt::fast_sincosf(xf2_[k], s_[k], c_[k]);
+  }
+  float d1_[n];
+  d1_[0]=0.f;
+  for (k = 1; k < n; ++k) {
+    d1_[k] = q_[k] * d * vdt::fast_expf(xf1_[k]) / k;
+  }
   for (k = 1; k < n; ++k) {
     l = n - k;
-    x = omega_ * k;
-    x1 = h6 * x;
-    VVIObjFDetails::sincosint(x1, c2, c1);
-    c1 = vdt::fast_logf(x) - c1;
-    vdt::fast_sincosf(x1, c3, c4);
-    xf1 = kappa * (c1 - c4) - x * c2;
-    xf2 = x * c1 + kappa * (c3 + c2) + t0_ * x;
-    float s, c;
-    vdt::fast_sincosf(xf2, s, c);
-    d1 = q * d * vdt::fast_expf(xf1) / k;
-    a_[l - 1] = d1 * s;
-    b_[l - 1] = d1 * c;
-    a_[n - 1] += q2 * a_[l - 1];
-    q = -q;
-    q2 = -q2;
+    a_[l - 1] = d1_[k] * s_[k];
+  }
+  for (k = 1; k < n; ++k) {
+    l = n - k;
+    b_[l - 1] = d1_[k] * c_[k];
+  }
+  for (k = 1; k < n; ++k) {
+    l = n - k;
+    a_[n - 1] += q2_[k] * a_[l - 1];
   }
 
 }  // VVIObjF with kappa only


### PR DESCRIPTION
Using Intel Advisor to profile workflow r39634.21 with a CMSSW_12_5_LTO integration build release showed the top time consuming loop with floating point operation is in VVIObjF::VVIObjF constructor. 
```
"1381";"[loop in VVIObjF::VVIObjF at log.h:179]";"41.230s";"28.288s";"Scalar";"";"";"";"";"log.h:179";"libRecoLocalTrackerSiPixelRecHits.so"
```
With this change the loop calculations are vectorized and the time is reduced.
```
"1772";"[loop in VVIObjF::VVIObjF at log.h:179]";"3.824s";"3.824s";"Vectorized (Body)";"";"SSE2";"";"";"log.h:179";"libRecoLocalTrackerSiPixelRecHits.so"
```

Further profiling is being done with CMSSW_12_5_X integration build release.
