### PR TITLE
MTD Validation: add protection against infinite weight in simpvz histogram

### DIFF
--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -1590,6 +1590,8 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
 
   //fill vertices histograms here in a new loop
   for (unsigned int is = 0; is < simpv.size(); is++) {
+    // protect against particle guns with very displaced vertices
+    if ( std::isinf(1. / puLineDensity(simpv.at(is).z)) ) { continue; }
     meSimPVZ_->Fill(simpv.at(is).z, 1. / puLineDensity(simpv.at(is).z));
     if (is == 0 && optionalPlots_) {
       meSimPosInSimOrigCollection_->Fill(simpv.at(is).OriginalIndex);

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -1591,7 +1591,9 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
   //fill vertices histograms here in a new loop
   for (unsigned int is = 0; is < simpv.size(); is++) {
     // protect against particle guns with very displaced vertices
-    if ( std::isinf(1. / puLineDensity(simpv.at(is).z)) ) { continue; }
+    if (std::isinf(1. / puLineDensity(simpv.at(is).z))) {
+      continue;
+    }
     meSimPVZ_->Fill(simpv.at(is).z, 1. / puLineDensity(simpv.at(is).z));
     if (is == 0 && optionalPlots_) {
       meSimPosInSimOrigCollection_->Fill(simpv.at(is).OriginalIndex);


### PR DESCRIPTION
#### PR description:

This PR is addressing issue #39214 , reporting a long standing problem with comparisons with the simpvz validation histogram in ```Validation/MtdValidation``` ```Primary4DVertexValidation``` module. This turns to be due to samples with very displaced vertices (used for HGCAL studies), which cause the weight of vertices to be infinite.

#### PR validation:

This fix removes infinite entries appearing in the statistics of the histogram for relval 39496.