### PR TITLE
Extend onnxruntime gpu interface to producers using onnxruntime

### DIFF
--- a/PhysicsTools/ONNXRuntime/BuildFile.xml
+++ b/PhysicsTools/ONNXRuntime/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="onnxruntime"/>
 <use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/CUDAServices" source_only="1"/>
+<use name="FWCore/ServiceRegistry" source_only="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/ONNXRuntime/BuildFile.xml
+++ b/PhysicsTools/ONNXRuntime/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="onnxruntime"/>
 <use name="FWCore/Utilities"/>
-<use name="HeterogeneousCore/CUDAServices" source_only="1"/>
-<use name="FWCore/ServiceRegistry" source_only="1"/>
+<use name="HeterogeneousCore/CUDAServices"/>
+<use name="FWCore/ServiceRegistry"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
+++ b/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
@@ -14,8 +14,8 @@ namespace cms::Ort {
   //    cpu -> Use CPU backend
   //    cuda -> Use cuda backend
   //    default -> Use best available
-  inline ::Ort::SessionOptions getSessionOptions(const std::string &param_backend ) {
-    
+  inline ::Ort::SessionOptions getSessionOptions(const std::string &param_backend) {
+   
     auto backend = cms::Ort::Backend::cpu;
     if ( param_backend == "cuda" )
       backend = cms::Ort::Backend::cuda;
@@ -26,6 +26,7 @@ namespace cms::Ort {
 	backend = cms::Ort::Backend::cuda;
       }
     }    
+
     return ONNXRuntime::defaultSessionOptions(backend);
   }
 }

--- a/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
+++ b/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
@@ -3,7 +3,7 @@
 
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "ONNXRuntime.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 #include "onnxruntime/core/session/onnxruntime_cxx_api.h"
 #include <string>
 

--- a/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
+++ b/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
@@ -1,0 +1,24 @@
+#ifndef PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
+#define PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
+
+#include "ONNXRuntime.h"
+#include "onnxruntime/core/session/onnxruntime_cxx_api.h"
+#include <string>
+
+namespace cms::Ort {
+
+  // param_backend
+  //    cpu -> Use CPU backend
+  //    cuda -> Use cuda backend
+  //    default -> Use best available
+  inline ::Ort::SessionOptions getSessionOptions(const std::string &param_backend ) {
+    
+    auto backend = cms::Ort::Backend::cpu;
+    if ( param_backend == "cuda" )
+      backend = cms::Ort::Backend::cuda;
+    
+    return ONNXRuntime::defaultSessionOptions(backend);
+  }
+}
+
+#endif

--- a/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
+++ b/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
@@ -1,6 +1,9 @@
 #ifndef PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
 #define PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
 
+
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "ONNXRuntime.h"
 #include "onnxruntime/core/session/onnxruntime_cxx_api.h"
 #include <string>
@@ -16,7 +19,13 @@ namespace cms::Ort {
     auto backend = cms::Ort::Backend::cpu;
     if ( param_backend == "cuda" )
       backend = cms::Ort::Backend::cuda;
-    
+
+    if ( param_backend == "default" ) {
+      edm::Service<CUDAService> cs;
+      if (cs.isAvailable() and cs->enabled()) {
+	backend = cms::Ort::Backend::cuda;
+      }
+    }    
     return ONNXRuntime::defaultSessionOptions(backend);
   }
 }

--- a/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
+++ b/PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h
@@ -1,6 +1,5 @@
-#ifndef PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
-#define PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H 
-
+#ifndef PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H
+#define PHYSICSTOOLS_ONNXRUNTIME_ONNXSESSIONOPTIONS_H
 
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -15,20 +14,19 @@ namespace cms::Ort {
   //    cuda -> Use cuda backend
   //    default -> Use best available
   inline ::Ort::SessionOptions getSessionOptions(const std::string &param_backend) {
-   
     auto backend = cms::Ort::Backend::cpu;
-    if ( param_backend == "cuda" )
+    if (param_backend == "cuda")
       backend = cms::Ort::Backend::cuda;
 
-    if ( param_backend == "default" ) {
+    if (param_backend == "default") {
       edm::Service<CUDAService> cs;
       if (cs.isAvailable() and cs->enabled()) {
-	backend = cms::Ort::Backend::cuda;
+        backend = cms::Ort::Backend::cuda;
       }
-    }    
+    }
 
     return ONNXRuntime::defaultSessionOptions(backend);
   }
-}
+}  // namespace cms::Ort
 
 #endif

