### PR TITLE
Change LG and HG Tk PCL output tags

### DIFF
--- a/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliHGRcd_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAliHG_PCL_v0_hlt": {}, 
-        "TrackerAlignmentHG_PCL_byRun_v2_express": {}
+        "SiPixelAli_PCL_v0_hlt": {}, 
+        "TrackerAlignment_PCL_byRun_v2_express": {}
     }, 
     "inputTag": "SiPixelAliHG_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/SiPixelAliRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliRcd_prod.json
@@ -1,8 +1,8 @@
 {
     "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
     "destinationTags": {
-        "SiPixelAli_PCL_v0_hlt": {}, 
-        "TrackerAlignment_PCL_byRun_v2_express": {}
+        "SiPixelAli_PCL_v0_hlt_off": {}, 
+        "TrackerAlignment_PCL_byRun_v2_express_off": {}
     }, 
     "inputTag": "SiPixelAli_pcl", 
     "since": null, 


### PR DESCRIPTION
#### PR description:

From now on the LG PCL should go into the `_off` tags, while the HG should go into the production tag.
More about this on https://cms-talk.web.cern.ch/t/strategy-for-restart-concerning-high-granularity-pcl-alignment/15195/4

#### PR validation:

Produced an sqlite file and uploaded and appended. 
Diff:
https://cern.ch/go/xcl6

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No a backport, but should go back to 12_4_X for documentation purposes