### PR TITLE
Adding V0 Validation Wfs to the RelVal Matrix 

### DIFF
--- a/Configuration/Generator/python/B0ToJpsiK0s_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
+++ b/Configuration/Generator/python/B0ToJpsiK0s_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
@@ -1,0 +1,142 @@
+# Found 139 output events for 5000 input events.
+# Filter efficiency = 0.0278
+# Timing = 0.684644 sec/event
+# Event size = 581.0 kB/event
+
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(54000000000),
+                         filterEfficiency = cms.untracked.double(3.0e-4),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+#                          maxEventsToPrint = cms.untracked.int32(1),
+#                          pythiaPylistVerbosity = cms.untracked.int32(12),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+##            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2010_NOLONGLIFE.DEC'),
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+#            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2014.pdl'),
+            #user_decay_file = cms.vstring('GeneratorInterface/ExternalDecays/data/Bs_Jpsiphi.dec'),
+            user_decay_embedded= cms.vstring(
+'#',
+'# Particles updated from PDG2018 https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.030001',
+'Particle   pi+           1.3957061e-01   0.0000000e+00',
+'Particle   pi-           1.3957061e-01   0.0000000e+00',
+'Particle   mu+           1.0565837e-01   0.0000000e+00', ## id 13
+'Particle   mu-           1.0565837e-01   0.0000000e+00',
+'Particle   K+            4.9367700e-01   0.0000000e+00', ## id 321
+'Particle   K-            4.9367700e-01   0.0000000e+00',
+'Particle   p+            9.3827203e-01   0.0000000e+00', ## id 2212
+'Particle   anti-p-       9.3827203e-01   0.0000000e+00',
+'Particle   K_S0          4.9761100e-01   0.0000000e+00', ## id 310
+'Particle   K*+           8.9176000e-01   5.0300000e-02',
+'Particle   K*-           8.9176000e-01   5.0300000e-02',
+'Particle   K*0           8.9555000e-01   4.7300000e-02',
+'Particle   anti-K*0      8.9555000e-01   4.7300000e-02',
+'Particle   rho0          7.7526000e-01   1.4910000e-01',
+'Particle   phi           1.0194610e+00   4.2490000e-03',
+'Particle   Lambda0       1.1156830e+00   0.0000000e+00', ## id 3122
+'Particle   anti-Lambda0  1.1156830e+00   0.0000000e+00',
+'Particle   Sigma0        1.1926420e+00   8.8947595e-06', ## id 3212
+'Particle   anti-Sigma0   1.1926420e+00   8.8947595e-06',
+'Particle   B-            5.2793200e+00   0.0000000e+00',
+'Particle   B+            5.2793200e+00   0.0000000e+00',
+'Particle   B0            5.2796300e+00   0.0000000e+00', ## id 511
+'Particle   anti-B0       5.2796300e+00   0.0000000e+00',
+'Particle   B_s0          5.3668900e+00   0.0000000e+00',
+'Particle   anti-B_s0     5.3668900e+00   0.0000000e+00',
+'Particle   J/psi         3.0969000e+00   9.2900006e-05', ## id 443
+'Particle   psi(2S)       3.6860970e+00   2.9400000e-04', ## id 100443
+'Particle   Lambda_b0     5.6196000e+00   0.0000000e-04', ## id 5122,
+'Particle anti-Lambda_b0  5.6196000e+00   0.0000000e-04',
+'#',
+'#',
+'#',
+'Alias       MyB        B0',
+'Alias       Myanti-B   anti-B0',
+'ChargeConj  Myanti-B   MyB',
+'#',
+'Alias       Mypsi      J/psi',
+'ChargeConj  Mypsi      Mypsi',
+'#',
+'Alias       MyK0s      K_S0',
+'ChargeConj  MyK0s      MyK0s',
+'#',
+'Decay Mypsi',
+'1.000       mu+    mu-        PHOTOS VLL;',
+'Enddecay',
+'#',
+'Decay MyB',
+'1.000       Mypsi  MyK0s      PHSP;',
+'Enddecay',
+'CDecay Myanti-B',
+'End'
+), 
+            list_forced_decays = cms.vstring('MyB','Myanti-B'),
+            operates_on_particles = cms.vint32(),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            "SoftQCD:nonDiffractive = on",
+            "511:m0=5.27963",       ## changing also lambda_b0 mass in pythia
+            'PTFilter:filter = on', # this turn on the filter
+            'PTFilter:quarkToFilter = 5', # PDG id of q quark
+            'PTFilter:scaleToFilter = 1.0'),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'processParameters',
+        )
+    )
+)
+###########
+# Filters #
+###########
+
+#
+bfilter = cms.EDFilter("PythiaFilter", ParticleID = cms.untracked.int32(511))
+
+# psifilter = cms.EDFilter("PythiaFilter",
+#         MotherID        = cms.untracked.int32(5122),
+#         ParticleID      = cms.untracked.int32(443)
+# #         MinPt           = cms.untracked.double(4.95),
+# #         MinEta          = cms.untracked.double(-3.0),
+# #         MaxEta          = cms.untracked.double( 3.0)
+# )
+psifilter = cms.EDFilter("PythiaDauVFilter",
+        verbose         = cms.untracked.int32(0),
+        NumberDaughters = cms.untracked.int32(2),
+        MotherID        = cms.untracked.int32(511),
+        ParticleID      = cms.untracked.int32(443),
+        DaughterIDs     = cms.untracked.vint32(13, -13),
+        MinPt           = cms.untracked.vdouble(3., 3.),
+        MinEta          = cms.untracked.vdouble(-2.5, -2.5),
+        MaxEta          = cms.untracked.vdouble(2.5, 2.5)
+)
+decayfilter = cms.EDFilter("PythiaDauVFilter",
+	    verbose         = cms.untracked.int32(0),
+	    NumberDaughters = cms.untracked.int32(2),
+	    MotherID        = cms.untracked.int32(0),
+	    ParticleID      = cms.untracked.int32(511),
+        DaughterIDs     = cms.untracked.vint32(443, 310),
+	    MinPt           = cms.untracked.vdouble(5, 0.5),
+	    MinEta          = cms.untracked.vdouble(-99999, -3),
+	    MaxEta          = cms.untracked.vdouble( 99999,  3)
+)
+
+
+# ProductionFilterSequence = cms.Sequence(generator*lbfilter*psifilter)
+ProductionFilterSequence = cms.Sequence(generator*bfilter*decayfilter*psifilter)

