### PR TITLE
Read SoA scalars and Eigen columns from a ROOT streamer

### DIFF
--- a/CUDADataFormats/PortableTestObjects/interface/TestDeviceCollection.h
+++ b/CUDADataFormats/PortableTestObjects/interface/TestDeviceCollection.h
@@ -6,7 +6,10 @@
 
 namespace cudatest {
 
-  // SoA with x, y, z, id fields in device global memory
+  // Eigen matrix
+  using Matrix = portabletest::Matrix;
+
+  // SoA with x, y, z, id fields, r scalar, m matrix, in device global memory
   using TestDeviceCollection = cms::cuda::PortableDeviceCollection<portabletest::TestSoA>;
 
 }  // namespace cudatest

--- a/CUDADataFormats/PortableTestObjects/interface/TestHostCollection.h
+++ b/CUDADataFormats/PortableTestObjects/interface/TestHostCollection.h
@@ -6,7 +6,10 @@
 
 namespace cudatest {
 
-  // SoA with x, y, z, id fields in host memory
+  // Eigen matrix
+  using Matrix = portabletest::Matrix;
+
+  // SoA with x, y, z, id fields, r scalar, m matrix, in host memory
   using TestHostCollection = cms::cuda::PortableHostCollection<portabletest::TestSoA>;
 
 }  // namespace cudatest

--- a/DataFormats/PortableTestObjects/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="rootcore"/>
+<use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>

--- a/DataFormats/PortableTestObjects/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="eigen"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>

--- a/DataFormats/PortableTestObjects/interface/TestSoA.h
+++ b/DataFormats/PortableTestObjects/interface/TestSoA.h
@@ -1,12 +1,16 @@
 #ifndef DataFormats_PortableTestObjects_interface_TestSoA_h
 #define DataFormats_PortableTestObjects_interface_TestSoA_h
 
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
 #include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "DataFormats/SoATemplate/interface/SoAView.h"
 
 namespace portabletest {
 
+  using Matrix = Eigen::Matrix<double, 3, 6>;
   // SoA layout with x, y, z, id fields
   GENERATE_SOA_LAYOUT(TestSoALayout,
                       // columns: one value per element
@@ -15,7 +19,10 @@ namespace portabletest {
                       SOA_COLUMN(double, z),
                       SOA_COLUMN(int32_t, id),
                       // scalars: one value for the whole structure
-                      SOA_SCALAR(double, r))
+                      SOA_SCALAR(double, r),
+                      // Eigen columns
+                      // the typedef is needed because commas confuse macros
+                      SOA_EIGEN_COLUMN(Matrix, m))
 
   using TestSoA = TestSoALayout<>;
 

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -6,6 +6,7 @@
     <field name="y_" comment="[elements_]"/>
     <field name="z_" comment="[elements_]"/>
     <field name="id_" comment="[elements_]"/>
+    <field name="m_" comment="[mElementsWithPadding_]"/>
     <field name="r_" comment="[scalar_]"/>
   </class>
   <class name="portabletest::TestSoA::View"/>

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -390,7 +390,7 @@ namespace cms::soa {
     }
 
     using ValueType = typename C::Scalar;
-    static constexpr auto valueSize = sizeof(C::Scalar);
+    static constexpr auto valueSize = sizeof(typename C::Scalar);
     SOA_HOST_DEVICE SOA_INLINE byte_size_type stride() const { return stride_; }
 
   private:
@@ -503,7 +503,7 @@ namespace cms::soa {
     SOA_HOST_DEVICE SOA_INLINE const C* operator&() const { return &cVal_; }
 
     using ValueType = typename C::Scalar;
-    static constexpr auto valueSize = sizeof(C::Scalar);
+    static constexpr auto valueSize = sizeof(typename C::Scalar);
 
     SOA_HOST_DEVICE SOA_INLINE byte_size_type stride() const { return stride_; }
 

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -7,7 +7,6 @@
  */
 
 #include <cassert>
-#include <iostream>
 
 #include "SoACommon.h"
 #include "SoAView.h"
@@ -361,7 +360,7 @@
 #define _STREAMER_READ_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
-      /* TODO: implement*/                                                                                             \
+      memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE));                                   \
       ,                                                                                                                \
       /* Column */                                                                                                     \
       memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE) * onfile.elements_);                \

--- a/HeterogeneousCore/AlpakaCore/interface/ContextState.h
+++ b/HeterogeneousCore/AlpakaCore/interface/ContextState.h
@@ -7,6 +7,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/ScopedContextFwd.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 

