### PR TITLE
Converted RecoMET/METFilters module to global

### DIFF
--- a/RecoMET/METFilters/plugins/EENoiseFilter.cc
+++ b/RecoMET/METFilters/plugins/EENoiseFilter.cc
@@ -1,17 +1,16 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-class EENoiseFilter : public edm::EDFilter {
+class EENoiseFilter : public edm::global::EDFilter<> {
 public:
   explicit EENoiseFilter(const edm::ParameterSet& iConfig);
-  ~EENoiseFilter() override {}
 
 private:
-  bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  bool filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   edm::EDGetTokenT<EcalRecHitCollection> ebRHSrcToken_;
   edm::EDGetTokenT<EcalRecHitCollection> eeRHSrcToken_;
@@ -30,7 +29,7 @@ EENoiseFilter::EENoiseFilter(const edm::ParameterSet& iConfig)
   produces<bool>();
 }
 
-bool EENoiseFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool EENoiseFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<EcalRecHitCollection> ebRHs, eeRHs;
   iEvent.getByToken(ebRHSrcToken_, ebRHs);
   iEvent.getByToken(eeRHSrcToken_, eeRHs);

--- a/RecoMET/METFilters/plugins/GreedyMuonPFCandidateFilter.cc
+++ b/RecoMET/METFilters/plugins/GreedyMuonPFCandidateFilter.cc
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,15 +21,12 @@
 // class declaration
 //
 
-class GreedyMuonPFCandidateFilter : public edm::EDFilter {
+class GreedyMuonPFCandidateFilter : public edm::global::EDFilter<> {
 public:
   explicit GreedyMuonPFCandidateFilter(const edm::ParameterSet&);
-  ~GreedyMuonPFCandidateFilter() override;
 
 private:
-  void beginJob() override;
-  bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   const edm::EDGetTokenT<reco::PFCandidateCollection> tokenPFCandidates_;
   // ----------member data ---------------------------
@@ -62,17 +59,12 @@ GreedyMuonPFCandidateFilter::GreedyMuonPFCandidateFilter(const edm::ParameterSet
   produces<reco::PFCandidateCollection>("muons");
 }
 
-GreedyMuonPFCandidateFilter::~GreedyMuonPFCandidateFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool GreedyMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool GreedyMuonPFCandidateFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace std;
   using namespace edm;
 
@@ -122,12 +114,6 @@ bool GreedyMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSet
 
   return taggingMode_ || pass;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void GreedyMuonPFCandidateFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void GreedyMuonPFCandidateFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(GreedyMuonPFCandidateFilter);

--- a/RecoMET/METFilters/plugins/InconsistentMuonPFCandidateFilter.cc
+++ b/RecoMET/METFilters/plugins/InconsistentMuonPFCandidateFilter.cc
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,15 +23,12 @@
 // class declaration
 //
 
-class InconsistentMuonPFCandidateFilter : public edm::EDFilter {
+class InconsistentMuonPFCandidateFilter : public edm::global::EDFilter<> {
 public:
   explicit InconsistentMuonPFCandidateFilter(const edm::ParameterSet&);
-  ~InconsistentMuonPFCandidateFilter() override;
 
 private:
-  void beginJob() override;
-  bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
@@ -63,14 +60,12 @@ InconsistentMuonPFCandidateFilter::InconsistentMuonPFCandidateFilter(const edm::
   produces<reco::PFCandidateCollection>("muons");
 }
 
-InconsistentMuonPFCandidateFilter::~InconsistentMuonPFCandidateFilter() {}
-
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool InconsistentMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool InconsistentMuonPFCandidateFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace std;
   using namespace edm;
 
@@ -125,12 +120,6 @@ bool InconsistentMuonPFCandidateFilter::filter(edm::Event& iEvent, const edm::Ev
 
   return taggingMode_ || pass;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void InconsistentMuonPFCandidateFilter::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void InconsistentMuonPFCandidateFilter::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(InconsistentMuonPFCandidateFilter);

--- a/RecoMET/METFilters/plugins/JetIDFailureFilter.cc
+++ b/RecoMET/METFilters/plugins/JetIDFailureFilter.cc
@@ -1,19 +1,18 @@
 
 #include <memory>
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-class JetIDFailureFilter : public edm::EDFilter {
+class JetIDFailureFilter : public edm::global::EDFilter<> {
 public:
   explicit JetIDFailureFilter(const edm::ParameterSet& iConfig);
-  ~JetIDFailureFilter() override;
 
 private:
-  bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  bool filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   edm::EDGetTokenT<edm::View<pat::Jet> > theJetToken_;
   const double minJetPt_, maxJetEta_, maxNeutHadF_, maxNeutEmF_;
@@ -32,9 +31,7 @@ JetIDFailureFilter::JetIDFailureFilter(const edm::ParameterSet& iConfig)
   produces<bool>();
 }
 
-JetIDFailureFilter::~JetIDFailureFilter() {}
-
-bool JetIDFailureFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool JetIDFailureFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // read in the objects
   edm::Handle<edm::View<pat::Jet> > jets;
   iEvent.getByToken(theJetToken_, jets);

--- a/RecoMET/METFilters/plugins/MultiEventFilter.cc
+++ b/RecoMET/METFilters/plugins/MultiEventFilter.cc
@@ -1,6 +1,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Parse.h"
@@ -11,7 +11,7 @@
 
 #include <fstream>
 
-class MultiEventFilter : public edm::EDFilter {
+class MultiEventFilter : public edm::global::EDFilter<> {
   class Event {
   public:
     Event(edm::RunNumber_t r, edm::LuminosityBlockNumber_t l, edm::EventNumber_t e) : run(r), lumi(l), event(e) {}
@@ -22,10 +22,9 @@ class MultiEventFilter : public edm::EDFilter {
 
 public:
   explicit MultiEventFilter(const edm::ParameterSet& iConfig);
-  ~MultiEventFilter() override {}
 
 private:
-  bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  bool filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   std::vector<Event> events_;
   const std::vector<std::string> eventList_;
@@ -62,7 +61,7 @@ MultiEventFilter::MultiEventFilter(const edm::ParameterSet& iConfig)
   produces<bool>();
 }
 
-bool MultiEventFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool MultiEventFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   bool pass = true;
 
   for (unsigned int i = 0; i < events_.size(); ++i) {


### PR DESCRIPTION
#### PR description:

All remaining legacy modules were converted to global. This fixes all CMS deprecation warnings in the package.

#### PR validation:

Code compiles without issuing a CMS deprecation warning.