### PR TITLE
Migrate DummyReadDQMStore from legacy to one type

### DIFF
--- a/DQMServices/FwkIO/test/DummyReadDQMStore.cc
+++ b/DQMServices/FwkIO/test/DummyReadDQMStore.cc
@@ -16,12 +16,10 @@
 //
 //
 
-// system include files
 #include <memory>
 
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,9 +29,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-//
-// class declaration
-//
 namespace {
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -60,8 +55,6 @@ namespace {
       }
       m_name = iPSet.getUntrackedParameter<std::string>("name") + extension;
     }
-
-    ~TH1Reader() override{};
 
     void read(int run, int lumi) override {
       double expected_mean = -1, expected_entries = -1;
@@ -104,17 +97,14 @@ namespace {
 
 }  // namespace
 
-class DummyReadDQMStore : public edm::EDAnalyzer {
+class DummyReadDQMStore : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit DummyReadDQMStore(const edm::ParameterSet&);
-  ~DummyReadDQMStore() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -126,17 +116,6 @@ private:
   std::vector<std::shared_ptr<ReaderBase> > m_lumiReaders;
 };
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 DummyReadDQMStore::DummyReadDQMStore(const edm::ParameterSet& iConfig) {
   edm::Service<DQMStore> dstore;
 
@@ -168,46 +147,10 @@ DummyReadDQMStore::DummyReadDQMStore(const edm::ParameterSet& iConfig) {
   }
 }
 
-DummyReadDQMStore::~DummyReadDQMStore() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
+void DummyReadDQMStore::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {}
 
-//
-// member functions
-//
-
-// ------------ method called to produce the data  ------------
-void DummyReadDQMStore::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
-  using namespace edm;
-  /* This is an event example
-   //Read 'ExampleData' from the Event
-   Handle<ExampleData> pIn;
-   iEvent.getByLabel("example",pIn);
-
-   //Use the ExampleData to create an ExampleData2 which 
-   // is put into the Event
-   std::unique_ptr<ExampleData2> pOut(new ExampleData2(*pIn));
-   iEvent.put(pOut);
-*/
-
-  /* this is an EventSetup example
-   //Read SetupData from the SetupRecord in the EventSetup
-   ESHandle<SetupData> pSetup;
-   iSetup.get<SetupRecord>().get(pSetup);
-*/
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void DummyReadDQMStore::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DummyReadDQMStore::endJob() {}
-
-// ------------ method called when starting to processes a run  ------------
 void DummyReadDQMStore::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
-// ------------ method called when ending the processing of a run  ------------
 void DummyReadDQMStore::endRun(edm::Run const& run, edm::EventSetup const&) {
   for (std::vector<std::shared_ptr<ReaderBase> >::iterator it = m_runReaders.begin(), itEnd = m_runReaders.end();
        it != itEnd;
@@ -216,10 +159,8 @@ void DummyReadDQMStore::endRun(edm::Run const& run, edm::EventSetup const&) {
   }
 }
 
-// ------------ method called when starting to processes a luminosity block  ------------
 void DummyReadDQMStore::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
-// ------------ method called when ending the processing of a luminosity block  ------------
 void DummyReadDQMStore::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const&) {
   for (std::vector<std::shared_ptr<ReaderBase> >::iterator it = m_lumiReaders.begin(), itEnd = m_lumiReaders.end();
        it != itEnd;
@@ -228,7 +169,6 @@ void DummyReadDQMStore::endLuminosityBlock(edm::LuminosityBlock const& lumi, edm
   }
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void DummyReadDQMStore::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
@@ -237,5 +177,4 @@ void DummyReadDQMStore::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.addDefault(desc);
 }
 
-//define this as a plug-in
 DEFINE_FWK_MODULE(DummyReadDQMStore);


### PR DESCRIPTION
#### PR description:

Migrate DummyReadDQMStore from "legacy" module type to "one" module type.

I also deleted some unnecessary lines of code that served no purpose as a matter of cleanup.

I considered converting this to be a DQMEDHarvestor, but it didn't seem worth the effort as it is only used in a unit test. This could be done later as a separate PR if someone decided it was worth the effort.

#### PR validation:

This is only used in a unit test and that test passes.
