### PR TITLE
Migrate legacy type modules to one type

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDaqInfoTask.h
@@ -1,14 +1,14 @@
 #ifndef ESDaqInfoTask_h
 #define ESDaqInfoTask_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/EcalMapping/interface/ESElectronicsMapper.h"  // definition in line 75
 #include "DQMServices/Core/interface/DQMStore.h"
 
-class ESDaqInfoTask : public edm::EDAnalyzer {
+class ESDaqInfoTask : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -31,6 +31,9 @@ protected:
 
   /// BeginLuminosityBlock
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) override;
+
+  /// EndLuminosityBlock
+  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   /// Reset
   void reset(void);

--- a/DQM/EcalPreshowerMonitorModule/interface/ESDataCertificationTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDataCertificationTask.h
@@ -1,12 +1,13 @@
 #ifndef ESDataCertificationTask_h
 #define ESDataCertificationTask_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-class ESDataCertificationTask : public edm::EDAnalyzer {
+class ESDataCertificationTask
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -19,6 +20,7 @@ protected:
   void beginJob(void) override;
   void endJob(void) override;
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) override;
+  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void reset(void);
 
 private:

--- a/DQM/EcalPreshowerMonitorModule/interface/ESDcsInfoTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESDcsInfoTask.h
@@ -1,14 +1,14 @@
 #ifndef ESDcsInfoTask_h
 #define ESDcsInfoTask_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-class ESDcsInfoTask : public edm::EDAnalyzer {
+class ESDcsInfoTask : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -31,6 +31,9 @@ protected:
 
   /// BeginLuminosityBlock
   void beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, const edm::EventSetup& iSetup) override;
+
+  /// EndLuminosityBlock
+  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   /// Reset
   void reset(void);

--- a/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDaqInfoTask.cc
@@ -27,6 +27,7 @@ using namespace edm;
 using namespace std;
 
 ESDaqInfoTask::ESDaqInfoTask(const ParameterSet& ps) {
+  usesResource("DQMStore");
   dqmStore_ = Service<DQMStore>().operator->();
   runInfoToken_ = esConsumes<edm::Transition::BeginLuminosityBlock>();
   prefixME_ = ps.getUntrackedParameter<string>("prefixME", "");
@@ -160,6 +161,8 @@ void ESDaqInfoTask::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, 
     LogWarning("ESDaqInfoTask") << "Cannot find any RunInfoRcd" << endl;
   }
 }
+
+void ESDaqInfoTask::endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
 
 void ESDaqInfoTask::reset(void) {
   if (meESDaqFraction_)

--- a/DQM/EcalPreshowerMonitorModule/src/ESDataCertificationTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDataCertificationTask.cc
@@ -23,6 +23,7 @@ using namespace edm;
 using namespace std;
 
 ESDataCertificationTask::ESDataCertificationTask(const ParameterSet& ps) {
+  usesResource("DQMStore");
   dqmStore_ = Service<DQMStore>().operator->();
 
   prefixME_ = ps.getUntrackedParameter<string>("prefixME", "");
@@ -58,6 +59,8 @@ void ESDataCertificationTask::beginLuminosityBlock(const edm::LuminosityBlock& l
                                                    const edm::EventSetup& iSetup) {
   this->reset();
 }
+
+void ESDataCertificationTask::endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
 
 void ESDataCertificationTask::reset(void) {
   if (meESDataCertificationSummary_)

--- a/DQM/EcalPreshowerMonitorModule/src/ESDcsInfoTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESDcsInfoTask.cc
@@ -17,6 +17,7 @@ using namespace edm;
 using namespace std;
 
 ESDcsInfoTask::ESDcsInfoTask(const ParameterSet& ps) {
+  usesResource("DQMStore");
   dqmStore_ = Service<DQMStore>().operator->();
 
   prefixME_ = ps.getUntrackedParameter<string>("prefixME", "");
@@ -56,6 +57,8 @@ void ESDcsInfoTask::beginLuminosityBlock(const edm::LuminosityBlock& lumiBlock, 
     meESDcsActiveMap_->setBinContent(i + 1, -1.0);
   }
 }
+
+void ESDcsInfoTask::endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) {}
 
 void ESDcsInfoTask::reset(void) {
   if (meESDcsFraction_)


### PR DESCRIPTION
#### PR description:

Migrate three legacy type modules to one type

ESDaqInfoTask
ESDataCertificationTask
ESDcsInfoTask

#### PR validation:

Relies on existing tests. Minimal changes were done to migrate this code. They should behave the same.
