### PR TITLE
SiStrip Conditions tools: add `SiStripBadChannelPatcher` and related configurations

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripBadChannelPatcher.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelPatcher.cc
@@ -1,0 +1,229 @@
+// system include files
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+// user include files
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/DataRecord/interface/SiStripBadStripRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace sistrip {
+  static const uint16_t NOT_A_FEDID = static_cast<uint16_t>(FEDNumbering::NOT_A_FEDID);
+}
+
+class SiStripBadChannelPatcher : public edm::one::EDAnalyzer<> {
+public:
+  explicit SiStripBadChannelPatcher(const edm::ParameterSet& iConfig)
+      : record_(iConfig.getParameter<std::string>("Record")),
+        printDebug_(iConfig.getParameter<bool>("printDebug")),
+        detIdsToExclude_(iConfig.getParameter<std::vector<unsigned int>>("detIdsToExclude")),
+        detIdsToInclude_(iConfig.getParameter<std::vector<unsigned int>>("detIdsToInclude")),
+        fedsToExclude_(iConfig.getParameter<std::vector<unsigned int>>("FEDsToExclude")),
+        fedsToInclude_(iConfig.getParameter<std::vector<unsigned int>>("FEDsToInclude")),
+        badStripToken_(esConsumes()),
+        cablingToken_(esConsumes()) {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  ~SiStripBadChannelPatcher() override = default;
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  std::unique_ptr<SiStripBadStrip> getNewObject(const edm::EventSetup& iSetup);
+  unsigned int fedFromDetId(const uint32_t& detid);
+  void addDetIdsFromExcludedFEDs(const std::vector<uint32_t>& allDetIds);
+
+  // member data
+  const SiStripDetCabling* detCabling_;
+  const std::string record_;
+  const bool printDebug_;
+  std::vector<uint32_t> detIdsToExclude_;
+  std::vector<uint32_t> detIdsToInclude_;
+  std::vector<unsigned int> fedsToExclude_;
+  std::vector<unsigned int> fedsToInclude_;
+  const edm::ESGetToken<SiStripBadStrip, SiStripBadStripRcd> badStripToken_;    /*!< ES token for the bad strips */
+  const edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> cablingToken_; /*!< ES token for the cabling */
+};
+
+//-----------------------------------------------------------------------------------------------//
+void SiStripBadChannelPatcher::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment(
+      "create a SiStripBadStrip payload starting from one in DB and excluding or adding entire modules from a list");
+  desc.add<std::string>("Record", "SiStripBadStrip")->setComment("Record to match in the PoolDBOutputService");
+  desc.add<bool>("printDebug", false)->setComment("full debug printout");
+  desc.add<std::vector<unsigned int>>("detIdsToExclude", {})->setComment("list of detIds to exclude");
+  desc.add<std::vector<unsigned int>>("detIdsToInclude", {})->setComment("list of detIds to include");
+  desc.add<std::vector<unsigned int>>("FEDsToExclude", {})->setComment("list of FEDs to exclude");
+  desc.add<std::vector<unsigned int>>("FEDsToInclude", {})->setComment("list of FEDs to include");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//-----------------------------------------------------------------------------------------------//
+unsigned int SiStripBadChannelPatcher::fedFromDetId(const uint32_t& detid) {
+  // For the cabled det_id retrieve the FEDid
+  const std::vector<const FedChannelConnection*>& conns = detCabling_->getConnections(detid);
+  if (!(conns.size())) {
+    edm::LogWarning("SiStripBadChannelPatcher")
+        << " DetId " << detid << " appears to be uncabled, returning NOT_A_FEDID !";
+    return sistrip::NOT_A_FEDID;
+  }
+  unsigned int lFedId = sistrip::NOT_A_FEDID;
+  for (uint32_t ch = 0; ch < conns.size(); ch++) {
+    if (conns[ch] && conns[ch]->isConnected()) {
+      lFedId = conns[ch]->fedId();
+      LogDebug("SiStripBadChannelPatcher") << "obtained FED id " << ch << " " << lFedId;
+      if (lFedId < sistrip::FED_ID_MIN || lFedId > sistrip::FED_ID_MAX) {
+        edm::LogWarning("SiStripBadChannelPatcher") << lFedId << " for detid " << detid << " connection " << ch;
+        continue;
+      } else {
+        break;
+      }
+    }
+  }
+  return lFedId;
+}
+
+//-----------------------------------------------------------------------------------------------//
+void SiStripBadChannelPatcher::addDetIdsFromExcludedFEDs(const std::vector<uint32_t>& allDetIds) {
+  for (const auto& detid : allDetIds) {
+    const auto& currentFED = this->fedFromDetId(detid);
+    if (std::count(fedsToInclude_.begin(), fedsToInclude_.end(), currentFED)) {
+      detIdsToInclude_.push_back(detid);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------------------------//
+void SiStripBadChannelPatcher::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  // create the patched bad strips payload
+  std::unique_ptr<SiStripBadStrip> theBadStrips = this->getNewObject(iSetup);
+
+  // write out the BadStrip record
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+
+  if (poolDbService.isAvailable()) {
+    poolDbService->writeOneIOV(*theBadStrips, poolDbService->currentTime(), record_);
+  } else {
+    throw std::runtime_error("PoolDBService required.");
+  }
+}
+
+//-----------------------------------------------------------------------------------------------//
+std::unique_ptr<SiStripBadStrip> SiStripBadChannelPatcher::getNewObject(const edm::EventSetup& iSetup) {
+  edm::LogInfo("SiStripBadChannelPatcher") << "... creating dummy SiStripBadStrip Data";
+
+  // this is the output object
+  auto obj = std::make_unique<SiStripBadStrip>();
+
+  // get the cabling object
+  detCabling_ = &iSetup.getData(cablingToken_);
+
+  // get the strips to add
+  std::vector<uint32_t> detids;
+  const auto& payload = iSetup.getData(badStripToken_);
+  payload.getDetIds(detids);
+
+  // copy the exisiting channels (excluding the ones to remove)
+  for (const auto& id : detids) {
+    // check on the detids to exclude
+    if (std::count(detIdsToExclude_.begin(), detIdsToExclude_.end(), id)) {
+      edm::LogInfo("SiStripBadChannelPatcher") << "I AM GOING TO EXCLUDE DETID: " << id;
+      continue;
+    } else {
+      LogDebug("SiStripBadChannelPatcher") << "I AM GOING TO KEEP DETID: " << id;
+    }
+
+    // check on the FEDs to exclude
+    const auto& currentFED = this->fedFromDetId(id);
+    if (std::count(fedsToExclude_.begin(), fedsToExclude_.end(), currentFED)) {
+      edm::LogInfo("SiStripBadChannelPatcher") << "I AM GOING TO EXCLUDE DETID: " << id;
+      continue;
+    } else {
+      LogDebug("SiStripBadChannelPatcher") << "I AM GOING TO KEEP DETID: " << id;
+    }
+
+    SiStripBadStrip::Range range = payload.getRange(id);
+    std::vector<unsigned int> theSiStripVector;
+    unsigned int theBadStripRange;
+    for (std::vector<unsigned int>::const_iterator badStrip = range.first; badStrip != range.second; ++badStrip) {
+      unsigned short firstBadStrip = payload.decode(*badStrip).firstStrip;
+      unsigned short nConsecutiveBadStrips = payload.decode(*badStrip).range;
+      theBadStripRange = obj->encode(firstBadStrip, nConsecutiveBadStrips);
+      theSiStripVector.push_back(theBadStripRange);
+    }
+    SiStripBadStrip::Range outRange(theSiStripVector.begin(), theSiStripVector.end());
+    if (!obj->put(id, outRange))
+      edm::LogError("SiStripBadChannelPatcher") << "[SiStripBadChannelPatcher::analyze] detid already exists";
+  }  // loop on the detids of the original payload
+
+  const auto& detInfo =
+      SiStripDetInfoFileReader::read(edm::FileInPath{SiStripDetInfoFileReader::kDefaultFile}.fullPath());
+
+  // add to the list of DetIds to include also the one from the list of FEDs
+  const std::vector<uint32_t>& allDetIds = detInfo.getAllDetIds();
+  this->addDetIdsFromExcludedFEDs(allDetIds);
+
+  // add more full bad detids
+  if (!detIdsToInclude_.empty()) {
+    edm::LogInfo("SiStripBadChannelPatcher") << "I AM GOING TO ADD MORE DETIDS";
+
+    std::stringstream ss;
+    for (const auto& detid : detIdsToInclude_) {
+      edm::LogInfo("SiStripBadChannelPatcher") << "I AM GOING TO ADD DETID: " << detid;
+      const auto& nAPVs = detInfo.getNumberOfApvsAndStripLength(detid).first;
+
+      std::vector<unsigned int> theSiStripVector;
+      unsigned short firstBadStrip{0}, nConsecutiveBadStrips{0};
+      unsigned int theBadStripRange;
+
+      for (unsigned int n = 0; n < nAPVs; n++) {
+        firstBadStrip = n * sistrip::STRIPS_PER_APV;
+        nConsecutiveBadStrips = sistrip::STRIPS_PER_APV;
+        theBadStripRange = obj->encode(firstBadStrip, nConsecutiveBadStrips);
+
+        if (printDebug_) {
+          ss << "detid " << detid << " \t"
+             << " firstBadStrip " << firstBadStrip << "\t "
+             << " nConsecutiveBadStrips " << nConsecutiveBadStrips << "\t "
+             << " packed integer " << std::hex << theBadStripRange << std::dec << std::endl;
+        }
+
+        theSiStripVector.push_back(theBadStripRange);
+      }
+
+      SiStripBadStrip::Range outRange(theSiStripVector.begin(), theSiStripVector.end());
+      if (!obj->put(detid, outRange))
+        edm::LogError("SiStripBadChannelPatcher") << "[SiStripBadChannelPatcher::analyze] detid already exists";
+    }  // loop on detids to include
+
+    if (printDebug_) {
+      // print the added strips
+      edm::LogInfo("SiStripBadChannelPatcher") << ss.str();
+    }
+
+  }  // if there is any new channel to append
+
+  return obj;
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(SiStripBadChannelPatcher);

--- a/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadChannelPatcher_cfg.py
@@ -1,0 +1,146 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("Test")
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('isUnitTest',
+                  False,
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.bool,            # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  359334,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "run number")
+
+options.register ('FEDsToAdd',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list,  # singleton or list
+                  VarParsing.VarParsing.varType.int,        # string, int, or float
+                  "list of FEDs to Add")
+
+options.register ('FEDsToRemove',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list,  # singleton or list
+                  VarParsing.VarParsing.varType.int,        # string, int, or float
+                  "list of FEDs to Remove")
+
+options.register ('DetIdsToAdd',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list,  # singleton or list
+                  VarParsing.VarParsing.varType.int,        # string, int, or float
+                  "list of DetIds to Add")
+
+options.register ('DetIdsToRemove',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list,  # singleton or list
+                  VarParsing.VarParsing.varType.int,        # string, int, or float
+                  "list of DetIds to Remove")
+
+
+options.register ('inputConnection',
+                  "frontier://FrontierProd/CMS_CONDITIONS",
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.string,            # string, int, or float
+                  "input DB connection")
+
+options.register ('inputTag',
+                  "SiStripBadChannel_Ideal_31X_v2",
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.string,            # string, int, or float
+                  "input DB tag")
+
+options.register ('outputTag',
+                  "output",
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.string,            # string, int, or float
+                  "output DB tag")
+
+
+options.parseArguments()
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING') if options.isUnitTest else cms.untracked.string('INFO')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+
+##
+## Database services
+##
+process.load("CondCore.CondDB.CondDB_cfi")
+
+##
+## Neeeded for the cabling
+##
+process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
+process.CablingESSource = cms.ESSource('PoolDBESSource',
+                                       process.CondDB,
+                                       BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                       toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
+                                                                   tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')   # real data cabling map
+                                                                   #tag     = cms.string('SiStripFedCabling_Ideal_31X_v2')  # ideal cabling map
+                                                               )))
+
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+process.load("CalibTracker.SiStripESProducers.SiStripConnectivity_cfi")
+
+##
+## Input bad components
+##
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                      DBParameters = cms.PSet(
+                                          messageLevel = cms.untracked.int32(2),
+                                          authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+                                      ),
+                                      timetype = cms.string('runnumber'),
+                                      toGet = cms.VPSet(cms.PSet(
+                                          record = cms.string('SiStripBadStripRcd'),
+                                          tag = cms.string(options.inputTag)
+                                      )),
+                                      connect = cms.string(options.inputConnection)
+                                      )
+
+##
+## Output database (in this case local sqlite file)
+##
+process.CondDB.connect = 'sqlite_file:outputDB.db'
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripBadStripRcd'),
+                                                                     tag = cms.string(options.outputTag)
+                                                                     )
+                                                            )
+                                          )
+
+process.prod = cms.EDAnalyzer("SiStripBadChannelPatcher",
+                              printDebug = cms.bool(True) if options.isUnitTest else cms.bool(False),
+                              Record = cms.string("SiStripBadStripRcd"),
+                              FEDsToExclude = cms.vuint32(options.FEDsToRemove),
+                              FEDsToInclude = cms.vuint32(options.FEDsToAdd),
+                              detIdsToExclude = cms.vuint32(options.DetIdsToAdd),
+                              detIdsToInclude = cms.vuint32(options.DetIdsToRemove))
+
+process.Timing = cms.Service("Timing")
+process.print = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.Path(process.prod)
+#process.ep = cms.EndPath(process.print)

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -83,3 +83,17 @@ echo -e " Done with the gain rescaler \n\n"
 (cmsRun "${LOCAL_TEST_DIR}/"SiStripCondVisualizer_cfg.py) || die "Failure using cmsRun SiStripCondVisualizer_cfg.py" $?
 (python3 "${LOCAL_TEST_DIR}/"db_tree_dump_wrapper.py) || die "Failure running python3 db_tree_dump_wrapper.py" $?
 echo -e " Done with the visualization \n\n"
