### PR TITLE
[GSF tracking] Add TSOS only if it is meaningful

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -30,7 +30,10 @@ TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSur
   int i = 0;
   for (auto const& tsosI : predictedComponents) {
     TrajectoryStateOnSurface updatedTSOS = KFUpdator().update(tsosI, aRecHit);
-    if (updatedTSOS.isValid() && updatedTSOS.localError().valid()) {
+
+    double det = 0;
+    if (updatedTSOS.isValid() && updatedTSOS.localError().valid() && updatedTSOS.localError().posDef() &&
+        (updatedTSOS.curvilinearError().matrix().Det2(det)) && det > 0) {
       result.addState(TrajectoryStateOnSurface(weights[i],
                                                updatedTSOS.localParameters(),
                                                updatedTSOS.localError(),


### PR DESCRIPTION
#### PR description:

It's an attempt to address github issue https://github.com/cms-sw/cmssw/issues/39234

There is a long-standing problem that Gsf track reconstruction in HLT (to a lesser extent also offline) generates a bit too many warning and error messages. The issue has been there since a while. Recently DAQ has also pointed it out: https://its.cern.ch/jira/browse/CMSHLT-2449 . This is a try to reduce the warnings/errors without compromising with performance. (FYI @missirol )

#### PR validation:
### _HLT_
Ran HLT on 200 raw events and checked HLT decisions before and after the PR. 

Running on `/store/data/Run2022C/EGamma/RAW/v1/000/355/872/00000/3b478527-d206-4b8e-8004-08e9aff7758b.root` (EGamma dataset, 2022C).  
```
HLT name                 | Passed (after PR) | Passed (Base) 

HLT_Ele32_WPTight_Gsf_v16                 | 33 |   33
HLT_Ele135_CaloIdVT_GsfTrkIdT_v8          | 0  |   0  
HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165_v19 | 1  |   1 
HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v14    | 5  |   5 
```
Running on `/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/Run2022B_HLTPhysics0_run355558/cd851cf4-0fca-4d76-b80e-1d33e1371929.root` (HLTPhysics, 2022B),  
```
HLT name                 | Passed (after PR) | Passed (Base) 

HLT_Ele32_WPTight_Gsf_v16                 | 0 | 0
HLT_Ele135_CaloIdVT_GsfTrkIdT_v8          | 0 | 0    
HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165_v19 | 0 | 0   
HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v14    | 0 | 0    
```
HLT decision of paths running Gsf tracking remain same before and after this PR.      

In the `HLTPhysics` file, warning/error messages from Gsf reconstruction before and after this PR are:
**Before**: `cat hlt_before_hltphysics.log | grep 'GsfTrackProducer:' | wc -l` **540**
**After**: `cat hlt_after_hltphysics.log | grep 'GsfTrackProducer:' | wc -l` **8**

### _Offline_
Ran Reco step on 200 events from `/store/relval/CMSSW_12_4_0/RelValTTbarToDilepton_14TeV/GEN-SIM-DIGI-RAW/124X_mcRun3_2022_realistic_v5-v1/2580000/0181721e-24a2-44dd-b514-8f53014ac9a0.root`; before and after this PR. Compared track related quantities of reconstructed electrons. No difference found.

`runTheMatrix.py -l 11834.0` worked fine.

This PR is not a backport.