### PR TITLE
[12_4_X] Modify RPC and GEM unpacker blocks in EMTF unpacker to match the new Run 3 format

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -127,6 +127,14 @@ namespace l1t {
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
         auto payload = block.payload();
 
+        // Run 3 has a different EMTF DAQ output format since August 26th
+        // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+        bool run3_DAQ_format =
+            (getAlgoVersion() >=
+             11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for GEMs - EY 13.09.22
+
+        int nTPs = run3_DAQ_format ? 2 : 1;
+
         // Check Format of Payload
         l1t::emtf::GEM GEM_;
         for (int err = 0; err < checkFormat(block); ++err) {
@@ -139,109 +147,144 @@ namespace l1t {
         uint16_t GEMc = payload[2];
         uint16_t GEMd = payload[3];
 
-        // res is a pointer to a collection of EMTFDaqOut class objects
-        // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
-        EMTFDaqOutCollection* res;
-        res = static_cast<EMTFCollections*>(coll)->getEMTFDaqOuts();
-        int iOut = res->size() - 1;
+        for (int i = 0; i < nTPs; i++) {
+          // res is a pointer to a collection of EMTFDaqOut class objects
+          // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
+          EMTFDaqOutCollection* res;
+          res = static_cast<EMTFCollections*>(coll)->getEMTFDaqOuts();
+          int iOut = res->size() - 1;
 
-        EMTFHitCollection* res_hit;
-        res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
-        EMTFHit Hit_;
+          EMTFHitCollection* res_hit;
+          res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
+          EMTFHit Hit_;
 
-        // TODO: Verify this is correct for GEM
-        GEMPadDigiClusterCollection* res_GEM;
-        res_GEM = static_cast<EMTFCollections*>(coll)->getEMTFGEMPadClusters();
+          // TODO: Verify this is correct for GEM
+          GEMPadDigiClusterCollection* res_GEM;
+          res_GEM = static_cast<EMTFCollections*>(coll)->getEMTFGEMPadClusters();
 
-        ////////////////////////////
-        // Unpack the GEM Data Record
-        ////////////////////////////
+          ////////////////////////////
+          // Unpack the GEM Data Record
+          ////////////////////////////
+          if (run3_DAQ_format) {  // Run 3 DAQ format has 2 TPs per block
+            if (i == 1) {
+              GEM_.set_pad(GetHexBits(GEMa, 0, 8));
+              GEM_.set_partition(GetHexBits(GEMa, 9, 11));
+              GEM_.set_cluster_size(GetHexBits(GEMa, 12, 14));
 
-        GEM_.set_pad(GetHexBits(GEMa, 0, 8));
-        GEM_.set_partition(GetHexBits(GEMa, 9, 11));
-        GEM_.set_cluster_size(GetHexBits(GEMa, 12, 14));
+              GEM_.set_tbin(GetHexBits(GEMb, 0, 2));
+              GEM_.set_vp(GetHexBits(GEMb, 3, 3));
+              GEM_.set_bc0(GetHexBits(GEMb, 7, 7));
+              GEM_.set_cluster_id(GetHexBits(GEMb, 8, 11));
+              GEM_.set_link(GetHexBits(GEMb, 12, 14));
+            } else if (i == 2) {
+              GEM_.set_pad(GetHexBits(GEMc, 0, 8));
+              GEM_.set_partition(GetHexBits(GEMc, 9, 11));
+              GEM_.set_cluster_size(GetHexBits(GEMc, 12, 14));
 
-        GEM_.set_cluster_id(GetHexBits(GEMb, 8, 11));
-        GEM_.set_link(GetHexBits(GEMb, 12, 14));
+              GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
+              GEM_.set_vp(GetHexBits(GEMd, 3, 3));
+              GEM_.set_bc0(GetHexBits(GEMd, 7, 7));
+              GEM_.set_cluster_id(GetHexBits(GEMd, 8, 11));
+              GEM_.set_link(GetHexBits(GEMd, 12, 14));
+            }
+          } else {
+            GEM_.set_pad(GetHexBits(GEMa, 0, 8));
+            GEM_.set_partition(GetHexBits(GEMa, 9, 11));
+            GEM_.set_cluster_size(GetHexBits(GEMa, 12, 14));
 
-        GEM_.set_gem_bxn(GetHexBits(GEMc, 0, 11));
-        GEM_.set_bc0(GetHexBits(GEMc, 14, 14));
+            GEM_.set_cluster_id(GetHexBits(GEMb, 8, 11));
+            GEM_.set_link(GetHexBits(GEMb, 12, 14));
 
-        GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
-        GEM_.set_vp(GetHexBits(GEMd, 3, 3));
+            GEM_.set_gem_bxn(GetHexBits(GEMc, 0, 11));
+            GEM_.set_bc0(GetHexBits(GEMc, 14, 14));
 
-        // GEM_.set_dataword(uint64_t dataword);
+            GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
+            GEM_.set_vp(GetHexBits(GEMd, 3, 3));
 
-        // Convert specially-encoded GEM quantities
-        // TODO: is the RPC or CSC method for this function better... - JS 06.07.20
-        int _station, _ring, _sector, _subsector, _neighbor, _layer;
-        convert_GEM_location(_station,
-                             _ring,
-                             _sector,
-                             _subsector,
-                             _neighbor,
-                             _layer,
-                             (res->at(iOut)).PtrEventHeader()->Sector(),
-                             GEM_.ClusterID(),
-                             GEM_.Link());
+            // GEM_.set_dataword(uint64_t dataword);
+          }
 
-        // Rotate by 20 deg to match GEM convention in CMSSW) // FIXME VERIFY
-        // int _sector_gem = (_subsector < 5) ? _sector : (_sector % 6) + 1; //
-        int _sector_gem = _sector;
-        // Rotate by 2 to match GEM convention in CMSSW (GEMDetId.h) // FIXME VERIFY
-        int _subsector_gem = ((_subsector + 1) % 6) + 1;
-        // Define chamber number) // FIXME VERIFY
-        int _chamber = (_sector_gem - 1) * 6 + _subsector_gem;
-        // Define CSC-like subsector) // FIXME WHY?? VERIFY
-        int _subsector_csc = (_station != 1) ? 0 : ((_chamber % 6 > 2) ? 1 : 2);
+          // Convert specially-encoded GEM quantities
+          // TODO: is the RPC or CSC method for this function better... - JS 06.07.20
+          int _station, _ring, _sector, _subsector, _neighbor, _layer;
+          convert_GEM_location(_station,
+                               _ring,
+                               _sector,
+                               _subsector,
+                               _neighbor,
+                               _layer,
+                               (res->at(iOut)).PtrEventHeader()->Sector(),
+                               GEM_.ClusterID(),
+                               GEM_.Link());
 
-        Hit_.set_station(_station);
-        Hit_.set_ring(_ring);
-        Hit_.set_sector(_sector);
-        Hit_.set_subsector(_subsector_csc);
-        Hit_.set_chamber(_chamber);
-        Hit_.set_neighbor(_neighbor);
+          // Rotate by 20 deg to match GEM convention in CMSSW) // FIXME VERIFY
+          // int _sector_gem = (_subsector < 5) ? _sector : (_sector % 6) + 1; //
+          int _sector_gem = _sector;
+          // Rotate by 2 to match GEM convention in CMSSW (GEMDetId.h) // FIXME VERIFY
+          int _subsector_gem = ((_subsector + 1) % 6) + 1;
+          // Define chamber number) // FIXME VERIFY
+          int _chamber = (_sector_gem - 1) * 6 + _subsector_gem;
+          // Define CSC-like subsector) // FIXME WHY?? VERIFY
+          int _subsector_csc = (_station != 1) ? 0 : ((_chamber % 6 > 2) ? 1 : 2);
 
-        // Fill the EMTFHit
-        ImportGEM(Hit_, GEM_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
+          Hit_.set_station(_station);
+          Hit_.set_ring(_ring);
+          Hit_.set_sector(_sector);
+          Hit_.set_subsector(_subsector_csc);
+          Hit_.set_chamber(_chamber);
+          Hit_.set_neighbor(_neighbor);
 
-        // Set the stub number for this hit
-        // Each chamber can send up to 2 stubs per BX // FIXME is this true for GEM, are stubs relevant for GEMs?
-        // Also count stubs in corresponding CSC chamber; GEM hit counting is on top of LCT counting
-        Hit_.set_stub_num(0);
-        // See if matching hit is already in event record
-        bool exact_duplicate = false;
-        for (auto const& iHit : *res_hit) {
-          if (Hit_.BX() == iHit.BX() && Hit_.Endcap() == iHit.Endcap() && Hit_.Station() == iHit.Station() &&
-              Hit_.Chamber() == iHit.Chamber()) {
-            if ((iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
-                (iHit.Is_GEM() == 1)) {  // Copied from RPC, but GEM has no ring 2/3...
-              if (Hit_.Neighbor() == iHit.Neighbor()) {
-                Hit_.set_stub_num(Hit_.Stub_num() + 1);
-                if (iHit.Is_GEM() == 1 && iHit.Ring() == Hit_.Ring() && iHit.Roll() == Hit_.Roll() &&
-                    iHit.Pad() == Hit_.Pad()) {
-                  exact_duplicate = true;
+          // Fill the EMTFHit
+          ImportGEM(Hit_, GEM_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
+
+          // Set the stub number for this hit
+          // Each chamber can send up to 2 stubs per BX // FIXME is this true for GEM, are stubs relevant for GEMs?
+          // Also count stubs in corresponding CSC chamber; GEM hit counting is on top of LCT counting
+          Hit_.set_stub_num(0);
+          // See if matching hit is already in event record
+          bool exact_duplicate = false;
+          for (auto const& iHit : *res_hit) {
+            if (Hit_.BX() == iHit.BX() && Hit_.Endcap() == iHit.Endcap() && Hit_.Station() == iHit.Station() &&
+                Hit_.Chamber() == iHit.Chamber()) {
+              if ((iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
+                  (iHit.Is_GEM() == 1)) {  // Copied from RPC, but GEM has no ring 2/3...
+                if (Hit_.Neighbor() == iHit.Neighbor()) {
+                  Hit_.set_stub_num(Hit_.Stub_num() + 1);
+                  if (iHit.Is_GEM() == 1 && iHit.Ring() == Hit_.Ring() && iHit.Roll() == Hit_.Roll() &&
+                      iHit.Pad() == Hit_.Pad()) {
+                    exact_duplicate = true;
+                  }
                 }
               }
             }
+          }  // End loop: for (auto const & iHit : *res_hit)
+
+          // Reject TPs with out-of-range BX values. This needs to be adjusted if we increase l1a_window parameter in EMTF config - EY 03.08.2022
+          if (Hit_.BX() > 3 or Hit_.BX() < -3) {
+            edm::LogWarning("L1T|EMTF") << "EMTF unpacked  GEM digis with out-of-range BX! BX " << Hit_.BX()
+                                        << ", endcap " << Hit_.Endcap() << ", station " << Hit_.Station()
+                                        << ", neighbor " << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber "
+                                        << Hit_.Chamber() << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad()
+                                        << std::endl;
+            return true;
           }
-        }  // End loop: for (auto const & iHit : *res_hit)
 
-        // TODO: Re-enable once GEM TP data format is fixed
-        // if (exact_duplicate)
-        //   edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate GEM digis: BX " << Hit_.BX() << ", endcap "
-        //                               << Hit_.Endcap() << ", station " << Hit_.Station() << ", neighbor "
-        //                               << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
-        //                               << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
+          // TODO: Re-enable once GEM TP data format is fixed
+          // if (exact_duplicate)
+          //   edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate GEM digis: BX " << Hit_.BX() << ", endcap "
+          //                               << Hit_.Endcap() << ", station " << Hit_.Station() << ", neighbor "
+          //                               << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber " << Hit_.Chamber()
+          //                               << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
 
-        (res->at(iOut)).push_GEM(GEM_);
-        if (!exact_duplicate)
-          res_hit->push_back(Hit_);
+          (res->at(iOut)).push_GEM(GEM_);
+          if (!exact_duplicate)
+            res_hit->push_back(Hit_);
 
-        if (!exact_duplicate)
-          res_GEM->insertDigi(Hit_.GEM_DetId(), Hit_.CreateGEMPadDigiCluster());
+          if (!exact_duplicate)
+            res_GEM->insertDigi(Hit_.GEM_DetId(), Hit_.CreateGEMPadDigiCluster());
 
-        // Finished with unpacking one GEM Data Record
+          // Finished with unpacking one GEM Data Record
+        }
         return true;
 
       }  // End bool GEMBlockUnpacker::unpack

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -55,15 +55,6 @@ namespace l1t {
         uint16_t RPCc = payload[2];
         uint16_t RPCd = payload[3];
 
-        // Run 3 has a different EMTF DAQ output format since August 26th
-        // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
-        // bool run3_DAQ_format =
-        //     (getAlgoVersion() >= 11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for GEMs - EY 13.09.22
-
-        // std::vector<int> format_bits{0, 0, 1, 0};
-        // if (run3_DAQ_format)
-        //   format_bits
-
         // Check Format
         if (GetHexBits(RPCa, 15, 15) != 0) {
           errors += 1;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -55,6 +55,15 @@ namespace l1t {
         uint16_t RPCc = payload[2];
         uint16_t RPCd = payload[3];
 
+        // Run 3 has a different EMTF DAQ output format since August 26th
+        // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+        // bool run3_DAQ_format =
+        //     (getAlgoVersion() >= 11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for GEMs - EY 13.09.22
+
+        // std::vector<int> format_bits{0, 0, 1, 0};
+        // if (run3_DAQ_format)
+        //   format_bits
+
         // Check Format
         if (GetHexBits(RPCa, 15, 15) != 0) {
           errors += 1;
@@ -121,6 +130,14 @@ namespace l1t {
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
         auto payload = block.payload();
 
+        // Run 3 has a different EMTF DAQ output format since August 26th
+        // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+        bool run3_DAQ_format =
+            (getAlgoVersion() >=
+             11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for RPCs - EY 13.09.22
+
+        int nTPs = run3_DAQ_format ? 2 : 1;
+
         // Check Format of Payload
         l1t::emtf::RPC RPC_;
         for (int err = 0; err < checkFormat(block); err++)
@@ -132,109 +149,145 @@ namespace l1t {
         uint16_t RPCc = payload[2];
         uint16_t RPCd = payload[3];
 
-        // res is a pointer to a collection of EMTFDaqOut class objects
-        // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
-        EMTFDaqOutCollection* res;
-        res = static_cast<EMTFCollections*>(coll)->getEMTFDaqOuts();
-        int iOut = res->size() - 1;
+        for (int i = 0; i < nTPs; i++) {
+          // res is a pointer to a collection of EMTFDaqOut class objects
+          // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
+          EMTFDaqOutCollection* res;
+          res = static_cast<EMTFCollections*>(coll)->getEMTFDaqOuts();
+          int iOut = res->size() - 1;
 
-        EMTFHitCollection* res_hit;
-        res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
-        EMTFHit Hit_;
+          EMTFHitCollection* res_hit;
+          res_hit = static_cast<EMTFCollections*>(coll)->getEMTFHits();
+          EMTFHit Hit_;
 
-        CPPFDigiCollection* res_CPPF;
-        res_CPPF = static_cast<EMTFCollections*>(coll)->getEMTFCPPFs();
+          CPPFDigiCollection* res_CPPF;
+          res_CPPF = static_cast<EMTFCollections*>(coll)->getEMTFCPPFs();
 
-        ////////////////////////////
-        // Unpack the RPC Data Record
-        ////////////////////////////
+          ////////////////////////////
+          // Unpack the RPC Data Record
+          ////////////////////////////
 
-        RPC_.set_phi(GetHexBits(RPCa, 0, 10));
+          if (run3_DAQ_format) {  // Run 3 DAQ format has 2 TPs per block
+            if (i == 0) {
+              RPC_.set_phi(GetHexBits(RPCa, 0, 10));
+              RPC_.set_word(GetHexBits(RPCa, 11, 12));
+              RPC_.set_frame(GetHexBits(RPCa, 13, 14));
 
-        RPC_.set_theta(GetHexBits(RPCb, 0, 4));
-        RPC_.set_word(GetHexBits(RPCb, 8, 9));
-        RPC_.set_frame(GetHexBits(RPCb, 10, 11));
-        RPC_.set_link(GetHexBits(RPCb, 12, 14));  // Link index (0 - 6); link number runs 1 - 7
+              RPC_.set_tbin(GetHexBits(RPCb, 0, 2));
+              RPC_.set_vp(GetHexBits(RPCb, 3, 3));
+              RPC_.set_theta(GetHexBits(RPCb, 4, 8));
+              RPC_.set_bc0(GetHexBits(RPCb, 9, 9));
+              RPC_.set_link(GetHexBits(RPCb, 12, 14));  // Link index (0 - 6); link number runs 1 - 7
+            } else if (i == 2) {
+              RPC_.set_phi(GetHexBits(RPCc, 0, 10));
+              RPC_.set_word(GetHexBits(RPCc, 11, 12));
+              RPC_.set_frame(GetHexBits(RPCc, 13, 14));
 
-        RPC_.set_rpc_bxn(GetHexBits(RPCc, 0, 11));
-        RPC_.set_bc0(GetHexBits(RPCc, 14, 14));
+              RPC_.set_tbin(GetHexBits(RPCd, 0, 2));
+              RPC_.set_vp(GetHexBits(RPCd, 3, 3));
+              RPC_.set_theta(GetHexBits(RPCd, 4, 8));
+              RPC_.set_bc0(GetHexBits(RPCd, 9, 9));
+              RPC_.set_link(GetHexBits(RPCd, 12, 14));  // Link index (0 - 6); link number runs 1 - 7
+            }
+          } else {  // Run 2 DAQ format
+            RPC_.set_phi(GetHexBits(RPCa, 0, 10));
 
-        RPC_.set_tbin(GetHexBits(RPCd, 0, 2));
-        RPC_.set_vp(GetHexBits(RPCd, 3, 3));
+            RPC_.set_theta(GetHexBits(RPCb, 0, 4));
+            RPC_.set_word(GetHexBits(RPCb, 8, 9));
+            RPC_.set_frame(GetHexBits(RPCb, 10, 11));
+            RPC_.set_link(GetHexBits(RPCb, 12, 14));  // Link index (0 - 6); link number runs 1 - 7
 
-        // RPC_.set_dataword            ( uint64_t dataword);
+            RPC_.set_rpc_bxn(GetHexBits(RPCc, 0, 11));
+            RPC_.set_bc0(GetHexBits(RPCc, 14, 14));
 
-        // Convert specially-encoded RPC quantities
-        int _station, _ring, _sector, _subsector, _neighbor, _segment;
-        convert_RPC_location(_station,
-                             _ring,
-                             _sector,
-                             _subsector,
-                             _neighbor,
-                             _segment,
-                             (res->at(iOut)).PtrEventHeader()->Sector(),
-                             RPC_.Frame(),
-                             RPC_.Word(),
-                             RPC_.Link());
+            RPC_.set_tbin(GetHexBits(RPCd, 0, 2));
+            RPC_.set_vp(GetHexBits(RPCd, 3, 3));
 
-        // Rotate by 20 deg to match RPC convention in CMSSW
-        int _sector_rpc = (_subsector < 5) ? _sector : (_sector % 6) + 1;
-        // Rotate by 2 to match RPC convention in CMSSW (RPCDetId.h)
-        int _subsector_rpc = ((_subsector + 1) % 6) + 1;
-        // Define chamber number
-        int _chamber = (_sector_rpc - 1) * 6 + _subsector_rpc;
-        // Define CSC-like subsector
-        int _subsector_csc = (_station != 1) ? 0 : ((_chamber % 6 > 2) ? 1 : 2);
+            // RPC_.set_dataword            ( uint64_t dataword);
+          }
 
-        Hit_.set_station(_station);
-        Hit_.set_ring(_ring);
-        Hit_.set_sector(_sector);
-        Hit_.set_subsector(_subsector_csc);
-        Hit_.set_sector_RPC(_sector_rpc);
-        Hit_.set_subsector_RPC(_subsector_rpc);
-        Hit_.set_chamber(_chamber);
-        Hit_.set_neighbor(_neighbor);
-        Hit_.set_pc_segment(_segment);
-        Hit_.set_fs_segment(_segment);
-        Hit_.set_bt_segment(_segment);
+          // Convert specially-encoded RPC quantities
+          int _station, _ring, _sector, _subsector, _neighbor, _segment;
+          convert_RPC_location(_station,
+                               _ring,
+                               _sector,
+                               _subsector,
+                               _neighbor,
+                               _segment,
+                               (res->at(iOut)).PtrEventHeader()->Sector(),
+                               RPC_.Frame(),
+                               RPC_.Word(),
+                               RPC_.Link());
 
-        // Fill the EMTFHit
-        ImportRPC(Hit_, RPC_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
+          // Rotate by 20 deg to match RPC convention in CMSSW
+          int _sector_rpc = (_subsector < 5) ? _sector : (_sector % 6) + 1;
+          // Rotate by 2 to match RPC convention in CMSSW (RPCDetId.h)
+          int _subsector_rpc = ((_subsector + 1) % 6) + 1;
+          // Define chamber number
+          int _chamber = (_sector_rpc - 1) * 6 + _subsector_rpc;
+          // Define CSC-like subsector
+          int _subsector_csc = (_station != 1) ? 0 : ((_chamber % 6 > 2) ? 1 : 2);
 
-        // Set the stub number for this hit
-        // Each chamber can send up to 2 stubs per BX
-        // Also count stubs in corresponding CSC chamber; RPC hit counting is on top of LCT counting
-        Hit_.set_stub_num(0);
-        // See if matching hit is already in event record
-        bool exact_duplicate = false;
-        for (auto const& iHit : *res_hit) {
-          if (Hit_.BX() == iHit.BX() && Hit_.Endcap() == iHit.Endcap() && Hit_.Station() == iHit.Station() &&
-              Hit_.Chamber() == iHit.Chamber()) {
-            if ((iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
-                (iHit.Is_RPC() == 1)) {  // RPC rings 2 and 3 both map to CSC ring 2
-              if (Hit_.Neighbor() == iHit.Neighbor()) {
-                Hit_.set_stub_num(Hit_.Stub_num() + 1);
-                if (iHit.Is_RPC() == 1 && iHit.Ring() == Hit_.Ring() && iHit.Theta_fp() == Hit_.Theta_fp() &&
-                    iHit.Phi_fp() == Hit_.Phi_fp()) {
-                  exact_duplicate = true;
+          Hit_.set_station(_station);
+          Hit_.set_ring(_ring);
+          Hit_.set_sector(_sector);
+          Hit_.set_subsector(_subsector_csc);
+          Hit_.set_sector_RPC(_sector_rpc);
+          Hit_.set_subsector_RPC(_subsector_rpc);
+          Hit_.set_chamber(_chamber);
+          Hit_.set_neighbor(_neighbor);
+          Hit_.set_pc_segment(_segment);
+          Hit_.set_fs_segment(_segment);
+          Hit_.set_bt_segment(_segment);
+
+          // Fill the EMTFHit
+          ImportRPC(Hit_, RPC_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
+
+          // Set the stub number for this hit
+          // Each chamber can send up to 2 stubs per BX
+          // Also count stubs in corresponding CSC chamber; RPC hit counting is on top of LCT counting
+          Hit_.set_stub_num(0);
+          // See if matching hit is already in event record
+          bool exact_duplicate = false;
+          for (auto const& iHit : *res_hit) {
+            if (Hit_.BX() == iHit.BX() && Hit_.Endcap() == iHit.Endcap() && Hit_.Station() == iHit.Station() &&
+                Hit_.Chamber() == iHit.Chamber()) {
+              if ((iHit.Is_CSC() == 1 && iHit.Ring() == 2) ||
+                  (iHit.Is_RPC() == 1)) {  // RPC rings 2 and 3 both map to CSC ring 2
+                if (Hit_.Neighbor() == iHit.Neighbor()) {
+                  Hit_.set_stub_num(Hit_.Stub_num() + 1);
+                  if (iHit.Is_RPC() == 1 && iHit.Ring() == Hit_.Ring() && iHit.Theta_fp() == Hit_.Theta_fp() &&
+                      iHit.Phi_fp() == Hit_.Phi_fp()) {
+                    exact_duplicate = true;
+                  }
                 }
               }
             }
+          }  // End loop: for (auto const & iHit : *res_hit)
+
+          // Reject TPs with out-of-range BX values. This needs to be adjusted if we increase l1a_window parameter in EMTF config - EY 03.08.2022
+          if (Hit_.BX() > 3 or Hit_.BX() < -3) {
+            edm::LogWarning("L1T|EMTF") << "EMTF unpacked CPPF digis with out-of-range BX! BX " << Hit_.BX()
+                                        << ", endcap " << Hit_.Endcap() << ", station " << Hit_.Station() << ", sector "
+                                        << Hit_.Sector() << ", neighbor " << Hit_.Neighbor() << ", ring " << Hit_.Ring()
+                                        << ", chamber " << Hit_.Chamber() << ", theta " << Hit_.Theta_fp() / 4
+                                        << ", phi " << Hit_.Phi_fp() / 4 << std::endl;
+            return true;
           }
-        }  // End loop: for (auto const & iHit : *res_hit)
 
-        if (exact_duplicate)
-          edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate CPPF digis: BX " << Hit_.BX() << ", endcap "
-                                      << Hit_.Endcap() << ", station " << Hit_.Station() << ", sector " << Hit_.Sector()
-                                      << ", neighbor " << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber "
-                                      << Hit_.Chamber() << ", theta " << Hit_.Theta_fp() / 4 << ", phi "
-                                      << Hit_.Phi_fp() / 4 << std::endl;
+          if (exact_duplicate)
+            edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate CPPF digis: BX " << Hit_.BX() << ", endcap "
+                                        << Hit_.Endcap() << ", station " << Hit_.Station() << ", sector "
+                                        << Hit_.Sector() << ", neighbor " << Hit_.Neighbor() << ", ring " << Hit_.Ring()
+                                        << ", chamber " << Hit_.Chamber() << ", theta " << Hit_.Theta_fp() / 4
+                                        << ", phi " << Hit_.Phi_fp() / 4 << std::endl;
 
-        (res->at(iOut)).push_RPC(RPC_);
-        if (!exact_duplicate)
-          res_hit->push_back(Hit_);
-        if (!exact_duplicate)
-          res_CPPF->push_back(Hit_.CreateCPPFDigi());
+          (res->at(iOut)).push_RPC(RPC_);
+          if (!exact_duplicate)
+            res_hit->push_back(Hit_);
+          if (!exact_duplicate)
+            res_CPPF->push_back(Hit_.CreateCPPFDigi());
+        }
 
         // Finished with unpacking one RPC Data Record
         return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -71,9 +71,11 @@ namespace l1t {
       auto emtf_trailers_unp =
           UnpackerFactory::get()->make("stage2::emtf::TrailersBlockUnpacker");  // Unpack "Event Record Trailer"
 
-      // Currently only the CSC LCT unpacking and SP unpacking need the firmware version, can add others as needed - AWB 09.04.18 + EY 01.02.22
+      // All unpacker units apart from header and trailer now requires algo version - EY 14.09.22
       emtf_me_unp->setAlgoVersion(fw);
       emtf_sp_unp->setAlgoVersion(fw);
+      emtf_rpc_unp->setAlgoVersion(fw);
+      emtf_gem_unp->setAlgoVersion(fw);
 
       // Index of res is block->header().getID(), matching block_patterns_ in src/Block.cc
       res[l1t::mtf7::EvHd] = emtf_headers_unp;


### PR DESCRIPTION
#### PR description:

This is a backport of https://github.com/cms-sw/cmssw/pull/39388.

This PR implements the necessary changes to unpack the new DAQ format that is implemented at P5 a couple of weeks ago. Our tests show that the new DAQ format significantly reduces EMTF dead time at very high PU scenarios. According to the new format 2 RPC (GEM) TPs are packed into 1 RPC (GEM) data block, thus reducing the total number of blocks in EMTF DAQ stream.

Modified `EMTFBlockGEM.cc`, `EMTFBlockRPC.cc` to add functionality to create 2 TPs per block depending on the firmware version. Changes in `EMTFSetup.cc` are made to pass firmware version to the RPC and GEM block unpackers.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Tested with unpacking data collected last week and running `l1tstage2_dqm_sourceclient-live_cfg.py` to confirm the DQM plots are as expected. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/39388.

It would be good to have this PR in the collisions runs to fix the EMTF DQM plots for RPC/GEM. This is important for promptly checking quality/timing of EMTF inputs during collisions.

The changes in EMTF unpacker shouldn't affect other workflows, as it's basically only used by DQM workflows and L1T experts. 
 

