### PR TITLE
Validation/RecoEGamma PF Cluster Iso v1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -2872,78 +2872,77 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                       "ELE_LOGY E1 P");
 
   h1_ele_ecalPFClusterIso = bookH1withSumw2(iBooker,
-                                        "ecalPFClusterIso",
-                                        "ecal PF Cluster Iso",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                            "ecalPFClusterIso",
+                                            "ecal PF Cluster Iso",
+                                            100,
+                                            0.0,
+                                            100.,
+                                            "hcal PF Cluser Iso",
+                                            "Events",
+                                            "ELE_LOGY E1 P");
   h1_ele_ecalPFClusterIso_barrel = bookH1withSumw2(iBooker,
-                                        "ecalPFClusterIso_barrel",
-                                        "ecal PF Cluster Iso barrel",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                                   "ecalPFClusterIso_barrel",
+                                                   "ecal PF Cluster Iso barrel",
+                                                   100,
+                                                   0.0,
+                                                   100.,
+                                                   "hcal PF Cluser Iso",
+                                                   "Events",
+                                                   "ELE_LOGY E1 P");
   h1_ele_ecalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
-                                        "ecalPFClusterIso_endcaps",
-                                        "ecal PF Cluster Iso endcaps",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                                    "ecalPFClusterIso_endcaps",
+                                                    "ecal PF Cluster Iso endcaps",
+                                                    100,
+                                                    0.0,
+                                                    100.,
+                                                    "hcal PF Cluser Iso",
+                                                    "Events",
+                                                    "ELE_LOGY E1 P");
   h1_ele_hcalPFClusterIso = bookH1withSumw2(iBooker,
-                                        "hcalPFClusterIso",
-                                        "hcal PF Cluster Iso",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                            "hcalPFClusterIso",
+                                            "hcal PF Cluster Iso",
+                                            100,
+                                            0.0,
+                                            100.,
+                                            "hcal PF Cluser Iso",
+                                            "Events",
+                                            "ELE_LOGY E1 P");
   h1_ele_hcalPFClusterIso_barrel = bookH1withSumw2(iBooker,
-                                        "hcalPFClusterIso_barrel",
-                                        "hcal PF Cluster Iso barrel",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                                   "hcalPFClusterIso_barrel",
+                                                   "hcal PF Cluster Iso barrel",
+                                                   100,
+                                                   0.0,
+                                                   100.,
+                                                   "hcal PF Cluser Iso",
+                                                   "Events",
+                                                   "ELE_LOGY E1 P");
   h1_ele_hcalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
-                                        "hcalPFClusterIso_endcaps",
-                                        "hcal PF Cluster Iso endcaps",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                                    "hcalPFClusterIso_endcaps",
+                                                    "hcal PF Cluster Iso endcaps",
+                                                    100,
+                                                    0.0,
+                                                    100.,
+                                                    "hcal PF Cluser Iso",
+                                                    "Events",
+                                                    "ELE_LOGY E1 P");
   h1_ele_ecalPFClusterIso_Extended = bookH1withSumw2(iBooker,
-                                        "ecalPFClusterIso_Extended",
-                                        "ecal PF Cluster Iso Extended",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
+                                                     "ecalPFClusterIso_Extended",
+                                                     "ecal PF Cluster Iso Extended",
+                                                     100,
+                                                     0.0,
+                                                     100.,
+                                                     "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                                     "Events",
+                                                     "ELE_LOGY E1 P");
   h1_ele_hcalPFClusterIso_Extended = bookH1withSumw2(iBooker,
-                                        "hcalPFClusterIso_Extended",
-                                        "hcal PF Cluster Iso Extended",
-                                        100,
-                                        0.0,
-                                        100.,
-                                        "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
-                                        "Events",
-                                        "ELE_LOGY E1 P");
-
+                                                     "hcalPFClusterIso_Extended",
+                                                     "hcal PF Cluster Iso Extended",
+                                                     100,
+                                                     0.0,
+                                                     100.,
+                                                     "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                                     "Events",
+                                                     "ELE_LOGY E1 P");
 
   // fbrem
   h1_ele_fbrem = bookH1withSumw2(
@@ -3635,7 +3634,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
         h2_ele_PoPtrueVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.p() / mcIter->p());
         h1_ele_ecalPFClusterIso_Extended->Fill(bestGsfElectron.ecalPFClusterIso());
         h1_ele_hcalPFClusterIso_Extended->Fill(bestGsfElectron.hcalPFClusterIso());
