### PR TITLE
Upgrade ConcurrentHadronizerFilter and ConcurrentGeneratorFilter to support concurrent runs

### DIFF
--- a/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
@@ -126,7 +126,7 @@ namespace edm {
     // The next two data members are thread safe and can be safely mutable because
     // they are only modified/read in globalBeginRun and globalBeginLuminosityBlock.
     mutable unsigned long long nGlobalBeginRuns_{0};
-    mutable unsigned long long nInitializedInGlobalLumi_{0};
+    mutable unsigned long long nInitializedInGlobalLumiAfterNewRun_{0};
   };
 
   //------------------------------------------------------------------------
@@ -321,10 +321,12 @@ namespace edm {
     while (useInLumi_.load() == nullptr) {
     }
 
-    if (nInitializedInGlobalLumi_ < nGlobalBeginRuns_) {
+    // streamEndRun also uses the hadronizer in the stream cache
+    // so we also need to wait for it to finish if there is a new run
+    if (nInitializedInGlobalLumiAfterNewRun_ < nGlobalBeginRuns_) {
       while (!streamEndRunComplete_.load()) {
       }
-      nInitializedInGlobalLumi_ = nGlobalBeginRuns_;
+      nInitializedInGlobalLumiAfterNewRun_ = nGlobalBeginRuns_;
     }
 
     auto lumiCache = std::make_shared<gen::GenLumiCache<HAD, DEC>>();

--- a/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentGeneratorFilter.h
@@ -6,6 +6,43 @@
 // the hadronizer type HAD to generate partons, hadronize them,
 // and decay the resulting particles, in the CMS framework.
 
+// Some additional notes related to concurrency:
+//
+//     This is an unusual module in CMSSW because its hadronizers are in stream caches
+//     (one hadronizer per stream cache). The Framework expects objects in a stream
+//     cache to only be used in stream transitions associated with that stream. That
+//     is how the Framework provides thread safety and avoids data races. In this module
+//     a global transition needs to use one of the hadronizers. The
+//     globalBeginLuminosityBlockProduce method uses one hadronizer to create the
+//     GenLumiInfoHeader which is put in the LuminosityBlock. This hadronizer must be
+//     initialized for the lumi before creating the product. This creates a problem because
+//     the global method might run concurrently with the stream methods. There is extra
+//     complexity in this module to deal with that unusual usage of an object in a stream cache.
+//
+//     The solution of this issue is conceptually simple. The module explicitly makes
+//     globalBeginLuminosityBlock wait until the previous lumi is finished on one stream
+//     and also until streamEndRun is finished on that stream if there was a new run. It
+//     avoids doing work in streamBeginRun. There is extra complexity in this module to
+//     ensure thread safety that normally does not appear in modules (usually this kind of
+//     thing is handled in the Framework).
+//
+//     Two alternative solutions were considered when designing this implementation and
+//     possibly someday we might reimplement this using one of them if we find this
+//     complexity hard to maintain.
+//
+//     1. We could make an extra hadronizer only for the global transition. We rejected
+//     that idea because that would require extra memory and CPU resources.
+//
+//     2. We could put the GenLumiInfoHeader product into the LuminosityBlock at the end
+//     global transition. We didn't know whether anything depended on the product being
+//     present in the begin transition or how difficult it would be to remove such a dependence
+//     so we also rejected that alternative.
+//
+//     There might be other ways to deal with this concurrency issue. This issue became
+//     important when run concurrency support was implemented in the Framework. That support
+//     allowed the streamBeginRun and streamEndRun transitions to run concurrently with other
+//     transitions even in the case where the number of concurrent runs was limited to 1.
+
 #ifndef GeneratorInterface_Core_ConcurrentGeneratorFilter_h
 #define GeneratorInterface_Core_ConcurrentGeneratorFilter_h
 

--- a/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
@@ -476,6 +476,8 @@ namespace edm {
     while (useInLumi_.load() == nullptr) {
     }
 
+    // streamEndRun also uses the hadronizer in the stream cache
+    // so we also need to wait for it to finish if there is a new run
     if (nInitializedWithLHERunInfo_ < nGlobalBeginRuns_) {
       while (!streamEndRunComplete_.load()) {
       }


### PR DESCRIPTION
#### PR description:

Upgrade the code in this module to support concurrent runs. When support for concurrent runs is added to the Framework in the near future, it will become possible for streamBeginRun and streamEndRun to run concurrently with other transitions. There is special code in this module which would be broken by this additional concurrency.

This should not affect the output of this module or its externally visible behavior. Results should be the same before and after this is merged.

@Dr15Jones and @makortel Could you take a look at this also? This is more a technical change related to Framework support of concurrency than a generator issue.

#### PR validation:

Given that this does not change the output or behavior of this module, I am relying on existing tests. The unit tests pass. I also ran existing tests under the debugger and with print statements manually added to verify things were working as expected.

If there are any additional tests that generator experts have available, it would be great if someone could run them to verify that I didn't inadvertently break something.