--- a/Configuration/Generator/python/DStarToD0Pi_D0ToKsPiPi_inclusive_SoftQCD_TuneCP5_13p6TeV-pythia8-evtgen.py
+++ b/Configuration/Generator/python/DStarToD0Pi_D0ToKsPiPi_inclusive_SoftQCD_TuneCP5_13p6TeV-pythia8-evtgen.py
@@ -1,0 +1,116 @@
+# Found 20 output events for 1500 input events.
+# Filter efficiency = 0.013333
+# Timing = 0.179750 sec/event
+# Event size = 636.9 kB/event
+
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+_generator = cms.EDFilter("Pythia8GeneratorFilter",
+    pythiaPylistVerbosity = cms.untracked.int32(0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    maxEventsToPrint = cms.untracked.int32(0),
+    comEnergy = cms.double(13600.0),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2014.pdl'),
+            list_forced_decays = cms.vstring('MyDStar+','MyDStar-'),        
+            operates_on_particles = cms.vint32(),    
+            convertPythiaCodes = cms.untracked.bool(False),
+            user_decay_embedded= cms.vstring(
+"""
+#
+# Particles updated from PDG2018 https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.030001
+Particle   pi+         1.3957061e-01   0.0000000e+00
+Particle   pi-         1.3957061e-01   0.0000000e+00
+Particle   K_S0        4.9761100e-01   0.0000000e+00
+Particle   B-          5.2793200e+00   0.0000000e+00
+Particle   B+          5.2793200e+00   0.0000000e+00
+Particle   B0          5.2796300e+00   0.0000000e+00
+Particle   anti-B0     5.2796300e+00   0.0000000e+00
+Particle   B_s0        5.3668900e+00   0.0000000e+00
+Particle   anti-B_s0   5.3668900e+00   0.0000000e+00
+Particle   phi         1.0194610e+00   4.2490000e-03
+Particle   D+          1.8696500e+00   0.0000000e+00
+Particle   D-          1.8696500e+00   0.0000000e+00
+Particle   D0          1.8648300e+00   0.0000000e+00
+Particle   D*+         2.0102600e+00   0.0000834e-05
+Particle   D*-         2.0102600e+00   0.0000834e-05
+Particle   K+          4.9367700e-01   0.0000000e+00
+Particle   K-          4.9367700e-01   0.0000000e+00
+
+#
+Alias      MyDStar+    D*+
+Alias      MyDStar-    D*-
+ChargeConj MyDStar-    MyDStar+
+#
+Alias      MyD0        D0
+Alias      MyAntiD0    anti-D0
+ChargeConj MyAntiD0    MyD0
+#
+Decay MyDStar+
+1.000  MyD0  pi+    VSS;
+Enddecay
+CDecay MyDStar-
+#
+Decay MyD0
+1.000  K_S0  pi+  pi-    PHSP;
+Enddecay
+CDecay MyAntiD0
+#
+End
+"""
+            )
+        ),
+        parameterSets = cms.vstring('EvtGen130')
+    ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring('SoftQCD:nonDiffractive = on',
+					                    'PTFilter:filter = on', # this turn on the filter
+                                        'PTFilter:quarkToFilter = 4', # PDG id of q quark
+                                        'PTFilter:scaleToFilter = 2.0'
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+    )
+)
+
+_generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+from GeneratorInterface.Core.ExternalGeneratorFilter import ExternalGeneratorFilter
+generator = ExternalGeneratorFilter(_generator)
+
+###### Filters ##########
+decayfilter = cms.EDFilter(
+    "PythiaDauVFilter",
+    verbose         = cms.untracked.int32(1),
+    NumberDaughters = cms.untracked.int32(2),
+    ParticleID      = cms.untracked.int32(413),  # DStar+
+    DaughterIDs     = cms.untracked.vint32(421, 211), # D0 and pi+
+    MinPt           = cms.untracked.vdouble(3.5, 0.1),
+    MinEta          = cms.untracked.vdouble(-3., -3.),
+    MaxEta          = cms.untracked.vdouble( 3.,  3.)
+)
+
+D0filter = cms.EDFilter(
+    "PythiaDauVFilter",
+    verbose         = cms.untracked.int32(1),
+    NumberDaughters = cms.untracked.int32(2),
+    MotherID        = cms.untracked.int32(413), # DStar+
+    ParticleID      = cms.untracked.int32(421),  # D0
+    DaughterIDs     = cms.untracked.vint32(310, 211, -211), # K0s pi+ pi-
+    MinPt           = cms.untracked.vdouble(0.5, 0.1, 0.1),
+    MinEta          = cms.untracked.vdouble(-3., -3., -3.),
+    MaxEta          = cms.untracked.vdouble( 3.,  3.,  3.)
+)
+    
+
+ProductionFilterSequence = cms.Sequence(generator*decayfilter*D0filter)

