### PR TITLE
add script to print stack trace for exceptions through gdb

### DIFF
--- a/FWCore/Utilities/scripts/edmTraceExceptions
+++ b/FWCore/Utilities/scripts/edmTraceExceptions
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat << EOF | gdb --args $@
+set pagination off
+catch throw
+command
+where
+continue
+end
+run
+quit
+EOF


### PR DESCRIPTION
#### PR description:

This script is intended to help users who are unfamiliar with `gdb` to generate stack traces when they encounter an exception, in order to provide useful information for debugging. It can just be prepended to any command, e.g.:
```bash
edmTraceException cmsRun ...
```

The `gdb` commands used come from @makortel in the Core Software Mattermost. (I just reorganized the commands to `cat` directly into `gdb`, avoiding the creation of a temporary file.)

#### PR validation:

Ran above command with a `cmsRun` config that was set up to produce an exception, and saw the stack trace printed as expected.