### PR TITLE
[12.4.X] `MillePedeDQMModule`: add string MonitorElement to signal if the update was vetoed

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -17,6 +17,7 @@
 
 struct mpPCLresults {
 private:
+  bool m_isHG;
   bool m_isDBUpdated;
   bool m_isDBUpdateVetoed;
   int m_nRecords;
@@ -30,14 +31,17 @@ public:
                int nRecords,
                int exitCode,
                std::string exitMessage,
-               std::bitset<4> updateBits)
-      : m_isDBUpdated(isDBUpdated),
+               std::bitset<4> updateBits,
+               bool isHG)
+      : m_isHG(isHG),
+        m_isDBUpdated(isDBUpdated),
         m_isDBUpdateVetoed(isDBUpdateVetoed),
         m_nRecords(nRecords),
         m_exitCode(exitCode),
         m_exitMessage(exitMessage),
         m_updateBits(updateBits) {}
 
+  const bool isHighGranularity() { return m_isHG; }
   const bool getDBUpdated() { return m_isDBUpdated; }
   const bool getDBVetoed() { return m_isDBUpdateVetoed; }
   const bool exceedsThresholds() { return m_updateBits.test(0); }
@@ -105,7 +109,7 @@ public:  //====================================================================
   const int binariesAmount() const { return binariesAmount_; }
 
   const mpPCLresults getResults() const {
-    return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_, exitMessage_, updateBits_);
+    return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_, exitMessage_, updateBits_, isHG_);
   }
 
   const std::map<std::string, std::array<bool, 6>>& getResultsHG() const { return fractionExceeded_; }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -131,6 +131,7 @@ private:  //===================================================================
   MonitorElement* statusResults;
   MonitorElement* binariesAvalaible;
   MonitorElement* exitCode;
+  MonitorElement* isVetoed;
 
   bool isHG_;
 };


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39552

#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/28318 some additional details plots were added to the `SiPixelAli` PCL in order to display more information about if and why the upload was vetoed.
On the other hand the current setup is not super-clear to read if one just wants to know if there was a veto or not.
For this reason we decided to add a simple `string` MonitorElement in order to write if the DB was updated, there was a veto or N/A in case the PCL was not run.

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/39552 (for data-taking purposes)