### PR TITLE
Use parabolic magnetic field in track final fit and modify min N(hits) condition in track duplicate merge

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -224,8 +224,8 @@ _fastSim_detachedQuadStepTrackCandidates = FastSimulation.Tracking.TrackCandidat
 fastSim.toReplaceWith(detachedQuadStepTrackCandidates,_fastSim_detachedQuadStepTrackCandidates)
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     AlgorithmName = 'detachedQuadStep',
     src           = 'detachedQuadStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother',

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -254,8 +254,8 @@ fastSim.toReplaceWith(detachedTripletStepTrackCandidates,_fastSim_detachedTriple
 
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-detachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+detachedTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     AlgorithmName = 'detachedTripletStep',
     src           = 'detachedTripletStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -269,8 +269,8 @@ _fastSim_highPtTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandida
 fastSim.toReplaceWith(highPtTripletStepTrackCandidates,_fastSim_highPtTripletStepTrackCandidates)
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'highPtTripletStepTrackCandidates',
     AlgorithmName = 'highPtTripletStep',
     Fitter        = 'FlexibleKFFittingSmoother',

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -164,8 +164,8 @@ trackingMkFitInitialStepPreSplitting.toReplaceWith(initialStepTrackCandidatesPre
 ))
 
 # fitting
-import RecoTracker.TrackProducer.TrackProducer_cfi
-initialStepTracksPreSplitting = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+initialStepTracksPreSplitting = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src              = 'initialStepTrackCandidatesPreSplitting',
     AlgorithmName    = 'initialStep',
     Fitter           = 'FlexibleKFFittingSmoother',

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -268,8 +268,8 @@ fastSim.toReplaceWith(initialStepTrackCandidates,
 
 
 # fitting
-import RecoTracker.TrackProducer.TrackProducer_cfi
-initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+initialStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'initialStepTrackCandidates',
     AlgorithmName = 'initialStep',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -218,8 +218,8 @@ jetCoreRegionalStepEndcapTrackCandidates = jetCoreRegionalStepTrackCandidates.cl
 )
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-jetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+jetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     AlgorithmName = 'jetCoreRegionalStep',
     src           = 'jetCoreRegionalStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -117,8 +117,8 @@ lowPtBarrelTripletStepKFFittingSmoother = TrackingTools.TrackFitters.KFFittingSm
     MinNumberOfHits        = 3
 )
 
-import RecoTracker.TrackProducer.TrackProducer_cfi
-lowPtBarrelTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+lowPtBarrelTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'lowPtBarrelTripletStepTrackCandidates',
     AlgorithmName = 'lowPtTripletStep',
     Fitter        = 'lowPtBarrelTripletStepKFFittingSmoother',

