### PR TITLE
Moved ConeIsolation to global module type

### DIFF
--- a/HLTrigger/btau/plugins/ConeIsolation.cc
+++ b/HLTrigger/btau/plugins/ConeIsolation.cc
@@ -49,7 +49,7 @@ using namespace std;
 //
 // constructors and destructor
 //
-ConeIsolation::ConeIsolation(const edm::ParameterSet& iConfig) {
+ConeIsolation::ConeIsolation(const edm::ParameterSet& iConfig) : m_algo{iConfig} {
   jetTrackTag = iConfig.getParameter<InputTag>("JetTrackSrc");
   jetTrackToken = consumes<reco::JetTracksAssociationCollection>(jetTrackTag);
   vertexTag = iConfig.getParameter<InputTag>("vertexSrc");
@@ -58,13 +58,9 @@ ConeIsolation::ConeIsolation(const edm::ParameterSet& iConfig) {
   beamSpotToken = consumes<reco::BeamSpot>(beamSpotTag);
   usingBeamSpot = iConfig.getParameter<bool>("useBeamSpot");  //If false the OfflinePrimaryVertex will be used.
 
-  m_algo = new ConeIsolationAlgorithm(iConfig);
-
   produces<reco::JetTagCollection>();
   produces<reco::IsolatedTauTagInfoCollection>();
 }
-
-ConeIsolation::~ConeIsolation() { delete m_algo; }
 
 //
 // member functions
@@ -81,7 +77,7 @@ void ConeIsolation::fillDescriptions(edm::ConfigurationDescriptions& description
 }
 
 // ------------ method called to produce the data  ------------
-void ConeIsolation::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ConeIsolation::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
   //Get jets with tracks
   Handle<reco::JetTracksAssociationCollection> jetTracksAssociation;
@@ -129,7 +125,7 @@ void ConeIsolation::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   for (unsigned int i = 0; i < jetTracksAssociation->size(); ++i) {
     pair<float, IsolatedTauTagInfo> myPair =
-        m_algo->tag(edm::Ref<JetTracksAssociationCollection>(jetTracksAssociation, i), myPV);
+        m_algo.tag(edm::Ref<JetTracksAssociationCollection>(jetTracksAssociation, i), myPV);
     tagCollection->setValue(i, myPair.first);
     extCollection->push_back(myPair.second);
   }

--- a/HLTrigger/btau/plugins/ConeIsolation.h
+++ b/HLTrigger/btau/plugins/ConeIsolation.h
@@ -14,16 +14,16 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "ConeIsolationAlgorithm.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-class ConeIsolation : public edm::EDProducer {
+class ConeIsolation : public edm::global::EDProducer<> {
 public:
   explicit ConeIsolation(const edm::ParameterSet&);
-  ~ConeIsolation() override;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   edm::InputTag jetTrackTag;
@@ -33,6 +33,6 @@ private:
   edm::InputTag beamSpotTag;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
   bool usingBeamSpot;
-  ConeIsolationAlgorithm* m_algo;
+  ConeIsolationAlgorithm m_algo;
 };
 #endif

--- a/HLTrigger/btau/plugins/ConeIsolationAlgorithm.cc
+++ b/HLTrigger/btau/plugins/ConeIsolationAlgorithm.cc
@@ -49,7 +49,7 @@ void ConeIsolationAlgorithm::fillDescription(edm::ParameterSetDescription& desc)
 }
 
 pair<float, IsolatedTauTagInfo> ConeIsolationAlgorithm::tag(const JetTracksAssociationRef& jetTracks,
-                                                            const Vertex& pv) {
+                                                            const Vertex& pv) const {
   const edm::RefVector<reco::TrackCollection>& tracks = jetTracks->second;
   edm::RefVector<reco::TrackCollection> myTracks;
 

--- a/HLTrigger/btau/plugins/ConeIsolationAlgorithm.h
+++ b/HLTrigger/btau/plugins/ConeIsolationAlgorithm.h
@@ -28,7 +28,7 @@ public:
   static void fillDescription(edm::ParameterSetDescription& desc);
 
   std::pair<float, reco::IsolatedTauTagInfo> tag(const reco::JetTracksAssociationRef& jetTracks,
-                                                 const reco::Vertex& pv);
+                                                 const reco::Vertex& pv) const;
 
 private:
   // algorithm parameters


### PR DESCRIPTION
#### PR description:

- made ConeIsolationAlgorithm to be const correct
- converted ConeIsolation to global::EDProducer

#### PR validation:

Code compiles without CMS deprecation warnings.