### PR TITLE
Protect against motherless leptons

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/MergedGenParticleProducer.cc
@@ -187,7 +187,7 @@ bool MergedGenParticleProducer::isLeptonFromPrunedPhoton(const reco::GenParticle
   if ((abs(pk.pdgId()) == 11 or abs(pk.pdgId()) == 13) and
       not(pk.statusFlags().fromHardProcess() or pk.statusFlags().isDirectTauDecayProduct())) {
     // this is probably not a prompt lepton but from pair production via a pruned photon
-    if (pk.mother(0)->pdgId() != 22) {
+    if (pk.numberOfMothers() > 0 and pk.mother(0)->pdgId() != 22) {
       return true;
     }
   }


### PR DESCRIPTION
#### PR description:

Fixes https://github.com/cms-sw/cmssw/issues/39250

Note that the crash only occurs for old particle guns before https://github.com/cms-sw/cmssw/commit/93b170d8a3b218290341568023384b433c7987b7 (12_3_X)

#### PR validation:

Ran 9000 events from `/eos/cms/store/relval/CMSSW_12_0_1/RelValSingleMuPt10/MINIAODSIM/120X_mcRun3_2021_realistic_v7-v1/10000/03e1cf94-8b28-40ad-8fde-2597e215d1a6.root` which crashed before as the single leptons did not have any mothers for older particle gun samples.