### PR TITLE
Use unique_ptr in edm::Factory::MakerMap

### DIFF
--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -12,16 +12,11 @@
 EDM_REGISTER_PLUGINFACTORY(edm::MakerPluginFactory, "CMS EDM Framework Module");
 namespace edm {
 
-  static void cleanup(const Factory::MakerMap::value_type& v) { delete v.second.get(); }
-
   Factory const Factory::singleInstance_;
 
-  Factory::~Factory() { for_all(makers_, cleanup); }
+  Factory::~Factory() = default;
 
-  Factory::Factory()
-      : makers_()
-
-  {}
+  Factory::Factory() = default;
 
   Factory const* Factory::get() { return &singleInstance_; }
 
@@ -34,10 +29,9 @@ namespace edm {
       std::unique_ptr<Maker> wm = detail::resolveMaker<MakerPluginFactory>(modtype, resolver);
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
 
-      std::pair<MakerMap::iterator, bool> ret = makers_.insert(std::pair<std::string, Maker*>(modtype, wm.get()));
+      std::pair<MakerMap::iterator, bool> ret = makers_.insert({modtype, std::move(wm)});
 
       it = ret.first;
-      wm.release();
     }
     return it->second;
   }

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -17,7 +17,7 @@ namespace edm {
 
   class Factory {
   public:
-    typedef std::map<std::string, edm::propagate_const<Maker*>> MakerMap;
+    typedef std::map<std::string, edm::propagate_const<std::unique_ptr<Maker>>> MakerMap;
 
     ~Factory();
 


### PR DESCRIPTION
#### PR description:

Smart pointer is generally better, and makes the code more consistent with the EventSetup-side `ComponentFactory`, of which I'll make use of in later development.

#### PR validation:

Code compiles.