### PR TITLE
[12_4_X] Release dependent modules only after the worker has finished for scheduled modules

### DIFF
--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -240,6 +240,9 @@ namespace edm {
 
     virtual bool hasAccumulator() const = 0;
 
+    // Used in PuttableProductResolver
+    edm::WaitingTaskList& waitingTaskList() { return waitingTasks_; }
+
   protected:
     template <typename O>
     friend class workerhelper::CallImpl;

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -201,7 +201,7 @@ namespace edm {
   class PuttableProductResolver : public ProducedProductResolver {
   public:
     explicit PuttableProductResolver(std::shared_ptr<BranchDescription const> bd)
-        : ProducedProductResolver(bd, ProductStatus::NotPut), worker_(nullptr), prefetchRequested_(false) {}
+        : ProducedProductResolver(bd, ProductStatus::NotPut) {}
 
     void setupUnscheduled(UnscheduledConfigurator const&) final;
 
@@ -218,12 +218,12 @@ namespace edm {
                         ModuleCallingContext const* mcc) const override;
     bool unscheduledWasNotRun_() const override { return false; }
 
-    void putProduct(std::unique_ptr<WrapperBase> edp) const override;
-    void resetProductData_(bool deleteEarly) override;
-
-    CMS_THREAD_SAFE mutable WaitingTaskList m_waitingTasks;
-    Worker* worker_;
-    mutable std::atomic<bool> prefetchRequested_;
+    // The WaitingTaskList below is the one from the worker, if one
+    // corresponds to this ProductResolver. For the Source-like cases
+    // where there is no such Worker, the tasks depending on the data
+    // depending on this ProductResolver are assumed to be eligible to
+    // run immediately after their prefetch.
+    WaitingTaskList* waitingTasks_ = nullptr;
   };
 
   class UnscheduledProductResolver : public ProducedProductResolver {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -877,6 +877,12 @@ namespace edm {
       ServiceRegistry::Operate guard(serviceToken);
       Traits::preScheduleSignal(actReg_.get(), &streamContext_);
 
+      // Data dependencies need to be set up before marking empty
+      // (End)Paths complete in case something consumes the status of
+      // the empty (EndPath)
+      workerManager_.setupResolvers(ep);
+      workerManager_.setupOnDemandSystem(info);
+
       HLTPathStatus hltPathStatus(hlt::Pass, 0);
       for (int empty_trig_path : empty_trig_paths_) {
         results_->at(empty_trig_path) = hltPathStatus;
@@ -898,9 +904,6 @@ namespace edm {
           return;
         }
       }
-
-      workerManager_.setupResolvers(ep);
-      workerManager_.setupOnDemandSystem(info);
 
       ++total_events_;
 


### PR DESCRIPTION
#### PR description:

Backport of #39245. Fixes a rare scheduling bug that was observed at the HLT in https://github.com/cms-sw/cmssw/issues/39064 (that was first mitigated in https://github.com/cms-sw/cmssw/pull/39211).

#### PR validation:

Original development. The reproducer I mentioned in https://github.com/cms-sw/cmssw/issues/39064#issuecomment-1228755900 succeeds with this change. Framework unit tests pass.