### PR TITLE
Making L1UpgradeNtuples to be more PyFWLite friendly

### DIFF
--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h
@@ -26,12 +26,21 @@ namespace L1Analysis {
     L1AnalysisL1Upgrade();
     ~L1AnalysisL1Upgrade();
     void Reset() { l1upgrade_.Reset(); }
-    void SetEm(const edm::Handle<l1t::EGammaBxCollection> em, unsigned maxL1Upgrade);
-    void SetTau(const edm::Handle<l1t::TauBxCollection> tau, unsigned maxL1Upgrade);
-    void SetJet(const edm::Handle<l1t::JetBxCollection> jet, unsigned maxL1Upgrade);
-    void SetSum(const edm::Handle<l1t::EtSumBxCollection> sums, unsigned maxL1Upgrade);
-    void SetMuon(const edm::Handle<l1t::MuonBxCollection> muon, unsigned maxL1Upgrade);
-    void SetMuonShower(const edm::Handle<l1t::MuonShowerBxCollection> muonShower, unsigned maxL1Upgrade);
+    void SetEm(const edm::Handle<l1t::EGammaBxCollection> em, unsigned maxL1Upgrade) { SetEm(*em, maxL1Upgrade); }
+    void SetTau(const edm::Handle<l1t::TauBxCollection> tau, unsigned maxL1Upgrade) { SetTau(*tau, maxL1Upgrade); }
+    void SetJet(const edm::Handle<l1t::JetBxCollection> jet, unsigned maxL1Upgrade) { SetJet(*jet, maxL1Upgrade); }
+    void SetSum(const edm::Handle<l1t::EtSumBxCollection> sums, unsigned maxL1Upgrade) { SetSum(*sums, maxL1Upgrade); }
+    void SetMuon(const edm::Handle<l1t::MuonBxCollection> muon, unsigned maxL1Upgrade) { SetMuon(*muon, maxL1Upgrade); }
+    void SetMuonShower(const edm::Handle<l1t::MuonShowerBxCollection> muonShower, unsigned maxL1Upgrade) {
+      SetMuonShower(*muonShower, maxL1Upgrade);
+    }
+    void SetEm(const l1t::EGammaBxCollection& em, unsigned maxL1Upgrade);
+    void SetTau(const l1t::TauBxCollection& tau, unsigned maxL1Upgrade);
+    void SetJet(const l1t::JetBxCollection& jet, unsigned maxL1Upgrade);
+    void SetSum(const l1t::EtSumBxCollection& sums, unsigned maxL1Upgrade);
+    void SetMuon(const l1t::MuonBxCollection& muon, unsigned maxL1Upgrade);
+    void SetMuonShower(const l1t::MuonShowerBxCollection& muonShower, unsigned maxL1Upgrade);
+
     L1AnalysisL1UpgradeDataFormat* getData() { return &l1upgrade_; }
 
   private:

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -4,10 +4,10 @@ L1Analysis::L1AnalysisL1Upgrade::L1AnalysisL1Upgrade() {}
 
 L1Analysis::L1AnalysisL1Upgrade::~L1AnalysisL1Upgrade() {}
 
-void L1Analysis::L1AnalysisL1Upgrade::SetEm(const edm::Handle<l1t::EGammaBxCollection> em, unsigned maxL1Upgrade) {
-  for (int ibx = em->getFirstBX(); ibx <= em->getLastBX(); ++ibx) {
-    for (l1t::EGammaBxCollection::const_iterator it = em->begin(ibx);
-         it != em->end(ibx) && l1upgrade_.nEGs < maxL1Upgrade;
+void L1Analysis::L1AnalysisL1Upgrade::SetEm(const l1t::EGammaBxCollection& em, unsigned maxL1Upgrade) {
+  for (int ibx = em.getFirstBX(); ibx <= em.getLastBX(); ++ibx) {
+    for (l1t::EGammaBxCollection::const_iterator it = em.begin(ibx);
+         it != em.end(ibx) && l1upgrade_.nEGs < maxL1Upgrade;
          it++) {
       if (it->pt() > 0) {
         l1upgrade_.egEt.push_back(it->pt());
@@ -33,10 +33,10 @@ void L1Analysis::L1AnalysisL1Upgrade::SetEm(const edm::Handle<l1t::EGammaBxColle
   }
 }
 
-void L1Analysis::L1AnalysisL1Upgrade::SetTau(const edm::Handle<l1t::TauBxCollection> tau, unsigned maxL1Upgrade) {
-  for (int ibx = tau->getFirstBX(); ibx <= tau->getLastBX(); ++ibx) {
-    for (l1t::TauBxCollection::const_iterator it = tau->begin(ibx);
-         it != tau->end(ibx) && l1upgrade_.nTaus < maxL1Upgrade;
+void L1Analysis::L1AnalysisL1Upgrade::SetTau(const l1t::TauBxCollection& tau, unsigned maxL1Upgrade) {
+  for (int ibx = tau.getFirstBX(); ibx <= tau.getLastBX(); ++ibx) {
+    for (l1t::TauBxCollection::const_iterator it = tau.begin(ibx);
+         it != tau.end(ibx) && l1upgrade_.nTaus < maxL1Upgrade;
          it++) {
       if (it->pt() > 0) {
         l1upgrade_.tauEt.push_back(it->et());
@@ -61,10 +61,10 @@ void L1Analysis::L1AnalysisL1Upgrade::SetTau(const edm::Handle<l1t::TauBxCollect
   }
 }
 
-void L1Analysis::L1AnalysisL1Upgrade::SetJet(const edm::Handle<l1t::JetBxCollection> jet, unsigned maxL1Upgrade) {
-  for (int ibx = jet->getFirstBX(); ibx <= jet->getLastBX(); ++ibx) {
-    for (l1t::JetBxCollection::const_iterator it = jet->begin(ibx);
-         it != jet->end(ibx) && l1upgrade_.nJets < maxL1Upgrade;
+void L1Analysis::L1AnalysisL1Upgrade::SetJet(const l1t::JetBxCollection& jet, unsigned maxL1Upgrade) {
+  for (int ibx = jet.getFirstBX(); ibx <= jet.getLastBX(); ++ibx) {
+    for (l1t::JetBxCollection::const_iterator it = jet.begin(ibx);
+         it != jet.end(ibx) && l1upgrade_.nJets < maxL1Upgrade;
          it++) {
       if (it->pt() > 0) {
         l1upgrade_.jetEt.push_back(it->et());
@@ -89,10 +89,10 @@ void L1Analysis::L1AnalysisL1Upgrade::SetJet(const edm::Handle<l1t::JetBxCollect
   }
 }
 
-void L1Analysis::L1AnalysisL1Upgrade::SetMuon(const edm::Handle<l1t::MuonBxCollection> muon, unsigned maxL1Upgrade) {
-  for (int ibx = muon->getFirstBX(); ibx <= muon->getLastBX(); ++ibx) {
-    for (l1t::MuonBxCollection::const_iterator it = muon->begin(ibx);
-         it != muon->end(ibx) && l1upgrade_.nMuons < maxL1Upgrade;
+void L1Analysis::L1AnalysisL1Upgrade::SetMuon(const l1t::MuonBxCollection& muon, unsigned maxL1Upgrade) {
+  for (int ibx = muon.getFirstBX(); ibx <= muon.getLastBX(); ++ibx) {
+    for (l1t::MuonBxCollection::const_iterator it = muon.begin(ibx);
+         it != muon.end(ibx) && l1upgrade_.nMuons < maxL1Upgrade;
          it++) {
       if (it->pt() > 0) {
         l1upgrade_.muonEt.push_back(it->et());
@@ -121,11 +121,11 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuon(const edm::Handle<l1t::MuonBxColle
   }
 }
 
-void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonShowerBxCollection> muonShower,
+void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const l1t::MuonShowerBxCollection& muonShower,
                                                     unsigned maxL1Upgrade) {
-  for (int ibx = muonShower->getFirstBX(); ibx <= muonShower->getLastBX(); ++ibx) {
-    for (l1t::MuonShowerBxCollection::const_iterator it = muonShower->begin(ibx);
-         it != muonShower->end(ibx) && l1upgrade_.nMuonShowers < maxL1Upgrade;
+  for (int ibx = muonShower.getFirstBX(); ibx <= muonShower.getLastBX(); ++ibx) {
+    for (l1t::MuonShowerBxCollection::const_iterator it = muonShower.begin(ibx);
+         it != muonShower.end(ibx) && l1upgrade_.nMuonShowers < maxL1Upgrade;
          it++) {
       if (it->isValid()) {
         l1upgrade_.muonShowerBx.push_back(ibx);
@@ -138,10 +138,10 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const edm::Handle<l1t::MuonS
   }
 }
 
-void L1Analysis::L1AnalysisL1Upgrade::SetSum(const edm::Handle<l1t::EtSumBxCollection> sums, unsigned maxL1Upgrade) {
-  for (int ibx = sums->getFirstBX(); ibx <= sums->getLastBX(); ++ibx) {
-    for (l1t::EtSumBxCollection::const_iterator it = sums->begin(ibx);
-         it != sums->end(ibx) && l1upgrade_.nSums < maxL1Upgrade;
+void L1Analysis::L1AnalysisL1Upgrade::SetSum(const l1t::EtSumBxCollection& sums, unsigned maxL1Upgrade) {
+  for (int ibx = sums.getFirstBX(); ibx <= sums.getLastBX(); ++ibx) {
+    for (l1t::EtSumBxCollection::const_iterator it = sums.begin(ibx);
+         it != sums.end(ibx) && l1upgrade_.nSums < maxL1Upgrade;
          it++) {
       int type = static_cast<int>(it->getType());
       l1upgrade_.sumType.push_back(type);

--- a/L1Trigger/L1TNtuples/src/classes.h
+++ b/L1Trigger/L1TNtuples/src/classes.h
@@ -29,3 +29,5 @@
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisRecoTauDataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisRecoMuon2DataFormat.h"
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisRecoElectronDataFormat.h"
+
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h"

--- a/L1Trigger/L1TNtuples/src/classes_def.xml
+++ b/L1Trigger/L1TNtuples/src/classes_def.xml
@@ -30,4 +30,7 @@
 <class name="L1Analysis::L1AnalysisRecoTauDataFormat"/>
 <class name="L1Analysis::L1AnalysisRecoMuon2DataFormat"/>
 <class name="L1Analysis::L1AnalysisRecoElectronDataFormat"/>
+
+<class name="L1Analysis::L1AnalysisL1Upgrade" persistent="false"/>
+
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This change modifies the signatures of the L1AnalysisL1Upgrade to take the collections or the handles (with the handles just calling the functions which take the collections).  It is difficult (impossible? please tell me if I'm wrong and this has changed) to get a proper handle in FWLite thus its much easier to just pass in the object itself.  

It also adds a root dictionary of the class so its available in pyroot. 

This means this can be trivially used in pyfwlite and thus I can embed the entire L1 upgrade ntuple in my trees without having to maintain a separate code base. 

Its not a big deal this goes in but it would be nice if possible. 

This doesnt run in production and regardless, zero changes are expected, its just a function signature change. 

#### PR validation:

L1ntuples still produced

