### PR TITLE
Validation/RecoEGamma  Removing Histos  V1

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -22,8 +22,6 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
   setBookStatOverflowFlag(set_StatOverflowFlag);
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "efficiency calculation";
-  bookH1andDivide(
-      iBooker, iGetter, "etaEff", "mc_Eta_matched", "mc_Eta", "#eta", "Efficiency", "Efficiency vs gen eta");
   bookH1andDivide(iBooker,
                   iGetter,
                   "etaEff_Extended",
@@ -33,7 +31,6 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
                   "Efficiency",
                   "Efficiency vs gen eta");  //Efficiency vs gen eta --- Eta of matched electrons
   bookH1andDivide(iBooker, iGetter, "zEff", "mc_Z_matched", "mc_Z", "z (cm)", "Efficiency", "");
-  bookH1andDivide(iBooker, iGetter, "absetaEff", "mc_AbsEta_matched", "mc_AbsEta", "|#eta|", "Efficiency", "");
   bookH1andDivide(iBooker,
                   iGetter,
                   "absetaEff_Extended",
@@ -44,7 +41,6 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
                   "");
   bookH1andDivide(iBooker, iGetter, "ptEff", "mc_Pt_matched", "mc_Pt", "p_{T} (GeV/c)", "Efficiency", "");
   bookH1andDivide(iBooker, iGetter, "phiEff", "mc_Phi_matched", "mc_Phi", "#phi (rad)", "Efficiency", "");
-  //bookH2andDivide(iBooker, iGetter, "ptEtaEff", "mc_PtEta_matched", "mc_PtEta", "#eta", "p_{T} (GeV/c)", "");
 
   edm::LogInfo("ElectronMcSignalPostValidator::finalize") << "q-misid calculation";
   bookH1andDivide(iBooker, iGetter, "etaQmisid", "mc_Eta_matched_qmisid", "mc_Eta", "#eta", "q misId", "");
@@ -81,7 +77,7 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
                   "|#eta|",
                   "Fraction of electrons",
                   "fraction of showering electrons vs eta");
-  /**/
+
   // fbrem
   MonitorElement* p1_ele_fbremVsEta_mean = get(iGetter, "fbremvsEtamean");
   TAxis* etaAxis = p1_ele_fbremVsEta_mean->getTProfile()->GetXaxis();
@@ -143,8 +139,7 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
            "E/E_{true}",
            0.8);
 