--- a/Configuration/Generator/python/LbToJpsiLambda_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
+++ b/Configuration/Generator/python/LbToJpsiLambda_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
@@ -1,0 +1,144 @@
+# Found 43 output events for 15000 input events.
+# Filter efficiency = 0.002867
+# Timing = 0.377745 sec/event
+# Event size = 501.9 kB/event
+
+
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(54000000000),
+                         filterEfficiency = cms.untracked.double(3.0e-4),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+#                          maxEventsToPrint = cms.untracked.int32(1),
+#                          pythiaPylistVerbosity = cms.untracked.int32(12),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+##            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2010_NOLONGLIFE.DEC'),
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+#            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2014.pdl'),
+            #user_decay_file = cms.vstring('GeneratorInterface/ExternalDecays/data/Bs_Jpsiphi.dec'),
+            user_decay_embedded= cms.vstring(
+'#',
+'# Particles updated from PDG2018 https://journals.aps.org/prd/abstract/10.1103/PhysRevD.98.030001',
+'Particle   pi+           1.3957061e-01   0.0000000e+00',
+'Particle   pi-           1.3957061e-01   0.0000000e+00',
+'Particle   mu+           1.0565837e-01   0.0000000e+00', ## id 13
+'Particle   mu-           1.0565837e-01   0.0000000e+00',
+'Particle   K+            4.9367700e-01   0.0000000e+00', ## id 321
+'Particle   K-            4.9367700e-01   0.0000000e+00',
+'Particle   p+            9.3827203e-01   0.0000000e+00', ## id 2212
+'Particle   anti-p-       9.3827203e-01   0.0000000e+00',
+'Particle   K_S0          4.9761100e-01   0.0000000e+00', ## id 310
+'Particle   K*+           8.9176000e-01   5.0300000e-02',
+'Particle   K*-           8.9176000e-01   5.0300000e-02',
+'Particle   K*0           8.9555000e-01   4.7300000e-02',
+'Particle   anti-K*0      8.9555000e-01   4.7300000e-02',
+'Particle   rho0          7.7526000e-01   1.4910000e-01',
+'Particle   phi           1.0194610e+00   4.2490000e-03',
+'Particle   Lambda0       1.1156830e+00   0.0000000e+00', ## id 3122
+'Particle   anti-Lambda0  1.1156830e+00   0.0000000e+00',
+'Particle   Sigma0        1.1926420e+00   8.8947595e-06', ## id 3212
+'Particle   anti-Sigma0   1.1926420e+00   8.8947595e-06',
+'Particle   B-            5.2793200e+00   0.0000000e+00',
+'Particle   B+            5.2793200e+00   0.0000000e+00',
+'Particle   B0            5.2796300e+00   0.0000000e+00',
+'Particle   anti-B0       5.2796300e+00   0.0000000e+00',
+'Particle   B_s0          5.3668900e+00   0.0000000e+00',
+'Particle   anti-B_s0     5.3668900e+00   0.0000000e+00',
+'Particle   J/psi         3.0969000e+00   9.2900006e-05', ## id 443
+'Particle   psi(2S)       3.6860970e+00   2.9400000e-04', ## id 100443
+'Particle   Lambda_b0     5.6196000e+00   0.0000000e-04', ## id 5122,
+'Particle anti-Lambda_b0  5.6196000e+00   0.0000000e-04',
+'#',
+'#',
+'#',
+'Alias      MyLb        Lambda_b0',
+'Alias      Myanti-Lb   anti-Lambda_b0',
+'ChargeConj Myanti-Lb   MyLb',
+'#',
+'Alias       Mypsi      J/psi',
+'ChargeConj  Mypsi      Mypsi',
+'#',
+'Alias      MyLam        Lambda0',
+'Alias      Myanti-Lam   anti-Lambda0',
+'ChargeConj Myanti-Lam  MyLam',
+'#',
+'Decay Mypsi',
+'1.000       mu+    mu-        PHOTOS VLL;',
+'Enddecay',
+'#',
+'Decay MyLb',
+'1.000       Mypsi  MyLam      PHSP;',
+'Enddecay',
+'CDecay Myanti-Lb',
+'End'
+), 
+            list_forced_decays = cms.vstring('MyLb','Myanti-Lb'),
+            operates_on_particles = cms.vint32(),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            "SoftQCD:nonDiffractive = on",
+            "5122:m0=5.6196",       ## changing also lambda_b0 mass in pythia
+            'PTFilter:filter = on', # this turn on the filter
+            'PTFilter:quarkToFilter = 5', # PDG id of q quark
+            'PTFilter:scaleToFilter = 1.0'),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'processParameters',
+        )
+    )
+)
+###########
+# Filters #
+###########
+
+#
+lbfilter = cms.EDFilter("PythiaFilter", ParticleID = cms.untracked.int32(5122))
+
+# psifilter = cms.EDFilter("PythiaFilter",
+#         MotherID        = cms.untracked.int32(5122),
+#         ParticleID      = cms.untracked.int32(443)
+# #         MinPt           = cms.untracked.double(4.95),
+# #         MinEta          = cms.untracked.double(-3.0),
+# #         MaxEta          = cms.untracked.double( 3.0)
+# )
+psifilter = cms.EDFilter("PythiaDauVFilter",
+        verbose         = cms.untracked.int32(0),
+        NumberDaughters = cms.untracked.int32(2),
+        MotherID        = cms.untracked.int32(5122),
+        ParticleID      = cms.untracked.int32(443),
+        DaughterIDs     = cms.untracked.vint32(13, -13),
+        MinPt           = cms.untracked.vdouble(3., 3.),
+        MinEta          = cms.untracked.vdouble(-2.5, -2.5),
+        MaxEta          = cms.untracked.vdouble(2.5, 2.5)
+)
+decayfilter = cms.EDFilter("PythiaDauVFilter",
+	    verbose         = cms.untracked.int32(0),
+	    NumberDaughters = cms.untracked.int32(2),
+	    MotherID        = cms.untracked.int32(0),
+	    ParticleID      = cms.untracked.int32(5122),
+        DaughterIDs     = cms.untracked.vint32(443, 3122),
+	    MinPt           = cms.untracked.vdouble(5, 0.5),
+	    MinEta          = cms.untracked.vdouble(-99999, -3),
+	    MaxEta          = cms.untracked.vdouble( 99999,  3)
+)
+
+
+# ProductionFilterSequence = cms.Sequence(generator*lbfilter*psifilter)
+ProductionFilterSequence = cms.Sequence(generator*lbfilter*decayfilter*psifilter)

