### PR TITLE
[12_4_X] Add check of Tracker HV in BeamSpot DQM clients

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -429,12 +429,32 @@ else:
         frontierKey = cms.untracked.string(options.runUniqueKey)
     )
 print("Configured frontierKey", options.runUniqueKey)
+
+#--------
+# Do no run on events with pixel or strip with HV off
+
+process.stripTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
+    DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
+    DcsStatusLabel = cms.untracked.InputTag( "scalersRawToDigi" ),
+    DebugOn = cms.untracked.bool( False ),
+    DetectorType = cms.untracked.string( "sistrip" )
+)
+
+process.pixelTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
+    DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
+    DcsStatusLabel = cms.untracked.InputTag( "scalersRawToDigi" ),
+    DebugOn = cms.untracked.bool( False ),
+    DetectorType = cms.untracked.string( "pixel" )
+)
+
 #---------
 # Final path
 if (not process.runType.getRunType() == process.runType.hi_run):
     process.p = cms.Path(process.scalersRawToDigi
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
+                       * process.pixelTrackerHVOn
+                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.dqmcommon
@@ -445,6 +465,8 @@ else:
     process.p = cms.Path(process.scalersRawToDigi
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
+                       * process.pixelTrackerHVOn
+                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.filter_step # the only extra: pix-multi filter
@@ -453,5 +475,6 @@ else:
                        * process.monitor
                        * process.BeamSpotProblemModule)
 
+print("Global Tag used:", process.GlobalTag.globaltag.value())
 print("Final Source settings:", process.source)
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -130,9 +130,6 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 # Set rawDataRepacker (HI and live) or hltFEDSelectorTCDS+hltFEDSelectorOnlineMetaData (for all the rest)
 if (process.runType.getRunType() == process.runType.hi_run and live):
     rawDataInputTag = "rawDataRepacker"
-elif unitTest:
-    # This is needed until we update the streamer files used for the unitTest
-    rawDataInputTag = "rawDataCollector"
 else:
     # Use raw data from selected TCDS FEDs (1024, 1025) and OnlineMetaData FED (1022)
     rawDataInputTag = "hltFEDSelectorTCDS"

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -39,32 +39,10 @@ if 'unitTest=True' in sys.argv:
 # Common part for PP and H.I Running
 #-----------------------------
 if unitTest:
-  process.load("DQM.Integration.config.unittestinputsource_cfi")
-  from DQM.Integration.config.unittestinputsource_cfi import options
-
-  # Overwrite source of the unitTest to use a streamer file instead of the DAS query output
-  print("[beamhlt_dqm_sourceclient-live_cfg]:: Overriding DAS input to use a streamer file")
-
-  # Read streamer files from https://github.com/cms-data/DQM-Integration
-  import os
-  dqm_integration_data = [os.path.join(dir,'DQM/Integration/data') for dir in os.getenv('CMSSW_SEARCH_PATH','').split(":") if os.path.exists(os.path.join(dir,'DQM/Integration/data'))][0]
-
-  # Set the process source
-  process.source = cms.Source("DQMStreamerReader",
-      runNumber = cms.untracked.uint32(346373),
-      runInputDir = cms.untracked.string(dqm_integration_data),
-      SelectEvents = cms.untracked.vstring('*'),
-      streamLabel = cms.untracked.string('streamDQMOnlineBeamspot'),
-      scanOnce = cms.untracked.bool(True),
-      minEventsPerLumi = cms.untracked.int32(1000),
-      delayMillis = cms.untracked.uint32(500),
-      nextLumiTimeoutMillis = cms.untracked.int32(0),
-      skipFirstLumis = cms.untracked.bool(False),
-      deleteDatFiles = cms.untracked.bool(False),
-      endOfRunKills  = cms.untracked.bool(False),
-      inputFileTransitionsEachEvent = cms.untracked.bool(False)
-  )
-
+  process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+  from DQM.Integration.config.unitteststreamerinputsource_cfi import options
+  # new stream label
+  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 elif live:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")

--- a/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
+++ b/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
@@ -1,0 +1,102 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
+import os
+import FWCore.ParameterSet.Config as cms
+
+# Parameters for runType
+import FWCore.ParameterSet.VarParsing as VarParsing
+from .dqmPythonTypes import *
+
+# Dedine and register options
+options = VarParsing.VarParsing("analysis")
+
+# Parameters for runType
+options.register ('runkey',
+          'pp_run',
+          VarParsing.VarParsing.multiplicity.singleton,
+          VarParsing.VarParsing.varType.string,
+          "Run Keys of CMS")
+
+# Parameter for frontierKey
+options.register('runUniqueKey',
+                 'InValid',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Unique run key from RCMS for Frontier")
+
+options.register('runNumber',
+                 356383,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number. This run number has to be present in https://github.com/cms-data/DQM-Integration")
+
+options.register('streamLabel',
+                 'streamDQM', # default DQM stream value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Name of the stream")
+
+options.register('noDB',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't upload the BeamSpot conditions to the DB")
+
+options.register('scanOnce',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Don't repeat file scans: use what was found during the initial scan. EOR file is ignored and the state is set to 'past end of run'.")
+
+options.register('skipFirstLumis',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+
+options.register('BeamSplashRun',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Set client source settings for beam SPLASH run")
+
+# This is used only by the online clients themselves. 
+# We need to register it here because otherwise an error occurs saying that there is an unidentified option.
+options.register('unitTest',
+                 True,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Required to avoid the error.")
+
+options.parseArguments()
+
+# Read streamer files from https://github.com/cms-data/DQM-Integration
+dqm_integration_data = [os.path.join(dir,'DQM/Integration/data') for dir in os.getenv('CMSSW_SEARCH_PATH','').split(":") if os.path.exists(os.path.join(dir,'DQM/Integration/data'))][0]
+print("Reading streamer files from:\n ", dqm_integration_data)
+
+# Set the process source
+source = cms.Source("DQMStreamerReader",
+    runNumber = cms.untracked.uint32(options.runNumber),
+    runInputDir = cms.untracked.string(dqm_integration_data),
+    SelectEvents = cms.untracked.vstring('*'),
+    streamLabel = cms.untracked.string(options.streamLabel),
+    scanOnce = cms.untracked.bool(options.scanOnce),
+    minEventsPerLumi = cms.untracked.int32(1000),
+    delayMillis = cms.untracked.uint32(500),
+    nextLumiTimeoutMillis = cms.untracked.int32(0),
+    skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
+    deleteDatFiles = cms.untracked.bool(False),
+    endOfRunKills  = cms.untracked.bool(False),
+    inputFileTransitionsEachEvent = cms.untracked.bool(False)
+)
+
+maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(-1)
+)
+
+runType = RunType()
+if not options.runkey.strip():
+  options.runkey = "pp_run"
+
+runType.setRunType(options.runkey.strip())

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -85,7 +85,7 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
   // 3. If both are newer than the limit threshold return
   //    the BS that converged and has larger sigmaZ
   if (diffBStime1 > limitTime && diffBStime2 > limitTime) {
-    edm::LogInfo("OnlineBeamSpotESProducer") << "Defaulting to fake becuase both payloads are too old.";
+    edm::LogInfo("OnlineBeamSpotESProducer") << "Defaulting to fake because both payloads are too old.";
     return nullptr;
   } else if (diffBStime2 > limitTime) {
     if (bs1->sigmaZ() > sigmaZThreshold_ && bs1->beamType() == 2) {


### PR DESCRIPTION
#### PR description:
Backport of #39347 
This also includes the backport of #38925 (update the unitTest input file) which is a 1 commit PR that was never backport to 12_4_X.

A check on the Tracker HV (both pixels and strips) is added in order not to run on events which are by construction not useful for the BeamSpot determination.
Plus some minor improvements to the DQM BeamSpot clients.

#### PR validation:
See master PR

#### Backport:
Backport of #39347 