### PR TITLE
PPS fixed LHCInfo PopCon skipping fills

### DIFF
--- a/CondTools/RunInfo/interface/OMSAccess.h
+++ b/CondTools/RunInfo/interface/OMSAccess.h
@@ -168,7 +168,9 @@ namespace cond {
     static constexpr const char* const NEQ = "NEQ";
     static constexpr const char* const EQ = "EQ";
     static constexpr const char* const LT = "LT";
+    static constexpr const char* const LE = "LE";
     static constexpr const char* const GT = "GT";
+    static constexpr const char* const GE = "GE";
     static constexpr const char* const SNULL = "null";
 
   public:
@@ -206,8 +208,16 @@ namespace cond {
       return filter<T>(GT, varName, value);
     }
     template <typename T>
+    inline OMSServiceQuery& filterGE(const std::string& varName, const T& value) {
+      return filter<T>(GE, varName, value);
+    }
+    template <typename T>
     inline OMSServiceQuery& filterLT(const std::string& varName, const T& value) {
       return filter<T>(LT, varName, value);
+    }
+    template <typename T>
+    inline OMSServiceQuery& filterLE(const std::string& varName, const T& value) {
+      return filter<T>(LE, varName, value);
     }
     // not null filter
     inline OMSServiceQuery& filterNotNull(const std::string& varName) { return filterNEQ(varName, SNULL); }

--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -686,8 +686,13 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
       startSampleTime = cond::time::to_boost(lastSince);
     } else {
       edm::LogInfo(m_name) << "Searching new fill after " << boost::posix_time::to_simple_string(targetTime);
-      boost::posix_time::ptime startTime = targetTime + boost::posix_time::seconds(1);
-      query->filterNotNull("start_stable_beam").filterGT("start_time", startTime).filterNotNull("fill_number");
+      query->filterNotNull("start_stable_beam").filterNotNull("fill_number");
+      if (targetTime > cond::time::to_boost(m_prevPayload->createTime())) {
+        query->filterGE("start_time", targetTime);
+      } else {
+        query->filterGT("start_time", targetTime);
+      }
+
       if (m_endFill)
         query->filterNotNull("end_time");
       bool foundFill = query->execute();


### PR DESCRIPTION
#### PR description:

Fixes a bug in LHCInfo PopCon. Before the fix it couldn't process two consecutive fills with stable beam with endTime of the first equal to startTime of the next one. In such case only the first one was processed and written to the database.

The fix consists of adding filterGE and filterLE methods to `cond::OMSServiceQuery` and using the "greater or equal" filter in the mechanism of choosing the next fill to process in the LHCInfo PopCon.

#### PR validation:

Verified processing of every fill after a certian timestamp with local tests running LHCInfoPopConAnalyzerStartFill.py and LHCInfoPopConAnalyzerEndFill.py and checking the logs. In the logs there are the same numbers of fills as there are fills with stable beams in OMS in the relevant time period. Particulary when running the scripts for fills after 2022-08-13 10:00:00 the fills: 8125, 8143, 8147, 8149 are not missing in the logs anymore. The tests were run both for empty tags and for tags with fill 8142 already written.