### PR TITLE
[12_4_X] Bug fix in EMTF GEM and RPC unpacker blocks

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -147,7 +147,8 @@ namespace l1t {
         uint16_t GEMc = payload[2];
         uint16_t GEMd = payload[3];
 
-        for (int i = 0; i < nTPs; i++) {
+        // If there are 2 TPs in the block we fill them 1 by 1
+        for (int i = 1; i <= nTPs; i++) {
           // res is a pointer to a collection of EMTFDaqOut class objects
           // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
           EMTFDaqOutCollection* res;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -140,7 +140,8 @@ namespace l1t {
         uint16_t RPCc = payload[2];
         uint16_t RPCd = payload[3];
 
-        for (int i = 0; i < nTPs; i++) {
+        // If there are 2 TPs in the block we fill them 1 by 1
+        for (int i = 1; i <= nTPs; i++) {
           // res is a pointer to a collection of EMTFDaqOut class objects
           // There is one EMTFDaqOut for each MTF7 (60 deg. sector) in the event
           EMTFDaqOutCollection* res;
@@ -159,7 +160,7 @@ namespace l1t {
           ////////////////////////////
 
           if (run3_DAQ_format) {  // Run 3 DAQ format has 2 TPs per block
-            if (i == 0) {
+            if (i == 1) {
               RPC_.set_phi(GetHexBits(RPCa, 0, 10));
               RPC_.set_word(GetHexBits(RPCa, 11, 12));
               RPC_.set_frame(GetHexBits(RPCa, 13, 14));


### PR DESCRIPTION
#### PR description:

This is the backport of https://github.com/cms-sw/cmssw/pull/39460

This PR fixes a bug that was mentioned in https://github.com/cms-sw/cmssw/issues/39456

The bug was introduced in https://github.com/cms-sw/cmssw/pull/39389

It was a stupid mistake on my part that somehow went in. The index for the for loop does not match the if/else statements, hence causing an empty GEM/RPC TP to be created which then causes the crash when we try to create detID.

This should be backported to 12_4_X and 12_5_X to fix the same ug in those releases. 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested with running the unpacker on the data files mentioned in https://github.com/cms-sw/cmssw/issues/39456. Unpacker runs and assigns the correct values to GEM/RPC TPs.

File used: `/eos/cms/store/t0streamer/Data/Express/000/359/045/run359045_ls0144_streamExpress_StorageManager.dat`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of https://github.com/cms-sw/cmssw/pull/39460
<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
<!-- Please delete the text above after you verified all points of the checklist  -->
