### PR TITLE
[L1T] Update track z0 in the fastHistoEmulation algorithm of VertexFinder

### DIFF
--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -44,8 +44,8 @@ for filePath in options.inputFiles:
 
 process = cms.Process("GTTFileWriter")
 
-process.load('Configuration.Geometry.GeometryExtended2026D77Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D77_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -44,29 +44,31 @@ for filePath in options.inputFiles:
 
 process = cms.Process("GTTFileWriter")
 
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D77Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D77_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(inputFiles) )
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(inputFiles),
+    inputCommands = cms.untracked.vstring("keep *", "drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__*")
+)
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
 process.options = cms.untracked.PSet(
     numberOfThreads = cms.untracked.uint32(options.threads),
     numberOfStreams = cms.untracked.uint32(options.streams if options.streams>0 else 0)
 )
 
-process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
 process.load('L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi')
 process.load('L1Trigger.VertexFinder.VertexProducer_cff')
 process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
 process.L1GTTInputProducer.debug = cms.int32(options.debug)
 process.VertexProducer.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
-process.VertexProducer.VertexReconstruction.Algorithm = cms.string("FastHistoEmulation")
+process.VertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
 process.VertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.VertexProducer.debug = options.debug
 if options.debug:
@@ -78,4 +80,4 @@ process.GTTFileWriter.format = cms.untracked.string(options.format)
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1HybridTracks * process.L1GTTInputProducer * process.VertexProducer * process.GTTFileWriter)
+process.p = cms.Path(process.L1GTTInputProducer * process.VertexProducer * process.GTTFileWriter)

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -63,11 +63,11 @@ process.options = cms.untracked.PSet(
 )
 
 process.load('L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi')
-process.load('L1Trigger.VertexFinder.VertexProducer_cff')
+process.load('L1Trigger.VertexFinder.l1tVertexProducer_cfi')
 process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
 process.L1GTTInputProducer.debug = cms.int32(options.debug)
-process.VertexProducer.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
+process.VertexProducer.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted")
 process.VertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
 process.VertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.VertexProducer.debug = options.debug
@@ -80,4 +80,4 @@ process.GTTFileWriter.format = cms.untracked.string(options.format)
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.L1GTTInputProducer * process.VertexProducer * process.GTTFileWriter)
+process.p = cms.Path(process.l1tGTTInputProducer * process.l1tVertexProducer * process.GTTFileWriter)

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -62,6 +62,10 @@ process.source = cms.Source ("PoolSource",
                             )
 
 process.source.inputCommands = cms.untracked.vstring("keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__*")
+process.Timing = cms.Service("Timing",
+  summaryOnly = cms.untracked.bool(False),
+  useJobReport = cms.untracked.bool(True)
+)
 
 process.TFileService = cms.Service("TFileService", fileName = cms.string('GTTObjects_ttbar200PU.root'), closeFileFast = cms.untracked.bool(True))
 

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -2,6 +2,7 @@
 #define __L1Trigger_VertexFinder_VertexFinder_h__
 
 #include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1Trigger/interface/VertexWord.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"

--- a/L1Trigger/VertexFinder/interface/VertexFinder.h
+++ b/L1Trigger/VertexFinder/interface/VertexFinder.h
@@ -11,6 +11,7 @@
 #include "L1Trigger/VertexFinder/interface/RecoVertex.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <vector>
 

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -34,8 +34,10 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # fastHisto algorithm histogram parameters (min,max,width) [cm]
         # TDR settings: [-14.95, 15.0, 0.1]
         # L1TkPrimaryVertexProducer: [-30.0, 30.0, 0.09983361065]
-        # Firmware: [-14.4, 14.4, 0.4]
-        FH_HistogramParameters = cms.vdouble(-30.0, 30.0, 0.09983361065),
+        # HLS Firmware: [-14.4, 14.4, 0.4]
+        # Track word limits (128 binns): [-20.46921512, 20.46921512, 0.31983008]
+        # Track word limits (256 binns): [-20.46921512, 20.46921512, 0.1599157431]
+        FH_HistogramParameters = cms.vdouble(-20.46921512, 20.46921512, 0.31983008),
         # The number of vertixes to return (i.e. N windows with the highest combined pT)
         FH_NVtx = cms.uint32(10),
         # fastHisto algorithm assumed vertex half-width [cm]

