### PR TITLE
Changed HcalTBTriggerFilter to global::EDFilter

### DIFF
--- a/RecoTBCalo/HcalTBTools/src/HcalTBTriggerFilter.cc
+++ b/RecoTBCalo/HcalTBTools/src/HcalTBTriggerFilter.cc
@@ -11,7 +11,7 @@ HcalTBTriggerFilter::HcalTBTriggerFilter(const edm::ParameterSet& ps)
   tok_tb_ = consumes<HcalTBTriggerData>(ps.getParameter<edm::InputTag>("hcalTBTriggerDataTag"));
 }
 
-bool HcalTBTriggerFilter::filter(edm::Event& e, edm::EventSetup const& c) {
+bool HcalTBTriggerFilter::filter(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const {
   edm::Handle<HcalTBTriggerData> h;
   e.getByToken(tok_tb_, h);
 

--- a/RecoTBCalo/HcalTBTools/src/HcalTBTriggerFilter.h
+++ b/RecoTBCalo/HcalTBTools/src/HcalTBTriggerFilter.h
@@ -1,7 +1,7 @@
 #ifndef HCALTBTRIGGERFILTER_H
 #define HCALTBTRIGGERFILTER_H 1
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -12,11 +12,10 @@
     
    \author J. Mans - Minnesota
 */
-class HcalTBTriggerFilter : public edm::EDFilter {
+class HcalTBTriggerFilter : public edm::global::EDFilter<> {
 public:
   HcalTBTriggerFilter(const edm::ParameterSet& ps);
-  ~HcalTBTriggerFilter() override {}
-  bool filter(edm::Event& e, edm::EventSetup const& c) override;
+  bool filter(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
 private:
   bool allowPedestal_;


### PR DESCRIPTION
#### PR description:

This removes the CMS deprecation warning.

#### PR validation:

Code compiles without issuing a CMS deprecation warning.