### PR TITLE
[12.5.X] Fix testNoParentDictionary to properly copy the package from release area

### DIFF
--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -18,7 +18,7 @@ eval `scram run -sh`
 for DIR in ${OLD_CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do
     if [ -d ${DIR}/src/DataFormats/TestObjects ]; then
         mkdir DataFormats
-        cp -r ${DIR}/src/DataFormats/TestObjects DataFormats/
+        cp -Lr ${DIR}/src/DataFormats/TestObjects DataFormats/
         break
     fi
 done


### PR DESCRIPTION
backport of #39367

In patch release we could have symlinks src/SubSystem/Package pointing to FULL_RELEASE/src/SubSystem/Package . This can cause the unit test testNoParentDictionary.sh to fail. This change now properly copies the package DataFormats/TestObjects from patch release by dereferencing the symlink