### PR TITLE
[DAQ] [GCC12] Fix build warnings

### DIFF
--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -214,7 +214,10 @@ namespace evf {
         } break;
         case 13: {
           void *vp = malloc(1024);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
           memset((char *)vp - 32, 0, 1024);
+#pragma GCC diagnostic pop
           free(vp);
         } break;
         case 14: {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -1239,7 +1239,7 @@ namespace evf {
     //copy contents
     const std::size_t buf_sz = 512;
     std::size_t tot_written = 0;
-    std::unique_ptr<char> buf(new char[buf_sz]);
+    std::unique_ptr<char[]> buf(new char[buf_sz]);
 
     ssize_t sz, sz_read = 1, sz_write;
     while (sz_read > 0 && (sz_read = ::read(infile, buf.get(), buf_sz)) > 0) {


### PR DESCRIPTION
This should fix the build warnings for gcc12 IBs
```
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/EventFilter/Utilities/plugins/ExceptionGenerator.cc: In member function 'virtual void evf::ExceptionGenerator::analyze(const edm::Event&, const edm::EventSetup&)':
  ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/EventFilter/Utilities/plugins/ExceptionGenerator.cc:217:17: warning: 'void* memset(void*, int, size_t)' writing 1024 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
   217 |           memset((char *)vp - 32, 0, 1024);
      |           ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/EventFilter/Utilities/plugins/ExceptionGenerator.cc:216:28: note: at offset -32 into destination object of size 1024 allocated by 'malloc'
  216 |           void *vp = malloc(1024);
      |                      ~~~~~~^~~~~~
----------
In file included from ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/memory:76,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/FWCore/Utilities/interface/atomic_value_ptr.h:20,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/FWCore/ParameterSet/interface/ParameterSetEntry.h:10,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/FWCore/ParameterSet/interface/ParameterSet.h:17,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/FWCore/ServiceRegistry/interface/ServiceRegistry.h:22,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/FWCore/ServiceRegistry/interface/Service.h:24,
                 from ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/EventFilter/Utilities/src/EvFDaqDirector.cc:2:
In member function 'void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = char]',
    inlined from 'std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = char; _Dp = std::default_delete<char>]' at ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/bits/unique_ptr.h:396:17,
    inlined from 'int evf::EvFDaqDirector::grabNextJsonFile(const std::string&, const std::string&, int64_t&, bool&)' at ...cms/cmssw/CMSSW_12_6_X_2022-09-24-1100/src/EventFilter/Utilities/src/EvFDaqDirector.cc:1363:3:
  ...external/gcc/12.2.0-f8ec77b592790702d83afb7106a458e3/include/c++/12.2.1/bits/unique_ptr.h:95:9: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
    95 |         delete __ptr;
```