### PR TITLE
[ALCA] [GCC12] Fix build warnings

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
@@ -75,12 +75,12 @@ public:
 
   Bool_t GetPaths();
 
-  TString ResultsRootFilePath();
-  TString ResultsAsciiFilePath();
-  TString HistoryRunListFilePath();
-  TString CMSSWBase();
-  TString CMSSWSubsystem();
-  TString SCRAMArch();
+  const TString &ResultsRootFilePath() const;
+  const TString &ResultsAsciiFilePath() const;
+  const TString &HistoryRunListFilePath() const;
+  const TString &CMSSWBase() const;
+  const TString &CMSSWSubsystem() const;
+  const TString &SCRAMArch() const;
 
   void SetResultsRootFilePath(const TString &);
   void SetResultsAsciiFilePath(const TString &);

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRead.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRead.h
@@ -531,7 +531,7 @@ public:
   TMatrixD ReadHighFrequencyMeanCorrelationsBetweenStins(const Int_t &);  // 1 of (Stin,Stin)
 
   //------------------------------------------------------------------------------------------------
-  TString GetAnalysisName();
+  const TString &GetAnalysisName() const;
   Int_t GetNbOfSamples();
   Int_t GetRunNumber();
   Int_t GetFirstReqEvtNumber();
@@ -541,10 +541,10 @@ public:
 
   time_t GetStartTime();
   time_t GetStopTime();
-  TString GetStartDate();
-  TString GetStopDate();
-  TString GetRootFileName();
-  TString GetRootFileNameShort();
+  const TString &GetStartDate() const;
+  const TString &GetStopDate() const;
+  const TString &GetRootFileName() const;
+  const TString &GetRootFileNameShort() const;
 
   TString GetRunType();
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
@@ -614,10 +614,10 @@ public:
   void HighFrequencyMeanCorrelationsBetweenStins();
 
   //...................................... ROOT file methods
-  TString GetRootFileName();
-  TString GetRootFileNameShort();
-  TString GetNewRootFileName();
-  TString GetNewRootFileNameShort();
+  const TString& GetRootFileName() const;
+  const TString& GetRootFileNameShort() const;
+  const TString& GetNewRootFileName() const;
+  const TString& GetNewRootFileNameShort() const;
 
   Bool_t WriteRootFile();
   Bool_t WriteNewRootFile(const TString&);

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
@@ -167,10 +167,10 @@ public:
   void WriteAsciiHisto(const TString&, const Int_t&, const TVectorD&);
 
   //...........................................................................