-
 
         double fbrem_mode = bestGsfElectron.fbrem();
         h1_ele_fbrem_Extended->Fill(fbrem_mode);

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -566,6 +566,15 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_hcalTowerSumEt_dr03_depth1_endcaps = nullptr;
   h1_ele_hcalTowerSumEt_dr03_depth2 = nullptr;
 
+  h1_ele_ecalPFClusterIso = nullptr;
+  h1_ele_hcalPFClusterIso = nullptr;
+  h1_ele_ecalPFClusterIso_Extended = nullptr;
+  h1_ele_hcalPFClusterIso_Extended = nullptr;
+  h1_ele_ecalPFClusterIso_barrel = nullptr;
+  h1_ele_hcalPFClusterIso_barrel = nullptr;
+  h1_ele_ecalPFClusterIso_endcaps = nullptr;
+  h1_ele_hcalPFClusterIso_endcaps = nullptr;
+
   // conversions
   h1_ele_convFlags = nullptr;
   h1_ele_convFlags_all = nullptr;
@@ -2862,6 +2871,80 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                       "Events",
                       "ELE_LOGY E1 P");
 
+  h1_ele_ecalPFClusterIso = bookH1withSumw2(iBooker,
+                                        "ecalPFClusterIso",
+                                        "ecal PF Cluster Iso",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_barrel = bookH1withSumw2(iBooker,
+                                        "ecalPFClusterIso_barrel",
+                                        "ecal PF Cluster Iso barrel",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
+                                        "ecalPFClusterIso_endcaps",
+                                        "ecal PF Cluster Iso endcaps",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso = bookH1withSumw2(iBooker,
+                                        "hcalPFClusterIso",
+                                        "hcal PF Cluster Iso",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_barrel = bookH1withSumw2(iBooker,
+                                        "hcalPFClusterIso_barrel",
+                                        "hcal PF Cluster Iso barrel",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
+                                        "hcalPFClusterIso_endcaps",
+                                        "hcal PF Cluster Iso endcaps",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_Extended = bookH1withSumw2(iBooker,
+                                        "ecalPFClusterIso_Extended",
+                                        "ecal PF Cluster Iso Extended",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_Extended = bookH1withSumw2(iBooker,
+                                        "hcalPFClusterIso_Extended",
+                                        "hcal PF Cluster Iso Extended",
+                                        100,
+                                        0.0,
+                                        100.,
+                                        "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                        "Events",
+                                        "ELE_LOGY E1 P");
+
+
   // fbrem
   h1_ele_fbrem = bookH1withSumw2(
       iBooker, "fbrem", "ele brem fraction, mode of GSF components", 100, 0., 1., "P_{in} - P_{out} / P_{in}");
@@ -3550,6 +3633,9 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
         h2_scl_EoEtrueVsrecOfflineVertices_Extended->Fill((*vertexCollectionHandle).size(),
                                                           bestGsfElectron.ecalEnergy() / mcIter->p());
         h2_ele_PoPtrueVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.p() / mcIter->p());
+        h1_ele_ecalPFClusterIso_Extended->Fill(bestGsfElectron.ecalPFClusterIso());
+        h1_ele_hcalPFClusterIso_Extended->Fill(bestGsfElectron.hcalPFClusterIso());
+
 
         double fbrem_mode = bestGsfElectron.fbrem();
         h1_ele_fbrem_Extended->Fill(fbrem_mode);
@@ -4167,6 +4253,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
 
     // isolation
     h1_ele_tkSumPt_dr03->Fill(bestGsfElectron.dr03TkSumPt());
+    h1_ele_ecalPFClusterIso->Fill(bestGsfElectron.ecalPFClusterIso());
+    h1_ele_hcalPFClusterIso->Fill(bestGsfElectron.hcalPFClusterIso());
     h1_ele_ecalRecHitSumEt_dr03->Fill(bestGsfElectron.dr03EcalRecHitSumEt());
     h1_ele_hcalTowerSumEt_dr03_depth1->Fill(bestGsfElectron.dr03HcalTowerSumEt(1));
     h1_ele_hcalTowerSumEt_dr03_depth2->Fill(bestGsfElectron.dr03HcalTowerSumEt(2));
@@ -4183,6 +4271,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_hcalTowerSumEtBc_dr03_depth2_barrel->Fill(bestGsfElectron.dr03HcalTowerSumEtBc(2));
       h1_ele_hcalDepth1OverEcalBc_barrel->Fill(bestGsfElectron.hcalOverEcalBc(1));
       h1_ele_hcalDepth2OverEcalBc_barrel->Fill(bestGsfElectron.hcalOverEcalBc(2));
+      h1_ele_ecalPFClusterIso_barrel->Fill(bestGsfElectron.ecalPFClusterIso());
+      h1_ele_hcalPFClusterIso_barrel->Fill(bestGsfElectron.hcalPFClusterIso());
     } else if (isEEflag) {
       h1_ele_tkSumPt_dr03_endcaps->Fill(bestGsfElectron.dr03TkSumPt());
       h1_ele_ecalRecHitSumEt_dr03_endcaps->Fill(bestGsfElectron.dr03EcalRecHitSumEt());
@@ -4192,6 +4282,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_hcalTowerSumEtBc_dr03_depth2_endcaps->Fill(bestGsfElectron.dr03HcalTowerSumEtBc(2));
       h1_ele_hcalDepth1OverEcalBc_endcaps->Fill(bestGsfElectron.hcalOverEcalBc(1));
       h1_ele_hcalDepth2OverEcalBc_endcaps->Fill(bestGsfElectron.hcalOverEcalBc(2));
+      h1_ele_ecalPFClusterIso_endcaps->Fill(bestGsfElectron.ecalPFClusterIso());
+      h1_ele_hcalPFClusterIso_endcaps->Fill(bestGsfElectron.hcalPFClusterIso());
     }
 
     // conversion rejection

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -582,6 +582,15 @@ private:
   MonitorElement *h1_ele_hcalTowerSumEtBc_dr03_depth2_barrel;
   MonitorElement *h1_ele_hcalTowerSumEtBc_dr03_depth2_endcaps;
 
+  MonitorElement *h1_ele_ecalPFClusterIso;
+  MonitorElement *h1_ele_hcalPFClusterIso;
+  MonitorElement *h1_ele_ecalPFClusterIso_Extended;
+  MonitorElement *h1_ele_hcalPFClusterIso_Extended;
+  MonitorElement *h1_ele_ecalPFClusterIso_barrel;
+  MonitorElement *h1_ele_hcalPFClusterIso_barrel;
+  MonitorElement *h1_ele_ecalPFClusterIso_endcaps;
+  MonitorElement *h1_ele_hcalPFClusterIso_endcaps;
+
   // conversions
   MonitorElement *h1_ele_convFlags;
   MonitorElement *h1_ele_convFlags_all;

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -60,7 +60,8 @@ process.electronMcSignalPostValidator.OutputFolderName = cms.string("EgammaV/Ele
 
 from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG']#+'::All'
-process.GlobalTag.globaltag = '124X_mcRun3_2021_realistic_v1'
+#process.GlobalTag.globaltag = '125X_mcRun3_2022_realistic_v3'
+#process.GlobalTag.globaltag = '125X_mcRun4_realistic_v2_2026D88noPU' # no more needed
 #process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
 #process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'
 

--- a/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
@@ -52,21 +52,10 @@ process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(*flist
 #    fileNames = cms.untracked.vstring(
 #    [
 # 'file:/eos/user/a/archiron/HGCal_Shares/step3_A8F750A4-6D87-E711-A476-0CC47A4D7600.root',
-# 'file:/eos/user/a/archiron/HGCal_Shares/step3_AE79E794-7287-E711-9D2A-0CC47A78A3EE.root',
-# 'file:/eos/user/a/archiron/HGCal_Shares/step3_D801BDAF-7087-E711-AEF8-0CC47A7C354A.root',
 
 # 'file:/eos/user/r/rovere/www/shared/step3.root',
 
 # 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_9_3_2/RelValQCD_Pt-15To7000_Flat_14TeV/GEN-SIM-RECO/93X_upgrade2023_realistic_v2_2023D17noPU-v1/10000/00FF6760-F8A6-E711-AA68-0025905A60D6.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/0d87e1b9-1398-4a32-9775-e2d170c00df3.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/22bff740-c71a-4527-a6ac-58360438960b.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/268ccf98-9216-493b-a1ff-403db31fbfd2.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/515c0b30-2803-490e-a1bf-06722f934a2f.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/7f266520-2cf7-4245-859c-3cb82b4e4cea.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/9c7caca7-9179-4d91-a4fa-2cc37cef73a1.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/a75081f2-16e5-499e-ac41-6b98afddbf28.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/b714a540-be23-423c-9b71-b92b07235dde.root',
-# 'root://cms-xrd-global.cern.ch//store/relval/CMSSW_11_3_0_pre4/RelValZEE_14/GEN-SIM-RECO/113X_mcRun4_realistic_v4_2026D76noPU-v1/00000/cf9fb9fc-8450-4d7f-a285-41007aed4158.root',
 
 # ]
 # )
@@ -89,7 +78,8 @@ from Configuration.AlCa.autoCond import autoCond
 
 # process.GlobalTag.globaltag = os.environ['TEST_GLOBAL_TAG'] + '::All'
 #process.GlobalTag.globaltag = '120X_mcRun3_2021_realistic_v1'
-process.GlobalTag.globaltag = '123X_mcRun3_2021_realistic_v14'
+#process.GlobalTag.globaltag = '125X_mcRun3_2022_realistic_v3'
+#process.GlobalTag.globaltag = '125X_mcRun4_realistic_v2_2026D88noPU' # no more needed
 # process.GlobalTag.globaltag = '113X_mcRun3_2021_realistic_v4'
 # process.GlobalTag.globaltag = '93X_mc2017_realistic_v1'
 # process.GlobalTag.globaltag = '92X_upgrade2017_realistic_v10'

--- a/Validation/RecoEgamma/test/electronValidationCheck_Env.py
+++ b/Validation/RecoEgamma/test/electronValidationCheck_Env.py
@@ -19,8 +19,8 @@ class env:
                 quit()
 
     def beginTag(self):
-        #beginTag = 'Phase2'
-        beginTag = 'Run3'
+        beginTag = 'Phase2'
+        #beginTag = 'Run3'
         return beginTag
 
     def dd_tier(self):
@@ -29,7 +29,8 @@ class env:
         return dd_tier
 
     def tag_startup(self):
-        tag_startup = '123X_mcRun3_2021_realistic_v14'
+        #tag_startup = '125X_mcRun3_2022_realistic_v3'
+        tag_startup = '125X_mcRun4_realistic_v2_2026D88noPU'
         # tag_startup = '113X_mcRun3_2021_realistic_v7'
         # tag_startup = '93X_upgrade2023_realistic_v2_2023D17PU140'
         # tag_startup = '93X_upgrade2023_realistic_v0_D17PU200'


### PR DESCRIPTION
#### PR description:

Monitoring of the hcalPF isolation and ecalPF isolation, which are important ingredients of the photon/electron ID at HLT, and which should also be monitored at the RECO level. These quantities are also likely to be used for the (offline) ID criteria for Run 3.
The monitoring of the "extended" region (2.5<|eta|<3) has also been added. 

Modifications are made on the following files :
Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc 
Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h 

Some other small (they do not concern the extended eta range) modifications are made on :
Validation/RecoEgamma/test/ElectronMcSignalValidation_gedGsfElectrons_cfg.py
Validation/RecoEgamma/python/ElectronMcSignalPostValidator_cfi.py
Validation/RecoEgamma/test/electronValidationCheck_Env.py 

This can be viewed with the following pictures:
for hcalPFClusterIso
![h_ele_hcalPFClusterIso](https://user-images.githubusercontent.com/5586847/190442066-e286f0d2-283b-49c7-b512-9d135e9fb034.GIF)

ecalPFClusterIso
![h_ele_ecalPFClusterIso](https://user-images.githubusercontent.com/5586847/190442127-b020d6ea-68d2-4bb4-b446-5c5a30ed0ec9.GIF)

and the Extended version with extended eta range
![h_ele_ecalPFClusterIso_Extended](https://user-images.githubusercontent.com/5586847/190442157-ed0dc4c6-b661-45b2-8113-829c046b914e.GIF)

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.

runTheMatrix.py -l limited -i all --ibeos tests are fine
50 49 48 35 18 4 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed

@beaudett @swagata87 