--- a/Configuration/Generator/python/LbToJpsiXiK0sPi_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
+++ b/Configuration/Generator/python/LbToJpsiXiK0sPi_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi.py
@@ -1,0 +1,113 @@
+# Found 48 output events for 8000 input events.
+# Filter efficiency = 0.006
+# Timing = 0.260728 sec/event
+# Event size = 546.5 kB/event
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from GeneratorInterface.EvtGenInterface.EvtGenSetting_cff import *
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(13600.0),
+                         crossSection = cms.untracked.double(54000000000),
+                         filterEfficiency = cms.untracked.double(3.0e-4),
+                         #pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(0),
+                         ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2014_NOLONGLIFE.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt_2014.pdl'),
+            user_decay_embedded= cms.vstring(
+'#',
+'# Particles updated from PDG2020 published in Prog. Theor. Exp. Phys. 2020, 083C01 (2020)',
+'Particle   pi+           1.3957039e-01   0.0000000e+00',
+'Particle   pi-           1.3957039e-01   0.0000000e+00',
+'Particle   Xi-           1.3217100e+00   0.0000000e+00', ## id 3312
+'Particle   anti-Xi+      1.3217100e+00   0.0000000e+00', ## id -3312
+'Particle   Lambda0       1.1156830e+00   0.0000000e+00', ## id 3122
+'Particle   anti-Lambda0  1.1156830e+00   0.0000000e+00', ## id -3122
+'Particle   Lambda_b0     5.6196000e+00   0.0000000e+00', ## id 5122
+'Particle   anti-Lambda_b0 5.6196000e+00   0.0000000e+00', ## id -5122
+'Particle   K+            4.9367700e-01   0.0000000e+00', ## id 321
+'Particle   K-            4.9367700e-01   0.0000000e+00',
+'Particle   K_S0          4.9761100e-01   0.0000000e+00', ## id 310
+'Particle   J/psi         3.0969000e+00   9.2900000e-05',
+'#',
+'Alias      MyLambda_b0    Lambda_b0',
+'Alias      Myanti-Lambda_b0   anti-Lambda_b0',
+'ChargeConj Myanti-Lambda_b0   MyLambda_b0',
+'Alias      MyJ/psi  J/psi',
+'ChargeConj MyJ/psi  MyJ/psi',
+'#',
+'Alias       MyK0s      K_S0',
+'ChargeConj  MyK0s      MyK0s',
+'#',
+'Decay MyLambda_b0',
+'1.000      MyJ/psi     Xi-         MyK0s    pi+  PHSP;',
+'Enddecay',
+'Decay Myanti-Lambda_b0',
+'1.000      MyJ/psi     anti-Xi+    MyK0s    pi-  PHSP;',
+'Enddecay',
+'#',
+'Decay MyJ/psi',
+'1.000         mu+         mu-          PHOTOS VLL;',
+'Enddecay',
+'#',
+'End'),
+            list_forced_decays = cms.vstring('MyLambda_b0','Myanti-Lambda_b0'),
+            operates_on_particles = cms.vint32(),
+            convertPythiaCodes = cms.untracked.bool(False)
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+        PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            "SoftQCD:nonDiffractive = on",
+            "5122:m0=5.61960",     ## changing also Lambda_b0 mass in pythia
+            'PTFilter:filter = on', # this turn on the filter
+            'PTFilter:quarkToFilter = 5', # PDG id of q quark
+            'PTFilter:scaleToFilter = 1.0'),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'processParameters',
+        )
+    )
+)
+
+generator.PythiaParameters.processParameters.extend(EvtGenExtraParticles)
+
+###########
+# Filters #
+###########
+# Filter only pp events which produce a Lambdab:
+lbfilter = cms.EDFilter("PythiaFilter", ParticleID = cms.untracked.int32(5122))
+
+decayfilter = cms.EDFilter(
+        "PythiaDauVFilter",
+  verbose         = cms.untracked.int32(0),
+  NumberDaughters = cms.untracked.int32(3),
+  MotherID        = cms.untracked.int32(0),
+  ParticleID      = cms.untracked.int32(5122),
+  DaughterIDs     = cms.untracked.vint32(443, 3312, 310, 211),
+  MinPt           = cms.untracked.vdouble(2.5, 0.7, 0.5, 0.1),
+  MinEta          = cms.untracked.vdouble(-9999., -3.0, -3.0, -3.0),
+  MaxEta          = cms.untracked.vdouble( 9999.,  3.0,  3.0,  3.0)
+        )
+
+jpsifilter = cms.EDFilter("PythiaDauVFilter",
+  verbose         = cms.untracked.int32(0),
+  NumberDaughters = cms.untracked.int32(2),
+  MotherID        = cms.untracked.int32(5122),
+  ParticleID      = cms.untracked.int32(443),
+  DaughterIDs     = cms.untracked.vint32(13, -13),
+  MinPt           = cms.untracked.vdouble(1., 1.),
+  MinEta          = cms.untracked.vdouble(-3., -3.),
+  MaxEta          = cms.untracked.vdouble( 3.,  3.)
+          )
+
+ProductionFilterSequence = cms.Sequence(generator*lbfilter*decayfilter*jpsifilter)