-  profileX(iBooker, iGetter, "PoPtrueVsEta", "mean ele momentum / gen momentum vs eta", "#eta", "<P/P_{gen}>");
-  profileX(iBooker, iGetter, "PoPtrueVsEta_Extended", "mean ele momentum / gen momentum vs eta", "#eta", "<P/P_{gen}>");
+ profileX(iBooker, iGetter, "PoPtrueVsEta_Extended", "mean ele momentum / gen momentum vs eta", "#eta", "<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi", "mean ele momentum / gen momentum vs phi", "#phi (rad)", "<P/P_{gen}>");
   profileX(iBooker, iGetter, "sigmaIetaIetaVsPt", "SigmaIetaIeta vs pt", "p_{T} (GeV/c)", "SigmaIetaIeta");
   profileX(iBooker,
@@ -167,7 +162,6 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
   profileX(iBooker, iGetter, "PhiMnPhiTrueVsPhi", "mean ele phi - gen phi vs phi", "#phi (rad)", "");
   profileX(iBooker, iGetter, "vertexPtVsEta", "mean ele transverse momentum vs eta", "#eta", "<p_{T}> (GeV/c)");
   profileX(iBooker, iGetter, "vertexPtVsPhi", "mean ele transverse momentum vs phi", "#phi (rad)", "<p_{T}> (GeV/c)");
-  profileX(iBooker, iGetter, "EoPVsEta", "mean ele E/p vs eta", "#eta", "<E/P_{vertex}>");
   profileX(iBooker, iGetter, "EoPVsEta_Extended", "mean ele E/p vs eta", "#eta", "<E/P_{vertex}>");
   profileX(iBooker, iGetter, "EoPVsPhi", "mean ele E/p vs phi", "#phi (rad)", "<E/P_{vertex}>");
   profileX(iBooker, iGetter, "EoPoutVsEta", "mean ele E/pout vs eta", "#eta", "<E_{seed}/P_{out}>");
@@ -179,7 +173,6 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
   profileX(iBooker, iGetter, "chi2VsEta", "mean ele track chi2 vs eta", "#eta", "<#Chi^{2}>");
   profileX(iBooker, iGetter, "chi2VsPhi", "mean ele track chi2 vs phi", "#phi (rad)", "<#Chi^{2}>");
   profileX(iBooker, iGetter, "ambiguousTracksVsEta", "mean ele # ambiguous tracks  vs eta", "#eta", "<N_{ambiguous}>");
-  profileX(iBooker, iGetter, "foundHitsVsEta", "mean ele track # found hits vs eta", "#eta", "<N_{hits}>");
   profileX(iBooker, iGetter, "foundHitsVsEta_Extended", "mean ele track # found hits vs eta", "#eta", "<N_{hits}>");
   profileX(iBooker, iGetter, "foundHitsVsEta_mAOD", "mean ele track # found hits vs eta", "#eta", "<N_{hits}>");
   profileX(iBooker, iGetter, "foundHitsVsPhi", "mean ele track # found hits vs phi", "#phi (rad)", "<N_{hits}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -139,7 +139,7 @@ void ElectronMcSignalPostValidator::finalize(DQMStore::IBooker& iBooker, DQMStor
            "E/E_{true}",
            0.8);
 
- profileX(iBooker, iGetter, "PoPtrueVsEta_Extended", "mean ele momentum / gen momentum vs eta", "#eta", "<P/P_{gen}>");
+  profileX(iBooker, iGetter, "PoPtrueVsEta_Extended", "mean ele momentum / gen momentum vs eta", "#eta", "<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi", "mean ele momentum / gen momentum vs phi", "#phi (rad)", "<P/P_{gen}>");
   profileX(iBooker, iGetter, "sigmaIetaIetaVsPt", "SigmaIetaIeta vs pt", "p_{T} (GeV/c)", "SigmaIetaIeta");
   profileX(iBooker,

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -208,7 +208,6 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_mc_Z = nullptr;
   h2_mc_PtEta = nullptr;
 
-  h1_mc_Eta_matched = nullptr;
   h1_mc_Eta_Extended_matched = nullptr;
   h1_mc_AbsEta_matched = nullptr;
   h1_mc_AbsEta_Extended_matched = nullptr;
@@ -351,7 +350,6 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_foundHits = nullptr;
   h1_ele_foundHits_barrel = nullptr;
   h1_ele_foundHits_endcaps = nullptr;
-  h2_ele_foundHitsVsEta = nullptr;
   h2_ele_foundHitsVsEta_Extended = nullptr;
   h2_ele_foundHitsVsEta_mAOD = nullptr;
   h2_ele_foundHitsVsPhi = nullptr;
@@ -373,7 +371,6 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_PoPtrue_barrel = nullptr;
   h1_ele_PoPtrue_endcaps = nullptr;
 
-  h2_ele_PoPtrueVsEta = nullptr;
   h2_ele_PoPtrueVsEta_Extended = nullptr;
   h2_ele_PoPtrueVsPhi = nullptr;
   h2_ele_PoPtrueVsPt = nullptr;
@@ -419,7 +416,6 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_EoP = nullptr;
   h1_ele_EoP_barrel = nullptr;
   h1_ele_EoP_endcaps = nullptr;
-  h2_ele_EoPVsEta = nullptr;
   h2_ele_EoPVsEta_Extended = nullptr;
   h2_ele_EoPVsPhi = nullptr;
   h2_ele_EoPVsE = nullptr;
@@ -565,6 +561,15 @@ ElectronMcSignalValidator::ElectronMcSignalValidator(const edm::ParameterSet &co
   h1_ele_hcalTowerSumEt_dr03_depth1_barrel = nullptr;
   h1_ele_hcalTowerSumEt_dr03_depth1_endcaps = nullptr;
   h1_ele_hcalTowerSumEt_dr03_depth2 = nullptr;
+
+  h1_ele_ecalPFClusterIso = nullptr;
+  h1_ele_hcalPFClusterIso = nullptr;
+  h1_ele_ecalPFClusterIso_Extended = nullptr;
+  h1_ele_hcalPFClusterIso_Extended = nullptr;
+  h1_ele_ecalPFClusterIso_barrel = nullptr;
+  h1_ele_hcalPFClusterIso_barrel = nullptr;
+  h1_ele_ecalPFClusterIso_endcaps = nullptr;
+  h1_ele_hcalPFClusterIso_endcaps = nullptr;
 
   // conversions
   h1_ele_convFlags = nullptr;
@@ -1061,7 +1066,6 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
 
   // matched electrons
   setBookPrefix("h_mc");
-  h1_mc_Eta_matched = bookH1withSumw2(iBooker, "Eta_matched", "Eta of matched electrons", eta_nbin, eta_min, eta_max);
   h1_mc_Eta_Extended_matched = bookH1withSumw2(iBooker,
                                                "Eta_Extended_matched",
                                                "Eta of matched electrons",
@@ -1151,15 +1155,6 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                                            poptrue_min,
                                            poptrue_max,
                                            "P/P_{gen}");
-  h2_ele_PoPtrueVsEta = bookH2withSumw2(iBooker,
-                                        "PoPtrueVsEta",
-                                        "ele momentum / gen momentum vs eta",
-                                        eta2D_nbin,
-                                        eta_min,
-                                        eta_max,
-                                        50,
-                                        poptrue_min,
-                                        poptrue_max);
   h2_ele_PoPtrueVsEta_Extended = bookH2withSumw2(iBooker,
                                                  "PoPtrueVsEta_Extended",
                                                  "ele momentum / gen momentum vs eta",
@@ -1677,15 +1672,6 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
       iBooker, "foundHits_barrel", "ele track # found hits, barrel", fhits_nbin, 0., fhits_max, "N_{hits}");
   h1_ele_foundHits_endcaps = bookH1withSumw2(
       iBooker, "foundHits_endcaps", "ele track # found hits, endcaps", fhits_nbin, 0., fhits_max, "N_{hits}");
-  h2_ele_foundHitsVsEta = bookH2(iBooker,
-                                 "foundHitsVsEta",
-                                 "ele track # found hits vs eta",
-                                 eta2D_nbin,
-                                 eta_min,
-                                 eta_max,
-                                 fhits_nbin,
-                                 0.,
-                                 fhits_max);
   h2_ele_foundHitsVsEta_Extended = bookH2(iBooker,
                                           "foundHitsVsEta_Extended",
                                           "ele track # found hits vs eta",
@@ -1860,8 +1846,6 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                                        "E/P_{vertex}",
                                        "Events",
                                        "ELE_LOGY E1 P");
-  h2_ele_EoPVsEta =
-      bookH2(iBooker, "EoPVsEta", "ele E/P_{vertex} vs eta", eta2D_nbin, eta_min, eta_max, eop2D_nbin, 0., eopmaxsht);
   h2_ele_EoPVsEta_Extended = bookH2(iBooker,
                                     "EoPVsEta_Extended",
                                     "ele E/P_{vertex} vs eta",
@@ -2862,6 +2846,79 @@ void ElectronMcSignalValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::
                       "Events",
                       "ELE_LOGY E1 P");
 
+  h1_ele_ecalPFClusterIso = bookH1withSumw2(iBooker,
+                                            "ecalPFClusterIso",
+                                            "ecal PF Cluster Iso",
+                                            100,
+                                            0.0,
+                                            100.,
+                                            "hcal PF Cluser Iso",
+                                            "Events",
+                                            "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_barrel = bookH1withSumw2(iBooker,
+                                                   "ecalPFClusterIso_barrel",
+                                                   "ecal PF Cluster Iso barrel",
+                                                   100,
+                                                   0.0,
+                                                   100.,
+                                                   "hcal PF Cluser Iso",
+                                                   "Events",
+                                                   "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
+                                                    "ecalPFClusterIso_endcaps",
+                                                    "ecal PF Cluster Iso endcaps",
+                                                    100,
+                                                    0.0,
+                                                    100.,
+                                                    "hcal PF Cluser Iso",
+                                                    "Events",
+                                                    "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso = bookH1withSumw2(iBooker,
+                                            "hcalPFClusterIso",
+                                            "hcal PF Cluster Iso",
+                                            100,
+                                            0.0,
+                                            100.,
+                                            "hcal PF Cluser Iso",
+                                            "Events",
+                                            "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_barrel = bookH1withSumw2(iBooker,
+                                                   "hcalPFClusterIso_barrel",
+                                                   "hcal PF Cluster Iso barrel",
+                                                   100,
+                                                   0.0,
+                                                   100.,
+                                                   "hcal PF Cluser Iso",
+                                                   "Events",
+                                                   "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_endcaps = bookH1withSumw2(iBooker,
+                                                    "hcalPFClusterIso_endcaps",
+                                                    "hcal PF Cluster Iso endcaps",
+                                                    100,
+                                                    0.0,
+                                                    100.,
+                                                    "hcal PF Cluser Iso",
+                                                    "Events",
+                                                    "ELE_LOGY E1 P");
+  h1_ele_ecalPFClusterIso_Extended = bookH1withSumw2(iBooker,
+                                                     "ecalPFClusterIso_Extended",
+                                                     "ecal PF Cluster Iso Extended",
+                                                     100,
+                                                     0.0,
+                                                     100.,
+                                                     "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                                     "Events",
+                                                     "ELE_LOGY E1 P");
+  h1_ele_hcalPFClusterIso_Extended = bookH1withSumw2(iBooker,
+                                                     "hcalPFClusterIso_Extended",
+                                                     "hcal PF Cluster Iso Extended",
+                                                     100,
+                                                     0.0,
+                                                     100.,
+                                                     "hcal PF Cluser Iso Extended, 2.5<|eta|<3",
+                                                     "Events",
+                                                     "ELE_LOGY E1 P");
+
   // fbrem
   h1_ele_fbrem = bookH1withSumw2(
       iBooker, "fbrem", "ele brem fraction, mode of GSF components", 100, 0., 1., "P_{in} - P_{out} / P_{in}");
@@ -3550,6 +3607,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
         h2_scl_EoEtrueVsrecOfflineVertices_Extended->Fill((*vertexCollectionHandle).size(),
                                                           bestGsfElectron.ecalEnergy() / mcIter->p());
         h2_ele_PoPtrueVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.p() / mcIter->p());
+        h1_ele_ecalPFClusterIso_Extended->Fill(bestGsfElectron.ecalPFClusterIso());
+        h1_ele_hcalPFClusterIso_Extended->Fill(bestGsfElectron.hcalPFClusterIso());
 
         double fbrem_mode = bestGsfElectron.fbrem();
         h1_ele_fbrem_Extended->Fill(fbrem_mode);
@@ -3618,7 +3677,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
     h1_mc_Phi_matched->Fill(mcIter->phi());
     h1_mc_AbsEta_matched->Fill(std::abs(mcIter->eta()));
     h1_mc_AbsEta_Extended_matched->Fill(std::abs(mcIter->eta()));
-    h1_mc_Eta_matched->Fill(mcIter->eta());
     h1_mc_Eta_Extended_matched->Fill(mcIter->eta());
     h2_mc_PtEta_matched->Fill(mcIter->eta(), mcIter->pt());
     h2_ele_vertexEtaVsPhi->Fill(bestGsfElectron.phi(), bestGsfElectron.eta());
@@ -3645,7 +3703,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
     h2_ele_PhiMnPhiTrueVsPt->Fill(bestGsfElectron.pt(), bestGsfElectron.phi() - mcIter->phi());
     h1_ele_PoPtrue->Fill(bestGsfElectron.p() / mcIter->p());
     h1_ele_PtoPttrue->Fill(bestGsfElectron.pt() / mcIter->pt());
-    h2_ele_PoPtrueVsEta->Fill(bestGsfElectron.eta(), bestGsfElectron.p() / mcIter->p());
     h2_ele_PoPtrueVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.p() / mcIter->p());
     h2_ele_PoPtrueVsPhi->Fill(bestGsfElectron.phi(), bestGsfElectron.p() / mcIter->p());
     h2_ele_PoPtrueVsPt->Fill(bestGsfElectron.py(), bestGsfElectron.p() / mcIter->p());
@@ -3768,7 +3825,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
     if (!readAOD_)  // track extra does not exist in AOD
     {
       h1_ele_foundHits->Fill(bestGsfElectron.gsfTrack()->numberOfValidHits());
-      h2_ele_foundHitsVsEta->Fill(bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits());
       h2_ele_foundHitsVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.gsfTrack()->numberOfValidHits());
       h2_ele_foundHitsVsPhi->Fill(bestGsfElectron.phi(), bestGsfElectron.gsfTrack()->numberOfValidHits());
       h2_ele_foundHitsVsPt->Fill(bestGsfElectron.pt(), bestGsfElectron.gsfTrack()->numberOfValidHits());
@@ -3863,7 +3919,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
 
     // match distributions
     h1_ele_EoP->Fill(bestGsfElectron.eSuperClusterOverP());
-    h2_ele_EoPVsEta->Fill(bestGsfElectron.eta(), bestGsfElectron.eSuperClusterOverP());
     h2_ele_EoPVsEta_Extended->Fill(bestGsfElectron.eta(), bestGsfElectron.eSuperClusterOverP());
     h2_ele_EoPVsPhi->Fill(bestGsfElectron.phi(), bestGsfElectron.eSuperClusterOverP());
     h2_ele_EoPVsE->Fill(bestGsfElectron.caloEnergy(), bestGsfElectron.eSuperClusterOverP());
@@ -4167,6 +4222,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
 
     // isolation
     h1_ele_tkSumPt_dr03->Fill(bestGsfElectron.dr03TkSumPt());
+    h1_ele_ecalPFClusterIso->Fill(bestGsfElectron.ecalPFClusterIso());
+    h1_ele_hcalPFClusterIso->Fill(bestGsfElectron.hcalPFClusterIso());
     h1_ele_ecalRecHitSumEt_dr03->Fill(bestGsfElectron.dr03EcalRecHitSumEt());
     h1_ele_hcalTowerSumEt_dr03_depth1->Fill(bestGsfElectron.dr03HcalTowerSumEt(1));
     h1_ele_hcalTowerSumEt_dr03_depth2->Fill(bestGsfElectron.dr03HcalTowerSumEt(2));
@@ -4183,6 +4240,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_hcalTowerSumEtBc_dr03_depth2_barrel->Fill(bestGsfElectron.dr03HcalTowerSumEtBc(2));
       h1_ele_hcalDepth1OverEcalBc_barrel->Fill(bestGsfElectron.hcalOverEcalBc(1));
       h1_ele_hcalDepth2OverEcalBc_barrel->Fill(bestGsfElectron.hcalOverEcalBc(2));
+      h1_ele_ecalPFClusterIso_barrel->Fill(bestGsfElectron.ecalPFClusterIso());
+      h1_ele_hcalPFClusterIso_barrel->Fill(bestGsfElectron.hcalPFClusterIso());
     } else if (isEEflag) {
       h1_ele_tkSumPt_dr03_endcaps->Fill(bestGsfElectron.dr03TkSumPt());
       h1_ele_ecalRecHitSumEt_dr03_endcaps->Fill(bestGsfElectron.dr03EcalRecHitSumEt());
@@ -4192,6 +4251,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
       h1_ele_hcalTowerSumEtBc_dr03_depth2_endcaps->Fill(bestGsfElectron.dr03HcalTowerSumEtBc(2));
       h1_ele_hcalDepth1OverEcalBc_endcaps->Fill(bestGsfElectron.hcalOverEcalBc(1));
       h1_ele_hcalDepth2OverEcalBc_endcaps->Fill(bestGsfElectron.hcalOverEcalBc(2));
+      h1_ele_ecalPFClusterIso_endcaps->Fill(bestGsfElectron.ecalPFClusterIso());
+      h1_ele_hcalPFClusterIso_endcaps->Fill(bestGsfElectron.hcalPFClusterIso());
     }
 
     // conversion rejection

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -166,7 +166,6 @@ private:
   MonitorElement *h1_mc_Z;
   MonitorElement *h2_mc_PtEta;
 
