### PR TITLE
Explicitly state which Associations need Trajectories

### DIFF
--- a/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
+++ b/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
@@ -16,7 +16,8 @@ def customiseEarlyDelete(process):
 
     (products, references) = customiseEarlyDeleteForSeeding(process, products)
     products = customiseEarlyDeleteForMkFit(process, products)
-    products = customiseEarlyDeleteForCKF(process, products)
+    (products, newReferences) = customiseEarlyDeleteForCKF(process, products)
+    references.update(newReferences)
 
     products = customiseEarlyDeleteForCandIsoDeposits(process, products)
 

--- a/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
+++ b/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
@@ -4,8 +4,10 @@ import collections
 
 def customiseEarlyDeleteForCKF(process, products):
 
+    references = collections.defaultdict(list)
+    
     if "trackExtenderWithMTD" not in process.producerNames():
-        return products
+        return (products, references)
 
     def _branchName(productType, moduleLabel, instanceLabel=""):
         return "%s_%s_%s_%s" % (productType, moduleLabel, instanceLabel, process.name_())
@@ -15,6 +17,7 @@ def customiseEarlyDeleteForCKF(process, products):
     def _addProduct(name):
         products[name].append(_branchName("Trajectorys", name))
         products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+        references[_branchName("TrajectorysToOnerecoTracksAssociation", name)] = [_branchName("Trajectorys", name)]
         trajectoryLabels.append(name)
 
     for name, module in process.producers_().items():
@@ -53,4 +56,4 @@ def customiseEarlyDeleteForCKF(process, products):
                 noTrajectoryYet.append(tlm)
         trackListMergers = noTrajectoryYet
 
-    return products
+    return (products, references)


### PR DESCRIPTION
#### PR description:

Avoid early delete of Trajectories if a module reads an Association which uses the Trajectory.

#### PR validation:

This should fix the problem seen in the IB RelVals. I ran workflow 28234.0 without the fix and the job failed. After the fix I ran the job three times and it succeeded each time.