### PR TITLE
Override the input branch settings for SIM AOD

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -466,6 +466,7 @@ AODSIMEventContent = cms.PSet(
     eventAutoFlushCompressedSize=cms.untracked.int32(30*1024*1024),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4),
+    overrideInputFileSplitLevels=cms.untracked.bool(True)
 )
 AODSIMEventContent.outputCommands.extend(AODEventContent.outputCommands)
 AODSIMEventContent.outputCommands.extend(GeneratorInterfaceAOD.outputCommands)


### PR DESCRIPTION
#### PR description:

Having the input branches be fully split can save ~5% on the output file size.

#### PR validation:

Change based on the study described in #39449.