### PR TITLE
Extend alternative module type loading to EventSetup

### DIFF
--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -46,7 +46,7 @@ namespace edm {
       //~ComponentFactory();
 
       typedef ComponentMakerBase<T> Maker;
-      typedef std::map<std::string, std::shared_ptr<Maker> > MakerMap;
+      typedef std::map<std::string, std::shared_ptr<Maker>> MakerMap;
       typedef typename T::base_type base_type;
       // ---------- const member functions ---------------------
       std::shared_ptr<base_type> addTo(EventSetupsController& esController,
@@ -76,7 +76,7 @@ namespace edm {
           //cerr << "Factory: created the worker" << endl;
 
           std::pair<typename MakerMap::iterator, bool> ret =
-              makers_.insert(std::pair<std::string, std::shared_ptr<Maker> >(modtype, wm));
+              makers_.insert(std::pair<std::string, std::shared_ptr<Maker>>(modtype, wm));
 
           if (ret.second == false) {
             Exception::throwThis(errors::Configuration, "Maker Factory map insert failed");

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -32,6 +32,7 @@ namespace edm {
   class EventSetupImpl;
   class EventSetupRecordIntervalFinder;
   class IOVSyncValue;
+  class ModuleTypeResolverBase;
   class ParameterSet;
 
   namespace eventsetup {
@@ -89,6 +90,7 @@ namespace edm {
       void forceCacheClear();
 
       void checkESProducerSharing(
+          ModuleTypeResolverBase const* resolver,
           EventSetupProvider& precedingESProvider,
           std::set<ParameterSetIDHolder>& sharingCheckDone,
           std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers,

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -34,6 +34,7 @@ namespace edm {
   class EventSetupRecordIntervalFinder;
   class ParameterSet;
   class IOVSyncValue;
+  class ModuleTypeResolverBase;
   class WaitingTaskHolder;
   class WaitingTaskList;
 
@@ -79,6 +80,7 @@ namespace edm {
     class EventSetupsController {
     public:
       EventSetupsController();
+      explicit EventSetupsController(ModuleTypeResolverBase const* resolver);
 
       EventSetupsController(EventSetupsController const&) = delete;
       EventSetupsController const& operator=(EventSetupsController const&) = delete;
@@ -182,6 +184,8 @@ namespace edm {
       // to the component.
       std::multimap<ParameterSetID, ESProducerInfo> esproducers_;
       std::multimap<ParameterSetID, ESSourceInfo> essources_;
+
+      ModuleTypeResolverBase const* typeResolver_ = nullptr;
 
       bool hasNonconcurrentFinder_ = false;
       bool mustFinishConfiguration_ = true;

--- a/FWCore/Framework/interface/resolveMaker.h
+++ b/FWCore/Framework/interface/resolveMaker.h
@@ -7,12 +7,10 @@
 #include <memory>
 #include <string>
 
-namespace edm {
-  namespace detail {
-    void annotateResolverMakerExceptionAndRethrow(cms::Exception& except,
-                                                  std::string const& modtype,
-                                                  ModuleTypeResolverBase const* resolver);
-  }
+namespace edm::detail {
+  void annotateResolverMakerExceptionAndRethrow(cms::Exception& except,
+                                                std::string const& modtype,
+                                                ModuleTypeResolverBase const* resolver);
 
   template <typename TFactory>
   auto resolveMaker(std::string const& moduleType, ModuleTypeResolverBase const* resolver) {
@@ -37,6 +35,6 @@ namespace edm {
     }
     return TFactory::get()->create(moduleType);
   }
-}  // namespace edm
+}  // namespace edm::detail
 
 #endif

--- a/FWCore/Framework/interface/resolveMaker.h
+++ b/FWCore/Framework/interface/resolveMaker.h
@@ -1,0 +1,42 @@
+#ifndef FWCore_Framework_interface_resolveMaker_h
+#define FWCore_Framework_interface_resolveMaker_h
+
+#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+#include <string>
+
+namespace edm {
+  namespace detail {
+    void annotateResolverMakerExceptionAndRethrow(cms::Exception& except,
+                                                  std::string const& modtype,
+                                                  ModuleTypeResolverBase const* resolver);
+  }
+
+  template <typename TFactory>
+  auto resolveMaker(std::string const& moduleType, ModuleTypeResolverBase const* resolver) {
+    if (resolver) {
+      auto index = resolver->kInitialIndex;
+      auto newType = moduleType;
+      do {
+        auto [ttype, tindex] = resolver->resolveType(std::move(newType), index);
+        newType = std::move(ttype);
+        index = tindex;
+        auto m = TFactory::get()->tryToCreate(newType);
+        if (m) {
+          return m;
+        }
+      } while (index != resolver->kLastIndex);
+      try {
+        //failed to find a plugin
+        return TFactory::get()->create(moduleType);
+      } catch (cms::Exception& iExcept) {
+        detail::annotateResolverMakerExceptionAndRethrow(iExcept, moduleType, resolver);
+      }
+    }
+    return TFactory::get()->create(moduleType);
+  }
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -227,7 +227,8 @@ namespace edm {
       ParameterSet* providerPSet = params.getPSetForUpdate(looperName);
       validateLooper(*providerPSet);
       providerPSet->registerIt();
-      vLooper = eventsetup::LooperFactory::get()->addTo(esController, cp, *providerPSet);
+      // Unlikely we would ever need the ModuleTypeResolver in Looper
+      vLooper = eventsetup::LooperFactory::get()->addTo(esController, cp, *providerPSet, nullptr);
     }
     return vLooper;
   }

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -394,6 +394,7 @@ namespace edm {
     }
 
     void EventSetupProvider::checkESProducerSharing(
+        ModuleTypeResolverBase const* resolver,
         EventSetupProvider& precedingESProvider,
         std::set<ParameterSetIDHolder>& sharingCheckDone,
         std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers,
@@ -530,7 +531,7 @@ namespace edm {
         } else {
           if (esController.isLastMatch(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_)) {
             ParameterSet const& pset = *esController.getESProducerPSet(psetID, subProcessIndex_);
-            ModuleFactory::get()->addTo(esController, *this, pset, true);
+            ModuleFactory::get()->addTo(esController, *this, pset, resolver, true);
           }
         }
       }

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -91,7 +91,10 @@ namespace edm {
     }
 
     // ---------------------------------------------------------------
-    void fillEventSetupProvider(EventSetupsController& esController, EventSetupProvider& cp, ParameterSet& params) {
+    void fillEventSetupProvider(ModuleTypeResolverBase const* resolver,
+                                EventSetupsController& esController,
+                                EventSetupProvider& cp,
+                                ParameterSet& params) {
       std::vector<std::string> providers = params.getParameter<std::vector<std::string> >("@all_esmodules");
 
       for (std::vector<std::string>::iterator itName = providers.begin(), itNameEnd = providers.end();
@@ -100,7 +103,7 @@ namespace edm {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
         validateEventSetupParameters(*providerPSet);
         providerPSet->registerIt();
-        ModuleFactory::get()->addTo(esController, cp, *providerPSet);
+        ModuleFactory::get()->addTo(esController, cp, *providerPSet, resolver);
       }
 
       std::vector<std::string> sources = params.getParameter<std::vector<std::string> >("@all_essources");
@@ -110,7 +113,7 @@ namespace edm {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
         validateEventSetupParameters(*providerPSet);
         providerPSet->registerIt();
-        SourceFactory::get()->addTo(esController, cp, *providerPSet);
+        SourceFactory::get()->addTo(esController, cp, *providerPSet, resolver);
       }
     }
 

--- a/FWCore/Framework/src/EventSetupProviderMaker.h
+++ b/FWCore/Framework/src/EventSetupProviderMaker.h
@@ -7,6 +7,7 @@
 // forward declarations
 namespace edm {
   class ActivityRegistry;
+  class ModuleTypeResolverBase;
   class ParameterSet;
   namespace eventsetup {
     class EventSetupProvider;
@@ -16,7 +17,10 @@ namespace edm {
                                                                unsigned subProcessIndex,
                                                                ActivityRegistry*);
 
-    void fillEventSetupProvider(EventSetupsController& esController, EventSetupProvider& cp, ParameterSet& params);
+    void fillEventSetupProvider(ModuleTypeResolverBase const* resolver,
+                                EventSetupsController& esController,
+                                EventSetupProvider& cp,
+                                ParameterSet& params);
 
     void validateEventSetupParameters(ParameterSet& pset);
   }  // namespace eventsetup

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -33,6 +33,7 @@ namespace edm {
   namespace eventsetup {
 
     EventSetupsController::EventSetupsController() {}
+    EventSetupsController::EventSetupsController(ModuleTypeResolverBase const* resolver) : typeResolver_(resolver) {}
 
     void EventSetupsController::endIOVsAsync(edm::WaitingTaskHolder iEndTask) {
       for (auto& eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
@@ -54,7 +55,7 @@ namespace edm {
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this
       // EventSetupsController and in the EventSetupProvider
-      fillEventSetupProvider(*this, *returnValue, iPSet);
+      fillEventSetupProvider(typeResolver_, *this, *returnValue, iPSet);
 
       numberOfConcurrentIOVs_.readConfigurationParameters(eventSetupPset, maxConcurrentIOVs, dumpOptions);
 
@@ -381,7 +382,9 @@ namespace edm {
         // preceding process will be the top level process and the others
         // SubProcess's)
         for (auto precedingESProvider = providers_.begin(); precedingESProvider != esProvider; ++precedingESProvider) {
-          (*esProvider)->checkESProducerSharing(**precedingESProvider, sharingCheckDone, referencedESProducers, *this);
+          (*esProvider)
+              ->checkESProducerSharing(
+                  typeResolver_, **precedingESProvider, sharingCheckDone, referencedESProducers, *this);
         }
 
         (*esProvider)->resetRecordToProxyPointers();

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/src/Factory.h"
 #include "FWCore/Framework/interface/maker/MakerPluginFactory.h"
 #include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Framework/interface/resolveMaker.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
@@ -24,64 +25,13 @@ namespace edm {
 
   Factory const* Factory::get() { return &singleInstance_; }
 
-  static void annotateExceptionAndRethrow(cms::Exception& except,
-                                          std::string const& modtype,
-                                          ModuleTypeResolverBase const* resolver) {
-    if (not resolver) {
-      throw except;
-    }
-    //if needed, create list of alternative types that were tried
-    std::string alternativeTypes;
-    auto index = resolver->kInitialIndex;
-    auto newType = modtype;
-    int tries = 0;
-    do {
-      ++tries;
-      if (not alternativeTypes.empty()) {
-        alternativeTypes.append(", ");
-      }
-      auto [ttype, tindex] = resolver->resolveType(std::move(newType), index);
-      newType = std::move(ttype);
-      index = tindex;
-      alternativeTypes.append(newType);
-    } while (index != resolver->kLastIndex);
-    if (tries == 1 and alternativeTypes == modtype) {
-      throw except;
-    }
-    alternativeTypes.insert(0, "These alternative types were tried: ");
-    except.addAdditionalInfo(alternativeTypes);
-    throw except;
-  }
-
   Maker* Factory::findMaker(const MakeModuleParams& p, ModuleTypeResolverBase const* resolver) const {
     std::string modtype = p.pset_->getParameter<std::string>("@module_type");
     FDEBUG(1) << "Factory: module_type = " << modtype << std::endl;
     MakerMap::iterator it = makers_.find(modtype);
 
     if (it == makers_.end()) {
-      auto make = [](auto resolver, const auto& modtype) {
-        if (resolver) {
-          auto index = resolver->kInitialIndex;
-          auto newType = modtype;
-          do {
-            auto [ttype, tindex] = resolver->resolveType(std::move(newType), index);
-            newType = std::move(ttype);
-            index = tindex;
-            auto m = MakerPluginFactory::get()->tryToCreate(newType);
-            if (m) {
-              return m;
-            }
-          } while (index != resolver->kLastIndex);
-          try {
-            //failed to find a plugin
-            return MakerPluginFactory::get()->create(modtype);
-          } catch (cms::Exception& iExcept) {
-            annotateExceptionAndRethrow(iExcept, modtype, resolver);
-          }
-        }
-        return MakerPluginFactory::get()->create(modtype);
-      };
-      std::unique_ptr<Maker> wm = make(resolver, modtype);
+      std::unique_ptr<Maker> wm = resolveMaker<MakerPluginFactory>(modtype, resolver);
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
 
       std::pair<MakerMap::iterator, bool> ret = makers_.insert(std::pair<std::string, Maker*>(modtype, wm.get()));

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -25,7 +25,6 @@ namespace edm {
   Factory const* Factory::get() { return &singleInstance_; }
 
   static void annotateExceptionAndRethrow(cms::Exception& except,
-                                          const MakeModuleParams& p,
                                           std::string const& modtype,
                                           ModuleTypeResolverBase const* resolver) {
     if (not resolver) {
@@ -60,7 +59,7 @@ namespace edm {
     MakerMap::iterator it = makers_.find(modtype);
 
     if (it == makers_.end()) {
-      auto make = [](auto resolver, const auto& modtype, auto const& p) {
+      auto make = [](auto resolver, const auto& modtype) {
         if (resolver) {
           auto index = resolver->kInitialIndex;
           auto newType = modtype;
@@ -77,12 +76,12 @@ namespace edm {
             //failed to find a plugin
             return MakerPluginFactory::get()->create(modtype);
           } catch (cms::Exception& iExcept) {
-            annotateExceptionAndRethrow(iExcept, p, modtype, resolver);
+            annotateExceptionAndRethrow(iExcept, modtype, resolver);
           }
         }
         return MakerPluginFactory::get()->create(modtype);
       };
-      std::unique_ptr<Maker> wm = make(resolver, modtype, p);
+      std::unique_ptr<Maker> wm = make(resolver, modtype);
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
 
       std::pair<MakerMap::iterator, bool> ret = makers_.insert(std::pair<std::string, Maker*>(modtype, wm.get()));

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -31,7 +31,7 @@ namespace edm {
     MakerMap::iterator it = makers_.find(modtype);
 
     if (it == makers_.end()) {
-      std::unique_ptr<Maker> wm = resolveMaker<MakerPluginFactory>(modtype, resolver);
+      std::unique_ptr<Maker> wm = detail::resolveMaker<MakerPluginFactory>(modtype, resolver);
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
 
       std::pair<MakerMap::iterator, bool> ret = makers_.insert(std::pair<std::string, Maker*>(modtype, wm.get()));

--- a/FWCore/Framework/src/resolverMaker.cc
+++ b/FWCore/Framework/src/resolverMaker.cc
@@ -1,0 +1,32 @@
+#include "FWCore/Framework/interface/resolveMaker.h"
+
+namespace edm::detail {
+  void annotateResolverMakerExceptionAndRethrow(cms::Exception& except,
+                                                std::string const& modtype,
+                                                ModuleTypeResolverBase const* resolver) {
+    if (not resolver) {
+      throw except;
+    }
+    //if needed, create list of alternative types that were tried
+    std::string alternativeTypes;
+    auto index = resolver->kInitialIndex;
+    auto newType = modtype;
+    int tries = 0;
+    do {
+      ++tries;
+      if (not alternativeTypes.empty()) {
+        alternativeTypes.append(", ");
+      }
+      auto [ttype, tindex] = resolver->resolveType(std::move(newType), index);
+      newType = std::move(ttype);
+      index = tindex;
+      alternativeTypes.append(newType);
+    } while (index != resolver->kLastIndex);
+    if (tries == 1 and alternativeTypes == modtype) {
+      throw except;
+    }
+    alternativeTypes.insert(0, "These alternative types were tried: ");
+    except.addAdditionalInfo(alternativeTypes);
+    throw except;
+  }
+}  // namespace edm::detail

--- a/FWCore/Framework/test/TestTypeResolvers.h
+++ b/FWCore/Framework/test/TestTypeResolvers.h
@@ -1,0 +1,38 @@
+#ifndef FWCore_Framework_test_TestTypeResolvers_h
+#define FWCore_Framework_test_TestTypeResolvers_h
+
+#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+
+#include <string>
+#include <utility>
+
+namespace edm::test {
+  class SimpleTestTypeResolver : public edm::ModuleTypeResolverBase {
+  public:
+    SimpleTestTypeResolver() = default;
+    std::pair<std::string, int> resolveType(std::string basename, int index) const final {
+      return {basename, kLastIndex};
+    }
+  };
+
+  class ComplexTestTypeResolver : public edm::ModuleTypeResolverBase {
+  public:
+    ComplexTestTypeResolver() = default;
+    std::pair<std::string, int> resolveType(std::string basename, int index) const final {
+      constexpr auto kGeneric = "generic::";
+      constexpr auto kOther = "edm::test::other::";
+      constexpr auto kCPU = "edm::test::cpu::";
+      if (index != kInitialIndex and index != kLastIndex) {
+        basename.replace(basename.find(kOther), strlen(kOther), kCPU);
+        return {basename, kLastIndex};
+      }
+      if (index == kInitialIndex and basename.find(kGeneric) != std::string::npos) {
+        basename.replace(basename.find(kGeneric), strlen(kGeneric), kOther);
+        return {basename, kInitialIndex + 1};
+      }
+      return {basename, kLastIndex};
+    }
+  };
+}  // namespace edm::test
+
+#endif

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -24,16 +24,94 @@
 #include "FWCore/Framework/interface/EventSetupsController.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
+#include "DummyFinder.h"
+#include "DummyProxyProvider.h"
+#include "TestTypeResolvers.h"
+
 using namespace edm::eventsetup;
 
 namespace {
   edm::ActivityRegistry activityRegistry;
 }
 
+namespace edm::test {
+  namespace other {
+    class LoadableDummyFinderA : public DummyFinder {
+    public:
+      LoadableDummyFinderA(const edm::ParameterSet&) { ++count_; }
+      static int count_;
+    };
+    int LoadableDummyFinderA::count_ = 0;
+
+    class LoadableDummyProviderA : public edm::eventsetup::test::DummyProxyProvider {
+    public:
+      LoadableDummyProviderA(const edm::ParameterSet& iPSet)
+          : DummyProxyProvider(edm::eventsetup::test::DummyData(iPSet.getUntrackedParameter<int>("value", 1))) {
+        ++count_;
+      }
+      static int count_;
+    };
+    int LoadableDummyProviderA::count_ = 0;
+
+    class LoadableDummyESSourceA : public edm::eventsetup::test::DummyProxyProvider, public DummyFinder {
+    public:
+      LoadableDummyESSourceA(const edm::ParameterSet& iPSet)
+          : DummyProxyProvider(edm::eventsetup::test::DummyData(iPSet.getUntrackedParameter<int>("value", 2))) {
+        setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 0, 0)), edm::IOVSyncValue::endOfTime()));
+        ++count_;
+      }
+      static int count_;
+    };
+    int LoadableDummyESSourceA::count_ = 0;
+  }  // namespace other
+  namespace cpu {
+    class LoadableDummyFinderA : public DummyFinder {
+    public:
+      LoadableDummyFinderA(const edm::ParameterSet&) { ++count_; }
+      static int count_;
+    };
+    int LoadableDummyFinderA::count_ = 0;
+
+    class LoadableDummyProviderA : public edm::eventsetup::test::DummyProxyProvider {
+    public:
+      LoadableDummyProviderA(const edm::ParameterSet& iPSet)
+          : DummyProxyProvider(edm::eventsetup::test::DummyData(iPSet.getUntrackedParameter<int>("value", 1))) {
+        ++count_;
+      }
+      static int count_;
+    };
+    int LoadableDummyProviderA::count_ = 0;
+    using LoadableDummyProviderB = LoadableDummyProviderA;
+
+    class LoadableDummyESSourceA : public edm::eventsetup::test::DummyProxyProvider, public DummyFinder {
+    public:
+      LoadableDummyESSourceA(const edm::ParameterSet& iPSet)
+          : DummyProxyProvider(edm::eventsetup::test::DummyData(iPSet.getUntrackedParameter<int>("value", 2))) {
+        setInterval(edm::ValidityInterval(edm::IOVSyncValue(edm::EventID(1, 0, 0)), edm::IOVSyncValue::endOfTime()));
+        ++count_;
+      }
+      static int count_;
+    };
+    int LoadableDummyESSourceA::count_ = 0;
+    using LoadableDummyESSourceB = LoadableDummyESSourceA;
+  }  // namespace cpu
+}  // namespace edm::test
+
+DEFINE_FWK_EVENTSETUP_SOURCE(edm::test::other::LoadableDummyFinderA);
+DEFINE_FWK_EVENTSETUP_SOURCE(edm::test::cpu::LoadableDummyFinderA);
+DEFINE_FWK_EVENTSETUP_SOURCE(edm::test::other::LoadableDummyESSourceA);
+DEFINE_FWK_EVENTSETUP_SOURCE(edm::test::cpu::LoadableDummyESSourceA);
+DEFINE_FWK_EVENTSETUP_SOURCE(edm::test::cpu::LoadableDummyESSourceB);
+DEFINE_FWK_EVENTSETUP_MODULE(edm::test::other::LoadableDummyProviderA);
+DEFINE_FWK_EVENTSETUP_MODULE(edm::test::cpu::LoadableDummyProviderA);
+DEFINE_FWK_EVENTSETUP_MODULE(edm::test::cpu::LoadableDummyProviderB);
+
 class testEventsetupplugin : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testEventsetupplugin);
 
   CPPUNIT_TEST(finderTest);
+  CPPUNIT_TEST(simpleResolverTest);
+  CPPUNIT_TEST(complexResolverTest);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -42,6 +120,8 @@ public:
   void tearDown() {}
 
   void finderTest();
+  void simpleResolverTest();
+  void complexResolverTest();
 };
 
 ///registration of the test so that the runner can find it
@@ -63,12 +143,13 @@ void testEventsetupplugin::finderTest()
   doInit();
   EventSetupsController esController;
   EventSetupProvider provider(&activityRegistry);
+  edm::ModuleTypeResolverBase const* resolver = nullptr;
 
   edm::ParameterSet dummyFinderPSet;
   dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
   dummyFinderPSet.addParameter("@module_label", std::string(""));
   dummyFinderPSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet);
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, resolver);
 
   ComponentDescription descFinder("LoadableDummyFinder", "", ComponentDescription::unknownID(), true);
   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
@@ -79,7 +160,7 @@ void testEventsetupplugin::finderTest()
   dummyProviderPSet.addParameter("@module_type", std::string("LoadableDummyProvider"));
   dummyProviderPSet.addParameter("@module_label", std::string(""));
   dummyProviderPSet.registerIt();
-  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet);
+  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, resolver);
 
   ComponentDescription desc("LoadableDummyProvider", "", ComponentDescription::unknownID(), false);
   descriptions = provider.proxyProviderDescriptions();
@@ -90,10 +171,142 @@ void testEventsetupplugin::finderTest()
   dummySourcePSet.addParameter("@module_type", std::string("LoadableDummyESSource"));
   dummySourcePSet.addParameter("@module_label", std::string(""));
   dummySourcePSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummySourcePSet);
+  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, resolver);
 
   ComponentDescription descSource("LoadableDummyESSource", "", ComponentDescription::unknownID(), true);
   descriptions = provider.proxyProviderDescriptions();
   CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
   CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
+}
+
+void testEventsetupplugin::simpleResolverTest() {
+  doInit();
+
+  edm::test::SimpleTestTypeResolver resolver;
+  EventSetupsController esController(&resolver);
+  EventSetupProvider provider(&activityRegistry);
+
+  edm::ParameterSet dummyFinderPSet;
+  dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
+  dummyFinderPSet.addParameter("@module_label", std::string(""));
+  dummyFinderPSet.registerIt();
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolver);
+
+  ComponentDescription descFinder("LoadableDummyFinder", "", ComponentDescription::unknownID(), true);
+  std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
+  //should not be found since not a provider
+  CPPUNIT_ASSERT(descriptions.find(descFinder) == descriptions.end());
+
+  edm::ParameterSet dummyProviderPSet;
+  dummyProviderPSet.addParameter("@module_type", std::string("LoadableDummyProvider"));
+  dummyProviderPSet.addParameter("@module_label", std::string(""));
+  dummyProviderPSet.registerIt();
+  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+
+  ComponentDescription desc("LoadableDummyProvider", "", ComponentDescription::unknownID(), false);
+  descriptions = provider.proxyProviderDescriptions();
+  CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
+  CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
+
+  edm::ParameterSet dummySourcePSet;
+  dummySourcePSet.addParameter("@module_type", std::string("LoadableDummyESSource"));
+  dummySourcePSet.addParameter("@module_label", std::string(""));
+  dummySourcePSet.registerIt();
+  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+
+  ComponentDescription descSource("LoadableDummyESSource", "", ComponentDescription::unknownID(), true);
+  descriptions = provider.proxyProviderDescriptions();
+  CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
+  CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
+}
+
+void testEventsetupplugin::complexResolverTest() {
+  doInit();
+
+  edm::test::ComplexTestTypeResolver resolver;
+  EventSetupsController esController(&resolver);
+  EventSetupProvider provider(&activityRegistry);
+
+  edm::ParameterSet dummyFinderPSet;
+  dummyFinderPSet.addParameter("@module_type", std::string("generic::LoadableDummyFinderA"));
+  dummyFinderPSet.addParameter("@module_label", std::string(""));
+  dummyFinderPSet.registerIt();
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolver);
+
+  ComponentDescription descFinder("generic::LoadableDummyFinderA", "", ComponentDescription::unknownID(), true);
+  std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
+  //should not be found since not a provider
+  CPPUNIT_ASSERT(descriptions.find(descFinder) == descriptions.end());
+
+  // find other
+  {
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyProviderA::count_ == 0);
+    CPPUNIT_ASSERT(edm::test::other::LoadableDummyProviderA::count_ == 0);
+    edm::ParameterSet dummyProviderPSet;
+    dummyProviderPSet.addParameter("@module_type", std::string("generic::LoadableDummyProviderA"));
+    dummyProviderPSet.addParameter("@module_label", std::string(""));
+    dummyProviderPSet.registerIt();
+    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+
+    ComponentDescription desc("generic::LoadableDummyProviderA", "", ComponentDescription::unknownID(), false);
+    descriptions = provider.proxyProviderDescriptions();
+    CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
+    CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyProviderA::count_ == 0);
+    CPPUNIT_ASSERT(edm::test::other::LoadableDummyProviderA::count_ == 1);
+    edm::test::other::LoadableDummyProviderA::count_ = 0;
+  }
+
+  // find cpu
+  {
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyProviderB::count_ == 0);
+    edm::ParameterSet dummyProviderPSet;
+    dummyProviderPSet.addParameter("@module_type", std::string("generic::LoadableDummyProviderB"));
+    dummyProviderPSet.addParameter("@module_label", std::string(""));
+    dummyProviderPSet.registerIt();
+    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+
+    ComponentDescription desc("generic::LoadableDummyProviderB", "", ComponentDescription::unknownID(), false);
+    descriptions = provider.proxyProviderDescriptions();
+    CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
+    CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyProviderB::count_ == 1);
+    edm::test::cpu::LoadableDummyProviderB::count_ = 0;
+  }
+
+  // find other
+  {
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyESSourceA::count_ == 0);
+    CPPUNIT_ASSERT(edm::test::other::LoadableDummyESSourceA::count_ == 0);
+    edm::ParameterSet dummySourcePSet;
+    dummySourcePSet.addParameter("@module_type", std::string("generic::LoadableDummyESSourceA"));
+    dummySourcePSet.addParameter("@module_label", std::string(""));
+    dummySourcePSet.registerIt();
+    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+
+    ComponentDescription descSource("generic::LoadableDummyESSourceA", "", ComponentDescription::unknownID(), true);
+    descriptions = provider.proxyProviderDescriptions();
+    CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
+    CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyESSourceA::count_ == 0);
+    CPPUNIT_ASSERT(edm::test::other::LoadableDummyESSourceA::count_ == 1);
+    edm::test::other::LoadableDummyESSourceA::count_ = 0;
+  }
+
+  // find cpu
+  {
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyESSourceB::count_ == 0);
+    edm::ParameterSet dummySourcePSet;
+    dummySourcePSet.addParameter("@module_type", std::string("generic::LoadableDummyESSourceB"));
+    dummySourcePSet.addParameter("@module_label", std::string(""));
+    dummySourcePSet.registerIt();
+    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+
+    ComponentDescription descSource("generic::LoadableDummyESSourceB", "", ComponentDescription::unknownID(), true);
+    descriptions = provider.proxyProviderDescriptions();
+    CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
+    CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);
+    CPPUNIT_ASSERT(edm::test::cpu::LoadableDummyESSourceB::count_ == 1);
+    edm::test::cpu::LoadableDummyESSourceB::count_ = 0;
+  }
 }

--- a/FWCore/Framework/test/test_catch2_Factory.cc
+++ b/FWCore/Framework/test/test_catch2_Factory.cc
@@ -1,7 +1,6 @@
 #include "catch.hpp"
 
 #include "FWCore/Framework/src/Factory.h"
-#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
@@ -9,36 +8,11 @@
 #include "FWCore/PluginManager/interface/standard.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 
+#include "TestTypeResolvers.h"
+
 #include <iostream>
 
 namespace edm::test {
-  class SimpleTestTypeResolver : public edm::ModuleTypeResolverBase {
-  public:
-    SimpleTestTypeResolver() = default;
-    std::pair<std::string, int> resolveType(std::string basename, int index) const final {
-      return {basename, kLastIndex};
-    }
-  };
-
-  class ComplexTestTypeResolver : public edm::ModuleTypeResolverBase {
-  public:
-    ComplexTestTypeResolver() = default;
-    std::pair<std::string, int> resolveType(std::string basename, int index) const final {
-      constexpr auto kGeneric = "generic::";
-      constexpr auto kOther = "edm::test::other::";
-      constexpr auto kCPU = "edm::test::cpu::";
-      if (index != kInitialIndex and index != kLastIndex) {
-        basename.replace(basename.find(kOther), strlen(kOther), kCPU);
-        return {basename, kLastIndex};
-      }
-      if (index == kInitialIndex and basename.find(kGeneric) != std::string::npos) {
-        basename.replace(basename.find(kGeneric), strlen(kGeneric), kOther);
-        return {basename, kInitialIndex + 1};
-      }
-      return {basename, kLastIndex};
-    }
-  };
-
   class FactoryTestAProd : public edm::global::EDProducer<> {
   public:
     explicit FactoryTestAProd(edm::ParameterSet const&) { ++count_; }


### PR DESCRIPTION
#### PR description:

This PR extends the alternative module type loading, that was introduced in #37731 for EDModules, to EventSetup sources and modules. I'm not sure if this feature would be really useful for ESSources, because for GPUs the use case is really about transferring data from existing ESProducts on existing Records, but it was tiny bit simpler to allow the mechanism also for ESSources. For Loopers the mechanism is explicitly disabled.

Resolves https://github.com/makortel/framework/issues/435

#### PR validation:

Framework unit tests run.