--- a/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
@@ -76,8 +76,8 @@ lowPtForwardTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidat
 )
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-lowPtForwardTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+lowPtForwardTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'lowPtForwardTripletStepTrackCandidates',
     AlgorithmName = 'lowPtTripletStep'
 )

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -214,8 +214,8 @@ _fastSim_lowPtQuadStepTrackCandidates = FastSimulation.Tracking.TrackCandidatePr
 fastSim.toReplaceWith(lowPtQuadStepTrackCandidates,_fastSim_lowPtQuadStepTrackCandidates)
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'lowPtQuadStepTrackCandidates',
     AlgorithmName = 'lowPtQuadStep',
     Fitter        = 'FlexibleKFFittingSmoother',

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -281,8 +281,8 @@ fastSim.toReplaceWith(lowPtTripletStepTrackCandidates,
 )
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'lowPtTripletStepTrackCandidates',
     AlgorithmName = 'lowPtTripletStep',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -340,8 +340,8 @@ trackingLowPU.toModify(mixedTripletStepTrajectoryCleanerBySharedHits, fractionSh
 
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     AlgorithmName = 'mixedTripletStep',
     src           = 'mixedTripletStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -354,8 +354,8 @@ trackingLowPU.toModify(pixelLessStepTrajectoryCleanerBySharedHits, fractionShare
 
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-pixelLessStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+pixelLessStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'pixelLessStepTrackCandidates',
     AlgorithmName = 'pixelLessStep',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -353,8 +353,8 @@ pixelPairStepTrajectoryCleanerBySharedHits = _trajectoryCleanerBySharedHits.clon
 trackingPhase2PU140.toModify(pixelPairStepTrajectoryCleanerBySharedHits, fractionShared = 0.09)
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     AlgorithmName = 'pixelPairStep',
     src           = 'pixelPairStepTrackCandidates',
     Fitter        = 'FlexibleKFFittingSmoother'

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -379,8 +379,8 @@ tobTecFlexibleKFFittingSmoother = TrackingTools.TrackFitters.FlexibleKFFittingSm
 
 
 # TRACK FITTING
-import RecoTracker.TrackProducer.TrackProducer_cfi
-tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+import RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi
+tobTecStepTracks = RecoTracker.TrackProducer.TrackProducerIterativeDefault_cfi.TrackProducer.clone(
     src           = 'tobTecStepTrackCandidates',
     AlgorithmName = 'tobTecStep',
     #Fitter = 'tobTecStepFitterSmoother',

--- a/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
@@ -1,28 +1,8 @@
 import FWCore.ParameterSet.Config as cms
+import RecoTracker.TrackProducer.TrackProducer_cfi
 
-TrackProducer = cms.EDProducer("TrackProducer",
+TrackProducer = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     useSimpleMF = cms.bool(True),
     SimpleMagneticField = cms.string("ParabolicMf"),
-    src = cms.InputTag("ckfTrackCandidates"),
-    clusterRemovalInfo = cms.InputTag(""),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    Fitter = cms.string('KFFittingSmootherWithOutliersRejectionAndRK'),
-    useHitsSplitting = cms.bool(False),
-    alias = cms.untracked.string('ctfWithMaterialTracks'),
-    TrajectoryInEvent = cms.bool(False),
-    TTRHBuilder = cms.string('WithAngleAndTemplate'),
-    AlgorithmName = cms.string('undefAlgorithm'),
     Propagator = cms.string('PropagatorWithMaterialParabolicMf'),
-
-    # this parameter decides if the propagation to the beam line
-    # for the track parameters defiition is from the first hit
-    # or from the closest to the beam line
-    # true for cosmics/beam halo, false for collision tracks (needed by loopers)
-    GeometricInnerState = cms.bool(False),
-
-    ### These are paremeters related to the filling of the Secondary hit-patterns                               
-    #set to "", the secondary hit pattern will not be filled (backward compatible with DetLayer=0)    
-    NavigationSchool = cms.string('SimpleNavigationSchool'),          
-    MeasurementTracker = cms.string(''),
-    MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent'),                   
 )

--- a/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 TrackProducer = cms.EDProducer("TrackProducer",
-    useSimpleMF = cms.bool(False),
-    SimpleMagneticField = cms.string(""),
+    useSimpleMF = cms.bool(True),
+    SimpleMagneticField = cms.string("ParabolicMf"),
     src = cms.InputTag("ckfTrackCandidates"),
     clusterRemovalInfo = cms.InputTag(""),
     beamSpot = cms.InputTag("offlineBeamSpot"),
@@ -12,7 +12,7 @@ TrackProducer = cms.EDProducer("TrackProducer",
     TrajectoryInEvent = cms.bool(False),
     TTRHBuilder = cms.string('WithAngleAndTemplate'),
     AlgorithmName = cms.string('undefAlgorithm'),
-    Propagator = cms.string('RungeKuttaTrackerPropagator'),
+    Propagator = cms.string('PropagatorWithMaterialParabolicMf'),
 
     # this parameter decides if the propagation to the beam line
     # for the track parameters defiition is from the first hit

--- a/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducer_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 TrackProducer = cms.EDProducer("TrackProducer",
-    useSimpleMF = cms.bool(False),
-    SimpleMagneticField = cms.string(""),
+    useSimpleMF = cms.bool(True),
+    SimpleMagneticField = cms.string("ParabolicMf"),
     src = cms.InputTag("ckfTrackCandidates"),
     clusterRemovalInfo = cms.InputTag(""),
     beamSpot = cms.InputTag("offlineBeamSpot"),
@@ -12,7 +12,7 @@ TrackProducer = cms.EDProducer("TrackProducer",
     TrajectoryInEvent = cms.bool(False),
     TTRHBuilder = cms.string('WithAngleAndTemplate'),
     AlgorithmName = cms.string('undefAlgorithm'),
-    Propagator = cms.string('RungeKuttaTrackerPropagator'),
+    Propagator = cms.string('PropagatorWithMaterialParabolicMf'),
 
     # this parameter decides if the propagation to the beam line
     # for the track parameters defiition is from the first hit

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -65,7 +65,7 @@ namespace {
       desc.add<int>("MaxNumberOfOutliers", 3);
       desc.add<int>("MinDof", 2);
       desc.add<bool>("NoOutliersBeginEnd", false);
-      desc.add<int>("MinNumberOfHits", 5);
+      desc.add<int>("MinNumberOfHits", 3);
       desc.add<int>("MinNumberOfHitsHighEta", 5);
       desc.add<double>("HighEtaSwitch", 5.0);
       desc.add<bool>("RejectTracks", true);


### PR DESCRIPTION
### PR description:
This PR:
(1) introduces the usage of parabolic magnetic field with corresponding propagator in track final fit, for main tracking iterations;
(2) modifies the condition on min N(hits) in KFFittingSmoother used in track duplicate merge.

(1) allows to reduce track fitting time by ~10%, with no visible change in tracking physics performance.
(2) allows to reduce duplicate rate at low pT and high pseudorapidity.

### PR validation:

Please, refer to presentation at Tracking POG on September 12:
https://indico.cern.ch/event/1197539/#2-tracking-final-fit-opportuni
For (1): slides 5-8.
For (2): slides 26-27.

FYI: @mmusich @slava77 
