### PR TITLE
[12.5.X] Update to sqrt(s) in the PV alignment validation plotting macros 

### DIFF
--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -36,6 +36,7 @@ TString lumi_13TeV = "20.1 fb^{-1}";
 TString lumi_8TeV = "19.7 fb^{-1}";
 TString lumi_7TeV = "5.1 fb^{-1}";
 TString lumi_0p9TeV = "";
+TString lumi_13p6TeV = "";
 TString lumi_sqrtS = "";
 bool drawLogo = false;
 
@@ -92,6 +93,9 @@ void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
   } else if (iPeriod == 5) {
     lumiText += lumi_0p9TeV;
     lumiText += " (#sqrt{s} = 0.9 TeV)";
+  } else if (iPeriod == 6) {
+    lumiText += lumi_13p6TeV;
+    lumiText += " (#sqrt{s} = 13.6 TeV)";
   } else if (iPeriod == 7) {
     if (outOfFrame)
       lumiText += "#scale[0.85]{";

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -2360,7 +2360,7 @@ void arrangeBiasCanvas(TCanvas *canv,
     lego->Draw();
 
     TPad *current_pad = static_cast<TPad *>(canv->GetPad(k + 1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
     if (theDate != "")
       ptDate->Draw("same");
   }
@@ -2521,7 +2521,7 @@ void arrangeCanvas(TCanvas *canv,
     current_pad = static_cast<TPad *>(canv->GetPad(0));
   }
 
-  CMS_lumi(current_pad, 4, 33);
+  CMS_lumi(current_pad, 6, 33);
   if (theDate != "")
     ptDate->Draw("same");
 
@@ -2567,7 +2567,7 @@ void arrangeCanvas(TCanvas *canv,
     lego->Draw();
 
     TPad *current_pad2 = static_cast<TPad *>(canv->GetPad(2));
-    CMS_lumi(current_pad2, 4, 33);
+    CMS_lumi(current_pad2, 6, 33);
     if (theDate != "")
       ptDate->Draw("same");
   }
@@ -2805,7 +2805,7 @@ void arrangeFitCanvas(TCanvas *canv, TH1F *meanplots[100], Int_t nFiles, TString
 
   //TkAlStyle::drawStandardTitle(Coll0T15);
   lego->Draw("same");
-  CMS_lumi(canv, 4, 33);
+  CMS_lumi(canv, 6, 33);
   if (theDate != "")
     ptDate->Draw("same");
   //pt->Draw("same");
@@ -3868,7 +3868,9 @@ void setStyle() {
   /*--------------------------------------------------------------------*/
 
   writeExtraText = true;  // if extra text
-  lumi_13TeV = "p-p collisions";
+  lumi_13p6TeV = "pp collisions";
+  lumi_13TeV = "pp collisions";
+  lumi_0p9TeV = "pp collisions";
   extraText = "Internal";
 
   TH1::StatOverflows(kTRUE);

--- a/Alignment/OfflineValidation/macros/FitPVResolution.C
+++ b/Alignment/OfflineValidation/macros/FitPVResolution.C
@@ -751,7 +751,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     TPad* current_pad = static_cast<TPad*>(c1->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c1->cd(2);
     j == 0 ? p_resolY_vsSumPt_[j]->Draw("E1") : p_resolY_vsSumPt_[j]->Draw("E1same");
@@ -761,7 +761,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c1->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c1->cd(3);
     j == 0 ? p_resolZ_vsSumPt_[j]->Draw("E1") : p_resolZ_vsSumPt_[j]->Draw("E1same");
@@ -771,7 +771,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c1->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     // second canvas
 
@@ -783,7 +783,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c2->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c2->cd(2);
     j == 0 ? p_pullY_vsSumPt_[j]->Draw("E1") : p_pullY_vsSumPt_[j]->Draw("E1same");
@@ -793,7 +793,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c2->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c2->cd(3);
     j == 0 ? p_pullZ_vsSumPt_[j]->Draw("E1") : p_pullZ_vsSumPt_[j]->Draw("E1same");
@@ -803,7 +803,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c2->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     // third canvas
 
@@ -815,7 +815,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c3->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c3->cd(2);
     j == 0 ? p_resolY_vsNtracks_[j]->Draw("E1") : p_resolY_vsNtracks_[j]->Draw("E1same");
@@ -825,7 +825,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c3->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c3->cd(3);
     j == 0 ? p_resolZ_vsNtracks_[j]->Draw("E1") : p_resolZ_vsNtracks_[j]->Draw("E1same");
@@ -835,7 +835,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c3->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     // fourth canvas
 
@@ -847,7 +847,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c4->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c4->cd(2);
     j == 0 ? p_pullY_vsNtracks_[j]->Draw("E1") : p_pullY_vsNtracks_[j]->Draw("E1same");
@@ -857,7 +857,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c4->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c4->cd(3);
     j == 0 ? p_pullZ_vsNtracks_[j]->Draw("E1") : p_pullZ_vsNtracks_[j]->Draw("E1same");
@@ -867,7 +867,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c4->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     // fifth canvas
 
@@ -879,7 +879,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c5->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c5->cd(2);
     j == 0 ? p_resolY_vsNVtx_[j]->Draw("E1") : p_resolY_vsNVtx_[j]->Draw("E1same");
@@ -889,7 +889,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c5->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c5->cd(3);
     j == 0 ? p_resolZ_vsNVtx_[j]->Draw("E1") : p_resolZ_vsNVtx_[j]->Draw("E1same");
@@ -899,7 +899,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c5->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     // sixth canvas
 
@@ -911,7 +911,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c6->GetPad(1));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c6->cd(2);
     j == 0 ? p_pullY_vsNVtx_[j]->Draw("E1") : p_pullY_vsNVtx_[j]->Draw("E1same");
@@ -921,7 +921,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c6->GetPad(2));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
 
     c6->cd(3);
     j == 0 ? p_pullZ_vsNVtx_[j]->Draw("E1") : p_pullZ_vsNVtx_[j]->Draw("E1same");
@@ -931,7 +931,7 @@ void FitPVResolution(TString namesandlabels, TString theDate = "", bool isStrict
     if (theDate.Length() != 0)
       ptDate->Draw("same");
     current_pad = static_cast<TPad*>(c6->GetPad(3));
-    CMS_lumi(current_pad, 4, 33);
+    CMS_lumi(current_pad, 6, 33);
   }
 
   if (theDate.Length() != 0)
@@ -1130,8 +1130,9 @@ void setPVResolStyle() {
   /*--------------------------------------------------------------------*/
 
   writeExtraText = true;  // if extra text
-  lumi_13TeV = "p-p collisions";
-  lumi_0p9TeV = "p-p collisions";
+  lumi_13p6TeV = "pp collisions";
+  lumi_13TeV = "pp collisions";
+  lumi_0p9TeV = "pp collisions";
   extraText = "Internal";
 
   TH1::StatOverflows(kTRUE);

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -19,7 +19,7 @@
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testSubmitters.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
-  <bin file="testPVPlotting.cpp">
+  <bin file="testPVPlotting.cpp" name="testPVPlotting">
     <flags PRE_TEST="testPVValidation"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>


### PR DESCRIPTION
backport of #39550 

#### PR description:

Long overdue update to the plotting macros in order to show correctly the sqrt(s) = 13.6 TeV as default for Run-3.

#### PR validation:

Run successfully `scram b runtests_testPVPlotting use-ibeos` and obtained the following (empty on 10 events) plots, which show the update is done correctly, see master PR #39550 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #39550 to 12.5.X for data-taking purposes.
