### PR TITLE
[12_4_X] RPCOccupancyTest crash protection for 0 LS

### DIFF
--- a/DQM/RPCMonitorClient/src/RPCOccupancyTest.cc
+++ b/DQM/RPCMonitorClient/src/RPCOccupancyTest.cc
@@ -29,6 +29,9 @@ void RPCOccupancyTest::beginJob(std::string& workingFolder) {
 
   totalStrips_ = 0.;
   totalActive_ = 0.;
+  
+  Active_Dead = nullptr;
+  Active_Fraction = nullptr;
 }
 
 void RPCOccupancyTest::getMonitorElements(std::vector<MonitorElement*>& meVector,


### PR DESCRIPTION
#### PR description:
To fix RPC client crash (e.g. [0]) in online DQM when 0 LS is available in the run we set default nullptr value for [Active_Dead & Active_Fraction](https://github.com/cms-sw/cmssw/commit/62949aa733cd216f3ce0b11a656e4abe947d748e) pointers. Line of the crash:
https://github.com/cms-sw/cmssw/blob/75b3627bd7b176732ae1dbebd24525c3d2f29af0/DQM/RPCMonitorClient/src/RPCOccupancyTest.cc#L60-L63
Normally Active_Dead will be created during myBooker call:
https://github.com/cms-sw/cmssw/blob/4ca4ed7589ef4fc809d44ae8868c71f3081af67b/DQM/RPCMonitorClient/plugins/RPCDqmClient.cc#L83
but it is in the RPCDqmClient::dqmEndLuminosityBlock ...

[0] https://cmsweb.cern.ch/dqm/dqm-square-k8/api?what=get_logs&id=dqm-source-state-run359683-hostfu-c2f11-11-03-pid013536&db=production

#### PR validation:
Tested locally, to be tested at P5

