### PR TITLE
Calo L1 emulator for LLP trigger: masking the 6:1 LUT for HE

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
@@ -205,7 +205,8 @@ public:
         int prompt = (fb & 0b10) >> 1;
         int delay1 = (fb & 0b100) >> 2;
         int delay2 = (fb & 0b1000) >> 3;
-        data |= (depth | ((!prompt) & (delay1 | delay2))) << tower;  // bit[0] | (!bit[1] & (bit[2] | bit[3]))
+        if (cEta < 16)
+          data |= (depth | ((!prompt) & (delay1 | delay2))) << tower;  // bit[0] | (!bit[1] & (bit[2] | bit[3]))
       } else
         data |= (fb & 0x1) << tower;
     }

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -223,7 +223,7 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             // fg2 should only be set for HF
             if (fg2)
               featureBits |= 0b10;
-          } else
+          } else if (absCaloEta < 16)
             featureBits |= (fg | ((!fg2) & (fg3 | fg4)));  // depth | (!prompt & (delay1 | delay2))
           if (!layer1->setHCALData(t, featureBits, et)) {
             LOG_ERROR << "caloEta = " << caloEta << "; caloPhi =" << caloPhi << std::endl;


### PR DESCRIPTION
#### PR description:

This PR edits the L1 emulator of the HCAL LLP trigger (#36919) to mask the HE at the Calo L1 6:1 LUT. HE uHTR f/w is not yet updated to send triggerable LLP bits, so HE will be masked online, and this mirrors that in the emulator. Coordinated with Ales Svetek and Sascha Savin. 

iEta restrictions are added, to only perform the 6:1 LUT in HB at abs(iEta) = 15 and below. HF is unaffected. 

#### PR validation:

Tested in CMSSW_12_6_X_2022-08-29-1100, passed runTheMatrix.py
