### PR TITLE
Update HiggsMonitoring_cff.py

### DIFF
--- a/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
@@ -168,15 +168,11 @@ mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone(
     #FolderName = 'HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
     FolderName = 'HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"]),
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*","HLT_TkMu20_v*",
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*",
                                                   "HLT_IsoMu24_eta2p1_v*",
                                                   "HLT_IsoMu24_v*",
                                                   "HLT_IsoMu27_v*",
-                                                  "HLT_IsoMu20_v*",
-                                                  "HLT_IsoTkMu24_eta2p1_v*",
-                                                  "HLT_IsoTkMu24_v*",
-                                                  "HLT_IsoTkMu27_v*",
-                                                  "HLT_IsoTkMu20_v*"])
+                                                  "HLT_IsoMu20_v*"])
 )
 
 mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone(
@@ -198,15 +194,10 @@ mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone(
     FolderName = 'HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"]), #        
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*",
-                                                  "HLT_TkMu20_v*",
                                                   "HLT_IsoMu24_eta2p1_v*",
                                                   "HLT_IsoMu24_v*",
                                                   "HLT_IsoMu27_v*",
-                                                  "HLT_IsoMu20_v*",
-                                                  "HLT_IsoTkMu24_eta2p1_v*",
-                                                  "HLT_IsoTkMu24_v*",
-                                                  "HLT_IsoTkMu27_v*",
-                                                  "HLT_IsoTkMu20_v*"])
+                                                  "HLT_IsoMu20_v*"])
 )
 
 
@@ -227,7 +218,7 @@ higgsTrimumon = hltHIGmonitoring.clone(
     FolderName = 'HLT/HIG/TriLepton/HLT_TripleMu_12_10_5/',
     nmuons = 3,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TripleMu_12_10_5_v*"]), #                                      
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*"])
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*"])
 )
 
 higgsTrimu10_5_5_dz_mon = hltHIGmonitoring.clone(
@@ -235,7 +226,7 @@ higgsTrimu10_5_5_dz_mon = hltHIGmonitoring.clone(
     FolderName = 'HLT/HIG/TriLepton/HLT_TripleM_10_5_5_DZ/',
     nmuons = 3,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TripleMu_10_5_5_DZ_v*"]), #                                    
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*"])
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*"])
 )
 
 #######TripleElectron####
@@ -267,11 +258,7 @@ diMu9Ele9CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-                                                  "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-                                                  "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
-                                                  "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*",
-                                                  "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
-                                                  "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*"])
+                                                  "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*"])
 )
 
 ##Eff of the HLT with DZ w.ref to non-DZ one


### PR DESCRIPTION
**PR description:**
This PR contains updates for Run3, small fixes to the trigger DQM codes for the Dileptonic and TriLeptonic paths within Higgs Monitoring module.

[Slide 38,39](https://indico.cern.ch/event/1196192/contributions/5037333/attachments/2505075/4304046/20220908_HIG_Trigger_performance_summary.pdf)

**PR validation:**

Successful tests:

- CMSSW_12_4_0: Test performed with 100 events from the TTbar sample, in which folders/histograms were correctly produced and filled with events:

    followed the instruction from twiki : [HLTValidationAndDQM](https://twiki.cern.ch/twiki/bin/viewauth/CMS/HLTValidationAndDQM#Testing_Run_3_work_in_progress)

- Basic tests:

    scram b distclean
    git cms-checkdeps -a -A
    scram b -j 8
    scram b runtests
    scram build code-checks
    scram build code-format
    runTheMatrix.py -l 11634.0

**If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:**

No backport
