### PR TITLE
[L1T] Phase-2, Create GTT to GT test vectors, and test vectors from the L1TrackSelectionProducer outputs

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_EtSum_h
+#define L1Trigger_DemonstratorTools_codecs_EtSum_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeEtSum(const l1t::EtSum& v);
+
+  // Encodes EtSum collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeEtSums(const edm::View<l1t::EtSum>&);
+
+  std::vector<l1t::EtSum> decodeEtSums(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/etsums.h
@@ -9,8 +9,6 @@
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
-#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
 #include "L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h"
 
 namespace l1t::demo::codecs {

--- a/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
@@ -9,8 +9,6 @@
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
-#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
 #include "L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h"
 
 namespace l1t::demo::codecs {

--- a/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/htsums.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_HtSum_h
+#define L1Trigger_DemonstratorTools_codecs_HtSum_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+#include "L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeHtSum(const l1t::EtSum& v);
+
+  // Encodes EtSum collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>&);
+
+  std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
@@ -1,0 +1,27 @@
+
+#ifndef L1Trigger_DemonstratorTools_codecs_tkjets_h
+#define L1Trigger_DemonstratorTools_codecs_tkjets_h
+
+#include <array>
+#include <vector>
+
+#include "ap_int.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/L1TCorrelator/interface/TkJet.h"
+#include "DataFormats/L1TCorrelator/interface/TkJetFwd.h"
+#include "DataFormats/L1Trigger/interface/TkJetWord.h"
+#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeTkJet(const l1t::TkJetWord& t);
+
+  // Encodes TkJet collection onto 1 'logical' output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeTkJets(const edm::View<l1t::TkJetWord>&);
+
+  std::vector<l1t::TkJetWord> decodeTkJets(const std::vector<ap_uint<64>>&);
+
+}  // namespace l1t::demo::codecs
+
+#endif

--- a/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tkjets.h
@@ -11,7 +11,6 @@
 #include "DataFormats/L1TCorrelator/interface/TkJet.h"
 #include "DataFormats/L1TCorrelator/interface/TkJetFwd.h"
 #include "DataFormats/L1Trigger/interface/TkJetWord.h"
-#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
 
 namespace l1t::demo::codecs {
 

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -27,8 +27,9 @@ namespace l1t::demo::codecs {
 
   // Return the 96-bit track words from a given track collection and place them on the appropriate 18 'logical' links
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&);
-  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
-                                                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(
+      const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
+      const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
 
   // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&,
@@ -36,9 +37,10 @@ namespace l1t::demo::codecs {
 
   // Encodes a track collection based off the ordering of another track collection
   // Requirement: The second collection must be a subset of the first
-  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
-                                                        const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&,
-                                                        int debug = 0);
+  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(
+      const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
+      const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&,
+      int debug = 0);
 
   // Decodes the tracks for a single link
   std::vector<TTTrack_TrackWord> decodeTracks(const std::vector<ap_uint<64>>&);

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -14,8 +14,6 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
-#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
-
 namespace l1t::demo::codecs {
 
   // Return true if a track is contained within a collection

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -8,6 +8,8 @@
 
 #include "ap_int.h"
 
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
@@ -16,11 +18,33 @@
 
 namespace l1t::demo::codecs {
 
+  // Return true if a track is contained within a collection
+  bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
+                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
+
+  // Encodes a single track into a 96-bit track word
   ap_uint<96> encodeTrack(const TTTrack_TrackWord& t);
+
+  // Return the 96-bit track words from a given track collection and place them on the appropriate 18 'logical' links
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&);
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
+                                                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
 
   // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&,
                                                         int debug = 0);
+
+  // Encodes a track collection based off the ordering of another track collection
+  // Requirement: The second collection must be a subset of the first
+  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
+                                                        const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&,
+                                                        int debug = 0);
+
+  // Decodes the tracks for a single link
+  std::vector<TTTrack_TrackWord> decodeTracks(const std::vector<ap_uint<64>>&);
+
+  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
+  std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>&);
 
 }  // namespace l1t::demo::codecs
 

--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -31,7 +31,7 @@ namespace l1t::demo::codecs {
       const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,
       const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>&);
 
-  // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Encodes track collection onto 18 'logical' output links (2x9 eta-phi sectors; -/+ eta pairs)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>&,
                                                         int debug = 0);
 
@@ -45,7 +45,7 @@ namespace l1t::demo::codecs {
   // Decodes the tracks for a single link
   std::vector<TTTrack_TrackWord> decodeTracks(const std::vector<ap_uint<64>>&);
 
-  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>&);
 
 }  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/interface/codecs/vertices.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/vertices.h
@@ -10,7 +10,6 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/L1Trigger/interface/Vertex.h"
 #include "DataFormats/L1Trigger/interface/VertexWord.h"
-#include "L1Trigger/DemonstratorTools/interface/BoardData.h"
 
 namespace l1t::demo::codecs {
 

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -297,7 +297,8 @@ void GTTFileWriter::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<edm::InputTag>("selectedTracks",
                                    edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"));
   desc.addUntracked<edm::InputTag>(
-      "vertexAssociatedTracks", edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"));
+      "vertexAssociatedTracks",
+      edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"));
   desc.addUntracked<edm::InputTag>("vertices", edm::InputTag("l1tVertexProducer", "l1verticesEmulation"));
   desc.addUntracked<edm::InputTag>("jets", edm::InputTag("l1tTrackJetsEmulation", "L1TrackJets"));
   desc.addUntracked<edm::InputTag>("htmiss", edm::InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"));

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -126,15 +126,15 @@ private:
   void endJob() override;
 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<edm::View<Track_t>> tracksToken_;
-  edm::EDGetTokenT<edm::View<Track_t>> convertedTracksToken_;
-  edm::EDGetTokenT<TrackCollection_t> convertedTrackCollectionToken_;
-  edm::EDGetTokenT<TrackRefCollection_t> selectedTracksToken_;
-  edm::EDGetTokenT<TrackRefCollection_t> vertexAssociatedTracksToken_;
-  edm::EDGetTokenT<edm::View<l1t::VertexWord>> verticesToken_;
-  edm::EDGetTokenT<edm::View<l1t::TkJetWord>> jetsToken_;
-  edm::EDGetTokenT<edm::View<l1t::EtSum>> htMissToken_;
-  edm::EDGetTokenT<edm::View<l1t::EtSum>> etMissToken_;
+  const edm::EDGetTokenT<edm::View<Track_t>> tracksToken_;
+  const edm::EDGetTokenT<edm::View<Track_t>> convertedTracksToken_;
+  const edm::EDGetTokenT<TrackCollection_t> convertedTrackCollectionToken_;
+  const edm::EDGetTokenT<TrackRefCollection_t> selectedTracksToken_;
+  const edm::EDGetTokenT<TrackRefCollection_t> vertexAssociatedTracksToken_;
+  const edm::EDGetTokenT<edm::View<l1t::VertexWord>> verticesToken_;
+  const edm::EDGetTokenT<edm::View<l1t::TkJetWord>> jetsToken_;
+  const edm::EDGetTokenT<edm::View<l1t::EtSum>> htMissToken_;
+  const edm::EDGetTokenT<edm::View<l1t::EtSum>> etMissToken_;
 
   l1t::demo::BoardDataWriter fileWriterInputTracks_;
   l1t::demo::BoardDataWriter fileWriterConvertedTracks_;

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -213,8 +213,9 @@ void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   l1t::demo::EventData eventDataGlobalTrigger;
   eventDataGlobalTrigger.add({"sums", 0}, sumsData);
-  eventDataGlobalTrigger.add({"taus", 1}, std::vector<ap_uint<64>>(18, 0)); // Placeholder until tau object is written
-  eventDataGlobalTrigger.add({"mesons", 2}, std::vector<ap_uint<64>>(39, 0)); // Placeholder until light meson objects are written
+  eventDataGlobalTrigger.add({"taus", 1}, std::vector<ap_uint<64>>(18, 0));  // Placeholder until tau object is written
+  eventDataGlobalTrigger.add({"mesons", 2},
+                             std::vector<ap_uint<64>>(39, 0));  // Placeholder until light meson objects are written
   eventDataGlobalTrigger.add({"vertices", 3}, tracksVerticesData);
 
   // 3) Pass the 'event data' object to the file writer

--- a/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
+++ b/L1Trigger/DemonstratorTools/plugins/GTTFileWriter.cc
@@ -177,19 +177,20 @@ GTTFileWriter::GTTFileWriter(const edm::ParameterSet& iConfig)
                                  kChannelIdsInput,
                                  kChannelSpecsInput),
       fileWriterSelectedTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
-                                 iConfig.getUntrackedParameter<std::string>("selectedTracksFilename"),
-                                 kFramesPerTMUXPeriod,
-                                 kGTTBoardTMUX,
-                                 kMaxLinesPerFile,
-                                 kChannelIdsInput,
-                                 kChannelSpecsInput),
-      fileWriterVertexAssociatedTracks_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
-                                 iConfig.getUntrackedParameter<std::string>("vertexAssociatedTracksFilename"),
-                                 kFramesPerTMUXPeriod,
-                                 kGTTBoardTMUX,
-                                 kMaxLinesPerFile,
-                                 kChannelIdsInput,
-                                 kChannelSpecsInput),
+                                iConfig.getUntrackedParameter<std::string>("selectedTracksFilename"),
+                                kFramesPerTMUXPeriod,
+                                kGTTBoardTMUX,
+                                kMaxLinesPerFile,
+                                kChannelIdsInput,
+                                kChannelSpecsInput),
+      fileWriterVertexAssociatedTracks_(
+          l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
+          iConfig.getUntrackedParameter<std::string>("vertexAssociatedTracksFilename"),
+          kFramesPerTMUXPeriod,
+          kGTTBoardTMUX,
+          kMaxLinesPerFile,
+          kChannelIdsInput,
+          kChannelSpecsInput),
       fileWriterOutputToCorrelator_(l1t::demo::parseFileFormat(iConfig.getUntrackedParameter<std::string>("format")),
                                     iConfig.getUntrackedParameter<std::string>("outputCorrelatorFilename"),
                                     kFramesPerTMUXPeriod,
@@ -209,12 +210,12 @@ void GTTFileWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   using namespace l1t::demo::codecs;
 
   // 0) Gather the necessary collections
-  const auto tracksCollection = iEvent.get(tracksToken_);
-  const auto convertedTracksCollection = iEvent.get(convertedTracksToken_);
-  const auto verticesCollection = iEvent.get(verticesToken_);
-  const auto jetsCollection = iEvent.get(jetsToken_);
-  const auto htMissCollection = iEvent.get(htMissToken_);
-  const auto etMissCollection = iEvent.get(etMissToken_);
+  const auto& tracksCollection = iEvent.get(tracksToken_);
+  const auto& convertedTracksCollection = iEvent.get(convertedTracksToken_);
+  const auto& verticesCollection = iEvent.get(verticesToken_);
+  const auto& jetsCollection = iEvent.get(jetsToken_);
+  const auto& htMissCollection = iEvent.get(htMissToken_);
+  const auto& etMissCollection = iEvent.get(etMissToken_);
 
   edm::Handle<TrackCollection_t> convertedTracksHandle;
   edm::Handle<TrackRefCollection_t> selectedTracksHandle;
@@ -293,8 +294,10 @@ void GTTFileWriter::fillDescriptions(edm::ConfigurationDescriptions& description
   edm::ParameterSetDescription desc;
   desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
   desc.addUntracked<edm::InputTag>("convertedTracks", edm::InputTag("l1tGTTInputProducer", "Level1TTTracksConverted"));
-  desc.addUntracked<edm::InputTag>("selectedTracks", edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"));
-  desc.addUntracked<edm::InputTag>("vertexAssociatedTracks", edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"));
+  desc.addUntracked<edm::InputTag>("selectedTracks",
+                                   edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"));
+  desc.addUntracked<edm::InputTag>(
+      "vertexAssociatedTracks", edm::InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"));
   desc.addUntracked<edm::InputTag>("vertices", edm::InputTag("l1tVertexProducer", "l1verticesEmulation"));
   desc.addUntracked<edm::InputTag>("jets", edm::InputTag("l1tTrackJetsEmulation", "L1TrackJets"));
   desc.addUntracked<edm::InputTag>("htmiss", edm::InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"));

--- a/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
@@ -2,10 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 GTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   tracks = cms.untracked.InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"),
-  convertedTracks = cms.untracked.InputTag("l1tGTTInputProducer","Level1TTTracksConverted"),
+  convertedTracks = cms.untracked.InputTag("l1tGTTInputProducer", "Level1TTTracksConverted"),
   vertices = cms.untracked.InputTag("l1tVertexProducer", "l1verticesEmulation"),
+  jets = cms.untracked.InputTag("l1tTrackJetsEmulation","L1TrackJets"),
+  htmiss = cms.untracked.InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
+  etmiss = cms.untracked.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
   inputFilename = cms.untracked.string("L1GTTInputFile"),
   inputConvertedFilename = cms.untracked.string("L1GTTInputConvertedFile"),
-  outputFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
+  outputCorrelatorFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
+  outputGlobalTriggerFilename = cms.untracked.string("L1GTTOutputToGlobalTriggerFile"),
   format = cms.untracked.string("APx")
 )

--- a/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
@@ -2,13 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 GTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   tracks = cms.untracked.InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"),
-  convertedTracks = cms.untracked.InputTag("l1tGTTInputProducer", "Level1TTTracksConverted"),
+  convertedTracks = cms.untracked.InputTag("l1tL1GTTInputProducer", "Level1TTTracksConverted"),
   vertices = cms.untracked.InputTag("l1tVertexProducer", "l1verticesEmulation"),
+  selectedTracks = cms.untracked.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"),
+  vertexAssociatedTracks = cms.untracked.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"),
   jets = cms.untracked.InputTag("l1tTrackJetsEmulation","L1TrackJets"),
   htmiss = cms.untracked.InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
   etmiss = cms.untracked.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
   inputFilename = cms.untracked.string("L1GTTInputFile"),
   inputConvertedFilename = cms.untracked.string("L1GTTInputConvertedFile"),
+  selectedTracksFilename = cms.untracked.string("L1GTTSelectedTracksFile"),
+  vertexAssociatedTracksFilename = cms.untracked.string("L1GTTVertexAssociatedTracksFile"),
   outputCorrelatorFilename = cms.untracked.string("L1GTTOutputToCorrelatorFile"),
   outputGlobalTriggerFilename = cms.untracked.string("L1GTTOutputToGlobalTriggerFile"),
   format = cms.untracked.string("APx")

--- a/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
+++ b/L1Trigger/DemonstratorTools/python/GTTFileWriter_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 GTTFileWriter = cms.EDAnalyzer('GTTFileWriter',
   tracks = cms.untracked.InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"),
-  convertedTracks = cms.untracked.InputTag("l1tL1GTTInputProducer", "Level1TTTracksConverted"),
+  convertedTracks = cms.untracked.InputTag("l1tGTTInputProducer", "Level1TTTracksConverted"),
   vertices = cms.untracked.InputTag("l1tVertexProducer", "l1verticesEmulation"),
   selectedTracks = cms.untracked.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"),
   vertexAssociatedTracks = cms.untracked.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedAssociatedEmulation"),

--- a/L1Trigger/DemonstratorTools/src/BoardDataWriter.cc
+++ b/L1Trigger/DemonstratorTools/src/BoardDataWriter.cc
@@ -61,7 +61,7 @@ namespace l1t::demo {
     // Check that data is supplied for each channel
     for (const auto& [id, info] : channelMap_) {
       if (not eventData.has(id))
-        throw std::runtime_error("Event data for link " + id.interface + ", " + std::to_string(id.channel) +
+        throw std::runtime_error("Event data for link [" + id.interface + ", " + std::to_string(id.channel) +
                                  "] is missing.");
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -4,15 +4,13 @@
 namespace l1t::demo::codecs {
 
   ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
-
-  	l1tmetemu::EtMiss etMiss;
-  	etMiss.Et = etSum.hwPt();
-  	etMiss.Phi = etSum.hwPhi();
-  	ap_uint<1> valid = (etSum.hwQual() > 0);
-  	ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
-  	return etSumWord;
-
+    l1tmetemu::EtMiss etMiss;
+    etMiss.Et = etSum.hwPt();
+    etMiss.Phi = etSum.hwPhi();
+    ap_uint<1> valid = (etSum.hwQual() > 0);
+    ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
+    ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
+    return etSumWord;
   }
 
   // Encodes etsum collection onto 1 output link
@@ -41,8 +39,12 @@ namespace l1t::demo::codecs {
         break;
 
       math::XYZTLorentzVector v(0, 0, 0, 0);
-      l1t::EtSum s(v, l1t::EtSum::EtSumType::kMissingEt, l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(), 0,
-                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(), 0);
+      l1t::EtSum s(v,
+                   l1t::EtSum::EtSumType::kMissingEt,
+                   l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(),
+                   0,
+                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(),
+                   0);
       etSums.push_back(s);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -1,5 +1,5 @@
-
 #include "L1Trigger/DemonstratorTools/interface/codecs/etsums.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
 
 namespace l1t::demo::codecs {
 

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -1,0 +1,52 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/etsums.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeEtSum(const l1t::EtSum& etSum) {
+
+  	l1tmetemu::EtMiss etMiss;
+  	etMiss.Et = etSum.hwPt();
+  	etMiss.Phi = etSum.hwPhi();
+  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	ap_uint<64 - (l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize + 1)> unassigned = 0;
+  	ap_uint<64> etSumWord = (unassigned, etMiss.Phi, etMiss.Et, valid);
+  	return etSumWord;
+
+  }
+
+  // Encodes etsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeEtSums(const edm::View<l1t::EtSum>& etSums) {
+    std::vector<ap_uint<64>> etSumWords;
+
+    for (const auto& etSum : etSums)
+      etSumWords.push_back(encodeEtSum(etSum));
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
+      etSumWords.resize(1, 0);
+      linkData.at(i) = etSumWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::EtSum> decodeEtSums(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::EtSum> etSums;
+
+    for (const auto& x : frames) {
+      if (not x.test(0))
+        break;
+
+      math::XYZTLorentzVector v(0, 0, 0, 0);
+      l1t::EtSum s(v, l1t::EtSum::EtSumType::kMissingEt, l1tmetemu::MET_t(x(1 + l1tmetemu::kMETSize, 1)).to_int(), 0,
+                   l1tmetemu::METphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(), 0);
+      etSums.push_back(s);
+    }
+
+    return etSums;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -3,39 +3,39 @@
 
 namespace l1t::demo::codecs {
 
-  ap_uint<64> encodeHtSum(const l1t::EtSum& etSum) {
+  ap_uint<64> encodeHtSum(const l1t::EtSum& htSum) {
 
-  	l1tmhtemu::EtMiss etMiss;
-  	etMiss.Et = etSum.p4().energy();
-  	etMiss.Phi = etSum.hwPhi();
-    l1tmhtemu::Et_t HT = etSum.hwPt();
-  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	l1tmhtemu::EtMiss htMiss;
+  	htMiss.Et = htSum.p4().energy();
+  	htMiss.Phi = htSum.hwPhi();
+    l1tmhtemu::Et_t HT = htSum.hwPt();
+  	ap_uint<1> valid = (htSum.hwQual() > 0);
   	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> etSumWord = (unassigned, HT, etMiss.Phi, etMiss.Et, valid);
-  	return etSumWord;
+  	ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
+  	return htSumWord;
 
   }
 
-  // Encodes etsum collection onto 1 output link
-  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& etSums) {
-    std::vector<ap_uint<64>> etSumWords;
+  // Encodes htsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& htSums) {
+    std::vector<ap_uint<64>> htSumWords;
 
-    for (const auto& etSum : etSums)
-      etSumWords.push_back(encodeHtSum(etSum));
+    for (const auto& htSum : htSums)
+      htSumWords.push_back(encodeHtSum(htSum));
 
     std::array<std::vector<ap_uint<64>>, 1> linkData;
 
     for (size_t i = 0; i < linkData.size(); i++) {
-      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
-      etSumWords.resize(1, 0);
-      linkData.at(i) = etSumWords;
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 htsum max)
+      htSumWords.resize(1, 0);
+      linkData.at(i) = htSumWords;
     }
 
     return linkData;
   }
 
   std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>& frames) {
-    std::vector<l1t::EtSum> etSums;
+    std::vector<l1t::EtSum> htSums;
 
     for (const auto& x : frames) {
       if (not x.test(0))
@@ -47,10 +47,10 @@ namespace l1t::demo::codecs {
                    l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
                    0,
                    l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
-      etSums.push_back(s);
+      htSums.push_back(s);
     }
 
-    return etSums;
+    return htSums;
   }
 
 }  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -1,5 +1,5 @@
-
 #include "L1Trigger/DemonstratorTools/interface/codecs/htsums.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
 
 namespace l1t::demo::codecs {
 

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -1,0 +1,56 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/htsums.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeHtSum(const l1t::EtSum& etSum) {
+
+  	l1tmhtemu::EtMiss etMiss;
+  	etMiss.Et = etSum.p4().energy();
+  	etMiss.Phi = etSum.hwPhi();
+    l1tmhtemu::Et_t HT = etSum.hwPt();
+  	ap_uint<1> valid = (etSum.hwQual() > 0);
+  	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
+  	ap_uint<64> etSumWord = (unassigned, HT, etMiss.Phi, etMiss.Et, valid);
+  	return etSumWord;
+
+  }
+
+  // Encodes etsum collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeHtSums(const edm::View<l1t::EtSum>& etSums) {
+    std::vector<ap_uint<64>> etSumWords;
+
+    for (const auto& etSum : etSums)
+      etSumWords.push_back(encodeHtSum(etSum));
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad etsum vectors -> full packet length (48 frames, but only 1 etsum max)
+      etSumWords.resize(1, 0);
+      linkData.at(i) = etSumWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::EtSum> decodeHtSums(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::EtSum> etSums;
+
+    for (const auto& x : frames) {
+      if (not x.test(0))
+        break;
+
+      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTSize + 1, 1)).to_int());
+      l1t::EtSum s(v,
+                   l1t::EtSum::EtSumType::kMissingHt,
+                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
+                   0,
+                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
+      etSums.push_back(s);
+    }
+
+    return etSums;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_htsums.cc
@@ -4,16 +4,14 @@
 namespace l1t::demo::codecs {
 
   ap_uint<64> encodeHtSum(const l1t::EtSum& htSum) {
-
-  	l1tmhtemu::EtMiss htMiss;
-  	htMiss.Et = htSum.p4().energy();
-  	htMiss.Phi = htSum.hwPhi();
+    l1tmhtemu::EtMiss htMiss;
+    htMiss.Et = htSum.p4().energy();
+    htMiss.Phi = htSum.hwPhi();
     l1tmhtemu::Et_t HT = htSum.hwPt();
-  	ap_uint<1> valid = (htSum.hwQual() > 0);
-  	ap_uint<64 - (l1tmhtemu::kHTSize + l1tmhtemu::kMHTSize + l1tmhtemu::kMHTPhiSize + 1)> unassigned = 0;
-  	ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
-  	return htSumWord;
-
+    ap_uint<l1tmhtemu::kValidSize> valid = (htSum.hwQual() > 0);
+    ap_uint<l1tmhtemu::kUnassignedSize> unassigned = 0;
+    ap_uint<64> htSumWord = (unassigned, HT, htMiss.Phi, htMiss.Et, valid);
+    return htSumWord;
   }
 
   // Encodes htsum collection onto 1 output link
@@ -41,12 +39,13 @@ namespace l1t::demo::codecs {
       if (not x.test(0))
         break;
 
-      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTSize + 1, 1)).to_int());
+      math::XYZTLorentzVector v(0, 0, 0, l1tmhtemu::MHT_t(x(l1tmhtemu::kMHTMSB, l1tmhtemu::kMHTLSB)).to_int());
       l1t::EtSum s(v,
                    l1t::EtSum::EtSumType::kMissingHt,
-                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTSize + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1)).to_int(),
+                   l1tmhtemu::Et_t(x(l1tmhtemu::kHTMSB, l1tmhtemu::kHTLSB)).to_int(),
                    0,
-                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiSize + l1tmhtemu::kMHTSize + 1, 1 + l1tmhtemu::kMHTSize + 1)).to_int(), 0);
+                   l1tmhtemu::MHTphi_t(x(l1tmhtemu::kMHTPhiMSB, l1tmhtemu::kMHTPhiLSB)).to_int(),
+                   0);
       htSums.push_back(s);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
@@ -35,12 +35,12 @@ namespace l1t::demo::codecs {
       //  break;
 
       TkJetWord j(TkJetWord::pt_t(frames[f](TkJetWord::kPtMSB, TkJetWord::kPtLSB)),
-                   TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
-                   TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
-                   TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
-                   TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
-                   TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
-                   TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
+                  TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
+                  TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
+                  TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
+                  TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
+                  TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
+                  TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
       tkJets.push_back(j);
     }
 

--- a/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
@@ -1,0 +1,50 @@
+
+#include "L1Trigger/DemonstratorTools/interface/codecs/tkjets.h"
+
+namespace l1t::demo::codecs {
+
+  ap_uint<64> encodeTkJet(const l1t::TkJetWord& j) { return j.tkJetWord(); }
+
+  // Encodes vertex collection onto 1 output link
+  std::array<std::vector<ap_uint<64>>, 1> encodeTkJets(const edm::View<l1t::TkJetWord>& tkJets) {
+    std::vector<ap_uint<64>> tkJetWords;
+
+    for (const auto& tkJet : tkJets) {
+      tkJetWords.push_back(encodeTkJet(tkJet));
+      tkJetWords.push_back(ap_uint<64>(0));
+    }
+
+    std::array<std::vector<ap_uint<64>>, 1> linkData;
+
+    for (size_t i = 0; i < linkData.size(); i++) {
+      // Pad TkJet vectors -> full packet length (48 frames, but only 12 TkJets max, two words per jet)
+      tkJetWords.resize(24, 0);
+      linkData.at(i) = tkJetWords;
+    }
+
+    return linkData;
+  }
+
+  std::vector<l1t::TkJetWord> decodeTkJets(const std::vector<ap_uint<64>>& frames) {
+    std::vector<l1t::TkJetWord> tkJets;
+
+    for (size_t f = 0; f < frames.size(); f += 2) {
+      // There is no valid bit in the definition right now.
+      // Uncomment the next two lines when this is available.
+      //if (not x.test(TkJetWord::kValidLSB))
+      //  break;
+
+      TkJetWord j(TkJetWord::pt_t(frames[f](TkJetWord::kPtMSB, TkJetWord::kPtLSB)),
+                   TkJetWord::glbeta_t(frames[f](TkJetWord::kGlbEtaMSB, TkJetWord::kGlbEtaLSB)),
+                   TkJetWord::glbphi_t(frames[f](TkJetWord::kGlbPhiMSB, TkJetWord::kGlbPhiLSB)),
+                   TkJetWord::z0_t(frames[f](TkJetWord::kZ0MSB, TkJetWord::kZ0LSB)),
+                   TkJetWord::nt_t(frames[f](TkJetWord::kNtMSB, TkJetWord::kNtLSB)),
+                   TkJetWord::nx_t(frames[f](TkJetWord::kXtMSB, TkJetWord::kXtLSB)),
+                   TkJetWord::tkjetunassigned_t(frames[f](TkJetWord::kUnassignedMSB, TkJetWord::kUnassignedLSB)));
+      tkJets.push_back(j);
+    }
+
+    return tkJets;
+  }
+
+}  // namespace l1t::demo::codecs

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -4,13 +4,13 @@
 namespace l1t::demo::codecs {
 
   // Return true if a track is contained within a collection
-  bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& trackRef,
-                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& trackRefCollection) {
-    auto it = std::find_if(trackRefCollection->begin(),
-                           trackRefCollection->end(),
-                           [&trackRef](edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> const& obj) {
-                            return obj == trackRef;
-                          });
+  bool trackInCollection(
+      const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& trackRef,
+      const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& trackRefCollection) {
+    auto it = std::find_if(
+        trackRefCollection->begin(),
+        trackRefCollection->end(),
+        [&trackRef](edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> const& obj) { return obj == trackRef; });
     if (it != trackRefCollection->end())
       return true;
     else
@@ -30,17 +30,18 @@ namespace l1t::demo::codecs {
   }
 
   // Return the 96-bit track words from a given track collection and place them on the appropriate 18 'logical' links
-  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
-                                                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks) {
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(
+      const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
+      const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (unsigned int itrack = 0; itrack < referenceTracks->size(); itrack++) {
       const auto& referenceTrack = referenceTracks->at(itrack);
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(encodeTrack(referenceTrack));
-      }
-      else {
+        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector())
+            .push_back(encodeTrack(referenceTrack));
+      } else {
         trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(ap_uint<96>(0));
       }
     }
@@ -87,9 +88,10 @@ namespace l1t::demo::codecs {
 
   // Encodes a track collection based off the ordering of another track collection
   // Requirement: The second collection must be a subset of the first
-  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
-                                                        const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks,
-                                                        int debug) {
+  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(
+      const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
+      const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks,
+      int debug) {
     if (debug > 0) {
       edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoding " << tracks->size() << " tracks";
     }

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -3,20 +3,53 @@
 
 namespace l1t::demo::codecs {
 
+  // Return true if a track is contained within a collection
+  bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& trackRef,
+                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& trackRefCollection) {
+    auto it = std::find_if(trackRefCollection->begin(),
+                           trackRefCollection->end(),
+                           [&trackRef](edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> const& obj) {
+                            return obj == trackRef;
+                          });
+    if (it != trackRefCollection->end())
+      return true;
+    else
+      return false;
+  }
+
+  // Encodes a single track into a 96-bit track word
   ap_uint<96> encodeTrack(const TTTrack_TrackWord& t) { return t.getTrackWord(); }
 
-  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)
-  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks,
-                                                        int debug) {
+  // Return the 96-bit track words from a given track collection and place them on the appropriate 18 'logical' links
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
-    if (debug > 0) {
-      edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoding " << tracks.size() << " tracks";
-    }
-    for (const auto& track : tracks)
+    for (const auto& track : tracks) {
       trackWords.at((track.eta() >= 0 ? 9 : 0) + track.phiSector()).push_back(encodeTrack(track));
+    }
+    return trackWords;
+  }
 
-    std::array<std::vector<ap_uint<64>>, 18> linkData;
+  // Return the 96-bit track words from a given track collection and place them on the appropriate 18 'logical' links
+  std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
+                                                         const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks) {
+    std::array<std::vector<ap_uint<96>>, 18> trackWords;
+    for (unsigned int itrack = 0; itrack < referenceTracks->size(); itrack++) {
+      const auto& referenceTrack = referenceTracks->at(itrack);
+      edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
+      if (trackInCollection(referenceTrackRef, tracks)) {
+        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(encodeTrack(referenceTrack));
+      }
+      else {
+        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(ap_uint<96>(0));
+      }
+    }
+    return trackWords;
+  }
+
+  // Encodes a set of tracks onto a set of links
+  size_t encodeLinks(std::array<std::vector<ap_uint<96>>, 18>& trackWords,
+                     std::array<std::vector<ap_uint<64>>, 18>& linkData) {
     size_t counter = 0;
     for (size_t i = 0; i < linkData.size(); i++) {
       // Pad track vectors -> full packet length (156 frames = 104 tracks)
@@ -31,6 +64,40 @@ namespace l1t::demo::codecs {
         counter += trackWords.at(i).at(j)(95, 95) + trackWords.at(i).at(j + 1)(95, 95);
       }
     }
+    return counter;
+  }
+
+  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)
+  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks,
+                                                        int debug) {
+    if (debug > 0) {
+      edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoding " << tracks.size() << " tracks";
+    }
+
+    std::array<std::vector<ap_uint<96>>, 18> trackWords = getTrackWords(tracks);
+    std::array<std::vector<ap_uint<64>>, 18> linkData;
+    size_t counter = encodeLinks(trackWords, linkData);
+
+    if (debug > 0) {
+      edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoded " << counter << " tracks";
+    }
+
+    return linkData;
+  }
+
+  // Encodes a track collection based off the ordering of another track collection
+  // Requirement: The second collection must be a subset of the first
+  std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>& referenceTracks,
+                                                        const edm::Handle<edm::RefVector<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>>& tracks,
+                                                        int debug) {
+    if (debug > 0) {
+      edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoding " << tracks->size() << " tracks";
+    }
+
+    std::array<std::vector<ap_uint<96>>, 18> trackWords = getTrackWords(referenceTracks, tracks);
+    std::array<std::vector<ap_uint<64>>, 18> linkData;
+    size_t counter = encodeLinks(trackWords, linkData);
+
     if (debug > 0) {
       edm::LogInfo("l1t::demo::codecs") << "encodeTrack::Encoded " << counter << " tracks";
     }

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,7 +24,7 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      trackWords.at((track.eta() >= 0 ? 9 : 0) + track.phiSector()).push_back(encodeTrack(track));
+      trackWords.at((track.eta() >= 0 ? 1 : 0) + (2 * track.phiSector())).push_back(encodeTrack(track));
     }
     return trackWords;
   }
@@ -39,10 +39,10 @@ namespace l1t::demo::codecs {
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector())
+        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector()))
             .push_back(encodeTrack(referenceTrack));
       } else {
-        trackWords.at((referenceTrack.eta() >= 0 ? 9 : 0) + referenceTrack.phiSector()).push_back(ap_uint<96>(0));
+        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector())).push_back(ap_uint<96>(0));
       }
     }
     return trackWords;
@@ -68,7 +68,7 @@ namespace l1t::demo::codecs {
     return counter;
   }
 
-  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; first 9 negative eta)
+  // Encodes track collection onto 18 output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<ap_uint<64>>, 18> encodeTracks(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks,
                                                         int debug) {
     if (debug > 0) {
@@ -157,6 +157,7 @@ namespace l1t::demo::codecs {
     return tracks;
   }
 
+  // Decodes the tracks from 18 'logical' output links (2x9 eta-phi sectors; , -/+ eta pairs)
   std::array<std::vector<TTTrack_TrackWord>, 18> decodeTracks(const std::array<std::vector<ap_uint<64>>, 18>& frames) {
     std::array<std::vector<TTTrack_TrackWord>, 18> tracks;
 

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -79,6 +79,7 @@ process.L1TrackSelectionProducer.processSimulatedTracks = cms.bool(False)
 process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
 process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackerEmuEtMiss.debug = options.debug
 
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -70,16 +70,16 @@ process.load("L1Trigger.L1TTrackMatch.l1tTrackerEmuHTMiss_cfi")
 process.load("L1Trigger.L1TTrackMatch.l1tTrackerEmuEtMiss_cfi")
 process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
-process.L1GTTInputProducer.debug = cms.int32(options.debug)
-process.VertexProducer.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted")
-process.VertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
-process.VertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
-process.VertexProducer.debug = options.debug
-process.L1TrackSelectionProducer.processSimulatedTracks = cms.bool(False)
-process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
-process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
-process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
-process.L1TrackerEmuEtMiss.debug = options.debug
+process.l1tGTTInputProducer.debug = cms.int32(options.debug)
+process.l1tVertexProducer.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted")
+process.l1tVertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
+process.l1tVertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
+process.l1tVertexProducer.debug = options.debug
+process.l1tTrackSelectionProducer.processSimulatedTracks = cms.bool(False)
+process.l1tTrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
+process.l1tTrackJetsEmulation.VertexInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
+process.l1tTrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
+process.l1tTrackerEmuEtMiss.debug = options.debug
 
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -64,6 +64,10 @@ process.options = cms.untracked.PSet(
 
 process.load('L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi')
 process.load('L1Trigger.VertexFinder.l1tVertexProducer_cfi')
+process.load("L1Trigger.L1TTrackMatch.l1tTrackSelectionProducer_cfi")
+process.load("L1Trigger.L1TTrackMatch.l1tTrackJetsEmulation_cfi")
+process.load("L1Trigger.L1TTrackMatch.l1tTrackerEmuHTMiss_cfi")
+process.load("L1Trigger.L1TTrackMatch.l1tTrackerEmuEtMiss_cfi")
 process.load('L1Trigger.DemonstratorTools.GTTFileWriter_cff')
 
 process.L1GTTInputProducer.debug = cms.int32(options.debug)
@@ -71,6 +75,11 @@ process.VertexProducer.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Le
 process.VertexProducer.VertexReconstruction.Algorithm = cms.string("fastHistoEmulation")
 process.VertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.VertexProducer.debug = options.debug
+process.L1TrackSelectionProducer.processSimulatedTracks = cms.bool(False)
+process.L1TrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackJetsEmulation.VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+process.L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("VertexProducer", "l1verticesEmulation")
+
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)
 
@@ -80,4 +89,4 @@ process.GTTFileWriter.format = cms.untracked.string(options.format)
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-process.p = cms.Path(process.l1tGTTInputProducer * process.l1tVertexProducer * process.GTTFileWriter)
+process.p = cms.Path(process.l1tGTTInputProducer * process.l1tVertexProducer * process.l1tTrackSelectionProducer * process.l1tTrackJetsEmulation * process.l1tTrackerEmuHTMiss * process.l1tTrackerEmuEtMiss * process.GTTFileWriter)

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -27,10 +27,27 @@ namespace l1tmhtemu {
   // extra room for sumPx, sumPy
   const unsigned int kEtExtra{10};
 
+  const unsigned int kValidSize{1};
   const unsigned int kMHTSize{15};     // For output Magnitude default 15
   const unsigned int kMHTPhiSize{14};  // For output Phi default 14
   const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
-  const float kMaxMHT{4096};           // 4 TeV
+  const unsigned int kUnassignedSize{64 - (kHTSize + kMHTSize + kMHTPhiSize + kValidSize)};
+
+  enum BitLocations {
+    // The location of the least significant bit (LSB) and most significant bit (MSB) in the sum word for different fields
+    kValidLSB = 0,
+    kValidMSB = kValidLSB + kValidSize - 1,
+    kMHTLSB = kValidMSB + 1,
+    kMHTMSB = kMHTLSB + kMHTSize - 1,
+    kMHTPhiLSB = kMHTMSB + 1,
+    kMHTPhiMSB = kMHTPhiLSB + kMHTPhiSize - 1,
+    kHTLSB = kMHTPhiMSB + 1,
+    kHTMSB = kHTLSB + kHTSize - 1,
+    kUnassignedLSB = kHTMSB + 1,
+    kUnassignedMSB = kUnassignedLSB + kUnassignedSize - 1
+  };
+
+  const float kMaxMHT{4096};  // 4 TeV
   const float kMaxMHTPhi{2 * M_PI};
 
   typedef ap_uint<5> ntracks_t;

--- a/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkHTMissEmulatorProducer.h
@@ -29,6 +29,7 @@ namespace l1tmhtemu {
 
   const unsigned int kMHTSize{15};     // For output Magnitude default 15
   const unsigned int kMHTPhiSize{14};  // For output Phi default 14
+  const unsigned int kHTSize{kInternalPtWidth + kEtExtra};
   const float kMaxMHT{4096};           // 4 TeV
   const float kMaxMHTPhi{2 * M_PI};
 
@@ -37,7 +38,7 @@ namespace l1tmhtemu {
   typedef ap_int<kInternalEtaWidth> eta_t;
   typedef ap_int<kInternalPhiWidth> phi_t;
 
-  typedef ap_int<kInternalPtWidth + kEtExtra> Et_t;
+  typedef ap_int<kHTSize> Et_t;
   typedef ap_uint<kMHTSize> MHT_t;
   typedef ap_uint<kMHTPhiSize> MHTphi_t;
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -272,11 +272,13 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
       sumPy[link_number] += temppy;
       if (debug_ == 4) {
         edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
-              << "Sector: " << EtTrack.Sector << " Eta: " << EtTrack.EtaSector << "\n"
-              << "Int Track Px: " << temppx << " Int Track Py: " << temppy << "\n"
-              << "Float Track Px: " << (float)temppx * l1tmetemu::kStepPt << " Float Track Py:" << (float)temppy * l1tmetemu::kStepPt << "\n"
-              << "Int Sector Sum Px: " << sumPx[link_number] << " Int Sector Sum Py: " << sumPy[link_number] << "\n"
-              << "Float Sector Sum Px: " << (float)sumPx[link_number] * l1tmetemu::kStepPt << " Float Sector Sum Py: " << (float) sumPy[link_number] * l1tmetemu::kStepPt << "\n";
+            << "Sector: " << EtTrack.Sector << " Eta: " << EtTrack.EtaSector << "\n"
+            << "Int Track Px: " << temppx << " Int Track Py: " << temppy << "\n"
+            << "Float Track Px: " << (float)temppx * l1tmetemu::kStepPt
+            << " Float Track Py:" << (float)temppy * l1tmetemu::kStepPt << "\n"
+            << "Int Sector Sum Px: " << sumPx[link_number] << " Int Sector Sum Py: " << sumPy[link_number] << "\n"
+            << "Float Sector Sum Px: " << (float)sumPx[link_number] * l1tmetemu::kStepPt
+            << " Float Sector Sum Py: " << (float)sumPy[link_number] * l1tmetemu::kStepPt << "\n";
       }
     }
 
@@ -338,7 +340,8 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
     edm::LogVerbatim("L1TrackerEtMissEmulatorProducer")
         << "====Sector Pt====\n"
         << "Float Px: " << flpxarray.str() << "\nFloat Py: " << flpyarray.str() << "\nInteger Px: " << intpyarray.str()
-        << "\nInteger Px: " << intpyarray.str() << "\nLink Totals: " << linksarray.str() << "\nSector Totals: " << totalsarray.str() << "\n"
+        << "\nInteger Px: " << intpyarray.str() << "\nLink Totals: " << linksarray.str()
+        << "\nSector Totals: " << totalsarray.str() << "\n"
 
         << "====Global Pt====\n"
         << "Integer Global Px: " << GlobalPx << "| Integer Global Py: " << GlobalPy << "\n"

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2395,19 +2395,17 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
   if (SaveTrackSums) {
     if (Displaced == "Prompt" || Displaced == "Both") {
-      if (L1TkMETHandle.isValid()){
+      if (L1TkMETHandle.isValid()) {
         trkMET = L1TkMETHandle->begin()->etMiss();
         trkMETPhi = L1TkMETHandle->begin()->p4().phi();
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMET handle not found" << std::endl;
       }
 
       if (L1TkMETEmuHandle.isValid()) {
         trkMETEmu = L1TkMETEmuHandle->begin()->hwPt() * l1tmetemu::kStepMET;
         trkMETEmuPhi = L1TkMETEmuHandle->begin()->hwPhi() * l1tmetemu::kStepMETPhi - M_PI;
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMETEmu handle not found" << std::endl;
       }
 
@@ -2429,8 +2427,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       if (L1TkMETExtendedHandle.isValid()) {
         trkMETExt = L1TkMETExtendedHandle->begin()->etMiss();
         trkMETPhiExt = L1TkMETExtendedHandle->begin()->p4().phi();
-      }
-      else {
+      } else {
         edm::LogWarning("DataNotFound") << "\nWarning: tkMETExtended handle not found" << std::endl;
       }
 

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -107,10 +107,11 @@ process.load('L1Trigger.VertexFinder.l1tVertexProducer_cfi')
 # Primary vertex
 ############################################################
 process.l1tVertexFinder = process.l1tVertexProducer.clone()
-process.pPV = cms.Path(process.L1VertexFinder)
+process.pPV = cms.Path(process.l1tVertexFinder)
 process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
 process.l1tVertexFinderEmulator.VertexReconstruction.Algorithm = "fastHistoEmulation"
 process.l1tVertexFinderEmulator.l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted")
+process.l1tVertexFinderEmulator.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.pPVemu = cms.Path(process.l1tVertexFinderEmulator)
 
 process.l1tTrackFastJets.L1PrimaryVertexTag = cms.InputTag("l1tVertexFinder", "l1vertices")


### PR DESCRIPTION
#### PR description:

This PR adds to the DemonstratorTools package the ability to write test vectors for the GTT to GT links. This is in addition to the existing files which contain the TF to GTT inputs, the converted track words created by the GTT common framework, and the GTT to Correlator Layer 1 link. Following the interface document, there are 4 links in total represented in these new files. The links contain words for jets/sums, hadronic taus, light mesons, and isolated tracks/vertices. Some of the formats specified in the interface document have not been written yet. In those cases, 64-bit packets willed with 0s were added in place of the words. In order to check that the 64-bit hexadecimal packets written to the file were correct, a few more branches were added to the L1TrackObjectsNtuple. Local PR: https://github.com/cms-l1t-offline/cmssw/pull/1042

It also adds to the DemonstratorTools package the ability to write test vectors for outputs from the L1TrackSelectionProducer module. This emulates two firmware modules, one which filters tracks based on the track parameters and another which filters them based on their distance to the primary vertex. These two new files will be created in addition to all the existing test vectors. The format for these files matches the existing track inputs, but with certain track words zeroed out if the tracks are not selected. Local PR: https://github.com/cms-l1t-offline/cmssw/pull/1043

Right now the L1TrackerEtMissEmulationProducer and the DemonstratorTools package assume a TF to GTT link ordering of the 18 links to have the first 9 be from all of the phi sectors and to care the -eta tracks. The second 9 links would carry the positive eta tracks. However, the GTT firmware and the TF group have been assuming that the -eta and +eta links would be paired, where the first two carry -eta and +eta for sector 0, the second pair does the same for sector 1, and so on. This PR also converts the code to using the latter scheme. Local PR: https://github.com/cms-l1t-offline/cmssw/pull/1044


#### PR validation:

From Alexx Perloff: "A set of test vectors was created for the GTT. These test vectors were then compared to the emulator outputs saved in the L1TrackObjectNtuples. I checked by hand that the hexadecimal values saved in the test vectors corresponded to the floating point values saved in the ROOT ntuple (after appropriate un-digitization). I also compared these values to the floating point simulation values in the ROOT ntuple to make sure the simulation and emulation values were close. Everything seems to check out."

The code has also passed the recommended code checks:

scram b code-checks
scram b code-format