--- a/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
+++ b/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
@@ -16,7 +16,6 @@
 #include <memory>
 #include <numeric>
 
-
 namespace cms::Ort {
 
   using namespace ::Ort;

--- a/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
+++ b/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc
@@ -16,11 +16,16 @@
 #include <memory>
 #include <numeric>
 
+
 namespace cms::Ort {
 
   using namespace ::Ort;
 
+#ifdef ONNXDebug
+  const Env ONNXRuntime::env_(ORT_LOGGING_LEVEL_INFO, "");
+#else
   const Env ONNXRuntime::env_(ORT_LOGGING_LEVEL_ERROR, "");
+#endif
 
   ONNXRuntime::ONNXRuntime(const std::string& model_path, const SessionOptions* session_options) {
     // create session
@@ -80,10 +85,12 @@ namespace cms::Ort {
     SessionOptions sess_opts;
     sess_opts.SetIntraOpNumThreads(1);
     if (backend == Backend::cuda) {
-      // https://www.onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html
       OrtCUDAProviderOptions options;
       sess_opts.AppendExecutionProvider_CUDA(options);
     }
+#ifdef ONNX_PROFILE
+    sess_opts.EnableProfiling("ONNXProf");
+#endif
     return sess_opts;
   }
 
@@ -140,6 +147,7 @@ namespace cms::Ort {
     }
 
     // run
+
     auto output_tensors = session_->Run(RunOptions{nullptr},
                                         input_node_names_.data(),
                                         input_tensors.data(),

--- a/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
 
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
-
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 #include "RecoBTag/FeatureTools/interface/deep_helpers.h"
 
 #include <iostream>
@@ -126,12 +126,14 @@ void BoostedJetONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
                                          "probQCDothers",
                                      });
   desc.addOptionalUntracked<bool>("debugMode", false);
+  desc.add<std::string>("onnx_backend","default");
 
   descriptions.addWithDefaultLabel(desc);
 }
 
 std::unique_ptr<ONNXRuntime> BoostedJetONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet &iConfig) {
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
 }
 
 void BoostedJetONNXJetTagsProducer::globalEndJob(const ONNXRuntime *cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
@@ -126,19 +126,20 @@ void BoostedJetONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
                                          "probQCDothers",
                                      });
   desc.addOptionalUntracked<bool>("debugMode", false);
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
 
   descriptions.addWithDefaultLabel(desc);
 }
 
 std::unique_ptr<ONNXRuntime> BoostedJetONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet &iConfig) {
-  std::string backend= iConfig.getParameter<std::string>("onnx_backend");
- 
+  std::string backend = iConfig.getParameter<std::string>("onnx_backend");
+
   auto session_options = cms::Ort::getSessionOptions(backend);
   // Sept 8, 2022 - on gpu, this model crashes with all optimizations on
-  if ( backend != "cpu" )
+  if (backend != "cpu")
     session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_BASIC);
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),
+                                       &session_options);
 }
 
 void BoostedJetONNXJetTagsProducer::globalEndJob(const ONNXRuntime *cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
@@ -132,7 +132,12 @@ void BoostedJetONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
 }
 
 std::unique_ptr<ONNXRuntime> BoostedJetONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet &iConfig) {
-  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  std::string backend= iConfig.getParameter<std::string>("onnx_backend");
+ 
+  auto session_options = cms::Ort::getSessionOptions(backend);
+  // Sept 8, 2022 - on gpu, this model crashes with all optimizations on
+  if ( backend != "cpu" )
+    session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_BASIC);
   return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
 }
 

--- a/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
@@ -136,7 +136,7 @@ void DeepCombinedONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
-  desc.add<std::string>("onnx_backend","cpu");
+  desc.add<std::string>("onnx_backend","default");
 
   descriptions.add("pfDeepCombinedJetTags", desc);
 }

--- a/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
@@ -136,14 +136,15 @@ void DeepCombinedONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
 
   descriptions.add("pfDeepCombinedJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepCombinedONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
   auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),
+                                       &session_options);
 }
 
 void DeepCombinedONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepCombinedONNXJetTagsProducer.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/BTauReco/interface/DeepFlavourTagInfo.h"
 
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
-
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 #include "RecoBTag/ONNXRuntime/interface/tensor_fillers.h"
 #include "RecoBTag/ONNXRuntime/interface/tensor_configs.h"
 