-  MonitorElement *h1_mc_Eta_matched;
   MonitorElement *h1_mc_Eta_Extended_matched;
   MonitorElement *h1_mc_AbsEta_matched;
   MonitorElement *h1_mc_AbsEta_Extended_matched;
@@ -313,7 +312,6 @@ private:
   MonitorElement *h1_ele_foundHits;
   MonitorElement *h1_ele_foundHits_barrel;
   MonitorElement *h1_ele_foundHits_endcaps;
-  MonitorElement *h2_ele_foundHitsVsEta;
   MonitorElement *h2_ele_foundHitsVsEta_Extended;
   MonitorElement *h2_ele_foundHitsVsEta_mAOD;
   MonitorElement *h2_ele_foundHitsVsPhi;
@@ -334,7 +332,6 @@ private:
   MonitorElement *h1_ele_PoPtrue;
   MonitorElement *h1_ele_PoPtrue_barrel;
   MonitorElement *h1_ele_PoPtrue_endcaps;
-  MonitorElement *h2_ele_PoPtrueVsEta;
   MonitorElement *h2_ele_PoPtrueVsEta_Extended;
   MonitorElement *h2_ele_PoPtrueVsPhi;
   MonitorElement *h2_ele_PoPtrueVsPt;
@@ -378,7 +375,6 @@ private:
   MonitorElement *h1_ele_EoP;
   MonitorElement *h1_ele_EoP_barrel;
   MonitorElement *h1_ele_EoP_endcaps;
