### PR TITLE
Fixing the maximum number of OMTF final candidates

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBuster.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBuster.cc
@@ -32,6 +32,9 @@ AlgoMuons GhostBuster::select(AlgoMuons refHitCands, int charge) {
     }
     if ((*it1)->getQ() > 0 && !isGhost)
       refHitCleanCands.emplace_back(new AlgoMuon(**it1));
+
+    if (refHitCleanCands.size() >= 3)
+      break;
   }
 
   while (refHitCleanCands.size() < 3)

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBusterPreferRefDt.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBusterPreferRefDt.cc
@@ -157,6 +157,8 @@ AlgoMuons GhostBusterPreferRefDt::select(AlgoMuons muonsIN, int charge) {
     AlgoMuon fixed = mu;
     fixed.setEta(mu.fixedEta);
     refHitCleanCands.emplace_back(new AlgoMuon(fixed));
+    if (refHitCleanCands.size() >= 3)
+      break;
   }
 
   while (refHitCleanCands.size() < 3)

--- a/L1Trigger/L1TMuonOverlapPhase1/test/runMuonOverlap_run3_data.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/runMuonOverlap_run3_data.py
@@ -4,7 +4,7 @@ process = cms.Process("L1TMuonEmulation")
 import os
 import sys
 
-loadConfigFrom_sqlite_file = True
+loadConfigFrom_sqlite_file = False
 
 loadConfigFrom_fakeOmtfParams = False
 
@@ -59,9 +59,12 @@ process.source = cms.Source('PoolSource',
      #'/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/344/566/00000/19ef107a-4cd9-4df0-ba93-dbfbab8df1cb.root',
      
      #'/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/342/094/00000/038c179a-d2ce-45f0-a7d5-8b2d40017042.root', # only DT, fw 0x0008
-     '/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/344/266/00000/db2cfbdd-5edf-4ee4-aab0-5bdba105728d.root' #DT and RPC fw 0x0008
+     #'/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/344/266/00000/db2cfbdd-5edf-4ee4-aab0-5bdba105728d.root' #DT and RPC fw 0x0008
      #'/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/344/566/00000/19ef107a-4cd9-4df0-ba93-dbfbab8df1cb.root'  
      #'/store/express/Commissioning2021/ExpressCosmics/FEVT/Express-v1/000/347/053/00000/7b486245-96ea-4b7c-9fe7-76c957968785.root'  #RPC noise only
+     
+     #'file:/eos/cms/store/express/Run2022D/ExpressPhysics/FEVT/Express-v1/000/357/815/00000/ffe8b95d-25cb-45cd-9f45-b96d8e18ed4f.root'
+     'file:/eos/cms/store/data/Run2022C/BTagMu/RAW/v1/000/356/531/00000/9cd8bc50-5bac-487a-b491-848e7ece92fc.root'
      ),             
  )
 	                    


### PR DESCRIPTION
#### PR description:

Fix in the:
L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBusterPreferRefDt.cc L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GhostBuster.cc The maximum number of the OMTF final candidates is limited to 3 - as in the hardware. Without his fix, the maximum number of final candidates could be 4. This addresses https://github.com/cms-sw/cmssw/issues/39453

#### PR validation:
The PR was checked looking at the Run: 356531 Event: 9968011 - with the fix the OMTF emulator produces 3 candidates (and not 4 as without the fix), the candidates are the same as recorded from the hardware. In other events there are no changes.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.
