### PR TITLE
AlCa Run3 Heavy Ion scenarios

### DIFF
--- a/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run3_pp_on_PbPb.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run3_pp_on_PbPb.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+_hcalnzsEra_Run3_pp_on_AA_
+
+Scenario supporting Run3 heavyIon collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Impl.hcalnzs import hcalnzs
+from Configuration.Eras.Era_Run3_pp_on_PbPb_cff import Run3_pp_on_PbPb
+
+class hcalnzsEra_Run3_pp_on_PbPb(hcalnzs):
+    def __init__(self):
+        hcalnzs.__init__(self)
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb
+        #keep post-era parts the same as in the default Run3 era
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+    """
+    _hcalnzsEra_Run3_pp_on_PbPb_
+
+    Implement configuration building for data processing for heavyIon Run3
+    collision data taking for Run3 hcal nzs workflow in pp_on_PbPb data taking
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_pp_on_PbPb_cff import Run3_pp_on_PbPb
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+    """
+    _ppEra_Run3_pp_on_PbPb_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3
+
+    """

--- a/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run3_pp_on_PbPb.py
+++ b/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run3_pp_on_PbPb.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+_trackingOnlyEra_Run3_pp_on_PbPb
+
+Scenario supporting Run3 heavyIon collisions and tracking only reconstruction for HP beamspot
+
+"""
+
+import os
+import sys
+
+from   Configuration.DataProcessing.Impl.trackingOnly import trackingOnly
+import FWCore.ParameterSet.Config as cms
+from   Configuration.Eras.Era_Run3_pp_on_PbPb_cff import Run3_pp_on_PbPb
+
+from   Configuration.DataProcessing.Impl.pp import pp
+
+class trackingOnlyEra_Run3_pp_on_PbPb(trackingOnly):
+    def __init__(self):
+        trackingOnly.__init__(self)
+        # tracking only RECO is sufficient, to run high performance BS at PCL;
+        # some dedicated customization are required, though: customisePostEra_Run2_2018_trackingOnly
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb
+        #keep post-era parts the same as in the default 2018 era
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_express_trackingOnly' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb' ]
+
+    """
+    _trackingOnlyEra_Run3_pp_on_PbPb
+
+    Implement configuration building for data processing for Run3 heavyIon
+    collision data taking for Run3, high performance beamspot in pp_on_PbPb data taking
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -95,6 +95,16 @@ def customisePostEra_Run3_express_trackingOnly(process):
     customisePostEra_Run2_2018_express_trackingOnly(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_express_trackingOnly(process):
+    #start with repeat of 2018
+    customisePostEra_Run2_2018_pp_on_AA_express_trackingOnly(process)
+    return process
+
+def customisePostEra_Run3_pp_on_PbPb(process):
+    customisePostEra_Run3(process)
+    return process
+
+
 ##############################################################################
 def customisePPData(process):
     #deprecated process= customiseCommon(process)

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
@@ -78,7 +78,7 @@ runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaLumiPixels_Run
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaLumiPixels_Run3 --lfn=/store/whatever --global-tag GLOBALTAG --skims AlCaPCCRandom,PromptCalibProdLumiPCC"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaLumiPixels_Run3 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdLumiPCC"
 
-declare -a arr=("trackingOnlyEra_Run2_2018" "trackingOnlyEra_Run2_2018_highBetaStar" "trackingOnlyEra_Run2_2018_pp_on_AA" "trackingOnlyEra_Run3")
+declare -a arr=("trackingOnlyEra_Run2_2018" "trackingOnlyEra_Run2_2018_highBetaStar" "trackingOnlyEra_Run2_2018_pp_on_AA" "trackingOnlyEra_Run3" "trackingOnlyEra_Run3_pp_on_PbPb")
 for scenario in "${arr[@]}"
 do
     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG  --lfn /store/whatever  --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP"

--- a/DQM/TrackingMonitorSource/python/PPonAATrackingOnly_custom.py
+++ b/DQM/TrackingMonitorSource/python/PPonAATrackingOnly_custom.py
@@ -6,13 +6,14 @@ Tools to customise the DQM offline configuration run on the dedicated express-li
 import FWCore.ParameterSet.Config as cms
 
 def customise_PPonAATrackingOnlyDQM(process):
-    if hasattr(process,'dqmofflineOnPAT_step'):
+    if hasattr(process,'dqmofflineOnPAT_step') or hasattr(process,'dqmoffline_step'):
         process=customise_DQMSequenceHiConformalTracks(process)
-    return process   
+    return process
 
 def customise_DQMSequenceHiConformalTracks(process):
-    process.TrackingDQMSourceTier0Common.remove(process.hiConformalPixelTracksQA)	
+    process.TrackingDQMSourceTier0Common.remove(process.hiConformalPixelTracksQA)
+    process.TrackingDQMSourceTier0MinBias.remove(process.hiConformalPixelTracksQA)
+    process.TrackingDQMSourceTier0.remove(process.hiConformalPixelTracksQA)
     return process
 
 
-	


### PR DESCRIPTION
#### PR description:

This is a tentative to integrate the AlCa related Run3 scenarios for the HI Run.

We have adapted three scenarios existing for Run2 2018 HI Run to create the corresponding Run3 ones, namely: 

- `trackingOnlyEra_Run3_pp_on_PbPb` (adapted from [trackingOnlyEra_Run2_2018_pp_on_AA.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/python/Impl/trackingOnlyEra_Run2_2018_pp_on_AA.py) ), 
- `ppEra_Run3_pp_on_PbPb` ( from [ppEra_Run2_2018_pp_on_AA.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/python/Impl/ppEra_Run2_2018_pp_on_AA.py) ) 
- `hcalnzsEra_Run3_pp_on_PbPb` (from [hcalnzsEra_Run2_2018_pp_on_AA.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/python/Impl/hcalnzsEra_Run2_2018_pp_on_AA.py) ).

Once these scenarios are integrated, the plan is to test them with a Tier0 replay on HI 2018 data.

In order to be able to run the Express processing without crashes, we had to introduce a new customization for the offline Tracking DQM, `PPonPbPbTrackingOnly_custom.py`. @mandrenguyen, please advise and feel free to include any interested parties. We would be specially interested in knowing how will the tracking be handled for the HI and if/how we should adapt the AlCa scenarios introduced here to take it into account.

#### PR validation:

We have used the tests below for validating each of the workflows. They all run without any crashes.

+=+=+=
**trackingOnlyEra_Run3_pp_on_PbPb** scenario:
+=+=+=

`python3 Configuration/DataProcessing/test/RunRepack.py --lfn file:/eos/cms/store/t0streamer/Data/HIExpressAlignment/000/327/527/run327527_ls0051_streamHIExpressAlignment_StorageManager.dat`

`python3 Configuration/DataProcessing/test/RunExpressProcessing.py --scenario trackingOnlyEra_Run3_pp_on_PbPb --global-tag 124X_dataRun3_Express_TIER0_REPLAY_Run2_v2 --lfn file:write_PrimDS1_RAW.root --alcarecos=TkAlMinBias+PromptCalibProdBeamSpotHP`

`python3 Configuration/DataProcessing/test/RunAlcaSkimming.py --scenario trackingOnlyEra_Run3_pp_on_PbPb --lfn file:output.root --global-tag 124X_dataRun3_Express_TIER0_REPLAY_Run2_v2 --skims TkAlMinBias,PromptCalibProdBeamSpotHP`

`python3 Configuration/DataProcessing/test//RunAlcaHarvesting.py --scenario trackingOnlyEra_Run3_pp_on_PbPb --lfn file:TkAlMinBias.root --dataset /A/B/C --global-tag 124X_dataRun3_Express_TIER0_REPLAY_Run2_v2 --alcapromptdataset=PromptCalibProdBeamSpotHP`

+=+=+=
**ppEra_Run3_pp_on_PbPb** scenario:
+=+=+=

`python3 Configuration/DataProcessing/test/RunRepack.py --lfn file:/eos/cms/store/t0streamer/Data/HIExpressAlignment/000/327/527/run327527_ls0051_streamHIExpressAlignment_StorageManager.dat`

`python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run3_pp_on_PbPb --reco --aod --dqmio --global-tag 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v2 --lfn file:write_PrimDS1_RAW.root --alcareco TkAlMinBias+SiStripCalMinBias`

+=+=+=
**hcalnzsEra_Run3_pp_on_PbPb** scenario:
+=+=+=

`python3 Configuration/DataProcessing/test/RunRepack.py --lfn file:/eos/cms/store/t0streamer/Data/HIExpressAlignment/000/327/527/run327527_ls0051_streamHIExpressAlignment_StorageManager.dat`

`python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario hcalnzsEra_Run3_pp_on_PbPb --reco --aod --dqmio --global-tag 124X_dataRun3_Prompt_TIER0_REPLAY_Run2_v2 --lfn file:write_PrimDS1_RAW.root --alcareco HcalCalMinBias`


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

If/when it decided to move forward with this, it should be backported to the HI data-taking release, 125X.
