### PR TITLE
Require the AlpakaService to be enabled before running on a Device

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/ContextState.h
+++ b/HeterogeneousCore/AlpakaCore/interface/ContextState.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 #define HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -1,15 +1,28 @@
 #ifndef HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 #define HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
 namespace cms::alpakatools {
 
   template <typename TPlatform, typename = std::enable_if_t<is_platform_v<TPlatform>>>
   alpaka::Dev<TPlatform> const& chooseDevice(edm::StreamID id) {
+    edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+    if (not service->enabled()) {
+      cms::Exception ex("RuntimeError");
+      ex << "Unable to choose current device because " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.\n"
+         << "If " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " was not explicitly disabled in the configuration,\n"
+         << "the probable cause is that there is no accelerator or there is some problem\n"
+         << "with the accelerator runtime or drivers.";
+      ex.addContext("Calling cms::alpakatools::chooseDevice()");
+      throw ex;
+    }
+
     // For startes we "statically" assign the device based on
     // edm::Stream number. This is suboptimal if the number of
     // edm::Streams is not a multiple of the number of devices

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -7,13 +7,11 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaCore/interface/ScopedContext.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
 #include "TestAlgo.h"
 
@@ -23,13 +21,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     TestAlpakaProducer(edm::ParameterSet const& config)
         : deviceToken_{produces()}, size_{config.getParameter<int32_t>("size")} {}
-
-    void beginStream(edm::StreamID) override {
-      edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
-      if (not service->enabled()) {
-        throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
-      }
-    }
 
     void produce(edm::Event& event, edm::EventSetup const&) override {
       // create a context based on the EDM stream number

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -10,13 +10,11 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaCore/interface/ScopedContext.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -24,13 +22,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     TestAlpakaTranscriber(edm::ParameterSet const& config)
         : deviceToken_{consumes(config.getParameter<edm::InputTag>("source"))}, hostToken_{produces()} {}
-
-    void beginStream(edm::StreamID) override {
-      edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
-      if (not service->enabled()) {
-        throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
-      }
-    }
 
     void acquire(edm::Event const& event, edm::EventSetup const& setup, edm::WaitingTaskWithArenaHolder task) override {
       // create a context reusing the same device and queue as the producer of the input collection


### PR DESCRIPTION
#### PR description:

Require the `AlpakaService` to be enabled before running on a `Device`.
    
Move the check that the corresponding `AlpakaService` is enabled from the `beginStream()` method of each `EDProducer` to the `alpakatools::chooseDevice()` central function.
    
This replicates the behaviour currently used by the CUDA "framework".


#### PR validation:

Unit tests pass.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 12.5.x.