--- a/Configuration/Generator/python/OmegaMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi.py
+++ b/Configuration/Generator/python/OmegaMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi.py
@@ -1,0 +1,38 @@
+# Found 37 output events for 40000 input events.
+# Filter efficiency = 0.000925
+# Timing = 0.015818 sec/event
+# Event size = 456.1 kB/event
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         crossSection = cms.untracked.double(71.39e+09),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SoftQCD:inelastic = on'),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters',
+                                    )
+        )
+                         )
+
+OmegaFilter = cms.EDFilter("PythiaFilter",
+    MinPt = cms.untracked.double(1.),
+    ParticleID = cms.untracked.int32(3334),
+    MaxEta = cms.untracked.double(3.),
+    MinEta = cms.untracked.double(-3.)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*OmegaFilter)

--- a/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi.py
+++ b/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi.py
@@ -1,0 +1,38 @@
+# Found 60 output events for 2000 input events.
+# Filter efficiency = 0.03
+# Timing = 0.298047 sec/event
+# Event size = 410.3 kB/event
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         crossSection = cms.untracked.double(71.39e+09),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13600.0),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'SoftQCD:inelastic = on'),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters',
+                                    )
+        )
+                         )
+
+XiFilter = cms.EDFilter("PythiaFilter",
+    MinPt = cms.untracked.double(0.7),
+    ParticleID = cms.untracked.int32(3312),
+    MaxEta = cms.untracked.double(3.),
+    MinEta = cms.untracked.double(-3.)
+)
+
+ProductionFilterSequence = cms.Sequence(generator*XiFilter)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,6 +1,6 @@
 from copy import copy, deepcopy
 from collections import OrderedDict
