### PR TITLE
Revive the green status on the lumi-based plots in GEM onlineDQM, a backport to 12_4_X

### DIFF
--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -634,7 +634,6 @@ void GEMDQMHarvester::createLumiFuncHist(edm::Service<DQMStore> &store,
         }
       }
 
-      nStatusSum &= ~(1 << nBitOcc_);  // No need of displaying the digi occupancy
       h2Summary->setBinContent(nIdxLumi + 1, nIdxCh, nStatusSum);
       if (nMaxBin < nIdxLumi + 1)
         nMaxBin = nIdxLumi + 1;


### PR DESCRIPTION
#### PR description:

The green status on the lumi-block-based status plot was discarded before, but end-users pointed out that the green status is more useful than the expectation. So, it is decided to revive the function.

#### PR validation:

Test are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True`

@jshlee @watson-ij @seungjin-yang

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #39310 to CMSSW_12_4_X
