### PR TITLE
A possible solution for RPCAMCLink out-of-range issue[12_5_X]

### DIFF
--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -146,7 +146,8 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
   LogDebug("RPCCPPFRawToDigi") << "RXRecord " << std::hex << record.getRecord() << std::dec << std::endl;
   unsigned int fed(link.getFED());
   unsigned int amc_number(link.getAMCNumber());
-  if ( record.getLink() > 80 )return;
+  if (record.getLink() > 80)
+    return;
   link.setAMCInput(record.getLink());
 
   int bx_offset = (int)(record.getBXCounterMod() + 31 - bx_counter_mod) % 27 - 4;

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -146,6 +146,7 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
   LogDebug("RPCCPPFRawToDigi") << "RXRecord " << std::hex << record.getRecord() << std::dec << std::endl;
   unsigned int fed(link.getFED());
   unsigned int amc_number(link.getAMCNumber());
+  if ( record.getLink() > 80 )return;
   link.setAMCInput(record.getLink());
 
   int bx_offset = (int)(record.getBXCounterMod() + 31 - bx_counter_mod) % 27 - 4;


### PR DESCRIPTION
backport of #39307

#### PR description:

After the PR #38564 merged, there is an issue about RPCAMCLink #38939.

The reason for the crash is that during the run 314890 (used by the workflow 136.8561_RunZeroBias) the CPPF data were considered as corrupted. The reason was an firmware update, which led to some problems.. The CPPF good data have been restored after the run 315764.( Copy from https://github.com/cms-sw/cmssw/issues/38939#issuecomment-1210364325 )

This is fixed by adding a sanity check to RPCCPPFUnpacker. 

@mileva @andresib @minerva1993  @jhgoh  @ram1123 @vukasinmilosevic 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

runTheMatrix.py -l limited -i all --ibeos

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

#39307 for CMSSW_12_5_X