### PR TITLE
[12_5_X] [L1T] Backport of : Bug fix on L1TrackJetEmulator

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -243,6 +243,10 @@ void L1TrackJetEmulationProducer::produce(Event &iEvent, const EventSetup &iSetu
     delete[] mzb.clusters;
   } else if (L1TrkPtrs_.empty()) {
     edm::LogWarning("L1TrackJetEmulationProducer") << "L1TrkPtrs Not Assigned!\n";
+    if (displaced_)
+      iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJetsExtended");
+    else
+      iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJets");
   }
 }
 


### PR DESCRIPTION
#### PR description:

Bug fix on the L1 phase2 trackjet emulation.

Description of the problem: In cases were no tracks are found the code does not return empty containers. It returns nothing with result of failing in later steps or in offline analysis when we try to access them. This is important for samples with PU=0 were the possibility to have events w/o tracks is non-negligible.
Solution: Straightforward just added the empty containers. The change is transparent, just the minimum to prevent the crashes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/39479 
Backport needed for phase-2 L1 MC production
