### PR TITLE
Removed unnecessary includes in CommonTools/ParticleFlow

### DIFF
--- a/CommonTools/ParticleFlow/interface/PFMETAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFMETAlgo.h
@@ -7,11 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-/* #include "FWCore/Framework/interface/EDProducer.h" */
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-/* #include "FWCore/Framework/interface/Event.h" */
-/* #include "FWCore/Framework/interface/MakerMacros.h" */
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 

--- a/CommonTools/ParticleFlow/interface/PFPileUpAlgo.h
+++ b/CommonTools/ParticleFlow/interface/PFPileUpAlgo.h
@@ -2,7 +2,6 @@
 #define CommonTools_PFCandProducer_PFPileUpAlgo_
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 


### PR DESCRIPTION
#### PR description:

Removed include and commented include of deprecated header.

#### PR validation:

Code compiles without CMS deprecation warnings.