### PR TITLE
deprecate integer types for L1T and HLT prescales in `HLTConfigData` and its clients [`12_5_X`]

### DIFF
--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -83,7 +83,7 @@
 
 struct EopTriggerType {
   bool fired;
-  int prescale;
+  double prescale;
   int index;
 
   EopTriggerType() {
@@ -411,7 +411,7 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
     const unsigned int prescaleSize = hltConfig_.prescaleSize();
     for (unsigned int ps = 0; ps < prescaleSize; ps++) {
-      const unsigned int prescaleValue = hltConfig_.prescaleValue(ps, triggerName);
+      auto const prescaleValue = hltConfig_.prescaleValue<double>(ps, triggerName);
       if (prescaleValue != 1) {
         myTrigger.prescale = prescaleValue;
       }

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -245,9 +245,9 @@ private:
   // trigger info
   HLTPrescaleProvider hltPrescaleProvider_;
   std::vector<int> photonTrigFired_;
-  std::vector<int> photonTrigPrescale_;
+  std::vector<double> photonTrigPrescale_;
   std::vector<int> jetTrigFired_;
-  std::vector<int> jetTrigPrescale_;
+  std::vector<double> jetTrigPrescale_;
 
   // Event info
   int runNumber_, lumiBlock_, eventNumber_;
@@ -782,8 +782,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
         photonTrigPrescale_.push_back(-1);
       else {
         // for triggers with two L1 seeds this fails
-        std::pair<int, int> prescaleVals =
-            hltPrescaleProvider_.prescaleValues(iEvent, evSetup, evTrigNames.triggerName(id));
+        auto const prescaleVals =
+            hltPrescaleProvider_.prescaleValues<double>(iEvent, evSetup, evTrigNames.triggerName(id));
         photonTrigPrescale_.push_back(prescaleVals.first * prescaleVals.second);
       }
     }
@@ -799,8 +799,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       if (fired)
         jetTrigFlag = true;
       jetTrigFired_.push_back(fired);
-      std::pair<int, int> prescaleVals =
-          hltPrescaleProvider_.prescaleValues(iEvent, evSetup, evTrigNames.triggerName(id));
+      auto const prescaleVals =
+          hltPrescaleProvider_.prescaleValues<double>(iEvent, evSetup, evTrigNames.triggerName(id));
       jetTrigPrescale_.push_back(prescaleVals.first * prescaleVals.second);
     }
   }

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -18,6 +18,7 @@
 
 // system include files
 #include <memory>
+#include <unordered_map>
 
 // Root objects
 #include "TROOT.h"
@@ -198,8 +199,8 @@ private:
   const CaloGeometry *geo_;
   math::XYZPoint leadPV_;
 
-  std::map<unsigned int, unsigned int> trigList_;
-  std::map<unsigned int, const std::pair<int, int>> trigPreList_;
+  std::unordered_map<unsigned int, unsigned int> trigList_;
+  std::unordered_map<unsigned int, const std::pair<double, double>> trigPreList_;
   bool changed_;
   double pLimits_[6];
   edm::Service<TFileService> fs_;
@@ -263,7 +264,8 @@ private:
   TH1D *h_eMaxNearP[2], *h_eNeutIso[2];
   TH1D *h_etaCalibTracks[5][2][2], *h_etaMipTracks[5][2][2];
   TH1D *h_eHcal[5][6][48], *h_eCalo[5][6][48];
-  TH1I *g_Pre, *g_PreL1, *g_PreHLT, *g_Accepts;
+  TH1D *g_Pre, *g_PreL1, *g_PreHLT;
+  TH1I *g_Accepts;
   std::vector<math::XYZTLorentzVector> vec_[3];
 };
 
@@ -660,7 +662,8 @@ void IsoTrig::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
     const std::vector<std::string> &triggerNames_ = triggerNames.triggerNames();
     if (verbosity_ % 10 > 1)
       edm::LogVerbatim("IsoTrack") << "number of HLTs " << triggerNames_.size();