@@ -136,12 +136,14 @@ void DeepCombinedONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
+  desc.add<std::string>("onnx_backend","cpu");
 
   descriptions.add("pfDeepCombinedJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepCombinedONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
 }
 
 void DeepCombinedONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
@@ -121,7 +121,7 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
            "CvB" >> (PDPSD("flav_names", std::vector<std::string>{"probHbb", "probHcc"}, true) and
                      PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.onnx"), true));
   };
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
 
   auto descBvL(desc);
   descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
@@ -138,7 +138,8 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
 
 std::unique_ptr<ONNXRuntime> DeepDoubleXONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
   auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),
+                                       &session_options);
 }
 
 void DeepDoubleXONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
@@ -121,7 +121,7 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
            "CvB" >> (PDPSD("flav_names", std::vector<std::string>{"probHbb", "probHcc"}, true) and
                      PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.onnx"), true));
   };
-  desc.add<std::string>("onnx_backend","cpu");
+  desc.add<std::string>("onnx_backend","default");
 
   auto descBvL(desc);
   descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());

--- a/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepDoubleXONNXJetTagsProducer.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/BTauReco/interface/DeepDoubleXTagInfo.h"
 
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
-
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 #include <algorithm>
 #include <iostream>
 #include <fstream>
@@ -121,6 +121,8 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
            "CvB" >> (PDPSD("flav_names", std::vector<std::string>{"probHbb", "probHcc"}, true) and
                      PDFIP("model_path", FIP("RecoBTag/Combined/data/DeepDoubleX/94X/V01/DDCvB.onnx"), true));
   };
+  desc.add<std::string>("onnx_backend","cpu");
+
   auto descBvL(desc);
   descBvL.ifValue(edm::ParameterDescription<std::string>("flavor", "BvL", true), flavorCases());
   descriptions.add("pfDeepDoubleBvLJetTags", descBvL);
@@ -135,7 +137,8 @@ void DeepDoubleXONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
 }
 
 std::unique_ptr<ONNXRuntime> DeepDoubleXONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),&session_options);
 }
 
 void DeepDoubleXONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
@@ -85,14 +85,15 @@ void DeepFlavourONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
   desc.add<std::vector<std::string>>("output_names", {"ID_pred/Softmax:0"});
   desc.add<std::vector<std::string>>(
       "flav_names", std::vector<std::string>{"probb", "probbb", "problepb", "probc", "probuds", "probg"});
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
 
   descriptions.add("pfDeepFlavourJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepFlavourONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
   auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),
+                                       &session_options);
 }
 
 void DeepFlavourONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
@@ -14,6 +14,7 @@
 #include "DataFormats/BTauReco/interface/DeepFlavourTagInfo.h"
 
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 
 using namespace cms::Ort;
 
@@ -84,12 +85,14 @@ void DeepFlavourONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
   desc.add<std::vector<std::string>>("output_names", {"ID_pred/Softmax:0"});
   desc.add<std::vector<std::string>>(
       "flav_names", std::vector<std::string>{"probb", "probbb", "problepb", "probc", "probuds", "probg"});
+  desc.add<std::string>("onnx_backend","cpu");
 
   descriptions.add("pfDeepFlavourJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepFlavourONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
 }
 
 void DeepFlavourONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepFlavourONNXJetTagsProducer.cc
@@ -85,7 +85,7 @@ void DeepFlavourONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescript
   desc.add<std::vector<std::string>>("output_names", {"ID_pred/Softmax:0"});
   desc.add<std::vector<std::string>>(
       "flav_names", std::vector<std::string>{"probb", "probbb", "problepb", "probc", "probuds", "probg"});
-  desc.add<std::string>("onnx_backend","cpu");
+  desc.add<std::string>("onnx_backend","default");
 
   descriptions.add("pfDeepFlavourJetTags", desc);
 }

--- a/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
@@ -112,7 +112,7 @@ void DeepVertexONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
-  desc.add<std::string>("onnx_backend","cpu");
+  desc.add<std::string>("onnx_backend","default");
 
   descriptions.add("pfDeepVertexJetTags", desc);
 }

--- a/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
@@ -112,14 +112,15 @@ void DeepVertexONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
 
   descriptions.add("pfDeepVertexJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepVertexONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
   auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(),
+                                       &session_options);
 }
 
 void DeepVertexONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/DeepVertexONNXJetTagsProducer.cc
