### PR TITLE
Simplify L1TPhase2MuonOffline and fix L1TRate_Offline and L1TStage2CaloLayer2Offline [CMSSW_12_5_X]

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
@@ -11,43 +11,23 @@
 // DataFormats
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
-#include "DataFormats/L1TMuonPhase2/interface/MuonStub.h"
 #include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
-#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 // FWCore
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // DQMServices
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-
-// HLTrigger
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-
-// Common tools
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TrackTransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 
 #include <memory>
 #include "TRegexp.h"
@@ -63,7 +43,7 @@ class GenMuonGMTPair;
 class L1TPhase2MuonOffline : public DQMEDAnalyzer {
 public:
   L1TPhase2MuonOffline(const edm::ParameterSet& ps);
-  ~L1TPhase2MuonOffline() override;
+  ~L1TPhase2MuonOffline() override = default;
 
   enum MuType { kSAMuon, kTkMuon, kNMuTypes };
   enum VarType { kPt, kEta, kPhi, kIso, kQual, kZ0, kD0, kNVarTypes };
@@ -105,13 +85,13 @@ private:
   const std::vector<MuType> muonTypes_;
   const std::vector<EffType> effTypes_;
   const std::vector<ResType> resTypes_;
-  const std::vector<VarType> varTypes_;
+  //  const std::vector<VarType> varTypes_;
   const std::vector<EtaRegion> etaRegions_;
   const std::vector<QualLevel> qualLevels_;
 
   // maps with histogram name bits
-  std::map<EffType, std::string> effNames_;
-  std::map<EffType, std::string> effLabels_;
+  //  std::map<EffType, std::string> effNames_;
+  //  std::map<EffType, std::string> effLabels_;
   std::map<ResType, std::string> resNames_;
   std::map<ResType, std::string> resLabels_;
   std::map<EtaRegion, std::string> etaNames_;
@@ -143,11 +123,11 @@ private:
   std::vector<GenMuonGMTPair> gmtTkMuonPairs_;
   std::vector<std::pair<int, QualLevel>> cuts_;
 
-  float lsb_pt = Phase2L1GMT::LSBpt;
-  float lsb_phi = Phase2L1GMT::LSBphi;
-  float lsb_eta = Phase2L1GMT::LSBeta;
-  float lsb_z0 = Phase2L1GMT::LSBSAz0;
-  float lsb_d0 = Phase2L1GMT::LSBSAd0;
+  const float lsb_pt = Phase2L1GMT::LSBpt;
+  const float lsb_phi = Phase2L1GMT::LSBphi;
+  const float lsb_eta = Phase2L1GMT::LSBeta;
+  const float lsb_z0 = Phase2L1GMT::LSBSAz0;
+  const float lsb_d0 = Phase2L1GMT::LSBSAd0;
 };
 
 //

--- a/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
@@ -139,7 +139,7 @@ public:
   GenMuonGMTPair(const GenMuonGMTPair& muongmtPair);
   ~GenMuonGMTPair(){};
 
-  float dR();
+  float dR2();
   float pt() const { return mu_->pt(); };
   float eta() const { return mu_->eta(); };
   float phi() const { return mu_->phi(); };

