### PR TITLE
[12.5.X]   Add Tracker Alignment di-muon monitoring to other resonances

### DIFF
--- a/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
@@ -50,8 +50,11 @@ private:
   //used to select what vertices to read from configuration file
   const edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
 
+  const std::string motherName_;
   const std::string MEFolderName_;  // Top-level folder name
   const bool useClosestVertex_;
+
+  std::pair<float, float> massLimits_; /* for the mass plot x-range */
   const float maxSVdist_;
 
   // vertex quantities
@@ -73,7 +76,7 @@ private:
   MonitorElement *hCosPhi3D_;
   MonitorElement *hCosPhiInv_;
   MonitorElement *hCosPhiInv3D_;
-  MonitorElement *hTrackInvMass_;
+  MonitorElement *hInvMass_;
   MonitorElement *hCutFlow_;
 
   // impact parameters information

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -160,6 +160,7 @@ ALCARECOTkAlJpsiMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
 
 ALCARECOTkAlJpsiMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuonVertexMonitor.clone(
     muonTracks = 'ALCARECO'+__selectionName,
+    decayMotherName = "J/#psi",
     vertices = 'offlinePrimaryVertices',
     FolderName = "AlCaReco/"+__selectionName,
     maxSVdist = 50
@@ -229,6 +230,7 @@ ALCARECOTkAlUpsilonMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
 
 ALCARECOTkAlUpsilonMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuonVertexMonitor.clone(
     muonTracks = 'ALCARECO'+__selectionName,
+    decayMotherName = "#Upsilon",
     vertices = 'offlinePrimaryVertices',
     FolderName = "AlCaReco/"+__selectionName,
     maxSVdist = 50

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -158,7 +158,20 @@ ALCARECOTkAlJpsiMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     TrackPtMax = 50
 )
 
-ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM )
+ALCARECOTkAlJpsiMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuonVertexMonitor.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    vertices = 'offlinePrimaryVertices',
+    FolderName = "AlCaReco/"+__selectionName,
+    maxSVdist = 50
+)
+
+ALCARECOTkAlJpsiMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    decaMotherName = 'J/#psi',
+    DiMuonMassConfig = dict(ymin = 2.7 ,ymax = 3.4))
+
+ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM + ALCARECOTkAlJpsiMuMuVtxDQM + ALCARECOTkAlJpsiMassBiasDQM)
 
 #########################################################
 #############---  TkAlJpsiMuMuHI ---#####################
@@ -214,7 +227,20 @@ ALCARECOTkAlUpsilonMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     TrackPtMax = 50
 )
 
-ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM )
+ALCARECOTkAlUpsilonMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuonVertexMonitor.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    vertices = 'offlinePrimaryVertices',
+    FolderName = "AlCaReco/"+__selectionName,
+    maxSVdist = 50
+)
+
+ALCARECOTkAlUpsilonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
+    muonTracks = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    decaMotherName = '#Upsilon',
+    DiMuonMassConfig = dict(ymin = 8.9 ,ymax = 9.9))
+
+ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuVtxDQM + ALCARECOTkAlUpsilonMassBiasDQM)
 
 ############################################################
 #############---  TkAlUpsilonMuMuHI ---#####################

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -168,8 +168,8 @@ ALCARECOTkAlJpsiMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuon
 ALCARECOTkAlJpsiMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
     muonTracks = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    decaMotherName = 'J/#psi',
-    DiMuonMassConfig = dict(ymin = 2.7 ,ymax = 3.4))
+    decayMotherName = 'J/#psi',
+    DiMuMassConfig = dict(ymin = 2.7 ,ymax = 3.4))
 
 ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM + ALCARECOTkAlJpsiMuMuVtxDQM + ALCARECOTkAlJpsiMassBiasDQM)
 
@@ -237,8 +237,8 @@ ALCARECOTkAlUpsilonMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiM
 ALCARECOTkAlUpsilonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
     muonTracks = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    decaMotherName = '#Upsilon',
-    DiMuonMassConfig = dict(ymin = 8.9 ,ymax = 9.9))
+    decayMotherName = '#Upsilon',
+    DiMuMassConfig = dict(ymin = 8.9 ,ymax = 9.9))
 
 ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuVtxDQM + ALCARECOTkAlUpsilonMassBiasDQM)
 

