### PR TITLE
Move RecoLocalCalo/Castor modules to global types

### DIFF
--- a/RecoLocalCalo/Castor/src/CastorCellProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorCellProducer.cc
@@ -25,7 +25,7 @@
 
 // user include
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,14 +40,13 @@
 // class declaration
 //
 
-class CastorCellProducer : public edm::EDProducer {
+class CastorCellProducer : public edm::global::EDProducer<> {
 public:
   explicit CastorCellProducer(const edm::ParameterSet&);
-  ~CastorCellProducer() override;
 
 private:
   void beginJob() override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   void endJob() override;
 
   // member data
@@ -60,9 +59,9 @@ private:
 //
 // constants, enums and typedefs
 //
-
-const double MYR2D = 180 / M_PI;
-
+namespace {
+  constexpr double MYR2D = 180 / M_PI;
+}
 //
 // static data member definitions
 //
@@ -79,18 +78,13 @@ CastorCellProducer::CastorCellProducer(const edm::ParameterSet& iConfig) {
   // now do what ever other initialization is needed
 }
 
-CastorCellProducer::~CastorCellProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
 
-void CastorCellProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void CastorCellProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
   using namespace reco;
   using namespace TMath;

--- a/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorClusterProducer.cc
@@ -24,7 +24,7 @@
 
 // user include
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -45,15 +45,15 @@
 // class decleration
 //
 
-class CastorClusterProducer : public edm::EDProducer {
+class CastorClusterProducer : public edm::global::EDProducer<> {
 public:
   explicit CastorClusterProducer(const edm::ParameterSet&);
   ~CastorClusterProducer() override;
 
 private:
   void beginJob() override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  double phiangle(double testphi);
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  double phiangle(double testphi) const;
   void endJob() override;
 
   // ----------member data ---------------------------
@@ -104,7 +104,7 @@ CastorClusterProducer::~CastorClusterProducer() {
 //
 
 // ------------ method called to produce the data  ------------
-void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void CastorClusterProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
   using namespace reco;
   using namespace TMath;
@@ -239,7 +239,7 @@ void CastorClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 }
 
 // help function to calculate phi within [-pi,+pi]
-double CastorClusterProducer::phiangle(double testphi) {
+double CastorClusterProducer::phiangle(double testphi) const {
   double phi = testphi;
   while (phi > M_PI)
     phi -= (2 * M_PI);

--- a/RecoLocalCalo/Castor/src/CastorInvalidDataFilter.cc
+++ b/RecoLocalCalo/Castor/src/CastorInvalidDataFilter.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -34,15 +34,14 @@
 // class declaration
 //
 
-class CastorInvalidDataFilter : public edm::EDFilter {
+class CastorInvalidDataFilter : public edm::global::EDFilter<> {
 public:
   explicit CastorInvalidDataFilter(const edm::ParameterSet&);
-  ~CastorInvalidDataFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   edm::EDGetTokenT<std::vector<edm::ErrorSummaryEntry> > tok_summary_;
 };
@@ -63,17 +62,12 @@ CastorInvalidDataFilter::CastorInvalidDataFilter(const edm::ParameterSet& iConfi
   tok_summary_ = consumes<std::vector<edm::ErrorSummaryEntry> >(edm::InputTag("logErrorHarvester"));
 }
 
-CastorInvalidDataFilter::~CastorInvalidDataFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool CastorInvalidDataFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool CastorInvalidDataFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   edm::Handle<std::vector<ErrorSummaryEntry> > summary;
@@ -94,10 +88,7 @@ bool CastorInvalidDataFilter::filter(edm::Event& iEvent, const edm::EventSetup& 
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void CastorInvalidDataFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
   descriptions.addDefault(desc);
 }
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

Converted legacy modules to global. This fixes the CMS deprecation warnings.

#### PR validation:

Code compiles without issuing a CMS deprecation warning.