### PR TITLE
[Backport] [GEM] Unpacker update for the vfat masking information [12_4_X]

### DIFF
--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -506,7 +506,7 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     const GEMVFATStatusCollection::Range &range = (*vfatIt).second;
 
     for (auto vfatStat = range.first; vfatStat != range.second; ++vfatStat) {
-      Int_t nIdxVFAT = getVFATNumber(gid.station(), gid.ieta(), vfatStat->vfatPosition());
+      Int_t nIdxVFAT = vfatStat->vfatPosition();
 
       GEMVFATStatus::Warnings warnings{vfatStat->warnings()};
       if (warnings.basicOFW)
@@ -515,7 +515,8 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
         mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 3);
 
       GEMVFATStatus::Errors errors{(uint8_t)vfatStat->errors()};
-      mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
+      if (errors.vc)
+        mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 4);
       if (errors.InValidHeader)
         mapStatusVFATPerCh_.Fill(key4Ch, nIdxVFAT, 5);
       if (errors.EC)

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -31,6 +31,7 @@ public:
       uint8_t L1aNF : 1;   // L1A FIFO near full
       uint8_t EvtSzW : 1;  // Event size warning
       uint8_t InValidVFAT : 1;
+      uint8_t missingVFAT : 1;
     };
   };
 
@@ -51,10 +52,15 @@ public:
     errors_ = error.codes;
 
     Warnings warn{0};
+    existVFATs_ = oh.existVFATs();
+    vfatMask_ = oh.vfatMask();
+    zsMask_ = oh.zsMask();
+    missingVFATs_ = (existVFATs_ ^ 0xffffff) & (vfatMask_ & (zsMask_ ^ 0xffffff));
     warn.EvtNF = oh.evtNF();
     warn.InNF = oh.inNF();
     warn.L1aNF = (oh.l1aNF() and (oh.version() == 0));
     warn.EvtSzW = oh.evtSzW();
+    warn.missingVFAT = (oh.version() != 0) and (missingVFATs_ != 0);
     warnings_ = warn.wcodes;
   }
 
@@ -67,10 +73,18 @@ public:
   bool isBad() const { return errors_ != 0; }
   uint16_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }
+  uint32_t missingVFATs() const { return missingVFATs_; }
+  uint32_t vfatMask() const { return vfatMask_; }
+  uint32_t zsMask() const { return zsMask_; }
+  uint32_t existVFATs() const { return existVFATs_; }
 
 private:
   uint16_t errors_;
   uint8_t warnings_;
+  uint32_t missingVFATs_;
+  uint32_t vfatMask_;
+  uint32_t zsMask_;
+  uint32_t existVFATs_;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const GEMOHStatus& status) {

--- a/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
+++ b/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
@@ -73,7 +73,7 @@ public:
     };
   };
 
-  GEMOptoHybrid() : ch_(0), ct_(0){};
+  GEMOptoHybrid() : ch_(0), ct_(0), existVFATs_(0){};
   ~GEMOptoHybrid() { vfatd_.clear(); }
 
   void setVersion(uint8_t i) { ver_ = i; }
@@ -147,9 +147,13 @@ public:
   uint32_t zsMask() const { return GEBchamberTrailer{ct_}.ZSMask; }
 
   //!Adds VFAT data to the vector
-  void addVFAT(GEMVFAT v) { vfatd_.push_back(v); }
+  void addVFAT(GEMVFAT v) {
+    existVFATs_ = existVFATs_ | (0x1 << v.vfatId());
+    vfatd_.push_back(v);
+  }
   //!Returns the vector of VFAT data
   const std::vector<GEMVFAT>* vFATs() const { return &vfatd_; }
+  uint32_t existVFATs() const { return existVFATs_; }
   //!Clear the vector rof VFAT data
   void clearVFATs() { vfatd_.clear(); }
 
@@ -160,6 +164,8 @@ private:
 
   uint64_t ch_;  // GEBchamberHeader
   uint64_t ct_;  // GEBchamberTrailer
+
+  uint32_t existVFATs_;
 
   std::vector<GEMVFAT> vfatd_;
 };

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_GEMDigi_GEMVFATStatus_h
 #define DataFormats_GEMDigi_GEMVFATStatus_h
 #include "GEMAMC.h"
+#include "GEMOptoHybrid.h"
 #include "GEMVFAT.h"
 #include <bitset>
 #include <ostream>
