### PR TITLE
Protect against NaN in KinematicConstrainedVertexUpdator

### DIFF
--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -138,7 +138,7 @@ RefCountedKinematicVertex KinematicConstrainedVertexUpdatorT<nTrk, nConstraint>:
   //full math case now!
   val += g * delta_alpha;
   lambda = v_g_sym * val;
-  if (! edm::isFinite(lambda[0])) {
+  if (!edm::isFinite(lambda[0])) {
     edm::LogWarning("KinematicConstrainedVertexUpdatorFailed") << "infinite lamba[0] \n";
     LogDebug("KinematicConstrainedVertexUpdatorFailed") << "infinite lambda[0] \n";
     return RefCountedKinematicVertex();

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -7,6 +7,7 @@
 
 #include "DataFormats/Math/interface/invertPosDefMatrix.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/MultiTrackKinematicConstraintT.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/KinematicVertexFactory.h"
 #include "RecoVertex/KinematicFit/interface/VertexKinematicConstraintT.h"

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -139,8 +139,8 @@ RefCountedKinematicVertex KinematicConstrainedVertexUpdatorT<nTrk, nConstraint>:
   //full math case now!
   val += g * delta_alpha;
   lambda = v_g_sym * val;
-  
-  for (auto lambda_element : lambda){
+
+  for (auto lambda_element : lambda) {
     if (!edm::isFinite(lambda_element)) {
       edm::LogWarning("KinematicConstrainedVertexUpdatorFailed") << "caught nan in lamba \n";
       LogDebug("KinematicConstrainedVertexUpdatorFailed") << "caught nan in lambda \n";

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -139,10 +139,13 @@ RefCountedKinematicVertex KinematicConstrainedVertexUpdatorT<nTrk, nConstraint>:
   //full math case now!
   val += g * delta_alpha;
   lambda = v_g_sym * val;
-  if (!edm::isFinite(lambda[0])) {
-    edm::LogWarning("KinematicConstrainedVertexUpdatorFailed") << "infinite lamba[0] \n";
-    LogDebug("KinematicConstrainedVertexUpdatorFailed") << "infinite lambda[0] \n";
-    return RefCountedKinematicVertex();
+  
+  for (auto lambda_element : lambda){
+    if (!edm::isFinite(lambda_element)) {
+      edm::LogWarning("KinematicConstrainedVertexUpdatorFailed") << "caught nan in lamba \n";
+      LogDebug("KinematicConstrainedVertexUpdatorFailed") << "caught nan in lambda \n";
+      return RefCountedKinematicVertex();
+    }
   }
 
   //final parameters

--- a/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
+++ b/RecoVertex/KinematicFit/interface/KinematicConstrainedVertexUpdatorT.h
@@ -138,6 +138,11 @@ RefCountedKinematicVertex KinematicConstrainedVertexUpdatorT<nTrk, nConstraint>:
   //full math case now!
   val += g * delta_alpha;
   lambda = v_g_sym * val;
+  if (! edm::isFinite(lambda[0])) {
+    edm::LogWarning("KinematicConstrainedVertexUpdatorFailed") << "infinite lamba[0] \n";
+    LogDebug("KinematicConstrainedVertexUpdatorFailed") << "infinite lambda[0] \n";
+    return RefCountedKinematicVertex();
+  }
 
   //final parameters
   finPar = inPar - inCov * (ROOT::Math::Transpose(g) * lambda);


### PR DESCRIPTION
Remove infinite values by returning empty RefCountedKinematicVertex()
Addresses issue #39267 in which relvals are failing with ARCH64.