### PR TITLE
Update XiMinus fragment to use Pythia8ConcurrentHadronizerFilter

### DIFF
--- a/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
+++ b/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
@@ -4,7 +4,7 @@ from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
 
 
-generator = cms.EDFilter("Pythia8GeneratorFilter",
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
                          crossSection = cms.untracked.double(71.39e+09),
                          maxEventsToPrint = cms.untracked.int32(0),
                          pythiaPylistVerbosity = cms.untracked.int32(1),

--- a/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
+++ b/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
@@ -1,8 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
-from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
-
+from Configuration.Generator.MCTunesRun3ECM13p6TeV.PythiaCP5Settings_cfi import *
 
 generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
                          crossSection = cms.untracked.double(71.39e+09),


### PR DESCRIPTION
#### PR description:
Update `XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py` to use `Pythia8ConcurrentHadronizerFilter` following the instruction in https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookGenMultithread

#### PR validation:
Test with 11741.0 workflow.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
To backport if need.