@@ -14,6 +14,7 @@
 #include "DataFormats/BTauReco/interface/DeepFlavourTagInfo.h"
 
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 
 #include "RecoBTag/ONNXRuntime/interface/tensor_fillers.h"
 #include "RecoBTag/ONNXRuntime/interface/tensor_configs.h"
@@ -111,12 +112,14 @@ void DeepVertexONNXJetTagsProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::vector<std::string>>("flav_names", std::vector<std::string>{"probb", "probc", "probuds", "probg"});
   desc.add<double>("min_jet_pt", 15.0);
   desc.add<double>("max_jet_eta", 2.5);
+  desc.add<std::string>("onnx_backend","cpu");
 
   descriptions.add("pfDeepVertexJetTags", desc);
 }
 
 std::unique_ptr<ONNXRuntime> DeepVertexONNXJetTagsProducer::initializeGlobalCache(const edm::ParameterSet& iConfig) {
-  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(iConfig.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
 }
 
 void DeepVertexONNXJetTagsProducer::globalEndJob(const ONNXRuntime* cache) {}

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -175,7 +175,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
       edm::FileInPath(
           "RecoParticleFlow/PFProducer/data/mlpf/"
           "mlpf_2021_11_16__no_einsum__all_data_cms-best-of-asha-scikit_20211026_042043_178263.workergpu010.onnx"));
-  desc.add<std::string>("onnx_backend","default");
+  desc.add<std::string>("onnx_backend", "default");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -175,7 +175,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
       edm::FileInPath(
           "RecoParticleFlow/PFProducer/data/mlpf/"
           "mlpf_2021_11_16__no_einsum__all_data_cms-best-of-asha-scikit_20211026_042043_178263.workergpu010.onnx"));
-  desc.add<std::string>("onnx_backend","cpu");
+  desc.add<std::string>("onnx_backend","default");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -5,6 +5,7 @@
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXSessionOptions.h"
 #include "RecoParticleFlow/PFProducer/interface/MLPFModel.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
@@ -160,7 +161,8 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 }
 
 std::unique_ptr<ONNXRuntime> MLPFProducer::initializeGlobalCache(const edm::ParameterSet& params) {
-  return std::make_unique<ONNXRuntime>(params.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = cms::Ort::getSessionOptions(params.getParameter<std::string>("onnx_backend"));
+  return std::make_unique<ONNXRuntime>(params.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
 }
 
 void MLPFProducer::globalEndJob(const ONNXRuntime* cache) {}
@@ -173,6 +175,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
       edm::FileInPath(
           "RecoParticleFlow/PFProducer/data/mlpf/"
           "mlpf_2021_11_16__no_einsum__all_data_cms-best-of-asha-scikit_20211026_042043_178263.workergpu010.onnx"));
+  desc.add<std::string>("onnx_backend","cpu");
   descriptions.addWithDefaultLabel(desc);
 }
 


### PR DESCRIPTION
Extends #36963 by adding a backend parameter to models, used by

cms::Ort::getSessionOptions(iConfig.getParameter<std::string>("onnx_backend"));

Current options are
   cpu -> Use CPU backend
   cuda -> Use cuda backend
   default -> Use best available

The model used in BoostedJetONNXJetTagsProducer crashes on GPU if the full optimization is included. I reduced this optimization in case a GPU is used (following recipes found on the web). The sort of error one gets is

```
Base::CudnnHandle(), &alpha, Base::s_.z_tensor, Base::s_.z_data, &alpha, Base::s_.y_tensor, Base::s_.y_data); 
2022-08-26 13:26:51.964709271 [E:onnxruntime:, sequential_executor.cc:346 Execute] Non-zero status code returned while running FusedConv node. Name:'Conv_98_Add_99_Relu_100'
 Status Message: CUDNN error executing cudnnAddTensor(Base::CudnnHandle(), &alpha, Base::s_.z_tensor, Base::s_.z_data, &alpha, Base::s_.y_tensor, Base::s_.y_data)
----- Begin Fatal Exception 26-Aug-2022 14:26:51 CEST-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
```

So far I do not see any significant performance improvement (at least on lxplus-gpu) nor loss. At least BoostedJetONNXJetTagsProducer.cc can be improved to send more than one jet to onnxruntime at a time.