### PR TITLE
prepare DQMStore for Framework concurrent run support

### DIFF
--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -93,6 +93,7 @@ public:
   }
 
   void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) final {
+    edm::Service<DQMStore>()->initLumi(lumi.run(), lumi.luminosityBlock(), meId());
     edm::Service<DQMStore>()->enterLumi(lumi.run(), lumi.luminosityBlock(), meId());
   }
 


### PR DESCRIPTION
#### PR description:

Modify DQMStore so that it continues to function when the pull request adding Framework support for concurrent runs is merged. That pull request, #38801, adds additional concurrency that was always planned in the design and documented on the design TWIKI, but in fact was not implemented. After that PR is merged, the streamBeginRun and streamEndRun transitions may run concurrently with some other transitions, including globalBeginLuminosityBlock. The current implementation of DQMStore relies on globalBeginLuminosityBlock occurring before beginStreamRun to call initLumi for Monitor elements with lumi scope. DQMStore will break if beginStreamRun is called after globalBeginLuminosityBlock because new MonitorElements will be booked and then initLumi will never be called.

This is a one line fix for this problem.

Note that this fix is intended to allow DQMStore to function properly in the case where the number of concurrent runs is configured to 1, which will be the default. There might or might not be additional work necessary in DQMStore to support a configuration where the number of concurrent runs is configured to be greater than 1. That case has not been tested. The plan is to get support for concurrent runs implemented in the Framework and later improve modules and services outside the Framework to support that mode of operation as resources are available.

Note that PR #38801 cannot be merged until after this PR is merged and we would like to merge that one soon.

@makortel and @Dr15Jones, you might be interested in this also.

#### PR validation:

Behavior should remain exactly the same, so this relies on existing tests.
