### PR TITLE
Removed unused headers from IOMC/ParticleGuns

### DIFF
--- a/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
@@ -5,7 +5,6 @@
 #include <ostream>
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseRandomtXiGunProducer.cc
@@ -7,7 +7,6 @@
 #include <ostream>
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"


### PR DESCRIPTION
#### PR description:

The headers removed are deprecated.

#### PR validation:

Code compiles.