### PR TITLE
Simplify L1TPhase2MuonOffline and fix the matching with gen muons in it

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
@@ -11,43 +11,23 @@
 // DataFormats
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
-#include "DataFormats/L1TMuonPhase2/interface/MuonStub.h"
 #include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
-#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 // FWCore
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // DQMServices
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-
-// HLTrigger
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-
-// Common tools
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TrackTransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 
 #include <memory>
 #include "TRegexp.h"
@@ -63,7 +43,7 @@ class GenMuonGMTPair;
 class L1TPhase2MuonOffline : public DQMEDAnalyzer {
 public:
   L1TPhase2MuonOffline(const edm::ParameterSet& ps);
-  ~L1TPhase2MuonOffline() override;
+  ~L1TPhase2MuonOffline() override = default;
 
   enum MuType { kSAMuon, kTkMuon, kNMuTypes };
   enum VarType { kPt, kEta, kPhi, kIso, kQual, kZ0, kD0, kNVarTypes };
@@ -105,13 +85,13 @@ private:
   const std::vector<MuType> muonTypes_;
   const std::vector<EffType> effTypes_;
   const std::vector<ResType> resTypes_;
-  const std::vector<VarType> varTypes_;
+  //  const std::vector<VarType> varTypes_;
   const std::vector<EtaRegion> etaRegions_;
   const std::vector<QualLevel> qualLevels_;
 
   // maps with histogram name bits
-  std::map<EffType, std::string> effNames_;
-  std::map<EffType, std::string> effLabels_;
+  //  std::map<EffType, std::string> effNames_;
+  //  std::map<EffType, std::string> effLabels_;
   std::map<ResType, std::string> resNames_;
   std::map<ResType, std::string> resLabels_;
   std::map<EtaRegion, std::string> etaNames_;
@@ -143,11 +123,11 @@ private:
   std::vector<GenMuonGMTPair> gmtTkMuonPairs_;
   std::vector<std::pair<int, QualLevel>> cuts_;
 
-  float lsb_pt = Phase2L1GMT::LSBpt;
-  float lsb_phi = Phase2L1GMT::LSBphi;
-  float lsb_eta = Phase2L1GMT::LSBeta;
-  float lsb_z0 = Phase2L1GMT::LSBSAz0;
-  float lsb_d0 = Phase2L1GMT::LSBSAd0;
+  const float lsb_pt = Phase2L1GMT::LSBpt;
+  const float lsb_phi = Phase2L1GMT::LSBphi;
+  const float lsb_eta = Phase2L1GMT::LSBeta;
+  const float lsb_z0 = Phase2L1GMT::LSBSAz0;
+  const float lsb_d0 = Phase2L1GMT::LSBSAd0;
 };
 
 //

--- a/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
@@ -139,7 +139,7 @@ public:
   GenMuonGMTPair(const GenMuonGMTPair& muongmtPair);
   ~GenMuonGMTPair(){};
 
-  float dR();
+  float dR2();
   float pt() const { return mu_->pt(); };
   float eta() const { return mu_->eta(); };
   float phi() const { return mu_->phi(); };

--- a/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
@@ -175,9 +175,6 @@ void L1TPhase2MuonOffline::analyze(const Event& iEvent, const EventSetup& eventS
   }
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::analyze() N of genmus: " << genmus.size() << endl;
 
-  if (genmus.empty())
-    return;
-
   // Collect both muon collection:
   iEvent.getByToken(gmtMuonToken_, gmtSAMuon_);
   iEvent.getByToken(gmtTkMuonToken_, gmtTkMuon_);
@@ -187,6 +184,8 @@ void L1TPhase2MuonOffline::analyze(const Event& iEvent, const EventSetup& eventS
   fillControlHistos();
 
   // Match each muon to a gen muon, if possible.
+  if (genmus.empty())
+    return;
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::analyze() calling matchMuonsToGen() " << endl;
   matchMuonsToGen(genmus);
 
@@ -210,6 +209,7 @@ void L1TPhase2MuonOffline::bookControlHistos(DQMStore::IBooker& ibooker, MuType 
   controlHistos_[mutype][kZ0] = ibooker.book1D(muonNames_[mutype] + "Z0", "MuonZ0; Z_{0}", 50, 0, 50.0);
   controlHistos_[mutype][kD0] = ibooker.book1D(muonNames_[mutype] + "D0", "MuonD0; D_{0}", 50, 0, 200.);
 }
+
 void L1TPhase2MuonOffline::bookEfficiencyHistos(DQMStore::IBooker& ibooker, MuType mutype) {
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::bookEfficiencyHistos()" << endl;
 
@@ -240,6 +240,7 @@ void L1TPhase2MuonOffline::bookEfficiencyHistos(DQMStore::IBooker& ibooker, MuTy
     }
   }
 }
+
 void L1TPhase2MuonOffline::bookResolutionHistos(DQMStore::IBooker& ibooker, MuType mutype) {
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::bookResolutionHistos()" << endl;
 
@@ -281,6 +282,7 @@ void L1TPhase2MuonOffline::fillControlHistos() {
     controlHistos_[kTkMuon][kD0]->Fill(lsb_d0 * muIt.hwD0());
   }
 }
+
 void L1TPhase2MuonOffline::fillEfficiencyHistos() {
   for (const auto& muIt : gmtSAMuonPairs_) {
     auto eta = muIt.etaRegion();
@@ -315,7 +317,6 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
         efficiencyDen_[kTkMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
           continue;  // gmt muon does not exits
-
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
@@ -326,6 +327,7 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     }
   }
 }
+
 void L1TPhase2MuonOffline::fillResolutionHistos() {
   for (const auto& muIt : gmtSAMuonPairs_) {
     if (muIt.gmtPt() < 0)
@@ -359,6 +361,7 @@ void L1TPhase2MuonOffline::fillResolutionHistos() {
     }
   }
 }
+
 //_____________________________________________________________________
 void L1TPhase2MuonOffline::matchMuonsToGen(std::vector<const reco::GenParticle*> genmus) {
   gmtSAMuonPairs_.clear();


### PR DESCRIPTION
#### PR description:

The last item listed in the github issue https://github.com/cms-sw/cmssw/issues/39194 reports about a non reproducibility observed in DQM in the PR tests for the efficiencies for Phase2 muons.

The class that provides those efficiency plots is L1TPhase2MuonOffline, recently introduced in the release with the merging of #38442.

I do not expect that this PR can fix such a non reproducibility issue (say I would be surprised if so). However, cleaning the code a bit could help possible further degugging of the same. This is what this PR is intended to.

@cms-sw/l1-l2 please only consider this PR if it does not interfere with other updates that you are independently implementing in that code to fix the reported issue. Still you can take these simplifications into account for your own code, if so.

Further simplifications and or optimizations are also certainly possible for this code!

#### PR validation:

It compiles and runs on a few Phase2 workflows
