### PR TITLE
Release dependent modules only after the worker has finished for scheduled modules

### DIFF
--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -241,6 +241,9 @@ namespace edm {
 
     virtual bool hasAccumulator() const = 0;
 
+    // Used in PuttableProductResolver
+    edm::WaitingTaskList& waitingTaskList() { return waitingTasks_; }
+
   protected:
     template <typename O>
     friend class workerhelper::CallImpl;

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -201,7 +201,7 @@ namespace edm {
   class PuttableProductResolver : public ProducedProductResolver {
   public:
     explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd)
-        : ProducedProductResolver(bd, ProductStatus::NotPut), worker_(nullptr), prefetchRequested_(false) {}
+        : ProducedProductResolver(bd, ProductStatus::NotPut) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
@@ -218,12 +218,12 @@ namespace edm {
                         ModuleCallingContext const* mcc) const override;
     bool unscheduledWasNotRun_() const override { return false; }
 
-    void putProduct(std::unique_ptr<WrapperBase> edp) const override;
-    void resetProductData_(bool deleteEarly) override;
-
-    CMS_THREAD_SAFE mutable WaitingTaskList m_waitingTasks;
-    Worker* worker_;
-    mutable std::atomic<bool> prefetchRequested_;
+    // The WaitingTaskList below is the one from the worker, if one
+    // corresponds to this ProductResolver. For the Source-like cases
+    // where there is no such Worker, the tasks depending on the data
+    // depending on this ProductResolver are assumed to be eligible to
+    // run immediately after their prefetch.
+    WaitingTaskList* waitingTasks_ = nullptr;
   };
 
   class UnscheduledProductResolver : public ProducedProductResolver {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -890,6 +890,12 @@ namespace edm {
       ServiceRegistry::Operate guard(serviceToken);
       Traits::preScheduleSignal(actReg_.get(), &streamContext_);
 
+      // Data dependencies need to be set up before marking empty
+      // (End)Paths complete in case something consumes the status of
+      // the empty (EndPath)
+      workerManager_.setupResolvers(ep);
+      workerManager_.setupOnDemandSystem(info);
+
       HLTPathStatus hltPathStatus(hlt::Pass, 0);
       for (int empty_trig_path : empty_trig_paths_) {
         results_->at(empty_trig_path) = hltPathStatus;
@@ -911,9 +917,6 @@ namespace edm {
           return;
         }
       }
-
-      workerManager_.setupResolvers(ep);
-      workerManager_.setupOnDemandSystem(info);
 
       ++total_events_;
 


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/issues/39064#issuecomment-1227671651 we found that the `PuttableProductResolver::putProduct()` releasing the task(s) for dependent modules can lead to rare problems if the producing module produces two (or more) products that refer to each other. Specifically, a consuming module may get run when only one of the products has been put in place, that can lead to deference of a Ref to fail on "missing product".

All consuming modules call the `prefetchAsync_()`, which for `PuttableProductResolver` already creates a task to release the dependent modules (`m_waitingTasks`), and inserts that into the Worker's `WaitingTaskList` (that is released after the Worker finishes). I think we could just rely on that ~~, and therefore this PR removes the override of `putProduct()` from `PuttableProductResolver`~~. This assumption turned out to be wrong, because there is also another use case for `PuttableProductResolver`: `PuttableSourceBase` sources (and `TestProcessor`, where it is also used like for sources).

As a simple way forward to fulfill the requirements of both use cases, this PR makes `PuttableProductResolver` to directly use the `Worker`'s `WaitingTaskList` in prefetching, if a `Worker` has been associated to the `PuttableProductResolver`. If no `Worker` has been associated, the `PuttableProductResolver` assumes it is from a Source (or similar), and the product is available for any consuming module without any further waiting in the prefetching. See also https://github.com/cms-sw/cmssw/pull/39245#issuecomment-1253916692 for some further discussion.

Resolves #39064 .

#### PR validation:

The reproducer I mentioned in https://github.com/cms-sw/cmssw/issues/39064#issuecomment-1228755900 succeeds with this change. Framework unit tests pass.
