### PR TITLE
Fix CMS deprecation warnings in EgammaAnalysis/ElectronTools

### DIFF
--- a/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
+++ b/EgammaAnalysis/ElectronTools/test/CorrectECALIsolation.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,13 +20,13 @@
 
 #include <iostream>
 
-class CorrectECALIsolation : public edm::EDAnalyzer {
+class CorrectECALIsolation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit CorrectECALIsolation(const edm::ParameterSet&);
-  ~CorrectECALIsolation();
+  ~CorrectECALIsolation() override;
 
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   edm::ParameterSet conf_;
 
@@ -40,6 +40,8 @@ private:
 };
 
 CorrectECALIsolation::CorrectECALIsolation(const edm::ParameterSet& iConfig) : conf_(iConfig) {
+  usesResource(TFileService::kSharedResource);
+
   isData_ = iConfig.getUntrackedParameter<bool>("isData", false);
   tokenGsfElectrons_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("Electrons"));
 

--- a/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
@@ -18,7 +18,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -42,16 +42,16 @@
 // class decleration
 //
 
-class ElectronIsoAnalyzer : public edm::EDAnalyzer {
+class ElectronIsoAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit ElectronIsoAnalyzer(const edm::ParameterSet&);
-  ~ElectronIsoAnalyzer();
+  ~ElectronIsoAnalyzer() override;
   //
 
 private:
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   edm::ParameterSet conf_;
 
@@ -101,6 +101,8 @@ ElectronIsoAnalyzer::ElectronIsoAnalyzer(const edm::ParameterSet& iConfig)
     : conf_(iConfig)
 
 {
+  usesResource(TFileService::kSharedResource);
+
   verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
   tokenGsfElectrons_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("Electrons"));
   tokensIsoValElectrons_ =

--- a/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -57,10 +57,10 @@
 // class declaration
 //
 
-class MiniAODElectronIDValidationAnalyzer : public edm::EDAnalyzer {
+class MiniAODElectronIDValidationAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit MiniAODElectronIDValidationAnalyzer(const edm::ParameterSet &);
-  ~MiniAODElectronIDValidationAnalyzer();
+  ~MiniAODElectronIDValidationAnalyzer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
@@ -72,9 +72,9 @@ public:
   };  // The last does not include tau parents
 
 private:
-  virtual void beginJob() override;
-  virtual void analyze(const edm::Event &, const edm::EventSetup &) override;
-  virtual void endJob() override;
+  void beginJob() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endJob() override;
 
   //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -136,6 +136,7 @@ MiniAODElectronIDValidationAnalyzer::MiniAODElectronIDValidationAnalyzer(const e
       electronIdTag_(iConfig.getParameter<edm::InputTag>("electronIDs")),
       electronIdToken_(consumes<edm::ValueMap<bool>>(iConfig.getParameter<edm::InputTag>("electronIDs"))) {
   //now do what ever initialization is needed
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   electronTree_ = fs->make<TTree>("ElectronTree", "Electron data");
 


### PR DESCRIPTION
#### PR description:

- switch to one modules
- delcare shared resources
- added esConsumes as needed

#### PR validation:

Code compiles without CMS warnings.