### PR TITLE
Updated G4FLowE method

### DIFF
--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -52,7 +52,7 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
   G4double energy = track->GetKineticEnergy();
   if (fMaterial != track->GetMaterial() || energy >= fEmax)
     return false;
-  
+
   /*
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"
@@ -67,7 +67,7 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
     if (ptr->isPrimary()) {
       int pdgMother = mother->GetDefinition()->GetPDGEncoding();
       if (std::abs(pdgMother) == 11 || pdgMother == 22)
-	return false;
+        return false;
     }
   }
   return true;

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -3,6 +3,7 @@
 
 #include "SimG4Core/Application/interface/LowEnergyFastSimModel.h"
 #include "SimG4Core/Application/interface/TrackingAction.h"
+#include "SimG4Core/Notification/interface/TrackInformation.h"
 
 #include "G4VFastSimulationModel.hh"
 #include "G4EventManager.hh"
@@ -15,13 +16,13 @@
 #include "G4PhysicalConstants.hh"
 
 constexpr G4double twomass = 2 * CLHEP::electron_mass_c2;
-constexpr G4double scaleFactor = 1.015;
+constexpr G4double scaleFactor = 1.05;
 
 LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* region, const edm::ParameterSet& parSet)
     : G4VFastSimulationModel(name, region),
       fRegion(region),
       fTrackingAction(nullptr),
-      fCheck(false),
+      fCheck(true),
       fTailPos(0., 0., 0.) {
   fEmax = parSet.getParameter<double>("LowEnergyGflashEcalEmax") * CLHEP::GeV;
   fPositron = G4Positron::Positron();
@@ -48,21 +49,28 @@ G4bool LowEnergyFastSimModel::IsApplicable(const G4ParticleDefinition& particle)
 
 G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
   const G4Track* track = fastTrack.GetPrimaryTrack();
-  if (fCheck) {
-    if (nullptr == fTrackingAction) {
-      fTrackingAction = static_cast<const TrackingAction*>(G4EventManager::GetEventManager()->GetUserTrackingAction());
-    }
-    int pdgMother = std::abs(fTrackingAction->geant4Track()->GetDefinition()->GetPDGEncoding());
-    if (pdgMother == 11 || pdgMother == 22)
-      return false;
-  }
   G4double energy = track->GetKineticEnergy();
+  if (fMaterial != track->GetMaterial() || energy >= fEmax)
+    return false;
+  
   /*
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"
                                             << track->GetMaterial()->GetName() << ">";
   */
-  return (energy < fEmax && fMaterial == track->GetMaterial());
+  if (fCheck) {
+    if (nullptr == fTrackingAction) {
+      fTrackingAction = static_cast<const TrackingAction*>(G4EventManager::GetEventManager()->GetUserTrackingAction());
+    }
+    const G4Track* mother = fTrackingAction->geant4Track();
+    const TrackInformation* ptr = static_cast<TrackInformation*>(mother->GetUserInformation());
+    if (ptr->isPrimary()) {
+      int pdgMother = mother->GetDefinition()->GetPDGEncoding();
+      if (std::abs(pdgMother) == 11 || pdgMother == 22)
+	return false;
+    }
+  }
+  return true;
 }
 
 void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -457,8 +457,8 @@ bool StackingAction::rrApplicable(const G4Track* aTrack, const G4Track& mother) 
 int StackingAction::isItFromPrimary(const G4Track& mother, int flagIn) const {
   int flag = flagIn;
   if (flag != 1) {
-    const TrackInformation& motherInfo(extractor(mother));
-    if (motherInfo.isPrimary()) {
+    const TrackInformation* ptr = static_cast<TrackInformation*>(mother.GetUserInformation());
+    if (ptr->isPrimary()) {
       flag = 3;
     }
   }


### PR DESCRIPTION
#### PR description:
G4FLowE method is updated: added check on primary particle, changed scale factor from 1.015 to 1.05. Motivation is described in SIM meeting https://indico.cern.ch/event/1197830/ 

By default this method is not used. So, no change in any WF is expected.

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

