### PR TITLE
Disactivate vertex recovery for HI miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -107,7 +107,7 @@ run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(primaryVertexWith
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(pfEGammaToCandidateRemapperCleaned,slimmingTask.copy()))
 
 from RecoHI.HiTracking.miniAODVertexRecovery_cff import offlinePrimaryVerticesRecovery, offlineSlimmedPrimaryVerticesRecovery
-pp_on_AA.toReplaceWith(
+run2_miniAOD_pp_on_AA_103X.toReplaceWith(
     slimmingTask,
     cms.Task(slimmingTask.copy(), offlinePrimaryVerticesRecovery, offlineSlimmedPrimaryVerticesRecovery))
 


### PR DESCRIPTION
#### PR description:

The primary vertex recovery sequence in the HI miniAOD was needed due to an inefficiency of the PV reco in peripheral events.  This has been fixed in #38097
The recovery is now moved to a process modifier intended only for re-miniAOD of old AOD data.

#### PR validation:

Ran with 158.0, 158.01, 159.0, 159.01, 140.5611

@abaty 
