### PR TITLE
drop `--catalog` option from `edmFileUtil` check in `unittestinputsource` (online DQM unit tests)

### DIFF
--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -102,7 +102,7 @@ for ls in range(options.minLumi, options.maxLumi+1):
     secFiles.extend(sec)
 
     # Get last eventsPerLumi of events in this file
-    command = "edmFileUtil --catalog file:/cvmfs/cms-ib.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=xrootd --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0]
+    command = "edmFileUtil --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0]
     print(command)
     events = subprocess.check_output(command, shell=True)
     events = events.split(b'\n')


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/39262

#### PR description:

Title says it all, no longer needed after integration of https://github.com/cms-sw/cmssw/pull/37278, as per https://github.com/cms-sw/cmssw/issues/39262#issuecomment-1232848626

#### PR validation:

Will be done in the PR unit tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A