### PR TITLE
Fixed misnamed files in EcalTPG unittest script

### DIFF
--- a/CondTools/Ecal/test/EcalTPG_updateWeightIdMap_test.sh
+++ b/CondTools/Ecal/test/EcalTPG_updateWeightIdMap_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cmsRun ./src/CondTools/Ecal/python/updateTPGWeightIdMap.py output=EcalTPGWeightGroup_TEST.db input=./src/CondTools/Ecal/data/EcalTPGWeightIdMap_perstrip_test.txt filetype=txt outputtag=unittest
+cmsRun ./src/CondTools/Ecal/python/updateTPGWeightIdMap.py output=EcalTPGWeightIdMap_TEST.db input=./src/CondTools/Ecal/data/EcalTPGWeightIdMap_perstrip_test.txt filetype=txt outputtag=unittest
 ret=$?
 echo "return code is $ret"
 exit $ret


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39235

This PR fixes the issue https://github.com/cms-sw/cmssw/issues/38964 created in CondTools/Ecal unittests by the merged PR https://github.com/cms-sw/cmssw/pull/38856. The issue was still present in 12_5_X, but the fix was only submitted for the master, 12_6_X (as noticed by @makortel in https://github.com/cms-sw/cmssw/pull/39485#issuecomment-1258655365)

Two different unit tests were writing on the same local sqlite file, causing troubles. The output files are now unique.