### PR TITLE
Bugfix to the destructor of two TkDQM scripts

### DIFF
--- a/DQM/SiStripMonitorClient/scripts/PhaseITreeProducer.py
+++ b/DQM/SiStripMonitorClient/scripts/PhaseITreeProducer.py
@@ -314,8 +314,9 @@ class ModuleLvlValuesReader:
     print(len(self.availableNames))
       
   def __del__(self):
-    if self.inputFile.IsOpen():
-      self.inputFile.Close()
+    if self.inputFile:
+      if self.inputFile.IsOpen():
+        self.inputFile.Close()
     
 #--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--
 for i in range(1, len(sys.argv), 1):

--- a/DQM/SiStripMonitorClient/scripts/TH2PolyOfflineMaps.py
+++ b/DQM/SiStripMonitorClient/scripts/TH2PolyOfflineMaps.py
@@ -526,8 +526,9 @@ class TH2PolyOfflineMaps:
         c1.Print(self.outputDirName + mv + ".png")
       
   def __del__(self):
-    if self.inputFile.IsOpen():
-      self.inputFile.Close()
+    if self.inputFile :
+      if self.inputFile.IsOpen():
+        self.inputFile.Close()
       
 #--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--
 for i in range(1, len(sys.argv), 1):

--- a/DQM/SiStripMonitorClient/test/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/test/BuildFile.xml
@@ -2,3 +2,8 @@
   <flags TEST_RUNNER_ARGS="/bin/bash DQM/SiStripMonitorClient/test test_SiStripDQM_OfflineTkMap.sh"/>
   <use name="FWCore/Utilities"/>
 </bin>
+
+<bin name="test_TreeAndTkMapProducer" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash DQM/SiStripMonitorClient/test test_TreeAndTkMapProducer.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/DQM/SiStripMonitorClient/test/test_TreeAndTkMapProducer.sh
+++ b/DQM/SiStripMonitorClient/test/test_TreeAndTkMapProducer.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+DQMFILE="/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root"
+COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $DQMFILE`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+if [ $STATUS -eq 0 ]; then
+    echo "Using file ${DQMFILE} Running in ${LOCAL_TEST_DIR}."
+    xrdcp root://cms-xrd-global.cern.ch//$DQMFILE DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root 
+    (python3 ${LOCAL_TEST_DIR}/../scripts/PhaseITreeProducer.py DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root) || die 'failed running PhaseITreeProducer.py' $?
+    (python3 ${LOCAL_TEST_DIR}/../scripts/TH2PolyOfflineMaps.py DQM_V0001_R000319176__ZeroBias__Run2018B-PromptReco-v2__DQMIO.root 3000 2000 ) || die 'failed running TH2PolyOfflineMaps.py' $?
+else 
+  die "SKIPPING test, file ${DQMFILE} not found" 0
+fi


### PR DESCRIPTION
#### PR description:

Tracker Offline DQM shift scripts, such as
`python3 PhaseITreeProducer.py DQM_V0001_R000359278__ZeroBias__Run2022E-PromptReco-v1__DQMIO.root`
gave the following
```
Histograms to read 114
Histograms saved to internal data structure
Data saved as TTree object
Exception ignored in: <function ModuleLvlValuesReader.__del__ at 0x7f99aa46ed30>
Traceback (most recent call last):
  File "/data/vami/projects/DQM/CMSSW_12_4_9/src/DQM/SiStripMonitorClient/scripts/PhaseITreeProducer.py", line 317, in __del__
AttributeError: 'CPyCppyy_NoneType' object has no attribute 'IsOpen'
```

After adding a check on the existence, this is gone.

#### PR validation:

`PhaseITreeProducer.py` runs fine. 
Added new unit test
```
scram b runtests_test_TreeAndTkMapProducer
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

PhaseITreeProducer.py is used during the shifts for every run, so it should be backported to 12_4_X (and then of course 12_5_X too)
