### PR TITLE
[MUO] Suppress excessive warnings in muon tracking at HLT

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -227,7 +227,7 @@ MuonCandidate::CandidateContainer GlobalTrajectoryBuilderBase::build(const Track
         if (!refitted0.empty())
           tkTrajectory = std::make_unique<Trajectory>(*(refitted0.begin()));
         else
-          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+          LogDebug(theCategory) << "     Failed to load tracker track trajectory";
       } else
         tkTrajectory = it->releaseTrackerTrajectory();
       if (tkTrajectory)
@@ -263,7 +263,7 @@ MuonCandidate::CandidateContainer GlobalTrajectoryBuilderBase::build(const Track
         if (!refitted0.empty()) {
           tkTrajectory = std::make_unique<Trajectory>(*(refitted0.begin()));
         } else
-          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+          LogDebug(theCategory) << "     Failed to load tracker track trajectory";
       } else
         tkTrajectory = it->releaseTrackerTrajectory();
       std::unique_ptr<Trajectory> cpy;


### PR DESCRIPTION
#### PR description:

Follow-up PR for issue https://github.com/cms-sw/cmssw/issues/39234

Demoting the warning message for an empty trajectory in `RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc` from `LogWarning` to `LogDebug`.
The warning mostly occurs when there are insufficient hits (< 7) to rebuild the trajectory.
No impact on muon tracking performance is expected.

#### PR validation:

Tested in `CMSSW_12_6_X_2022-10-03-1100` using the following menu

```
hltGetConfiguration /dev/CMSSW_12_4_0/GRun \
--eras Run3 \
--globaltag 124X_dataRun3_HLT_forTSG_newJECs_v1 \
--data \
--unprescale \
--output none \
--max-events 1000 \
--l1-emulator uGT --l1 L1Menu_Collisions2022_v1_3_0-d1_xml \
--input root://eoscms.cern.ch//eos/cms/store/data/Run2022C/Muon/RAW/v1/000/356/578/00000/fbf0187b-2564-4dd1-bee8-eccb0a4c8086.root
```

Before update:
```
Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
Info               150096              150096
FwkInfo            195203              195203
Warning               617                 617
Error                  41                  41
System                  3                   3
```

After update:
```
Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
Info               150096              150096
FwkInfo            195203              195203
Warning                 5                   5
Error                  41                  41
System                  3                   3
```
