### PR TITLE
[CORE] [GCC12] Fix build warnings

### DIFF
--- a/DataFormats/Common/test/testOneToManyAssociation.cc
+++ b/DataFormats/Common/test/testOneToManyAssociation.cc
@@ -42,9 +42,9 @@ void testOneToManyAssociation::dummy() {
     Assoc::const_iterator f = v.find(edm::Ref<CKey>());
     v.numberOfAssociations(edm::Ref<CKey>());
     const edm::RefVector<CVal>& x = v[edm::Ref<CKey>()];
-    x.size();
+    int n = x.size();
     ++f;
-    int n = v.numberOfAssociations(edm::Ref<CKey>());
+    n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];
@@ -63,9 +63,9 @@ void testOneToManyAssociation::dummy() {
     Assoc::const_iterator f = v.find(edm::Ref<CKey>());
     v.numberOfAssociations(edm::Ref<CKey>());
     const std::vector<std::pair<edm::Ref<CVal>, double> >& x = v[edm::Ref<CKey>()];
-    x.size();
+    int n = x.size();
     ++f;
-    int n = v.numberOfAssociations(edm::Ref<CKey>());
+    n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -176,6 +176,7 @@ void testRefInROOT::testEventBase() {
       edm::Handle<edmtest::OtherThingCollection> pOthers;
       eventBase->getByLabel(tag, pOthers);
       CPPUNIT_ASSERT(pOthers.isValid());
+      CPPUNIT_ASSERT(pOthers->size() > 0);
     }
 
     {

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -176,7 +176,6 @@ void testRefInROOT::testEventBase() {
       edm::Handle<edmtest::OtherThingCollection> pOthers;
       eventBase->getByLabel(tag, pOthers);
       CPPUNIT_ASSERT(pOthers.isValid());
-      pOthers->size();
     }
 
     {


### PR DESCRIPTION
This should fix the build warnings for gcc12 IBs
```
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/Common/test/testOneToManyAssociation.cc: In member function 'void testOneToManyAssociation::dummy()':
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/Common/test/testOneToManyAssociation.cc:66:11: warning: ignoring return value of 'std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::size() const [with _Tp = std::pair<edm::Ref<std::vector<double>, double, edm::refhelper::FindUsingAdvance<std::vector<double>, double> >, double>; _Alloc = std::allocator<std::pair<edm::Ref<std::vector<double>, double, edm::refhelper::FindUsingAdvance<std::vector<double>, double> >, double> >; size_type = long unsigned int]', declared with attribute 'nodiscard' [-Wunused-result]
    66 |     x.size();
--------
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/FWLite/test/test.cppunit.cpp: In member function 'void testRefInROOT::testEventBase()':
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/DataFormats/FWLite/test/test.cppunit.cpp:179:20: warning: ignoring return value of 'std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::size() const [with _Tp = edmtest::OtherThing; _Alloc = std::allocator<edmtest::OtherThing>; size_type = long unsigned int]', declared with attribute 'nodiscard' [-Wunused-result]
   179 |       pOthers->size();
```