-    int hlt(-1), preL1(-1), preHLT(-1), prescale(-1);
+    double preL1(-1), preHLT(-1), prescale(-1);
+    int hlt(-1);
     for (unsigned int i = 0; i < triggerResults->size(); i++) {
       unsigned int triggerindx = hltConfig.triggerIndex(triggerNames_[i]);
       const std::vector<std::string> &moduleLabels(hltConfig.moduleLabels(triggerindx));
@@ -680,7 +683,7 @@ void IsoTrig::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
             edm::Handle<trigger::TriggerFilterObjectWithRefs> L1cands;
             iEvent.getByToken(tok_l1cand_, L1cands);
 
-            const std::pair<int, int> prescales(hltPrescaleProvider_.prescaleValues(iEvent, iSetup, triggerNames_[i]));
+            auto const prescales = hltPrescaleProvider_.prescaleValues<double>(iEvent, iSetup, triggerNames_[i]);
             preL1 = prescales.first;
             preHLT = prescales.second;
             prescale = preL1 * preHLT;
@@ -692,8 +695,8 @@ void IsoTrig::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
             if (trigList_.find(RunNo) != trigList_.end()) {
               trigList_[RunNo] += 1;
             } else {
-              trigList_.insert(std::pair<unsigned int, unsigned int>(RunNo, 1));
-              trigPreList_.insert(std::pair<unsigned int, std::pair<int, int>>(RunNo, prescales));
+              trigList_.insert({RunNo, 1});
+              trigPreList_.insert({RunNo, prescales});
             }
             //loop over all trigger filters in event (i.e. filters passed)
             for (unsigned int ifilter = 0; ifilter < triggerEvent.sizeFilters(); ++ifilter) {
@@ -1174,27 +1177,24 @@ void IsoTrig::beginJob() {
 
 // ------------ method called once each job just after ending the event loop  ------------
 void IsoTrig::endJob() {
-  unsigned int preL1, preHLT;
-  std::map<unsigned int, unsigned int>::iterator itr;
-  std::map<unsigned int, const std::pair<int, int>>::iterator itrPre;
   edm::LogWarning("IsoTrack") << trigNames_.size() << "Triggers were run. RunNo vs HLT accepts for";
   for (unsigned int i = 0; i < trigNames_.size(); ++i)
     edm::LogWarning("IsoTrack") << "[" << i << "]: " << trigNames_[i];
   unsigned int n = maxRunNo_ - minRunNo_ + 1;
-  g_Pre = fs_->make<TH1I>("h_PrevsRN", "PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
-  g_PreL1 = fs_->make<TH1I>("h_PreL1vsRN", "L1 PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
-  g_PreHLT = fs_->make<TH1I>("h_PreHLTvsRN", "HLT PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
+  g_Pre = fs_->make<TH1D>("h_PrevsRN", "PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
+  g_PreL1 = fs_->make<TH1D>("h_PreL1vsRN", "L1 PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
+  g_PreHLT = fs_->make<TH1D>("h_PreHLTvsRN", "HLT PreScale Vs Run Number", n, minRunNo_, maxRunNo_);
   g_Accepts = fs_->make<TH1I>("h_HLTAcceptsvsRN", "HLT Accepts Vs Run Number", n, minRunNo_, maxRunNo_);
 
-  for (itr = trigList_.begin(), itrPre = trigPreList_.begin(); itr != trigList_.end(); itr++, itrPre++) {
-    preL1 = (itrPre->second).first;
-    preHLT = (itrPre->second).second;
-    edm::LogVerbatim("IsoTrack") << itr->first << " " << itr->second << " " << itrPre->first << " " << preL1 << " "
-                                 << preHLT;
-    g_Accepts->Fill(itr->first, itr->second);
-    g_PreL1->Fill(itr->first, preL1);
-    g_PreHLT->Fill(itr->first, preHLT);
-    g_Pre->Fill(itr->first, preL1 * preHLT);
+  for (auto const &[runNum, nAccept] : trigList_) {
+    auto const &triggerPrescales = trigPreList_[runNum];
+    auto const preL1 = triggerPrescales.first;
+    auto const preHLT = triggerPrescales.second;
+    edm::LogVerbatim("IsoTrack") << runNum << " " << nAccept << " " << preL1 << " " << preHLT;
+    g_Accepts->Fill(runNum, nAccept);
+    g_PreL1->Fill(runNum, preL1);
+    g_PreHLT->Fill(runNum, preHLT);
+    g_Pre->Fill(runNum, preL1 * preHLT);
   }
 }
 

--- a/CommonTools/TriggerUtils/interface/PrescaleWeightProvider.h
+++ b/CommonTools/TriggerUtils/interface/PrescaleWeightProvider.h
@@ -6,7 +6,7 @@
 // Package:    CommonTools/TriggerUtils
 // Class:      PrescaleWeightProvider
 //
-/**
+/*
   \class    PrescaleWeightProvider PrescaleWeightProvider.h "CommonTools/TriggerUtils/interface/PrescaleWeightProvider.h"
   \brief
 
@@ -14,13 +14,13 @@
    HLT and L1 prescales. The weight is equal to the lowest combined (L1*HLT) prescale
    of the selected paths
 
-
   \author   Aram Avetisyan
 */
 
 #include <memory>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -72,8 +73,10 @@ public:
 
   // to be called from the ED module's beginRun() method
   void initRun(const edm::Run& run, const edm::EventSetup& setup);
+
   // to be called from the ED module's event loop method
-  int prescaleWeight(const edm::Event& event, const edm::EventSetup& setup);
+  template <typename T = int>
+  T prescaleWeight(const edm::Event& event, const edm::EventSetup& setup);
 
 private:
   PrescaleWeightProvider(const edm::ParameterSet& config, edm::ConsumesCollector& iC);
@@ -90,4 +93,113 @@ PrescaleWeightProvider::PrescaleWeightProvider(const edm::ParameterSet& config, 
     : PrescaleWeightProvider(config, iC) {
   hltPrescaleProvider_ = std::make_unique<HLTPrescaleProvider>(config, iC, module);
 }
-#endif
+
+template <typename T>
+T PrescaleWeightProvider::prescaleWeight(const edm::Event& event, const edm::EventSetup& setup) {
+  static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                "\n\tPlease use prescaleWeight<double> or prescaleWeight<FractionalPrescale>"
+                "\n\t(other types for HLT prescales are not supported anymore by PrescaleWeightProvider");
+  if (!init_)
+    return 1;
+
+  // L1
+  L1GtUtils const& l1GtUtils = hltPrescaleProvider_->l1GtUtils();
+
+  // HLT
+  HLTConfigProvider const& hltConfig = hltPrescaleProvider_->hltConfigProvider();
+
+  edm::Handle<edm::TriggerResults> triggerResults;
+  event.getByToken(triggerResultsToken_, triggerResults);
+  if (!triggerResults.isValid()) {
+    if (verbosity_ > 0)
+      edm::LogError("PrescaleWeightProvider::prescaleWeight")
+          << "TriggerResults product not found for InputTag \"" << triggerResultsTag_.encode() << "\"";
+    return 1;
+  }
+
+  const int SENTINEL(-1);
+  int weight(SENTINEL);
+
+  for (unsigned ui = 0; ui < hltPaths_.size(); ui++) {
+    const std::string hltPath(hltPaths_.at(ui));
+    unsigned hltIndex(hltConfig.triggerIndex(hltPath));
+    if (hltIndex == hltConfig.size()) {
+      if (verbosity_ > 0)
+        edm::LogError("PrescaleWeightProvider::prescaleWeight") << "HLT path \"" << hltPath << "\" does not exist";
+      continue;
+    }
+    if (!triggerResults->accept(hltIndex))
+      continue;
+
+    const std::vector<std::pair<bool, std::string> >& level1Seeds = hltConfig.hltL1GTSeeds(hltPath);
+    if (level1Seeds.size() != 1) {
+      if (verbosity_ > 0)
+        edm::LogError("PrescaleWeightProvider::prescaleWeight")
+            << "HLT path \"" << hltPath << "\" provides too many L1 seeds";
+      return 1;
+    }
+    parseL1Seeds(level1Seeds.at(0).second);
+    if (l1SeedPaths_.empty()) {
+      if (verbosity_ > 0)
+        edm::LogWarning("PrescaleWeightProvider::prescaleWeight")
+            << "Failed to parse L1 seeds for HLT path \"" << hltPath << "\"";
+      continue;
+    }
+
+    int l1Prescale(SENTINEL);
+    for (unsigned uj = 0; uj < l1SeedPaths_.size(); uj++) {
+      int l1TempPrescale(SENTINEL);
+      int errorCode(0);
+      if (level1Seeds.at(0).first) {  // technical triggers
+        unsigned techBit(atoi(l1SeedPaths_.at(uj).c_str()));
+        const std::string techName(*(triggerMenuLite_->gtTechTrigName(techBit, errorCode)));
+        if (errorCode != 0)
+          continue;
+        if (!l1GtUtils.decision(event, techName, errorCode))
+          continue;
+        if (errorCode != 0)
+          continue;
+        l1TempPrescale = l1GtUtils.prescaleFactor(event, techName, errorCode);
+        if (errorCode != 0)
+          continue;
+      } else {  // algorithmic triggers
+        if (!l1GtUtils.decision(event, l1SeedPaths_.at(uj), errorCode))
+          continue;
+        if (errorCode != 0)
+          continue;
+        l1TempPrescale = l1GtUtils.prescaleFactor(event, l1SeedPaths_.at(uj), errorCode);
+        if (errorCode != 0)
+          continue;
+      }
+      if (l1TempPrescale > 0) {
+        if (l1Prescale == SENTINEL || l1Prescale > l1TempPrescale)
+          l1Prescale = l1TempPrescale;
+      }
+    }
+    if (l1Prescale == SENTINEL) {
+      if (verbosity_ > 0)
+        edm::LogError("PrescaleWeightProvider::prescaleWeight")
+            << "Unable to find the L1 prescale for HLT path \"" << hltPath << "\"";
+      continue;
+    }
+
+    auto const prescale = l1Prescale * hltPrescaleProvider_->prescaleValue<T>(event, setup, hltPath);
+
+    if (prescale > 0) {
+      if (weight == SENTINEL || weight > prescale) {
+        weight = prescale;
+      }
+    }
+  }
+
+  if (weight == SENTINEL) {
+    if (verbosity_ > 0)
+      edm::LogWarning("PrescaleWeightProvider::prescaleWeight")
+          << "No valid weight for any requested HLT path, returning default weight of 1";
+    return 1;
+  }
+
+  return weight;
+}
+
+#endif  // CommonTools_TriggerUtils_PrescaleWeightProvider_h

--- a/CommonTools/TriggerUtils/plugins/CandidateTriggerObjectProducer.cc
+++ b/CommonTools/TriggerUtils/plugins/CandidateTriggerObjectProducer.cc
@@ -88,8 +88,8 @@ void CandidateTriggerObjectProducer::produce(edm::Event& iEvent, const edm::Even
     //matching with regexp filter name. More than 1 matching filter is allowed
     if (TString(*iHLT).Contains(TRegexp(TString(triggerName_)))) {
       triggerInMenu[*iHLT] = true;
-      const std::pair<int, int> prescales(hltPrescaleProvider_.prescaleValues(iEvent, iSetup, *iHLT));
-      if (prescales.first * prescales.second == 1)
+      auto const prescales = hltPrescaleProvider_.prescaleValues<double>(iEvent, iSetup, *iHLT);
+      if (prescales.first == 1 and prescales.second == 1)
         triggerUnprescaled[*iHLT] = true;
     }
   }

--- a/CommonTools/TriggerUtils/src/PrescaleWeightProvider.cc
+++ b/CommonTools/TriggerUtils/src/PrescaleWeightProvider.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtTriggerMenuLite.h"
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 
@@ -92,109 +91,6 @@ void PrescaleWeightProvider::initRun(const edm::Run& run, const edm::EventSetup&
           << "L1GtTriggerMenuLite with label \"" << l1GtTriggerMenuLiteTag_.label() << "\" not found";
     init_ = false;
   }
-}
-
-int PrescaleWeightProvider::prescaleWeight(const edm::Event& event, const edm::EventSetup& setup) {
-  if (!init_)
-    return 1;
-
-  // L1
-  L1GtUtils const& l1GtUtils = hltPrescaleProvider_->l1GtUtils();
-
-  // HLT
-  HLTConfigProvider const& hltConfig = hltPrescaleProvider_->hltConfigProvider();
-
-  edm::Handle<edm::TriggerResults> triggerResults;
-  event.getByToken(triggerResultsToken_, triggerResults);
-  if (!triggerResults.isValid()) {
-    if (verbosity_ > 0)
-      edm::LogError("PrescaleWeightProvider::prescaleWeight")
-          << "TriggerResults product not found for InputTag \"" << triggerResultsTag_.encode() << "\"";
-    return 1;
-  }
-
-  const int SENTINEL(-1);
-  int weight(SENTINEL);
-
-  for (unsigned ui = 0; ui < hltPaths_.size(); ui++) {
-    const std::string hltPath(hltPaths_.at(ui));
-    unsigned hltIndex(hltConfig.triggerIndex(hltPath));
-    if (hltIndex == hltConfig.size()) {
-      if (verbosity_ > 0)
-        edm::LogError("PrescaleWeightProvider::prescaleWeight") << "HLT path \"" << hltPath << "\" does not exist";
-      continue;
-    }
-    if (!triggerResults->accept(hltIndex))
-      continue;
-
-    const std::vector<std::pair<bool, std::string> >& level1Seeds = hltConfig.hltL1GTSeeds(hltPath);
-    if (level1Seeds.size() != 1) {
-      if (verbosity_ > 0)
-        edm::LogError("PrescaleWeightProvider::prescaleWeight")
-            << "HLT path \"" << hltPath << "\" provides too many L1 seeds";
-      return 1;
-    }
-    parseL1Seeds(level1Seeds.at(0).second);
-    if (l1SeedPaths_.empty()) {
-      if (verbosity_ > 0)
-        edm::LogWarning("PrescaleWeightProvider::prescaleWeight")
-            << "Failed to parse L1 seeds for HLT path \"" << hltPath << "\"";
-      continue;
-    }
-
-    int l1Prescale(SENTINEL);
-    for (unsigned uj = 0; uj < l1SeedPaths_.size(); uj++) {
-      int l1TempPrescale(SENTINEL);
-      int errorCode(0);
-      if (level1Seeds.at(0).first) {  // technical triggers
-        unsigned techBit(atoi(l1SeedPaths_.at(uj).c_str()));
-        const std::string techName(*(triggerMenuLite_->gtTechTrigName(techBit, errorCode)));
-        if (errorCode != 0)
-          continue;
-        if (!l1GtUtils.decision(event, techName, errorCode))
-          continue;
-        if (errorCode != 0)
-          continue;
-        l1TempPrescale = l1GtUtils.prescaleFactor(event, techName, errorCode);
-        if (errorCode != 0)
-          continue;
-      } else {  // algorithmic triggers
-        if (!l1GtUtils.decision(event, l1SeedPaths_.at(uj), errorCode))
-          continue;
-        if (errorCode != 0)
-          continue;
-        l1TempPrescale = l1GtUtils.prescaleFactor(event, l1SeedPaths_.at(uj), errorCode);
-        if (errorCode != 0)
-          continue;
-      }
-      if (l1TempPrescale > 0) {
-        if (l1Prescale == SENTINEL || l1Prescale > l1TempPrescale)
-          l1Prescale = l1TempPrescale;
-      }
-    }
-    if (l1Prescale == SENTINEL) {
-      if (verbosity_ > 0)
-        edm::LogError("PrescaleWeightProvider::prescaleWeight")
-            << "Unable to find the L1 prescale for HLT path \"" << hltPath << "\"";
-      continue;
-    }
-
-    int hltPrescale(hltPrescaleProvider_->prescaleValue(event, setup, hltPath));
-
-    if (hltPrescale * l1Prescale > 0) {
-      if (weight == SENTINEL || weight > hltPrescale * l1Prescale) {
-        weight = hltPrescale * l1Prescale;
-      }
-    }
-  }
-
-  if (weight == SENTINEL) {
-    if (verbosity_ > 0)
-      edm::LogWarning("PrescaleWeightProvider::prescaleWeight")
-          << "No valid weight for any requested HLT path, returning default weight of 1";
-    return 1;
-  }
-  return weight;
 }
 
 void PrescaleWeightProvider::parseL1Seeds(const std::string& l1Seeds) {

--- a/DPGAnalysis/Skims/interface/TriggerMatchProducer.h
+++ b/DPGAnalysis/Skims/interface/TriggerMatchProducer.h
@@ -139,7 +139,7 @@ void TriggerMatchProducer<object>::produce(edm::Event& event, const edm::EventSe
 
     if (TString(*iHLT).Contains(TRegexp(hltTag_))) {
       triggerInMenu[*iHLT] = true;
-      if (hltPrescaleProvider_.prescaleValue(event, eventSetup, *iHLT) == 1)
+      if (hltPrescaleProvider_.prescaleValue<double>(event, eventSetup, *iHLT) == 1)
         triggerUnprescaled[*iHLT] = true;
     }
   }

--- a/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
+++ b/DQM/Physics/src/EwkMuLumiMonitorDQM.cc
@@ -235,11 +235,8 @@ void EwkMuLumiMonitorDQM::analyze(const Event& ev, const EventSetup&) {
       bool prescaled = false;
       const unsigned int prescaleSize = hltConfigProvider_.prescaleSize();
       for (unsigned int ps = 0; ps < prescaleSize; ps++) {
-        const unsigned int prescaleValue = hltConfigProvider_.prescaleValue(ps, trig);
-        if (prescaleValue != 1)
+        if (hltConfigProvider_.prescaleValue<double>(ps, trig) != 1)
           prescaled = true;
-        //	std::cout<< " prescaleValue[" << ps << "] =" << prescaleValue
-        //<<std::endl;
       }
       if (!prescaled) {
         // looking now for the lowest hlt path not prescaled, with name of the

--- a/DQMOffline/Trigger/plugins/BPHMonitor.cc
+++ b/DQMOffline/Trigger/plugins/BPHMonitor.cc
@@ -1357,18 +1357,19 @@ double BPHMonitor::Prescale(const std::string hltpath1,
                             edm::Event const& iEvent,
                             edm::EventSetup const& iSetup,
                             HLTPrescaleProvider* hltPrescale_) {
-  int PrescaleHLT_num = 1;
-  int PrescaleHLT_den = 1;
   double Prescale_num = 1;
   double L1P = 1, HLTP = 1;
   bool flag = true;
   std::vector<bool> theSame_den;
   std::vector<bool> theSame_num;
-  //retrieving HLT prescale
-  PrescaleHLT_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).second;
-  PrescaleHLT_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).second;
+  // object holding L1T (double) and HLT (uint) prescales
+  auto const prescales_den = hltPrescale_->prescaleValuesInDetail<double>(iEvent, iSetup, hltpath);
+  auto const prescales_num = hltPrescale_->prescaleValuesInDetail<double>(iEvent, iSetup, hltpath1);
+  // retrieving HLT prescale
+  auto PrescaleHLT_den = prescales_den.second;
+  auto PrescaleHLT_num = prescales_num.second;
   if (PrescaleHLT_den > 0 && PrescaleHLT_num > 0)
-    HLTP = PrescaleHLT_num / std::__gcd(PrescaleHLT_num, PrescaleHLT_den);
+    HLTP = PrescaleHLT_num / std::min(PrescaleHLT_num, PrescaleHLT_den);
 
   //retrieving L1 prescale
   //Checking if we have the same l1 seeds in den and num
@@ -1376,18 +1377,16 @@ double BPHMonitor::Prescale(const std::string hltpath1,
   //and some of them can be also switched off
 
   //check if for each den l1 there is the same l1 seed in num
-  if (!(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.empty()) {
-    for (size_t iSeed = 0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.size();
-         ++iSeed) {
-      std::string l1_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed).first;
-      int l1_denp = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed).second;
+  if (not prescales_den.first.empty()) {
+    for (size_t iSeed = 0; iSeed < prescales_den.first.size(); ++iSeed) {
+      auto l1_den = prescales_den.first.at(iSeed).first;
+      auto l1_denp = prescales_den.first.at(iSeed).second;
       if (l1_denp < 1)
         continue;
       flag = false;
-      for (size_t iSeed1 = 0; iSeed1 < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size();
-           ++iSeed1) {
-        std::string l1_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed1).first;
-        int l1_nump = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed1).second;
+      for (size_t iSeed1 = 0; iSeed1 < prescales_num.first.size(); ++iSeed1) {
+        auto l1_num = prescales_num.first.at(iSeed1).first;
+        auto l1_nump = prescales_num.first.at(iSeed1).second;
         if (l1_num == l1_den && l1_nump >= 1)  //the same seed
         {
           flag = true;
@@ -1398,18 +1397,16 @@ double BPHMonitor::Prescale(const std::string hltpath1,
     }
   }
   //check if for each num l1 there is the same l1 seed in den
-  if (!(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.empty()) {
-    for (size_t iSeed = 0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size();
-         ++iSeed) {
-      std::string l1_num = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).first;
-      int l1_nump = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).second;
+  if (not prescales_num.first.empty()) {
+    for (size_t iSeed = 0; iSeed < prescales_num.first.size(); ++iSeed) {
+      auto l1_num = prescales_num.first.at(iSeed).first;
+      auto l1_nump = prescales_num.first.at(iSeed).second;
       if (l1_nump < 1)
         continue;
       flag = false;
-      for (size_t iSeed1 = 0; iSeed1 < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.size();
-           ++iSeed1) {
-        std::string l1_den = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed1).first;
-        int l1_denp = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath)).first.at(iSeed1).second;
+      for (size_t iSeed1 = 0; iSeed1 < prescales_den.first.size(); ++iSeed1) {
+        auto l1_den = prescales_den.first.at(iSeed1).first;
+        auto l1_denp = prescales_den.first.at(iSeed1).second;
         if (l1_den == l1_num && l1_denp >= 1)  //the same seed
         {
           flag = true;
@@ -1433,11 +1430,10 @@ double BPHMonitor::Prescale(const std::string hltpath1,
   if (flag && (theSame_num.size() == theSame_den.size())) {
     L1P = 1;  //den and num have the same set of l1 seeds
   } else {
-    if (!(hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.empty()) {
+    if (not prescales_num.first.empty()) {
       Prescale_num = 1;
-      for (size_t iSeed = 0; iSeed < (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.size();
-           ++iSeed) {
-        int l1 = (hltPrescale_->prescaleValuesInDetail(iEvent, iSetup, hltpath1)).first.at(iSeed).second;
+      for (size_t iSeed = 0; iSeed < prescales_num.first.size(); ++iSeed) {
+        auto l1 = prescales_num.first.at(iSeed).second;
         if (l1 < 1)
           continue;
         if (l1 == 1) {

--- a/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
+++ b/DataFormats/PatCandidates/interface/PackedTriggerPrescales.h
@@ -1,8 +1,11 @@
-#ifndef _DataFormats_PatCandidates_PackedTriggerPrescales_H_
-#define _DataFormats_PatCandidates_PackedTriggerPrescales_H_
+#ifndef DataFormats_PatCandidates_PackedTriggerPrescales_h
+#define DataFormats_PatCandidates_PackedTriggerPrescales_h
 
-#include "DataFormats/Common/interface/TriggerResults.h"
+#include <cstring>
+#include <type_traits>
+
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Common/interface/Ref.h"
 
 namespace pat {
@@ -11,12 +14,19 @@ namespace pat {
   public:
     PackedTriggerPrescales() : triggerNames_(nullptr) {}
     PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> &handle);
-    ~PackedTriggerPrescales() {}
+    ~PackedTriggerPrescales() = default;
 
-    // get prescale by index.
-    int getPrescaleForIndex(int index) const;
+    // get prescale by index
+    //  method templated to force correct choice of output type
+    //  (as part of deprecating integer types for trigger prescales)
+    template <typename T = int>
+    T getPrescaleForIndex(int index) const;
+
     // get prescale by name or name prefix (if setTriggerNames was called)
-    int getPrescaleForName(const std::string &name, bool prefixOnly = false) const;
+    //  method templated to force correct choice of output type
+    //  (as part of deprecating integer types for trigger prescales)
+    template <typename T = int>
+    T getPrescaleForName(const std::string &name, bool prefixOnly = false) const;
 
     // return the TriggerResults associated with this
     const edm::TriggerResults &triggerResults() const { return *edm::getProduct<edm::TriggerResults>(triggerResults_); }
@@ -26,14 +36,51 @@ namespace pat {
     void setTriggerNames(const edm::TriggerNames &names) { triggerNames_ = &names; }
 
     // set that the trigger of given index has a given prescale
-    void addPrescaledTrigger(int index, int prescale);
+    void addPrescaledTrigger(int index, double prescale);
 
   protected:
-    std::vector<int> prescaleValues_;
+    std::vector<double> prescaleValues_;
     edm::RefCore triggerResults_;
     const edm::TriggerNames *triggerNames_;
   };
 
+  template <typename T>
+  T PackedTriggerPrescales::getPrescaleForIndex(int index) const {
+    static_assert(std::is_same_v<T, double>,
+                  "\n\n\tPlease use getPrescaleForIndex<double> "
+                  "(other types for trigger prescales are not supported anymore by PackedTriggerPrescales)");
+    if (unsigned(index) >= triggerResults().size())
+      throw cms::Exception("InvalidReference", "Index out of bounds");
+    return prescaleValues_[index];
+  }
+
+  template <typename T>
+  T PackedTriggerPrescales::getPrescaleForName(const std::string &name, bool prefixOnly) const {
+    static_assert(std::is_same_v<T, double>,
+                  "\n\n\tPlease use getPrescaleForName<double> "
+                  "(other types for trigger prescales are not supported anymore by PackedTriggerPrescales)");
+    if (triggerNames_ == nullptr)
+      throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
+    if (prefixOnly) {
+      auto const &names = triggerNames_->triggerNames();
+      if (name.empty())
+        throw cms::Exception("EmptyName",
+                             "getPrescaleForName called with invalid arguments (name is empty, prefixOnly=true");
+      size_t siz = name.length() - 1;
+      while (siz > 0 && (name[siz] == '*' || name[siz] == '\0'))
+        siz--;
+      for (unsigned int i = 0, n = names.size(); i < n; ++i) {
+        if (strncmp(name.c_str(), names[i].c_str(), siz) == 0) {
+          return getPrescaleForIndex<T>(i);
+        }
+      }
+      throw cms::Exception("InvalidReference", "Index out of bounds");
+    } else {
+      int index = triggerNames_->triggerIndex(name);
+      return getPrescaleForIndex<T>(index);
+    }
+  }
+
 }  // namespace pat
 
-#endif
+#endif  // DataFormats_PatCandidates_PackedTriggerPrescales_h

--- a/DataFormats/PatCandidates/interface/TriggerPath.h
+++ b/DataFormats/PatCandidates/interface/TriggerPath.h
@@ -7,7 +7,7 @@
 // Class:      pat::TriggerPath
 //
 //
-/**
+/*
   \class    pat::TriggerPath TriggerPath.h "DataFormats/PatCandidates/interface/TriggerPath.h"
   \brief    Analysis-level HLTrigger path class
 
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <type_traits>
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
@@ -41,7 +42,7 @@ namespace pat {
     /// Path index in trigger table
     unsigned index_;
     /// Pre-scale
-    unsigned prescale_;
+    double prescale_;
     /// Was path run?
     bool run_;
     /// Did path succeed?
@@ -76,7 +77,7 @@ namespace pat {
     /// Constructor from values
     TriggerPath(const std::string& name,
                 unsigned index,
-                unsigned prescale,
+                double prescale,
                 bool run,
                 bool accept,
                 bool error,
@@ -84,7 +85,7 @@ namespace pat {
                 unsigned l3Filters = 0);
 
     /// Destructor
-    virtual ~TriggerPath(){};
+    virtual ~TriggerPath() = default;
 
     /// Methods
 
@@ -93,7 +94,7 @@ namespace pat {
     /// Set the path index
     void setIndex(unsigned index) { index_ = index; };
     /// Set the path pre-scale
-    void setPrescale(unsigned prescale) { prescale_ = prescale; };
+    void setPrescale(double prescale) { prescale_ = prescale; };
     /// Set the run flag
     void setRun(bool run) { run_ = run; };
     /// Set the success flag
@@ -116,7 +117,13 @@ namespace pat {
     /// Get the path index
     unsigned index() const { return index_; };
     /// Get the path pre-scale
-    unsigned prescale() const { return prescale_; };
+    template <typename T = unsigned int>
+    T prescale() const {
+      static_assert(std::is_same_v<T, double>,
+                    "\n\tPlease use prescale<double>"
+                    "\n\t(other types for prescales are not supported anymore by pat::TriggerPath");
+      return prescale_;
+    };
     /// Get the run flag
     bool wasRun() const { return run_; };
     /// Get the success flag

--- a/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
+++ b/DataFormats/PatCandidates/src/PackedTriggerPrescales.cc
@@ -1,39 +1,12 @@
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "DataFormats/Common/interface/RefProd.h"
-#include <cstring>
 
 pat::PackedTriggerPrescales::PackedTriggerPrescales(const edm::Handle<edm::TriggerResults> &handle)
     : prescaleValues_(), triggerResults_(edm::RefProd<edm::TriggerResults>(handle).refCore()), triggerNames_(nullptr) {
   prescaleValues_.resize(handle->size(), 0);
 }
 
-int pat::PackedTriggerPrescales::getPrescaleForIndex(int index) const {
-  if (unsigned(index) >= triggerResults().size())
-    throw cms::Exception("InvalidReference", "Index out of bounds");
-  return prescaleValues_[index];
-}
-
-int pat::PackedTriggerPrescales::getPrescaleForName(const std::string &name, bool prefixOnly) const {
-  if (triggerNames_ == nullptr)
-    throw cms::Exception("LogicError", "getPrescaleForName called without having called setTriggerNames first");
-  if (prefixOnly) {
-    const std::vector<std::string> &names = triggerNames_->triggerNames();
-    size_t siz = name.length() - 1;
-    while (siz > 0 && (name[siz] == '*' || name[siz] == '\0'))
-      siz--;
-    for (unsigned int i = 0, n = names.size(); i < n; ++i) {
-      if (strncmp(name.c_str(), names[i].c_str(), siz) == 0) {
-        return getPrescaleForIndex(i);
-      }
-    }
-    throw cms::Exception("InvalidReference", "Index out of bounds");
-  } else {
-    int index = triggerNames_->triggerIndex(name);
-    return getPrescaleForIndex(index);
-  }
-}
-
-void pat::PackedTriggerPrescales::addPrescaledTrigger(int index, int prescale) {
+void pat::PackedTriggerPrescales::addPrescaledTrigger(int index, double prescale) {
   if (unsigned(index) >= triggerResults().size())
     throw cms::Exception("InvalidReference", "Index out of bounds");
   prescaleValues_[index] = prescale;

--- a/DataFormats/PatCandidates/src/TriggerPath.cc
+++ b/DataFormats/PatCandidates/src/TriggerPath.cc
@@ -1,35 +1,30 @@
-//
-//
-
 #include "DataFormats/PatCandidates/interface/TriggerPath.h"
-
-using namespace pat;
 
 // Constructors and Destructor
 
 // Default constructor
-TriggerPath::TriggerPath()
+pat::TriggerPath::TriggerPath()
     : name_(), index_(), prescale_(), run_(), accept_(), error_(), lastActiveFilterSlot_(), l3Filters_(0) {
   modules_.clear();
   filterIndices_.clear();
 }
 
 // Constructor from path name only
-TriggerPath::TriggerPath(const std::string& name)
+pat::TriggerPath::TriggerPath(const std::string& name)
     : name_(name), index_(), prescale_(), run_(), accept_(), error_(), lastActiveFilterSlot_(), l3Filters_(0) {
   modules_.clear();
   filterIndices_.clear();
 }
 
 // Constructor from values
-TriggerPath::TriggerPath(const std::string& name,
-                         unsigned index,
-                         unsigned prescale,
-                         bool run,
-                         bool accept,
-                         bool error,
-                         unsigned lastActiveFilterSlot,
-                         unsigned l3Filters)
+pat::TriggerPath::TriggerPath(const std::string& name,
+                              unsigned index,
+                              double prescale,
+                              bool run,
+                              bool accept,
+                              bool error,
+                              unsigned lastActiveFilterSlot,
+                              unsigned l3Filters)
     : name_(name),
       index_(index),
       prescale_(prescale),
@@ -45,14 +40,14 @@ TriggerPath::TriggerPath(const std::string& name,
 // Methods
 
 // Get the index of a certain module
-int TriggerPath::indexModule(const std::string& name) const {
+int pat::TriggerPath::indexModule(const std::string& name) const {
   if (modules_.begin() == modules_.end())
     return -1;
   return (std::find(modules_.begin(), modules_.end(), name) - modules_.begin());
 }
 
 // Get names of all L1 seeds with a certain decision
-std::vector<std::string> TriggerPath::l1Seeds(const bool decision) const {
+std::vector<std::string> pat::TriggerPath::l1Seeds(const bool decision) const {
   std::vector<std::string> seeds;
   for (L1SeedCollection::const_iterator iSeed = l1Seeds().begin(); iSeed != l1Seeds().end(); ++iSeed) {
     if (iSeed->first == decision)

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -58,7 +58,8 @@
   <class name="pat::TriggerFilterRefVector" />
   <class name="pat::TriggerFilterRefVectorIterator" />
 
-  <class name="pat::TriggerPath"  ClassVersion="10">
+  <class name="pat::TriggerPath"  ClassVersion="11">
+   <version ClassVersion="11" checksum="565824196"/>
    <version ClassVersion="10" checksum="2458567651"/>
   </class>
   <class name="std::vector&lt;pat::TriggerPath&gt;" />
@@ -103,7 +104,8 @@
   </class>
   <class name="edm::Wrapper&lt;pat::TriggerEvent&gt;" />
 
-  <class name="pat::PackedTriggerPrescales"  ClassVersion="10">
+  <class name="pat::PackedTriggerPrescales"  ClassVersion="11">
+   <version ClassVersion="11" checksum="3391959050"/>
    <version ClassVersion="10" checksum="2688342584"/>
    <field name="triggerNames_" transient="true" />
   </class>

--- a/HLTrigger/HLTanalyzers/plugins/HLTInfo.cc
+++ b/HLTrigger/HLTanalyzers/plugins/HLTInfo.cc
@@ -60,7 +60,7 @@ void HLTInfo::setup(const edm::ParameterSet& pSet, TTree* HltTree) {
   HltEvtCnt = 0;
   const int kMaxTrigFlag = 10000;
   trigflag = new int[kMaxTrigFlag];
-  trigPrescl = new int[kMaxTrigFlag];
+  trigPrescl = new double[kMaxTrigFlag];
 
   L1EvtCnt = 0;
   const int kMaxL1Flag = 10000;
@@ -136,8 +136,7 @@ void HLTInfo::analyze(const edm::Handle<edm::TriggerResults>& hltresults,
       const std::string& trigName = triggerNames.triggerName(itrig);
       bool accept = hltresults->accept(itrig);
 
-      //trigPrescl[itrig] = hltConfig_.prescaleValue(iEvent, eventSetup, trigName);
-      trigPrescl[itrig] = hltPrescaleProvider_->prescaleValue(iEvent, eventSetup, trigName);
+      trigPrescl[itrig] = hltPrescaleProvider_->prescaleValue<double>(iEvent, eventSetup, trigName);
 
       if (accept) {
         trigflag[itrig] = 1;

--- a/HLTrigger/HLTanalyzers/plugins/HLTInfo.h
+++ b/HLTrigger/HLTanalyzers/plugins/HLTInfo.h
@@ -80,7 +80,8 @@ private:
   int L1EvtCnt, HltEvtCnt, nhltpart;
 
   int *trigflag, *l1flag, *l1flag5Bx, *l1techflag;
-  int *trigPrescl, *l1Prescl, *l1techPrescl;
+  double* trigPrescl;
+  int *l1Prescl, *l1techPrescl;
 
   TString* algoBitToName;
   TString* techBitToName;

--- a/HLTrigger/HLTcore/interface/HLTConfigData.h
+++ b/HLTrigger/HLTcore/interface/HLTConfigData.h
@@ -1,5 +1,5 @@
-#ifndef HLTcore_HLTConfigData_h
-#define HLTcore_HLTConfigData_h
+#ifndef HLTrigger_HLTcore_HLTConfigData_h
+#define HLTrigger_HLTcore_HLTConfigData_h
 
 /** \class HLTConfigData
  *
@@ -11,12 +11,14 @@
  *
  */
 
-#include "DataFormats/HLTReco/interface/HLTPrescaleTable.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/HLTReco/interface/HLTPrescaleTable.h"
+#include "HLTrigger/HLTcore/interface/FractionalPrescale.h"
 
 #include <map>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 //
 // class declaration
@@ -91,15 +93,15 @@ public:
 
   /// HLTLevel1GTSeed module
   /// HLTLevel1GTSeed modules for all trigger paths
-  const std::vector<std::vector<std::pair<bool, std::string> > >& hltL1GTSeeds() const;
+  const std::vector<std::vector<std::pair<bool, std::string>>>& hltL1GTSeeds() const;
   /// HLTLevel1GTSeed modules for trigger path with name
-  const std::vector<std::pair<bool, std::string> >& hltL1GTSeeds(const std::string& trigger) const;
+  const std::vector<std::pair<bool, std::string>>& hltL1GTSeeds(const std::string& trigger) const;
   /// HLTLevel1GTSeed modules for trigger path with index i
-  const std::vector<std::pair<bool, std::string> >& hltL1GTSeeds(unsigned int trigger) const;
+  const std::vector<std::pair<bool, std::string>>& hltL1GTSeeds(unsigned int trigger) const;
 
   /// HLTL1TSeed module
   /// HLTL1TSeed modules for all trigger paths
-  const std::vector<std::vector<std::string> >& hltL1TSeeds() const;
+  const std::vector<std::vector<std::string>>& hltL1TSeeds() const;
   /// HLTL1TSeed modules for trigger path with name
   const std::vector<std::string>& hltL1TSeeds(const std::string& trigger) const;
   /// HLTL1TSeed modules for trigger path with index i
@@ -113,7 +115,7 @@ public:
   /// index of stream with name
   unsigned int streamIndex(const std::string& stream) const;
   /// names of datasets for all streams
-  const std::vector<std::vector<std::string> >& streamContents() const;
+  const std::vector<std::vector<std::string>>& streamContents() const;
   /// names of datasets in stream with index i
   const std::vector<std::string>& streamContent(unsigned int stream) const;
   /// names of datasets in stream with name
@@ -127,7 +129,7 @@ public:
   /// index of dataset with name
   unsigned int datasetIndex(const std::string& dataset) const;
   /// names of trigger paths for all datasets
-  const std::vector<std::vector<std::string> >& datasetContents() const;
+  const std::vector<std::vector<std::string>>& datasetContents() const;
   /// names of trigger paths in dataset with index i
   const std::vector<std::string>& datasetContent(unsigned int dataset) const;
   /// names of trigger paths in dataset with name
@@ -137,10 +139,13 @@ public:
   /// Number of HLT prescale sets
   unsigned int prescaleSize() const;
   /// HLT prescale value in specific prescale set for a specific trigger path
-  unsigned int prescaleValue(unsigned int set, const std::string& trigger) const;
-  /// low-level data member access
+  template <typename T = unsigned int>
+  T prescaleValue(unsigned int set, const std::string& trigger) const;
+  /// labels of HLT prescale columns
   const std::vector<std::string>& prescaleLabels() const;
-  const std::map<std::string, std::vector<unsigned int> >& prescaleTable() const;
+  /// map of HLT prescales by trigger-path name (key=path, value=prescales)
+  template <typename T = unsigned int>
+  std::map<std::string, std::vector<T>> const& prescaleTable() const;
 
   /// technical: id() function needed for use with ThreadSafeRegistry
   edm::ParameterSetID id() const;
@@ -152,24 +157,49 @@ private:
   std::string globalTag_;
   std::string tableName_;
   std::vector<std::string> triggerNames_;
-  std::vector<std::vector<std::string> > moduleLabels_;
-  std::vector<std::vector<std::string> > saveTagsModules_;
+  std::vector<std::vector<std::string>> moduleLabels_;
+  std::vector<std::vector<std::string>> saveTagsModules_;
 
   std::map<std::string, unsigned int> triggerIndex_;
-  std::vector<std::map<std::string, unsigned int> > moduleIndex_;
+  std::vector<std::map<std::string, unsigned int>> moduleIndex_;
 
   unsigned int l1tType_;
-  std::vector<std::vector<std::pair<bool, std::string> > > hltL1GTSeeds_;
-  std::vector<std::vector<std::string> > hltL1TSeeds_;
+  std::vector<std::vector<std::pair<bool, std::string>>> hltL1GTSeeds_;
+  std::vector<std::vector<std::string>> hltL1TSeeds_;
 
   std::vector<std::string> streamNames_;
   std::map<std::string, unsigned int> streamIndex_;
-  std::vector<std::vector<std::string> > streamContents_;
+  std::vector<std::vector<std::string>> streamContents_;
 
   std::vector<std::string> datasetNames_;
   std::map<std::string, unsigned int> datasetIndex_;
-  std::vector<std::vector<std::string> > datasetContents_;
+  std::vector<std::vector<std::string>> datasetContents_;
 
   trigger::HLTPrescaleTable hltPrescaleTable_;
+  std::map<std::string, std::vector<double>> hltPrescaleTableValuesDouble_;
+  std::map<std::string, std::vector<FractionalPrescale>> hltPrescaleTableValuesFractional_;
 };
-#endif
+
+template <typename T>
+T HLTConfigData::prescaleValue(unsigned int set, const std::string& trigger) const {
+  static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                "\n\tPlease use prescaleValue<double> or prescaleValue<FractionalPrescale>"
+                "\n\t(other types for HLT prescales are not supported anymore by HLTConfigData)");
+  return hltPrescaleTable_.prescale(set, trigger);
+}
+
+template <typename T>
+std::map<std::string, std::vector<T>> const& HLTConfigData::prescaleTable() const {
+  static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                "\n\tPlease use prescaleTable<double> or prescaleTable<FractionalPrescale>"
+                "\n\t(other types for HLT prescales are not supported anymore by HLTConfigData)");
+  return hltPrescaleTable_.table();
+}
+
+template <>
+std::map<std::string, std::vector<double>> const& HLTConfigData::prescaleTable() const;
+
+template <>
+std::map<std::string, std::vector<FractionalPrescale>> const& HLTConfigData::prescaleTable() const;
+
+#endif  // HLTrigger_HLTcore_HLTConfigData_h

--- a/HLTrigger/HLTcore/interface/HLTConfigProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTConfigProvider.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 //
 // class declaration
@@ -120,21 +121,21 @@ public:
 
   /// HLTLevel1GTSeed module
   /// HLTLevel1GTSeed modules for all trigger paths
-  const std::vector<std::vector<std::pair<bool, std::string> > >& hltL1GTSeeds() const {
+  const std::vector<std::vector<std::pair<bool, std::string>>>& hltL1GTSeeds() const {
     return hltConfigData_->hltL1GTSeeds();
   }
   /// HLTLevel1GTSeed modules for trigger path with name
-  const std::vector<std::pair<bool, std::string> >& hltL1GTSeeds(const std::string& trigger) const {
+  const std::vector<std::pair<bool, std::string>>& hltL1GTSeeds(const std::string& trigger) const {
     return hltConfigData_->hltL1GTSeeds(trigger);
   }
   /// HLTLevel1GTSeed modules for trigger path with index i
-  const std::vector<std::pair<bool, std::string> >& hltL1GTSeeds(unsigned int trigger) const {
+  const std::vector<std::pair<bool, std::string>>& hltL1GTSeeds(unsigned int trigger) const {
     return hltConfigData_->hltL1GTSeeds(trigger);
   }
 
   /// HLTL1TSeed module
   /// HLTL1TSeed modules for all trigger paths
-  const std::vector<std::vector<std::string> >& hltL1TSeeds() const { return hltConfigData_->hltL1TSeeds(); }
+  const std::vector<std::vector<std::string>>& hltL1TSeeds() const { return hltConfigData_->hltL1TSeeds(); }
   /// HLTL1TSeed modules for trigger path with name
   const std::vector<std::string>& hltL1TSeeds(const std::string& trigger) const {
     return hltConfigData_->hltL1TSeeds(trigger);
@@ -152,7 +153,7 @@ public:
   /// index of stream with name
   unsigned int streamIndex(const std::string& stream) const { return hltConfigData_->streamIndex(stream); }
   /// names of datasets for all streams
-  const std::vector<std::vector<std::string> >& streamContents() const { return hltConfigData_->streamContents(); }
+  const std::vector<std::vector<std::string>>& streamContents() const { return hltConfigData_->streamContents(); }
   /// names of datasets in stream with index i
   const std::vector<std::string>& streamContent(unsigned int stream) const {
     return hltConfigData_->streamContent(stream);
@@ -170,7 +171,7 @@ public:
   /// index of dataset with name
   unsigned int datasetIndex(const std::string& dataset) const { return hltConfigData_->datasetIndex(dataset); }
   /// names of trigger paths for all datasets
-  const std::vector<std::vector<std::string> >& datasetContents() const { return hltConfigData_->datasetContents(); }
+  const std::vector<std::vector<std::string>>& datasetContents() const { return hltConfigData_->datasetContents(); }
   /// names of trigger paths in dataset with index i
   const std::vector<std::string>& datasetContent(unsigned int dataset) const {
     return hltConfigData_->datasetContent(dataset);
@@ -186,18 +187,21 @@ public:
   /// HLT prescale value in specific prescale set for a specific trigger path
   template <typename T = unsigned int>
   T prescaleValue(unsigned int set, const std::string& trigger) const {
-    //limit to only 4 allowed types
-    static_assert(std::is_same_v<T, unsigned int> or std::is_same_v<T, FractionalPrescale> or std::is_same_v<T, int> or
-                      std::is_same_v<T, double>,
-                  "Please use prescaleValue<unsigned int>, prescaleValue<int>, prescaleValue<double>, or "
-                  "prescaleValue<FractionalPrescale>,\n note int and unsigned int will be depreated soon");
-    return hltConfigData_->prescaleValue(set, trigger);
+    static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                  "\n\tPlease use prescaleValue<double> or prescaleValue<FractionalPrescale>"
+                  "\n\t(other types for HLT prescales are not supported anymore by HLTConfigProvider)");
+    return hltConfigData_->prescaleValue<T>(set, trigger);
   }
 
   /// low-level data member access
   const std::vector<std::string>& prescaleLabels() const { return hltConfigData_->prescaleLabels(); }
-  const std::map<std::string, std::vector<unsigned int> >& prescaleTable() const {
-    return hltConfigData_->prescaleTable();
+
+  template <typename T = unsigned int>
+  std::map<std::string, std::vector<T>> const& prescaleTable() const {
+    static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                  "\n\tPlease use prescaleTable<double> or prescaleTable<FractionalPrescale>"
+                  "\n\t(other types for HLT prescales are not supported anymore by HLTConfigProvider)");
+    return hltConfigData_->prescaleTable<T>();
   }
 
   /// regexp processing

--- a/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
@@ -1,11 +1,10 @@
-#ifndef HLTcore_HLTPrescaleProvider_h
-#define HLTcore_HLTPrescaleProvider_h
+#ifndef HLTrigger_HLTcore_HLTPrescaleProvider_h
+#define HLTrigger_HLTcore_HLTPrescaleProvider_h
 
 /** \class HLTPrescaleProvider
  *
- *  
- *  This class provides access routines to get hold of the HLT Configuration
- *
+ *  This class provides access routines to get hold of the HLT Configuration,
+ *  as well as the prescales of Level-1 and High-Level triggers.
  *
  *  \author Martin Grunewald
  *
@@ -26,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <type_traits>
 
 namespace edm {
   class ConsumesCollector;
@@ -80,10 +80,10 @@ public:
 
   // In case of a complex Boolean expression as L1 seed
   template <typename TL1 = int, typename THLT = TL1>
-  std::pair<std::vector<std::pair<std::string, TL1> >, THLT> prescaleValuesInDetail(const edm::Event& iEvent,
-                                                                                    const edm::EventSetup& iSetup,
-                                                                                    const std::string& trigger) {
-    std::pair<std::vector<std::pair<std::string, TL1> >, THLT> retval;
+  std::pair<std::vector<std::pair<std::string, TL1>>, THLT> prescaleValuesInDetail(const edm::Event& iEvent,
+                                                                                   const edm::EventSetup& iSetup,
+                                                                                   const std::string& trigger) {
+    std::pair<std::vector<std::pair<std::string, TL1>>, THLT> retval;
     for (auto& entry : getL1PrescaleValueInDetail(iEvent, iSetup, trigger)) {
       retval.first.emplace_back(std::move(entry.first), convertL1PS<TL1>(entry.second));
     }
@@ -103,19 +103,32 @@ public:
 private:
   void checkL1GtUtils() const;
   void checkL1TGlobalUtil() const;
+
   template <typename T>
   T convertL1PS(double val) const {
+    static_assert(std::is_same_v<T, double> or std::is_same_v<T, FractionalPrescale>,
+                  "\n\n\tPlease use convertL1PS<double> or convertL1PS<FractionalPrescale>"
+                  " (other types for L1T prescales are not supported anymore by HLTPrescaleProvider)"
+                  "\n\tconvertL1PS is used inside prescaleValues and prescaleValuesInDetail,"
+                  " so it might be necessary to specify template arguments for those calls,"
+                  "\n\te.g. prescaleValues<double, FractionalPrescale>"
+                  " (the 1st argument applies to L1T prescales, the 2nd to HLT prescales)\n");
     return T(val);
   }
 
   double getL1PrescaleValue(const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger);
-  std::vector<std::pair<std::string, double> > getL1PrescaleValueInDetail(const edm::Event& iEvent,
-                                                                          const edm::EventSetup& iSetup,
-                                                                          const std::string& trigger);
+
+  std::vector<std::pair<std::string, double>> getL1PrescaleValueInDetail(const edm::Event& iEvent,
+                                                                         const edm::EventSetup& iSetup,
+                                                                         const std::string& trigger);
+
   static constexpr int kL1PrescaleDenominator_ = 100;
+
   HLTConfigProvider hltConfigProvider_;
+
   std::unique_ptr<L1GtUtils> l1GtUtils_;
   std::unique_ptr<l1t::L1TGlobalUtil> l1tGlobalUtil_;
+
   unsigned char count_[5] = {0, 0, 0, 0, 0};
   bool inited_ = false;
 };
@@ -135,11 +148,6 @@ HLTPrescaleProvider::HLTPrescaleProvider(edm::ParameterSet const& pset, edm::Con
 }
 
 template <>
-FractionalPrescale HLTPrescaleProvider::convertL1PS<FractionalPrescale>(double val) const;
+FractionalPrescale HLTPrescaleProvider::convertL1PS(double val) const;
 
-template <>
-unsigned int HLTPrescaleProvider::prescaleValue<unsigned int>(const edm::Event& iEvent,
-                                                              const edm::EventSetup& iSetup,
-                                                              const std::string& trigger);
-
-#endif
+#endif  // HLTrigger_HLTcore_HLTPrescaleProvider_h

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
@@ -151,12 +151,11 @@ void HLTEventAnalyzerAOD::analyzeTrigger(const edm::Event& iEvent,
     return;
   }
 
-  const std::pair<int, int> prescales(hltPrescaleProvider_.prescaleValues(iEvent, iSetup, triggerName));
+  auto const prescales = hltPrescaleProvider_.prescaleValues<double>(iEvent, iSetup, triggerName);
   LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD::analyzeTrigger: path " << triggerName << " ["
                                      << triggerIndex << "] "
                                      << "prescales L1T,HLT: " << prescales.first << "," << prescales.second << endl;
-  const std::pair<std::vector<std::pair<std::string, int> >, int> prescalesInDetail(
-      hltPrescaleProvider_.prescaleValuesInDetail(iEvent, iSetup, triggerName));
+  auto const prescalesInDetail = hltPrescaleProvider_.prescaleValuesInDetail<double>(iEvent, iSetup, triggerName);
   std::ostringstream message;
   for (unsigned int i = 0; i < prescalesInDetail.first.size(); ++i) {
     message << " " << i << ":" << prescalesInDetail.first[i].first << "/" << prescalesInDetail.first[i].second;

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleExample.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleExample.cc
@@ -1,10 +1,11 @@
+#include <string>
 
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
-#include <iostream>
 
 class HLTPrescaleExample : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
@@ -18,8 +19,8 @@ public:
 
 private:
   HLTPrescaleProvider hltPSProvider_;
-  std::string hltProcess_;
-  std::string hltPath_;
+  std::string const hltProcess_;
+  std::string const hltPath_;
 };
 
 HLTPrescaleExample::HLTPrescaleExample(edm::ParameterSet const& iPSet)
@@ -33,39 +34,34 @@ void HLTPrescaleExample::beginRun(edm::Run const& iRun, edm::EventSetup const& i
 }
 
 void HLTPrescaleExample::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
-  auto hltPSDouble = hltPSProvider_.prescaleValue<double>(iEvent, iSetup, hltPath_);
-  auto hltPSInt = hltPSProvider_.prescaleValue<int>(iEvent, iSetup, hltPath_);
-  auto hltPSUInt = hltPSProvider_.prescaleValue<unsigned int>(iEvent, iSetup, hltPath_);
-  auto hltPSFrac = hltPSProvider_.prescaleValue<FractionalPrescale>(iEvent, iSetup, hltPath_);
+  auto const hltPSDouble = hltPSProvider_.prescaleValue<double>(iEvent, iSetup, hltPath_);
+  auto const hltPSFrac = hltPSProvider_.prescaleValue<FractionalPrescale>(iEvent, iSetup, hltPath_);
 
-  auto l1HLTPSDouble = hltPSProvider_.prescaleValues<double>(iEvent, iSetup, hltPath_);
-  auto l1HLTPSInt = hltPSProvider_.prescaleValues<int>(iEvent, iSetup, hltPath_);
-  auto l1HLTPSFrac = hltPSProvider_.prescaleValues<FractionalPrescale>(iEvent, iSetup, hltPath_);
-  auto l1HLTPSDoubleFrac = hltPSProvider_.prescaleValues<double, FractionalPrescale>(iEvent, iSetup, hltPath_);
+  auto const l1HLTPSDouble = hltPSProvider_.prescaleValues<double>(iEvent, iSetup, hltPath_);
+  auto const l1HLTPSFrac = hltPSProvider_.prescaleValues<FractionalPrescale>(iEvent, iSetup, hltPath_);
+  auto const l1HLTPSDoubleFrac = hltPSProvider_.prescaleValues<double, FractionalPrescale>(iEvent, iSetup, hltPath_);
 
-  auto l1HLTDetailPSDouble = hltPSProvider_.prescaleValuesInDetail<double>(iEvent, iSetup, hltPath_);
-  auto l1HLTDetailPSInt = hltPSProvider_.prescaleValuesInDetail<int>(iEvent, iSetup, hltPath_);
-  auto l1HLTDetailPSFrac = hltPSProvider_.prescaleValuesInDetail<FractionalPrescale>(iEvent, iSetup, hltPath_);
+  auto const l1HLTDetailPSDouble = hltPSProvider_.prescaleValuesInDetail<double>(iEvent, iSetup, hltPath_);
+  auto const l1HLTDetailPSFrac = hltPSProvider_.prescaleValuesInDetail<FractionalPrescale>(iEvent, iSetup, hltPath_);
 
-  std::cout << "---------Begin Event--------" << std::endl;
-  std::cout << "hltDouble " << hltPSDouble << " hltInt " << hltPSInt << " hltPSUInt " << hltPSUInt << " hltFrac "
-            << hltPSFrac << std::endl;
+  edm::LogPrint log("");
 
-  std::cout << " l1HLTDouble " << l1HLTPSDouble.first << " " << l1HLTPSDouble.second << " l1HLTInt " << l1HLTPSInt.first
-            << " " << l1HLTPSInt.second << " l1HLTFrac " << l1HLTPSFrac.first << " " << l1HLTPSFrac.second
-            << " l1HLTDoubleFrac " << l1HLTPSDoubleFrac.first << " " << l1HLTPSDoubleFrac.second << std::endl;
-  auto printL1HLTDetail = [](const std::string& text, const auto& val, std::ostream& out) {
-    out << text;
+  log << "---------Begin Event--------\n";
+  log << "hltDouble " << hltPSDouble << " hltFrac " << hltPSFrac << "\n";
+  log << " l1HLTDouble " << l1HLTPSDouble.first << " " << l1HLTPSDouble.second << " l1HLTFrac " << l1HLTPSFrac.first
+      << " " << l1HLTPSFrac.second << " l1HLTDoubleFrac " << l1HLTPSDoubleFrac.first << " " << l1HLTPSDoubleFrac.second
+      << "\n";
+  auto printL1HLTDetail = [&log](const std::string& text, const auto& val) {
+    log << text;
     for (const auto& entry : val.first) {
-      out << entry.first << ":" << entry.second << " ";
+      log << entry.first << ":" << entry.second << " ";
     }
-    out << " HLT : " << val.second << std::endl;
+    log << " HLT : " << val.second << "\n";
   };
 
-  printL1HLTDetail("l1HLTDetailDouble ", l1HLTDetailPSDouble, std::cout);
-  printL1HLTDetail("l1HLTDetailInt ", l1HLTDetailPSInt, std::cout);
-  printL1HLTDetail("l1HLTDetailFrac ", l1HLTDetailPSFrac, std::cout);
-  std::cout << "---------End Event--------" << std::endl << std::endl;
+  printL1HLTDetail("l1HLTDetailDouble ", l1HLTDetailPSDouble);
+  printL1HLTDetail("l1HLTDetailFrac ", l1HLTDetailPSFrac);
+  log << "---------End Event--------\n\n";
 }
 
 DEFINE_FWK_MODULE(HLTPrescaleExample);

--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -10,8 +10,8 @@
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/path_configuration.h"
+#include "FWCore/Utilities/interface/transform.h"
 
-#include <unordered_set>
 #include <iostream>
 
 //Using this function with the 'const static within s_dummyPSet'
@@ -47,7 +47,9 @@ HLTConfigData::HLTConfigData()
       datasetNames_(),
       datasetIndex_(),
       datasetContents_(),
-      hltPrescaleTable_() {
+      hltPrescaleTable_(),
+      hltPrescaleTableValuesDouble_{},
+      hltPrescaleTableValuesFractional_{} {
   if (processPSet_->id().isValid()) {
     extract();
   }
@@ -72,7 +74,9 @@ HLTConfigData::HLTConfigData(const edm::ParameterSet* iPSet)
       datasetNames_(),
       datasetIndex_(),
       datasetContents_(),
-      hltPrescaleTable_() {
+      hltPrescaleTable_(),
+      hltPrescaleTableValuesDouble_{},
+      hltPrescaleTableValuesFractional_{} {
   if (processPSet_->id().isValid()) {
     extract();
   }
@@ -271,6 +275,14 @@ void HLTConfigData::extract() {
     }
   }
 
+  // fill maps to return prescales values with allowed types (double, FractionalPrescale)
+  for (auto const& [key, psVals] : hltPrescaleTable_.table()) {
+    hltPrescaleTableValuesDouble_.insert(
+        {key, edm::vector_transform(psVals, [](auto const ps) -> double { return ps; })});
+    hltPrescaleTableValuesFractional_.insert(
+        {key, edm::vector_transform(psVals, [](auto const ps) -> FractionalPrescale { return ps; })});
+  }
+
   // Determine L1T Type (0=unknown, 1=legacy/stage-1 or 2=stage-2)
   l1tType_ = 0;
   unsigned int stage1(0), stage2(0);
@@ -411,15 +423,13 @@ void HLTConfigData::dump(const std::string& what) const {
     }
     if (n > 0)
       cout << endl;
-    const map<string, vector<unsigned int>>& table(hltPrescaleTable_.table());
+    auto const& table = hltPrescaleTable_.table();
     cout << "HLTConfigData::dump: PrescaleTable: # of paths: " << table.size() << endl;
-    const map<string, vector<unsigned int>>::const_iterator tb(table.begin());
-    const map<string, vector<unsigned int>>::const_iterator te(table.end());
-    for (map<string, vector<unsigned int>>::const_iterator ti = tb; ti != te; ++ti) {
+    for (auto const& [key, val] : table) {
       for (unsigned int i = 0; i != n; ++i) {
-        cout << " " << ti->second.at(i);
+        cout << " " << val.at(i);
       }
-      cout << " " << ti->first << endl;
+      cout << " " << key << endl;
     }
   } else {
     cout << "HLTConfigData::dump: Unkown dump request: " << what << endl;
@@ -594,13 +604,17 @@ const std::vector<std::string>& HLTConfigData::datasetContent(const std::string&
 }
 
 unsigned int HLTConfigData::prescaleSize() const { return hltPrescaleTable_.size(); }
-unsigned int HLTConfigData::prescaleValue(unsigned int set, const std::string& trigger) const {
-  return hltPrescaleTable_.prescale(set, trigger);
+
+template <>
+std::map<std::string, std::vector<double>> const& HLTConfigData::prescaleTable() const {
+  return hltPrescaleTableValuesDouble_;
+}
+
+template <>
+std::map<std::string, std::vector<FractionalPrescale>> const& HLTConfigData::prescaleTable() const {
+  return hltPrescaleTableValuesFractional_;
 }
 
 const std::vector<std::string>& HLTConfigData::prescaleLabels() const { return hltPrescaleTable_.labels(); }
-const std::map<std::string, std::vector<unsigned int>>& HLTConfigData::prescaleTable() const {
-  return hltPrescaleTable_.table();
-}
 
 edm::ParameterSetID HLTConfigData::id() const { return processPSet_->id(); }

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -104,12 +104,12 @@ int HLTPrescaleProvider::prescaleSet(const edm::Event& iEvent, const edm::EventS
 }
 
 template <>
-FractionalPrescale HLTPrescaleProvider::convertL1PS<FractionalPrescale>(double val) const {
+FractionalPrescale HLTPrescaleProvider::convertL1PS(double val) const {
   int numer = static_cast<int>(val * kL1PrescaleDenominator_ + 0.5);
   static constexpr double kL1RoundingEpsilon = 0.001;
   if (std::abs(numer - val * kL1PrescaleDenominator_) > kL1RoundingEpsilon) {
     edm::LogWarning("ValueError") << " Error, L1 prescale val " << val
-                                  << "does not appear to precisely expressable as int / " << kL1PrescaleDenominator_
+                                  << " does not appear to precisely expressable as int / " << kL1PrescaleDenominator_
                                   << ", using a FractionalPrescale is a loss of precision";
   }
 
@@ -215,9 +215,9 @@ double HLTPrescaleProvider::getL1PrescaleValue(const edm::Event& iEvent,
   return result;
 }
 
-std::vector<std::pair<std::string, double> > HLTPrescaleProvider::getL1PrescaleValueInDetail(
+std::vector<std::pair<std::string, double>> HLTPrescaleProvider::getL1PrescaleValueInDetail(
     const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger) {
-  std::vector<std::pair<std::string, double> > result;
+  std::vector<std::pair<std::string, double>> result;
 
   const unsigned int l1tType(hltConfigProvider_.l1tType());
   if (l1tType == 1) {
@@ -232,7 +232,7 @@ std::vector<std::pair<std::string, double> > HLTPrescaleProvider::getL1PrescaleV
       const std::string l1tname(hltConfigProvider_.hltL1GTSeeds(trigger).at(0).second);
       L1GtUtils::LogicalExpressionL1Results l1Logical(l1tname, *l1GtUtils_);
       l1Logical.logicalExpressionRunUpdate(iEvent.getRun(), iSetup, l1tname);
-      const std::vector<std::pair<std::string, int> >& errorCodes(l1Logical.errorCodes(iEvent));
+      const std::vector<std::pair<std::string, int>>& errorCodes(l1Logical.errorCodes(iEvent));
       auto resultInt = l1Logical.prescaleFactors();
       result.clear();
       for (const auto& entry : resultInt) {
@@ -360,14 +360,6 @@ void HLTPrescaleProvider::checkL1TGlobalUtil() const {
                                              "the module configuration does not use the era properly\n"
                                              "or input is from mixed eras";
   }
-}
-
-template <>
-unsigned int HLTPrescaleProvider::prescaleValue<unsigned int>(const edm::Event& iEvent,
-                                                              const edm::EventSetup& iSetup,
-                                                              const std::string& trigger) {
-  const int set(prescaleSet(iEvent, iSetup));
-  return set < 0 ? 1 : hltConfigProvider_.prescaleValue<unsigned int>(static_cast<unsigned int>(set), trigger);
 }
 
 void HLTPrescaleProvider::fillPSetDescription(edm::ParameterSetDescription& desc,

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -9,3 +9,6 @@
   <use name="HLTrigger/HLTcore"/>
   <use name="catch2"/>
 </bin>
+
+<!-- test the HLTPrescaleExample plugin -->
+<test name="test_HLTPrescaleExample" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py"/>

--- a/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py
+++ b/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py
@@ -1,54 +1,52 @@
-
 import FWCore.ParameterSet.Config as cms
-process = cms.Process("HLTPSCheck")
+
+process = cms.Process('HLTPSCheck')
 
 import FWCore.ParameterSet.VarParsing as VarParsing
-options = VarParsing.VarParsing ('analysis') 
-options.register('globalTag','auto:run2_data',options.multiplicity.singleton,options.varType.string,"global tag to use")
+options = VarParsing.VarParsing ('analysis')
+options.register('globalTag', 'auto:run3_data', options.multiplicity.singleton, options.varType.string, 'global tag to use')
+options.setDefault('inputFiles', [
+  '/store/data/Run2022D/HLTPhysics/MINIAOD/PromptReco-v2/000/357/898/00000/99afb702-5640-453c-8d48-49b9ba7098d9.root'
+])
+options.setDefault('maxEvents', 10)
 options.parseArguments()
 
-print options.inputFiles
-process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring(options.inputFiles),  
-                          )
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(options.inputFiles)
+)
+print('process.source.fileNames =', process.source.fileNames)
 
 # initialize MessageLogger and output report
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
     reportEvery = cms.untracked.int32(5000),
     limit = cms.untracked.int32(10000000)
 )
 
-process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
-
+process.options.wantSummary = False
+process.maxEvents.input = options.maxEvents
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+print('process.GlobalTag.globaltag =', process.GlobalTag.globaltag)
 
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(options.maxEvents)
+_hltPSExample = cms.EDAnalyzer('HLTPrescaleExample',
+    hltProcess = cms.string('HLT'),
+    hltPath = cms.string(''),
+    hltPSProvCfg = cms.PSet(
+        stageL1Trigger = cms.uint32(2),
+        l1tAlgBlkInputTag = cms.InputTag('gtStage2Digis'),
+        l1tExtBlkInputTag = cms.InputTag('gtStage2Digis')
+    )
 )
 
-
-process.hltPSExample = cms.EDAnalyzer("HLTPrescaleExample",
-                                      hltProcess=cms.string("HLT"),
-#                                      hltPath=cms.string("HLT_Photon50_v13"),
-                                      hltPath=cms.string("HLT_Photon33_v5"),                         
-                                      hltPSProvCfg=cms.PSet(
-                                          stageL1Trigger = cms.uint32(2)
-                                      )
-                                  )
-
+process.hltPSExample1 = _hltPSExample.clone(hltPath = 'HLT_Photon33_v6')
+process.hltPSExample2 = _hltPSExample.clone(hltPath = 'HLT_Photon50_v14')
+process.hltPSExample3 = _hltPSExample.clone(hltPath = 'HLT_Random_v3')
 
 process.p = cms.Path(
-    process.hltPSExample
+    process.hltPSExample1
+  + process.hltPSExample2
+  + process.hltPSExample3
 )
-
-
-
-print "global tag: ",process.GlobalTag.globaltag
-
-
-

--- a/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
@@ -4,7 +4,12 @@
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <string>
+#include <vector>
+#include <map>
+
 namespace {
+  // build PSet of generic module
   edm::ParameterSet buildModulePSet(std::string const& iLabel, std::string const& iType, std::string const& iEDMType) {
     edm::ParameterSet pset;
     pset.addParameter<std::string>("@module_label", iLabel);
@@ -12,6 +17,28 @@ namespace {
     pset.addParameter<std::string>("@module_edm_type", iEDMType);
     return pset;
   }
+
+  // build PSet of PrescaleService module
+  edm::ParameterSet buildPrescaleServicePSet(std::string const& iLabel,
+                                             std::string const& iType,
+                                             std::string const& iEDMType,
+                                             std::vector<std::string> const& labels,
+                                             std::map<std::string, std::vector<unsigned int>> const& prescaleTable) {
+    auto pset = buildModulePSet(iLabel, iType, iEDMType);
+    pset.addParameter("lvl1Labels", labels);
+    std::vector<edm::ParameterSet> psTable;
+    psTable.reserve(psTable.size());
+    for (auto const& [key, val] : prescaleTable) {
+      REQUIRE(labels.size() == val.size());
+      edm::ParameterSet psEntry;
+      psEntry.addParameter<std::string>("pathName", key);
+      psEntry.addParameter<std::vector<unsigned int>>("prescales", val);
+      psTable.emplace_back(psEntry);
+    }
+    pset.addParameter<std::vector<edm::ParameterSet>>("prescaleTable", psTable);
+    return pset;
+  }
+
 }  // namespace
 
 TEST_CASE("Test HLTConfigData", "[HLTConfigData]") {
@@ -37,6 +64,15 @@ TEST_CASE("Test HLTConfigData", "[HLTConfigData]") {
 
     pset.addParameter<edm::ParameterSet>("c1", buildModulePSet("c1", "CProducer", "EDProducer"));
     pset.addParameter<edm::ParameterSet>("c2", buildModulePSet("c2", "CProducer", "EDProducer"));
+
+    pset.addParameter<edm::ParameterSet>(
+        "PrescaleService",
+        buildPrescaleServicePSet("PrescaleService",
+                                 "PrescaleService",
+                                 "Service",
+                                 {"col0", "col1", "col2", "col3", "col4"},
+                                 {{"b1", {45, 12, 1, 0, 1000}}, {"b2", {12000, 2, 0, 7, 0}}}));
+
     pset.registerIt();
 
     HLTConfigData cd(&pset);
@@ -67,6 +103,31 @@ TEST_CASE("Test HLTConfigData", "[HLTConfigData]") {
       REQUIRE(cd.size(3) == 1);
       REQUIRE(cd.moduleLabel(3, 0) == "f5");
       //cd.dump("Modules");
+    }
+
+    SECTION("check prescales") {
+      // get prescale table reading values as double and FractionalPrescale
+      auto const& psTableDouble = cd.prescaleTable<double>();
+      auto const& psTableFractl = cd.prescaleTable<FractionalPrescale>();
+      REQUIRE(psTableDouble.size() == psTableFractl.size());
+      for (auto const& [key, vec_d] : psTableDouble) {
+        auto const& vec_f = psTableFractl.at(key);
+        REQUIRE(vec_d.size() == vec_f.size());
+        for (size_t idx = 0; idx < vec_d.size(); ++idx) {
+          auto const& val_d = vec_d[idx];
+          auto const& val_f = vec_f[idx];
+          // conversion of prescale value to unsigned int
+          unsigned int const val_u = vec_d[idx];
+          // equal-to comparison of double-or-FractionalPrescale to unsigned int must succeed:
+          // HLT does not yet fully support non-integer HLT prescales (example: PrescaleService),
+          // but the HLTConfigData utility (interface to downstream clients) provides access
+          // to HLT prescales only via types 'double' and 'FractionalPrescale',
+          // in anticipation of when HLT will fully support the use of non-integer prescales
+          REQUIRE(val_d == val_u);
+          REQUIRE(val_f == val_u);
+        }
+      }
+      //cd.dump("PrescaleTable");
     }
   }
 }

--- a/PhysicsTools/Heppy/src/TriggerBitChecker.cc
+++ b/PhysicsTools/Heppy/src/TriggerBitChecker.cc
@@ -1,8 +1,5 @@
 #include "PhysicsTools/Heppy/interface/TriggerBitChecker.h"
-
 #include "FWCore/Common/interface/TriggerNames.h"
-#include <cassert>
-#include <iostream>
 
 namespace heppy {
 
@@ -45,31 +42,12 @@ namespace heppy {
     }
     bool outcome = true;
     for (std::vector<unsigned int>::const_iterator it = indices_.begin(), ed = indices_.end(); it != ed; ++it) {
-      if (result.getPrescaleForIndex(*it) != 1) {
+      if (result.getPrescaleForIndex<double>(*it) != 1) {
         outcome = false;
         break;
       }
     }
     return outcome;  // true only if all paths are unprescaled
-  }
-
-  int TriggerBitChecker::getprescale(const edm::EventBase &event,
-                                     const edm::TriggerResults &result_tr,
-                                     const pat::PackedTriggerPrescales &result) const {
-    if (result_tr.parameterSetID() != lastID_) {
-      syncIndices(event, result_tr);
-      lastID_ = result_tr.parameterSetID();
-    }
-    if (indices_.empty()) {
-      //            std::cout << " trying to check an inexistent trigger" << std::endl;
-      return -999;
-    }
-    if (indices_.size() > 1) {
-      std::cout << " trying to get prescale for multiple trigger objects at the same time" << std::endl;
-      assert(0);
-    }
-
-    return result.getPrescaleForIndex(*(indices_.begin()));
   }
 
   void TriggerBitChecker::syncIndices(const edm::EventBase &event, const edm::TriggerResults &result) const {

--- a/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/LeptonUpdater.cc
@@ -13,6 +13,8 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
+#include <type_traits>
+
 namespace pat {
 
   template <typename T>

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -558,7 +558,7 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       if (hltConfig.prescaleSize() > 0) {
         if (hltPrescaleProvider_.prescaleSet(iEvent, iSetup) != -1) {
           hltPrescaleTable = trigger::HLTPrescaleTable(
-              hltPrescaleProvider_.prescaleSet(iEvent, iSetup), hltConfig.prescaleLabels(), hltConfig.prescaleTable());
+              hltPrescaleProvider_.prescaleSet(iEvent, iSetup), hltConfig.prescaleLabels(), {});
           LogDebug("hltPrescaleTable") << "HLT prescale table found in event setup";
         } else {
           LogWarning("hltPrescaleSet") << "HLTPrescaleTable from event setup has error";
@@ -620,7 +620,7 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
         }
         TriggerPath triggerPath(namePath,
                                 indexPath,
-                                hltConfig.prescaleValue(set, namePath),
+                                hltConfig.prescaleValue<double>(set, namePath),
                                 handleTriggerResults->wasrun(indexPath),
                                 handleTriggerResults->accept(indexPath),
                                 handleTriggerResults->error(indexPath),
@@ -786,15 +786,13 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       packedPrescalesL1min = std::make_unique<PackedTriggerPrescales>(handleTriggerResults);
       packedPrescalesL1max = std::make_unique<PackedTriggerPrescales>(handleTriggerResults);
       const edm::TriggerNames& names = iEvent.triggerNames(*handleTriggerResults);
-      //std::cout << "Run " << iEvent.id().run() << ", LS " << iEvent.id().luminosityBlock() << ": pset " << set << std::endl;
       for (unsigned int i = 0, n = names.size(); i < n; ++i) {
-        auto pvdet = hltPrescaleProvider_.prescaleValuesInDetail(iEvent, iSetup, names.triggerName(i));
-        //int hltprescale = hltConfig_.prescaleValue(set, names.triggerName(i));
+        auto pvdet = hltPrescaleProvider_.prescaleValuesInDetail<double, double>(iEvent, iSetup, names.triggerName(i));
         if (pvdet.first.empty()) {
           packedPrescalesL1max->addPrescaledTrigger(i, 1);
           packedPrescalesL1min->addPrescaledTrigger(i, 1);
         } else {
-          int pmin = -1, pmax = -1;
+          double pmin = -1, pmax = -1;
           for (const auto& p : pvdet.first) {
             pmax = std::max(pmax, p.second);
             if (p.second > 0 && (pmin == -1 || pmin > p.second))
@@ -802,10 +800,8 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
           }
           packedPrescalesL1max->addPrescaledTrigger(i, pmax);
           packedPrescalesL1min->addPrescaledTrigger(i, pmin);
-          //std::cout << "\tTrigger " << names.triggerName(i) << ", L1 ps " << pmin << "-" << pmax << ", HLT ps " << hltprescale << std::endl;
         }
         packedPrescales->addPrescaledTrigger(i, pvdet.second);
-        //assert( hltprescale == pvdet.second );
       }
       iEvent.put(std::move(packedPrescales));
       iEvent.put(std::move(packedPrescalesL1max), "l1max");

--- a/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.icc
+++ b/PhysicsTools/TagAndProbe/interface/TriggerCandProducer.icc
@@ -108,7 +108,7 @@ void TriggerCandProducer<object>::produce(edm::Event& event, const edm::EventSet
     for (std::vector<edm::InputTag>::const_iterator iMyHLT = hltTags_.begin(); iMyHLT != hltTags_.end(); ++iMyHLT) {
       if ((*iMyHLT).label() == *iHLT) {
         triggerInMenu[(*iMyHLT).label()] = true;
-        if (hltPrescaleProvider_.prescaleValue(event, eventSetup, *iHLT) == 1)
+        if (hltPrescaleProvider_.prescaleValue<double>(event, eventSetup, *iHLT) == 1)
           triggerUnprescaled[(*iMyHLT).label()] = true;
       }
     }

--- a/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
@@ -102,15 +102,10 @@ AnotherPrimaryVertexAnalyzer::~AnotherPrimaryVertexAnalyzer() {}
 
 // ------------ method called to for each event  ------------
 void AnotherPrimaryVertexAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // compute event weigth
-
-  double weight = 1.;
-
-  if (_weightprov)
-    weight = _weightprov->prescaleWeight(iEvent, iSetup);
+  // compute event weight
+  auto const weight = _weightprov ? _weightprov->prescaleWeight<double>(iEvent, iSetup) : 1.;
 
   // get PV
-
   edm::Handle<reco::VertexCollection> pvcoll;
   iEvent.getByToken(_recoVertexCollectionToken, pvcoll);
 


### PR DESCRIPTION
backport of #39220

#### PR description:

A full description of the scope and implementation of this PR can be found in #39220.

Summary:
 - support only `double` and `FractionalPrescale` as valid types to access the values of L1T and HLT prescales in `HLTConfigData` and all of its clients (e.g. `HLTConfigProvider`, `HLTPrescaleProvider`, `PATTriggerProducer`, etc);
 - client code in CMSSW is updated accordingly; user code outside CMSSW that uses these methods will run into a compile-time error, in order to force users to specify one of the supported types (avoiding silent conversion of non-integer values into integers in user code);
 - a bi-product of this PR is a bugfix to MINIAOD, which has so far mistakenly saved L1T prescales as integers (even though in Run 3 L1T prescales can actually have non-integer values); this requires a change in `DataFormats/PatCandidates`.

Verbatim backport.

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#39220

Bugfix for MINIAOD.
