### PR TITLE
Removed unused headers from GeneratorInterface/HydjetInterface

### DIFF
--- a/GeneratorInterface/HydjetInterface/interface/HydjetHadronizer.h
+++ b/GeneratorInterface/HydjetInterface/interface/HydjetHadronizer.h
@@ -14,7 +14,6 @@
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"

--- a/GeneratorInterface/HydjetInterface/test/HydjetAnalyzer.cc
+++ b/GeneratorInterface/HydjetInterface/test/HydjetAnalyzer.cc
@@ -45,7 +45,6 @@
 #include "TH1.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 using namespace edm;


### PR DESCRIPTION
#### PR description:

The headers removed are deprecated.

#### PR validation:

Code compiles.