### PR TITLE
PPS NANOAOD dependency hotfix

### DIFF
--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -6,8 +6,8 @@ from PhysicsTools.NanoAOD.nano_eras_cff import *
 singleRPProtons = True
 
 protonTable = cms.EDProducer("ProtonProducer",
-                             tagRecoProtonsSingle = cms.InputTag("filteredProctppsProtonstons", "singleRP"),
-                             tagRecoProtonsMulti  = cms.InputTag("filteredProctppsProtonstons", "multiRP"),
+                             tagRecoProtonsSingle = cms.InputTag("ctppsProtons", "singleRP"),
+                             tagRecoProtonsMulti  = cms.InputTag("ctppsProtons", "multiRP"),
                              tagTrackLite         = cms.InputTag("ctppsLocalTrackLiteProducer"),
                              storeSingleRPProtons = cms.bool(singleRPProtons)
 )

--- a/PhysicsTools/NanoAOD/python/protons_cff.py
+++ b/PhysicsTools/NanoAOD/python/protons_cff.py
@@ -2,26 +2,18 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.genProtonTable_cfi import genProtonTable as _genproton
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from RecoPPS.ProtonReconstruction.ppsFilteredProtonProducer_cfi import *
 
 singleRPProtons = True
 
-filteredProtons = ppsFilteredProtonProducer.clone(
-    protons_single_rp = cms.PSet(
-        include = cms.bool(singleRPProtons)
-    )
-)
-
 protonTable = cms.EDProducer("ProtonProducer",
-                             tagRecoProtonsMulti  = cms.InputTag("filteredProtons", "multiRP"),
+                             tagRecoProtonsSingle = cms.InputTag("filteredProctppsProtonstons", "singleRP"),
+                             tagRecoProtonsMulti  = cms.InputTag("filteredProctppsProtonstons", "multiRP"),
                              tagTrackLite         = cms.InputTag("ctppsLocalTrackLiteProducer"),
                              storeSingleRPProtons = cms.bool(singleRPProtons)
 )
-protonTable.tagRecoProtonsSingle = cms.InputTag("filteredProtons" if singleRPProtons else "ctppsProtons","singleRP")
-
 
 multiRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
-    src = cms.InputTag("filteredProtons","multiRP"),
+    src = cms.InputTag("ctppsProtons","multiRP"),
     cut = cms.string(""),
     name = cms.string("Proton_multiRP"),
     doc  = cms.string("bon"),
@@ -42,7 +34,7 @@ multiRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
 )
 
 singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
-    src = cms.InputTag("filteredProtons","singleRP"),
+    src = cms.InputTag("ctppsProtons","singleRP"),
     cut = cms.string(""),
     name = cms.string("Proton_singleRP"),
     doc  = cms.string("bon"),
@@ -58,7 +50,7 @@ singleRPTable = cms.EDProducer("SimpleProtonTrackFlatTableProducer",
     ),
 )
 
-protonTablesTask = cms.Task(filteredProtons,protonTable,multiRPTable)
+protonTablesTask = cms.Task(protonTable,multiRPTable)
 if singleRPProtons: protonTablesTask.add(singleRPTable)
 
 # GEN-level signal/PU protons collection


### PR DESCRIPTION
#### PR description:

This PR resolves an issue reported by @mariadalfonso in https://github.com/cms-sw/cmssw/issues/39197#issuecomment-1228305691
Production of proton tables in PPS NANOAOD builders used a filtering method (set of Proton POG quality checks) which was implemented as an EDProducer located in `RecoCTPPS/ProtonReconstruction/plugins/PPSFilteredProtonProducer.cc`.
With that modification this filtering is disabled, removing dependencies on `RecoCTPPS/ProtonReconstruction`, instead proton data is directly taken from MINIAOD collection.

We foresee adding in the future another modification which enables to use of such filtering in an on-demand scenario and with proper dependencies. 

#### PR validation:

The limited battery of tests shows no errors (`runTheMatrix`).
Impact on the NANOAOD production was cross-checked by the proton POG group (@diemort )

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.