### PR TITLE
Removed deprecation warnings from  HLTrigger/JetMET

### DIFF
--- a/HLTrigger/JetMET/interface/HLTHcalLaserFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHcalLaserFilter.h
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMET/METAlgorithms/interface/HcalNoiseAlgo.h"
@@ -19,23 +19,21 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTHcalLaserFilter : public edm::EDFilter {
+class HLTHcalLaserFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTHcalLaserFilter(const edm::ParameterSet&);
-  ~HLTHcalLaserFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
-  edm::EDGetTokenT<HcalCalibDigiCollection> m_theCalibToken;
+  const edm::EDGetTokenT<HcalCalibDigiCollection> m_theCalibToken;
   // parameters
-  edm::InputTag hcalDigiCollection_;
-  std::vector<int> timeSlices_;
-  std::vector<double> thresholdsfC_;
-  std::vector<int> CalibCountFilterValues_;
-  std::vector<double> CalibChargeFilterValues_;
-  double maxTotalCalibCharge_;
-  int maxAllowedHFcalib_;
+  const std::vector<int> timeSlices_;
+  const std::vector<double> thresholdsfC_;
+  const std::vector<int> CalibCountFilterValues_;
+  const std::vector<double> CalibChargeFilterValues_;
+  const double maxTotalCalibCharge_;
+  const int maxAllowedHFcalib_;
 };
 
 #endif  //HLTHcalLaserFilter_h

--- a/HLTrigger/JetMET/interface/HLTHcalMETNoiseCleaner.h
+++ b/HLTrigger/JetMET/interface/HLTHcalMETNoiseCleaner.h
@@ -7,7 +7,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "RecoMET/METAlgorithms/interface/HcalNoiseAlgo.h"
 #include "DataFormats/METReco/interface/HcalNoiseRBX.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