--- a/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
@@ -289,17 +289,15 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     for (const auto var : effTypes_) {
       auto varToFill = muIt.getVar(var);
       for (const auto& cut : cuts_) {
-        const auto gmtPtCut = cut.first;
         const auto q = cut.second;
-
         efficiencyDen_[kSAMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
-          continue;  // gmt muon does not exits
+          continue;  // there is not an assciated gmt muon
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
+        const auto gmtPtCut = cut.first;
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
           continue;  // pt requirement
-
         efficiencyNum_[kSAMuon][eta][q][var]->Fill(varToFill);
       }
     }
@@ -311,17 +309,15 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     for (const auto var : effTypes_) {
       auto varToFill = muIt.getVar(var);
       for (const auto& cut : cuts_) {
-        const auto gmtPtCut = cut.first;
         const auto q = cut.second;
-
         efficiencyDen_[kTkMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
-          continue;  // gmt muon does not exits
+          continue;  // there is not an assciated gmt muon
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
+        const auto gmtPtCut = cut.first;
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
           continue;  // pt requirement
-
         efficiencyNum_[kTkMuon][eta][q][var]->Fill(varToFill);
       }
     }
@@ -373,33 +369,27 @@ void L1TPhase2MuonOffline::matchMuonsToGen(std::vector<const reco::GenParticle*>
     edm::LogInfo("L1TPhase2MuonOffline") << "Looping on genmus: " << gen << endl;
     GenMuonGMTPair pairBestCand(&(*gen), nullptr);
     float dr2Best = maxGmtMuonDR_ * maxGmtMuonDR_;
-    bool matchFound = false;
     for (auto& muIt : *gmtSAMuon_) {
       GenMuonGMTPair pairTmpCand(&(*gen), &(muIt));
       float dr2Tmp = pairTmpCand.dR2();
       if (dr2Tmp < dr2Best) {
         dr2Best = dr2Tmp;
         pairBestCand = pairTmpCand;
-        matchFound = true;
       }
     }
-    if (matchFound)
-      gmtSAMuonPairs_.emplace_back(pairBestCand);
+    gmtSAMuonPairs_.emplace_back(pairBestCand);
 
     GenMuonGMTPair pairBestCand2(&(*gen), nullptr);
     dr2Best = maxGmtMuonDR_ * maxGmtMuonDR_;
-    matchFound = false;
     for (auto& tkmuIt : *gmtTkMuon_) {
       GenMuonGMTPair pairTmpCand(&(*gen), &(tkmuIt));
       float dr2Tmp = pairTmpCand.dR2();
       if (dr2Tmp < dr2Best) {
         dr2Best = dr2Tmp;
         pairBestCand2 = pairTmpCand;
-        matchFound = true;
       }
     }
-    if (matchFound)
-      gmtTkMuonPairs_.emplace_back(pairBestCand2);
+    gmtTkMuonPairs_.emplace_back(pairBestCand2);
   }
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::matchMuonsToGen() gmtSAMuons: "
                                        << gmtSAMuonPairs_.size() << endl;

--- a/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TPhase2MuonOffline.cc
@@ -175,9 +175,6 @@ void L1TPhase2MuonOffline::analyze(const Event& iEvent, const EventSetup& eventS
   }
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::analyze() N of genmus: " << genmus.size() << endl;
 
-  if (genmus.empty())
-    return;
-
   // Collect both muon collection:
   iEvent.getByToken(gmtMuonToken_, gmtSAMuon_);
   iEvent.getByToken(gmtTkMuonToken_, gmtTkMuon_);
@@ -187,6 +184,8 @@ void L1TPhase2MuonOffline::analyze(const Event& iEvent, const EventSetup& eventS
   fillControlHistos();
 
   // Match each muon to a gen muon, if possible.
+  if (genmus.empty())
+    return;
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::analyze() calling matchMuonsToGen() " << endl;
   matchMuonsToGen(genmus);
 
@@ -210,6 +209,7 @@ void L1TPhase2MuonOffline::bookControlHistos(DQMStore::IBooker& ibooker, MuType 
   controlHistos_[mutype][kZ0] = ibooker.book1D(muonNames_[mutype] + "Z0", "MuonZ0; Z_{0}", 50, 0, 50.0);
   controlHistos_[mutype][kD0] = ibooker.book1D(muonNames_[mutype] + "D0", "MuonD0; D_{0}", 50, 0, 200.);
 }
+
 void L1TPhase2MuonOffline::bookEfficiencyHistos(DQMStore::IBooker& ibooker, MuType mutype) {
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::bookEfficiencyHistos()" << endl;
 
@@ -240,6 +240,7 @@ void L1TPhase2MuonOffline::bookEfficiencyHistos(DQMStore::IBooker& ibooker, MuTy
     }
   }
 }
+
 void L1TPhase2MuonOffline::bookResolutionHistos(DQMStore::IBooker& ibooker, MuType mutype) {
   edm::LogInfo("L1TPhase2MuonOffline") << "L1TPhase2MuonOffline::bookResolutionHistos()" << endl;
 
@@ -281,6 +282,7 @@ void L1TPhase2MuonOffline::fillControlHistos() {
     controlHistos_[kTkMuon][kD0]->Fill(lsb_d0 * muIt.hwD0());
   }
 }
+
 void L1TPhase2MuonOffline::fillEfficiencyHistos() {
   for (const auto& muIt : gmtSAMuonPairs_) {
     auto eta = muIt.etaRegion();
@@ -315,7 +317,6 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
         efficiencyDen_[kTkMuon][eta][q][var]->Fill(varToFill);
         if (muIt.gmtPt() < 0)
           continue;  // gmt muon does not exits
-
         if (muIt.gmtQual() < q * 4)
           continue;  //quality requirements
         if (var != kEffPt && muIt.gmtPt() < gmtPtCut)
@@ -326,6 +327,7 @@ void L1TPhase2MuonOffline::fillEfficiencyHistos() {
     }
   }
 }
+
 void L1TPhase2MuonOffline::fillResolutionHistos() {
   for (const auto& muIt : gmtSAMuonPairs_) {
     if (muIt.gmtPt() < 0)
@@ -359,6 +361,7 @@ void L1TPhase2MuonOffline::fillResolutionHistos() {
     }
   }
 }
+
 //_____________________________________________________________________
 void L1TPhase2MuonOffline::matchMuonsToGen(std::vector<const reco::GenParticle*> genmus) {
   gmtSAMuonPairs_.clear();

--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -505,14 +505,14 @@ bool L1TRate_Offline::getXSexFitsPython(const edm::ParameterSet& ps) {
           foundFit = true;
           break;
         }
+      }
 
-        if (!foundFit) {
-          noError = false;
+      if (!foundFit) {
+        noError = false;
 
-          int eCount = m_ErrorMonitor->getTH1()->GetBinContent(WARNING_PY_MISSING_FIT);
-          eCount++;
-          m_ErrorMonitor->getTH1()->SetBinContent(WARNING_PY_MISSING_FIT, eCount);
-        }
+        int eCount = m_ErrorMonitor->getTH1()->GetBinContent(WARNING_PY_MISSING_FIT);
+        eCount++;
+        m_ErrorMonitor->getTH1()->SetBinContent(WARNING_PY_MISSING_FIT, eCount);
       }
     }
   }

--- a/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TStage2CaloLayer2Offline.cc
@@ -422,7 +422,6 @@ void L1TStage2CaloLayer2Offline::fillJets(edm::Event const& e, const unsigned in
       minDeltaR = currentDeltaR;
       closestL1Jet = *jet;
       foundMatch = true;
-      break;
     }
   }
   //	}


### PR DESCRIPTION
#### PR description:

This PR comprehensively backports #39283 and #39297 by cherry picking the very same commits from them.

At the end, this PR does not apply any bug fix (the one originally included in #39283 was lately removed with #3929 because it was not correct) but clean up and simplify largely the structure of the class.

Since Phase2 L1T production is expected to come with 12_5_X, and there are still quite several issues to fix in that code overall, I think it can be better to keep the versions of the code synchronized between the two release cycles, and therefore also merge this PR. Moreover, it allows some performance improvement for that code.

=== Later comment:

I realized that not even #39261 was backported to 12_5_X, and that was a real bug fix for the L1T Phase2 DQM. I cherry picked also that PR here, then.
#### PR validation:

It builds, and it was already tested in master

backport of #39283, #39297 and #39261
