### PR TITLE
Avoid inf/nan generation in VertexKinematicConstraint

### DIFF
--- a/RecoVertex/KinematicFit/src/VertexKinematicConstraintT.cc
+++ b/RecoVertex/KinematicFit/src/VertexKinematicConstraintT.cc
@@ -46,7 +46,7 @@ void VertexKinematicConstraintT::fillValue() const {
       double pt2Inverse = 1. / mom[j].perp2();
       super::vl(j * 2) = dpos[j].y() * mom[j].x() - dpos[j].x() * mom[j].y();
       super::vl(j * 2 + 1) =
-          dpos[j].z() - mom[j].z() * (dpos[j].x() * mom[j].x() + dpos[j].y() * mom[j].y()) * pt2Inverse;
+          dpos[j].z() - mom[j].z() * ((dpos[j].x() * mom[j].x() + dpos[j].y() * mom[j].y()) * pt2Inverse);
     }
   }
 }


### PR DESCRIPTION
This should fix the `inf` generation which causes few workflows for `aarch64` IBs to fail. See the detail discussion at https://github.com/cms-sw/cmssw/pull/39282  (specially https://github.com/cms-sw/cmssw/pull/39282#issuecomment-1236077370 which explains why `inf` are generated)

Resolves https://github.com/cms-sw/cmssw/issues/39267