### PR TITLE
Fix nano aod customize v10

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2748,9 +2748,8 @@ steps['RECODR3_ZBOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,ALCA:SiStripCa
 steps['RECODR3_HLTPhysics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,ALCA:TkAlMinBias+HcalCalIterativePhiSym+HcalCalIsoTrkProducerFilter+HcalCalHO+HcalCalHBHEMuonProducerFilter,DQM:@commonReduced+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_2021']])
 steps['RECODR3_AlCaTkCosmics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXONoBPTXSkim,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQMFakeHLT+@miniAODDQM'},steps['RECODR3_2021']])
 
-steps['RECONANORUN3']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@miniAODDQM+@nanoAODDQM'},steps['RECODR3']])
+steps['RECONANORUN3']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO:PhysicsTools/NanoAOD/V10/nano_cff,DQM:@miniAODDQM+@nanoAODDQM'},steps['RECODR3']])
 steps['RECOCOSMRUN3']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L1Reco,RECO,DQM','--datatier':'RECO,DQMIO','--eventcontent':'RECO,DQM'},steps['RECONANORUN3']])
-steps['RECONANORUN3']['--customise'] += ',PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10'
 
 # mask away - to be removed once we'll migrate the matrix to be fully unscheduled for RECO step
 #steps['RECOmAOD']=merge([step3DefaultsUnsch])

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -193,7 +193,7 @@ class UpgradeWorkflow_NanoV10(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if stepDict[step][k] != None:
             if 'RecoNano' in step:
-                stepDict[stepName][k] = merge([{'--customise': 'PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10'}, stepDict[step][k]])
+                stepDict[stepName][k] = merge([{'-s': stepDict[step][k]['-s'].replace('NANO','NANO:PhysicsTools/NanoAOD/V10/nano_cff')}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return True
 upgradeWFs['NanoV10'] = UpgradeWorkflow_NanoV10(

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1338,15 +1338,11 @@ def PrepJMECustomNanoAOD(process,runOnMC):
 
   return process
 
-from PhysicsTools.NanoAOD.V10.nano_cff import nanoAOD_customizeV10
-
 def PrepJMECustomNanoAOD_MC(process):
-  process = nanoAOD_customizeV10(process)
   process = PrepJMECustomNanoAOD(process,runOnMC=True)
 
   return process
 
 def PrepJMECustomNanoAOD_Data(process):
-  process = nanoAOD_customizeV10(process)
   process = PrepJMECustomNanoAOD(process,runOnMC=False)
   return process

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -521,7 +521,8 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
     from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
     from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
-    process.load("PhysicsTools.PatUtils.L1PrefiringWeightProducer_cff")
+    if not hasattr(process,'prefiringweight'):
+        process.load("PhysicsTools.PatUtils.L1PrefiringWeightProducer_cff")
     (stage2L1Trigger & tracker_apv_vfp30_2016).toModify(process.prefiringweight, DataEraECAL = "UL2016preVFP", DataEraMuon = "2016preVFP" )
     (stage2L1Trigger & ~tracker_apv_vfp30_2016).toModify(process.prefiringweight, DataEraECAL = "UL2016postVFP", DataEraMuon = "2016postVFP" )
     stage2L1Trigger_2017.toModify(process.prefiringweight, DataEraECAL = "UL2017BtoF", DataEraMuon = "20172018")


### PR DESCRIPTION
#### PR description:

this mitigate the migration of V10 Nano configuration from an unmaintainable customise to the `-s NANO:PhysicsTools/NanoAOD/V10/nano_cff` syntax in cmsDriver (migration done in #39337  

#### PR validation:

the workflow in the matrix that were calling for V10 customise now configure properly