### PR TITLE
Call RootHandlers::willBeUsingThreads() based on number of threads rather than streams

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -461,7 +461,7 @@ namespace edm {
     ServiceRegistry::Operate operate(serviceToken_);
 
     CMS_SA_ALLOW try {
-      if (nStreams > 1) {
+      if (nThreads > 1) {
         edm::Service<RootHandlers> handler;
         handler->willBeUsingThreads();
       }


### PR DESCRIPTION
#### PR description:

While working on something else I noticed `EventProcessor` calls `RootHandlers::willBeUsingThreads()` if the job was configured to use more than one stream. Given what `InitRootHandlers::willBeUsingThreads()` does
https://github.com/cms-sw/cmssw/blob/a2ee5cb99a9c2e713e7b919852d0bafec25c1166/FWCore/Services/plugins/InitRootHandlers.cc#L874-L883
I'd think the check should be based on the number of threads (thinking of a job with one stream and at least two threads).

#### PR validation:

None (edited on the web editor)