-  MonitorElement *h2_ele_EoPVsEta;
   MonitorElement *h2_ele_EoPVsEta_Extended;
   MonitorElement *h2_ele_EoPVsPhi;
   MonitorElement *h2_ele_EoPVsE;
@@ -581,6 +577,15 @@ private:
   MonitorElement *h1_ele_hcalTowerSumEtBc_dr03_depth2;
   MonitorElement *h1_ele_hcalTowerSumEtBc_dr03_depth2_barrel;
   MonitorElement *h1_ele_hcalTowerSumEtBc_dr03_depth2_endcaps;
+
+  MonitorElement *h1_ele_ecalPFClusterIso;
+  MonitorElement *h1_ele_hcalPFClusterIso;
+  MonitorElement *h1_ele_ecalPFClusterIso_Extended;
+  MonitorElement *h1_ele_hcalPFClusterIso_Extended;
+  MonitorElement *h1_ele_ecalPFClusterIso_barrel;
+  MonitorElement *h1_ele_hcalPFClusterIso_barrel;
+  MonitorElement *h1_ele_ecalPFClusterIso_endcaps;
+  MonitorElement *h1_ele_hcalPFClusterIso_endcaps;
 
   // conversions
   MonitorElement *h1_ele_convFlags;


### PR DESCRIPTION
#### PR description:
This PR follows one of the previous (3856, 394049) where we had added a few histos, promising that we would remove other one later. In the PR 38569 we remove some unusued histos and in this one we are removing some new ones :
- h_mc_Eta_matched
- h_ele_PoPtrueVsEta_pfx
- h_ele_EoPVsEta_pfx
- h_ele_foundHitsVsEta_pfx
- h_ele_absetaEff
- h_ele_etaEff
Those histos are redundant in PHASE2 and we kept the "Extended" ones into RECO validation which have a longer range (-3<|eta|<3 instead of 2.5<|eta|<2.5).

#### PR validation:
scram build code-checks → OK
scram build code-format → OK

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine (50 49 48 35 18 4 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed).
here is the run-log : [runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/9654051/runall-report-step123-.log)

This PR must be added after the last one i.e. : 39404
@beaudett @swagata87 


[runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/9654051/runall-report-step123-.log)
