### PR TITLE
Add standalone track.extra() criteria to internal duplicate removal in MuonIdProducer

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -637,7 +637,9 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       for (auto& muon : *outputMuons) {
         if (!muon.standAloneMuon().isNull()) {
           // global muon
-          if (muon.standAloneMuon().get() == &outerTrack) {
+          if (muon.standAloneMuon().get() == &outerTrack ||
+              (muon.standAloneMuon()->extra().isNonnull() &&
+               muon.standAloneMuon()->extra().get() == outerTrack.extra().get())) {
             newMuon = false;
             break;
           }


### PR DESCRIPTION
#### PR description:

This PR is a fix for one of the issues that are caused by the disambiguation in `GlobalMuonProducer` when choosing the standalone track (with or without BS contraint) to seed the global muon reconstruction.

The issue is described in https://github.com/cms-sw/cmssw/issues/38201 and consists of the duplication of some standalone muon tracks in the muons collection when global muons are fitted from the non-updated standalone track. Two `reco::Muon` objects are saved for the same physical muon:
- One Global Muon with non-updated standalone track (from `standAloneMuons` collection)
- One Standalone Muon (only) with updated standalone track (from `standAloneMuons::UpdatedAtVtx` collection)

Internal duplicate removal fails to compare these standalone tracks as they are different refits of the same muon track. This PR doesn't modify the track choice to fit the global muons in `GlobalMuonProducer` but fixes the internal duplicate removal when filling the `muons` collection in `MuonIdProducer`.

The changes were built on top of CMSSW_12_5_0_pre5.

#### PR validation:

The proposed changes passed all code format, unit and runTheMatrix tests.

This PR removes all standalone muons in `muons` collection that share the same `track.extra()` and no standalone muons sharing hits are found after the fix is done. The performance was tested in the following dataset where 1891290 out of 172618407 muons where removed:

/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16RECO-1
06X_mcRun2_asymptotic_v13-v2/AODSIM

After the fix the number of standalone muons decreases and the number of global muons remains the same, which is expected. Some plots are:

![h_nSTA](https://user-images.githubusercontent.com/29282388/188828464-436aff79-d950-45d6-a6e3-5744ee7f1494.png)
![h_nGLB](https://user-images.githubusercontent.com/29282388/188828489-3456e9e2-feb4-4176-95f4-7054f1a1cb5d.png)

@andrea21z @cms-sw/muon-pog-l2 
