### PR TITLE
Phase 2 tracker: adding tracker T31 

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -63,7 +63,8 @@ Tracker:
 * T24: Phase2 tilted tracker. Tracker detector description itself is identical to T21 (OT800 IT615). Change of paradigm, entire description reworked to be compatible with DD4hep library.
 * T25: Phase2 tilted tracker. Outer Tracker (v8.0.0): same as T24/T21. Inner Tracker (v7.0.2): Based on (v6.1.5) (T24/T21), but with 3D sensors in TBPX L1. Compatible with DD4hep library.
 * T26: Phase2 tilted tracker. Outer Tracker (v8.0.0): same as T24/T21. Inner Tracker (v7.0.3): Based on (v6.1.5) (T24/T21), but with 3D sensors in TBPX L1 and 50x50 pixel aspect ratio in TFPX and TEPX. Compatible with DD4hep library.
-* T30: Phase2 titled tracker. Exploratory geometry *only to be used in D91 for now*. Outer Tracker (v8.0.1): based on v8.0.0 with updated TB2S spacing. Inner Tracker (v6.4.0): based on v6.1.5 but TFPX with more realistic module positions.
+* T30: Phase2 tilted tracker. Exploratory geometry *only to be used in D91 for now*. Outer Tracker (v8.0.1): based on v8.0.0 with updated TB2S spacing. Inner Tracker (v6.4.0): based on v6.1.5 but TFPX with more realistic module positions.
+* T31: Phase2 tilted tracker. The tracker description is identical to T24/T21. The outer radius of the tracker volume is reduced to avoid a clash with the BTL geometry. The positions of the tracker components are not affected
 
 Calorimeters:
 * C9: HGCal (v11 post TDR HGCal Geometry w/ corner centering for HE part) + Phase2 HCAL and EB + Tracker cables (used in 2026D49)

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -427,8 +427,7 @@ trackerDict = {
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
         "era" : "phase2_tracker, trackingPhase2PU140",
-    },
-
+    }
 }
 
 

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -390,7 +390,45 @@ trackerDict = {
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
         "era" : "phase2_tracker, trackingPhase2PU140",
-    } 
+    }, 
+    "T31" : {
+        1 : [
+            'Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml',
+            'Geometry/TrackerCommonData/data/pixfwdCommon.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/pixfwd.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_OT800_IT615_2022_10/pixbar.xml',
+            'Geometry/TrackerCommonData/data/trackermaterial.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/tracker.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/OuterTracker616_2020_04/otst.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/pixel.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerbar.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerfwd.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/trackerStructureTopology.xml',
+            'Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/pixelStructureTopology.xml',
+            'Geometry/TrackerSimData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/trackersens.xml',
+            'Geometry/TrackerSimData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/pixelsens.xml',
+            'Geometry/TrackerRecoData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/trackerRecoMaterial.xml',
+            'SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseII/v1/trackingMaterialGroups_ForPhaseII.xml',
+            'Geometry/TrackerSimData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/trackerProdCuts.xml',
+            'Geometry/TrackerSimData/data/PhaseII/Tracker_DD4hep_compatible_2021_02/pixelProdCuts.xml',
+            'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
+        ],
+        "sim" : [
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
+        ],
+        "reco" : [
+            'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
+            'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
+            'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
+            'trackerGeometry.applyAlignment = cms.bool(False)',
+        ],
+        "era" : "phase2_tracker, trackingPhase2PU140",
+    },
+
 }
 
 

