### PR TITLE
[SIMULATION] [GCC12] Fix build warnings

### DIFF
--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -341,7 +341,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   std::vector<double> momz = cherenkov_->getMom();
 
   for (int i = 0; i < npe; ++i) {
-    hit.depth = 0;
+    hit.depth = depth;
     hit.time = tSlice + time;
     hit.wavelength = wavelength[i];
     hit.momentum = momz[i];

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -341,6 +341,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   std::vector<double> momz = cherenkov_->getMom();
 
   for (int i = 0; i < npe; ++i) {
+    hit.depth = 0;
     hit.time = tSlice + time;
     hit.wavelength = wavelength[i];
     hit.momentum = momz[i];

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.h
@@ -51,6 +51,8 @@ private:
   typedef std::vector<edm::ParameterSet> Parameters;
   typedef boost::multi_array<float, 2> array_2d;
 
+  std::vector<SiPixelTemplateStore2D> templateStores_;
+
   // Variables and objects for the charge reweighting using 2D templates
   SiPixelTemplate2D templ2D;
   std::vector<bool> xdouble;
@@ -64,8 +66,6 @@ private:
   const bool PrintTemplates;
 
   static constexpr float cmToMicrons = 10000.f;
-
-  std::vector<SiPixelTemplateStore2D> templateStores_;
 
   edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectRcd> SiPixel2DTemp_den_token_;
   edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectRcd> SiPixel2DTemp_num_token_;


### PR DESCRIPTION
This should fix the build warnings for gcc12 IBs
```
In copy constructor 'HFShower::Hit::Hit(const HFShower::Hit&)',
    inlined from 'void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = HFShower::Hit; _Args = {const HFShower::Hit&}; _Tp = HFShower::Hit]' at ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/bits/new_allocator.h:175:4,
    inlined from 'static void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = HFShower::Hit; _Args = {const HFShower::Hit&}; _Tp = HFShower::Hit]' at ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/bits/alloc_traits.h:516:17,
    inlined from 'void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = HFShower::Hit; _Alloc = std::allocator<HFShower::Hit>]' at ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/bits/stl_vector.h:1281:30,
    inlined from 'std::vector<HFShower::Hit> HFShower::getHits(const G4Step*, bool)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/SimG4CMS/Calo/src/HFShower.cc:348:19:
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/SimG4CMS/Calo/interface/HFShower.h:32:10: warning: 'hit.HFShower::Hit::depth' may be used uninitialized [-Wmaybe-uninitialized]
    32 |   struct Hit {
      |          ^~~
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/SimG4CMS/Calo/src/HFShower.cc: In member function 'std::vector<HFShower::Hit> HFShower::getHits(const G4Step*, bool)':
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/SimG4CMS/Calo/src/HFShower.cc:280:17: note: 'hit' declared here
  280 |   HFShower::Hit hit;
------
CMSSW_12_6_X_2022-09-24-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc: In constructor 'SiPixelChargeReweightingAlgorithm::SiPixelChargeReweightingAlgorithm(const edm::ParameterSet&, edm::ConsumesCollector)':
  CMSSW_12_6_X_2022-09-24-1100/src/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.cc:65:15: warning: member 'SiPixelChargeReweightingAlgorithm::templateStores_' is used uninitialized [-Wuninitialized]
    65 |       templ2D(templateStores_),
```