### PR TITLE
[12.4.X] `SiStripHitEfficiency` PCL workflow, take into account modules with `FEDErrors`

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
@@ -8,17 +8,63 @@
 
 struct SiStripHitEffData {
 public:
-  SiStripHitEffData() : EventStats(), FEDErrorOccupancy(nullptr) {}
+  SiStripHitEffData() : EventStats(), FEDErrorOccupancy(nullptr), m_isLoaded(false) {}
 
   void fillTkMapFromMap() {
     for (const auto& [id, count] : fedErrorCounts) {
-      FEDErrorOccupancy.fill(id, count);
+      FEDErrorOccupancy->fill(id, count);
+    }
+  }
+
+  void fillMapFromTkMap(const int nevents, const float threshold, const std::vector<DetId>& stripDetIds) {
+    const auto& Maps = FEDErrorOccupancy->getAllMaps();
+    std::vector<bool> isThere;
+    isThere.reserve(Maps.size());
+    std::transform(Maps.begin() + 1, Maps.end(), std::back_inserter(isThere), [](auto& x) { return !(x == nullptr); });
+
+    int count{0};
+    for (const auto& it : isThere) {
+      count++;
+      LogTrace("SiStripHitEffData") << " layer: " << count << " " << it << std::endl;
+      if (it)
+        LogTrace("SiStripHitEffData") << "resolving to " << Maps[count]->getName()
+                                      << " with entries: " << Maps[count]->getEntries() << std::endl;
+      // color the map
+      Maps[count]->setOption("colz");
+    }
+
+    for (const auto& det : stripDetIds) {
+      const auto& counts = FEDErrorOccupancy->getValue(det);
+
+      if (counts > 0) {
+        float fraction = counts / nevents;
+
+        LogTrace("SiStripHitEffData") << det.rawId() << " has " << counts << " counts, " << fraction * 100
+                                      << "% fraction of the " << nevents << " events processed" << std::endl;
+
+        if (fraction > threshold) {
+          fedErrorCounts.insert(std::make_pair(det, 1));
+        }
+      }  // do not check functioning modules
+    }
+    // the map has been loaded
+    m_isLoaded = true;
+  }
+
+  const bool checkFedError(const DetId det) {
+    if (m_isLoaded) {
+      return (fedErrorCounts.find(det) == fedErrorCounts.end());
+    } else {
+      throw cms::Exception("LogicError") << __PRETTY_FUNCTION__ << "cannot check DetId when map not filled";
     }
   }
 
   dqm::reco::MonitorElement* EventStats;
   std::unordered_map<uint32_t, int> fedErrorCounts;
-  TkHistoMap FEDErrorOccupancy;
+  std::unique_ptr<TkHistoMap> FEDErrorOccupancy;
+
+private:
+  bool m_isLoaded;
 };
 
 #endif

--- a/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/TrajectoryAtInvalidHit.cc
@@ -1,18 +1,19 @@
 #include "CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h"
-#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-// #include "RecoTracker/MeasurementDet/interface/RecHitPropagator.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h"
+// #include "RecoTracker/MeasurementDet/interface/RecHitPropagator.h"
 
 using namespace std;
 TrajectoryAtInvalidHit::TrajectoryAtInvalidHit(const TrajectoryMeasurement& tm,
@@ -67,7 +68,7 @@ TrajectoryAtInvalidHit::TrajectoryAtInvalidHit(const TrajectoryMeasurement& tm,
     theCombinedPredictedState = propagator.propagate(theCombinedPredictedState, surface);
 
     if (!theCombinedPredictedState.isValid()) {
-      cout << "found invalid combinedpredictedstate after propagation" << endl;
+      edm::LogWarning("TrajectoryAtInvalidHit") << "found invalid combinedpredictedstate after propagation" << endl;
       return;
     }
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39351

#### PR description:

When using the DQM files produced by the `SiStripHitEfficiency` PCL in 2022 data, it was noticed that not all the modules that should be masked with the `SiStripQuality` are effectively masked within the DQM workflow, when comparing with the traditional calibrations-tree based workflow.
The issue has been traced down on the usage of the modules affected by `FEDErrors` in the  computation of the efficiency.
In PR https://github.com/cms-sw/cmssw/pull/38592 a mechanism to count the `FEDErrors` per module (via commit https://github.com/cms-sw/cmssw/pull/38592/commits/44999ca0086ab0a28320bc9c815c68bfa94c5aef ) was introduced since at the harvesting step level it's not possible to access directly at the per-event `FEDErrors` edm collection. This entailed populating a `TkHistoMap` with the occupancy of modules in FEDError per event, but this approach had two problems:
   * the filling of the map occurred in the `endJob` transition of `StripHitEfficiencyWorker` (that in a `DQMEDAnalyzer` is not run by the framework, resulting in empty maps cf https://tinyurl.com/2p5tdgqs)
   * secondly the information was never propagated to the `SiStripHitEfficiencyHarvester` such that those modules could be excluded from the list of inefficient ones.
   
This PR solves the issue by changing the `SiStripHitEffData` ancillary `struct` and its usage in the classes of the `SiStripHitEfficiency` PCL workflow. A somewhat arbitrary threshold of 75% of the events is used to flag modules that have problems with FEDErrors, permanently excluding them from the computation.

Finally I profit of this to transform a relic thread-unsafe `cout` to the message logging system in commit dee035970063c42e5c3d2838a34c7bd8d2d4041e.

#### PR validation:

Run the following commands:

```console
cmsDriver.py stepReAlCa -s ALCA:PromptCalibProdSiStripHitEff --conditions 124X_dataRun3_Express_v5 --scenario pp --data --era Run3 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100000 --dasquery='file dataset=/StreamExpress/Run2022D-SiStripCalMinBias-Express-v2/ALCARECO run=357898' --nThreads=4
``` 

followed by:

```console
cmsDriver.py stepHarvest -s ALCAHARVEST:SiStripHitEff --conditions 124X_dataRun3_Express_v5 --scenario pp --data --era Run3 --filein file:PromptCalibProdSiStripHitEff.root -n -1
```

with this branch and without it and observed the following features:
   - the `FEDErrorTkDetMaps` folder now contains full plots (as can be checked at https://tinyurl.com/2z7nrg9a after logging with ` ssh -NL 8060:localhost:8060 <USER>@lxplus724.cern.ch`)
   - some regions in TEC that were contributing to the inefficiency (because in FED Error) are now correctly excluded:
   
| Name     | Pre-fix | Post-fix |
| ---           | ---       |  ---       |
| Efficiency Map |  ![image](https://user-images.githubusercontent.com/5082376/189116210-0ae09a44-229d-4f62-aed4-67560532e47e.png) | ![image](https://user-images.githubusercontent.com/5082376/189123336-dc252a86-28dc-4a4f-b6fc-a5bfc026f20a.png) |
| Inefficient Modules       |   ![image](https://user-images.githubusercontent.com/5082376/189116635-ae39f26d-122a-42c9-a2d5-534a8a570e56.png) | ![image](https://user-images.githubusercontent.com/5082376/189116575-f2ee86ae-e510-402c-920d-864c1b182149.png) |
  
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/39351 to CMSSW_12_5_X (for data-taking purposes)