### PR TITLE
Revert the requirement of having an associated L1T muon in L1TPhase2MuonOffline::matchMuonsToGen

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
@@ -289,17 +289,15 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     for (const auto var : effTypes_) {
       auto varToFill = muIt.getVar(var);
       for (const auto& cut : cuts_) {
-        const auto gmtPtCut = cut.first;
         const auto q = cut.second;
-
         efficiencyDen_[kSAMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
-          continue;  // gmt muon does not exits
+          continue;  // there is not an assciated gmt muon
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
+        const auto gmtPtCut = cut.first;
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
           continue;  // pt requirement
-
         efficiencyNum_[kSAMuon][eta][q][var]->Fill(varToFill);
       }
     }
@@ -311,17 +309,15 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     for (const auto var : effTypes_) {
       auto varToFill = muIt.getVar(var);
       for (const auto& cut : cuts_) {
-        const auto gmtPtCut = cut.first;
         const auto q = cut.second;
-
         efficiencyDen_[kTkMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
-          continue;  // gmt muon does not exits
+          continue;  // there is not an assciated gmt muon
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
+        const auto gmtPtCut = cut.first;
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
           continue;  // pt requirement
-
         efficiencyNum_[kTkMuon][eta][q][var]->Fill(varToFill);
       }
     }
@@ -373,33 +369,27 @@ void L1TPhase2MuonOffline::matchMuonsToGen(std::vector<const reco::GenParticle*>
     edm::LogInfo("L1TPhase2MuonOffline") << "Looping on genmus: " << gen << endl;
     GenMuonGMTPair pairBestCand(&(*gen), nullptr);
     float dr2Best = maxGmtMuonDR_ * maxGmtMuonDR_;
-    bool matchFound = false;
     for (auto& muIt : *gmtSAMuon_) {
       GenMuonGMTPair pairTmpCand(&(*gen), &(muIt));
       float dr2Tmp = pairTmpCand.dR2();
       if (dr2Tmp < dr2Best) {
         dr2Best = dr2Tmp;
         pairBestCand = pairTmpCand;
-        matchFound = true;
       }
     }
-    if (matchFound)
-      gmtSAMuonPairs_.emplace_back(pairBestCand);
+    gmtSAMuonPairs_.emplace_back(pairBestCand);
 
     GenMuonGMTPair pairBestCand2(&(*gen), nullptr);
     dr2Best = maxGmtMuonDR_ * maxGmtMuonDR_;
-    matchFound = false;
     for (auto& tkmuIt : *gmtTkMuon_) {
       GenMuonGMTPair pairTmpCand(&(*gen), &(tkmuIt));
       float dr2Tmp = pairTmpCand.dR2();
       if (dr2Tmp < dr2Best) {
         dr2Best = dr2Tmp;
         pairBestCand2 = pairTmpCand;
-        matchFound = true;
       }
     }
-    if (matchFound)
-      gmtTkMuonPairs_.emplace_back(pairBestCand2);
+    gmtTkMuonPairs_.emplace_back(pairBestCand2);
   }
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::matchMuonsToGen() gmtSAMuons: "
                                        << gmtSAMuonPairs_.size() << endl;


### PR DESCRIPTION
#### PR description:

The fix I implemented in #39283 was not correct. The (quite convoluted) logic of the L1TPhase2MuonOffline class does require that a (generated muon, l1t muon) pair is created even if there is not a l1t muon. I restore here that feature as it was in origin, still maintaining all the other code improvements implemented in #39283

Also this PR **will not** fix the non reproducibility issue observed in DQM for the Phase2 L1T muon efficiency plots. Such a fix will require a more detailed check and debug, made this time not by the release manager but by the @cms-sw/dqm-l2 experts.

By the way: who's filling the
L1T__L1TPhase2_Muons_TkMuon_efficiencies_globalEfficiencies
L1T__L1TPhase2_Muons_SAMuon_efficiencies_globalEfficiencies
histos? I supposed it was the L1TPhase2MuonOffline class that I was trying to fix, but I start to doubt it... That class fills the differential efficiencies, instead. Perhaps some harvester called after it? 

Could some @cms-sw/dqm-l2 and/or @cms-sw/l1-l2 experts investigate, and at least identify who's filling the non reproducible histo?


#### PR validation:

It builds