### PR TITLE
Removed unnecessary includes of deprecated headers in DQMOffline/Muon

### DIFF
--- a/DQMOffline/Muon/interface/CSCOfflineMonitor.h
+++ b/DQMOffline/Muon/interface/CSCOfflineMonitor.h
@@ -13,8 +13,6 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQMOffline/Muon/interface/DTSegmentsTask.h
+++ b/DQMOffline/Muon/interface/DTSegmentsTask.h
@@ -9,7 +9,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 
 //RecHit
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"


### PR DESCRIPTION
#### PR description:

Removed include of legacy module headers.

#### PR validation:

Code compiles.