### PR TITLE
Add new classes - CTPPSAlignmentCorrectionsData and PPSAlignmentConfi…

### DIFF
--- a/CondCore/CTPPSPlugins/interface/CTPPSRPAlignmentCorrectionsDataHelper.h
+++ b/CondCore/CTPPSPlugins/interface/CTPPSRPAlignmentCorrectionsDataHelper.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * This is a part of PPS PI software.
+ *
+ ****************************************************************************/
+
+#ifndef CONDCORE_CTPPSPLUGINS_CTPPSRPALIGNMENTCORRECTIONSDATAHELPER_H
+#define CONDCORE_CTPPSPLUGINS_CTPPSRPALIGNMENTCORRECTIONSDATAHELPER_H
+
+// User includes
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+
+class CTPPSRPAlignment {
+public:
+  enum RP { RP3 = 3, RP23 = 23, RP103 = 103, RP123 = 123 };
+
+  enum Shift { x = 1, y = 2 };
+
+  static std::string getStringFromRPEnum(const RP& rp) {
+    switch (rp) {
+      case 3:
+        return "RP 3";
+      case 23:
+        return "RP 23";
+      case 103:
+        return "RP 103";
+      case 123:
+        return "RP 123";
+
+      default:
+        return "not here";
+    }
+  }
+
+  static std::string getStringFromShiftEnum(const Shift& sh, bool unc) {
+    switch (sh) {
+      case 1:
+        if (unc)
+          return "x shift uncertainty";
+        else
+          return "x shift";
+      case 2:
+        if (unc)
+          return "y shift uncertainty";
+        else
+          return "y shift";
+
+      default:
+        return "not here";
+    }
+  }
+};
+
+/************************************************
+    History plots
+*************************************************/
+template <CTPPSRPAlignment::RP rp, CTPPSRPAlignment::Shift sh, bool unc, class PayloadType>
+class RPShift_History : public cond::payloadInspector::HistoryPlot<PayloadType, float> {
+public:
+  RPShift_History()
+      : cond::payloadInspector::HistoryPlot<PayloadType, float>(
+            CTPPSRPAlignment::getStringFromRPEnum(rp) + " " + CTPPSRPAlignment::getStringFromShiftEnum(sh, unc) +
+                " [mm] vs. Runs",
+            CTPPSRPAlignment::getStringFromRPEnum(rp) + " " + CTPPSRPAlignment::getStringFromShiftEnum(sh, unc) +
+                " [mm]") {}
+
+  uint decodeRP(uint r) {
+    if (r == CTPPSRPAlignment::RP3 || r == CTPPSRPAlignment::RP23 || r == CTPPSRPAlignment::RP103 ||
+        r == CTPPSRPAlignment::RP123)
+      return r;
+    else {
+      CTPPSDetId* config = new CTPPSDetId(r);
+      int potId = config->arm() * 100 + config->station() * 10 + config->rp();
+      delete config;
+      return potId;
+    }
+  }
+
+  //uncertainty graphs should be considered as +\- getShXUnc() uncertainty value
+  //in case record does not exist it returns nonsense -1 value
+  float getFromPayload(PayloadType& payload) override {
+    for (auto& configuration : payload.getRPMap()) {
+      if (decodeRP(configuration.first) == rp) {
+        if (unc) {
+          if (sh == 1)
+            return configuration.second.getShXUnc();
+          if (sh == 2)
+            return configuration.second.getShYUnc();
+        } else {
+          if (sh == 1)
+            return configuration.second.getShX();
+          if (sh == 2)
+            return configuration.second.getShY();
+        }
+      }
+    }
+    if (unc)
+      return -1;
+    return 0;
+  }
+};
+
+#endif