--- a/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
+++ b/L1Trigger/VertexFinder/python/l1tVertexProducer_cfi.py
@@ -35,9 +35,9 @@ l1tVertexProducer = cms.EDProducer('VertexProducer',
         # TDR settings: [-14.95, 15.0, 0.1]
         # L1TkPrimaryVertexProducer: [-30.0, 30.0, 0.09983361065]
         # HLS Firmware: [-14.4, 14.4, 0.4]
-        # Track word limits (128 binns): [-20.46921512, 20.46921512, 0.31983008]
-        # Track word limits (256 binns): [-20.46921512, 20.46921512, 0.1599157431]
-        FH_HistogramParameters = cms.vdouble(-20.46921512, 20.46921512, 0.31983008),
+        # Track word limits (128 binns): [-20.46921512, 20.46921512, 0.31983148625]
+        # Track word limits (256 binns): [-20.46921512, 20.46921512, 0.159915743125]
+        FH_HistogramParameters = cms.vdouble(-20.46921512, 20.46921512, 0.31983148625),
         # The number of vertixes to return (i.e. N windows with the highest combined pT)
         FH_NVtx = cms.uint32(10),
         # fastHisto algorithm assumed vertex half-width [cm]

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -785,12 +785,10 @@ namespace l1tVertexFinder {
 
     static constexpr unsigned int kTableSize =
         ((1 << HistogramBitWidths::kSumPtLinkSize) - 1) * HistogramBitWidths::kWindowSize;
-    static constexpr double kZ0Scale =
-        (TTTrack_TrackWord::stepZ0 *
-         (1 << (TrackBitWidths::kZ0Size - TrackBitWidths::kZ0MagSize)));  // scale = 1.27932032
 
     typedef ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize, AP_RND_CONV, AP_SAT> pt_t;
-    typedef ap_fixed<TrackBitWidths::kZ0Size, TrackBitWidths::kZ0MagSize, AP_RND_CONV, AP_SAT> z0_t;
+    // Same size as TTTrack_TrackWord::z0_t, but now taking into account the sign bit (i.e. 2's complement)
+    typedef ap_int<TrackBitWidths::kZ0Size> z0_t;
     // 7 bits chosen to represent values between [0,127]
     // This is the next highest power of 2 value to our chosen track pt saturation value (100)
     typedef ap_ufixed<TrackBitWidths::kReducedPrecisionPt, TrackBitWidths::kReducedPrecisionPt, AP_RND_INF, AP_SAT>
@@ -819,16 +817,22 @@ namespace l1tVertexFinder {
         inverse_t;
 
     auto track_quality_check = [&](const track_pt_fixed_t& pt) -> bool {
-      // track quality cuts
+      // Track quality cuts
       if (pt.to_double() < settings_->vx_TrackMinPt())
         return false;
       return true;
     };
 
     auto fetch_bin = [&](const z0_t& z0, int nbins) -> std::pair<histbin_t, bool> {
-      histbin_t bin = (z0 * histbin_fixed_t(1.0 / settings_->vx_histogram_binwidth())) +
-                      histbin_t(std::floor(
-                          nbins / 2.));  // Rounding down (std::floor) taken care of by implicitly casting to ap_uint
+       // Increase the the number of bits in the word to allow for additional dynamic range
+       ap_int<TrackBitWidths::kZ0Size + 1> z0_13 = z0;
+       // Add a number equal to half of the range in z0, meaning that the range is now [0, 2*z0_max]
+       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13 = z0_13 + (1 << (TrackBitWidths::kZ0Size - 1));
+       // Shift the bits down to truncate the dynamic range to the most significant HistogramBitWidths::kBinFixedSize bits
+       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13_reduced = absz0_13 >> (TrackBitWidths::kZ0Size - HistogramBitWidths::kBinFixedSize);
+       // Put the relevant bits into the histbin_t container
+       histbin_t bin = absz0_13_reduced.range(HistogramBitWidths::kBinFixedSize - 1, 0);
+
       if (settings_->debug() > 2) {
         edm::LogInfo("VertexProducer")
             << "fastHistoEmulation::fetchBin() Checking the mapping from z0 to bin index ... \n"
@@ -872,7 +876,7 @@ namespace l1tVertexFinder {
       return inversion_table.at(index);
     };
 
-    auto bin_center = [&](zsliding_t iz, int nbins) -> z0_t {
+    auto bin_center = [&](zsliding_t iz, int nbins) -> l1t::VertexWord::vtxz0_t {
       zsliding_t z = iz - histbin_t(std::floor(nbins / 2.));
       std::unique_ptr<edm::LogInfo> log;
       if (settings_->debug() >= 1) {
@@ -883,9 +887,9 @@ namespace l1tVertexFinder {
              << "binwidth = " << zsliding_t(settings_->vx_histogram_binwidth()) << "\n"
              << "z = " << z << "\n"
              << "zsliding_t(z * zsliding_t(binwidth)) = " << std::setprecision(7)
-             << z0_t(z * zsliding_t(settings_->vx_histogram_binwidth()));
+             << l1t::VertexWord::vtxz0_t(z * zsliding_t(settings_->vx_histogram_binwidth()));
       }
-      return z0_t(z * zsliding_t(settings_->vx_histogram_binwidth()));
+      return l1t::VertexWord::vtxz0_t(z * zsliding_t(settings_->vx_histogram_binwidth()));
     };
 
     auto weighted_position = [&](histbin_t b_max,
@@ -963,12 +967,7 @@ namespace l1tVertexFinder {
       tkpt.V = track.getTTTrackPtr()->getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1,
                                                      TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
       track_pt_fixed_t pt_tmp = tkpt;
-      //z0_t tkZ0 = track.getTTTrackPtr()->getZ0();
-      z0_t tkZ0 = 0;
-      tkZ0.V = track.getTTTrackPtr()->getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kZ0MSB,
-                                                     TTTrack_TrackWord::TrackBitLocations::kZ0LSB);
-      ap_ufixed<32, 1> kZ0Scale_fixed = kZ0Scale;
-      tkZ0 *= kZ0Scale_fixed;
+      z0_t tkZ0 = track.getTTTrackPtr()->getZ0Word();
 
       if ((settings_->vx_DoQualityCuts() && track_quality_check(tkpt)) || (!settings_->vx_DoQualityCuts())) {
         //

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -951,8 +951,8 @@ namespace l1tVertexFinder {
     };
 
     // Create the histogram
-    unsigned int nbins =
-        std::round((settings_->vx_histogram_max() - settings_->vx_histogram_min()) / settings_->vx_histogram_binwidth());
+    unsigned int nbins = std::round((settings_->vx_histogram_max() - settings_->vx_histogram_min()) /
+                                    settings_->vx_histogram_binwidth());
     unsigned int nsums = nbins - settings_->vx_windowSize();
     std::vector<link_pt_sum_fixed_t> hist(nbins, 0);
 

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -824,14 +824,15 @@ namespace l1tVertexFinder {
     };
 
     auto fetch_bin = [&](const z0_t& z0, int nbins) -> std::pair<histbin_t, bool> {
-       // Increase the the number of bits in the word to allow for additional dynamic range
-       ap_int<TrackBitWidths::kZ0Size + 1> z0_13 = z0;
-       // Add a number equal to half of the range in z0, meaning that the range is now [0, 2*z0_max]
-       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13 = z0_13 + (1 << (TrackBitWidths::kZ0Size - 1));
-       // Shift the bits down to truncate the dynamic range to the most significant HistogramBitWidths::kBinFixedSize bits
-       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13_reduced = absz0_13 >> (TrackBitWidths::kZ0Size - HistogramBitWidths::kBinFixedSize);
-       // Put the relevant bits into the histbin_t container
-       histbin_t bin = absz0_13_reduced.range(HistogramBitWidths::kBinFixedSize - 1, 0);
+      // Increase the the number of bits in the word to allow for additional dynamic range
+      ap_int<TrackBitWidths::kZ0Size + 1> z0_13 = z0;
+      // Add a number equal to half of the range in z0, meaning that the range is now [0, 2*z0_max]
+      ap_int<TrackBitWidths::kZ0Size + 1> absz0_13 = z0_13 + (1 << (TrackBitWidths::kZ0Size - 1));
+      // Shift the bits down to truncate the dynamic range to the most significant HistogramBitWidths::kBinFixedSize bits
+      ap_int<TrackBitWidths::kZ0Size + 1> absz0_13_reduced =
+          absz0_13 >> (TrackBitWidths::kZ0Size - HistogramBitWidths::kBinFixedSize);
+      // Put the relevant bits into the histbin_t container
+      histbin_t bin = absz0_13_reduced.range(HistogramBitWidths::kBinFixedSize - 1, 0);
 
       if (settings_->debug() > 2) {
         edm::LogInfo("VertexProducer")

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -952,7 +952,7 @@ namespace l1tVertexFinder {
 
     // Create the histogram
     unsigned int nbins =
-        std::ceil((settings_->vx_histogram_max() - settings_->vx_histogram_min()) / settings_->vx_histogram_binwidth());
+        std::round((settings_->vx_histogram_max() - settings_->vx_histogram_min()) / settings_->vx_histogram_binwidth());
     unsigned int nsums = nbins - settings_->vx_windowSize();
     std::vector<link_pt_sum_fixed_t> hist(nbins, 0);
 


### PR DESCRIPTION
#### PR description:

This PR makes some changes to how the vertexing algorithm treats the track z0 parameter. It allows for the use of the full dynamic range of the track parameters. Additionally, this PR updates some of the ancillary code used by the GTT developers.

Porting local https://github.com/cms-l1t-offline/cmssw/pull/1037

#### PR validation

This PR was validated by passing the resulting test vectors through the Xilinx HLS firmware generation stage. We also performed many of the calculations by hand in order to validate that the code was performing the correct operations. Finally, we ran the scram code-checks and code-format commands to make sure the code complied with the CMS code rules.