--- a/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
@@ -2,9 +2,34 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Alignment.DiMuonMassBiasClient_cfi import DiMuonMassBiasClient as diMuonMassBiasClient
 
+# Z-> mm
 __selectionName = 'TkAlDiMuonAndVertex'
 ALCARECOTkAlZMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName
 )
 
 alcaTkAlZMuMuBiasClients = cms.Sequence(ALCARECOTkAlZMuMuMassBiasClient)
+
+# J/psi -> mm
+__selectionName = 'TkAlJpsiMuMu'
+ALCARECOTkAlJpsiMuMuMassBiasClient = diMuonMassBiasClient.clone(
+    FolderName = "AlCaReco/"+__selectionName,
+    fitBackground = True,
+    fit_par = dict(mean_par = [3.09, 2.7, 3.4],
+                   width_par = [1.0, 0.0, 5.0],
+                   sigma_par = [1.0, 0.0, 5.0])
+)
+
+alcaTkAlJpsiMuMuBiasClients = cms.Sequence(ALCARECOTkAlJpsiMuMuMassBiasClient)
+
+# Upsilon -> mm
+__selectionName = 'TkAlUpsilonMuMu'
+ALCARECOTkAlUpsilonMuMuMassBiasClient = diMuonMassBiasClient.clone(
+    FolderName = "AlCaReco/"+__selectionName,
+    fitBackground = True,
+    fit_par = dict(mean_par = [9.46, 8.9, 9.9],
+                   width_par = [1.0, 0.0, 5.0],
+                   sigma_par = [1.0, 0.0, 5.0])
+)
+
+alcaTkAlUpsilonMuMuBiasClients = cms.Sequence(ALCARECOTkAlUpsilonMuMuMassBiasClient)

--- a/DQMOffline/Alignment/python/DiMuonVertexMonitor_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonVertexMonitor_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 DiMuonVertexMonitor = DQMEDAnalyzer('DiMuonVertexMonitor',
                                     muonTracks = cms.InputTag('ALCARECOTkAlDiMuon'),
+                                    decayMotherName = cms.string('Z'),
                                     vertices = cms.InputTag('offlinePrimaryVertices'),
                                     FolderName = cms.string('DiMuonVertexMonitor'),
                                     maxSVdist = cms.double(50))

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
@@ -22,6 +22,11 @@ options.register('globalTag',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "conditions")
+options.register('resonance',
+                 'Z',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "resonance type")
 options.parseArguments()
 
 # import of standard configurations
