### PR TITLE
Fix the mismatch in transition ID for idealGeo

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -85,7 +85,9 @@ private:
   edm::ESGetToken<PDetGeomDesc, VeryForwardIdealGeometryRecord> dbToken_;
   const bool fromPreprocessedDB_, fromDD4hep_;
 
+  edm::ESGetToken<DetGeomDesc, IdealGeometryRecord> idealGDToken2_;
   edm::ESGetToken<DetGeomDesc, IdealGeometryRecord> idealGDToken_;
+  edm::ESGetToken<DetGeomDesc, VeryForwardIdealGeometryRecord> idealDBGDToken2_;
   edm::ESGetToken<DetGeomDesc, VeryForwardIdealGeometryRecord> idealDBGDToken_;
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPRealAlignmentRecord> realAlignmentToken_;
   edm::ESGetToken<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord> misAlignmentToken_;
@@ -110,6 +112,7 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
 
     if (buildMisalignedGeometry_) {
       auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB);
+      idealDBGDToken2_ = c2.consumesFrom<DetGeomDesc, VeryForwardIdealGeometryRecord>(edm::ESInputTag());
       misAlignmentToken_ =
           c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
     }
@@ -123,6 +126,7 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
 
     if (buildMisalignedGeometry_) {
       auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+      idealGDToken2_ = c2.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
       misAlignmentToken_ =
           c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
     }
@@ -137,6 +141,7 @@ CTPPSGeometryESModule::CTPPSGeometryESModule(const edm::ParameterSet& iConfig)
 
     if (buildMisalignedGeometry_) {
       auto c2 = setWhatProduced(this, &CTPPSGeometryESModule::produceMisalignedGD);
+      idealGDToken2_ = c2.consumesFrom<DetGeomDesc, IdealGeometryRecord>(edm::ESInputTag());
       misAlignmentToken_ =
           c2.consumesFrom<CTPPSRPAlignmentCorrectionsData, RPMisalignedAlignmentRecord>(edm::ESInputTag());
     }
@@ -239,7 +244,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceMisalignedGDFromPrepr
     const VeryForwardMisalignedGeometryRecord& iRecord) {
   return produceGD(iRecord.getRecord<VeryForwardIdealGeometryRecord>(),
                    iRecord.tryToGetRecord<RPMisalignedAlignmentRecord>(),
-                   idealDBGDToken_,
+                   idealDBGDToken2_,
                    misAlignmentToken_,
                    "CTPPSGeometryESModule::produceMisalignedGDFromPreprocessedDB");
 }
@@ -260,7 +265,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::produceMisalignedGD(
     const VeryForwardMisalignedGeometryRecord& iRecord) {
   return produceGD(iRecord.getRecord<IdealGeometryRecord>(),
                    iRecord.tryToGetRecord<RPMisalignedAlignmentRecord>(),
-                   idealGDToken_,
+                   idealGDToken2_,
                    misAlignmentToken_,
                    "CTPPSGeometryESModule::produceMisalignedGD");
 }


### PR DESCRIPTION
#### PR description:

This RP fixes an error caused by loading misaligned geometry record together with the aligned geometry record and hit the transitionID error:

> The transition ID stored in the ESGetToken does not match the transition where the token is being used


