### PR TITLE
HGCAL simulation of ToA constant jitter noise term

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -90,7 +90,7 @@ public:
 
   void generateTimeOffset(CLHEP::HepRandomEngine* engine) {
     for (int i = 0; i < 3; i++)
-      eventTimeOffset_ns_[i] = CLHEP::RandGaussQ::shoot(engine, 0, std::sqrt(jitterConstant2_ns_.at(i)));
+      eventTimeOffset_ns_[i] = CLHEP::RandGaussQ::shoot(engine, 0, jitterConstant_ns_[i]);
   };
 
   /**
@@ -198,7 +198,7 @@ private:
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_, adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_,
       tdcResolutionInNs_;
   uint32_t targetMIPvalue_ADC_;
-  std::array<float, 3> jitterNoise2_ns_, jitterConstant2_ns_, eventTimeOffset_ns_;
+  std::array<float, 3> jitterNoise_ns_, jitterConstant_ns_, eventTimeOffset_ns_;
   std::vector<float> noise_fC_;
   uint32_t toaMode_;
   uint32_t tdcNbits_;

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCFEElectronics.h
@@ -44,15 +44,26 @@ public:
                         uint32_t gainIdx = 0,
                         float maxADC = -1,
                         int thickness = 1,
-                        float tdcOnsetAuto = -1) {
+                        float tdcOnsetAuto = -1,
+                        float noiseWidth = -1) {
     switch (fwVersion_) {
       case SIMPLE: {
         runSimpleShaper(dataFrame, chargeColl, thrADC, lsbADC, gainIdx, maxADC, adcPulse);
         break;
       }
       case WITHTOT: {
-        runShaperWithToT(
-            dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse);
+        runShaperWithToT(dataFrame,
+                         chargeColl,
+                         toa,
+                         engine,
+                         thrADC,
+                         lsbADC,
+                         gainIdx,
+                         maxADC,
+                         thickness,
+                         tdcOnsetAuto,
+                         noiseWidth,
+                         adcPulse);
         break;
       }
       default: {
@@ -77,12 +88,9 @@ public:
     noise_fC_.insert(noise_fC_.end(), noise_fC.begin(), noise_fC.end());
   };
 
-  float getTimeJitter(float totalCharge, int thickness) {
-    float A2 = jitterNoise2_ns_.at(thickness - 1);
-    float C2 = jitterConstant2_ns_.at(thickness - 1);
-    float X2 = pow((totalCharge / noise_fC_.at(thickness - 1)), 2.);
-    float jitter2 = A2 / X2 + C2;
-    return sqrt(jitter2);
+  void generateTimeOffset(CLHEP::HepRandomEngine* engine) {
+    for (int i = 0; i < 3; i++)
+      eventTimeOffset_ns_[i] = CLHEP::RandGaussQ::shoot(engine, 0, std::sqrt(jitterConstant2_ns_.at(i)));
   };
 
   /**
@@ -139,6 +147,7 @@ public:
                         float maxADC,
                         int thickness,
                         float tdcOnsetAuto,
+                        float noiseWidth,
                         const hgc_digi::FEADCPulseShape& adcPulse);
   void runShaperWithToT(DFr& dataFrame,
                         hgc::HGCSimHitData& chargeColl,
@@ -149,9 +158,20 @@ public:
                         uint32_t gainIdx,
                         float maxADC,
                         int thickness,
-                        float tdcOnsetAuto) {
-    runShaperWithToT(
-        dataFrame, chargeColl, toa, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto, adcPulse_);
+                        float tdcOnsetAuto,
+                        float noiseWidth) {
+    runShaperWithToT(dataFrame,
+                     chargeColl,
+                     toa,
+                     engine,
+                     thrADC,
+                     lsbADC,
+                     gainIdx,
+                     maxADC,
+                     thickness,
+                     tdcOnsetAuto,
+                     noiseWidth,
+                     adcPulse_);
   }
 
   /**
@@ -178,7 +198,7 @@ private:
   float adcSaturation_fC_, adcLSB_fC_, tdcLSB_fC_, tdcSaturation_fC_, adcThreshold_fC_, tdcOnset_fC_, toaLSB_ns_,
       tdcResolutionInNs_;
   uint32_t targetMIPvalue_ADC_;
-  std::array<float, 3> jitterNoise2_ns_, jitterConstant2_ns_;
+  std::array<float, 3> jitterNoise2_ns_, jitterConstant2_ns_, eventTimeOffset_ns_;
   std::vector<float> noise_fC_;
   uint32_t toaMode_;
   uint32_t tdcNbits_;

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -103,6 +103,7 @@ void HGCDigitizerBase::run(std::unique_ptr<HGCDigitizerBase::DColl>& digiColl,
       RandNoiseGenerationFlag_ = true;
     }
   }
+  myFEelectronics_->generateTimeOffset(engine);
   if (digitizationType == 0)
     runSimple(digiColl, simData, theGeom, validIds, engine);
   else
@@ -207,8 +208,18 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
     //run the shaper to create a new data frame
     DFr rawDataFrame(id);
     int thickness = cell.thickness > 0 ? cell.thickness : 1;
-    myFEelectronics_->runShaper(
-        rawDataFrame, chargeColl, toa, adcPulse, engine, thrADC, lsbADC, gainIdx, maxADC, thickness, tdcOnsetAuto);
+    myFEelectronics_->runShaper(rawDataFrame,
+                                chargeColl,
+                                toa,
+                                adcPulse,
+                                engine,
+                                thrADC,
+                                lsbADC,
+                                gainIdx,
+                                maxADC,
+                                thickness,
+                                tdcOnsetAuto,
+                                noiseWidth);
 
     //update the output according to the final shape
     updateOutput(coll, rawDataFrame);

--- a/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcROCParameters_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #define base parameters for the HGCROC simulation in the SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
 
-hgcROCSettings = cms.PSet( 
+hgcROCSettings = cms.PSet(
     # 0 only ADC, 1 ADC with pulse shape, 2 ADC+TDC with pulse shape
     fwVersion         = cms.uint32(2),
     # leakage to bunches -2, -1, in-time, +1, +2, +3 (from J. Kaplon)
@@ -16,9 +16,9 @@ hgcROCSettings = cms.PSet(
     # the tdc resolution smearing (in picoseconds)
     tdcResolutionInPs = cms.double( 0.001 ),
     # jitter for timing noise term ns
-    jitterNoise_ns = cms.vdouble(25., 25., 25.),
+    jitterNoise_ns = cms.vdouble(5., 5., 5.),
     # jitter for timing noise term ns
-    jitterConstant_ns = cms.vdouble(0.0004, 0.0004, 0.0004),
+    jitterConstant_ns = cms.vdouble(0.02, 0.02, 0.02),
     # LSB for TDC, assuming 12 bit dynamic range to 10 pC
     tdcNbits          = cms.uint32(12),
     # TDC saturation

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -23,8 +23,8 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
       toaLSB_ns_{},
       tdcResolutionInNs_{1e-9},  // set time resolution very small by default
       targetMIPvalue_ADC_{},
-      jitterNoise2_ns_{},
-      jitterConstant2_ns_{},
+      jitterNoise_ns_{},
+      jitterConstant_ns_{},
       eventTimeOffset_ns_{{0.02, 0.02, 0.02}},
       noise_fC_{},
       toaMode_(WEIGHTEDBYE) {
@@ -87,16 +87,16 @@ HGCFEElectronics<DFr>::HGCFEElectronics(const edm::ParameterSet& ps)
 
   if (ps.exists("jitterNoise_ns")) {
     auto temp = ps.getParameter<std::vector<double> >("jitterNoise_ns");
-    if (temp.size() == jitterNoise2_ns_.size()) {
-      std::copy_n(temp.begin(), temp.size(), jitterNoise2_ns_.begin());
+    if (temp.size() == jitterNoise_ns_.size()) {
+      std::copy_n(temp.begin(), temp.size(), jitterNoise_ns_.begin());
     } else {
       throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for ToA jitterNoise ";
     }
   }
   if (ps.exists("jitterConstant_ns")) {
     auto temp = ps.getParameter<std::vector<double> >("jitterConstant_ns");
-    if (temp.size() == jitterConstant2_ns_.size()) {
-      std::copy_n(temp.begin(), temp.size(), jitterConstant2_ns_.begin());
+    if (temp.size() == jitterConstant_ns_.size()) {
+      std::copy_n(temp.begin(), temp.size(), jitterConstant_ns_.begin());
     } else {
       throw cms::Exception("BadConfiguration") << " HGCFEElectronics wrong size for ToA jitterConstant ";
     }
@@ -250,14 +250,14 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
   //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing
   if (toaColl[fireBX] != 0.f) {
     timeToA = toaColl[fireBX];
-    float sensor_noise = noiseWidth <= 0 ? noise_fC_.at(thickness - 1) : noiseWidth;
-    float noise = std::sqrt(jitterNoise2_ns_.at(thickness - 1)) * sensor_noise;
+    float sensor_noise = noiseWidth <= 0 ? noise_fC_[thickness - 1] : noiseWidth;
+    float noise = jitterNoise_ns_[thickness - 1] * sensor_noise;
     float jitter = chargeColl[fireBX] == 0 ? 0 : (noise / chargeColl[fireBX]);
     if (jitter != 0)
       timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, jitter);
     else if (tdcResolutionInNs_ != 0)
       timeToA = CLHEP::RandGaussQ::shoot(engine, timeToA, tdcResolutionInNs_);
-    timeToA += eventTimeOffset_ns_.at(thickness - 1);
+    timeToA += eventTimeOffset_ns_[thickness - 1];
     if (timeToA >= 0.f && timeToA <= 25.f)
       toaFlags[fireBX] = true;
   }


### PR DESCRIPTION
#### PR description:

This PR introduces the simulation of the constant term of the jitter noise on the time of arrival (ToA) measurement of the HGCAL. This is done by modelling a Gaussian noise term common to all HGCAL hits and added as a bias to the ToA.
This is part of the set of updates already announced in the HGCAL DPG meeting (see https://indico.cern.ch/event/1158758/contributions/4880969/attachments/2451390/4201020/Timining%2020220525%20v2-2.pdf).

#### PR validation:

PR was validated using the runTheMatrix.py -w upgrade -l 23234.103 test.
HGCAL-related changes were mainly observed on the ToA distribution as expected while changes in the ADC are due to different number of calls of the random number generator, which causes some smearing visible at lower ADC values.

Plots of ToA for jitter constant of 20 ps: 
![image](https://user-images.githubusercontent.com/14130873/188619506-f2bb8a52-274f-4b5f-8d61-01701809e731.png)
Plots of ToA for jitter constant of 1000 ps: 
![image](https://user-images.githubusercontent.com/14130873/188619638-59ac1745-ccc5-4515-a432-0d235a4784d3.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: