### PR TITLE
add summary plot for differences for all coordinates in the Tracker Alignment Payload Inspector

### DIFF
--- a/CondCore/AlignmentPlugins/test/testTrackerAlignment.sh
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignment.sh
@@ -103,3 +103,16 @@ getPayloadData.py \
     --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test ;
+
+# add examples of full 6 coordinate comparisons
+#*************************************************************************#
+getPayloadData.py \
+    --plugin pluginTrackerAlignment_PayloadInspector \
+    --plot plot_TrackerAlignmentComparatorTwoTags \
+    --tag TrackerAlignment_collisions22_v3 \
+    --tagtwo TrackerAlignment_PCL_byRun_v2_express \
+    --time_type Run \
+    --iovs '{"start_iov": "357710", "end_iov": "357710"}' \
+    --iovstwo '{"start_iov": "358156", "end_iov": "358156"}' \
+    --db Prod \
+    --test ;


### PR DESCRIPTION
#### PR description:

The goal of this PR is to add a new class to the `TrackerAlignment_PayloadInspector` class in order to display at one time in one canavs all  the 6 rigid body degrees of freedom differences for a couple of different tracker alignment paylaods.

#### PR validation:

Tested with the commands:

```bash
getPayloadData.py \
    --plugin pluginTrackerAlignment_PayloadInspector \
    --plot plot_TrackerAlignmentComparatorTwoTags \
    --tag TrackerAlignment_collisions22_v3 \
    --tagtwo TrackerAlignment_PCL_byRun_v2_express \
    --time_type Run \
    --iovs '{"start_iov": "357710", "end_iov": "357710"}' \
    --iovstwo '{"start_iov": "358156", "end_iov": "358156"}' \
    --db Prod \
    --test ;
```

and obtained the following plot:

![image](https://user-images.githubusercontent.com/5082376/190659230-64cbd16a-8667-4135-8e89-d9f3c5ce9ec9.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A