### PR TITLE
Fix double counting in HepMC to G4 handoff

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -473,8 +473,7 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     if (verbose > 2)
       LogDebug("SimG4CoreGenerator") << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id();
 
-    if (((*vpdec)->status() == 2 || ((*vpdec)->status() == 23 && std::abs(vp->pdg_id()) == 1000015)) &&
-        (*vpdec)->end_vertex() != nullptr) {
+    if (((*vpdec)->status() == 2 || (*vpdec)->status() > 3) && (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();


### PR DESCRIPTION
#### PR description:

HSCP group discovered a bug in the handoff from HepMC to G4 for long-lived particles (either SM or BSM), which causes a double counting of tracks. More details in [1]. This PR changes the condition on the status code so special cases (like the status 91 mentioned in the talk below) are handled properly. As agreed with @civanch we are submitting this PR.

[1] https://indico.cern.ch/event/1198290/contributions/5043130/attachments/2510066/4313973/091622_LLee_HSCP_SIMBug.pdf

#### PR validation:

Code compiles, 10026.0 runs passes. Further HS tests are required, but for Jenkins tests and possibly a PdmV level specific release validation campaign. 

Proposed test here
```
10026.0 2017+QCD_Pt_600_800_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano 
10059.0 2017+QCD_Pt_3000_3500_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano 
10024.0 2017+TTbar_13TeV_TuneCUETP8M1_GenSim+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano 
2017.7 H125GGgluonfusionFS_13_UP17+HARVESTUP17FS+MINIAODMCUP17FS 
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but affects UL samples, so we should consider to backport to 10_6_X ?