### PR TITLE
Removed unnecessary include of deprecated headers in DPGAnalysis/Skims

### DIFF
--- a/DPGAnalysis/Skims/interface/CSCSkim.h
+++ b/DPGAnalysis/Skims/interface/CSCSkim.h
@@ -19,7 +19,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"

--- a/DPGAnalysis/Skims/src/BeamSplash.cc
+++ b/DPGAnalysis/Skims/src/BeamSplash.cc
@@ -17,7 +17,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DPGAnalysis/Skims/src/ECALActivity.cc
+++ b/DPGAnalysis/Skims/src/ECALActivity.cc
@@ -16,7 +16,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DPGAnalysis/Skims/src/EcalSkim.cc
+++ b/DPGAnalysis/Skims/src/EcalSkim.cc
@@ -19,7 +19,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DPGAnalysis/Skims/src/HLTInspect.cc
+++ b/DPGAnalysis/Skims/src/HLTInspect.cc
@@ -16,7 +16,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DPGAnalysis/Skims/src/PhysDecl.cc
+++ b/DPGAnalysis/Skims/src/PhysDecl.cc
@@ -16,7 +16,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Removed use of legacy module includes.

#### PR validation:

Code compiles.