This is happens if a user set buildMisalignedGeometry=True in [CTPPSGeometryESModule.cc](https://github.com/cms-sw/cmssw/blob/master/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc)

#### PR validation:

```
cmsrel CMSSW_12_4_3
cd CMSSW_12_4_3/src
cmsenv
voms-proxy-init --voms cms --valid 168:00
cmsRun cfg.py
```
where the `cfg.py` is the following:

```
import FWCore.ParameterSet.Config as cms
 
from Configuration.StandardSequences.Eras import eras
process = cms.Process("trackBasedAlignment", eras.Run3)
 
# minimum of logs
process.MessageLogger = cms.Service("MessageLogger",
  statistics = cms.untracked.vstring(),
  destinations = cms.untracked.vstring('cout'),
  cout = cms.untracked.PSet(
    threshold = cms.untracked.string('WARNING')
  )
)
 
# input data
process.source = cms.Source("PoolSource",
    skipBadFiles = cms.untracked.bool(True),
    fileNames = cms.untracked.vstring(
        '/store/data/Run2022A/ZeroBias/RAW/v1/000/354/329/00000/e2fefed8-a6e8-42d3-90b3-d8df8534769d.root'
    ),
)
 
#load condisions using GT
process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
from Configuration.AlCa.GlobalTag import GlobalTag
process.GlobalTag = GlobalTag(process.GlobalTag, '124X_dataRun3_Prompt_Candidate_2022_07_26_15_08_24', '')
 
# PPS reco modules
process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
process.load("RecoPPS.Configuration.recoCTPPS_cff")
 
# reload geometry
process.load("Geometry.VeryForwardGeometry.geometryRPFromDD_2022_cfi")
process.ctppsGeometryESModule.buildMisalignedGeometry = cms.bool(True) #false will just complain about missing VeryForwardMisalignedGeometryRecord
 
# initial alignments
process.load("CalibPPS.ESProducers.ctppsRPAlignmentCorrectionsDataESSourceXML_cfi")
process.ctppsRPAlignmentCorrectionsDataESSourceXML.RealFiles = cms.vstring()
process.es_prefer_AlignmentCorrections = cms.ESPrefer("CTPPSRPAlignmentCorrectionsDataESSourceXML","ctppsRPAlignmentCorrectionsDataESSourceXML")
 
# aligner
process.load("CalibPPS.AlignmentRelative.ppsStraightTrackAligner_cfi")
 
process.ppsStraightTrackAligner.verbosity = 1
 
process.ppsStraightTrackAligner.tagUVPatternsStrip = cms.InputTag("totemRPUVPatternFinder")
process.ppsStraightTrackAligner.tagDiamondHits = cms.InputTag("")
process.ppsStraightTrackAligner.tagPixelHits = cms.InputTag("")
process.ppsStraightTrackAligner.tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks")
 
process.ppsStraightTrackAligner.maxEvents = int(1E5)
 
process.ppsStraightTrackAligner.rpIds = [103,104,105,123,124,125]
process.ppsStraightTrackAligner.excludePlanes = cms.vuint32()
process.ppsStraightTrackAligner.z0 = +217000
 
process.ppsStraightTrackAligner.maxResidualToSigma = 30
process.ppsStraightTrackAligner.minimumHitsPerProjectionPerRP = 3
 
process.ppsStraightTrackAligner.removeImpossible = True
process.ppsStraightTrackAligner.requireNumberOfUnits = 2
process.ppsStraightTrackAligner.requireOverlap = False
process.ppsStraightTrackAligner.requireAtLeast3PotsInOverlap = True
process.ppsStraightTrackAligner.additionalAcceptedRPSets = ""
 
process.ppsStraightTrackAligner.cutOnChiSqPerNdf = True
process.ppsStraightTrackAligner.chiSqPerNdfCut = 500
 
process.ppsStraightTrackAligner.maxTrackAx = 0.5E-3
process.ppsStraightTrackAligner.maxTrackAy = 0.5E-3
 
optimize="s"
process.ppsStraightTrackAligner.resolveShR = True
process.ppsStraightTrackAligner.resolveShZ = False
process.ppsStraightTrackAligner.resolveRotZ = False
 
process.ppsStraightTrackAligner.constraintsType = "standard"
process.ppsStraightTrackAligner.standardConstraints.units = cms.vuint32(101,121)
process.ppsStraightTrackAligner.oneRotZPerPot = False
process.ppsStraightTrackAligner.useEqualMeanUMeanVRotZConstraints = True
 
process.ppsStraightTrackAligner.algorithms = cms.vstring("Jan")
 
process.ppsStraightTrackAligner.JanAlignmentAlgorithm.stopOnSingularModes = False
 
results_dir="./"
 
process.ppsStraightTrackAligner.taskDataFileName = "" # results_dir + "/task_data.root"
 
process.ppsStraightTrackAligner.fileNamePrefix = results_dir + "/results_iteration_"
process.ppsStraightTrackAligner.expandedFileNamePrefix = results_dir + "/results_cumulative_expanded_"
process.ppsStraightTrackAligner.factoredFileNamePrefix = results_dir + "/results_cumulative_factored_"
 
process.ppsStraightTrackAligner.diagnosticsFile = results_dir + '/diagnostics.root'
process.ppsStraightTrackAligner.buildDiagnosticPlots = True
process.ppsStraightTrackAligner.JanAlignmentAlgorithm.buildDiagnosticPlots = True
 
 
# processing sequence
process.p = cms.Path(
  # it is important to re-run part of the reconstruction as it may influence
  # the choice of rec-hits used in the alignment
  process.ctppsRawToDigi * process.recoCTPPS * process.ppsStraightTrackAligner
)
```