-from .MatrixUtil import merge, Kby
+from .MatrixUtil import merge, Kby, Mby
 import re
 
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
@@ -2343,4 +2343,10 @@ upgradeFragments = OrderedDict([
     ('XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi', UpgradeFragment(Kby(8000,90000),'XiMinus_13p6TeV')), #2%
     ('Chib1PToUpsilon1SGamma_MuFilter_TuneCP5_14TeV-pythia8_evtgen_cfi', UpgradeFragment(Kby(3600,36000),'Chib1PToUpsilon1SGamma_14TeV')), #2.8%
     ('ChicToJpsiGamma_MuFilter_TuneCP5_14TeV_pythia8_evtgen_cfi', UpgradeFragment(Kby(2000,20000),'ChicToJpsiGamma_14TeV')), #5%
+    ('B0ToJpsiK0s_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi',UpgradeFragment(Kby(38000,38000),'B0ToJpsiK0s_DGamma0_13p6TeV')), #2.7%
+    ('DStarToD0Pi_D0ToKsPiPi_inclusive_SoftQCD_TuneCP5_13p6TeV-pythia8-evtgen',UpgradeFragment(Kby(38000,38000),'DStarToD0Pi_D0ToKsPiPi_13p6TeV')), #1.3%
+    ('LbToJpsiLambda_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi',UpgradeFragment(Mby(66,660000),'LbToJpsiLambda_DGamma0_13p6TeV')), #0.3%
+    ('LbToJpsiXiK0sPi_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi',UpgradeFragment(Mby(50,500000),'LbToJpsiXiK0sPr_DGamma0_13p6TeV')), #0.6%
+    ('OmegaMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi',UpgradeFragment(Mby(100,1000000),'OmegaMinus_13p6TeV')), #0.1%
+    ('XiMinus_13p6TeV_SoftQCDInel_TuneCUEP8M1_cfi',UpgradeFragment(Kby(1700,17000),'XiMinus_SoftQCDInel_13p6TeV')), #3%
 ])


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39215 and https://github.com/cms-sw/cmssw/pull/39178

#### PR description:

This PR adds new genFragments at 13.6 TeV for BPH and TRK:
   * B0ToJpsiK0s w/ Jspi to muons
   * DStarToD0Pi w/ D0 To KsPiPi
   *  LbToJpsiLambda w/ Jspi to muons
   * LbToJpsiXiK0sPi w/ Jspi to muons
   * OmegaMinus
   * XiMinus

And also the wfs to be used for BPH-TRK V0 reconstruction validation to the RelVal matrix.

#### PR validation:

Running wfs `11744.0`, `11745.0`, `11746.0`, `11747.0`, `11748.0`, `11749.0`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/39215 and https://github.com/cms-sw/cmssw/pull/39178



