### PR TITLE
Removed unused headers from GeneratorInterface/PyquenInterface

### DIFF
--- a/GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h
+++ b/GeneratorInterface/PyquenInterface/interface/PyquenHadronizer.h
@@ -14,7 +14,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"

--- a/GeneratorInterface/PyquenInterface/test/PyquenAnalyzer.h
+++ b/GeneratorInterface/PyquenInterface/test/PyquenAnalyzer.h
@@ -7,7 +7,6 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 // forward declarations


### PR DESCRIPTION
#### PR description:

The headers removed are deprecated.

#### PR validation:

Code compiles