### PR TITLE
avoid non-reproducible ordering in `l1tPhase2MuonEfficiency` harvester

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TPhase2MuonDQMEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TPhase2MuonDQMEfficiency_cfi.py
@@ -5,7 +5,7 @@ def generateEfficiencyStrings(ptQualCuts):
     numDenDir = "nums_and_dens/"
     varStrings = ['Pt', 'Eta', 'Phi']
     etaStrings = ['etaMin0_etaMax0p83', 'etaMin0p83_etaMax1p24', 'etaMin1p24_etaMax2p4', 'etaMin0_etaMax2p4']
-    qualStrings = {'qualOpen', 'qualDouble', 'qualSingle'}
+    qualStrings = ['qualOpen', 'qualDouble', 'qualSingle']
     muonStrings = ['SAMuon','TkMuon'] 
 
     efficiencyStrings = []


### PR DESCRIPTION
#### PR description:

This PR is a guess to try and solve Item-6 of https://github.com/cms-sw/cmssw/issues/39194.

[This comment](https://github.com/cms-sw/cmssw/pull/39297#issue-1360801439) by @perrotta led me to [L1TPhase2MuonDQMEfficiency_cfi](https://github.com/cms-sw/cmssw/blob/b2a2b0b6796fc95549f1b73c0ab233a0f6a92451/DQMOffline/L1Trigger/python/L1TPhase2MuonDQMEfficiency_cfi.py), where one sees that `qualStrings` is a `set`, and not a `list`. Afaiu, `set`s are unordered and there is no guarantee on their ordering when iterating on them. This means that the output of `generateEfficiencyStrings` will always contain the same elements, but with non-reproducible ordering.

Once fed to `DQMGenericClient`, the latter creates a single histogram with bins containing the global efficiency of each element of `efficiencyProfile`. I'm guessing that if the ordering of `efficiencyProfile` is not reproducible, the binning of the "global" histogram in question won't be either.

https://github.com/cms-sw/cmssw/blob/b2a2b0b6796fc95549f1b73c0ab233a0f6a92451/DQMServices/Components/plugins/DQMGenericClient.cc#L857
https://root.cern.ch/doc/master/classTH1.html#alpha

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_12_5_X`
