### PR TITLE
[Fix] Decrease cut on min number of hits only in RKFittingSmoother

### DIFF
--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -65,7 +65,7 @@ namespace {
       desc.add<int>("MaxNumberOfOutliers", 3);
       desc.add<int>("MinDof", 2);
       desc.add<bool>("NoOutliersBeginEnd", false);
-      desc.add<int>("MinNumberOfHits", 3);
+      desc.add<int>("MinNumberOfHits", 5);
       desc.add<int>("MinNumberOfHitsHighEta", 5);
       desc.add<double>("HighEtaSwitch", 5.0);
       desc.add<bool>("RejectTracks", true);

--- a/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
@@ -16,7 +16,8 @@ import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 RKFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
     ComponentName = 'RKFittingSmoother',
     Fitter        = 'RKFitter',
-    Smoother      = 'RKSmoother'
+    Smoother      = 'RKSmoother',
+    MinNumberOfHits = 3
 )
 
 KFFittingSmootherWithOutliersRejectionAndRK = RKFittingSmoother.clone(


### PR DESCRIPTION
### PR description:

This PR fixes one feature of PR #39578, as highlighted in [this comment](https://github.com/cms-sw/cmssw/pull/39578#discussion_r987127475).
In particular, the lower cut on min number of hits is now applied *only* for `RKFittingSmoother`, used in `mergedDuplicateTracks`.

