### PR TITLE
Revert "[124X] Fix double counting in HepMC to G4 handoff"

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -473,7 +473,8 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     if (verbose > 2)
       LogDebug("SimG4CoreGenerator") << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id();
 
-    if (((*vpdec)->status() == 2 || (*vpdec)->status() > 3) && (*vpdec)->end_vertex() != nullptr) {
+    if (((*vpdec)->status() == 2 || ((*vpdec)->status() == 23 && std::abs(vp->pdg_id()) == 1000015)) &&
+        (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();


### PR DESCRIPTION
According to the discussion in https://its.cern.ch/jira/browse/PDMVRELVALS-165 we:
- merged https://github.com/cms-sw/cmssw/pull/39440 in 12_4_X (SIM, not affecting data taking)
- built CMSSW_12_4_9_patch1 (to be used for data taking)
- and now revert https://github.com/cms-sw/cmssw/pull/39440 with this PR, in the head of 12_4_X 

Now pdmv can use CMSSW_12_4_9_patch1 to produce the validation samples needed 

Reverts cms-sw/cmssw#39440