--- a/Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_OT800_IT615_2022_10/pixbar.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/Tracker_DD4hep_compatible_OT800_IT615_2022_10/pixbar.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0"?>
+<!--
+============= XML GENERATION METADATA HEADER =============
+tkLayout revision: dev-reduce-tk2souter-3555-6297061
+tkLayout developed by https://github.com/tkLayout/tkLayout/graphs/contributors .
+Adinda De Wit (adewit on lxplus725.cern.ch) responsible for cross-check of the automatically-generated description below.
+generation date: 2022-10-03.12:26:23
+note: see OT800_IT615_2022_10_03.cfg for full config files
+=========== END XML GENERATION METADATA HEADER ===========
+-->
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+  <ConstantsSection label="pixbar.xml" eval="true">
+    <Constant name="zero" value="0.0*fm"/>
+    <Constant name="Rin1" value="2.6*cm"/>
+    <Constant name="Rin2" value="18.00*cm"/>
+    <Constant name="Rin3" value="18.6*cm"/>
+    <Constant name="RinSupTubCab"      value="15.00*cm"/>
+    <Constant name="Zv1" value="22.70*cm"/> <!-- For Tilted Inner Tracker 501: value="41.50*cm"  -->
+    <Constant name="Zv2" value="56.00*cm"/>
+    <Constant name="Zv3" value="110.5*cm"/>
+    <Constant name="Zv4" value="282.0*cm"/>
+    <Constant name="ZvSupTubCab" value="248.0*cm"/>
+    <Constant name="SupportL" value="221.0*cm"/>
+    <Constant name="SupportRin" value="20.2*cm"/> <!-- 21.2*cm-->
+    <Constant name="SupportL_cut" value="[FlangeT]"/>
+    <Constant name="SupportW_cut" value="7.00*cm"/>
+    <Constant name="SupportW" value="20.00*cm"/>
+    <Constant name="SupportT" value="0.350*cm"/>
+    <Constant name="SupportY_base" value="19.00*cm"/>
+    <Constant name="SupportY"          value="[SupportY_base]+[SupportT]/2"/>
+    <Constant name="ShieldL" value="54.0*cm"/>
+    <Constant name="Shield1Rin" value="[FlangeRin]"/>
+    <Constant name="Shield1Rout" value="[FlangeRin]+[ShieldAL_T]"/>
+    <Constant name="Shield2Rout" value="[FlangeRin]+[ShieldAL_T]+[ShieldKevlar_T]"/>
+    <Constant name="Shield3Rin" value="[FlangeRout]-[ShieldAL_T]-[ShieldKevlar_T]"/>
+    <Constant name="Shield3Rout" value="[FlangeRout]-[ShieldKevlar_T]"/>
+    <Constant name="Shield4Rout" value="[FlangeRout]"/>
+    <Constant name="ShieldAL_T" value="0.005*cm"/>
+    <Constant name="ShieldKevlar_T" value="0.025*cm"/>
+    <Constant name="FlangeRin" value="2.500*cm"/>
+    <Constant name="FlangeRout" value="18.980*cm"/>
+    <Constant name="FlangeR12" value="4.900*cm"/>
+    <Constant name="FlangeR23" value="8.850*cm"/>
+    <Constant name="FlangeR34" value="13.450*cm"/>
+    <Constant name="FlangeT_Airex" value="0.400*cm"/>
+    <Constant name="FlangeT_CFK" value="0.020*cm"/>
+    <Constant name="FlangeT" value="[FlangeT_Airex]+2*[FlangeT_CFK]"/>
+    <Constant name="FlangeZ" value="27.22*cm"/>
+    <Constant name="FlangeHCT" value="0.528*cm"/>
+    <Constant name="CableSignal1Rin" value="3.00*cm"/>
+    <Constant name="CableSignal1T1" value="0.00335*cm"/>
+    <Constant name="CableSignal1T2" value="0.02088*cm"/>
+    <Constant name="CableSignal2Rin" value="6.800*cm"/>
+    <Constant name="CableSignal2T1" value="0.0114*cm"/>
+    <Constant name="CableSignal2T2" value="0.03135*cm"/>
+    <Constant name="CableSignal3Rin" value="10.90*cm"/>
+    <Constant name="CableSignal3T1" value="0.0203*cm"/>
+    <Constant name="CableSignal3T2" value="0.034827*cm"/>
+    <Constant name="CableSignal4Rin" value="16.0*cm"/>
+    <Constant name="CableSignal4T1" value="0.0308*cm"/>
+    <Constant name="CableSignal4T2" value="0.035998*cm"/>
+    <Constant name="CableRout" value="18.70*cm"/>
+    <Constant name="CableSignal4Z1" value="[FlangeZ]+[FlangeT]/2+[CoolT]+[CoolRadialDZp]"/>
+    <Constant name="CableSignal4Z2" value="[CableSignal4Z1]+[CableSignal4T1]"/>
+    <Constant name="CableSignal4Z3" value="[CableSignal4Z1]+[CableSignal4T2]"/>
+    <Constant name="CableSignal3Z1" value="[CableSignal4Z3]"/>
+    <Constant name="CableSignal3Z2" value="[CableSignal3Z1]+[CableSignal3T1]"/>
+    <Constant name="CableSignal3Z3" value="[CableSignal3Z1]+[CableSignal3T2]"/>
+    <Constant name="CableSignal2Z1" value="[CableSignal3Z3]"/>
+    <Constant name="CableSignal2Z2" value="[CableSignal2Z1]+[CableSignal2T1]"/>
+    <Constant name="CableSignal2Z3" value="[CableSignal2Z1]+[CableSignal2T2]"/>
+    <Constant name="CableSignal1Z1" value="[CableSignal2Z3]"/>
+    <Constant name="CableSignal1Z2" value="[CableSignal1Z1]+[CableSignal1T1]"/>
+    <Constant name="CableSignal1Z3" value="[CableSignal1Z1]+[CableSignal1T2]"/>
+    <Constant name="CablePower1Rin" value="3.00*cm"/>
+    <Constant name="CablePower1T1" value="0.0098*cm"/>
+    <Constant name="CablePower1T2" value="0.0611*cm"/>
+    <Constant name="CablePower2Rin" value="6.800*cm"/>
+    <Constant name="CablePower2T1" value="0.0334*cm"/>
+    <Constant name="CablePower2T2" value="0.09185*cm"/>
+    <Constant name="CablePower3Rin" value="10.90*cm"/>
+    <Constant name="CablePower3T1" value="0.0593*cm"/>
+    <Constant name="CablePower3T2" value="0.101735*cm"/>
+    <Constant name="CablePower4Rin" value="16.0*cm"/>
+    <Constant name="CablePower4T1" value="0.0902*cm"/>
+    <Constant name="CablePower4T2" value="0.105421*cm"/>
+    <Constant name="CablePower4Z1" value="[CableSignal1Z3]"/>
+    <Constant name="CablePower4Z2" value="[CablePower4Z1]+[CablePower4T1]"/>
+    <Constant name="CablePower4Z3" value="[CablePower4Z1]+[CablePower4T2]"/>
+    <Constant name="CablePower3Z1" value="[CablePower4Z3]"/>
+    <Constant name="CablePower3Z2" value="[CablePower3Z1]+[CablePower3T1]"/>
+    <Constant name="CablePower3Z3" value="[CablePower3Z1]+[CablePower3T2]"/>
+    <Constant name="CablePower2Z1" value="[CablePower3Z3]"/>
+    <Constant name="CablePower2Z2" value="[CablePower2Z1]+[CablePower2T1]"/>
+    <Constant name="CablePower2Z3" value="[CablePower2Z1]+[CablePower2T2]"/>
+    <Constant name="CablePower1Z1" value="[CablePower2Z3]"/>
+    <Constant name="CablePower1Z2" value="[CablePower1Z1]+[CablePower1T1]"/>
+    <Constant name="CablePower1Z3" value="[CablePower1Z1]+[CablePower1T2]"/>
+    <Constant name="CableSignalFlangeToST_L" value="1.680*cm"/>
+    <Constant name="CablePowerFlangeToST_L" value="1.680*cm"/>
+    <Constant name="CableSignalFlangeToST_dR" value="0.087*cm"/>
+    <Constant name="CablePowerFlangeToST_dR" value="0.258*cm"/>
+    <Constant name="CableSignalFlangeToST_Rmin" value="[CableRout]"/>
+    <Constant name="CableSignalFlangeToST_Rmax" value="[CableSignalFlangeToST_Rmin]+[CableSignalFlangeToST_dR]"/>
+    <Constant name="CablePowerFlangeToST_Rmin" value="[CableSignalFlangeToST_Rmax]"/>
+    <Constant name="CablePowerFlangeToST_Rmax" value="[CablePowerFlangeToST_Rmin]+[CablePowerFlangeToST_dR]"/>
+    <Constant name="PixelBarrelCableSignal_FlangeToST_Z" value="[FlangeZ]+[FlangeT]/2+[CableSignalFlangeToST_L]/2"/>
+    <Constant name="PixelBarrelCablePower_FlangeToST_Z" value="[FlangeZ]+[FlangeT]/2+[CablePowerFlangeToST_L]/2"/>
+    <Constant name="PipeFlangeToST_L" value="1.680*cm"/>
+    <Constant name="PipeFlangeToST_dR" value="0.0742*cm"/>
+    <Constant name="PipeFlangeToST_Rmin" value="[CablePowerFlangeToST_Rmax]"/>
+    <Constant name="PipeFlangeToST_Rmax" value="[PipeFlangeToST_Rmin]+[PipeFlangeToST_dR]"/>
+    <Constant name="PixelBarrelPipe_FlangeToST_Z" value="[FlangeZ]+[FlangeT]/2+[PipeFlangeToST_L]/2"/>
+    <Constant name="Conn1T" value="0.190*cm"/>
+    <Constant name="Cool1Rin" value="3.0*cm"/>
+    <Constant name="Cool2Rin" value="6.80*cm"/>
+    <Constant name="Cool3Rin" value="10.90*cm"/>
+    <Constant name="Cool4Rin" value="16.00*cm"/>
+    <Constant name="CoolRout" value="18.70*cm"/>
+    <Constant name="Cool1DRZp" value="0.195*cm"/>
+    <Constant name="Cool1DRZm" value="0.245*cm"/>
+    <Constant name="Cool2DRZp" value="0.178*cm"/>
+    <Constant name="Cool2DRZm" value="0.240*cm"/>
+    <Constant name="Cool3DRZp" value="0.170*cm"/>
+    <Constant name="Cool3DRZm" value="0.227*cm"/>
+    <Constant name="Cool4DRZp" value="0.1685*cm"/>
+    <Constant name="Cool4DRZm" value="0.221*cm"/>
+    <Constant name="CoolRadialDZp" value="0.00439*cm"/>
+    <Constant name="CoolRadialDZm" value="0.00365*cm"/>
+    <Constant name="CoolT" value="0.050*cm"/>
+    <Constant name="CoolZ" value="[FlangeZ]+[FlangeT]/2+[CoolT]/2"/>
+    <Constant name="CoolRadialZp" value="[CoolZ]+[CoolT]/2+[CoolRadialDZp]/2"/>
+    <Constant name="CoolRadialZm" value="[CoolZ]+[CoolT]/2+[CoolRadialDZm]/2"/>
+    <Constant name="Cool1RoutZp" value="[Cool1Rin]+[Cool1DRZp]"/>
+    <Constant name="Cool2RoutZp" value="[Cool2Rin]+[Cool2DRZp]"/>
+    <Constant name="Cool3RoutZp" value="[Cool3Rin]+[Cool3DRZp]"/>
+    <Constant name="Cool4RoutZp" value="[Cool4Rin]+[Cool4DRZp]"/>
+    <Constant name="Cool1RoutZm" value="[Cool1Rin]+[Cool1DRZm]"/>
+    <Constant name="Cool2RoutZm" value="[Cool2Rin]+[Cool2DRZm]"/>
+    <Constant name="Cool3RoutZm" value="[Cool3Rin]+[Cool3DRZm]"/>
+    <Constant name="Cool4RoutZm" value="[Cool4Rin]+[Cool4DRZm]"/>
+    <Constant name="Conn1Rin" value="12.00*cm"/>
+    <Constant name="Conn2Rin" value="11.00*cm"/>
+    <Constant name="Conn1Z" value="[FlangeZ]-[FlangeT]/2-[Conn1T]/2"/>
+    <Constant name="Conn2Z" value="[FlangeZ]+[FlangeT]/2+[Conn1T]/2"/>
+    <Constant name="ConnToSTT" value="3.00*cm"/>
+    <Constant name="ConnToSTRin" value="18.0*cm"/>
+    <Constant name="ConnToSTRout" value="18.8*cm"/>
+    <Constant name="RadialCoolZ" value="29.5*cm"/>
+    <Constant name="RadialCoolDZ" value="1.0*cm"/>
+    <Constant name="RadialCoolRin" value="4.0*cm"/>
+    <Constant name="Tracker2SOuterRadius" value="114.0*cm"/>
+  </ConstantsSection>
+  <RotationSection label="pixbar.xml">
+    <Rotation name="180D" thetaX="90*deg" phiX="180*deg" thetaY="90*deg" phiY="90*deg" thetaZ="180*deg" phiZ="0*deg"/>
+  </RotationSection>
+  <SolidSection label="pixbar.xml">
+    <Polycone name="Barrel" startPhi="0*deg" deltaPhi="360*deg">  <!-- TEMPORARY!! Should be defined automatically -->
+      <ZSection z="-125.0*cm" rMin="[pixfwd:TBPXAndTFPXOuterRadius]" rMax="[Tracker2SOuterRadius]"/>
+      <ZSection z="-[Zv1]" rMin="[pixfwd:TBPXAndTFPXOuterRadius]" rMax="[Tracker2SOuterRadius]"/>
+      <ZSection z="-[Zv1]" rMin="[Rin1]" rMax="[Tracker2SOuterRadius]"/>
+      <ZSection z="[Zv1]" rMin="[Rin1]" rMax="[Tracker2SOuterRadius]"/>
+      <ZSection z="[Zv1]" rMin="[pixfwd:TBPXAndTFPXOuterRadius]" rMax="[Tracker2SOuterRadius]"/>
+      <ZSection z="125.0*cm" rMin="[pixfwd:TBPXAndTFPXOuterRadius]" rMax="[Tracker2SOuterRadius]"/>
+    </Polycone>
+    <Polycone name="Phase2PixelBarrel" startPhi="0*deg" deltaPhi="360*deg">
+      <ZSection z="-[Zv1]"         rMin="[Rin1]"          rMax="[pixfwd:TBPXAndTFPXOuterRadius]" />
+      <ZSection z="[Zv1]"          rMin="[Rin1]"          rMax="[pixfwd:TBPXAndTFPXOuterRadius]" />
+    </Polycone>
+    <SubtractionSolid name="Phase2OTBarrel">
+      <rSolid name="Barrel"/>
+      <rSolid name="Phase2PixelBarrel"/>
+      <Translation x="0*cm" y="0*cm" z="0*cm"/>
+    </SubtractionSolid> 
+  </SolidSection>
+  <LogicalPartSection label="pixbar.xml">
+    <LogicalPart name="Phase2PixelBarrel" category="unspecified">
+      <rSolid name="Phase2PixelBarrel"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+    <LogicalPart name="Phase2OTBarrel" category="unspecified">
+      <rSolid name="Phase2OTBarrel"/>
+      <rMaterial name="materials:Air"/>
+    </LogicalPart>
+  </LogicalPartSection>
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

This adds a new tracker (T31) that is identical to T24, except for the outer radius of the tracker volume, which is reduced by 2cm to avoid clashes with the BTL in a soon-to-be integrated development on the MTD geometry.

This does not affect the positions of any of the tracker components.

The PR only adds this new tracker, so that the addition of a detector description and workflows using this tracker can be left for the integration of the new MTD geometry.

FYI @emiglior @fabiocos 

#### PR validation:

Ran code-checks and code-format. It was checked that the reduction of this volume is harmless for the positioning of tracker components

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