+
+echo -e "\n\n Testing the conditions patching code: \n\n"
+## do the bad components patching code
+myFEDs=""
+for i in {51..490..2}; do
+    myFEDs+="${i},"
+done
+myFEDs+=491
+echo " masking the following FEDs: "${myFEDs}
+
+(cmsRun "${LOCAL_TEST_DIR}/"SiStripBadChannelPatcher_cfg.py isUnitTest=True FEDsToAdd=${myFEDs} outputTag=OddFEDs) || die "Failure using cmsRun SiStripBadChannelPatcher_cfg.py when adding FEDs" $?
+(cmsRun "${LOCAL_TEST_DIR}/"SiStripBadChannelPatcher_cfg.py isUnitTest=True inputConnection=sqlite_file:outputDB.db inputTag=OddFEDs FEDsToRemove=${myFEDs} outputTag=OddFEDsRemoved) || die "Failure using cmsRun SiStripBadChannelPatcher_cfg.py when removing FEDs" $?
+
+echo -e " Done with the bad components patching \n\n"


### PR DESCRIPTION
#### PR description:

It is from time to time necessary to patch preexisting `SiStripBadStrip` conditions objects to add and / or remove some `DetId`s or even full FEDs from the list of bad components.
A recent occurrence of this lead to the creation of the object proposed in this [cmsTalk thread](https://cms-talk.web.cern.ch/t/mc-new-sistrip-tag-for-bad-components/15449).
This PR adds a new plugin `SiStripBadChannelPatcher`  in order to perform such operations, the related configuration and adds it to the existing battery of unit tests. 

#### PR validation:

`scram b runtests_testCondToolsSiStripBuildersReaders` was run successfully.
I have also run the following script:

``` bash
#!/bin/bash
cmsRun SiStripBadChannelPatcher_cfg.py

conddb_import -f sqlite_file:SiStripBadComponents_merged_v0.db -c sqlite_file:toCompare.db -i SiStripBadComponents_merged_v0 -t toCompare
conddb_import -f sqlite_file:SiStripBadComponents_merged_noFED124withFED50.db -c sqlite_file:toCompare.db -i SiStripBadComponents_merged_noFED124withFED50 -t toCompare -b 359334
getPayloadData.py --plugin pluginSiStripBadStrip_PayloadInspector --plot plot_SiStripBadStripFractionComparisonTrackerMapSingleTag --tag toCompare --time_type Run --iovs '{"start_iov": "1", "end_iov": "359334"}' --db sqlite_file:toCompare.db --test ;
getPayloadData.py --plugin pluginSiStripBadStrip_PayloadInspector --plot plot_SiStripBadStripFractionTrackerMap --tag toCompare --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db sqlite_file:toCompare.db --test ;
getPayloadData.py --plugin pluginSiStripBadStrip_PayloadInspector --plot plot_SiStripBadStripFractionTrackerMap --tag toCompare --time_type Run --iovs '{"start_iov": "359334", "end_iov": "359334"}' --db  sqlite_file:toCompare.db --test ;
```

and obtained the following plots:

| Source  | Target | Comparison |
| ------------- | ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/193005922-6b0c586b-7d81-47d0-b7ba-3bd6916bbac4.png) | ![image](https://user-images.githubusercontent.com/5082376/193005971-cb34a064-aa0d-4447-a40a-c9a379317c1d.png) | ![image](https://user-images.githubusercontent.com/5082376/193006011-cdcd655b-d388-4044-8de6-bbe415d82a5a.png) |






#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A