--- a/CondCore/CTPPSPlugins/interface/PPSAlignmentConfigurationHelper.h
+++ b/CondCore/CTPPSPlugins/interface/PPSAlignmentConfigurationHelper.h
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ * This is a part of PPS PI software.
+ *
+ ****************************************************************************/
+
+#ifndef CONDCORE_CTPPSPLUGINS_PPSALIGNMENTCONFIGURATIONHELPER_H
+#define CONDCORE_CTPPSPLUGINS_PPSALIGNMENTCONFIGURATIONHELPER_H
+
+// User includes
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/PPSObjects/interface/PPSAlignmentConfiguration.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+#include <fstream>
+
+// ROOT includes
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TH2F.h"
+#include "TLatex.h"
+#include "TGraph.h"
+
+template <class PayloadType>
+class AlignmentPayloadInfo : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
+public:
+  AlignmentPayloadInfo()
+      : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+            "PPSAlignmentConfiguration payload information") {}
+
+  bool fill() override {
+    auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+    auto tagname = tag.name;
+    auto iov = tag.iovs.back();
+    auto m_payload = this->fetchPayload(std::get<1>(iov));
+
+    if (m_payload != nullptr) {
+      std::string line;
+      std::vector<std::string> lines;
+      std::stringstream ss;
+      ss << *m_payload;
+      while (getline(ss, line)) {
+        lines.push_back(line);
+      }
+
+      TCanvas canvas(
+          "PPSAlignmentConfiguration payload information", "PPSAlignmentConfiguration payload information", 1000, 1400);
+      canvas.cd(1);
+      TLatex t;
+      t.SetTextSize(0.018);
+
+      int index = 0;
+      for (float y = 0.98; index < int(lines.size()); y -= 0.02) {
+        if (index < int(lines.size() / 2) + 3)
+          t.DrawLatex(0.02, y, lines[index++].c_str());
+        else if (index == int(lines.size() / 2) + 3) {
+          y = 0.98;
+          t.DrawLatex(0.5, y, lines[index++].c_str());
+        } else
+          t.DrawLatex(0.5, y, lines[index++].c_str());
+      }
+      t.Draw();
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+#endif

--- a/CondCore/CTPPSPlugins/plugins/BuildFile.xml
+++ b/CondCore/CTPPSPlugins/plugins/BuildFile.xml
@@ -3,3 +3,13 @@
   <use name="CondCore/CondDB"/>
   <use name="boost_python"/>
 </library>
+<library file="PPSAlignmentConfiguration_PayloadInspector.cc" name="PPSAlignmentConfiguration_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>
+<library file="CTPPSRPAlignmentCorrectionsData_PayloadInspector.cc" name="CTPPSRPAlignmentCorrectionsData_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/CTPPSPlugins/plugins/CTPPSRPAlignmentCorrectionsData_PayloadInspector.cc
+++ b/CondCore/CTPPSPlugins/plugins/CTPPSRPAlignmentCorrectionsData_PayloadInspector.cc
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ * This is a part of PPS PI software.
+ *
+ ****************************************************************************/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+#include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
+#include "CondCore/CTPPSPlugins/interface/CTPPSRPAlignmentCorrectionsDataHelper.h"
+
+namespace {
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP3, CTPPSRPAlignment::Shift::x, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP3_x;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP23, CTPPSRPAlignment::Shift::x, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP23_x;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP103, CTPPSRPAlignment::Shift::x, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP103_x;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP123, CTPPSRPAlignment::Shift::x, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP123_x;
+
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP3, CTPPSRPAlignment::Shift::x, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP3_x_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP23, CTPPSRPAlignment::Shift::x, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP23_x_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP103, CTPPSRPAlignment::Shift::x, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP103_x_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP123, CTPPSRPAlignment::Shift::x, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP123_x_uncertainty;
+
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP3, CTPPSRPAlignment::Shift::y, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP3_y;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP23, CTPPSRPAlignment::Shift::y, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP23_y;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP103, CTPPSRPAlignment::Shift::y, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP103_y;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP123, CTPPSRPAlignment::Shift::y, false, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP123_y;
+
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP3, CTPPSRPAlignment::Shift::y, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP3_y_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP23, CTPPSRPAlignment::Shift::y, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP23_y_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP103, CTPPSRPAlignment::Shift::y, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP103_y_uncertainty;
+  typedef RPShift_History<CTPPSRPAlignment::RP::RP123, CTPPSRPAlignment::Shift::y, true, CTPPSRPAlignmentCorrectionsData>
+      RPShift_History_RP123_y_uncertainty;
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(CTPPSRPAlignmentCorrectionsData) {
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP3_x);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP23_x);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP103_x);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP123_x);
+
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP3_x_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP23_x_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP103_x_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP123_x_uncertainty);
+
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP3_y);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP23_y);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP103_y);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP123_y);
+
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP3_y_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP23_y_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP103_y_uncertainty);
+  PAYLOAD_INSPECTOR_CLASS(RPShift_History_RP123_y_uncertainty);
+}

