### PR TITLE
[Backport 124X] [MUO] Suppress excessive warnings in muon tracking at HLT

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -227,7 +227,7 @@ MuonCandidate::CandidateContainer GlobalTrajectoryBuilderBase::build(const Track
         if (!refitted0.empty())
           tkTrajectory = std::make_unique<Trajectory>(*(refitted0.begin()));
         else
-          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+          LogDebug(theCategory) << "     Failed to load tracker track trajectory";
       } else
         tkTrajectory = it->releaseTrackerTrajectory();
       if (tkTrajectory)
@@ -263,7 +263,7 @@ MuonCandidate::CandidateContainer GlobalTrajectoryBuilderBase::build(const Track
         if (!refitted0.empty()) {
           tkTrajectory = std::make_unique<Trajectory>(*(refitted0.begin()));
         } else
-          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+          LogDebug(theCategory) << "     Failed to load tracker track trajectory";
       } else
         tkTrajectory = it->releaseTrackerTrajectory();
       std::unique_ptr<Trajectory> cpy;


### PR DESCRIPTION
This is a backport of PR #39596 (related issue #39234)