### PR TITLE
Update fine calo proc modifier

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -65,7 +65,9 @@ common_MCtruth = cms.PSet(
 ## enable fine calorimeter functionality: must occur *before* common PSet is used below
 from Configuration.ProcessModifiers.fineCalo_cff import fineCalo
 fineCalo.toModify(common_MCtruth,
-    DoFineCalo = True
+    DoFineCalo = True,
+    UseFineCalo = [2],
+    EminFineTrack = cms.double(0.0),
 )
 
 ## enable CaloBoundary information for all Phase2 workflows

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -67,7 +67,7 @@ from Configuration.ProcessModifiers.fineCalo_cff import fineCalo
 fineCalo.toModify(common_MCtruth,
     DoFineCalo = True,
     UseFineCalo = [2],
-    EminFineTrack = cms.double(0.0),
+    EminFineTrack = 0.0,
 )
 
 ## enable CaloBoundary information for all Phase2 workflows


### PR DESCRIPTION
#### PR description:

Fix the use of the fineCalo procmodifer to properly set EMinFineTrack to 0, which is needed in master

#### PR validation:

Tested that the --fineCalo proc modifier works as intended when added to the cmsDriver command from 41034.202

Additional point: it would be good to have a workflow that tests fineCalo as well. Should I create one copying 41034.202, or another workflow?
