### PR TITLE
Herwig7 jet partonFlavour (10_6_X)

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -258,18 +258,20 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
        leptons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
    }
 
-   // select partons
+   // select algorithmic partons
    if ( partonMode_!="Undefined" ) {
      partonSelector_->run(particles,partons);
-     for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
-     {
-      if(!fullChainPhysPartons_)
-      {
-         if( !(it->status()==3 || (( partonMode_=="Pythia8" ) && (it->status()==23)))) continue;
-      }
-       if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
-       physicsPartons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
-     }
+   }
+
+   // select physics partons
+   for(reco::GenParticleCollection::const_iterator it = particles->begin(); it != particles->end(); ++it)
+   {
+    if(!fullChainPhysPartons_)
+    {
+       if( !(it->status()==3 || (( partonMode_=="Pythia8" ) && (it->status()==23)))) continue;
+    }
+     if( !CandMCTagUtils::isParton( *it ) ) continue;  // skip particle if not a parton
+     physicsPartons->push_back( reco::GenParticleRef( particles, it - particles->begin() ) );
    }
 
    iEvent.put(std::move(bHadrons), "bHadrons" );

--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -165,6 +165,8 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
        partonMode_="Herwig6";
      else if( moduleName.find("ThePEG")!=std::string::npos )
        partonMode_="Herwig++";
+     else if( moduleName.find("Herwig7")!=std::string::npos )
+       partonMode_="Herwig++";
      else if( moduleName.find("Sherpa")!=std::string::npos )
        partonMode_="Sherpa";
      else


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/26885

Needed for jet flavor correction / uncertainty studies to distinguish light quark and gluon jets. Will ask for new 10_6 release and reprocessing of Herwig7 JMENanos afterwards.

Note that will also fix the issue for any newly produced MiniAods.

#### PR validation:

`Jet_partonFlavour` becomes available in `TT_TuneCH3_13TeV-powheg-herwig7` JMENano after applying patches:
```
 Jet_hadronFlavour = 0,                                                                                                                                                                                     
                  4, 5, 5, 0, 0, 0, 0, 0, 0, 0,                                                                                                                                                             
                  0, 0, 0, 0, 0, 0, 0, 0, 0                                                                                                                                                                 
 Jet_partonFlavour = -2,                                                                                                                                                                                    
                  4, 5, -5, 21, -3, 0, 1, 21, 0, -2,                                                                                                                                                        
                  0, 0, 21, 0, 21, 21, 0, 0, 2
```

@cms-sw/jetmet-pog-l2 FYI