### PR TITLE
[12_5_X] Add missing includes to two AlpakaCore headers

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/ContextState.h
+++ b/HeterogeneousCore/AlpakaCore/interface/ContextState.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 #define HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"


### PR DESCRIPTION
#### PR description:

Backport of #39463

#### PR validation:

None beyond the tests in ##39463