--- a/CondCore/CTPPSPlugins/plugins/PPSAlignmentConfiguration_PayloadInspector.cc
+++ b/CondCore/CTPPSPlugins/plugins/PPSAlignmentConfiguration_PayloadInspector.cc
@@ -1,0 +1,18 @@
+/****************************************************************************
+ *
+ * This is a part of PPS PI software.
+ *
+ ****************************************************************************/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+#include "CondFormats/PPSObjects/interface/PPSAlignmentConfiguration.h"
+#include "CondCore/CTPPSPlugins/interface/PPSAlignmentConfigurationHelper.h"
+
+namespace {
+  typedef AlignmentPayloadInfo<PPSAlignmentConfiguration> PPSAlignmentConfig_Payload_TextInfo;
+}
+
+PAYLOAD_INSPECTOR_MODULE(PPSAlignmentConfiguration) { PAYLOAD_INSPECTOR_CLASS(PPSAlignmentConfig_Payload_TextInfo); }

--- a/CondCore/CTPPSPlugins/test/BuildFile.xml
+++ b/CondCore/CTPPSPlugins/test/BuildFile.xml
@@ -2,3 +2,5 @@
 <use name="FWCore/PluginManager"/>
 <bin file="testPPSTimingCalibration.cpp" name="testPPSTimingCalibration">
 </bin>
+<bin file="testPPSRPAlignmentCorrections.cpp" name="testPPSRPAlignmentCorrections">
+</bin>

