### PR TITLE
ECAL - Switch off online ECAL RecHit GPU vs. CPU monitoring - 12_4_X

### DIFF
--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -88,11 +88,6 @@ process.ecalMonitorTask.collectionTags.EBCpuUncalibRecHit = cms.untracked.InputT
 process.ecalMonitorTask.collectionTags.EECpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitLegacy", "EcalUncalibRecHitsEE")
 process.ecalMonitorTask.collectionTags.EBGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEB")
 process.ecalMonitorTask.collectionTags.EEGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEE")
-# RecHit GPU collection tags are temp placeholder
-process.ecalMonitorTask.collectionTags.EBCpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEB")
-process.ecalMonitorTask.collectionTags.EECpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEE")
-process.ecalMonitorTask.collectionTags.EBGpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEB")
-process.ecalMonitorTask.collectionTags.EEGpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEE")
 
 ### Paths ###
 

--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -67,6 +67,7 @@ process.dqmSaverPB.tag = 'EcalGPU'
 process.dqmSaverPB.runNumber = options.runNumber
 
 process.ecalGpuTask.params.runGpuTask = True
+process.ecalGpuTask.params.enableRecHit = False
 process.ecalMonitorTask.workers = ['GpuTask']
 process.ecalMonitorTask.workerParameters = cms.untracked.PSet(GpuTask = process.ecalGpuTask)
 process.ecalMonitorTask.verbosity = 0
@@ -88,10 +89,10 @@ process.ecalMonitorTask.collectionTags.EECpuUncalibRecHit = cms.untracked.InputT
 process.ecalMonitorTask.collectionTags.EBGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEB")
 process.ecalMonitorTask.collectionTags.EEGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEE")
 # RecHit GPU collection tags are temp placeholder
-process.ecalMonitorTask.collectionTags.EBCpuRecHit = cms.untracked.InputTag("hltEcalRecHitWithoutTPs", "EcalRecHitsEB")
-process.ecalMonitorTask.collectionTags.EECpuRecHit = cms.untracked.InputTag("hltEcalRecHitWithoutTPs", "EcalRecHitsEE")
-process.ecalMonitorTask.collectionTags.EBGpuRecHit = cms.untracked.InputTag("hltEcalRecHitWithTPs", "EcalRecHitsEB")
-process.ecalMonitorTask.collectionTags.EEGpuRecHit = cms.untracked.InputTag("hltEcalRecHitWithTPs", "EcalRecHitsEE")
+process.ecalMonitorTask.collectionTags.EBCpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEB")
+process.ecalMonitorTask.collectionTags.EECpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEE")
+process.ecalMonitorTask.collectionTags.EBGpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEB")
+process.ecalMonitorTask.collectionTags.EEGpuRecHit = cms.untracked.InputTag("hltEcalRecHit", "EcalRecHitsEE")
 
 ### Paths ###
 


### PR DESCRIPTION
#### PR description:

Switches off the online ECAL RecHit GPU vs. CPU comparisons since the RecHit module is identical in both options.
~~Until PR #39373 is merged the collections are still consumed so the same existing RecHit collection is used for CPU and GPU inputs.~~
Requires PR #39373 to be merged since the RecHit collection tags have been removed from the configuration.

#### PR validation:

Configured and ran cmsRun with the configuration but no events were processed since the source is a stream that was not available. Should be tested on the playback system as well.

Backport of #39393