### PR TITLE
Removed unused headers from GeneratorInterface/Pythia6Interface

### DIFF
--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6ParticleGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6ParticleGun.cc
@@ -5,14 +5,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-//#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-
-//#include "FWCore/Framework/interface/MakerMacros.h"
 
 using namespace edm;
 using namespace gen;

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6ParticleGun.h
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6ParticleGun.h
@@ -11,15 +11,6 @@
 #include <vector>
 
 #include "Pythia6Gun.h"
-// #include "HepMC/GenEvent.h"
-
-// #include "FWCore/Framework/interface/ESHandle.h"
-// #include "FWCore/Framework/interface/EDProducer.h"
-
-//#include "GeneratorInterface/Pythia6Interface/interface/Pythia6Service.h"
-//#include "GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h"
-
-// #include "HepPID/ParticleIDTranslations.hh"
 
 namespace gen {
 

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonGun.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6PartonGun.cc
@@ -5,7 +5,6 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

The headers removed are deprecated.

#### PR validation:

Code compiles.