### PR TITLE
`PrimaryVertexMonitor`: fix beamspot centering for Run3 and actually fill the beamspot type histograms

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -152,8 +152,8 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   dqmLabel = TopFolderName_ + "/" + beamSpotInputTag_.label();
   iBooker.setCurrentFolder(dqmLabel);
 
-  bsX = iBooker.book1D("bsX", "BeamSpot x0", 100, -0.1, 0.1);
-  bsY = iBooker.book1D("bsY", "BeamSpot y0", 100, -0.1, 0.1);
+  bsX = iBooker.book1D("bsX", "BeamSpot x0", 100, vposx - 0.1, vposx + 0.1);
+  bsY = iBooker.book1D("bsY", "BeamSpot y0", 100, vposy - 0.1, vposy + 0.1);
   bsZ = iBooker.book1D("bsZ", "BeamSpot z0", 100, -2., 2.);
   bsSigmaZ = iBooker.book1D("bsSigmaZ", "BeamSpot sigmaZ", 100, 0., 10.);
   bsDxdz = iBooker.book1D("bsDxdz", "BeamSpot dxdz", 100, -0.0003, 0.0003);
@@ -454,7 +454,7 @@ void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
   bsDydz->Fill(beamSpot.dydz());
   bsBeamWidthX->Fill(beamSpot.BeamWidthX() * cmToUm);
   bsBeamWidthY->Fill(beamSpot.BeamWidthY() * cmToUm);
-  // bsType->Fill(beamSpot.type());
+  bsType->Fill(beamSpot.type());
 }
 
 void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {


### PR DESCRIPTION
#### PR description:

When casually looking at the GUI, I noticed that:
   * [X0](https://tinyurl.com/2gunazwd) and [Y0](https://tinyurl.com/2mxv4alm) coordinate plots are empty (because the position of the Run-3 Beam Spot exceeds the current range. 
   * the [Beam Spot type plot](https://tinyurl.com/2pa2ne4w) is also empty (because not filled)

#### PR validation:

None, but changes are trivial

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported.