### PR TITLE
Extension of LHEGenericMassFilter capabilities to filter on non-outgoing particles

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -24,6 +24,7 @@ class LHEGenericMassFilter : public edm::global::EDFilter<> {
 public:
   explicit LHEGenericMassFilter(const edm::ParameterSet&);
   ~LHEGenericMassFilter() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
   bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
@@ -91,7 +92,7 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
 void LHEGenericMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<int>("NumRequired", 1);
-  desc.add<std::vector<int>>("ParticleID", 1);
+  desc.add<vector<int>>("ParticleID", std::vector<int>{1});
   desc.add<double>("MinMass", 0.0);
   desc.add<double>("MaxMass", 1.0);
   desc.add<bool>("RequiredOutgoingStatus", true);

--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -42,7 +42,7 @@ private:
 LHEGenericMassFilter::LHEGenericMassFilter(const edm::ParameterSet& iConfig)
     : src_(consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("src"))),
       numRequired_(iConfig.getParameter<int>("NumRequired")),
-      particleID_(iConfig.getParameter<std::vector<int> >("ParticleID")),
+      particleID_(iConfig.getParameter<std::vector<int>>("ParticleID")),
       minMass_(iConfig.getParameter<double>("MinMass")),
       maxMass_(iConfig.getParameter<double>("MaxMass")),
       requiredOutgoingStatus_(iConfig.getParameter<bool>("RequiredOutgoingStatus")) {}
@@ -61,7 +61,7 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
 
   for (int i = 0; i < EvtHandle->hepeup().NUP; ++i) {
     // if requiredOutgoingStatus_ keep only outgoing particles, otherwise keep them all
-    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {  
+    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {
       continue;
     }
     for (unsigned int j = 0; j < particleID_.size(); ++j) {

--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -35,7 +35,7 @@ private:
   const std::vector<int> particleID_;  // vector of particle IDs to look for
   const double minMass_;
   const double maxMass_;
-  const bool requiredOutgoingStatus_; // Whether particles required to pass filter must have outgoing status
+  const bool requiredOutgoingStatus_;  // Whether particles required to pass filter must have outgoing status
 };
 
 LHEGenericMassFilter::LHEGenericMassFilter(const edm::ParameterSet& iConfig)

--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -87,5 +87,16 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
   return false;
 }
 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void LHEGenericMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("NumRequired", 1);
+  desc.add<std::vector<int>>("ParticleID", 1);
+  desc.add<double>("MinMass", 0.0);
+  desc.add<double>("MaxMass", 1.0);
+  desc.add<bool>("RequiredOutgoingStatus", true);
+  descriptions.addDefault(desc);
+}
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(LHEGenericMassFilter);

--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -35,6 +35,7 @@ private:
   const std::vector<int> particleID_;  // vector of particle IDs to look for
   const double minMass_;
   const double maxMass_;
+  const bool requiredOutgoingStatus_; // Whether particles required to pass filter must have outgoing status
 };
 
 LHEGenericMassFilter::LHEGenericMassFilter(const edm::ParameterSet& iConfig)
@@ -42,7 +43,8 @@ LHEGenericMassFilter::LHEGenericMassFilter(const edm::ParameterSet& iConfig)
       numRequired_(iConfig.getParameter<int>("NumRequired")),
       particleID_(iConfig.getParameter<std::vector<int> >("ParticleID")),
       minMass_(iConfig.getParameter<double>("MinMass")),
-      maxMass_(iConfig.getParameter<double>("MaxMass")) {}
+      maxMass_(iConfig.getParameter<double>("MaxMass")),
+      requiredOutgoingStatus_(iConfig.getParameter<bool>("RequiredOutgoingStatus")) {}
 
 // ------------ method called to skim the data  ------------
 bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
@@ -57,7 +59,7 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
   double E = 0.;
 
   for (int i = 0; i < EvtHandle->hepeup().NUP; ++i) {
-    if (EvtHandle->hepeup().ISTUP[i] != 1) {  // keep only outgoing particles
+    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {  // keep only outgoing particles
       continue;
     }
     for (unsigned int j = 0; j < particleID_.size(); ++j) {

--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -59,7 +59,8 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
   double E = 0.;
 
   for (int i = 0; i < EvtHandle->hepeup().NUP; ++i) {
-    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {  // keep only outgoing particles
+    // if requiredOutgoingStatus_ keep only outgoing particles, otherwise keep them all
+    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {  
       continue;
     }
     for (unsigned int j = 0; j < particleID_.size(); ++j) {


### PR DESCRIPTION
#### PR description:
Extended the capability of the LHEGenericMassFilter to filter on the invariant masses of non-outgoing particles by adding an additional boolean argument in the constructor. The reason this extension is required is for the production of the dileptonic and semileptonic decays of toponium. A filter on the invariant mass of toponium is required and since toponium is not an outgoing particle this filter currently is incapable of properly filtering these events. See the genproductions pull request and cards here: https://github.com/cms-sw/genproductions/pull/3132#issuecomment-1115223895

#### PR validation:
I ran
`scram b runtests`
and 
`runTheMatrix.py -l limited -i all --ibeos`.
No new code needs to be added for unit tests, test configurations, additions or updates to the runTheMatrix test workflows as far as I am concerned.