--- a/CondCore/CTPPSPlugins/test/testPPSRPAlignmentCorrections.cpp
+++ b/CondCore/CTPPSPlugins/test/testPPSRPAlignmentCorrections.cpp
@@ -6,8 +6,8 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-#include "CondCore/CTPPSPlugins/interface/PPSTimingCalibrationPayloadInspectorHelper.h"
+#include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
+#include "CondCore/CTPPSPlugins/interface/CTPPSRPAlignmentCorrectionsDataHelper.h"
 
 int main(int argc, char** argv) {
   Py_Initialize();
@@ -24,18 +24,14 @@ int main(int argc, char** argv) {
 
   std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
 
-  std::string tag = "CTPPPSTimingCalibration_HPTDC_byPCL_v0_prompt";
-  cond::Time_t start = static_cast<unsigned long long>(355892);
-  cond::Time_t end = static_cast<unsigned long long>(357079);
+  std::string tag = "CTPPSRPAlignment_real_offline_v8";
+  cond::Time_t start = static_cast<unsigned long long>(273725);
+  cond::Time_t end = static_cast<unsigned long long>(325159);
 
-  edm::LogPrint("testPPSCalibrationPI") << "## Exercising TimingCalibration plots ";
+  edm::LogPrint("testPPSCalibrationPI") << "## Exercising PPSRPAlignmentCorrections plots ";
 
-  ParametersPerChannel<PPSTimingCalibrationPI::db0,
-                       PPSTimingCalibrationPI::plane0,
-                       PPSTimingCalibrationPI::parameter0,
-                       PPSTimingCalibration>
-      test;
+  RPShift_History<CTPPSRPAlignment::RP::RP3, CTPPSRPAlignment::Shift::x, false, CTPPSRPAlignmentCorrectionsData> test;
   test.process(connectionString, PI::mk_input(tag, start, end));
-  edm::LogPrint("testparametersPerChannel") << test.data();
+  edm::LogPrint("testRPShift_History") << test.data();
   Py_Finalize();
 }

--- a/CondCore/CTPPSPlugins/test/testPPSRPAlignmentCorrections.sh
+++ b/CondCore/CTPPSPlugins/test/testPPSRPAlignmentCorrections.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+if [ "$1" == "run" ]
+then
+    mkdir -p CondCore/CTPPSPlugins/test/results
+    if [ -f *.png ]; then    
+    rm *.png
+    fi
+
+    echo "Testing Alignment Configuration txt-png"
+
+    python3 CondCore/Utilities/scripts/getPayloadData.py \
+        --plugin pluginPPSAlignmentConfiguration_PayloadInspector \
+        --plot plot_PPSAlignmentConfig_Payload_TextInfo \
+        --tag PPSAlignmentConfiguration_v1_express \
+        --time_type Run \
+        --iovs '{"start_iov": "303615", "end_iov": "314247"}' \
+        --db Prod \
+        --test
+    mv *.png CondCore/CTPPSPlugins/test/results/PPSAlignmentConfig_Payload_TextInfo.png    
+    
+    
+    echo "Testing history plots for AlignmentDataCorrections"
+
+    for rp in 3 23 103 123
+    do
+        for shift in x y
+        do
+        python3 CondCore/Utilities/scripts/getPayloadData.py \
+            --plugin pluginCTPPSRPAlignmentCorrectionsData_PayloadInspector \
+            --plot plot_RPShift_History_RP${rp}_${shift} \
+            --tag CTPPSRPAlignment_real_offline_v8 \
+            --time_type Run \
+            --iovs '{"start_iov": "322355", "end_iov": "322355"}' \
+            --db Prod \
+            --test 2> CondCore/CTPPSPlugins/test/results/RPShift_History_RP${rp}_${shift}Shift.json
+        done                    
+    done 
+
+    echo "Testing history plots for AlignmentDataCorrections Uncertainty"
+
+    for rp in 3 23 103 123
+    do
+        for shift in x y
+        do
+        python3 CondCore/Utilities/scripts/getPayloadData.py \
+            --plugin pluginCTPPSRPAlignmentCorrectionsData_PayloadInspector \
+            --plot plot_RPShift_History_RP${rp}_${shift}_uncertainty \
+            --tag CTPPSRPAlignment_real_offline_v8 \
+            --time_type Run \
+            --iovs '{"start_iov": "322355", "end_iov": "322355"}' \
+            --db Prod \
+            --test 2> CondCore/CTPPSPlugins/test/results/RPShift_History_RP${rp}_${shift}Shift_Unc.json
+        done                    
+    done 
+
+    python3 CondCore/CTPPSPlugins/test/graph_check.py
+
+elif [ "$1" == "clear" ]
+then
+    rm -rf CondCore/CTPPSPlugins/test/results
+
+else 
+    echo "Wrong option"
+fi


### PR DESCRIPTION
#### PR description:
The main aim of this PR is to add new plots for CTPPS classes - CTPPSRPAlignmentCorrectionsData and PPSAlignmentConfiguration - to Payload Inspector software so to be able to visualize it on the website.

#### PR validation:
The code was tested by a script testPPSRPAlignmentCorrections.sh (which is mostly based on getPayloadData.py from CondCore/Utilities) just to check whether the code is properly added to PI software and generate some proper data in JSON files produced by PI.
In case of testing - testPPSRPAlignmentCorrections.sh script should be run with 'run' argument.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport.
