### PR TITLE
A possible solution for RPCAMCLink out-of-range issue

### DIFF
--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -146,7 +146,8 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
   LogDebug("RPCCPPFRawToDigi") << "RXRecord " << std::hex << record.getRecord() << std::dec << std::endl;
   unsigned int fed(link.getFED());
   unsigned int amc_number(link.getAMCNumber());
-  if ( record.getLink() > 80 )return;
+  if (record.getLink() > 80)
+    return;
   link.setAMCInput(record.getLink());
 
   int bx_offset = (int)(record.getBXCounterMod() + 31 - bx_counter_mod) % 27 - 4;

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -146,6 +146,7 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
   LogDebug("RPCCPPFRawToDigi") << "RXRecord " << std::hex << record.getRecord() << std::dec << std::endl;
   unsigned int fed(link.getFED());
   unsigned int amc_number(link.getAMCNumber());
+  if ( record.getLink() > 80 )return;
   link.setAMCInput(record.getLink());
 
   int bx_offset = (int)(record.getBXCounterMod() + 31 - bx_counter_mod) % 27 - 4;


### PR DESCRIPTION
#### PR description:

After the PR #38564 merged, there is an issue about RPCAMCLink #38939.

The reason for the crash is that during the run 314890 (used by the workflow 136.8561_RunZeroBias) the CPPF data were considered as corrupted. The reason was an firmware update, which led to some problems.. The CPPF good data have been restored after the run 315764.( Copy from https://github.com/cms-sw/cmssw/issues/38939#issuecomment-1210364325 )

This is fixed by adding a sanity check to RPCCPPFUnpacker. 

#### PR validation:
runTheMatrix.py -l 136.8561 --job-reports -t 4 --ibeos