--- a/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
+++ b/HeterogeneousCore/AlpakaCore/interface/chooseDevice.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 #define HeterogeneousCore_AlpakaCore_interface_chooseDevice_h
 
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -57,32 +57,36 @@ public:
 
   void analyze(edm::Event const& event, edm::EventSetup const&) override {
     portabletest::TestHostCollection const& product = event.get(token_);
-
     auto const& view = product.const_view();
+
+    {
+      edm::LogInfo msg("TestAlpakaAnalyzer");
+      msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
+      msg << "  data @ " << product.buffer().data() << ",\n"
+          << "  x    @ " << view.metadata().addressOf_x() << " = " << Column(view.x(), view.metadata().size()) << ",\n"
+          << "  y    @ " << view.metadata().addressOf_y() << " = " << Column(view.y(), view.metadata().size()) << ",\n"
+          << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
+          << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size())
+          << ",\n"
+          << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
+      msg << std::hex << "  [y - x] = 0x"
+          << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_x())
+          << "  [z - y] = 0x"
+          << reinterpret_cast<intptr_t>(view.metadata().addressOf_z()) -
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_y())
+          << "  [id - z] = 0x"
+          << reinterpret_cast<intptr_t>(view.metadata().addressOf_id()) -
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_z())
+          << "  [r - id] = 0x"
+          << reinterpret_cast<intptr_t>(view.metadata().addressOf_r()) -
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_id());
+    }
+
+    assert(view.r() == 1);
     for (int32_t i = 0; i < view.metadata().size(); ++i) {
       assert(view[i].id() == i);
     }
-
-    edm::LogInfo msg("TestAlpakaAnalyzer");
-    msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
-    msg << "  data @ " << product.buffer().data() << ",\n"
-        << "  x    @ " << view.metadata().addressOf_x() << " = " << Column(view.x(), view.metadata().size()) << ",\n"
-        << "  y    @ " << view.metadata().addressOf_y() << " = " << Column(view.y(), view.metadata().size()) << ",\n"
-        << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
-        << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
-        << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
-    msg << std::hex << "  [y - x] = 0x"
-        << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
-               reinterpret_cast<intptr_t>(view.metadata().addressOf_x())
-        << "  [z - y] = 0x"
-        << reinterpret_cast<intptr_t>(view.metadata().addressOf_z()) -
-               reinterpret_cast<intptr_t>(view.metadata().addressOf_y())
-        << "  [id - z] = 0x"
-        << reinterpret_cast<intptr_t>(view.metadata().addressOf_id()) -
-               reinterpret_cast<intptr_t>(view.metadata().addressOf_z())
-        << "  [r - id] = 0x"
-        << reinterpret_cast<intptr_t>(view.metadata().addressOf_r()) -
-               reinterpret_cast<intptr_t>(view.metadata().addressOf_id());
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -12,6 +12,44 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+namespace {
+
+  template <typename T>
+  class Column {
+  public:
+    Column(T const* data, size_t size) : data_(data), size_(size) {}
+
+    void print(std::ostream& out) const {
+      std::stringstream buffer;
+      buffer << "{ ";
+      if (size_ > 0) {
+        buffer << data_[0];
+      }
+      if (size_ > 1) {
+        buffer << ", " << data_[1];
+      }
+      if (size_ > 2) {
+        buffer << ", " << data_[2];
+      }
+      if (size_ > 3) {
+        buffer << ", ...";
+      }
+      buffer << '}';
+      out << buffer.str();
+    }
+
+  private:
+    T const* const data_;
+    size_t const size_;
+  };
+
+  template <typename T>
+  std::ostream& operator<<(std::ostream& out, Column<T> const& column) {
+    column.print(out);
+    return out;
+  }
+}  // namespace
+
 class TestAlpakaAnalyzer : public edm::stream::EDAnalyzer<> {
 public:
   TestAlpakaAnalyzer(edm::ParameterSet const& config)
@@ -27,12 +65,12 @@ public:
 
     edm::LogInfo msg("TestAlpakaAnalyzer");
     msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
-    msg << "  data = " << product.buffer().data() << ",\n"
-        << "  x    = " << view.metadata().addressOf_x() << ",\n"
-        << "  y    = " << view.metadata().addressOf_y() << ",\n"
-        << "  z    = " << view.metadata().addressOf_z() << ",\n"
-        << "  id   = " << view.metadata().addressOf_id() << ",\n"
-        << "  r    = " << view.metadata().addressOf_r() << '\n';
+    msg << "  data @ " << product.buffer().data() << ",\n"
+        << "  x    @ " << view.metadata().addressOf_x() << " = " << Column(view.x(), view.metadata().size()) << ",\n"
+        << "  y    @ " << view.metadata().addressOf_y() << " = " << Column(view.y(), view.metadata().size()) << ",\n"
+        << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
+        << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
+        << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
     msg << std::hex << "  [y - x] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                reinterpret_cast<intptr_t>(view.metadata().addressOf_x())

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -68,7 +68,9 @@ public:
           << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
           << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size())
           << ",\n"
