### PR TITLE
avoid non-reproducible ordering in `l1tPhase2MuonEfficiency` harvester [`12_5_X`]

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TPhase2MuonDQMEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TPhase2MuonDQMEfficiency_cfi.py
@@ -5,7 +5,7 @@ def generateEfficiencyStrings(ptQualCuts):
     numDenDir = "nums_and_dens/"
     varStrings = ['Pt', 'Eta', 'Phi']
     etaStrings = ['etaMin0_etaMax0p83', 'etaMin0p83_etaMax1p24', 'etaMin1p24_etaMax2p4', 'etaMin0_etaMax2p4']
-    qualStrings = {'qualOpen', 'qualDouble', 'qualSingle'}
+    qualStrings = ['qualOpen', 'qualDouble', 'qualSingle']
     muonStrings = ['SAMuon','TkMuon'] 
 
     efficiencyStrings = []


### PR DESCRIPTION
backport of #39301

#### PR description:

This PR avoids non-reproducible behaviour in the construction of the value of the configuration parameter `l1tPhase2MuonEfficiency.efficiencyProfile`.

It is meant to address Item-6 of #39194.

See the description of the original PR for further details.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#39301