### PR TITLE
Fix the `NVProfilerService` and `ProcessCallGraph` [12.4.x]

### DIFF
--- a/HLTrigger/Timer/interface/ProcessCallGraph.h
+++ b/HLTrigger/Timer/interface/ProcessCallGraph.h
@@ -120,7 +120,7 @@ public:
 
 public:
   // default c'tor
-  ProcessCallGraph();
+  ProcessCallGraph() = default;
 
   // to be called from preSourceConstruction(...)
   void preSourceConstruction(edm::ModuleDescription const &);
@@ -172,7 +172,7 @@ private:
   GraphType graph_;
 
   // module id of the Source
-  unsigned int source_;
+  unsigned int source_ = edm::ModuleDescription::invalidID();
 
   // map each (sub)process name to a "process id"
   std::unordered_map<std::string, unsigned int> process_id_;

--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -29,8 +29,6 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "HLTrigger/Timer/interface/ProcessCallGraph.h"
 
-ProcessCallGraph::ProcessCallGraph() = default;
-
 // adaptor to use range-based for loops with boost::graph edges(...) and vertices(...) functions
 template <typename I>
 struct iterator_pair_as_a_range : std::pair<I, I> {
@@ -46,9 +44,10 @@ iterator_pair_as_a_range<I> make_range(std::pair<I, I> p) {
   return iterator_pair_as_a_range<I>(p);
 }
 
-// FIXME
-//   - check that the Source has not already been added
 void ProcessCallGraph::preSourceConstruction(edm::ModuleDescription const& module) {
+  // check that the Source has not already been added
+  assert(source_ == edm::ModuleDescription::invalidID());
+
   // keep track of the Source module id
   source_ = module.id();
 
@@ -58,12 +57,14 @@ void ProcessCallGraph::preSourceConstruction(edm::ModuleDescription const& modul
 }
 
 // FIXME
-//  - check that the Source has already been added
 //  - check that all module ids are valid (e.g. subprocesses are not being added in
 //    the wrong order)
 void ProcessCallGraph::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
                                    edm::ProcessContext const& context) {
   unsigned int pid = registerProcess(context);
+
+  // check that the Source has already been added
+  assert(source_ != edm::ModuleDescription::invalidID());
 
   // work on the full graph (for the main process) or a subgraph (for a subprocess)
   GraphType& graph = context.isSubProcess() ? graph_.create_subgraph() : graph_.root();

--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HLTrigger/Timer"/>
 
   <library file="*.cc" name="HeterogeneousCoreCUDAServicesPlugins">
     <flags EDM_PLUGIN="1"/>

--- a/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/NVProfilerService.cc
@@ -41,6 +41,7 @@
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HLTrigger/Timer/interface/ProcessCallGraph.h"
 
 using namespace std::string_literals;
 
@@ -287,6 +288,9 @@ private:
     return highlight(label) ? nvtxLightAmber : nvtxLightGreen;
   }
 
+  // build a complete representation of the modules in the whole job
+  ProcessCallGraph callgraph_;
+
   std::vector<std::string> highlightModules_;
   const bool showModulePrefetching_;
   const bool skipFirstEvent_;
@@ -502,7 +506,7 @@ void NVProfilerService::preallocate(edm::service::SystemBounds const& bounds) {
   std::stringstream out;
   out << "preallocate: " << bounds.maxNumberOfConcurrentRuns() << " concurrent runs, "
       << bounds.maxNumberOfConcurrentLuminosityBlocks() << " luminosity sections, " << bounds.maxNumberOfStreams()
-      << " streams\nrunning on" << bounds.maxNumberOfThreads() << " threads";
+      << " streams\nrunning on " << bounds.maxNumberOfThreads() << " threads";
   nvtxDomainMark(global_domain_, out.str().c_str());
 
   auto concurrentStreams = bounds.maxNumberOfStreams();
@@ -524,12 +528,13 @@ void NVProfilerService::preallocate(edm::service::SystemBounds const& bounds) {
 }
 
 void NVProfilerService::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes,
-                                    edm::ProcessContext const& pc) {
+                                    edm::ProcessContext const& context) {
+  callgraph_.preBeginJob(pathsAndConsumes, context);
   nvtxDomainMark(global_domain_, "preBeginJob");
 
-  // FIXME this probably works only in the absence of subprocesses
-  // size() + 1 because pathsAndConsumes.allModules() does not include the source
-  unsigned int modules = pathsAndConsumes.allModules().size() + 1;
+  // this assumes that preBeginJob is not called concurrently with the modules' beginJob method
+  // or the preBeginJob for a subprocess
+  unsigned int modules = callgraph_.size();
   global_modules_.resize(modules, nvtxInvalidRangeId);
   for (unsigned int sid = 0; sid < stream_modules_.size(); ++sid) {
     stream_modules_[sid].resize(modules, nvtxInvalidRangeId);
@@ -1115,6 +1120,8 @@ void NVProfilerService::postModuleGlobalEndLumi(edm::GlobalContext const& gc, ed
 }
 
 void NVProfilerService::preSourceConstruction(edm::ModuleDescription const& desc) {
+  callgraph_.preSourceConstruction(desc);
+
   if (not skipFirstEvent_) {
     auto mid = desc.id();
     global_modules_.grow_to_at_least(mid + 1);


### PR DESCRIPTION
#### PR description:

Implement a couple of fixes for the `ProcessCallGraph`:
  - check that the `Source` module is added exactly once to the `ProcessCallGraph`;
  - avoid static variables, that would result in invalid process ids when multiple
    `ProcessCallGraph` instances are used _e.g._ by different Services.

Fix the `NVProfilerService` to for the case where the number of modules in the current process is not a valid indicator of the highest module id, for example if some modules have been destroyed because they cannot be part of any schedule. Instead, use a `ProcessCallGraph` to get the highest possible module id.


#### PR validation:

With these changes, adding the `NVProfilerService` to complex configurations (_e.g._ a full HLT menu) works, instead of failing with an assertion.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #39398 to 12.4.x for data taking.