### PR TITLE
[RECONSTRUCTION] [GCC12] Fix build warnings

### DIFF
--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -166,7 +166,7 @@ namespace helper {
       SiStripMatchedRecHit2D &mhit = static_cast<SiStripMatchedRecHit2D &>(genericHit);
       cluRef = (SiStripDetId(detid_).stereo() ? &mhit.stereoClusterRef() : &mhit.monoClusterRef());
     } else if (typeid(ProjectedSiStripRecHit2D) == hit_type) {
-      cluRef = &static_cast<ProjectedSiStripRecHit2D &>(genericHit).originalHit().omniCluster();
+      cluRef = &static_cast<ProjectedSiStripRecHit2D &>(genericHit).omniCluster();
     }
 
     assert(cluRef != nullptr);            // to catch missing RecHit types

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -908,7 +908,6 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
     if (!muonRecHitsPhiBest.empty()) {
       muonRecHits[stat] = muonRecHitsPhiBest;
       stable_sort(muonRecHits[stat].begin(), muonRecHits[stat].end(), LessAbsMag());
-      muonRecHits[stat].front();
       GlobalPoint refpoint = muonRecHits[stat].front()->globalPosition();
       theStationShowerTSize.at(stat) = refpoint.mag() * dphimax;
     }

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -37,8 +37,9 @@ TempTrajectory::TempTrajectory(Trajectory&& traj)
       theCCCThreshold_(traj.cccThreshold()),
       stopReason_(traj.stopReason()) {
   for (auto& it : traj.measurements()) {
-    push(std::move(it));
+    push(it);
   }
+  traj.measurements().clear();
 }
 
 void TempTrajectory::pop() {


### PR DESCRIPTION
This should  fix the gcc 12 build warnings
```
In file included from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h:5,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h:17,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CommonTools/RecoAlgos/interface/ClusterStorer.h:18,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CommonTools/RecoAlgos/src/ClusterStorer.cc:1:
In member function 'OmniClusterRef& OmniClusterRef::operator=(OmniClusterRef&&)',
    inlined from 'void helper::ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType&) const [with RecHitType = SiStripRecHit2D; ClusterRefType = edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster>]' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CommonTools/RecoAlgos/src/ClusterStorer.cc:174:15:
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h:12:7: warning: dangling pointer 'cluRef' to an unnamed temporary may be used [-Wdangling-pointer=]
    12 | class OmniClusterRef {
      |       ^~~~~~~~~~~~~~
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CommonTools/RecoAlgos/src/ClusterStorer.cc: In member function 'void helper::ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType&) const [with RecHitType = SiStripRecHit2D; ClusterRefType = edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster>]':
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/CommonTools/RecoAlgos/src/ClusterStorer.cc:169:80: note: unnamed temporary defined here
  169 |       cluRef = &static_cast<ProjectedSiStripRecHit2D &>(genericHit).originalHit().omniCluster();
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
------------
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc: In member function 'void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon&)':
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc:911:30: warning: ignoring return value of 'std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::front() [with _Tp = std::shared_ptr<MuonTransientTrackingRecHit>; _Alloc = std::allocator<std::shared_ptr<MuonTransientTrackingRecHit> >; reference = std::shared_ptr<MuonTransientTrackingRecHit>&]', declared with attribute 'nodiscard' [-Wunused-result]
   911 |       muonRecHits[stat].front();
-------------
In member function 'void cmsutils::_bqueue_item<T>::delRef() [with T = TrajectoryMeasurement]',
    inlined from 'void cmsutils::intrusive_ptr_release(_bqueue_item<T>*) [with T = TrajectoryMeasurement]' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/interface/bqueue.h:82:15,
    inlined from 'boost::intrusive_ptr<T>::~intrusive_ptr() [with T = cmsutils::_bqueue_item<TrajectoryMeasurement>]' at ...external/boost/1.78.0-49e9f82055c62bfeccbed31e8e7ecd1b/include/boost/smart_ptr/intrusive_ptr.hpp:98:44,
    inlined from 'void cmsutils::bqueue<T>::push_back(T&&) [with T = TrajectoryMeasurement]' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/interface/bqueue.h:169:24,
    inlined from 'void TempTrajectory::push(TrajectoryMeasurement&&, double)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/interface/TempTrajectory.h:140:22,
    inlined from 'void TempTrajectory::push(TrajectoryMeasurement&&)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/interface/TempTrajectory.h:110:47,
    inlined from 'TempTrajectory::TempTrajectory(Trajectory&&)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/src/TempTrajectory.cc:40:9:
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/TrackingTools/PatternTools/interface/bqueue.h:57:14: warning: pointer used after 'void operator delete(void*, std::size_t)' [-Wuse-after-free]
    57 |       if ((--refCount) == 0)

```