### PR TITLE
Fix deprecation warnings in PhysicsTools/UtilAlgos

### DIFF
--- a/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
@@ -2,7 +2,7 @@
 #define PhysicsTools_UtilAlgos_interface_EDAnalyzerWrapper_h
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
@@ -41,7 +41,7 @@
 namespace edm {
 
   template <class T>
-  class AnalyzerWrapper : public EDAnalyzer {
+  class AnalyzerWrapper : public one::EDAnalyzer<one::SharedResources> {
   public:
     /// default contructor
     AnalyzerWrapper(const edm::ParameterSet& cfg);
@@ -62,6 +62,7 @@ namespace edm {
   /// default contructor
   template <class T>
   AnalyzerWrapper<T>::AnalyzerWrapper(const edm::ParameterSet& cfg) {
+    usesResource(TFileService::kSharedResource);
     // defined TFileService
     edm::Service<TFileService> fileService;
     // create analysis class of type BasicAnalyzer

--- a/PhysicsTools/UtilAlgos/interface/NTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/NTupler.h
@@ -2,8 +2,6 @@
 #define NTupler_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/VariableNTupler.h
@@ -5,8 +5,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"

--- a/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
@@ -21,14 +21,14 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -41,13 +41,11 @@
 // class decleration
 //
 
-class ConfigurableAnalysis : public edm::EDFilter {
+class ConfigurableAnalysis : public edm::one::EDFilter<edm::one::SharedResources> {
 public:
   explicit ConfigurableAnalysis(const edm::ParameterSet&);
-  ~ConfigurableAnalysis() override = default;
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
@@ -71,6 +69,8 @@ private:
 // constructors and destructor
 //
 ConfigurableAnalysis::ConfigurableAnalysis(const edm::ParameterSet& iConfig) {
+  usesResource(TFileService::kSharedResource);
+
   std::string moduleLabel = iConfig.getParameter<std::string>("@module_label");
 
   //configure inputag distributor
@@ -211,9 +211,6 @@ bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSe
   else
     return true;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void ConfigurableAnalysis::beginJob() {}
 
 // ------------ method called once each job just after ending the event loop  ------------
 void ConfigurableAnalysis::endJob() {

--- a/PhysicsTools/UtilAlgos/plugins/ErrorSummaryFilter.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ErrorSummaryFilter.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,13 +35,12 @@
 // class declaration
 //
 
-class ErrorSummaryFilter : public edm::EDFilter {
+class ErrorSummaryFilter : public edm::global::EDFilter<> {
 public:
   explicit ErrorSummaryFilter(edm::ParameterSet const&);
-  ~ErrorSummaryFilter() override;
 
 private:
-  bool filter(edm::Event&, edm::EventSetup const&) override;
+  bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry> > srcToken_;
@@ -72,17 +71,12 @@ ErrorSummaryFilter::ErrorSummaryFilter(edm::ParameterSet const& iConfig)
   }
 }
 
-ErrorSummaryFilter::~ErrorSummaryFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool ErrorSummaryFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+bool ErrorSummaryFilter::filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
   edm::Handle<std::vector<edm::ErrorSummaryEntry> > errorSummaryEntry;
   iEvent.getByToken(srcToken_, errorSummaryEntry);
 

--- a/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/NTuplingDevice.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -29,20 +29,19 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "PhysicsTools/UtilAlgos/interface/NTupler.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 //
 // class decleration
 //
 
-class NTuplingDevice : public edm::EDProducer {
+class NTuplingDevice : public edm::one::EDProducer<edm::one::SharedResources> {
 public:
   explicit NTuplingDevice(const edm::ParameterSet&);
   ~NTuplingDevice() override;
 
 private:
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
   std::unique_ptr<NTupler> ntupler_;
@@ -60,6 +59,7 @@ private:
 // constructors and destructor
 //
 NTuplingDevice::NTuplingDevice(const edm::ParameterSet& iConfig) {
+  usesResource(TFileService::kSharedResource);
   //this Ntupler can work with the InputTagDistributor, but should not be configured as such.
   edm::ParameterSet ntPset = iConfig.getParameter<edm::ParameterSet>("Ntupler");
   std::string ntuplerName = ntPset.getParameter<std::string>("ComponentName");
@@ -79,12 +79,6 @@ void NTuplingDevice::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   ntupler_->fill(iEvent);
   iEvent.put(std::make_unique<double>(0.), "dummy");
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void NTuplingDevice::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void NTuplingDevice::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(NTuplingDevice);

--- a/PhysicsTools/UtilAlgos/plugins/PlottingDevice.cc
+++ b/PhysicsTools/UtilAlgos/plugins/PlottingDevice.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -34,15 +34,12 @@
 #include "PhysicsTools/UtilAlgos/interface/Plotter.h"
 #include "PhysicsTools/UtilAlgos/interface/VariableHelper.h"
 
-class PlottingDevice : public edm::EDAnalyzer {
+class PlottingDevice : public edm::one::EDAnalyzer<> {
 public:
   explicit PlottingDevice(const edm::ParameterSet&);
-  ~PlottingDevice() override;
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
   std::string vHelperInstance_;
@@ -80,8 +77,6 @@ PlottingDevice::PlottingDevice(const edm::ParameterSet& iConfig) {
   plotter_ = PlotterFactory::get()->create(plotterName, plotPset);
 }
 
-PlottingDevice::~PlottingDevice() {}
-
 //
 // member functions
 //
@@ -92,9 +87,5 @@ void PlottingDevice::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
   plotter_->fill(plotDirectoryName_, iEvent);
 }
-
-void PlottingDevice::beginJob() {}
-void PlottingDevice::endJob() {}
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(PlottingDevice);


### PR DESCRIPTION
#### PR description:

- removed unnecessary include of deprecated headers
- switched modules to thread-friendly types.

#### PR validation:

Code compiles without issuing any CMS deprecation warnings.