### PR TITLE
Removed unused headers from GeneratorInterface/Hydjet2Interface

### DIFF
--- a/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
+++ b/GeneratorInterface/Hydjet2Interface/interface/Hydjet2Hadronizer.h
@@ -12,7 +12,6 @@
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"

--- a/GeneratorInterface/Hydjet2Interface/test/Hydjet2Analyzer.cc
+++ b/GeneratorInterface/Hydjet2Interface/test/Hydjet2Analyzer.cc
@@ -46,7 +46,6 @@
 #include "TH2.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 using namespace edm;


### PR DESCRIPTION
#### PR description:

The headers removed are deprecated.

#### PR validation:

Code compiles.