### PR TITLE
Use thread-friendly modules in IORawData/DTCommissioning

### DIFF
--- a/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTDDUFileReader.h
@@ -8,7 +8,7 @@
  *  $Revision: 1.11 $
  *  \author M. Zanetti - INFN Padova
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "IORawData/DTCommissioning/plugins/RawFile.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -19,7 +19,7 @@
 #include <fstream>
 #include <cstdint>
 
-class DTDDUFileReader : public edm::EDProducer {
+class DTDDUFileReader : public edm::one::EDProducer<> {
 public:
   /// Constructor
   DTDDUFileReader(const edm::ParameterSet& pset);

--- a/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTNewROS8FileReader.h
@@ -8,15 +8,15 @@
  *  $Date: 2015/12/17$
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include <fstream>
 
-class DTNewROS8FileReader : public edm::EDProducer {
+class DTNewROS8FileReader : public edm::one::EDProducer<> {
 public:
   /// Constructor
   DTNewROS8FileReader(const edm::ParameterSet& pset);

--- a/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS25FileReader.h
@@ -9,8 +9,8 @@
  *  \author M. Zanetti - INFN Padova
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -20,7 +20,7 @@
 #include <fstream>
 #include <cstdint>
 
-class DTROS25FileReader : public edm::EDProducer {
+class DTROS25FileReader : public edm::one::EDProducer<> {
 public:
   /// Constructor
   DTROS25FileReader(const edm::ParameterSet& pset);

--- a/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
+++ b/IORawData/DTCommissioning/plugins/DTROS8FileReader.h
@@ -9,8 +9,8 @@
  *  \author M. Zanetti - INFN Padova
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -18,7 +18,7 @@
 
 #include <fstream>
 
-class DTROS8FileReader : public edm::EDProducer {
+class DTROS8FileReader : public edm::one::EDProducer<> {
 public:
   /// Constructor
   DTROS8FileReader(const edm::ParameterSet& pset);

--- a/IORawData/DTCommissioning/plugins/DTSpyReader.h
+++ b/IORawData/DTCommissioning/plugins/DTSpyReader.h
@@ -8,12 +8,12 @@
  *  $Revision: 1.4 $
  *  \author M. Zanetti - INFN Padova
  */
-#include "FWCore/Framework/interface/EDProducer.h"
-#include <IORawData/DTCommissioning/plugins/RawFile.h>
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "IORawData/DTCommissioning/plugins/RawFile.h"
 #include "IORawData/DTCommissioning/plugins/DTSpy.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include <DataFormats/FEDRawData/interface/FEDRawData.h>
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <cstdint>
 
-class DTSpyReader : public edm::EDProducer {
+class DTSpyReader : public edm::one::EDProducer<> {
 public:
   /// Constructor
   DTSpyReader(const edm::ParameterSet& pset);


### PR DESCRIPTION
#### PR description:

- moved modules to `one` type.
- also fixed some include statements

#### PR validation:

Code compiles without CMS deprecation warnings.