### PR TITLE
Made L1GctInternJetProducer a global module

### DIFF
--- a/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.cc
+++ b/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.cc
@@ -33,9 +33,7 @@ L1GctInternJetProducer::L1GctInternJetProducer(const edm::ParameterSet& iConfig)
   produces<L1JetParticleCollection>("Internal");
 }
 
-L1GctInternJetProducer::~L1GctInternJetProducer() {}
-
-void L1GctInternJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1GctInternJetProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   //std::cout << "ARGGHHH!" << std::endl;
   using namespace edm;
   using namespace l1extra;
@@ -84,10 +82,6 @@ void L1GctInternJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
 
   OrphanHandle<L1JetParticleCollection> internalJetHandle = iEvent.put(std::move(internJetColl), "Internal");
 }
-
-void L1GctInternJetProducer::beginJob() {}
-
-void L1GctInternJetProducer::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(L1GctInternJetProducer);

--- a/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.h
+++ b/EventFilter/GctRawToDigi/plugins/L1GctInternJetProducer.h
@@ -14,7 +14,7 @@
 */
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -31,20 +31,12 @@
 // forward declarations
 class L1CaloGeometry;
 
-class L1GctInternJetProducer : public edm::EDProducer {
+class L1GctInternJetProducer : public edm::global::EDProducer<> {
 public:
   explicit L1GctInternJetProducer(const edm::ParameterSet&);
-  ~L1GctInternJetProducer() override;
 
 private:
-  void beginJob() override;
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
-
-  math::PtEtaPhiMLorentzVector gctLorentzVector(const double& et,
-                                                const L1GctCand& cand,
-                                                const L1CaloGeometry* geom,
-                                                bool central);
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   edm::InputTag internalJetSource_;
   edm::ESGetToken<L1CaloGeometry, L1CaloGeometryRecord> caloGeomToken_;


### PR DESCRIPTION
#### PR description:

This fixes the CMS deprecation warnings

#### PR validation:

The code compiles without CMS deprecation warnings.