-          << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
+          << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n'
+          << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::all)
+          << " } ... } \n";
       msg << std::hex << "  [y - x] = 0x"
           << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                  reinterpret_cast<intptr_t>(view.metadata().addressOf_x())
@@ -80,12 +82,21 @@ public:
                  reinterpret_cast<intptr_t>(view.metadata().addressOf_z())
           << "  [r - id] = 0x"
           << reinterpret_cast<intptr_t>(view.metadata().addressOf_r()) -
-                 reinterpret_cast<intptr_t>(view.metadata().addressOf_id());
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_id())
+          << "  [m - r] = 0x"
+          << reinterpret_cast<intptr_t>(view.metadata().addressOf_m()) -
+                 reinterpret_cast<intptr_t>(view.metadata().addressOf_r());
     }
 
-    assert(view.r() == 1);
+    const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
+    assert(view.r() == 1.);
     for (int32_t i = 0; i < view.metadata().size(); ++i) {
-      assert(view[i].id() == i);
+      auto vi = view[i];
+      assert(vi.x() == 0.);
+      assert(vi.y() == 0.);
+      assert(vi.z() == 0.);
+      assert(vi.id() == i);
+      assert(vi.m() == matrix * i);
     }
   }
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -20,11 +20,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // this example accepts an arbitrary number of blocks and threads, and always uses 1 element per thread
       const int32_t thread = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
       const int32_t stride = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
+
       if (thread == 0) {
         view.r() = 1.;
       }
       for (auto i = thread; i < size; i += stride) {
-        view[i] = {0., 0., 0., i};
+        view[i] = {0., 0., 0., i, matrix * i};
       }
     }
   };

--- a/HeterogeneousCore/AlpakaTest/test/testHeterogeneousCoreAlpakaTestWriteRead.sh
+++ b/HeterogeneousCore/AlpakaTest/test/testHeterogeneousCoreAlpakaTestWriteRead.sh
@@ -11,14 +11,14 @@ rm -f test.root
 echo "--------------------------------------------------------------------------------"
 echo "$ cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/writer.py"
 echo
-cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/writer.py
+cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/writer.py || exit $?
 echo
 echo "--------------------------------------------------------------------------------"
 echo "$ cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/reader.py"
 echo
-cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/reader.py
+cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/reader.py || exit $?
 echo
 echo "--------------------------------------------------------------------------------"
 echo "$ edmDumpEventContent test.root"
 echo
-edmDumpEventContent test.root
+edmDumpEventContent test.root || exit $?

