### PR TITLE
Improve `AlignPCLThresholds` payload inspector

### DIFF
--- a/CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
+++ b/CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
@@ -1,0 +1,59 @@
+#ifndef CONDCORE_PCLCONFIGPLUGINS_SIPIXELALIPCLTHRESHOLDSPAYLOADINSPECTORHELPER_H
+#define CONDCORE_PCLCONFIGPLUGINS_SIPIXELALIPCLTHRESHOLDSPAYLOADINSPECTORHELPER_H
+
+namespace PCLThresholdsPI {
+  enum types { DELTA, SIG, MAXMOVE, MAXERR, END_OF_TYPES };
+
+  /************************************************/
+  inline const std::string getStringFromCoordEnum(const AlignPCLThresholds::coordType& coord) {
+    switch (coord) {
+      case AlignPCLThresholds::X:
+        return "X";
+      case AlignPCLThresholds::Y:
+        return "Y";
+      case AlignPCLThresholds::Z:
+        return "Z";
+      case AlignPCLThresholds::theta_X:
+        return "#theta_{X}";
+      case AlignPCLThresholds::theta_Y:
+        return "#theta_{Y}";
+      case AlignPCLThresholds::theta_Z:
+        return "#theta_{Z}";
+      default:
+        return "should never be here";
+    }
+  }
+
+  /************************************************/
+  inline const std::string getStringFromTypeEnum(const types& type) {
+    switch (type) {
+      case types::DELTA:
+        return "#Delta";
+      case types::SIG:
+        return "#Delta/#sigma ";
+      case types::MAXMOVE:
+        return "max. move ";
+      case types::MAXERR:
+        return "max. err ";
+      default:
+        return "should never be here";
+    }
+  }
+
+  /************************************************/
+  inline std::string replaceAll(const std::string& str, const std::string& from, const std::string& to) {
+    std::string out(str);
+
+    if (from.empty())
+      return out;
+    size_t start_pos = 0;
+    while ((start_pos = out.find(from, start_pos)) != std::string::npos) {
+      out.replace(start_pos, from.length(), to);
+      start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }
+    return out;
+  }
+
+}  // namespace PCLThresholdsPI
+
+#endif

