### PR TITLE
HBHE: arrival time

### DIFF
--- a/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
+++ b/DataFormats/HcalRecHit/interface/HcalSpecialTimes.h
@@ -52,6 +52,8 @@ namespace HcalSpecialTimes {
   // Check if the given time represents one of the special values
   constexpr inline bool isSpecial(const float t) { return t <= UNKNOWN_T_UNDERSHOOT; }
 
+  constexpr float DEFAULT_ccTIME = -999.f;
+
   constexpr inline float getTDCTime(const int tdc) {
     constexpr float tdc_to_ns = 0.5f;
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -147,7 +147,7 @@ private:
   void updateCov(const SampleMatrix& invCovMat) const;
   void resetPulseShapeTemplate(int pulseShapeId, const HcalPulseShapes& ps, unsigned int nSamples);
 
-  float ccTime() const;
+  float ccTime(const float itQ) const;
   void updatePulseShape(const float itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -140,6 +140,8 @@ private:
   void onePulseMinimize() const;
   void updateCov(const SampleMatrix& invCovMat) const;
   void resetPulseShapeTemplate(int pulseShapeId, const HcalPulseShapes& ps, unsigned int nSamples);
+
+  float ccTime() const ;
   void updatePulseShape(const float itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -131,13 +131,17 @@ public:
                              const HcalPulseShapes& ps,
                              bool hasTimeInfo,
                              const HcalTimeSlew* hcalTimeSlewDelay,
-                             unsigned int nSamples);
+                             unsigned int nSamples,
+                             const float gain);
 
   typedef BXVector::Index Index;
   const HcalTimeSlew* hcalTimeSlewDelay_ = nullptr;
 
-  mutable float thEnergeticPulses_;
-  mutable float thLowPUOOT_;
+  float thEnergeticPulses_;
+  float thLowPUoot_;
+
+  float thEnergeticPulsesFC_;
+  float thLowPUootFC_;
 
 private:
   typedef std::pair<int, std::shared_ptr<FitterFuncs::PulseShapeFunctor> > ShapeWithId;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -147,7 +147,7 @@ private:
   void updateCov(const SampleMatrix& invCovMat) const;
   void resetPulseShapeTemplate(int pulseShapeId, const HcalPulseShapes& ps, unsigned int nSamples);
 
-  float ccTime() const ;
+  float ccTime() const;
   void updatePulseShape(const float itQ,
                         FullSampleVector& pulseShape,
                         FullSampleVector& pulseDeriv,

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -104,6 +104,9 @@ public:
                      bool iApplyTimeSlew,
                      HcalTimeSlew::BiasSetting slewFlavor,
                      bool iCalculateArrivalTime,
+                     int iTimeAlgo,
+                     double iThEnergeticPulses,
+                     double iThLowPUOOT,
                      double iMeanTime,
                      double iTimeSigmaHPD,
                      double iTimeSigmaSiPM,
@@ -132,6 +135,9 @@ public:
 
   typedef BXVector::Index Index;
   const HcalTimeSlew* hcalTimeSlewDelay_ = nullptr;
+
+  mutable float thEnergeticPulses_;
+  mutable float thLowPUOOT_;
 
 private:
   typedef std::pair<int, std::shared_ptr<FitterFuncs::PulseShapeFunctor> > ShapeWithId;
@@ -167,6 +173,8 @@ private:
   static constexpr float timeLimit_ = 12.5f;
 
   // Python-configurables
+  int timeAlgo_;
+
   bool dynamicPed_;
   float ts4Thresh_;
   float chiSqSwitch_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -106,7 +106,6 @@ public:
                      bool iCalculateArrivalTime,
                      int iTimeAlgo,
                      double iThEnergeticPulses,
-                     double iThLowPUOOT,
                      double iMeanTime,
                      double iTimeSigmaHPD,
                      double iTimeSigmaSiPM,
@@ -138,10 +137,7 @@ public:
   const HcalTimeSlew* hcalTimeSlewDelay_ = nullptr;
 
   float thEnergeticPulses_;
-  float thLowPUoot_;
-
   float thEnergeticPulsesFC_;
-  float thLowPUootFC_;
 
 private:
   typedef std::pair<int, std::shared_ptr<FitterFuncs::PulseShapeFunctor> > ShapeWithId;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -360,15 +360,15 @@ float MahiFit::ccTime(const float itQ) const {
 
   // Selecting energetic hits - (Energy in TS[3] and TS[4]) > 20 GeV
   if ((nnlsWork_.amplitudes.coeffRef(soi) + nnlsWork_.amplitudes.coeffRef(soi + 1U)) < thEnergeticPulsesFC_)
-    return 0.f;
+    return -999.f;
   // Rejecting late hits  Energy in TS[3] > (Energy in TS[4] and TS[5])
   if (nnlsWork_.amplitudes.coeffRef(soi) <
       (nnlsWork_.amplitudes.coeffRef(soi + 1U) + nnlsWork_.amplitudes.coeffRef(soi + 2U)))
-    return 0.f;
+    return -999.f;
   // With small OOTPU (Energy in TS[0] ,TS[1] and TS[2]) < 5 GeV
   if ((nnlsWork_.amplitudes.coeffRef(soi - 3U) + nnlsWork_.amplitudes.coeffRef(soi - 2U) +
        nnlsWork_.amplitudes.coeffRef(soi - 1U)) > thLowPUootFC_)
-    return 0.f;
+    return -999.f;
   // To speed up check around the fitted time (? to be checked with LLP)
 
   // distanze as in formula of page 6

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -101,8 +101,8 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
   tsTOT *= gain0;
   tstrig *= gain0;
 
-  thEnergeticPulses_ *= (1.f/gain0);
-  thLowPUOOT_ *= (1.f/gain0);
+  thEnergeticPulses_ *= (1.f / gain0);
+  thLowPUOOT_ *= (1.f / gain0);
 
   useTriple = false;
   if (tstrig > ts4Thresh_ && tsTOT > 0) {
@@ -219,9 +219,9 @@ void MahiFit::doFit(std::array<float, 4>& correctedOutput, int nbx) const {
     if (correctedOutput.at(0) != 0) {
       // fixME store the timeslew
       float arrivalTime = 0.f;
-      if (calculateArrivalTime_ && timeAlgo_==1)
+      if (calculateArrivalTime_ && timeAlgo_ == 1)
         arrivalTime = calculateArrivalTime(ipulseintime);
-      else if (calculateArrivalTime_ && timeAlgo_==2)
+      else if (calculateArrivalTime_ && timeAlgo_ == 2)
         arrivalTime = ccTime();
       correctedOutput.at(1) = arrivalTime;  //time
     } else
@@ -229,7 +229,6 @@ void MahiFit::doFit(std::array<float, 4>& correctedOutput, int nbx) const {
 
     correctedOutput.at(2) = chiSq;  //chi2
   }
-
 }
 
 const float MahiFit::minimize() const {
@@ -358,7 +357,6 @@ void MahiFit::updateCov(const SampleMatrix& samplecov) const {
 }
 
 float MahiFit::ccTime() const {
-
   float ccTime_ = 0.;
 
   // those conditions are now on data time slices, can be done on the fitted pulse i.e. using nlsWork_.ampVec.coeff(itIndex);
@@ -366,13 +364,17 @@ float MahiFit::ccTime() const {
   const int soi = nnlsWork_.tsOffset;
 
   // Selecting energetic hits - (Energy in TS[3] and TS[4]) > 20 GeV
-  const bool cond1 = (nnlsWork_.amplitudes.coeffRef(soi)+nnlsWork_.amplitudes.coeffRef(soi+1U) > thEnergeticPulses_ );
+  const bool cond1 =
+      (nnlsWork_.amplitudes.coeffRef(soi) + nnlsWork_.amplitudes.coeffRef(soi + 1U) > thEnergeticPulses_);
   // Rejecting late hits  Energy in TS[3] > (Energy in TS[4] and TS[5])
-  const bool cond2 = (nnlsWork_.amplitudes.coeffRef(soi)>(nnlsWork_.amplitudes.coeffRef(soi+1U)+nnlsWork_.amplitudes.coeffRef(soi+2U)));
+  const bool cond2 = (nnlsWork_.amplitudes.coeffRef(soi) >
+                      (nnlsWork_.amplitudes.coeffRef(soi + 1U) + nnlsWork_.amplitudes.coeffRef(soi + 2U)));
   // With small OOTPU (Energy in TS[0] ,TS[1] and TS[2]) < 5 GeV
-  const bool cond3 = ((nnlsWork_.amplitudes.coeffRef(soi-3U)+nnlsWork_.amplitudes.coeffRef(soi-1U)+nnlsWork_.amplitudes.coeffRef(soi-1U))< thLowPUOOT_ );
+  const bool cond3 = ((nnlsWork_.amplitudes.coeffRef(soi - 3U) + nnlsWork_.amplitudes.coeffRef(soi - 1U) +
+                       nnlsWork_.amplitudes.coeffRef(soi - 1U)) < thLowPUOOT_);
 
-  if (!(cond1 && cond2 && cond3)) return ccTime_;
+  if (!(cond1 && cond2 && cond3))
+    return ccTime_;
 
   // To speed up check around the fitted time (? to be checked with LLP)
 
@@ -392,12 +394,11 @@ float MahiFit::ccTime() const {
 
   std::array<double, hcal::constants::maxSamples> pulseN;
 
-  int TS_afterSOI = 25 * ( nnlsWork_.tsSize - nnlsWork_.tsOffset );
-  int TS_beforeSOI = - 25 * nnlsWork_.tsOffset;
+  int TS_afterSOI = 25 * (nnlsWork_.tsSize - nnlsWork_.tsOffset);
+  int TS_beforeSOI = -25 * nnlsWork_.tsOffset;
 
-  for (int deltaNS = TS_beforeSOI; deltaNS < TS_afterSOI; ++deltaNS ) {
-
-    const float xx = t0+deltaNS;
+  for (int deltaNS = TS_beforeSOI; deltaNS < TS_afterSOI; ++deltaNS) {
+    const float xx = t0 + deltaNS;
 
     psfPtr_->singlePulseShapeFuncMahi(&xx);
     psfPtr_->getPulseShape(pulseN);
@@ -408,24 +409,23 @@ float MahiFit::ccTime() const {
     //
 
     for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
-
       //pulseN[iTS] is the area of the template
       float norm = nnlsWork_.amplitudes.coeffRef(iTS);
 
       //  Finding the distance after each iteration.
       numerator += norm * pulseN[iTS];
-      pulse2 += pulseN[iTS]*pulseN[iTS];
+      pulse2 += pulseN[iTS] * pulseN[iTS];
       norm2 += norm * norm;
-
     }
 
     float distance = numerator / sqrt(pulse2 * norm2);
-    if(distance > distance_delta_max ) { distance_delta_max = distance; ccTime_ = deltaNS; }
-
+    if (distance > distance_delta_max) {
+      distance_delta_max = distance;
+      ccTime_ = deltaNS;
+    }
   }
 
   return ccTime_;
-
 }
 
 float MahiFit::calculateArrivalTime(const unsigned int itIndex) const {

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -578,8 +578,8 @@ void MahiFit::setPulseShapeTemplate(const int pulseShapeId,
   }
 
   // threshold in GeV for ccTime
-  thEnergeticPulsesFC_ = thEnergeticPulses_/gain0;
-  thLowPUootFC_ = thLowPUoot_/gain0;
+  thEnergeticPulsesFC_ = thEnergeticPulses_ / gain0;
+  thLowPUootFC_ = thLowPUoot_ / gain0;
 }
 
 void MahiFit::resetPulseShapeTemplate(const int pulseShapeId,

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -388,10 +388,11 @@ float MahiFit::ccTime(const float itQ) const {
 
   std::array<double, hcal::constants::maxSamples> pulseN;
 
-  int TS_afterSOI = 25 * (nnlsWork_.tsSize - nnlsWork_.tsOffset);
+  // making 8 TS out of the template i.e. 200 points
+  int TS_SOIandAfter = 25 * (nnlsWork_.tsSize - nnlsWork_.tsOffset);
   int TS_beforeSOI = -25 * nnlsWork_.tsOffset;
 
-  for (int deltaNS = TS_beforeSOI; deltaNS < TS_afterSOI; ++deltaNS) {
+  for (int deltaNS = TS_beforeSOI; deltaNS < TS_SOIandAfter; ++deltaNS) { // from -75ns and + 125ns
     const float xx = t0 + deltaNS;
 
     psfPtr_->singlePulseShapeFuncMahi(&xx);
@@ -401,14 +402,16 @@ float MahiFit::ccTime(const float itQ) const {
     float norm2 = 0;
     float numerator = 0;
     //
+    int delta = 4 - nnlsWork_.tsOffset; // like in updatePulseShape
 
-    for (unsigned int iTS = 0; iTS < nnlsWork_.tsSize; ++iTS) {
+    // rm TS0 and TS7, to speed up and reduce noise
+    for (unsigned int iTS = 1; iTS < (nnlsWork_.tsSize - 1); ++iTS) {
       //pulseN[iTS] is the area of the template
       float norm = nnlsWork_.amplitudes.coeffRef(iTS);
 
       //  Finding the distance after each iteration.
-      numerator += norm * pulseN[iTS];
-      pulse2 += pulseN[iTS] * pulseN[iTS];
+      numerator += norm * pulseN[iTS + delta];
+      pulse2 += pulseN[iTS + delta] * pulseN[iTS + delta];
       norm2 += norm * norm;
     }
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -354,8 +354,6 @@ void MahiFit::updateCov(const SampleMatrix& samplecov) const {
 float MahiFit::ccTime(const float itQ) const {
   // those conditions are now on data time slices, can be done on the fitted pulse i.e. using nlsWork_.ampVec.coeff(itIndex);
 
-  unsigned int soi = nnlsWork_.tsOffset;
-
   // Selecting energetic hits - Fitted Energy > 20 GeV
   if (itQ < thEnergeticPulsesFC_)
     return HcalSpecialTimes::DEFAULT_ccTIME;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -357,7 +357,8 @@ float MahiFit::ccTime(const float itQ) const {
   unsigned int soi = nnlsWork_.tsOffset;
 
   // Selecting energetic hits - Fitted Energy > 20 GeV
-  if (itQ < thEnergeticPulsesFC_) return HcalSpecialTimes::DEFAULT_ccTIME;
+  if (itQ < thEnergeticPulsesFC_)
+    return HcalSpecialTimes::DEFAULT_ccTIME;
 
   // Rejecting late hits  Energy in TS[3] > (Energy in TS[4] and TS[5])
   // With small OOTPU (Energy in TS[0] ,TS[1] and TS[2]) < 5 GeV

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -392,7 +392,7 @@ float MahiFit::ccTime(const float itQ) const {
   int TS_SOIandAfter = 25 * (nnlsWork_.tsSize - nnlsWork_.tsOffset);
   int TS_beforeSOI = -25 * nnlsWork_.tsOffset;
 
-  for (int deltaNS = TS_beforeSOI; deltaNS < TS_SOIandAfter; ++deltaNS) { // from -75ns and + 125ns
+  for (int deltaNS = TS_beforeSOI; deltaNS < TS_SOIandAfter; ++deltaNS) {  // from -75ns and + 125ns
     const float xx = t0 + deltaNS;
 
     psfPtr_->singlePulseShapeFuncMahi(&xx);
@@ -402,7 +402,7 @@ float MahiFit::ccTime(const float itQ) const {
     float norm2 = 0;
     float numerator = 0;
     //
-    int delta = 4 - nnlsWork_.tsOffset; // like in updatePulseShape
+    int delta = 4 - nnlsWork_.tsOffset;  // like in updatePulseShape
 
     // rm TS0 and TS7, to speed up and reduce noise
     for (unsigned int iTS = 1; iTS < (nnlsWork_.tsSize - 1); ++iTS) {

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -222,7 +222,7 @@ void MahiFit::doFit(std::array<float, 4>& correctedOutput, int nbx) const {
       if (calculateArrivalTime_ && timeAlgo_ == 1)
         arrivalTime = calculateArrivalTime(ipulseintime);
       else if (calculateArrivalTime_ && timeAlgo_ == 2)
-        arrivalTime = ccTime();
+        arrivalTime = ccTime(nnlsWork_.amplitudes.coeff(nnlsWork_.tsOffset));
       correctedOutput.at(1) = arrivalTime;  //time
     } else
       correctedOutput.at(1) = -9999.f;  //time
@@ -356,7 +356,7 @@ void MahiFit::updateCov(const SampleMatrix& samplecov) const {
   nnlsWork_.covDecomp.compute(invCovMat);
 }
 
-float MahiFit::ccTime() const {
+float MahiFit::ccTime(const float itQ) const {
   float ccTime_ = 0.;
 
   // those conditions are now on data time slices, can be done on the fitted pulse i.e. using nlsWork_.ampVec.coeff(itIndex);
@@ -383,12 +383,12 @@ float MahiFit::ccTime() const {
 
   float t0 = meanTime_;
 
-  //  if (applyTimeSlew_) {
-  //    if (itQ <= 1.f)
-  //      t0 += tsDelay1GeV_;
-  //    else
-  //      t0 += hcalTimeSlewDelay_->delay(float(itQ), slewFlavor_);
-  //  }
+  if (applyTimeSlew_) {
+    if (itQ <= 1.f)
+      t0 += tsDelay1GeV_;
+    else
+      t0 += hcalTimeSlewDelay_->delay(float(itQ), slewFlavor_);
+  }
 
   float distance_delta_max = 0.f;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/SimpleHBHEPhase1Algo.cc
@@ -106,7 +106,7 @@ HBHERecHit SimpleHBHEPhase1Algo::reconstruct(const HBHEChannelInfo& info,
 
   if (mahi) {
     mahiOOTpuCorr_->setPulseShapeTemplate(
-        info.recoShape(), theHcalPulseShapes_, info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples());
+        info.recoShape(), theHcalPulseShapes_, info.hasTimeInfo(), hcalTimeSlew_delay_, info.nSamples(), info.tsGain(0));
     mahi->phase1Apply(info, m4E, m4ESOIPlusOne, m4T, m4UseTriple, m4chi2);
     m4E *= hbminusCorrectionFactor(channelId, m4E, isData);
     m4ESOIPlusOne *= hbminusCorrectionFactor(channelId, m4ESOIPlusOne, isData);

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -19,6 +19,9 @@ static std::unique_ptr<MahiFit> parseHBHEMahiDescription(const edm::ParameterSet
   const bool iApplyTimeSlew = conf.getParameter<bool>("applyTimeSlew");
 
   const bool iCalculateArrivalTime = conf.getParameter<bool>("calculateArrivalTime");
+  const int iTimeAlgo = conf.getParameter<int>("timeAlgo");
+  const double iThEnergeticPulses = conf.getParameter<double>("thEnergeticPulses");
+  const double iThLowPUOOT = conf.getParameter<double>("thLowPUOOT");
   const double iMeanTime = conf.getParameter<double>("meanTime");
   const double iTimeSigmaHPD = conf.getParameter<double>("timeSigmaHPD");
   const double iTimeSigmaSiPM = conf.getParameter<double>("timeSigmaSiPM");
@@ -37,6 +40,9 @@ static std::unique_ptr<MahiFit> parseHBHEMahiDescription(const edm::ParameterSet
                       iApplyTimeSlew,
                       HcalTimeSlew::Medium,
                       iCalculateArrivalTime,
+                      iTimeAlgo,
+                      iThEnergeticPulses,
+                      iThLowPUOOT,
                       iMeanTime,
                       iTimeSigmaHPD,
                       iTimeSigmaSiPM,
@@ -159,6 +165,9 @@ edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo() {
   desc.add<bool>("correctForPhaseContainment", true);
   desc.add<bool>("applyLegacyHBMCorrection", true);
   desc.add<bool>("calculateArrivalTime", false);
+  desc.add<int>("timeAlgo", 1);
+  desc.add<double>("thEnergeticPulses", 20.);
+  desc.add<double>("thLowPUOOT", 5.);
   desc.add<bool>("applyFixPCC", false);
 
   return desc;

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -21,7 +21,6 @@ static std::unique_ptr<MahiFit> parseHBHEMahiDescription(const edm::ParameterSet
   const bool iCalculateArrivalTime = conf.getParameter<bool>("calculateArrivalTime");
   const int iTimeAlgo = conf.getParameter<int>("timeAlgo");
   const double iThEnergeticPulses = conf.getParameter<double>("thEnergeticPulses");
-  const double iThLowPUOOT = conf.getParameter<double>("thLowPUOOT");
   const double iMeanTime = conf.getParameter<double>("meanTime");
   const double iTimeSigmaHPD = conf.getParameter<double>("timeSigmaHPD");
   const double iTimeSigmaSiPM = conf.getParameter<double>("timeSigmaSiPM");
@@ -42,7 +41,6 @@ static std::unique_ptr<MahiFit> parseHBHEMahiDescription(const edm::ParameterSet
                       iCalculateArrivalTime,
                       iTimeAlgo,
                       iThEnergeticPulses,
-                      iThLowPUOOT,
                       iMeanTime,
                       iTimeSigmaHPD,
                       iTimeSigmaSiPM,
@@ -166,8 +164,7 @@ edm::ParameterSetDescription fillDescriptionForParseHBHEPhase1Algo() {
   desc.add<bool>("applyLegacyHBMCorrection", true);
   desc.add<bool>("calculateArrivalTime", false);
   desc.add<int>("timeAlgo", 1);
-  desc.add<double>("thEnergeticPulses", 20.);
-  desc.add<double>("thLowPUOOT", 5.);
+  desc.add<double>("thEnergeticPulses", 5.);
   desc.add<bool>("applyFixPCC", false);
 
   return desc;

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -248,7 +248,7 @@ void MahiDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
     const MahiFit* mahi = mahi_.get();
     mahi_->setPulseShapeTemplate(
-        hci.recoShape(), theHcalPulseShapes_, hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples(),hci.tsGain(0));
+        hci.recoShape(), theHcalPulseShapes_, hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples(), hci.tsGain(0));
     MahiDebugInfo mdi;
     // initialize energies so that the values in the previous iteration are not stored
     mdi.mahiEnergy = 0;

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -98,7 +98,6 @@ private:
   bool calculateArrivalTime_;
   int timeAlgo_;
   float thEnergeticPulses_;
-  float thLowPUOOT_;
   float meanTime_;
   float timeSigmaHPD_;
   float timeSigmaSiPM_;
@@ -179,7 +178,6 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
       calculateArrivalTime_(iConfig.getParameter<bool>("calculateArrivalTime")),
       timeAlgo_(iConfig.getParameter<int>("timeAlgo")),
       thEnergeticPulses_(iConfig.getParameter<double>("thEnergeticPulses")),
-      thLowPUOOT_(iConfig.getParameter<double>("thLowPUOOT")),
       meanTime_(iConfig.getParameter<double>("meanTime")),
       timeSigmaHPD_(iConfig.getParameter<double>("timeSigmaHPD")),
       timeSigmaSiPM_(iConfig.getParameter<double>("timeSigmaSiPM")),
@@ -201,7 +199,6 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
                        calculateArrivalTime_,
                        timeAlgo_,
                        thEnergeticPulses_,
-                       thLowPUOOT_,
                        meanTime_,
                        timeSigmaHPD_,
                        timeSigmaSiPM_,
@@ -369,7 +366,6 @@ void MahiDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<bool>("calculateArrivalTime");
   desc.add<int>("timeAlgo");
   desc.add<double>("thEnergeticPulse");
-  desc.add<double>("thLowPUOOT");
   desc.add<double>("ts4Thresh");
   desc.add<double>("chiSqSwitch");
   desc.add<bool>("applyTimeSlew");

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -248,7 +248,7 @@ void MahiDebugger::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
     const MahiFit* mahi = mahi_.get();
     mahi_->setPulseShapeTemplate(
-        hci.recoShape(), theHcalPulseShapes_, hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples());
+        hci.recoShape(), theHcalPulseShapes_, hci.hasTimeInfo(), hcalTimeSlewDelay, hci.nSamples(),hci.tsGain(0));
     MahiDebugInfo mdi;
     // initialize energies so that the values in the previous iteration are not stored
     mdi.mahiEnergy = 0;

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -96,6 +96,9 @@ private:
   double tsDelay1GeV_ = 0;
 
   bool calculateArrivalTime_;
+  int timeAlgo_;
+  float cond1_;
+  float cond3_;
   float meanTime_;
   float timeSigmaHPD_;
   float timeSigmaSiPM_;
@@ -174,6 +177,9 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
       chiSqSwitch_(iConfig.getParameter<double>("chiSqSwitch")),
       applyTimeSlew_(iConfig.getParameter<bool>("applyTimeSlew")),
       calculateArrivalTime_(iConfig.getParameter<bool>("calculateArrivalTime")),
+      timeAlgo_(iConfig.getParameter<int>("timeAlgo")),
+      cond1_(iConfig.getParameter<double>("cond1")),
+      cond3_(iConfig.getParameter<double>("cond3")),
       meanTime_(iConfig.getParameter<double>("meanTime")),
       timeSigmaHPD_(iConfig.getParameter<double>("timeSigmaHPD")),
       timeSigmaSiPM_(iConfig.getParameter<double>("timeSigmaSiPM")),
@@ -193,6 +199,9 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
                        applyTimeSlew_,
                        HcalTimeSlew::Medium,
                        calculateArrivalTime_,
+                       timeAlgo_,
+                       cond1_,
+                       cond3_,
                        meanTime_,
                        timeSigmaHPD_,
                        timeSigmaSiPM_,
@@ -358,6 +367,9 @@ void MahiDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("recoLabel");
   desc.add<bool>("dynamicPed");
   desc.add<bool>("calculateArrivalTime");
+  desc.add<int>("timeAlgo");
+  desc.add<double>("cond1");
+  desc.add<double>("cond2");
   desc.add<double>("ts4Thresh");
   desc.add<double>("chiSqSwitch");
   desc.add<bool>("applyTimeSlew");

--- a/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/MahiDebugger.cc
@@ -97,8 +97,8 @@ private:
 
   bool calculateArrivalTime_;
   int timeAlgo_;
-  float cond1_;
-  float cond3_;
+  float thEnergeticPulses_;
+  float thLowPUOOT_;
   float meanTime_;
   float timeSigmaHPD_;
   float timeSigmaSiPM_;
@@ -178,8 +178,8 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
       applyTimeSlew_(iConfig.getParameter<bool>("applyTimeSlew")),
       calculateArrivalTime_(iConfig.getParameter<bool>("calculateArrivalTime")),
       timeAlgo_(iConfig.getParameter<int>("timeAlgo")),
-      cond1_(iConfig.getParameter<double>("cond1")),
-      cond3_(iConfig.getParameter<double>("cond3")),
+      thEnergeticPulses_(iConfig.getParameter<double>("thEnergeticPulses")),
+      thLowPUOOT_(iConfig.getParameter<double>("thLowPUOOT")),
       meanTime_(iConfig.getParameter<double>("meanTime")),
       timeSigmaHPD_(iConfig.getParameter<double>("timeSigmaHPD")),
       timeSigmaSiPM_(iConfig.getParameter<double>("timeSigmaSiPM")),
@@ -200,8 +200,8 @@ MahiDebugger::MahiDebugger(const edm::ParameterSet& iConfig)
                        HcalTimeSlew::Medium,
                        calculateArrivalTime_,
                        timeAlgo_,
-                       cond1_,
-                       cond3_,
+                       thEnergeticPulses_,
+                       thLowPUOOT_,
                        meanTime_,
                        timeSigmaHPD_,
                        timeSigmaSiPM_,
@@ -368,8 +368,8 @@ void MahiDebugger::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<bool>("dynamicPed");
   desc.add<bool>("calculateArrivalTime");
   desc.add<int>("timeAlgo");
-  desc.add<double>("cond1");
-  desc.add<double>("cond2");
+  desc.add<double>("thEnergeticPulse");
+  desc.add<double>("thLowPUOOT");
   desc.add<double>("ts4Thresh");
   desc.add<double>("chiSqSwitch");
   desc.add<bool>("applyTimeSlew");

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -5,7 +5,7 @@ mahiParameters = cms.PSet(
 
     calculateArrivalTime  = cms.bool(True),
     timeAlgo          = cms.int32(2), # 1=MahiTime, 2=ccTime
-    thEnergeticPulses = cms.double(20.),
+    thEnergeticPulses = cms.double(5.),
     thLowPUOOT        = cms.double(5.),
     dynamicPed        = cms.bool(False),
     ts4Thresh         = cms.double(0.0),

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -6,7 +6,6 @@ mahiParameters = cms.PSet(
     calculateArrivalTime  = cms.bool(True),
     timeAlgo          = cms.int32(2), # 1=MahiTime, 2=ccTime
     thEnergeticPulses = cms.double(5.),
-    thLowPUOOT        = cms.double(5.),
     dynamicPed        = cms.bool(False),
     ts4Thresh         = cms.double(0.0),
     chiSqSwitch       = cms.double(15.0),

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEMahiParameters_cfi.py
@@ -4,6 +4,9 @@ import FWCore.ParameterSet.Config as cms
 mahiParameters = cms.PSet(
 
     calculateArrivalTime  = cms.bool(True),
+    timeAlgo          = cms.int32(2), # 1=MahiTime, 2=ccTime
+    thEnergeticPulses = cms.double(20.),
+    thLowPUOOT        = cms.double(5.),
     dynamicPed        = cms.bool(False),
     ts4Thresh         = cms.double(0.0),
     chiSqSwitch       = cms.double(15.0),


### PR DESCRIPTION
Implementation of a new arrival time definition, more robust when we have PU

Original authors Jayashri Padmanaban and  Jae Hyeok Yoo https://indico.cern.ch/event/1142347/contributions/4793749/attachments/2412936/4129323/HCAL%20timing%20update.pdf 

only activate offline.
complete the issue open here https://github.com/cms-sw/cmssw/issues/28423

@igv4321  @abdoulline

Ideally aiming to have in RECO of Run3 MC 12-4 
