### PR TITLE
Update alpaka::allocMappedBuf memory functions

### DIFF
--- a/DataFormats/Portable/BuildFile.xml
+++ b/DataFormats/Portable/BuildFile.xml
@@ -1,3 +1,2 @@
 <use name="alpaka"/>
-<use name="DataFormats/SoATemplate" source_only="1"/>
 <use name="HeterogeneousCore/AlpakaInterface" source_only="1"/>

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -23,7 +23,7 @@ public:
 
   PortableDeviceCollection() = default;
 
-  PortableDeviceCollection(int32_t elements, TDev const &device)
+  PortableDeviceCollection(int32_t elements, TDev const& device)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(device, Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
         view_{layout_} {
@@ -32,7 +32,7 @@ public:
   }
 
   template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
-  PortableDeviceCollection(int32_t elements, TQueue const &queue)
+  PortableDeviceCollection(int32_t elements, TQueue const& queue)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(queue, Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
         view_{layout_} {
@@ -40,26 +40,29 @@ public:
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
   }
 
-  ~PortableDeviceCollection() = default;
-
   // non-copyable
-  PortableDeviceCollection(PortableDeviceCollection const &) = delete;
-  PortableDeviceCollection &operator=(PortableDeviceCollection const &) = delete;
+  PortableDeviceCollection(PortableDeviceCollection const&) = delete;
+  PortableDeviceCollection& operator=(PortableDeviceCollection const&) = delete;
 
   // movable
-  PortableDeviceCollection(PortableDeviceCollection &&other) = default;
-  PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
+  PortableDeviceCollection(PortableDeviceCollection&&) = default;
+  PortableDeviceCollection& operator=(PortableDeviceCollection&&) = default;
 
-  View &view() { return view_; }
-  ConstView const &view() const { return view_; }
-  ConstView const &const_view() const { return view_; }
+  // default destructor
+  ~PortableDeviceCollection() = default;
 
-  View &operator*() { return view_; }
-  ConstView const &operator*() const { return view_; }
+  // access the View
+  View& view() { return view_; }
+  ConstView const& view() const { return view_; }
+  ConstView const& const_view() const { return view_; }
 
-  View *operator->() { return &view_; }
-  ConstView const *operator->() const { return &view_; }
+  View& operator*() { return view_; }
+  ConstView const& operator*() const { return view_; }
 
+  View* operator->() { return &view_; }
+  ConstView const* operator->() const { return &view_; }
+
+  // access the Buffer
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -3,7 +3,6 @@
 
 #include <optional>
 
-#include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
@@ -21,7 +20,7 @@ public:
 
   PortableHostCollection() = default;
 
-  PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host)
+  PortableHostCollection(int32_t elements, alpaka_common::DevHost const& host)
       // allocate pageable host memory
       : buffer_{cms::alpakatools::make_host_buffer<std::byte[]>(Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
@@ -31,7 +30,7 @@ public:
   }
 
   template <typename TQueue, typename = std::enable_if_t<cms::alpakatools::is_queue_v<TQueue>>>
-  PortableHostCollection(int32_t elements, TQueue const &queue)
+  PortableHostCollection(int32_t elements, TQueue const& queue)
       // allocate pinned host memory associated to the given work queue, accessible by the queue's device
       : buffer_{cms::alpakatools::make_host_buffer<std::byte[]>(queue, Layout::computeDataSize(elements))},
         layout_{buffer_->data(), elements},
@@ -40,32 +39,35 @@ public:
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
   }
 
-  ~PortableHostCollection() = default;
-
   // non-copyable
-  PortableHostCollection(PortableHostCollection const &) = delete;
-  PortableHostCollection &operator=(PortableHostCollection const &) = delete;
+  PortableHostCollection(PortableHostCollection const&) = delete;
+  PortableHostCollection& operator=(PortableHostCollection const&) = delete;
 
   // movable
-  PortableHostCollection(PortableHostCollection &&other) = default;
-  PortableHostCollection &operator=(PortableHostCollection &&other) = default;
+  PortableHostCollection(PortableHostCollection&&) = default;
+  PortableHostCollection& operator=(PortableHostCollection&&) = default;
 
-  View &view() { return view_; }
-  ConstView const &view() const { return view_; }
-  ConstView const &const_view() const { return view_; }
+  // default destructor
+  ~PortableHostCollection() = default;
 
-  View &operator*() { return view_; }
-  ConstView const &operator*() const { return view_; }
+  // access the View
+  View& view() { return view_; }
+  ConstView const& view() const { return view_; }
+  ConstView const& const_view() const { return view_; }
 
-  View *operator->() { return &view_; }
-  ConstView const *operator->() const { return &view_; }
+  View& operator*() { return view_; }
+  ConstView const& operator*() const { return view_; }
 
+  View* operator->() { return &view_; }
+  ConstView const* operator->() const { return &view_; }
+
+  // access the Buffer
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }
   ConstBuffer const_buffer() const { return *buffer_; }
 
   // part of the ROOT read streamer
-  static void ROOTReadStreamer(PortableHostCollection *newObj, Layout const &layout) {
+  static void ROOTReadStreamer(PortableHostCollection* newObj, Layout const& layout) {
     newObj->~PortableHostCollection();
     // use the global "host" object returned by cms::alpakatools::host()
     new (newObj) PortableHostCollection(layout.metadata().size(), cms::alpakatools::host());

--- a/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
+++ b/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
@@ -9,7 +9,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   namespace portabletest {
 
-    // import the top-level portabletest namespace
+    // make the names from the top-level portabletest namespace visible for unqualified lookup
+    // inside the ALPAKA_ACCELERATOR_NAMESPACE::portabletest namespace
     using namespace ::portabletest;
 
     // SoA with x, y, z, id fields in device global memory

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -336,8 +336,8 @@ namespace cms::alpakatools {
         // allocate device memory
         return alpaka::allocBuf<std::byte, size_t>(device_, bytes);
       } else if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
-        // allocate pinned host memory
-        return alpaka::allocMappedBuf<std::byte, size_t>(device_, alpaka::getDev(queue), bytes);
+        // allocate pinned host memory accessible by the queue's platform
+        return alpaka::allocMappedBuf<alpaka::Pltf<alpaka::Dev<Queue>>, std::byte, size_t>(device_, bytes);
       } else {
         // unsupported combination
         static_assert(std::is_same_v<Device, alpaka::Dev<Queue>> or std::is_same_v<Device, alpaka::DevCpu>,

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -1,5 +1,4 @@
 #include <cassert>
-#include <string>
 
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -1,8 +1,3 @@
-#include <optional>
-#include <string>
-
-#include <alpaka/alpaka.hpp>
-
 #include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -1,6 +1,3 @@
-#include <optional>
-#include <string>
-
 #include <alpaka/alpaka.hpp>
 
 #include "DataFormats/Portable/interface/Product.h"


### PR DESCRIPTION
#### PR description:

Update and extend the use of the `alpaka::allocMappedBuf` functions following the update of the Alpaka external to 2022.09.02 / b518e8c943a8.

Clean up whitespace, comments, and unused dependencies.


#### PR validation:

Integration tests pass.


#### If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 12.5.x.