@@ -43,7 +48,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("DQMRootSource",
-    fileNames = cms.untracked.vstring('file:step3_inDQM.root')
+    fileNames = cms.untracked.vstring('file:step3_inDQM_'+options.resonance+'.root')
 )
 
 process.options = cms.untracked.PSet(
@@ -93,16 +98,34 @@ process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
 
 process.dqmsave_step = cms.Path(process.DQMSaver)
 
+if (options.resonance == 'Z'):
+    print('',30*"#",'\n # will harvest Z file \n',30*"#")
+    _folderName = cms.string('AlCaReco/TkAlDiMuonAndVertex')
+    _doBkgFit = cms.bool(False)
+    _fitPar =  cms.PSet(mean_par = cms.vdouble(90.,60.,120.),
+                        width_par = cms.vdouble(5.0,0.0,120.0),
+                        sigma_par = cms.vdouble(5.0,0.0,120.0))
+elif (options.resonance == 'Jpsi'):
+    print('',30*"#",'\n # will harvest J/psi file \n',30*"#")
+    _folderName =  cms.string('AlCaReco/TkAlJpsiMuMu')
+    _doBkgFit = cms.bool(True)
+    _fitPar =  cms.PSet(mean_par = cms.vdouble(3.09, 2.7, 3.4),
+                        width_par = cms.vdouble(1.0, 0.0, 5.0),
+                        sigma_par = cms.vdouble(1.0, 0.0, 5.0))
+elif (options.resonance == 'Upsilon'):
+    print('',30*"#",'\n # will harvest Upsilon file \n',30*"#")
+    _folderName =  cms.string('AlCaReco/TkAlUpsilonMuMu')
+    _doBkgFit = cms.bool(True)
+    _fitPar =  cms.PSet(mean_par = cms.vdouble(9.46, 8.9, 9.9),
+                        width_par = cms.vdouble(1.0, 0.0, 5.0),
+                        sigma_par = cms.vdouble(1.0, 0.0, 5.0))
+
 # the module to harvest
 process.DiMuonMassBiasClient = cms.EDProducer("DiMuonMassBiasClient",
-                                              FolderName = cms.string('AlCaReco/TkAlDiMuonAndVertex'),
-                                              fitBackground = cms.bool(False),
+                                              FolderName = _folderName,
+                                              fitBackground = _doBkgFit,
                                               debugMode = cms.bool(True),
-                                              fit_par = cms.PSet(
-                                                  mean_par = cms.vdouble(90.,60.,120.),
-                                                  width_par = cms.vdouble(5.0,0.0,120.0),
-                                                  sigma_par = cms.vdouble(5.0,0.0,120.0)
-                                              ),
+                                              fit_par = _fitPar,
                                               MEtoHarvest = cms.vstring(
                                                   'DiMuMassVsMuMuPhi',
                                                   'DiMuMassVsMuMuEta',

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMValidator_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMValidator_cfg.py
@@ -17,6 +17,11 @@ options.register('globalTag',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "conditions")
+options.register('resonance',
+                 'Z',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "resonance type")
 options.parseArguments()
 
 # import of standard configurations
@@ -38,9 +43,30 @@ process.maxEvents = cms.untracked.PSet(
     output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
 )
 
+process.load("DQMOffline.Configuration.AlCaRecoDQM_cff")
+
+if (options.resonance == 'Z'):
+    # Z
+    print('',30*"#",'\n # will process Z->mm data\n',30*"#")
+    readFiles = ['/store/relval/CMSSW_12_5_0_pre2/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-124X_mcRun3_2022_realistic_v3-v1/2580000/4f9aee02-35a2-49b7-93f5-831214cf32d8.root']
+    process.seqALCARECOTkAlDQM = cms.Sequence(process.ALCARECOTkAlDiMuonAndVertexVtxDQM + process.ALCARECOTkAlDiMuonMassBiasDQM)
+elif (options.resonance == 'Jpsi'):
+    # J/psi
+    print('',30*"#",'\n # will process Jpsi->mm data\n',30*"#")
+    readFiles = ['/store/relval/CMSSW_12_5_0_pre2/RelValEtaBToJpsiJpsi_14TeV/ALCARECO/TkAlJpsiMuMu-124X_mcRun3_2022_realistic_v3-v1/2580000/fc77aaed-b0f5-4446-87f5-f7341099bd73.root']
+    process.seqALCARECOTkAlDQM = cms.Sequence(process.ALCARECOTkAlJpsiMuMuVtxDQM + process.ALCARECOTkAlJpsiMassBiasDQM)
+elif (options.resonance == 'Upsilon'):
+    # upsilon
+    print('',30*"#",'\n # will process Upsilon->mm data\n',30*"#")
+    readFiles = ['/store/relval/CMSSW_12_5_0_pre2/RelValUpsilon1SToMuMu_14/ALCARECO/TkAlUpsilonMuMu-124X_mcRun3_2022_realistic_v3-v1/2580000/fca73916-5076-4c9f-a460-2481588825ab.root']
+    process.seqALCARECOTkAlDQM = cms.Sequence(process.ALCARECOTkAlUpsilonMuMuVtxDQM + process.ALCARECOTkAlUpsilonMassBiasDQM)
+else:
+    print('unrecongnized %s resonance',options.resonance)
+    exit(1)
+
 # Input source
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring('/store/relval/CMSSW_12_5_0_pre2/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-124X_mcRun3_2022_realistic_v3-v1/2580000/4f9aee02-35a2-49b7-93f5-831214cf32d8.root'),
+                            fileNames = cms.untracked.vstring(readFiles),
                             secondaryFileNames = cms.untracked.vstring()
                             )
 
@@ -79,7 +105,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
         dataTier = cms.untracked.string('DQMIO'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('file:step3_inDQM.root'),
+    fileName = cms.untracked.string('file:step3_inDQM_'+options.resonance+'.root'),
     outputCommands = process.DQMEventContent.outputCommands,
     splitLevel = cms.untracked.int32(0)
 )
@@ -87,11 +113,7 @@ process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
 
-process.load("DQMOffline.Configuration.AlCaRecoDQM_cff")
-
-process.seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(process.ALCARECOTkAlDiMuonAndVertexVtxDQM + process.ALCARECOTkAlDiMuonMassBiasDQM)
-
-process.dqmoffline_step = cms.EndPath(process.seqALCARECOTkAlDiMuonAndVertex)
+process.dqmoffline_step = cms.EndPath(process.seqALCARECOTkAlDQM)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 process.schedule = cms.Schedule(process.dqmoffline_step,process.DQMoutput_step)

--- a/DQMOffline/Alignment/test/testDiMuonVertexMonitor.sh
+++ b/DQMOffline/Alignment/test/testDiMuonVertexMonitor.sh
@@ -7,5 +7,17 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   cd ${SCRAM_TEST_NAME}
 fi
 
-cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidator_cfg.py  || die "Failure using DiMuonVertexValidator_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/DiMuonVertex_HARVESTING.py || die "Failure using DiMuonVertex_HARVESTING.py" $? 
+echo -e " Tesing on Z->mm \n\n"
+
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMValidator_cfg.py resonance=Z  || die "Failure using DiMuonTkAlDQMValidator_cfg.py resonance=Z" $?
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMHarvester_cfg.py resonance=Z || die "Failure using DiMuonTkAlDQMHarvester_cfg.py resonance=Z" $? 
+
+echo -e " Testing on J/psi -> mm \n\n"
+
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMValidator_cfg.py resonance=Jpsi || die "Failure using DiMuonTkAlDQMValidator_cfg.py resonance=Jpsi" $?
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMHarvester_cfg.py resonance=Jpsi || die "Failure using DiMuonTkAlDQMHarvester_cfg.py resonance=Jpsi" $? 
+
+echo -e " Testing on Upsilon -> mm \n\n"
+
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMValidator_cfg.py resonance=Upsilon || die "Failure using DiMuonTkAlDQMValidator_cfg.py resonance=Upsilon" $?
+cmsRun ${LOCAL_TEST_DIR}/DiMuonTkAlDQMHarvester_cfg.py resonance=Upsilon || die "Failure using DiMuonTkAlDQMHarvester_cfg.py resonance=Upsilon" $? 

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -205,7 +205,9 @@ DQMHarvestMuon = cms.Sequence( dtClients *
                                rpcTier0Client *
                                cscOfflineCollisionsClients *
                                muonQualityTests *
-                               alcaTkAlZMuMuBiasClients
+                               alcaTkAlZMuMuBiasClients *
+                               alcaTkAlJpsiMuMuBiasClients *
+                               alcaTkAlUpsilonMuMuBiasClients
                                )
 
 _run3_GEM_DQMHarvestMuon = DQMHarvestMuon.copy()


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39295

#### PR description:

This PR extends on the concept introduced at https://github.com/cms-sw/cmssw/pull/39148 (and then followed up at https://github.com/cms-sw/cmssw/pull/39173 and https://github.com/cms-sw/cmssw/pull/39247) in order to monitor the vertexing and mass biases for other di-muon resonances (J/ψ→µµ  and Υ(1S) →µµ) used in the tracker alignment procedure.

#### PR validation:

Relies on the existing (and augmented) unit tests.
The output of it has been uploaded to a test GUI for convenience of inspection and it's available by connecting to:

```console
 ssh -NL 8060:localhost:8060 <USER>@lxplus724.cern.ch
````
and visiting:
   * for the J/ψ → µµ : https://tinyurl.com/2nlexqqx
   * for the Υ(1S) → µµ : https://tinyurl.com/2f2qkelc  

Morevor the single bin fits for the resonance masses are available [here](http://musich.web.cern.ch/musich/display/2022CMassBiasFits/)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/39295 to 12.5.X