-  TString GetAsciiFileName();
-  TString GetRootFileName();
-  TString GetRootFileNameShort();
-  TString GetAnalysisName();
+  const TString& GetAsciiFileName() const;
+  const TString& GetRootFileName() const;
+  const TString& GetRootFileNameShort() const;
+  const TString& GetAnalysisName() const;
 
   Int_t GetNbOfSamples();
   Int_t GetRunNumber();

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
@@ -349,12 +349,12 @@ void TEcnaParPaths::GetCMSSWParameters() {
 //        M E T H O D S    T O    R E T U R N    T H E    P A R A M E T E R S
 //
 //=======================================================================================
-TString TEcnaParPaths::ResultsRootFilePath() { return fCfgResultsRootFilePath; }
-TString TEcnaParPaths::ResultsAsciiFilePath() { return fCfgResultsAsciiFilePath; }
-TString TEcnaParPaths::HistoryRunListFilePath() { return fCfgHistoryRunListFilePath; }
-TString TEcnaParPaths::CMSSWBase() { return fCfgCMSSWBase; }
-TString TEcnaParPaths::CMSSWSubsystem() { return fCfgCMSSWSubsystem; }
-TString TEcnaParPaths::SCRAMArch() { return fCfgSCRAMArch; }
+const TString &TEcnaParPaths::ResultsRootFilePath() const { return fCfgResultsRootFilePath; }
+const TString &TEcnaParPaths::ResultsAsciiFilePath() const { return fCfgResultsAsciiFilePath; }
+const TString &TEcnaParPaths::HistoryRunListFilePath() const { return fCfgHistoryRunListFilePath; }
+const TString &TEcnaParPaths::CMSSWBase() const { return fCfgCMSSWBase; }
+const TString &TEcnaParPaths::CMSSWSubsystem() const { return fCfgCMSSWSubsystem; }
+const TString &TEcnaParPaths::SCRAMArch() const { return fCfgSCRAMArch; }
 
 //.....................................................................................
 TString TEcnaParPaths::PathModulesData() {

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
@@ -815,7 +815,7 @@ void TEcnaRead::FileParameters(const TString &typ_ana,
 //   GetLastReqEvtNumber, GetReqNbOfEvts, GetStexNumber
 //
 //=========================================================================
-TString TEcnaRead::GetAnalysisName() { return fFileHeader->fTypAna; }
+const TString &TEcnaRead::GetAnalysisName() const { return fFileHeader->fTypAna; }
 Int_t TEcnaRead::GetNbOfSamples() { return fFileHeader->fNbOfSamples; }
 Int_t TEcnaRead::GetRunNumber() { return fFileHeader->fRunNumber; }
 Int_t TEcnaRead::GetFirstReqEvtNumber() { return fFileHeader->fFirstReqEvtNumber; }
@@ -829,8 +829,8 @@ Int_t TEcnaRead::GetStexNumber() { return fFileHeader->fStex; }
 //=========================================================================
 time_t TEcnaRead::GetStartTime() { return fFileHeader->fStartTime; }
 time_t TEcnaRead::GetStopTime() { return fFileHeader->fStopTime; }
-TString TEcnaRead::GetStartDate() { return fFileHeader->fStartDate; }
-TString TEcnaRead::GetStopDate() { return fFileHeader->fStopDate; }
+const TString &TEcnaRead::GetStartDate() const { return fFileHeader->fStartDate; }
+const TString &TEcnaRead::GetStopDate() const { return fFileHeader->fStopDate; }
 TString TEcnaRead::GetRunType() {
   TString cType = "run type not defined";
   Int_t numtype = fFileHeader->fRunType;
@@ -4209,8 +4209,8 @@ TString TEcnaRead::GetTypeOfQuantity(const CnaResultTyp arg_typ) {
 //    Get the ROOT file name (long and short)
 //
 //-------------------------------------------------------------------------
-TString TEcnaRead::GetRootFileName() { return fCnaWrite->GetRootFileName(); }
-TString TEcnaRead::GetRootFileNameShort() { return fCnaWrite->GetRootFileNameShort(); }
+const TString &TEcnaRead::GetRootFileName() const { return fCnaWrite->GetRootFileName(); }
+const TString &TEcnaRead::GetRootFileNameShort() const { return fCnaWrite->GetRootFileNameShort(); }
 //-------------------------------------------------------------------------
 //
 //                     GetStexStinFromIndex

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -1326,8 +1326,8 @@ Bool_t TEcnaRun::ReadSampleAdcValues(const Int_t& nb_samp_for_calc) {
 //    Get the ROOT file name (long and short)
 //
 //-------------------------------------------------------------------------
-TString TEcnaRun::GetRootFileName() { return fRootFileName; }
-TString TEcnaRun::GetRootFileNameShort() { return fRootFileNameShort; }
+const TString& TEcnaRun::GetRootFileName() const { return fRootFileName; }
+const TString& TEcnaRun::GetRootFileNameShort() const { return fRootFileNameShort; }
 
 //###################################################################################################
 //
@@ -3426,8 +3426,8 @@ Bool_t TEcnaRun::WriteNewRootFile(const TString& TypAna) {
 //   (called by TEcnaGui in Calculations method)
 //
 //-------------------------------------------------------------------------
-TString TEcnaRun::GetNewRootFileName() { return fNewRootFileName; }
-TString TEcnaRun::GetNewRootFileNameShort() { return fNewRootFileNameShort; }
+const TString& TEcnaRun::GetNewRootFileName() const { return fNewRootFileName; }
+const TString& TEcnaRun::GetNewRootFileNameShort() const { return fNewRootFileNameShort; }
 
 //--------------------------------------------------------------------
 //

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
@@ -382,10 +382,10 @@ void TEcnaWrite::SetEcalSubDetector(const TString& SubDet, TEcnaParEcal* pEcal, 
 //     Int_t    fStexNumber    = super_module
 //
 //-------------------------------------------------------------------------
-TString TEcnaWrite::GetAsciiFileName() { return fAsciiFileName; }
-TString TEcnaWrite::GetRootFileName() { return fRootFileName; }
-TString TEcnaWrite::GetRootFileNameShort() { return fRootFileNameShort; }
-TString TEcnaWrite::GetAnalysisName() { return fAnaType; }
+const TString& TEcnaWrite::GetAsciiFileName() const { return fAsciiFileName; }
+const TString& TEcnaWrite::GetRootFileName() const { return fRootFileName; }
+const TString& TEcnaWrite::GetRootFileNameShort() const { return fRootFileNameShort; }
+const TString& TEcnaWrite::GetAnalysisName() const { return fAnaType; }
 Int_t TEcnaWrite::GetNbOfSamples() { return fNbOfSamples; }
 Int_t TEcnaWrite::GetRunNumber() { return fRunNumber; }
 Int_t TEcnaWrite::GetFirstReqEvtNumber() { return fFirstReqEvtNumber; }


### PR DESCRIPTION
This should fix the compilation warnings for GCC12 IBs
```
In file included from ...lcg/root/6.24.07-b2cee796fd454a5d25662f56310655d2/include/TNamed.h:26,
                 from ...lcg/root/6.24.07-b2cee796fd454a5d25662f56310655d2/include/TSystem.h:34,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h:5,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc:5:
In member function 'TString& TString::Append(const char*)',
    inlined from 'void TEcnaGui::SubmitOnBatchSystem(const TString&)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc:6254:30:
  ...lcg/root/6.24.07-b2cee796fd454a5d25662f56310655d2/include/TString.h:565:46: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
   565 | { return Replace(Length(), 0, cs, cs ? strlen(cs) : 0); }
```