--- a/CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
+++ b/CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
@@ -2,7 +2,7 @@
 #define CONDCORE_PCLCONFIGPLUGINS_SIPIXELALIPCLTHRESHOLDSPAYLOADINSPECTORHELPER_H
 
 namespace PCLThresholdsPI {
-  enum types { DELTA, SIG, MAXMOVE, MAXERR, END_OF_TYPES };
+  enum types { DELTA, SIG, MAXMOVE, MAXERR, FRACTION_CUT, END_OF_TYPES };
 
   /************************************************/
   inline const std::string getStringFromCoordEnum(const AlignPCLThresholds::coordType& coord) {
@@ -35,6 +35,8 @@ namespace PCLThresholdsPI {
         return "max. move ";
       case types::MAXERR:
         return "max. err ";
+      case types::FRACTION_CUT:
+        return "fraction cut ";
       default:
         return "should never be here";
     }

--- a/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholdsHG_PayloadInspector.cc
+++ b/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholdsHG_PayloadInspector.cc
@@ -1,6 +1,6 @@
 /*!
-  \file AlignPCLThresholds_PayloadInspector
-  \Payload Inspector Plugin for Alignment PCL thresholds
+  \file AlignPCLThresholdsHG_PayloadInspector
+  \Payload Inspector Plugin for High Granularity Alignment PCL thresholds
   \author M. Musich
   \version $Revision: 1.0 $
   \date $Date: 2017/10/19 12:51:00 $
@@ -11,7 +11,7 @@
 #include "CondCore/CondDB/interface/Time.h"
 
 // the data format of the condition to be inspected
-#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 
 // for the PI Helper
 #include "CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h"
@@ -26,8 +26,8 @@
 #include "TH2F.h"
 #include "TLegend.h"
 #include "TCanvas.h"
-#include "TLine.h"
 #include "TLatex.h"
+#include "TLine.h"
 #include "TStyle.h"
 
 namespace {
@@ -35,12 +35,12 @@ namespace {
   using namespace cond::payloadInspector;
 
   /************************************************
-    Display of AlignPCLThresholds
+    Display of AlignPCLThresholdsHG
   *************************************************/
-  class AlignPCLThresholds_Display : public PlotImage<AlignPCLThresholds, SINGLE_IOV> {
+  class AlignPCLThresholdsHG_Display : public PlotImage<AlignPCLThresholdsHG, SINGLE_IOV> {
   public:
-    AlignPCLThresholds_Display()
-        : PlotImage<AlignPCLThresholds, SINGLE_IOV>("Display of threshold parameters for SiPixelAli PCL") {}
+    AlignPCLThresholdsHG_Display()
+        : PlotImage<AlignPCLThresholdsHG, SINGLE_IOV>("Display of threshold parameters for SiPixelAli PCL") {}
 
     bool fill() override {
       // to be able to see zeros
@@ -48,25 +48,25 @@ namespace {
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
-      std::shared_ptr<AlignPCLThresholds> payload = fetchPayload(std::get<1>(iov));
-
+      std::shared_ptr<AlignPCLThresholdsHG> payload = fetchPayload(std::get<1>(iov));
       auto alignables = payload->getAlignableList();
 
       TCanvas canvas("Alignment PCL thresholds summary", "Alignment PCL thresholds summary", 1500, 800);
       canvas.cd();
 
       canvas.SetTopMargin(0.07);
-      canvas.SetBottomMargin(0.06);
+      canvas.SetBottomMargin(0.20);
       canvas.SetLeftMargin(0.11);
       canvas.SetRightMargin(0.05);
       canvas.Modified();
       canvas.SetGrid();
 
-      auto Thresholds = std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), 24, 0, 24);
+      auto Thresholds = std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), 30, 0, 30);
       Thresholds->SetStats(false);
+      Thresholds->GetXaxis()->SetLabelSize(0.028);
 
-      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholds::coordType)> cutFunctor =
-          [&payload](PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholds::coordType coord) {
+      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholdsHG::coordType)> cutFunctor =
+          [&payload](PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholdsHG::coordType coord) {
             float ret(-999.);
             switch (my_type) {
               case PCLThresholdsPI::DELTA:
@@ -77,6 +77,14 @@ namespace {
                 return payload->getMaxMoveCut(alignable, coord);
               case PCLThresholdsPI::MAXERR:
                 return payload->getMaxErrorCut(alignable, coord);
+              case PCLThresholdsPI::FRACTION_CUT: {
+                const AlignPCLThresholdsHG::param_map& floatMap = payload->getFloatMap();
+                if (floatMap.find(alignable) != floatMap.end()) {
+                  return payload->getFractionCut(alignable, coord);
+                } else {
+                  return 0.f;
+                }
+              }
               case PCLThresholdsPI::END_OF_TYPES:
                 return ret;
               default:
@@ -91,10 +99,10 @@ namespace {
         auto xLabel =
             PCLThresholdsPI::replaceAll(PCLThresholdsPI::replaceAll(alignable, "minus", "(-)"), "plus", "(+)");
         Thresholds->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
-        unsigned int yBin = 24;
-        for (int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++) {
-          AlignPCLThresholds::coordType coord = static_cast<AlignPCLThresholds::coordType>(foo);
-          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::FRACTION_CUT; bar++) {
+        unsigned int yBin = 30;
+        for (int foo = AlignPCLThresholdsHG::X; foo != AlignPCLThresholdsHG::extra_DOF; foo++) {
+          AlignPCLThresholdsHG::coordType coord = static_cast<AlignPCLThresholdsHG::coordType>(foo);
+          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::END_OF_TYPES; bar++) {
             PCLThresholdsPI::types type = static_cast<PCLThresholdsPI::types>(bar);
             std::string theLabel =
                 PCLThresholdsPI::getStringFromTypeEnum(type) + PCLThresholdsPI::getStringFromCoordEnum(coord);
@@ -109,7 +117,7 @@ namespace {
         }    // loop on coordinates
       }      // loop on alignables
 
-      Thresholds->GetXaxis()->LabelsOption("h");
+      Thresholds->GetXaxis()->LabelsOption("v");
       Thresholds->Draw("TEXT");
 
       auto ltx = TLatex();
@@ -129,13 +137,13 @@ namespace {
   };
 
   /************************************************
-    Compare AlignPCLThresholds mapping
+    Compare AlignPCLThresholdsHG mapping
   *************************************************/
   template <IOVMultiplicity nIOVs, int ntags>
-  class AlignPCLThresholds_CompareBase : public PlotImage<AlignPCLThresholds, nIOVs, ntags> {
+  class AlignPCLThresholdsHG_CompareBase : public PlotImage<AlignPCLThresholdsHG, nIOVs, ntags> {
   public:
-    AlignPCLThresholds_CompareBase()
-        : PlotImage<AlignPCLThresholds, nIOVs, ntags>("Table of AlignPCLThresholds comparison") {}
+    AlignPCLThresholdsHG_CompareBase()
+        : PlotImage<AlignPCLThresholdsHG, nIOVs, ntags>("Table of AlignPCLThresholdsHG comparison") {}
 
     bool fill() override {
       gStyle->SetPalette(kTemperatureMap);
@@ -161,8 +169,8 @@ namespace {
         lastiov = theIOVs.back();
       }
 
-      std::shared_ptr<AlignPCLThresholds> l_payload = this->fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<AlignPCLThresholds> f_payload = this->fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<AlignPCLThresholdsHG> l_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<AlignPCLThresholdsHG> f_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
@@ -171,8 +179,8 @@ namespace {
       const auto& alignables2 = f_payload->getAlignableList();
 
       if (!isEqual(alignables, alignables2)) {
-        edm::LogError("AlignPCLThresholds_PayloadInspector")
-            << "Cannot compare the two AlignPCLThresholds objects, as the list of alignables differs";
+        edm::LogError("AlignPCLThresholdsHG_PayloadInspector")
+            << "Cannot compare the two AlignPCLThresholdsHG objects, as the list of alignables differs";
         return false;
       }
 
@@ -180,21 +188,24 @@ namespace {
       canvas.cd();
 
       canvas.SetTopMargin(0.07);
-      canvas.SetBottomMargin(0.06);
+      canvas.SetBottomMargin(0.20);
       canvas.SetLeftMargin(0.11);
       canvas.SetRightMargin(0.12);
       canvas.Modified();
       canvas.SetGrid();
 
-      auto Thresholds = std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), 24, 0, 24);
+      auto Thresholds = std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), 30, 0, 30);
       Thresholds->SetStats(false);
-      auto ThresholdsColor =
-          std::make_unique<TH2F>("ThresholdsC", "", alignables.size(), 0, alignables.size(), 24, 0, 24);
-      ThresholdsColor->SetStats(false);
+      Thresholds->GetXaxis()->SetLabelSize(0.028);
 
-      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholds::coordType)> cutFunctor =
+      auto ThresholdsColor =
+          std::make_unique<TH2F>("ThresholdsC", "", alignables.size(), 0, alignables.size(), 30, 0, 30);
+      ThresholdsColor->SetStats(false);
+      ThresholdsColor->GetXaxis()->SetLabelSize(0.028);
+
+      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholdsHG::coordType)> cutFunctor =
           [&f_payload, &l_payload](
-              PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholds::coordType coord) {
+              PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholdsHG::coordType coord) {
             float ret(-999.);
             switch (my_type) {
               case PCLThresholdsPI::DELTA:
@@ -205,6 +216,15 @@ namespace {
                 return l_payload->getMaxMoveCut(alignable, coord) - f_payload->getMaxMoveCut(alignable, coord);
               case PCLThresholdsPI::MAXERR:
                 return l_payload->getMaxErrorCut(alignable, coord) - f_payload->getMaxErrorCut(alignable, coord);
+              case PCLThresholdsPI::FRACTION_CUT: {
+                const AlignPCLThresholdsHG::param_map& f_floatMap = f_payload->getFloatMap();
+                const AlignPCLThresholdsHG::param_map& l_floatMap = l_payload->getFloatMap();
+                if (f_floatMap.find(alignable) != f_floatMap.end() && l_floatMap.find(alignable) != l_floatMap.end()) {
+                  return l_payload->getFractionCut(alignable, coord) - f_payload->getFractionCut(alignable, coord);
+                } else {
+                  return +999.f;
+                }
+              }
               case PCLThresholdsPI::END_OF_TYPES:
                 return ret;
               default:
@@ -220,10 +240,10 @@ namespace {
             PCLThresholdsPI::replaceAll(PCLThresholdsPI::replaceAll(alignable, "minus", "(-)"), "plus", "(+)");
         Thresholds->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
         ThresholdsColor->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
-        unsigned int yBin = 24;
-        for (int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++) {
-          AlignPCLThresholds::coordType coord = static_cast<AlignPCLThresholds::coordType>(foo);
-          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::FRACTION_CUT; bar++) {
+        unsigned int yBin = 30;
+        for (int foo = AlignPCLThresholdsHG::X; foo != AlignPCLThresholdsHG::extra_DOF; foo++) {
+          AlignPCLThresholdsHG::coordType coord = static_cast<AlignPCLThresholdsHG::coordType>(foo);
+          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::END_OF_TYPES; bar++) {
             PCLThresholdsPI::types type = static_cast<PCLThresholdsPI::types>(bar);
             std::string theLabel =
                 PCLThresholdsPI::getStringFromTypeEnum(type) + PCLThresholdsPI::getStringFromCoordEnum(coord);
@@ -242,9 +262,9 @@ namespace {
       }      // loop on alignables
 
       ThresholdsColor->Draw("COLZ0");
-      ThresholdsColor->GetXaxis()->LabelsOption("h");
+      ThresholdsColor->GetXaxis()->LabelsOption("v");
       Thresholds->Draw("TEXTsame");
-      Thresholds->GetXaxis()->LabelsOption("h");
+      Thresholds->GetXaxis()->LabelsOption("v");
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
@@ -279,14 +299,14 @@ namespace {
     }
   };
 
-  using AlignPCLThresholds_Compare = AlignPCLThresholds_CompareBase<MULTI_IOV, 1>;
-  using AlignPCLThresholds_CompareTwoTags = AlignPCLThresholds_CompareBase<SINGLE_IOV, 2>;
+  using AlignPCLThresholdsHG_Compare = AlignPCLThresholdsHG_CompareBase<MULTI_IOV, 1>;
+  using AlignPCLThresholdsHG_CompareTwoTags = AlignPCLThresholdsHG_CompareBase<SINGLE_IOV, 2>;
 
 }  // namespace
 
 // Register the classes as boost python plugin
-PAYLOAD_INSPECTOR_MODULE(AlignPCLThresholds) {
-  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Display);
-  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Compare);
-  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_CompareTwoTags);
+PAYLOAD_INSPECTOR_MODULE(AlignPCLThresholdsHG) {
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholdsHG_Display);
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholdsHG_Compare);
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholdsHG_CompareTwoTags);
 }

--- a/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
+++ b/CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc
@@ -13,6 +13,9 @@
 // the data format of the condition to be inspected
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
 
+// for the PI Helper
+#include "CondCore/PCLConfigPlugins/interface/SiPixelAliPCLThresholdsPayloadInspectorHelper.h"
+
 #include <memory>
 #include <sstream>
 #include <iostream>
@@ -27,21 +30,21 @@
 
 namespace {
 
-  enum types { DELTA, SIG, MAXMOVE, MAXERR, END_OF_TYPES };
+  using namespace cond::payloadInspector;
 
   /************************************************
     Display of AlignPCLThresholds
   *************************************************/
-  class AlignPCLThresholds_Display : public cond::payloadInspector::PlotImage<AlignPCLThresholds> {
+  class AlignPCLThresholds_Display : public PlotImage<AlignPCLThresholds, SINGLE_IOV> {
   public:
     AlignPCLThresholds_Display()
-        : cond::payloadInspector::PlotImage<AlignPCLThresholds>("Display of threshold parameters for SiPixelAli PCL") {
-      setSingleIov(true);
-    }
+        : PlotImage<AlignPCLThresholds, SINGLE_IOV>("Display of threshold parameters for SiPixelAli PCL") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<AlignPCLThresholds> payload = fetchPayload(std::get<1>(iov));
+
       auto alignables = payload->getAlignableList();
 
       TCanvas canvas("Alignment PCL thresholds summary", "Alignment PCL thresholds summary", 1500, 800);
@@ -58,19 +61,19 @@ namespace {
           "Thresholds", "Alignment parameter thresholds", alignables.size(), 0, alignables.size(), 24, 0, 24);
       Thresholds->SetStats(false);
 
-      std::function<float(types, std::string, AlignPCLThresholds::coordType)> cutFunctor =
-          [&payload](types my_type, std::string alignable, AlignPCLThresholds::coordType coord) {
+      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholds::coordType)> cutFunctor =
+          [&payload](PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholds::coordType coord) {
             float ret(-999.);
             switch (my_type) {
-              case DELTA:
+              case PCLThresholdsPI::DELTA:
                 return payload->getCut(alignable, coord);
-              case SIG:
+              case PCLThresholdsPI::SIG:
                 return payload->getSigCut(alignable, coord);
-              case MAXMOVE:
+              case PCLThresholdsPI::MAXMOVE:
                 return payload->getMaxMoveCut(alignable, coord);
-              case MAXERR:
+              case PCLThresholdsPI::MAXERR:
                 return payload->getMaxErrorCut(alignable, coord);
-              case END_OF_TYPES:
+              case PCLThresholdsPI::END_OF_TYPES:
                 return ret;
               default:
                 return ret;
@@ -81,14 +84,16 @@ namespace {
       for (const auto& alignable : alignables) {
         xBin++;
 
-        auto xLabel = replaceAll(replaceAll(alignable, "minus", "(-)"), "plus", "(+)");
+        auto xLabel =
+            PCLThresholdsPI::replaceAll(PCLThresholdsPI::replaceAll(alignable, "minus", "(-)"), "plus", "(+)");
         Thresholds->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
         unsigned int yBin = 24;
         for (int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++) {
           AlignPCLThresholds::coordType coord = static_cast<AlignPCLThresholds::coordType>(foo);
-          for (int bar = types::DELTA; bar != types::END_OF_TYPES; bar++) {
-            types type = static_cast<types>(bar);
-            std::string theLabel = getStringFromTypeEnum(type) + getStringFromCoordEnum(coord);
+          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::END_OF_TYPES; bar++) {
+            PCLThresholdsPI::types type = static_cast<PCLThresholdsPI::types>(bar);
+            std::string theLabel =
+                PCLThresholdsPI::getStringFromTypeEnum(type) + PCLThresholdsPI::getStringFromCoordEnum(coord);
             if (xBin == 1) {
               Thresholds->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
             }
@@ -108,58 +113,131 @@ namespace {
 
       return true;
     }
+  };
 
-    /************************************************/
-    std::string getStringFromCoordEnum(const AlignPCLThresholds::coordType& coord) {
-      switch (coord) {
-        case AlignPCLThresholds::X:
-          return "X";
-        case AlignPCLThresholds::Y:
-          return "Y";
-        case AlignPCLThresholds::Z:
-          return "Z";
-        case AlignPCLThresholds::theta_X:
-          return "#theta_{X}";
-        case AlignPCLThresholds::theta_Y:
-          return "#theta_{Y}";
-        case AlignPCLThresholds::theta_Z:
-          return "#theta_{Z}";
-        default:
-          return "should never be here";
+  /************************************************
+    Compare AlignPCLThresholds mapping
+  *************************************************/
+  template <IOVMultiplicity nIOVs, int ntags>
+  class AlignPCLThresholds_CompareBase : public PlotImage<AlignPCLThresholds, nIOVs, ntags> {
+  public:
+    AlignPCLThresholds_CompareBase()
+        : PlotImage<AlignPCLThresholds, nIOVs, ntags>("Table of AlignPCLThresholds comparison") {}
+
+    bool fill() override {
+      gStyle->SetPalette(kTemperatureMap);
+
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto f_tagname = PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        l_tagname = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
       }
-    }
 
-    /************************************************/
-    std::string getStringFromTypeEnum(const types& type) {
-      switch (type) {
-        case types::DELTA:
-          return "#Delta";
-        case types::SIG:
-          return "#Delta/#sigma ";
-        case types::MAXMOVE:
-          return "max. move ";
-        case types::MAXERR:
-          return "max. err ";
-        default:
-          return "should never be here";
-      }
-    }
+      std::shared_ptr<AlignPCLThresholds> l_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<AlignPCLThresholds> f_payload = this->fetchPayload(std::get<1>(firstiov));
 
-    /************************************************/
-    std::string replaceAll(const std::string& str, const std::string& from, const std::string& to) {
-      std::string out(str);
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
-      if (from.empty())
-        return out;
-      size_t start_pos = 0;
-      while ((start_pos = out.find(from, start_pos)) != std::string::npos) {
-        out.replace(start_pos, from.length(), to);
-        start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
-      }
-      return out;
+      auto alignables = l_payload->getAlignableList();
+
+      TCanvas canvas("Alignment PCL thresholds summary", "Alignment PCL thresholds summary", 1500, 800);
+      canvas.cd();
+
+      canvas.SetTopMargin(0.07);
+      canvas.SetBottomMargin(0.06);
+      canvas.SetLeftMargin(0.11);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+      canvas.SetGrid();
+
+      auto Thresholds = std::make_unique<TH2F>(
+          "Thresholds", "Alignment parameter thresholds", alignables.size(), 0, alignables.size(), 24, 0, 24);
+      Thresholds->SetStats(false);
+
+      auto ThresholdsColor = std::make_unique<TH2F>(
+          "Thresholds", "Alignment parameter thresholds", alignables.size(), 0, alignables.size(), 24, 0, 24);
+      ThresholdsColor->SetStats(false);
+
+      std::function<float(PCLThresholdsPI::types, std::string, AlignPCLThresholds::coordType)> cutFunctor =
+          [&f_payload, &l_payload](
+              PCLThresholdsPI::types my_type, std::string alignable, AlignPCLThresholds::coordType coord) {
+            float ret(-999.);
+            switch (my_type) {
+              case PCLThresholdsPI::DELTA:
+                return l_payload->getCut(alignable, coord) - f_payload->getCut(alignable, coord);
+              case PCLThresholdsPI::SIG:
+                return l_payload->getSigCut(alignable, coord) - f_payload->getSigCut(alignable, coord);
+              case PCLThresholdsPI::MAXMOVE:
+                return l_payload->getMaxMoveCut(alignable, coord) - f_payload->getMaxMoveCut(alignable, coord);
+              case PCLThresholdsPI::MAXERR:
+                return l_payload->getMaxErrorCut(alignable, coord) - f_payload->getMaxErrorCut(alignable, coord);
+              case PCLThresholdsPI::END_OF_TYPES:
+                return ret;
+              default:
+                return ret;
+            }
+          };
+
+      unsigned int xBin = 0;
+      for (const auto& alignable : alignables) {
+        xBin++;
+
+        auto xLabel =
+            PCLThresholdsPI::replaceAll(PCLThresholdsPI::replaceAll(alignable, "minus", "(-)"), "plus", "(+)");
+        Thresholds->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
+        ThresholdsColor->GetXaxis()->SetBinLabel(xBin, (xLabel).c_str());
+        unsigned int yBin = 24;
+        for (int foo = AlignPCLThresholds::X; foo != AlignPCLThresholds::extra_DOF; foo++) {
+          AlignPCLThresholds::coordType coord = static_cast<AlignPCLThresholds::coordType>(foo);
+          for (int bar = PCLThresholdsPI::DELTA; bar != PCLThresholdsPI::END_OF_TYPES; bar++) {
+            PCLThresholdsPI::types type = static_cast<PCLThresholdsPI::types>(bar);
+            std::string theLabel =
+                PCLThresholdsPI::getStringFromTypeEnum(type) + PCLThresholdsPI::getStringFromCoordEnum(coord);
+            if (xBin == 1) {
+              Thresholds->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
+              ThresholdsColor->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
+            }
+
+            Thresholds->SetBinContent(xBin, yBin, cutFunctor(type, alignable, coord));
+            ThresholdsColor->SetBinContent(xBin, yBin, cutFunctor(type, alignable, coord));
+
+            yBin--;
+          }  // loop on types
+        }    // loop on coordinates
+      }      // loop on alignables
+
+      ThresholdsColor->Draw("COLZ");
+      Thresholds->GetXaxis()->LabelsOption("h");
+      Thresholds->Draw("TEXT");
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
     }
   };
+
+  using AlignPCLThresholds_Compare = AlignPCLThresholds_CompareBase<MULTI_IOV, 1>;
+  using AlignPCLThresholds_CompareTwoTags = AlignPCLThresholds_CompareBase<SINGLE_IOV, 2>;
+
 }  // namespace
 
 // Register the classes as boost python plugin
-PAYLOAD_INSPECTOR_MODULE(AlignPCLThresholds) { PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Display); }
+PAYLOAD_INSPECTOR_MODULE(AlignPCLThresholds) {
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Display);
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_Compare);
+  PAYLOAD_INSPECTOR_CLASS(AlignPCLThresholds_CompareTwoTags);
+}

--- a/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
+++ b/CondCore/PCLConfigPlugins/plugins/BuildFile.xml
@@ -2,3 +2,8 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
 </library>
+
+<library file="AlignPCLThresholdsHG_PayloadInspector.cc" name="AlignPCLThresholdsHG_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+</library>

--- a/CondCore/PCLConfigPlugins/test/BuildFile.xml
+++ b/CondCore/PCLConfigPlugins/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="CondCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<use name="roothistpainter"/>
+<bin file="testAlignPCLThresholdsPayloadInspector.cpp" name="testAlignPCLThresholdsPayloadInspector">
+</bin>

--- a/CondCore/PCLConfigPlugins/test/test.sh
+++ b/CondCore/PCLConfigPlugins/test/test.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 # Save current working dir so img can be outputted there later
 W_DIR=$(pwd);
-# Set SCRAM architecture var
-SCRAM_ARCH=slc6_amd64_gcc630;
-export SCRAM_ARCH;
 source /afs/cern.ch/cms/cmsset_default.sh;
 eval `scram run -sh`;
 # Go back to original working directory
 cd $W_DIR;
 # Run get payload data script
 
+mkdir $W_DIR/results/
+
 ####################
-# Test Gains
+# Test Display
 ####################
 getPayloadData.py \
     --plugin pluginAlignPCLThresholds_PayloadInspector \
@@ -21,3 +20,49 @@ getPayloadData.py \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
     --test;
+
+mv *.png $W_DIR/results/LG_display.png
+
+####################
+# Test Compare
+####################
+getPayloadData.py \
+    --plugin pluginAlignPCLThresholds_PayloadInspector \
+    --plot plot_AlignPCLThresholds_CompareTwoTags \
+    --tag SiPixelAliThresholds_offline_v0 \
+    --tagtwo SiPixelAliThresholds_express_v0 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/LG_compare.png
+
+####################
+# Test Display HG
+####################
+getPayloadData.py \
+    --plugin pluginAlignPCLThresholdsHG_PayloadInspector \
+    --plot plot_AlignPCLThresholdsHG_Display \
+    --tag SiPixelAliThresholdsHG_express_v0 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/HG_display.png
+
+####################
+# Test Compare HG
+####################
+getPayloadData.py \
+    --plugin pluginAlignPCLThresholdsHG_PayloadInspector \
+    --plot plot_AlignPCLThresholdsHG_Compare \
+    --tag SiPixelAliThresholdsHG_express_v0 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "359659"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/HG_compare.png

--- a/CondCore/PCLConfigPlugins/test/testAlignPCLThresholdsPayloadInspector.cpp
+++ b/CondCore/PCLConfigPlugins/test/testAlignPCLThresholdsPayloadInspector.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/PCLConfigPlugins/plugins/AlignPCLThresholds_PayloadInspector.cc"
+#include "CondCore/PCLConfigPlugins/plugins/AlignPCLThresholdsHG_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  // AlignPCLThresholds
+  std::string tag = "SiPixelAliThresholds_offline_v0";
+  cond::Time_t start = static_cast<unsigned long long>(1);
+  cond::Time_t end = static_cast<unsigned long long>(359659);
+
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << "## Exercising AlignPCLThresholds plots " << std::endl;
+
+  AlignPCLThresholds_Display histo1;
+  histo1.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << histo1.data() << std::endl;
+
+  std::string tag2 = "SiPixelAliThresholds_express_v0";
+
+  AlignPCLThresholds_CompareTwoTags histo2;
+  histo2.process(connectionString, PI::mk_input(tag, start, start, tag2, start, start));
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << histo2.data() << std::endl;
+
+  // AlignPCLThresholdsHG
+  tag = "SiPixelAliThresholdsHG_express_v0";
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << "## Exercising AlignPCLThresholdsHG plots " << std::endl;
+
+  AlignPCLThresholdsHG_Display histo3;
+  histo3.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << histo3.data() << std::endl;
+
+  AlignPCLThresholdsHG_Compare histo4;
+  histo4.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testAlignPCLThresholdsPayloadInspector") << histo4.data() << std::endl;
+
+  Py_Finalize();
+}


### PR DESCRIPTION
#### PR description:

With the activation of the high granularity alignment PCL workflow for data-taking it becomes necessary to be able to inspect the payloads used to configure the various thresholds for updating the tracker alignment tag used in the production Global Tags.
The goal of this PR is to add such capabilities, by means of the new classes  collected in the file [AlignPCLThresholdsHG_PayloadInspector.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:cmssw:AlignPCLThresholds_PayloadInspector_rehaul?expand=1#diff-8a9016c5edbd427e0eacad912308b4c0ee75a44eeb4d734c90e5caa2287c1897).
In addition I provide a comparator class also for the low granularity case in [AlignPCLThresholds_PayloadInspector.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:cmssw:AlignPCLThresholds_PayloadInspector_rehaul?expand=1#diff-14ea2ff35d573061232509a7b642a0c4016ef2ee571fa6c02e4302b6531c0d7d).
Common utility methods are moved out from the plugins file and put into an helper header file.
Unit tests are improved in order to test the new functionalities.

#### PR validation:

I've run successfully the unit tests with:

```console
scram b runtests_testAlignPCLThresholdsPayloadInspector
```

also using [this script](https://github.com/cms-sw/cmssw/compare/master...mmusich:cmssw:AlignPCLThresholds_PayloadInspector_rehaul?expand=1#diff-ca85a73674aeec8757d11b5ac4de828b28f0e169c6ea9698011d078134d29116) I produced the following plots:

|  | Display | Compare |   
| ---- |  ---- | ---- | 
| `AlignPCLThresholds` |  ![image](https://user-images.githubusercontent.com/5082376/193932826-3ed72bd3-1217-4cdd-aa75-cea6c99fe4a8.png) |  ![image](https://user-images.githubusercontent.com/5082376/193932919-474638a0-4234-4cc8-9cf5-10604a611db8.png) |
| `AlignPCLThresholdsHG` | ![image](https://user-images.githubusercontent.com/5082376/193933003-cf4f6f0a-ab58-46b2-8ea5-8f585536c77f.png) | ![image](https://user-images.githubusercontent.com/5082376/193933079-2dd6a5bf-0286-44bd-91b9-9b759036ce7b.png)|
 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A


