### PR TITLE
[Draft] Update HGCAL pset for Phase-2 HLT menu

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1358,6 +1358,33 @@ upgradeWFs['HLT75e33'] = UpgradeWorkflow_HLT75e33(
     offset = 0.75,
 )
 
+class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'DigiTrigger' in step:
+            stepDict[stepName][k] = merge([{'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@relval2026'}, stepDict[step][k]])
+        elif 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([{'-s':'RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM'}, stepDict[step][k]])
+        elif 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = merge([{'-s':'HARVESTING:@phase2Validation+@phase2+@miniAODValidation+@miniAODDQM'}, stepDict[step][k]])
+        else:
+            stepDict[stepName][k] = merge([stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment=="TTbar_14TeV" and '2026' in key
+upgradeWFs['HLTwDIGI75e33'] = UpgradeWorkflow_HLTwDIGI75e33(
+    steps = [
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal',
+    ],
+    PU = [
+        'DigiTrigger',
+        'RecoGlobal',
+        'HARVESTGlobal',
+    ],
+    suffix = '_HLTwDIGI75e33',
+    offset = 0.76,
+)
+
 class UpgradeWorkflow_Neutron(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'GenSim' in step:
@@ -2191,7 +2218,7 @@ upgradeProperties[2026] = {
     },
     '2026D88' : {
         'Geom' : 'Extended2026D88',
-        'HLTmenu': '@relval2026',
+        'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2191,7 +2191,7 @@ upgradeProperties[2026] = {
     },
     '2026D88' : {
         'Geom' : 'Extended2026D88',
-        'HLTmenu': '@relval2026',
+        'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2191,7 +2191,7 @@ upgradeProperties[2026] = {
     },
     '2026D88' : {
         'Geom' : 'Extended2026D88',
-        'HLTmenu': '@fake2',
+        'HLTmenu': '@relval2026',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
@@ -5,3 +5,6 @@ siPhase2Clusters = cms.EDProducer("Phase2TrackerClusterizer",
     maxNumberClusters = cms.uint32(0),
     src = cms.InputTag("mix","Tracker")
 )
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(siPhase2Clusters, src = "mixData:Tracker")

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
@@ -4,5 +4,6 @@ HGCAL_noise_fC = cms.PSet(
     doseMap = cms.string(''),
     scaleByDose = cms.bool(False),
     scaleByDoseAlgo = cms.uint32(0),
+    scaleByDoseFactor = cms.double(1),
     values = cms.vdouble(0.32041012, 0.384492144, 0.32041012)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_heback_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_heback_cfi.py
@@ -4,5 +4,9 @@ HGCAL_noise_heback = cms.PSet(
     doseMap = cms.string(''),
     noise_MIP = cms.double(0.01),
     scaleByDose = cms.bool(False),
-    scaleByDoseAlgo = cms.uint32(0)
+    scaleByDoseAlgo = cms.uint32(0),
+    scaleByDoseFactor = cms.double(1),
+    sipmMap = cms.string(""),
+    referenceIdark = cms.double(-1),
+    referenceXtalk = cms.double(-1)
 )

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -61,6 +61,9 @@ hltvalidationWithMC = cms.Sequence(
     +hltHCALdigisAnalyzer+hltHCALRecoAnalyzer+hltHCALNoiseRates # HCAL
 )
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([hltHCALdigisAnalyzer,hltHCALRecoAnalyzer,hltHCALNoiseRates]))
+
 hltvalidationWithData = cms.Sequence(
 )
 

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -9,7 +9,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     triggerEventObject    = cms.untracked.InputTag("hltTriggerSummaryRAW","","HLT"),
     DQMFolder             = cms.untracked.string(foldernm),
-    PatternJetTrg         = cms.untracked.string("HLT_PF(NoPU)?Jet([0-9])+(_v[0-9]+)?$"),                                   
+    PatternJetTrg         = cms.untracked.string("HLT_(AK4)?PF(NoPU|Puppi)?Jet([0-9])+(_v[0-9]+)?$"), #was "HLT_PF(NoPU)?Jet([0-9])+(_v[0-9]+)?$"),
     PatternMetTrg         = cms.untracked.string("HLT_+[Calo|PF]+MET([0-9])+[_NotCleaned|_BeamHaloCleaned]+(_v[0-9]+)?$"),
     PatternMuTrg          = cms.untracked.string("HLT_Mu([0-9])+(_v[0-9]+)?$"),
     LogFileName           = cms.untracked.string('JetMETSingleJetValidation.log'),

--- a/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
@@ -230,7 +230,7 @@ void HPSPFTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("maxSeedChargedPFCandEta", 2.4);
   desc.add<bool>("applyPreselection", false);
   desc.add<double>("isolationConeSize", 0.4);
-  desc.add<edm::InputTag>("srcL1Vertices", edm::InputTag("L1VertexFinderEmulator", "l1verticesEmulation"));
+  desc.add<edm::InputTag>("srcL1Vertices", edm::InputTag("l1tVertexFinderEmulator", "l1verticesEmulation"));
   desc.add<double>("maxChargedIso", 1000.0);
   {
     edm::ParameterSetDescription psd0;

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -47,6 +47,7 @@ from Validation.Configuration.mtdSimValid_cff import *
 from Validation.SiOuterTrackerV.OuterTrackerSourceConfigV_cff import *
 from Validation.Configuration.ecalSimValid_cff import *
 from Validation.SiTrackerPhase2V.Phase2TrackerValidationFirstStep_cff import *
+from HLTriggerOffline.Common.HLTValidation_cff import *
 
 # filter/producer "pre-" sequence for globalValidation
 globalPrevalidationTracking = cms.Sequence(
@@ -126,6 +127,10 @@ from Validation.Configuration.me0SimValid_cff import *
 
 baseCommonPreValidation = cms.Sequence(cms.SequencePlaceholder("mix"))
 baseCommonValidation = cms.Sequence()
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(baseCommonPreValidation,cms.Sequence(cms.SequencePlaceholder("mix")*hltassociation))
+phase2_common.toReplaceWith(baseCommonValidation,cms.Sequence(hltvalidation))
 
 # Tracking-only validation
 globalPrevalidationTrackingOnly = cms.Sequence(

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -73,6 +73,10 @@ from Validation.MtdValidation.MtdPostProcessor_cff import *
 
 postValidation_common = cms.Sequence()
 
+from HLTriggerOffline.Common.HLTValidationHarvest_cff import *
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(postValidation_common,cms.Sequence(hltpostvalidation))
+
 postValidation_trackingOnly = cms.Sequence(
       postProcessorTrackSequenceTrackingOnly
     + postProcessorVertexSequence


### PR DESCRIPTION
#### PR description:
This PR updates the pset used in Phase-2 HGCAL HLT. The update follows the pset defined in
https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py

To complete on PR test, and example of benefit from the new workflow, this PR also introduces 
- a new workfow `.76` which the `DIGI` and `HLT:@relval2026` steps are running together instead of `HLT:@fake`.  The new workflow will allow us to develop Phase2 HLT DQM and sequence to be used in future Phase-2 production. This PR is an effort to help on validation as mentioned in https://github.com/cms-sw/cmssw/issues/39362.
- a minimal change to have Validation HLT in sequence. There are still some warning massages, this will be cleaned up.

#### PR validation:
Run test with updated `39434.76`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
None.