@@ -17,44 +17,47 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTHcalMETNoiseCleaner : public edm::EDFilter {
+class HLTHcalMETNoiseCleaner : public edm::global::EDFilter<> {
 public:
   explicit HLTHcalMETNoiseCleaner(const edm::ParameterSet&);
   ~HLTHcalMETNoiseCleaner() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   edm::EDGetTokenT<reco::CaloMETCollection> m_theCaloMetToken;
   edm::EDGetTokenT<reco::HcalNoiseRBXCollection> m_theHcalNoiseToken;
   // parameters
-  edm::InputTag HcalNoiseRBXCollectionTag_;
-  edm::InputTag CaloMetCollectionTag_;
-  double CaloMetCut_;
-  int severity_;
-  int maxNumRBXs_;
-  int numRBXsToConsider_;
-  bool accept2NoiseRBXEvents_;
-  bool needEMFCoincidence_;
-  double minRBXEnergy_;
-  double minRatio_;
-  double maxRatio_;
-  int minHPDHits_;
-  int minRBXHits_;
-  int minHPDNoOtherHits_;
-  int minZeros_;
-  double minHighEHitTime_;
-  double maxHighEHitTime_;
-  double maxRBXEMF_;
+  const edm::InputTag HcalNoiseRBXCollectionTag_;
+  const edm::InputTag CaloMetCollectionTag_;
+  const double CaloMetCut_;
+  const int severity_;
+  const int maxNumRBXs_;
+  const int numRBXsToConsider_;
+  const bool accept2NoiseRBXEvents_;
+  const bool needEMFCoincidence_;
+  const double minRBXEnergy_;
+  const double minRatio_;
+  const double maxRatio_;
+  const int minHPDHits_;
+  const int minRBXHits_;
+  const int minHPDNoOtherHits_;
+  const int minZeros_;
+  const double minHighEHitTime_;
+  const double maxHighEHitTime_;
+  const double maxRBXEMF_;
 
   // imported from the RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi
-  double minRecHitE_, minLowHitE_, minHighHitE_, minR45HitE_;
+  const double minRecHitE_;
+  const double minLowHitE_;
+  const double minHighHitE_;
+  const double minR45HitE_;
 
-  double TS4TS5EnergyThreshold_;
+  const double TS4TS5EnergyThreshold_;
   std::vector<std::pair<double, double> > TS4TS5UpperCut_;
   std::vector<std::pair<double, double> > TS4TS5LowerCut_;
 
-  reco::CaloMET BuildCaloMet(float sumet, float pt, float phi);
+  reco::CaloMET BuildCaloMet(float sumet, float pt, float phi) const;
 
   // helper function to compare noise data energies
   struct noisedatacomp {

--- a/HLTrigger/JetMET/interface/HLTHcalMETNoiseFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHcalMETNoiseFilter.h
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMET/METAlgorithms/interface/HcalNoiseAlgo.h"
@@ -20,36 +20,38 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTHcalMETNoiseFilter : public edm::EDFilter {
+class HLTHcalMETNoiseFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTHcalMETNoiseFilter(const edm::ParameterSet&);
-  ~HLTHcalMETNoiseFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
-  edm::EDGetTokenT<reco::HcalNoiseRBXCollection> m_theHcalNoiseToken;
   // parameters
-  edm::InputTag HcalNoiseRBXCollectionTag_;
-  int severity_;
-  int maxNumRBXs_;
-  int numRBXsToConsider_;
-  bool needEMFCoincidence_;
-  double minRBXEnergy_;
-  double minRatio_;
-  double maxRatio_;
-  int minHPDHits_;
-  int minRBXHits_;
-  int minHPDNoOtherHits_;
-  int minZeros_;
-  double minHighEHitTime_;
-  double maxHighEHitTime_;
-  double maxRBXEMF_;
+  const edm::InputTag HcalNoiseRBXCollectionTag_;
+  edm::EDGetTokenT<reco::HcalNoiseRBXCollection> m_theHcalNoiseToken;
+  const int severity_;
+  const int maxNumRBXs_;
+  const int numRBXsToConsider_;
+  const bool needEMFCoincidence_;
+  const double minRBXEnergy_;
+  const double minRatio_;
+  const double maxRatio_;
+  const int minHPDHits_;
+  const int minRBXHits_;
+  const int minHPDNoOtherHits_;
+  const int minZeros_;
+  const double minHighEHitTime_;
+  const double maxHighEHitTime_;
+  const double maxRBXEMF_;
 
   // imported from the RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi
-  double minRecHitE_, minLowHitE_, minHighHitE_, minR45HitE_;
+  const double minRecHitE_;
+  const double minLowHitE_;
+  const double minHighHitE_;
+  const double minR45HitE_;
 
-  double TS4TS5EnergyThreshold_;
+  const double TS4TS5EnergyThreshold_;
   std::vector<std::pair<double, double> > TS4TS5UpperCut_;
   std::vector<std::pair<double, double> > TS4TS5LowerCut_;
 

--- a/HLTrigger/JetMET/interface/HLTRFilter.h
+++ b/HLTrigger/JetMET/interface/HLTRFilter.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/HLTrigger/JetMET/src/HLTHcalLaserFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHcalLaserFilter.cc
@@ -32,7 +32,7 @@
 #include <iostream>
 
 HLTHcalLaserFilter::HLTHcalLaserFilter(const edm::ParameterSet& iConfig)
-    : hcalDigiCollection_(iConfig.getParameter<edm::InputTag>("hcalDigiCollection")),
+    : m_theCalibToken(consumes(iConfig.getParameter<edm::InputTag>("hcalDigiCollection"))),
       timeSlices_(iConfig.getParameter<std::vector<int> >("timeSlices")),
       thresholdsfC_(iConfig.getParameter<std::vector<double> >("thresholdsfC")),
       CalibCountFilterValues_(iConfig.getParameter<std::vector<int> >("CalibCountFilterValues")),
@@ -40,13 +40,7 @@ HLTHcalLaserFilter::HLTHcalLaserFilter(const edm::ParameterSet& iConfig)
       maxTotalCalibCharge_(iConfig.getParameter<double>("maxTotalCalibCharge")),
       maxAllowedHFcalib_(iConfig.getParameter<int>("maxAllowedHFcalib"))
 
-{
-  //maxAllowedHFcalib_=10;
-
-  m_theCalibToken = consumes<HcalCalibDigiCollection>(hcalDigiCollection_);
-}
-
-HLTHcalLaserFilter::~HLTHcalLaserFilter() = default;
+{}
 
 void HLTHcalLaserFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -68,7 +62,7 @@ void HLTHcalLaserFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 // member functions
 //
 
-bool HLTHcalLaserFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool HLTHcalLaserFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<HcalCalibDigiCollection> hCalib;
   iEvent.getByToken(m_theCalibToken, hCalib);
 
@@ -85,7 +79,7 @@ bool HLTHcalLaserFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
     CalibCharge.push_back(0);
   }
 
-  const float adc2fC[128] = {
+  static constexpr float adc2fC[128] = {
       -0.5,   0.5,    1.5,    2.5,    3.5,    4.5,    5.5,    6.5,    7.5,    8.5,    9.5,    10.5,   11.5,
       12.5,   13.5,   15.,    17.,    19.,    21.,    23.,    25.,    27.,    29.5,   32.5,   35.5,   38.5,
       42.,    46.,    50.,    54.5,   59.5,   64.5,   59.5,   64.5,   69.5,   74.5,   79.5,   84.5,   89.5,

--- a/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
+++ b/HLTrigger/JetMET/src/HLTHcalMETNoiseCleaner.cc
@@ -66,7 +66,7 @@ HLTHcalMETNoiseCleaner::HLTHcalMETNoiseCleaner(const edm::ParameterSet& iConfig)
       minRecHitE_(iConfig.getParameter<double>("minRecHitE")),
       minLowHitE_(iConfig.getParameter<double>("minLowHitE")),
       minHighHitE_(iConfig.getParameter<double>("minHighHitE")),
-      minR45HitE_(5.0),
+      minR45HitE_(iConfig.getParameter<double>("minR45HitE")),
       TS4TS5EnergyThreshold_(iConfig.getParameter<double>("TS4TS5EnergyThreshold")) {
   std::vector<double> TS4TS5UpperThresholdTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperThreshold");
   std::vector<double> TS4TS5UpperCutTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperCut");
@@ -83,9 +83,6 @@ HLTHcalMETNoiseCleaner::HLTHcalMETNoiseCleaner(const edm::ParameterSet& iConfig)
 
   m_theCaloMetToken = consumes<reco::CaloMETCollection>(CaloMetCollectionTag_);
   m_theHcalNoiseToken = consumes<reco::HcalNoiseRBXCollection>(HcalNoiseRBXCollectionTag_);
-
-  if (iConfig.existsAs<double>("minR45HitE"))
-    minR45HitE_ = iConfig.getParameter<double>("minR45HitE");
 
   produces<reco::CaloMETCollection>();
 }
@@ -138,7 +135,7 @@ void HLTHcalMETNoiseCleaner::fillDescriptions(edm::ConfigurationDescriptions& de
 // member functions
 //
 
-bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool HLTHcalMETNoiseCleaner::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace reco;
 
   //output collection
@@ -339,7 +336,7 @@ bool HLTHcalMETNoiseCleaner::filter(edm::Event& iEvent, const edm::EventSetup& i
   return (corMet.pt() > CaloMetCut_);
 }
 
-reco::CaloMET HLTHcalMETNoiseCleaner::BuildCaloMet(float sumet, float pt, float phi) {
+reco::CaloMET HLTHcalMETNoiseCleaner::BuildCaloMet(float sumet, float pt, float phi) const {
   // Instantiate the container to hold the calorimeter specific information
 
   typedef math::XYZPoint Point;

--- a/HLTrigger/JetMET/src/HLTHcalMETNoiseFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHcalMETNoiseFilter.cc
@@ -33,6 +33,7 @@
 
 HLTHcalMETNoiseFilter::HLTHcalMETNoiseFilter(const edm::ParameterSet& iConfig)
     : HcalNoiseRBXCollectionTag_(iConfig.getParameter<edm::InputTag>("HcalNoiseRBXCollection")),
+      m_theHcalNoiseToken(consumes<reco::HcalNoiseRBXCollection>(HcalNoiseRBXCollectionTag_)),
       severity_(iConfig.getParameter<int>("severity")),
       maxNumRBXs_(iConfig.getParameter<int>("maxNumRBXs")),
       numRBXsToConsider_(iConfig.getParameter<int>("numRBXsToConsider")),
@@ -50,7 +51,7 @@ HLTHcalMETNoiseFilter::HLTHcalMETNoiseFilter(const edm::ParameterSet& iConfig)
       minRecHitE_(iConfig.getParameter<double>("minRecHitE")),
       minLowHitE_(iConfig.getParameter<double>("minLowHitE")),
       minHighHitE_(iConfig.getParameter<double>("minHighHitE")),
-      minR45HitE_(5.0),
+      minR45HitE_(iConfig.getParameter<double>("minR45HitE")),
       TS4TS5EnergyThreshold_(iConfig.getParameter<double>("TS4TS5EnergyThreshold")) {
   std::vector<double> TS4TS5UpperThresholdTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperThreshold");
   std::vector<double> TS4TS5UpperCutTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperCut");
@@ -64,14 +65,7 @@ HLTHcalMETNoiseFilter::HLTHcalMETNoiseFilter(const edm::ParameterSet& iConfig)
   for (int i = 0; i < (int)TS4TS5LowerThresholdTemp.size() && i < (int)TS4TS5LowerCutTemp.size(); i++)
     TS4TS5LowerCut_.push_back(std::pair<double, double>(TS4TS5LowerThresholdTemp[i], TS4TS5LowerCutTemp[i]));
   sort(TS4TS5LowerCut_.begin(), TS4TS5LowerCut_.end());
-
-  if (iConfig.existsAs<double>("minR45HitE"))
-    minR45HitE_ = iConfig.getParameter<double>("minR45HitE");
-
-  m_theHcalNoiseToken = consumes<reco::HcalNoiseRBXCollection>(HcalNoiseRBXCollectionTag_);
 }
-
-HLTHcalMETNoiseFilter::~HLTHcalMETNoiseFilter() = default;
 
 void HLTHcalMETNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -116,7 +110,7 @@ void HLTHcalMETNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 // member functions
 //
 
-bool HLTHcalMETNoiseFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool HLTHcalMETNoiseFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace reco;
 
   // in this case, do not filter anything

--- a/RecoMET/METAlgorithms/interface/HcalNoiseAlgo.h
+++ b/RecoMET/METAlgorithms/interface/HcalNoiseAlgo.h
@@ -15,8 +15,8 @@ public:
                          double minLowHitE,
                          double minHighHitE,
                          double TS4TS5EnergyThreshold,
-                         std::vector<std::pair<double, double> > &TS4TS5UpperCut,
-                         std::vector<std::pair<double, double> > &TS4TS5LowerCut,
+                         std::vector<std::pair<double, double> > const &TS4TS5UpperCut,
+                         std::vector<std::pair<double, double> > const &TS4TS5LowerCut,
                          double MinRBXRechitR45E);
   ~CommonHcalNoiseRBXData() {}
 
@@ -46,7 +46,10 @@ public:
   inline double r45Fraction(void) const { return r45Fraction_; }
   inline double r45EnergyFraction(void) const { return r45EnergyFraction_; }
 
-  bool CheckPassFilter(double Charge, double Discriminant, std::vector<std::pair<double, double> > &Cuts, int Side);
+  bool CheckPassFilter(double Charge,
+                       double Discriminant,
+                       std::vector<std::pair<double, double> > const &Cuts,
+                       int Side);
 
 private:
   // values

--- a/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
@@ -5,8 +5,8 @@ CommonHcalNoiseRBXData::CommonHcalNoiseRBXData(const reco::HcalNoiseRBX& rbx,
                                                double minLowHitE,
                                                double minHighHitE,
                                                double TS4TS5EnergyThreshold,
-                                               std::vector<std::pair<double, double> >& TS4TS5UpperCut,
-                                               std::vector<std::pair<double, double> >& TS4TS5LowerCut,
+                                               std::vector<std::pair<double, double> > const& TS4TS5UpperCut,
+                                               std::vector<std::pair<double, double> > const& TS4TS5LowerCut,
                                                double minRBXRechitR45E)
     : r45Count_(0), r45Fraction_(0), r45EnergyFraction_(0) {
   // energy
@@ -382,7 +382,7 @@ void JoinCaloTowerRefVectorsWithoutDuplicates::operator()(edm::RefVector<CaloTow
 
 bool CommonHcalNoiseRBXData::CheckPassFilter(double Charge,
                                              double Discriminant,
-                                             std::vector<std::pair<double, double> >& Cuts,
+                                             std::vector<std::pair<double, double> > const& Cuts,
                                              int Side) {
   //
   // Checks whether Discriminant value passes Cuts for the specified Charge.  True if pulse is good.


### PR DESCRIPTION
#### PR description:

- switched modules to be global::EDFilter
- improved const correctness of CommonHcalNoiseRBXData so it can be used with global::EDFilter
- removed unnecessary include of deprecated header

#### PR validation:

Code compiles without deprecation warnings.