### PR TITLE
Option to make track covariance Pos-def in packedcandidate

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -782,7 +782,7 @@ namespace pat {
 
     /// Return reference to a pseudo track made with candidate kinematics,
     /// parameterized error for eta,phi,pt and full IP covariance
-    virtual const reco::Track &pseudoTrack(bool forcePosDef=false) const {
+    virtual const reco::Track &pseudoTrack(bool forcePosDef = false) const {
       if (!track_)
         unpackTrk(forcePosDef);
       return *track_;
@@ -1034,7 +1034,7 @@ namespace pat {
       if (!track_)
         unpackTrk();
     }
-    void maybeUnpackCovariance(bool forcePosDef=false) const {
+    void maybeUnpackCovariance(bool forcePosDef = false) const {
       if (!m_)
         unpackCovariance(forcePosDef);
     }
@@ -1048,7 +1048,7 @@ namespace pat {
       unpackVtx();
     }  // do it this way, so that we don't loose precision on the angles before
     // computing dxy,dz
-    void unpackTrk(bool forcePosDef=false) const;
+    void unpackTrk(bool forcePosDef = false) const;
 
     uint8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_;  // storing the DIFFERENCE of (all - "no

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -782,15 +782,15 @@ namespace pat {
 
     /// Return reference to a pseudo track made with candidate kinematics,
     /// parameterized error for eta,phi,pt and full IP covariance
-    virtual const reco::Track &pseudoTrack(bool forcePosDef = false) const {
+    virtual const reco::Track &pseudoTrack() const {
       if (!track_)
-        unpackTrk(forcePosDef);
+        unpackTrk();
       return *track_;
     }
-    virtual void resetPseudoTrack() const {
-      delete m_.exchange(nullptr);
-      delete track_.exchange(nullptr);
-    }
+    /// Return reference to a pseudo track made with candidate kinematics,
+    /// parameterized error for eta,phi,pt and full IP covariance
+    /// and the coviriance matrix is forced to be positive definite according to BPH recommandations
+    virtual const reco::Track pseudoPosDefTrack() const;
 
     /// return a pointer to the track if present. otherwise, return a null pointer
     const reco::Track *bestTrack() const override {
@@ -1023,7 +1023,7 @@ namespace pat {
     void packVtx(bool unpackAfterwards = true);
     void unpackVtx() const;
     void packCovariance(const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards = true);
-    void unpackCovariance(bool forcePosDef = false) const;
+    void unpackCovariance() const;
     void maybeUnpackBoth() const {
       if (!p4c_)
         unpack();
@@ -1034,9 +1034,9 @@ namespace pat {
       if (!track_)
         unpackTrk();
     }
-    void maybeUnpackCovariance(bool forcePosDef = false) const {
+    void maybeUnpackCovariance() const {
       if (!m_)
-        unpackCovariance(forcePosDef);
+        unpackCovariance();
     }
     void packBoth() {
       pack(false);
@@ -1048,7 +1048,7 @@ namespace pat {
       unpackVtx();
     }  // do it this way, so that we don't loose precision on the angles before
     // computing dxy,dz
-    void unpackTrk(bool forcePosDef = false) const;
+    void unpackTrk() const;
 
     uint8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_;  // storing the DIFFERENCE of (all - "no

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -1023,7 +1023,7 @@ namespace pat {
     void packVtx(bool unpackAfterwards = true);
     void unpackVtx() const;
     void packCovariance(const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards = true);
-    void unpackCovariance(bool forcePosDef = true) const;
+    void unpackCovariance(bool forcePosDef = false) const;
     void maybeUnpackBoth() const {
       if (!p4c_)
         unpack();

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -782,10 +782,14 @@ namespace pat {
 
     /// Return reference to a pseudo track made with candidate kinematics,
     /// parameterized error for eta,phi,pt and full IP covariance
-    virtual const reco::Track &pseudoTrack() const {
+    virtual const reco::Track &pseudoTrack(bool forcePosDef=false) const {
       if (!track_)
-        unpackTrk();
+        unpackTrk(forcePosDef);
       return *track_;
+    }
+    virtual void resetPseudoTrack() const {
+      delete m_.exchange(nullptr);
+      delete track_.exchange(nullptr);
     }
 
     /// return a pointer to the track if present. otherwise, return a null pointer
@@ -1019,7 +1023,7 @@ namespace pat {
     void packVtx(bool unpackAfterwards = true);
     void unpackVtx() const;
     void packCovariance(const reco::TrackBase::CovarianceMatrix &m, bool unpackAfterwards = true);
-    void unpackCovariance() const;
+    void unpackCovariance(bool forcePosDef = true) const;
     void maybeUnpackBoth() const {
       if (!p4c_)
         unpack();
@@ -1030,9 +1034,9 @@ namespace pat {
       if (!track_)
         unpackTrk();
     }
-    void maybeUnpackCovariance() const {
+    void maybeUnpackCovariance(bool forcePosDef=false) const {
       if (!m_)
-        unpackCovariance();
+        unpackCovariance(forcePosDef);
     }
     void packBoth() {
       pack(false);
@@ -1044,7 +1048,7 @@ namespace pat {
       unpackVtx();
     }  // do it this way, so that we don't loose precision on the angles before
     // computing dxy,dz
-    void unpackTrk() const;
+    void unpackTrk(bool forcePosDef=false) const;
 
     uint8_t packedPuppiweight_;
     int8_t packedPuppiweightNoLepDiff_;  // storing the DIFFERENCE of (all - "no

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -179,7 +179,7 @@ const reco::Track pat::PackedCandidate::pseudoPosDefTrack() const {
                    (!(*m_).Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!(*m_).Det(det) || det < 0);
 
   if (notPosDef) {
-    std::cout << "during unpacking, the determinant is: " << det << std::endl;
+    //    std::cout << "during unpacking, the determinant is: " << det << std::endl;
     reco::TrackBase::CovarianceMatrix m(*m_);
     //if not positive-definite, alter values to allow for pos-def
     TMatrixDSym eigenCov(5);
@@ -200,10 +200,10 @@ const reco::Track pat::PackedCandidate::pseudoPosDefTrack() const {
         m(i, i) += delta - minEigenValue;
     }
 
-    bool notPosDef = (!m.Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det < 0) ||
-                     (!m.Sub<AlgebraicSymMatrix33>(0, 0).Det(det) || det < 0) ||
-                     (!m.Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!m.Det(det) || det < 0);
-    std::cout << "    the determinant of the corrected covariance matrix is: " << det << std::endl;
+    //    bool notPosDef = (!m.Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det < 0) ||
+    //                 (!m.Sub<AlgebraicSymMatrix33>(0, 0).Det(det) || det < 0) ||
+    //                 (!m.Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!m.Det(det) || det < 0);
+    //    std::cout << "    the determinant of the corrected covariance matrix is: " << det << std::endl;
     // make a track object with pos def covariance matrix
     return reco::Track(normalizedChi2_ * (*track_).ndof(),
                        (*track_).ndof(),

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -113,10 +113,9 @@ void pat::PackedCandidate::unpackCovariance(bool forcePosDef) const {
       //      std::cout<<"unpacking enforcing positive-definite cov matrix"<<std::endl;
       //calculate the determinant and verify positivity
       double det = 0;
-      bool notPosDef = (!m->Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det<0)
-	|| (!m->Sub<AlgebraicSymMatrix33>(0, 0).Det(det) || det<0)
-	|| (!m->Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det<0)
-	|| (!m->Det(det) || det<0);
+      bool notPosDef = (!m->Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det < 0) ||
+                       (!m->Sub<AlgebraicSymMatrix33>(0, 0).Det(det) || det < 0) ||
+                       (!m->Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!m->Det(det) || det < 0);
       //      std::cout<<"during unpacking, the determinant is: "<<det<<std::endl;
       if (notPosDef) {
         //if not positive-definite, alter values to allow for pos-def
@@ -125,7 +124,7 @@ void pat::PackedCandidate::unpackCovariance(bool forcePosDef) const {
           for (int j = 0; j < 5; j++) {
             if (std::isnan((*m)(i, j)) || std::isinf((*m)(i, j)))
               eigenCov(i, j) = 1e-6;
-	    else
+            else
               eigenCov(i, j) = (*m)(i, j);
           }
         }
@@ -138,7 +137,7 @@ void pat::PackedCandidate::unpackCovariance(bool forcePosDef) const {
             (*m)(i, i) += delta - minEigenValue;
         }
 
-	//        computed_ = m->Det(det);
+        //        computed_ = m->Det(det);
         //	std::cout<<"    the determinant of the corrected covariance matrix is: "<<det<<std::endl;
       }
     }

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -109,39 +109,39 @@ void pat::PackedCandidate::unpackCovariance(bool forcePosDef) const {
     unpackCovarianceElement(*m, packedCovariance_.dlambdadz, 1, 4);
     unpackCovarianceElement(*m, packedCovariance_.dphidxy, 2, 3);
 
-    if (forcePosDef){
+    if (forcePosDef) {
       //      std::cout<<"unpacking enforcing positive-definite cov matrix"<<std::endl;
       //calculate the determinant and verify positivity
       double det_(0);
       bool computed_ = m->Det(det_);
       //      std::cout<<"during unpacking, the determinant is: "<<det_<<std::endl;
-      if (computed_ && det_<0){
-	//if not positive-definite, alter values to allow for pos-def
-	TMatrixDSym COV(5);
-	for (int i = 0; i < 5; i++){
-	  for (int j = 0; j < 5; j++){
-	    if (std::isnan((*m)(i,j)) || std::isinf((*m)(i,j))){
-	      COV(i, j) = 1e-6;
-	    }else{
-	      COV(i,j) = (*m)(i,j);
-	    }
-	  }
-	}
-	TVectorD EIG(5);
-	COV.EigenVectors(EIG);
-	double MIN_EIG = 100000;
-	double DELTA = 1e-6;
-	for (int i = 0; i < 5; i++){
-	  if (EIG(i) < MIN_EIG)
-	    MIN_EIG = EIG(i);
-	}
-	if (MIN_EIG<0) { 
-	  for (int i = 0; i < 5; i++)
-	    (*m)(i,i) += DELTA - MIN_EIG;
-	}
+      if (computed_ && det_ < 0) {
+        //if not positive-definite, alter values to allow for pos-def
+        TMatrixDSym COV(5);
+        for (int i = 0; i < 5; i++) {
+          for (int j = 0; j < 5; j++) {
+            if (std::isnan((*m)(i, j)) || std::isinf((*m)(i, j))) {
+              COV(i, j) = 1e-6;
+            } else {
+              COV(i, j) = (*m)(i, j);
+            }
+          }
+        }
+        TVectorD EIG(5);
+        COV.EigenVectors(EIG);
+        double MIN_EIG = 100000;
+        double DELTA = 1e-6;
+        for (int i = 0; i < 5; i++) {
+          if (EIG(i) < MIN_EIG)
+            MIN_EIG = EIG(i);
+        }
+        if (MIN_EIG < 0) {
+          for (int i = 0; i < 5; i++)
+            (*m)(i, i) += DELTA - MIN_EIG;
+        }
 
-	computed_ = m->Det(det_);
-	//	std::cout<<"    the determinant of the corrected covariance matrix is: "<<det_<<std::endl;
+        computed_ = m->Det(det_);
+        //	std::cout<<"    the determinant of the corrected covariance matrix is: "<<det_<<std::endl;
       }
     }
 

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -166,12 +166,10 @@ float pat::PackedCandidate::dz(const Point &p) const {
 }
 
 const reco::Track pat::PackedCandidate::pseudoPosDefTrack() const {
-  //if (posdeftrack_) return *posdeftrack_;
   // perform the regular unpacking of the track
   if (!track_)
     unpackTrk();
 
-  //      std::cout<<"unpacking enforcing positive-definite cov matrix"<<std::endl;
   //calculate the determinant and verify positivity
   double det = 0;
   bool notPosDef = (!(*m_).Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det < 0) ||
@@ -179,7 +177,6 @@ const reco::Track pat::PackedCandidate::pseudoPosDefTrack() const {
                    (!(*m_).Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!(*m_).Det(det) || det < 0);
 
   if (notPosDef) {
-    //    std::cout << "during unpacking, the determinant is: " << det << std::endl;
     reco::TrackBase::CovarianceMatrix m(*m_);
     //if not positive-definite, alter values to allow for pos-def
     TMatrixDSym eigenCov(5);
@@ -200,10 +197,6 @@ const reco::Track pat::PackedCandidate::pseudoPosDefTrack() const {
         m(i, i) += delta - minEigenValue;
     }
 
-    //    bool notPosDef = (!m.Sub<AlgebraicSymMatrix22>(0, 0).Det(det) || det < 0) ||
-    //                 (!m.Sub<AlgebraicSymMatrix33>(0, 0).Det(det) || det < 0) ||
-    //                 (!m.Sub<AlgebraicSymMatrix44>(0, 0).Det(det) || det < 0) || (!m.Det(det) || det < 0);
-    //    std::cout << "    the determinant of the corrected covariance matrix is: " << det << std::endl;
     // make a track object with pos def covariance matrix
     return reco::Track(normalizedChi2_ * (*track_).ndof(),
                        (*track_).ndof(),


### PR DESCRIPTION
#### PR description:

as reported in BPH https://indico.cern.ch/event/1155820/contributions/4853223/ the packing scheme of the track covariance in MINIAOD introduces the possibility for the covariance matrix to not be positive-definite, with implications to vertex refitting.
The  PR adds a new method to PackedCanidate responsible for returning a reference to a pseudoTrack with positive defined covariance matrix.

#### PR validation:

a simple analyser reading packed candidate was run retrieving the `pseudoPosDefTrack` to check that the determinant is getting positive.

