### PR TITLE
[12_4_X] ECAL DQM GpuTask move enable flag checks to avoid unused collections from being consumed

### DIFF
--- a/DQM/EcalMonitorTasks/interface/GpuTask.h
+++ b/DQM/EcalMonitorTasks/interface/GpuTask.h
@@ -59,46 +59,46 @@ namespace ecaldqm {
   inline bool GpuTask::analyze(void const* collection_data, Collections collection) {
     switch (collection) {
       case kEBCpuDigi:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableDigi_)
           runOnCpuDigis(*static_cast<EBDigiCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEECpuDigi:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableDigi_)
           runOnCpuDigis(*static_cast<EEDigiCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEBGpuDigi:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableDigi_)
           runOnGpuDigis(*static_cast<EBDigiCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEEGpuDigi:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableDigi_)
           runOnGpuDigis(*static_cast<EEDigiCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEBCpuUncalibRecHit:
       case kEECpuUncalibRecHit:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableUncalib_)
           runOnCpuUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEBGpuUncalibRecHit:
       case kEEGpuUncalibRecHit:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableUncalib_)
           runOnGpuUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEBCpuRecHit:
       case kEECpuRecHit:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableRecHit_)
           runOnCpuRecHits(*static_cast<EcalRecHitCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;
       case kEBGpuRecHit:
       case kEEGpuRecHit:
-        if (collection_data && runGpuTask_)
+        if (collection_data && runGpuTask_ && enableRecHit_)
           runOnGpuRecHits(*static_cast<EcalRecHitCollection const*>(collection_data), collection);
         return runGpuTask_;
         break;

--- a/DQM/EcalMonitorTasks/src/GpuTask.cc
+++ b/DQM/EcalMonitorTasks/src/GpuTask.cc
@@ -163,10 +163,6 @@ namespace ecaldqm {
 
   template <typename DigiCollection>
   void GpuTask::runOnCpuDigis(DigiCollection const& cpuDigis, Collections collection) {
-    // Return if not enabled
-    if (!enableDigi_)
-      return;
-
     MESet& meDigiCpu(MEs_.at("DigiCpu"));
     MESet& meDigiCpuAmplitude(MEs_.at("DigiCpuAmplitude"));
 
@@ -200,10 +196,6 @@ namespace ecaldqm {
 
   template <typename DigiCollection>
   void GpuTask::runOnGpuDigis(DigiCollection const& gpuDigis, Collections collection) {
-    // Return if not enabled
-    if (!enableDigi_)
-      return;
-
     MESet& meDigiGpuCpu(MEs_.at("DigiGpuCpu"));
     MESet& meDigiGpuCpuAmplitude(MEs_.at("DigiGpuCpuAmplitude"));
 
@@ -279,10 +271,6 @@ namespace ecaldqm {
   }
 
   void GpuTask::runOnCpuUncalibRecHits(EcalUncalibratedRecHitCollection const& cpuHits, Collections collection) {
-    // Return if not enabled
-    if (!enableUncalib_)
-      return;
-
     MESet& meUncalibCpu(MEs_.at("UncalibCpu"));
     MESet& meUncalibCpuAmp(MEs_.at("UncalibCpuAmp"));
     MESet& meUncalibCpuAmpError(MEs_.at("UncalibCpuAmpError"));
@@ -335,10 +323,6 @@ namespace ecaldqm {
   }
 
   void GpuTask::runOnGpuUncalibRecHits(EcalUncalibratedRecHitCollection const& gpuHits, Collections collection) {
-    // Return if not enabled
-    if (!enableUncalib_)
-      return;
-
     MESet& meUncalibGpuCpu(MEs_.at("UncalibGpuCpu"));
     MESet& meUncalibGpuCpuAmp(MEs_.at("UncalibGpuCpuAmp"));
     MESet& meUncalibGpuCpuAmpError(MEs_.at("UncalibGpuCpuAmpError"));
@@ -477,10 +461,6 @@ namespace ecaldqm {
   }
 
   void GpuTask::runOnCpuRecHits(EcalRecHitCollection const& cpuHits, Collections collection) {
-    // Return if not enabled
-    if (!enableRecHit_)
-      return;
-
     MESet& meRecHitCpu(MEs_.at("RecHitCpu"));
     MESet& meRecHitCpuEnergy(MEs_.at("RecHitCpuEnergy"));
     MESet& meRecHitCpuTime(MEs_.at("RecHitCpuTime"));
@@ -509,10 +489,6 @@ namespace ecaldqm {
   }
 
   void GpuTask::runOnGpuRecHits(EcalRecHitCollection const& gpuHits, Collections collection) {
-    // Return if not enabled
-    if (!enableRecHit_)
-      return;
-
     MESet& meRecHitGpuCpu(MEs_.at("RecHitGpuCpu"));
     MESet& meRecHitGpuCpuEnergy(MEs_.at("RecHitGpuCpuEnergy"));
     MESet& meRecHitGpuCpuTime(MEs_.at("RecHitGpuCpuTime"));


### PR DESCRIPTION
#### PR description:

The `GpuTask` switches for toggling individual collections were not being checked before the collection tags were consumed. The initial check is done here:
https://github.com/cms-sw/cmssw/blob/e5ac8e997d5565e91eea5eaa91884a2b17a0fde4/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc#L46-L48
`task->analyze()` here needs to return `false` so the collections aren't consumed.

The `consumes` functions are then called inside this function:
https://github.com/cms-sw/cmssw/blob/e5ac8e997d5565e91eea5eaa91884a2b17a0fde4/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc#L64

The switches are moved to make sure that unused collections are not consumed if they are individually toggled.

#### PR validation:

Code compiles. The switches are now in the same spot as the "master" switch `runGpuTask` which we already know functions as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to use the fix in production. The PR to master is here:
- https://github.com/cms-sw/cmssw/pull/39371

The other backport is here:
- https://github.com/cms-sw/cmssw/pull/39372