### PR TITLE
specify compression settings in offline output modules used by HLT

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -479,16 +479,18 @@ from HLTrigger.Configuration.CustomConfigs import L1REPACK
       )
 
       self.data = re.sub("""\
-\\b(process\.)?hltOutput(\w+) *= *cms\.OutputModule\( *"(EvFOutputModule|GlobalEvFOutputModule)" *,
+\\b(process\.)?hltOutput(\w+) *= *cms\.OutputModule\( *['"](EvFOutputModule|GlobalEvFOutputModule)['"] *,
     use_compression = cms.untracked.bool\( (True|False) \),
-    compression_algorithm = cms.untracked.string\( "(.+?)" \),
+    compression_algorithm = cms.untracked.string\( ['"](.+?)['"] \),
     compression_level = cms.untracked.int32\( (-?\d+) \),
     lumiSection_interval = cms.untracked.int32\( (-?\d+) \),
 (.+?),
-    psetMap = cms.untracked.InputTag\( "hltPSetMap" \)
+    psetMap = cms.untracked.InputTag\( ['"]hltPSetMap['"] \)
 ""","""\
-\g<1>hltOutput\g<2> = cms.OutputModule( "PoolOutputModule",
+%(process)s.hltOutput\g<2> = cms.OutputModule( "PoolOutputModule",
     fileName = cms.untracked.string( "output\g<2>.root" ),
+    compressionAlgorithm = cms.untracked.string( "\g<5>" ),
+    compressionLevel = cms.untracked.int32( \g<6> ),
     fastCloning = cms.untracked.bool( False ),
     dataset = cms.untracked.PSet(
         filterName = cms.untracked.string( "" ),


### PR DESCRIPTION
#### PR description:

Follow-up of #39177 based on comments by @fwyzard:

 - more robust syntax in the replacement of online-to-offline output modules;
 - specify online compression settings (level, algorithm) in offline output modules.

This PR has no direct impact on any IB workflow. No differences are expected in the outputs of PR tests.

#### PR validation:

Private tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_12_4_X`
`CMSSW_12_5_X`