--- a/HeterogeneousCore/CUDATest/plugins/TestAlgo.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestAlgo.cc
@@ -5,10 +5,12 @@
 namespace cudatest {
 
   static void testAlgoKernel(cudatest::TestHostCollection::View view, int32_t size) {
+    const cudatest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
+
     view.r() = 1.;
 
     for (auto i = 0; i < size; ++i) {
-      view[i] = {0., 0., 0., i};
+      view[i] = {0., 0., 0., i, matrix * i};
     }
   }
 

--- a/HeterogeneousCore/CUDATest/plugins/TestAlgo.cu
+++ b/HeterogeneousCore/CUDATest/plugins/TestAlgo.cu
@@ -9,12 +9,13 @@ namespace cudatest {
   static __global__ void testAlgoKernel(cudatest::TestDeviceCollection::View view, int32_t size) {
     const int32_t thread = blockIdx.x * blockDim.x + threadIdx.x;
     const int32_t stride = blockDim.x * gridDim.x;
+    const cudatest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
 
     if (thread == 0) {
       view.r() = 1.;
     }
     for (auto i = thread; i < size; i += stride) {
-      view[i] = {0., 0., 0., i};
+      view[i] = {0., 0., 0., i, matrix * i};
     }
   }
 

--- a/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
@@ -12,6 +12,44 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+namespace {
+
+  template <typename T>
+  class Column {
+  public:
+    Column(T const* data, size_t size) : data_(data), size_(size) {}
+
+    void print(std::ostream& out) const {
+      std::stringstream buffer;
+      buffer << "{ ";
+      if (size_ > 0) {
+        buffer << data_[0];
+      }
+      if (size_ > 1) {
+        buffer << ", " << data_[1];
+      }
+      if (size_ > 2) {
+        buffer << ", " << data_[2];
+      }
+      if (size_ > 3) {
+        buffer << ", ...";
+      }
+      buffer << '}';
+      out << buffer.str();
+    }
+
+  private:
+    T const* const data_;
+    size_t const size_;
+  };
+
+  template <typename T>
+  std::ostream& operator<<(std::ostream& out, Column<T> const& column) {
+    column.print(out);
+    return out;
+  }
+}  // namespace
+
 class TestPortableAnalyzer : public edm::stream::EDAnalyzer<> {
 public:
   TestPortableAnalyzer(edm::ParameterSet const& config)
@@ -27,12 +65,12 @@ public:
 
     edm::LogInfo msg("TestPortableAnalyzer");
     msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
-    msg << "  data = " << product.buffer().get() << ",\n"
-        << "  x    = " << view.metadata().addressOf_x() << ",\n"
-        << "  y    = " << view.metadata().addressOf_y() << ",\n"
-        << "  z    = " << view.metadata().addressOf_z() << ",\n"
-        << "  id   = " << view.metadata().addressOf_id() << ",\n"
-        << "  r    = " << view.metadata().addressOf_r() << '\n';
+    msg << "  data @ " << product.buffer().get() << ",\n"
+        << "  x    @ " << view.metadata().addressOf_x() << " = " << Column(view.x(), view.metadata().size()) << ",\n"
+        << "  y    @ " << view.metadata().addressOf_y() << " = " << Column(view.y(), view.metadata().size()) << ",\n"
+        << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
+        << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
+        << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
     msg << std::hex << "  [y - x] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                reinterpret_cast<intptr_t>(view.metadata().addressOf_x())

--- a/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
@@ -70,7 +70,8 @@ public:
         << "  y    @ " << view.metadata().addressOf_y() << " = " << Column(view.y(), view.metadata().size()) << ",\n"
         << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
         << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
-        << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n';
+        << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n'
+        << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::all) << " } ... } \n";
     msg << std::hex << "  [y - x] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                reinterpret_cast<intptr_t>(view.metadata().addressOf_x())
@@ -82,7 +83,21 @@ public:
                reinterpret_cast<intptr_t>(view.metadata().addressOf_z())
         << "  [r - id] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_r()) -
-               reinterpret_cast<intptr_t>(view.metadata().addressOf_id());
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_id())
+        << "  [m - r] = 0x"
+        << reinterpret_cast<intptr_t>(view.metadata().addressOf_m()) -
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_r());
+
+    const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
+    assert(view.r() == 1.);
+    for (int32_t i = 0; i < view.metadata().size(); ++i) {
+      auto vi = view[i];
+      assert(vi.x() == 0.);
+      assert(vi.y() == 0.);
+      assert(vi.z() == 0.);
+      assert(vi.id() == i);
+      //assert(vi.m() == matrix * i);
+    }
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/CUDATest/test/testHeterogeneousCoreCUDATestWriteRead.sh
+++ b/HeterogeneousCore/CUDATest/test/testHeterogeneousCoreCUDATestWriteRead.sh
@@ -11,14 +11,14 @@ rm -f test.root
 echo "--------------------------------------------------------------------------------"
 echo "$ cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/writer.py"
 echo
-cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/writer.py
+cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/writer.py || exit $?
 echo
 echo "--------------------------------------------------------------------------------"
 echo "$ cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/reader.py"
 echo
-cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/reader.py
+cmsRun ${LOCALTOP}/src/HeterogeneousCore/CUDATest/test/reader.py || exit $?
 echo
 echo "--------------------------------------------------------------------------------"
 echo "$ edmDumpEventContent test.root"
 echo
-edmDumpEventContent test.root
+edmDumpEventContent test.root || exit $?


### PR DESCRIPTION
#### PR description:

Fix the ROOT streamers for the template-based SoA to read back the scalar variables, and to write and read back Eigen objects.

Update the `TestAlpakaAnalyzer` and CUDA `TestPortableAnalyzer` to check that scalars and matrices are read back correctly, and print a more verbose description of the SoA being read.

Update the test scripts so that the unit tests actually fail (exit with a non-zero value) if any of the cmsRun jobs fails.

#### PR validation:

The improved unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_12_5_X for the Alpaka migration.