### PR TITLE
Properly set SITECONFIG_PATH for runtheMatrix --ibeos option

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -399,6 +399,7 @@ if __name__ == '__main__':
         if os.path.exists(cmssw_base):
           os.environ["PATH"]=cmssw_base+":"+os.getenv("PATH")
           os.environ["CMS_PATH"]="/cvmfs/cms-ib.cern.ch"
+          os.environ["SITECONFIG_PATH"]="/cvmfs/cms-ib.cern.ch/SITECONF/local"
           os.environ["CMSSW_USE_IBEOS"]="true"
           print(">> WARNING: You are using SITECONF from /cvmfs/cms-ib.cern.ch")
           break


### PR DESCRIPTION
This change proposes to set  `SITECONFIG_PATH` pointing to `/cvmfs/cms-ib.cern.ch` so that `runTheMatrix.py --ibeos` can read the ibeos cache data. This change is needed after the merge of https://github.com/cms-sw/cmssw/pull/37278. 
- Without this change
```
> runTheMatrix.py -i all -l 4.22 --ibeos
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC Step0-PASSED Step1-FAILED Step2-NOTRUN Step3-NOTRUN Step4-NOTRUN  - time date Tue Sep  6 10:23:07 2022-date Tue Sep  6 10:20:38 2022; exit: 0 21504 0 0 0
1 0 0 0 0 tests passed, 0 1 0 0 0 failed
```

- with this change
```
> runTheMatrix.py -i all -l 4.22 --ibeos
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Sep  6 10:31:57 2022-date Tue Sep  6 10:27:29 2022; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```