### PR TITLE
[12.4.X] zeroing error of Pixel barycenter ME and other optimizations 

### DIFF
--- a/DQM/SiPixelPhase1Summary/interface/SiPixelBarycenter.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelBarycenter.h
@@ -37,7 +37,7 @@
 class SiPixelBarycenter : public DQMEDHarvester {
 public:
   explicit SiPixelBarycenter(const edm::ParameterSet& conf);
-  ~SiPixelBarycenter() override;
+  ~SiPixelBarycenter() override = default;
 
 protected:
   void beginRun(edm::Run const& run, edm::EventSetup const& eSetup) override;
@@ -54,6 +54,9 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
 
   std::map<std::string, MonitorElement*> barycenters_;
+
+  const std::array<std::string, 9> subdetectors_ = {
+      {"BPIX", "FPIX_zm", "FPIX_zp", "BPIX_xp", "BPIX_xm", "FPIX_zp_xp", "FPIX_zm_xp", "FPIX_zp_xm", "FPIX_zm_xm"}};
 
   //book the barycenter histograms
   void bookBarycenterHistograms(DQMStore::IBooker& iBooker);

--- a/DQM/SiPixelPhase1Summary/src/SiPixelBarycenter.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelBarycenter.cc
@@ -33,12 +33,6 @@ SiPixelBarycenter::SiPixelBarycenter(const edm::ParameterSet& iConfig)
   LogInfo("PixelDQM") << "SiPixelBarycenter::SiPixelBarycenter: Got DQM BackEnd interface" << endl;
 }
 
-SiPixelBarycenter::~SiPixelBarycenter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-  LogInfo("PixelDQM") << "SiPixelBarycenter::~SiPixelBarycenter: Destructor" << endl;
-}
-
 void SiPixelBarycenter::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {}
 
 void SiPixelBarycenter::dqmEndJob(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter) {}
@@ -63,8 +57,7 @@ void SiPixelBarycenter::bookBarycenterHistograms(DQMStore::IBooker& iBooker) {
 
   iBooker.setCurrentFolder("PixelPhase1/Barycenter");
   //Book one histogram for each subdetector
-  for (std::string subdetector :
-       {"BPIX", "FPIX_zm", "FPIX_zp", "BPIX_xp", "BPIX_xm", "FPIX_zp_xp", "FPIX_zm_xp", "FPIX_zp_xm", "FPIX_zm_xm"}) {
+  for (const std::string& subdetector : subdetectors_) {
     barycenters_[subdetector] =
         iBooker.book1D("barycenters_" + subdetector,
                        "Position of the barycenter for " + subdetector + ";Coordinate;Position [mm]",
@@ -101,12 +94,15 @@ void SiPixelBarycenter::fillBarycenterHistograms(DQMStore::IBooker& iBooker,
   auto Zbarycenters = barycenters.getZ();
 
   //Fill histogram for each subdetector
-  std::vector<std::string> subdetectors = {
-      "BPIX", "FPIX_zm", "FPIX_zp", "BPIX_xp", "BPIX_xm", "FPIX_zp_xp", "FPIX_zm_xp", "FPIX_zp_xm", "FPIX_zm_xm"};
-  for (std::size_t i = 0; i < subdetectors.size(); ++i) {
-    barycenters_[subdetectors[i]]->setBinContent(1, Xbarycenters[i]);
-    barycenters_[subdetectors[i]]->setBinContent(2, Ybarycenters[i]);
-    barycenters_[subdetectors[i]]->setBinContent(3, Zbarycenters[i]);
+  for (std::size_t i = 0; i < subdetectors_.size(); ++i) {
+    barycenters_[subdetectors_[i]]->setBinContent(1, Xbarycenters[i]);
+    barycenters_[subdetectors_[i]]->setBinContent(2, Ybarycenters[i]);
+    barycenters_[subdetectors_[i]]->setBinContent(3, Zbarycenters[i]);
+
+    // zero the errors for better comparison display
+    barycenters_[subdetectors_[i]]->setBinError(1, 0.);
+    barycenters_[subdetectors_[i]]->setBinError(2, 0.);
+    barycenters_[subdetectors_[i]]->setBinError(3, 0.);
   }
 }
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/39448

#### PR description:

Title says is all, to allow cleaner pixel barycenter comparisons when validating conditions updates, cf e.g.: https://tinyurl.com/2nupfvg2 .
Profited to add a couple of minor code optimizations.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/39448 for data-taking purposes
