### PR TITLE
Fix overflow in ECAL GPU unpacking

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/UnpackGPU.cu
+++ b/EventFilter/EcalRawToDigi/plugins/UnpackGPU.cu
@@ -53,7 +53,7 @@ namespace ecal {
       const uint64_t mask =
           0xC0001000D0000000 + (uint64_t(TOWER_L1_MASK) << TOWER_L1_B) + (uint64_t(TOWER_BX_MASK) << TOWER_BX_B);
 
-      while (next_tower_block != trailer) {
+      while (next_tower_block < trailer) {
         if ((*next_tower_block & mask) == sign) {
           current_tower_block = next_tower_block;
           return uint8_t(*next_tower_block & TOWER_ID_MASK);
@@ -232,7 +232,7 @@ namespace ecal {
       auto const* current_tower_block = tower_blocks_start;
       uint8_t iCh = 0;
       uint8_t next_tower_id = exp_ttids[iCh];
-      while (current_tower_block != trailer && iCh < numbChannels) {
+      while (current_tower_block < trailer && iCh < numbChannels) {
         auto const w = *current_tower_block;
         uint8_t ttid = w & TOWER_ID_MASK;
         uint16_t bxlocal = (w >> TOWER_BX_B) & TOWER_BX_MASK;


### PR DESCRIPTION
#### PR description:

Avoid a possible overflow in the ECAL GPU unpacking, that could lead to an out-of-bounds read from invalid memory.

The function `find_next_tower_block()` starts from the next memory location and keeps reading until it finds a valid payload, or it reaches the given trailer. However, there was no check that the initial value is not already at or beyond the trailer, which would result in loop that moves forward until it reaches an invalid memory address.

This condition has been observed online, for example
```
block (14,0,0) thread (0,0,0)
find_next_tower_block(current_tower_block = 0x7fa96ba042c8, trailer = 0x7fa96ba042c0, ...)
```
resulting in
```
Begin processing the 951st record. Run 359699, Event 317644311, LumiSection 218 on stream 0 at 05-Oct-2022 00:55:27.426 CEST

CUDA Exception: Warp Illegal Address
The exception was triggered at PC 0x7fff320ad230 (UnpackGPU.cu:57 in _ZN4ecal3raw21find_next_tower_blockERPKmS2_jj inlined from UnpackGPU.cu:252)

Thread 1 "cmsRun" received signal CUDA_EXCEPTION_14, Warp Illegal Address.
[Switching focus to CUDA kernel 854, grid 25544, block (14,0,0), thread (30,0,0), device 0, sm 28, warp 0, lane 30]
ecal::raw::kernel_unpack_test<32><<<(54,1,1),(32,1,1)>>> ()
    at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_12_4_9-el8_amd64_gcc10/build/CMSSW_12_4_9-build/tmp/BUILDROOT/dc6747a684df926e1faea7ef7c301e1a/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_4_9/src/EventFilter/EcalRawToDigi/plugins/UnpackGPU.cu:57 in _ZN4ecal3raw21find_next_tower_blockERPKmS2_jj inlined from UnpackGPU.cu:252
```

These changes will stop the loop if the initial value is at or beyond the trailer.

#### PR validation:

With these changes the ECAL unpacker runs successfully through 10'000 the _error stream_ events.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 12.4.x and 12.5.x for data taking.