### PR TITLE
Removed commented include from HLTCSCAcceptBusyFilter

### DIFF
--- a/HLTrigger/special/plugins/HLTCSCAcceptBusyFilter.cc
+++ b/HLTrigger/special/plugins/HLTCSCAcceptBusyFilter.cc
@@ -21,7 +21,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-//include "FWCore/Framework/interface/EDFilter.h"
 
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 


### PR DESCRIPTION
#### PR description:

The header is deprecated and all references are being removed.

This was just done to avoid grepping of CMSSW for the header turning up this again.

#### PR validation:

Code compiles.