### PR TITLE
Convert modules in L1Trigger/HardwareValidation to global

### DIFF
--- a/L1Trigger/HardwareValidation/interface/L1ComparatorRun2.h
+++ b/L1Trigger/HardwareValidation/interface/L1ComparatorRun2.h
@@ -7,9 +7,7 @@
 #include <string>
 #include <algorithm>
 
-//#include "FWCore/Framework/interface/global/EDProducer.h"
-
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -37,24 +35,24 @@
 
 namespace l1t {
 
-  class L1ComparatorRun2 : public edm::EDProducer {
+  class L1ComparatorRun2 : public edm::global::EDProducer<> {
   public:
     explicit L1ComparatorRun2(const edm::ParameterSet& ps);
     ~L1ComparatorRun2() override;
 
   private:
-    void produce(edm::Event&, edm::EventSetup const&) override;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
-    edm::EDGetToken JetDataToken_;
-    edm::EDGetToken JetEmulToken_;
-    edm::EDGetToken EGammaDataToken_;
-    edm::EDGetToken EGammaEmulToken_;
-    edm::EDGetToken TauDataToken_;
-    edm::EDGetToken TauEmulToken_;
-    edm::EDGetToken EtSumDataToken_;
-    edm::EDGetToken EtSumEmulToken_;
-    edm::EDGetToken CaloTowerDataToken_;
-    edm::EDGetToken CaloTowerEmulToken_;
+    edm::EDGetTokenT<JetBxCollection> JetDataToken_;
+    edm::EDGetTokenT<JetBxCollection> JetEmulToken_;
+    edm::EDGetTokenT<EGammaBxCollection> EGammaDataToken_;
+    edm::EDGetTokenT<EGammaBxCollection> EGammaEmulToken_;
+    edm::EDGetTokenT<TauBxCollection> TauDataToken_;
+    edm::EDGetTokenT<TauBxCollection> TauEmulToken_;
+    edm::EDGetTokenT<EtSumBxCollection> EtSumDataToken_;
+    edm::EDGetTokenT<EtSumBxCollection> EtSumEmulToken_;
+    edm::EDGetTokenT<CaloTowerBxCollection> CaloTowerDataToken_;
+    edm::EDGetTokenT<CaloTowerBxCollection> CaloTowerEmulToken_;
 
     int bxMax_;
     int bxMin_;

--- a/L1Trigger/HardwareValidation/plugins/L1DEFilter.cc
+++ b/L1Trigger/HardwareValidation/plugins/L1DEFilter.cc
@@ -2,10 +2,8 @@
 #include "L1Trigger/HardwareValidation/interface/DEtrait.h"
 using dedefs::DEnsys;
 
-L1DEFilter::L1DEFilter(const edm::ParameterSet& iConfig) {
+L1DEFilter::L1DEFilter(const edm::ParameterSet& iConfig) : nEvt_{0}, nAgree_{0} {
   DEsource_ = iConfig.getParameter<edm::InputTag>("DataEmulCompareSource");
-  nEvt_ = 0;
-  nAgree_ = 0;
   flagSys_ = iConfig.getUntrackedParameter<std::vector<unsigned int> >("FlagSystems");
 }
 
@@ -18,7 +16,7 @@ void L1DEFilter::endJob() {
 }
 
 // ------------ method called on each new Event  ------------
-bool L1DEFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool L1DEFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   nEvt_++;
 
   bool pass = true;

--- a/L1Trigger/HardwareValidation/plugins/L1DEFilter.h
+++ b/L1Trigger/HardwareValidation/plugins/L1DEFilter.h
@@ -9,10 +9,11 @@
 
 // system includes
 #include <memory>
+#include <atomic>
 
 // common includes
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -20,7 +21,7 @@
 // d|e record
 #include "DataFormats/L1Trigger/interface/L1DataEmulRecord.h"
 
-class L1DEFilter : public edm::EDFilter {
+class L1DEFilter : public edm::global::EDFilter<> {
 public:
   explicit L1DEFilter(const edm::ParameterSet&);
   ~L1DEFilter() override;
@@ -28,13 +29,13 @@ public:
 private:
   void beginJob(void) override{};
   //virtual void beginRun(edm::Run&, const edm::EventSetup&);
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   void endJob() override;
 
   edm::InputTag DEsource_;
   std::vector<unsigned int> flagSys_;
-  int nEvt_;
-  int nAgree_;
+  mutable std::atomic<int> nEvt_;
+  mutable std::atomic<int> nAgree_;
 };
 
 #endif

--- a/L1Trigger/HardwareValidation/plugins/L1DummyProducer.cc
+++ b/L1Trigger/HardwareValidation/plugins/L1DummyProducer.cc
@@ -138,7 +138,7 @@ L1DummyProducer::L1DummyProducer(const edm::ParameterSet& iConfig) {
 
 L1DummyProducer::~L1DummyProducer() {}
 
-void L1DummyProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1DummyProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
 
@@ -171,55 +171,56 @@ void L1DummyProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   std::unique_ptr<L1GlobalTriggerEvmReadoutRecord> glt_evm_data(new L1GlobalTriggerEvmReadoutRecord);
   std::unique_ptr<L1GlobalTriggerObjectMapRecord> glt_obj_data(new L1GlobalTriggerObjectMapRecord);
 
+  int nevt = nevt_++;
   /// fill candidate collections
   if (m_doSys[ETP])
-    SimpleDigi(engine, ecal_tp_data);
+    SimpleDigi(nevt, engine, ecal_tp_data);
   if (m_doSys[HTP])
-    SimpleDigi(engine, hcal_tp_data);
+    SimpleDigi(nevt, engine, hcal_tp_data);
   if (m_doSys[RCT])
-    SimpleDigi(engine, rct_em_data);
+    SimpleDigi(nevt, engine, rct_em_data);
   if (m_doSys[RCT])
-    SimpleDigi(engine, rct_rgn_data);
+    SimpleDigi(nevt, engine, rct_rgn_data);
   if (m_doSys[GCT])
-    SimpleDigi(engine, gct_isolaem_data, 0);
+    SimpleDigi(nevt, engine, gct_isolaem_data, 0);
   if (m_doSys[GCT])
-    SimpleDigi(engine, gct_noisoem_data, 1);
+    SimpleDigi(nevt, engine, gct_noisoem_data, 1);
   if (m_doSys[GCT])
-    SimpleDigi(engine, gct_cenjets_data, 0);
+    SimpleDigi(nevt, engine, gct_cenjets_data, 0);
   if (m_doSys[GCT])
-    SimpleDigi(engine, gct_forjets_data, 1);
+    SimpleDigi(nevt, engine, gct_forjets_data, 1);
   if (m_doSys[GCT])
-    SimpleDigi(engine, gct_taujets_data, 2);
+    SimpleDigi(nevt, engine, gct_taujets_data, 2);
   if (m_doSys[DTP])
-    SimpleDigi(engine, dtp_ph_data);
+    SimpleDigi(nevt, engine, dtp_ph_data);
   if (m_doSys[DTP])
-    SimpleDigi(engine, dtp_th_data);
+    SimpleDigi(nevt, engine, dtp_th_data);
   if (m_doSys[DTF])
-    SimpleDigi(engine, dtf_data, 0);
+    SimpleDigi(nevt, engine, dtf_data, 0);
   if (m_doSys[DTF])
-    SimpleDigi(engine, dtf_trk_data);
+    SimpleDigi(nevt, engine, dtf_trk_data);
   if (m_doSys[CTP])
-    SimpleDigi(engine, ctp_data);
+    SimpleDigi(nevt, engine, ctp_data);
   if (m_doSys[CTF])
-    SimpleDigi(engine, ctf_data, 2);
+    SimpleDigi(nevt, engine, ctf_data, 2);
   if (m_doSys[CTF])
-    SimpleDigi(engine, ctf_trk_data);
+    SimpleDigi(nevt, engine, ctf_trk_data);
   if (m_doSys[RPC])
-    SimpleDigi(engine, rpc_cen_data, 1);
+    SimpleDigi(nevt, engine, rpc_cen_data, 1);
   if (m_doSys[RPC])
-    SimpleDigi(engine, rpc_for_data, 3);
+    SimpleDigi(nevt, engine, rpc_for_data, 3);
   if (m_doSys[LTC])
-    SimpleDigi(engine, ltc_data);
+    SimpleDigi(nevt, engine, ltc_data);
   if (m_doSys[GMT])
-    SimpleDigi(engine, gmt_data);
+    SimpleDigi(nevt, engine, gmt_data);
   if (m_doSys[GMT])
-    SimpleDigi(engine, gmt_rdt_data);
+    SimpleDigi(nevt, engine, gmt_rdt_data);
   if (m_doSys[GLT])
-    SimpleDigi(engine, glt_rdt_data);
+    SimpleDigi(nevt, engine, glt_rdt_data);
   if (m_doSys[GLT])
-    SimpleDigi(engine, glt_evm_data);
+    SimpleDigi(nevt, engine, glt_evm_data);
   if (m_doSys[GLT])
-    SimpleDigi(engine, glt_obj_data);
+    SimpleDigi(nevt, engine, glt_obj_data);
 
   /// put collection
   if (m_doSys[ETP])
@@ -270,8 +271,6 @@ void L1DummyProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iEvent.put(std::move(glt_evm_data), instName[GLT][0]);
   if (m_doSys[GLT])
     iEvent.put(std::move(glt_obj_data), instName[GLT][0]);
-
-  nevt_++;
 
   if (verbose())
     std::cout << "L1DummyProducer::produce end.\n" << std::flush;

--- a/L1Trigger/HardwareValidation/plugins/L1EmulBias.cc
+++ b/L1Trigger/HardwareValidation/plugins/L1EmulBias.cc
@@ -139,7 +139,7 @@ L1EmulBias::L1EmulBias(const edm::ParameterSet& iConfig) {
 L1EmulBias::~L1EmulBias() {}
 
 // ------------ method called to produce the data  ------------
-void L1EmulBias::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1EmulBias::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
 

--- a/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
+++ b/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
@@ -19,7 +19,7 @@
 
 // common includes
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,24 +34,22 @@
 #include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
-class L1EmulBias : public edm::EDProducer {
+class L1EmulBias : public edm::global::EDProducer<> {
 public:
   explicit L1EmulBias(const edm::ParameterSet&);
   ~L1EmulBias() override;
 
 protected:
-  void beginJob(void) override{};
   //virtual void beginRun(edm::Run&, const edm::EventSetup&);
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob(void) override{};
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 public:
   template <class T>
-  void ModifyCollection(std::unique_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*);
+  void ModifyCollection(std::unique_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*) const;
 
 private:
   int verbose_;
-  int verbose() { return verbose_; }
+  int verbose() const { return verbose_; }
   edm::InputTag m_DEsource[dedefs::DEnsys][2];
   bool m_doSys[dedefs::DEnsys];
   std::string instName[dedefs::DEnsys][5];
@@ -65,14 +63,14 @@ private:
 */
 
 template <class T>
-void L1EmulBias::ModifyCollection(std::unique_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*) {
+void L1EmulBias::ModifyCollection(std::unique_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*) const {
   data = (std::unique_ptr<T>)(const_cast<T*>(emul.product()));
 }
 
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<EcalTrigPrimDigiCollection>& data,
                                          const edm::Handle<EcalTrigPrimDigiCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef EcalTrigPrimDigiCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     EcalTriggerPrimitiveDigi col(*it);
@@ -97,7 +95,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<EcalTrigPrimDigiCollect
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<HcalTrigPrimDigiCollection>& data,
                                          const edm::Handle<HcalTrigPrimDigiCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef HcalTrigPrimDigiCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     HcalTriggerPrimitiveDigi col(*it);
@@ -119,7 +117,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<HcalTrigPrimDigiCollect
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1CaloEmCollection>& data,
                                          const edm::Handle<L1CaloEmCollection> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef L1CaloEmCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     unsigned crate = it->rctCrate();
@@ -138,7 +136,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1CaloEmCollection>& da
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1CaloRegionCollection>& data,
                                          const edm::Handle<L1CaloRegionCollection> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef L1CaloRegionCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     unsigned crate = it->rctCrate();
@@ -156,7 +154,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1CaloRegionCollection>
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1GctEmCandCollection>& data,
                                          const edm::Handle<L1GctEmCandCollection> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef L1GctEmCandCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     unsigned raw = it->raw();
@@ -173,7 +171,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1GctEmCandCollection>&
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1GctJetCandCollection>& data,
                                          const edm::Handle<L1GctJetCandCollection> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef L1GctJetCandCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     unsigned raw = it->raw();
@@ -189,7 +187,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1GctJetCandCollection>
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuRegionalCandCollection>& data,
                                          const edm::Handle<L1MuRegionalCandCollection> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef L1MuRegionalCandCollection::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     L1MuRegionalCand cand(*it);
@@ -227,7 +225,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuRegionalCandCollect
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTTrackContainer>& data,
                                          const edm::Handle<L1MuDTTrackContainer> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef std::vector<L1MuDTTrackCand> TrackContainer;
   typedef TrackContainer::const_iterator col_cit;
   TrackContainer const* tracks_in = emul->getContainer();
@@ -258,7 +256,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTTrackContainer>& 
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTChambPhContainer>& data,
                                          const edm::Handle<L1MuDTChambPhContainer> emul,
-                                         CLHEP::HepRandomEngine* engine) {
+                                         CLHEP::HepRandomEngine* engine) const {
   typedef std::vector<L1MuDTChambPhDigi> Phi_Container;
   typedef Phi_Container::const_iterator col_it;
   Phi_Container const* tracks_in = emul->getContainer();
@@ -277,7 +275,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTChambPhContainer>
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTChambThContainer>& data,
                                          const edm::Handle<L1MuDTChambThContainer> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef std::vector<L1MuDTChambThDigi> Thi_Container;
   typedef Thi_Container::const_iterator col_cit;
   Thi_Container const* tracks_in = emul->getContainer();
@@ -299,7 +297,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuDTChambThContainer>
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<LTCDigiCollection>& data,
                                          const edm::Handle<LTCDigiCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef std::vector<LTCDigi>::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
     data->push_back(*it);
@@ -311,7 +309,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<LTCDigiCollection>& dat
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuGMTCandCollection>& data,
                                          const edm::Handle<L1MuGMTCandCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   //typedef std::vector<L1MuGMTCand>          L1MuGMTCandCollection;
   typedef std::vector<L1MuGMTCand>::const_iterator col_cit;
   for (col_cit it = emul->begin(); it != emul->end(); it++) {
@@ -329,7 +327,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuGMTCandCollection>&
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuGMTReadoutCollection>& data,
                                          const edm::Handle<L1MuGMTReadoutCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef std::vector<L1MuGMTReadoutRecord>::const_iterator col_cit;
   std::vector<L1MuGMTReadoutRecord> col = emul->getRecords();
   for (col_cit it = col.begin(); it != col.end(); it++) {
@@ -395,7 +393,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1MuGMTReadoutCollectio
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<CSCCorrelatedLCTDigiCollection>& data,
                                          const edm::Handle<CSCCorrelatedLCTDigiCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   //typedef MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi> CSCCorrelatedLCTDigiCollection;
   typedef CSCCorrelatedLCTDigiCollection::DigiRangeIterator mapIt;  //map iterator
   typedef CSCCorrelatedLCTDigiCollection::const_iterator vecIt;     //vec iterator
@@ -427,7 +425,7 @@ inline void L1EmulBias::ModifyCollection(std::unique_ptr<CSCCorrelatedLCTDigiCol
 template <>
 inline void L1EmulBias::ModifyCollection(std::unique_ptr<L1CSCTrackCollection>& data,
                                          const edm::Handle<L1CSCTrackCollection> emul,
-                                         CLHEP::HepRandomEngine*) {
+                                         CLHEP::HepRandomEngine*) const {
   typedef L1CSCTrackCollection::const_iterator col_cit;
   //typedef std::vector<L1CSCTrack> L1CSCTrackCollection;
   //typedef std::pair<csc::L1Track,CSCCorrelatedLCTDigiCollection> L1CSCTrack;

--- a/L1Trigger/HardwareValidation/src/L1ComparatorRun2.cc
+++ b/L1Trigger/HardwareValidation/src/L1ComparatorRun2.cc
@@ -25,7 +25,7 @@ L1ComparatorRun2::L1ComparatorRun2(const ParameterSet& ps) {
 
 L1ComparatorRun2::~L1ComparatorRun2() {}
 
-void L1ComparatorRun2::produce(Event& iEvent, const EventSetup& iSetup) {
+void L1ComparatorRun2::produce(StreamID, Event& iEvent, const EventSetup& iSetup) const {
   unique_ptr<L1DataEmulResultBxCollection> RESULT(new L1DataEmulResultBxCollection);
 
   if (doLayer2_) {


### PR DESCRIPTION
#### PR description:

- did minor changes to allow use of const member functions
- used mutable atomics for thread-safe incremented values

#### PR validation:

Code compiles without CMS deprecation warnings.