### PR TITLE
[LTO][GCC11] Fixed uninitialized warning for DQM/SiStripMonitorHardware

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc
@@ -211,7 +211,7 @@ void SiStripSpyMonitorModule::bookHistograms(DQMStore::IBooker& ibooker,
     histManager_.bookAllFEDHistograms(ibooker);
 
   //dummy error object
-  SPYHistograms::Errors lError;
+  SPYHistograms::Errors lError = {};
   for (uint16_t lFedId = sistrip::FED_ID_MIN; lFedId <= sistrip::FED_ID_MAX; ++lFedId)
     histManager_.bookFEDHistograms(ibooker, lFedId, lError, true);
 }


### PR DESCRIPTION
This should fix the warning
```
  DQM/SiStripMonitorHardware/src/SiStripSpyMonitorModule.cc:216:35: warning: 'lError' may be used uninitialized [-Wmaybe-uninitialized]
   216 |     histManager_.bookFEDHistograms(ibooker, lFedId, lError, true);
```