### PR TITLE
Add wfs for JetMET PD

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -493,6 +493,7 @@ workflows[140.115] = ['',['RunHLTPhysics2022B','HLTRUN3','RECONANORUN3','SKIMHLT
 workflows[140.116] = ['',['RunCommissioning2022B','HLTRUN3','RECONANORUN3','SKIMCOMMISSIONINGRUN3']]
 workflows[140.117] = ['',['RunCosmics2022B','HLTRUN3','RECOCOSMRUN3','SKIMCOSMICSRUN3']]
 #workflows[140.118] = ['',['RunParkingBPH2022B','HLTRUN3','RECONANORUN3','SKIMPARKINGBPHRUN3']]
+workflows[140.119] = ['', ['RunJetMET2022D','HLTRUN3','RECONANORUN3','SKIMJETMETRUN3']]
 
 ### fastsim ###
 workflows[5.1] = ['TTbar', ['TTbarFS','HARVESTFS']]


### PR DESCRIPTION
#### PR description:

Add Run3 skims to the standard relval wfs: 140.119

#### PR validation:

Should be tested on 140.119

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

None