@@ -12,8 +13,10 @@ public:
     struct {
       uint8_t vc : 1;  // VFAT CRC error
       uint8_t InValidHeader : 1;
-      uint8_t EC : 1;  // does not match AMC EC
-      uint8_t BC : 1;  // does not match AMC BC
+      uint8_t EC : 1;        // does not match AMC EC
+      uint8_t BC : 1;        // does not match AMC BC
+      uint8_t vfatMask : 1;  // VFAT mask error
+      uint8_t zsMask : 1;    // Zero Suppression mask error
     };
   };
   union Warnings {
@@ -25,13 +28,18 @@ public:
   };
 
   GEMVFATStatus() {}
-  GEMVFATStatus(const GEMAMC& amc, const GEMVFAT& vfat, uint16_t position, bool readMultiBX) {
+  GEMVFATStatus(const GEMAMC& amc, const GEMOptoHybrid& oh, const GEMVFAT& vfat, bool readMultiBX) {
     Errors error{0};
     Warnings warn{0};
 
     error.EC = vfat.ec() != amc.lv1Idt();
     if (!readMultiBX)
       error.BC = vfat.bc() != amc.bunchCrossing();
+
+    if (oh.version() != 0) {
+      error.vfatMask = (oh.vfatMask() >> vfat.vfatId()) ^ 0x1;
+      error.zsMask = (oh.zsMask() >> vfat.vfatId()) & 0x1;
+    }
 
     if (vfat.version() > 2) {
       error.vc = vfat.vc();
@@ -46,7 +54,7 @@ public:
       else
         error.InValidHeader = 1;
     }
-    vfatPosition_ = position;
+    vfatPosition_ = vfat.vfatId();
 
     errors_ = error.codes;
     warnings_ = warn.wcodes;
@@ -54,12 +62,12 @@ public:
 
   uint16_t vfatPosition() const { return vfatPosition_; }
   bool isBad() const { return errors_ != 0; }
-  uint16_t errors() const { return errors_; }
+  uint8_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }
 
 private:
   uint16_t vfatPosition_;
-  uint16_t errors_;
+  uint8_t errors_;
   uint8_t warnings_;
 };
 

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -61,8 +61,9 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="3">
+<class name="GEMOHStatus" ClassVersion="4">
  <version ClassVersion="3" checksum="1715607020"/>
+ <version ClassVersion="4" checksum="442197271"/>
 </class>
 <class name="std::vector<GEMOHStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
@@ -70,8 +71,9 @@
 <class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="3">
+<class name="GEMVFATStatus" ClassVersion="4">
  <version ClassVersion="3" checksum="2994917778"/>
+ <version ClassVersion="4" checksum="2298275534"/>
 </class>
 <class name="std::vector<GEMVFATStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -194,7 +194,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
             continue;
           }
 
-          GEMVFATStatus st_vfat(amc, vfat, vfat.phi(), readMultiBX_);
+          GEMVFATStatus st_vfat(amc, vfat, vfat.position(), readMultiBX_);
           if (st_vfat.isBad()) {
             LogDebug("GEMRawToDigiModule") << st_vfat;
             if (keepDAQStatus_) {

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -178,6 +178,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           if (keepDAQStatus_) {
             outOHStatus.get()->insertDigi(cId, st_oh);
           }
+          continue;
         }
 
         //Read vfat data
@@ -194,7 +195,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
             continue;
           }
 
-          GEMVFATStatus st_vfat(amc, vfat, vfat.position(), readMultiBX_);
+          GEMVFATStatus st_vfat(amc, optoHybrid, vfat, readMultiBX_);
           if (st_vfat.isBad()) {
             LogDebug("GEMRawToDigiModule") << st_vfat;
             if (keepDAQStatus_) {


### PR DESCRIPTION
#### PR description:

* GEM Unpacker and data formats are updated to save the vfat masking information
* Minor bugfix for the VFATStatus (Positional information)
* The results of this update has approved in GEM DPG meeting ([link](https://indico.cern.ch/event/1202028/contributions/5054418/attachments/2511952/4317915/Masking_status_20_Sep.pdf))
* Backport to `CMSSW_12_5_X` and `CMSSW_12_4_X` are needed.
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

* The code format has applied with `scram build code-format` and tested with `scram build code-checks`.
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* The original PR is #39487 