### PR TITLE
[HGCAL] Fix search box eta phi

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLLayerTile.h
+++ b/DataFormats/HGCalReco/interface/TICLLayerTile.h
@@ -34,10 +34,21 @@ public:
   }
 
   std::array<int, 4> searchBoxEtaPhi(float etaMin, float etaMax, float phiMin, float phiMax) const {
+    // The tile only handles one endcap at a time and does not hold mixed eta
+    // values.
+    if (etaMin * etaMax < 0) {
+      return std::array<int, 4>({{0, 0, 0, 0}});
+    }
+    if (etaMax - etaMin < 0) {
+      return std::array<int, 4>({{0, 0, 0, 0}});
+    }
     int etaBinMin = etaBin(etaMin);
     int etaBinMax = etaBin(etaMax);
     int phiBinMin = phiBin(phiMin);
     int phiBinMax = phiBin(phiMax);
+    if (etaMin < 0) {
+      std::swap(etaBinMin, etaBinMax);
+    }
     // If the search window cross the phi-bin boundary, add T::nPhiBins to the
     // MAx value. This guarantees that the caller can perform a valid doule
     // loop on eta and phi. It is the caller responsibility to perform a module

--- a/DataFormats/HGCalReco/test/BuildFile.xml
+++ b/DataFormats/HGCalReco/test/BuildFile.xml
@@ -1,3 +1,4 @@
 <bin   name="EtaPhiSearchInTile" file="EtaPhiSearchInTile_t.cpp">
+  <use name="catch2"/>
   <use name="DataFormats/HGCalReco" />
 </bin>

--- a/DataFormats/HGCalReco/test/EtaPhiSearchInTile_t.cpp
+++ b/DataFormats/HGCalReco/test/EtaPhiSearchInTile_t.cpp
@@ -4,15 +4,12 @@
 
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
 
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
 using namespace ticl;
 
-void runTest(TICLLayerTile const& t, int expected, float etaMin, float etaMax, float phiMin, float phiMax) {
-  auto limits = t.searchBoxEtaPhi(etaMin, etaMax, phiMin, phiMax);
-
-  std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
-  assert(limits[0] <= limits[1]);
-  assert(limits[2] <= limits[3]);
-
+int countEntries(const TICLLayerTile &t, const std::array<int, 4> &limits) {
   int entries = 0;
   for (int e = limits[0]; e <= limits[1]; ++e) {
     for (int p = limits[2]; p <= limits[3]; ++p) {
@@ -21,40 +18,149 @@ void runTest(TICLLayerTile const& t, int expected, float etaMin, float etaMax, f
       entries += t[global_bin].size();
     }
   }
-
-  std::cout << "Found " << entries << " entries, expected " << expected << std::endl;
-  assert(entries == expected);
+  return entries;
 }
 
-int main(int argc, char* argv[]) {
+TEST_CASE("Check the correct phi wrapping", "searchBoxEtaPhi") {
   auto constexpr phiBins = TICLLayerTile::type::nPhiBins;
   auto constexpr phi_bin_width = 2. * M_PI / phiBins;
-  auto constexpr phi_transition_left = M_PI - phi_bin_width;
-  auto constexpr phi_transition_right = M_PI + phi_bin_width;
-  auto constexpr phi_transition_right2 = -M_PI + 3. * phi_bin_width;
+  auto constexpr phi_transition_left = M_PI - phi_bin_width / 2.;
+  auto constexpr phi_transition_right = M_PI + phi_bin_width / 2.;
+  auto constexpr phi_transition_right2 = -M_PI + 3. * phi_bin_width / 2.;
+  auto constexpr phi_transition_right3 = M_PI + 3. * phi_bin_width / 2.;
   unsigned int constexpr entries_left = 11;
   unsigned int constexpr entries_right = 7;
-  float constexpr eta = 2.0;
+  float constexpr eta = 2.0f;
+  float constexpr eta_neg = -2.4f;
 
-  TICLLayerTile t, t2;
+  TICLLayerTile t, t2, t_neg;
   std::cout << "Testing a Tile with " << phiBins << " bins with binwidth: " << phi_bin_width << " at bin transition"
             << std::endl;
   std::cout << "Filling left-pi bin: " << t.phiBin(phi_transition_left) << std::endl;
   std::cout << "Filling right-pi bin: " << t.phiBin(phi_transition_right) << std::endl;
   std::cout << "Filling right2-pi bin: " << t.phiBin(phi_transition_right2) << std::endl;
+  std::cout << "Filling right3-pi bin: " << t.phiBin(phi_transition_right3) << std::endl;
 
   for (unsigned int i = 0; i < entries_left; ++i) {
     t.fill(eta, phi_transition_left, i);
     t2.fill(eta, phi_transition_left, i);
+    t_neg.fill(eta_neg, phi_transition_left, i);
   }
 
   for (unsigned int i = 0; i < entries_right; ++i) {
     t.fill(eta, phi_transition_right, i);
     t2.fill(eta, phi_transition_right2, i);
+    t_neg.fill(eta_neg, phi_transition_right, i);
   }
 
-  runTest(t, entries_left + entries_right, 1.95, 2.05, phi_transition_left, phi_transition_right);
-  runTest(t2, entries_left + entries_right, 1.95, 2.05, phi_transition_left, phi_transition_right2);
+  SECTION("Phi bins from positive and negative pi") {
+    REQUIRE(t.phiBin(phi_transition_right2) == t.phiBin(phi_transition_right3));
+  }
 
-  return 0;
+  SECTION("Symmetric case around pi") {
+    auto limits = t.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Asymmetric case around pi, negative") {
+    auto limits = t2.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t2, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Asymmetric case around pi, positive") {
+    auto limits = t2.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right3);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t2, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Correct all negative eta searchRange") {
+    auto limits = t_neg.searchBoxEtaPhi(-2.45, -2.35, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t_neg, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Correct all positive overflow eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(0., 5., phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Wrong mixed signs (neg,pos) eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(-2.05, 1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Wrong mixed signs (pos,neg) eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(2.05, -1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Wrong all positive eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(2.05, 1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Wrong all negative eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(-1.95, -2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
 }

--- a/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
+++ b/RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h
@@ -90,6 +90,9 @@ public:
   }
 
   std::array<int, 4> searchBoxEtaPhi(float etaMin, float etaMax, float phiMin, float phiMax) const {
+    if (etaMax - etaMin < 0) {
+      return std::array<int, 4>({{0, 0, 0, 0}});
+    }
     int etaBinMin = getEtaBin(etaMin);
     int etaBinMax = getEtaBin(etaMax);
     int phiBinMin = getPhiBin(phiMin);

--- a/RecoLocalCalo/HGCalRecProducers/test/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/test/BuildFile.xml
@@ -1,3 +1,4 @@
 <bin   name="EtaPhiSearchInTileLC" file="EtaPhiSearchInTile_t.cpp">
   <use name="RecoLocalCalo/HGCalRecProducers" />
+  <use name="catch2" />
 </bin>

--- a/RecoLocalCalo/HGCalRecProducers/test/EtaPhiSearchInTile_t.cpp
+++ b/RecoLocalCalo/HGCalRecProducers/test/EtaPhiSearchInTile_t.cpp
@@ -4,13 +4,10 @@
 
 #include "RecoLocalCalo/HGCalRecProducers/interface/HGCalLayerTiles.h"
 
-void runTest(HGCalLayerTiles const& t, int expected, float etaMin, float etaMax, float phiMin, float phiMax) {
-  auto limits = t.searchBoxEtaPhi(etaMin, etaMax, phiMin, phiMax);
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
-  std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
-  assert(limits[0] <= limits[1]);
-  assert(limits[2] <= limits[3]);
-
+int countEntries(const HGCalLayerTiles &t, const std::array<int, 4> &limits) {
   int entries = 0;
   for (int e = limits[0]; e <= limits[1]; ++e) {
     for (int p = limits[2]; p <= limits[3]; ++p) {
@@ -19,25 +16,29 @@ void runTest(HGCalLayerTiles const& t, int expected, float etaMin, float etaMax,
       entries += t[global_bin].size();
     }
   }
-
-  std::cout << "Found " << entries << " entries, expected " << expected << std::endl;
-  assert(entries == expected);
+  return entries;
 }
 
-int main(int argc, char* argv[]) {
-  auto constexpr phiBins = HGCalLayerTiles::type::nRowsPhi;
+TEST_CASE("Check the correct behaviour of searchBoxEtaPhi", "searchBoxEtaPhi") {
+  using T = HGCalLayerTiles::type;
+  auto constexpr phiBins = T::nRowsPhi;
+  auto constexpr etaBins = T::nColumnsEta;
   auto constexpr phi_bin_width = 2. * M_PI / phiBins;
-  auto constexpr phi_transition_left = M_PI - 3. * phi_bin_width;
-  auto constexpr phi_transition_right = M_PI + 3. * phi_bin_width;
-  auto constexpr phi_transition_right2 = -M_PI + 5. * phi_bin_width;
+  auto constexpr eta_bin_width = (T::maxEta - T::minEta) / etaBins;
+  auto constexpr phi_transition_left = M_PI - 3. * phi_bin_width / 2.;
+  auto constexpr phi_transition_right = M_PI + 3. * phi_bin_width / 2.;
+  auto constexpr phi_transition_right2 = -M_PI + 5. * phi_bin_width / 2.;
+  auto constexpr phi_transition_right3 = M_PI + 5. * phi_bin_width / 2.;
   unsigned int constexpr entries_left = 11;
   unsigned int constexpr entries_right = 7;
-  float constexpr eta = 2.0;
+  float constexpr eta = 2.0f;
+  float constexpr eta_neg = -2.4f;
 
   // Force filling using eta/phi vectors
   std::vector<bool> isSilicon(entries_left + entries_right, false);
   std::vector<float> dummy(entries_left + entries_right, 0.);
   std::vector<float> etas(entries_left + entries_right, eta);
+  std::vector<float> etas_neg(entries_left + entries_right, eta_neg);
   std::vector<float> phis_left(entries_left, phi_transition_left);
   std::vector<float> phis_right(entries_right, phi_transition_right);
   std::vector<float> phis_right2(entries_right, phi_transition_right2);
@@ -50,13 +51,18 @@ int main(int argc, char* argv[]) {
   phis2.insert(phis2.end(), phis_left.begin(), phis_left.end());
   phis2.insert(phis2.end(), phis_right2.begin(), phis_right2.end());
 
-  HGCalLayerTiles t, t2;
+  HGCalLayerTiles t, t2, t_neg;
   t.fill(dummy, dummy, etas, phis, isSilicon);
   t2.fill(dummy, dummy, etas, phis2, isSilicon);
+  t_neg.fill(dummy, dummy, etas_neg, phis2, isSilicon);
 
-  std::cout << "Testing a Tile with " << phiBins << " bins with binwidth: " << phi_bin_width << " at pi transition"
+  std::cout << "Testing a Tile with " << phiBins << " phi bins with binwidth: " << phi_bin_width << " at pi transition"
             << std::endl;
+  std::cout << "Testing a Tile with " << etaBins << " eta bins with binwidth: " << eta_bin_width << std::endl;
+
   std::cout << "-M_PI bin: " << t.mPiPhiBin << " M_PI bin: " << t.pPiPhiBin << std::endl;
+  std::cout << "Filling positive eta value: " << eta << " at bin: " << t.getEtaBin(eta) << std::endl;
+  std::cout << "Filling negative eta value: " << eta_neg << " at bin: " << t.getEtaBin(eta_neg) << std::endl;
   std::cout << "Filling phi value: " << phi_transition_left << " at left-pi bin: " << t.getPhiBin(phi_transition_left)
             << std::endl;
   std::cout << "Filling phi value: " << phi_transition_right
@@ -64,8 +70,134 @@ int main(int argc, char* argv[]) {
   std::cout << "Filling phi value: " << phi_transition_right2
             << " at right-pi bin: " << t.getPhiBin(phi_transition_right2) << std::endl;
 
-  runTest(t, entries_right + entries_left, 1.95, 2.05, phi_transition_left, phi_transition_right);
-  runTest(t2, entries_right + entries_left, 1.95, 2.05, phi_transition_left, phi_transition_right2);
+  SECTION("Phi bins from positive and negative pi") {
+    REQUIRE(t.getPhiBin(phi_transition_right2) == t.getPhiBin(phi_transition_right3));
+  }
 
-  return 0;
+  SECTION("Symmetric case around pi") {
+    auto limits = t.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Asymmetric case around pi, negative") {
+    auto limits = t2.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t2, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Asymmetric case around pi, positive") {
+    auto limits = t2.searchBoxEtaPhi(1.95, 2.05, phi_transition_left, phi_transition_right3);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t2, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Correct all negative eta searchRange") {
+    auto limits = t_neg.searchBoxEtaPhi(-2.45, -2.35, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t_neg, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Mixed signs (neg,pos) eta with no entries searchRange") {
+    auto limits = t.searchBoxEtaPhi(-2.05, 1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Mixed signs (neg,pos) eta with all entries searchRange") {
+    auto limits = t.searchBoxEtaPhi(-2.05, 2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Mixed signs (neg,pos) eta with all entries negative eta searchRange") {
+    auto limits = t_neg.searchBoxEtaPhi(-2.45, 2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t_neg, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Mixed signs (neg,pos) eta with all entries overflow eta searchRange") {
+    auto limits = t_neg.searchBoxEtaPhi(-5., 5., phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] <= limits[1]);
+    REQUIRE(limits[2] <= limits[3]);
+
+    auto entries = countEntries(t_neg, limits);
+    REQUIRE(entries == entries_left + entries_right);
+  }
+
+  SECTION("Wrong mixed signs (pos,neg) eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(2.05, -1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Wrong all positive eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(2.05, 1.95, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
+
+  SECTION("Wrong all negative eta searchRange") {
+    auto limits = t.searchBoxEtaPhi(-1.95, -2.05, phi_transition_left, phi_transition_right2);
+
+    std::cout << "Limits are: " << limits[0] << " " << limits[1] << " " << limits[2] << " " << limits[3] << std::endl;
+    REQUIRE(limits[0] == limits[1]);
+    REQUIRE(limits[2] == limits[3]);
+    REQUIRE(limits[0] == 0);
+    REQUIRE(limits[2] == 0);
+
+    auto entries = countEntries(t, limits);
+    REQUIRE(entries == 0);
+  }
 }


### PR DESCRIPTION
#### PR description:

Properly handle negative eta values in calls to `searchBoxEtaPhi` of the `Tile` data structures.
Rewrite unit tests to check its validity.

#### PR validation:

Unit tests run fine.
Expect no regression.
