### PR TITLE
do not drop pixel duplicates for phase-2 IT reconstruction

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -53,6 +53,7 @@ PixelThresholdClusterizer::PixelThresholdClusterizer(edm::ParameterSet const& co
       theOffset_L1(conf.getParameter<int>("VCaltoElectronOffset_L1")),
       theElectronPerADCGain(conf.getParameter<double>("ElectronPerADCGain")),
       doPhase2Calibration(conf.getParameter<bool>("Phase2Calibration")),
+      dropDuplicates(conf.getParameter<bool>("DropDuplicates")),
       thePhase2ReadoutMode(conf.getParameter<int>("Phase2ReadoutMode")),
       thePhase2DigiBaseline(conf.getParameter<double>("Phase2DigiBaseline")),
       thePhase2KinkADC(conf.getParameter<int>("Phase2KinkADC")),
@@ -82,6 +83,7 @@ void PixelThresholdClusterizer::fillPSetDescription(edm::ParameterSetDescription
   desc.add<int>("ClusterThreshold_L1", 4000);
   desc.add<int>("ClusterThreshold", 4000);
   desc.add<double>("ElectronPerADCGain", 135.);
+  desc.add<bool>("DropDuplicates", true);
   desc.add<bool>("Phase2Calibration", false);
   desc.add<int>("Phase2ReadoutMode", -1);
   desc.add<double>("Phase2DigiBaseline", 1200.);
@@ -296,8 +298,9 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
        of view of the final cluster charge since these are typically >= 20000.
     */
 
-    thePixelOccurrence[theBuffer.index(row, col)]++;                     // increment the occurrence counter
-    uint8_t occurrence = thePixelOccurrence[theBuffer.index(row, col)];  // get the occurrence counter
+    thePixelOccurrence[theBuffer.index(row, col)]++;  // increment the occurrence counter
+    uint8_t occurrence =
+        (!dropDuplicates) ? 1 : thePixelOccurrence[theBuffer.index(row, col)];  // get the occurrence counter
 
     switch (occurrence) {
       // the 1st occurrence (standard treatment)

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -111,6 +111,7 @@ protected:
   const double theElectronPerADCGain;  //  ADC to electrons conversion
 
   const bool doPhase2Calibration;      // The ADC --> electrons calibration is for phase-2 tracker
+  const bool dropDuplicates;           // Enabling dropping duplicate pixels
   const int thePhase2ReadoutMode;      // Readout mode of the phase-2 IT digitizer
   const double thePhase2DigiBaseline;  // Threshold above which digis are measured in the phase-2 IT
   const int thePhase2KinkADC;          // ADC count at which the kink in the dual slop kicks in

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -33,6 +33,7 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import PixelDigitizerAlgorithmCommon
 phase2_tracker.toModify(siPixelClusters, # FIXME
   src = 'simSiPixelDigis:Pixel',
+  DropDuplicates = False, # do not drop duplicates for phase-2 until the digitizer can handle them consistently
   MissCalibrate = False,
   Phase2Calibration = True,
   Phase2ReadoutMode = PixelDigitizerAlgorithmCommon.Phase2ReadoutMode.value(), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction


### PR DESCRIPTION
#### PR description:

Poor man solution to https://github.com/cms-sw/cmssw/issues/39007.
PR https://github.com/cms-sw/cmssw/pull/37559 has created a serious deterioration of the phase-2 track reconstruction (see https://cms-talk.web.cern.ch/t/new-validation-campaign-12-5-0-pre5-phase2-d88-added/14722/15), likely due to pixels being killed in the middle of the cluster when a PU simHit comes to overlap with a signal simHit.
This PR introduces a  `DropDuplicates` parameters in [PixelThresholdClusterizer.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:doNotDropDuplicatesPhase2?expand=1#diff-7aa95db5a7413c63dc3c64cd194dff15ed9d03473750c6a61b9cd32be929fad5) and turns that off for *all* phase-2 reconstruction.
Same mechanism was introduced (only for the heterogeneous version of the reconstruction) at https://github.com/cms-sw/cmssw/pull/38761, that would have to be rebased if this PR is merged.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will have to be backported if accepted

cc:
@AdrianoDee 