### PR TITLE
[12_4_X] Added protection against out-of-range BX values in EMTF unpacker blocks

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -328,6 +328,16 @@ namespace l1t {
           }
         }  // End loop: for (auto const & iHit : *res_hit)
 
+        // Reject TPs with out-of-range BX values. This needs to be adjusted if we increase l1a_window parameter in EMTF config - EY 03.08.2022
+        if (Hit_.BX() > 3 or Hit_.BX() < -3) {
+          edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCTs with out-of-range BX! BX " << Hit_.BX() << ", endcap "
+                                      << Hit_.Endcap() << ", station " << Hit_.Station() << ", sector " << Hit_.Sector()
+                                      << ", neighbor " << Hit_.Neighbor() << ", ring " << Hit_.Ring() << ", chamber "
+                                      << Hit_.Chamber() << ", strip " << Hit_.Strip() << ", wire " << Hit_.Wire()
+                                      << std::endl;
+          return true;
+        }
+
         if (exact_duplicate)
           edm::LogWarning("L1T|EMTF") << "EMTF unpacked duplicate LCTs: BX " << Hit_.BX() << ", endcap "
                                       << Hit_.Endcap() << ", station " << Hit_.Station() << ", sector " << Hit_.Sector()

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -577,6 +577,18 @@ namespace l1t {
         //   std::cout << "***********************************************************\n\n" << std::endl;
         // }
 
+        // Reject tracks with out-of-range BX values. This needs to be adjusted if we increase l1a_window parameter in EMTF config - EY 03.08.2022
+        if (Track_.BX() > 3 or Track_.BX() < -3) {
+          edm::LogWarning("L1T|EMTF") << "EMTF unpacked track with out-of-range BX! BX: " << Track_.BX()
+                                      << " endcap: " << (Track_.Endcap() == 1 ? 1 : 2) << " sector: " << Track_.Sector()
+                                      << " address: " << Track_.PtLUT().address << " mode: " << Track_.Mode()
+                                      << " eta: " << (Track_.GMT_eta() >= 0 ? Track_.GMT_eta() : Track_.GMT_eta() + 512)
+                                      << " phi: " << Track_.GMT_phi() << " charge: " << Track_.GMT_charge()
+                                      << " qual: " << Track_.GMT_quality() << " pt: " << Track_.Pt()
+                                      << " pt_dxy: " << Track_.Pt_dxy() << std::endl;
+          return true;
+        }
+
         (res->at(iOut)).push_SP(SP_);
 
         res_track->push_back(Track_);


### PR DESCRIPTION
#### PR description:

This PR is a partial backport of https://github.com/cms-sw/cmssw/pull/38961. The rest of the changes will go in with https://github.com/cms-sw/cmssw/pull/39389

The PR was made as discussed in https://github.com/cms-sw/cmssw/pull/39388

This PR fixes the crash reported in https://github.com/cms-sw/cmssw/issues/38940. EMTF DAQ readout window is 7 BX wide [-3, 3], but in cases of corrupted data from TPs or faulty configurations it can have a value of 4.

Apaprently, such cases happened during LS2 when GEMs were not working properly. Unpacking this data and trying to use the DQM plots added in https://github.com/cms-sw/cmssw/pull/38818 causes a crash. 

This PR adds a veto for any TP or EMTF track that falls out of this [-3, 3] window since these are clearly not valid.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated with the failing workflows from https://github.com/cms-sw/cmssw/issues/38940. Everything works and we print out the warning messages about corrupted data.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


This PR is a partial backport of https://github.com/cms-sw/cmssw/pull/38961. The rest of the changes will go in with https://github.com/cms-sw/cmssw/pull/39389

The PR was made as discussed in https://github.com/cms-sw/cmssw/pull/39388
