### PR TITLE
explicit type for input=output collections of `HLTJetsMatchedToFilteredJetsProducer`

### DIFF
--- a/HLTrigger/JetMET/plugins/SealModule.cc
+++ b/HLTrigger/JetMET/plugins/SealModule.cc
@@ -98,7 +98,7 @@
 #include "HLTrigger/JetMET/interface/HLTExclDiJetFilter.h"
 #include "HLTrigger/JetMET/src/HLTExclDiJetFilter.cc"
 //
-#include "HLTrigger/JetMET/interface/HLTPFJetsMatchedToFilteredJetsProducer.h"
+#include "HLTJetsMatchedToFilteredJetsProducer.h"
 
 using namespace reco;
 using namespace trigger;
@@ -251,10 +251,17 @@ DEFINE_FWK_MODULE(HLTFatPFJetMassFilter);
 DEFINE_FWK_MODULE(HLTExclDiCaloJetFilter);
 DEFINE_FWK_MODULE(HLTExclDiPFJetFilter);
 
-typedef HLTPFJetsMatchedToFilteredJetsProducer<reco::CaloJetRef> HLTPFJetsMatchedToFilteredCaloJetsProducer;
+typedef HLTJetsMatchedToFilteredJetsProducer<reco::CaloJet, reco::CaloJetRef>
+    HLTCaloJetsMatchedToFilteredCaloJetsProducer;
+DEFINE_FWK_MODULE(HLTCaloJetsMatchedToFilteredCaloJetsProducer);
+
+typedef HLTJetsMatchedToFilteredJetsProducer<reco::CaloJet, reco::PFJetRef> HLTCaloJetsMatchedToFilteredPFJetsProducer;
+DEFINE_FWK_MODULE(HLTCaloJetsMatchedToFilteredPFJetsProducer);
+
+typedef HLTJetsMatchedToFilteredJetsProducer<reco::PFJet, reco::CaloJetRef> HLTPFJetsMatchedToFilteredCaloJetsProducer;
 DEFINE_FWK_MODULE(HLTPFJetsMatchedToFilteredCaloJetsProducer);
 
-typedef HLTPFJetsMatchedToFilteredJetsProducer<reco::PFJetRef> HLTPFJetsMatchedToFilteredPFJetsProducer;
+typedef HLTJetsMatchedToFilteredJetsProducer<reco::PFJet, reco::PFJetRef> HLTPFJetsMatchedToFilteredPFJetsProducer;
 DEFINE_FWK_MODULE(HLTPFJetsMatchedToFilteredPFJetsProducer);
 
 typedef HLTJetHFCleaner<reco::CaloJet> HLTCaloJetHFCleaner;


### PR DESCRIPTION
#### PR description:

The plugin `HLTPFJetsMatchedToFilteredJetsProducer` currently produces a collection of `reco::PFJet`s, but it uses `edm::View<reco::Candidate>` to read its input jet collection (I guess this was done to be able to use different types of jet collections in input, e.g. `reco::CaloJet`). The side effect is that the output `reco::PFJet`s are produced with [dummy values for what concerns their PF-specific quantities](https://github.com/cms-sw/cmssw/blob/CMSSW_12_6_0_pre2/HLTrigger/JetMET/interface/HLTPFJetsMatchedToFilteredJetsProducer.h#L77) (e.g. PF jet-energy fractions).

[CMSHLT-2450](https://its.cern.ch/jira/browse/CMSHLT-2450) highlighted a use case that would profit from having the full information of the input `reco::PFJet`s in the output product [0].

In order to so, this PR converts the plugin `HLTPFJetsMatchedToFilteredJetsProducer` to an instantiation of the plugin template `HLTJetsMatchedToFilteredJetsProducer`. With respect to the current version of `HLTPFJetsMatchedToFilteredJetsProducer`, one template argument is added, corresponding to the type of input and output jet collection, thus requiring the two to be equal.

Meant to be merely technical [1]. Changes are in principle possible [2], but not expected.

--

[0] This use case is not considered critical enough to justify backports of this PR.

[1] From a technical point of view, this update is fully backward-compatible, and it does not require any change to the HLT configurations.

[2] The output collection currently holds dummy values, and this PR will change that, filling them properly. If these values are used by anything downstream of these HLT modules (which I don't believe is the case, but I can't be 100% certain), this may lead to differences.

#### PR validation:

`addOnTests.py` and `runTheMatrix -l 11634.0` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A