### PR TITLE
Made L1Trigger/GlobalCaloTrigger test modules thread-friendly

### DIFF
--- a/L1Trigger/GlobalCaloTrigger/test/FakeGctInputProducer.cc
+++ b/L1Trigger/GlobalCaloTrigger/test/FakeGctInputProducer.cc
@@ -15,9 +15,7 @@ FakeGctInputProducer::FakeGctInputProducer(const edm::ParameterSet& iConfig) {
   niemMode_ = iConfig.getUntrackedParameter<int>("nonIsoEmMode", 0);
 }
 
-FakeGctInputProducer::~FakeGctInputProducer() {}
-
-void FakeGctInputProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void FakeGctInputProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   // containers

--- a/L1Trigger/GlobalCaloTrigger/test/FakeGctInputProducer.h
+++ b/L1Trigger/GlobalCaloTrigger/test/FakeGctInputProducer.h
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -29,13 +29,12 @@
 // class decleration
 //
 
-class FakeGctInputProducer : public edm::EDProducer {
+class FakeGctInputProducer : public edm::global::EDProducer<> {
 public:
   explicit FakeGctInputProducer(const edm::ParameterSet&);
-  ~FakeGctInputProducer();
 
 private:
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   int rgnMode_;
   int iemMode_;

--- a/L1Trigger/GlobalCaloTrigger/test/FakeGctInputTester.cc
+++ b/L1Trigger/GlobalCaloTrigger/test/FakeGctInputTester.cc
@@ -32,11 +32,6 @@ FakeGctInputTester::FakeGctInputTester(const edm::ParameterSet& iConfig) {
   hFileName_ = iConfig.getUntrackedParameter<string>("histoFile", "FakeRctTest.root");
 }
 
-FakeGctInputTester::~FakeGctInputTester() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //

--- a/L1Trigger/GlobalCaloTrigger/test/FakeGctInputTester.h
+++ b/L1Trigger/GlobalCaloTrigger/test/FakeGctInputTester.h
@@ -21,22 +21,21 @@
 #define FAKEGCTINPUTTESTER_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include <string>
 
 class TH1F;
 class TFile;
 
-class FakeGctInputTester : public edm::EDAnalyzer {
+class FakeGctInputTester : public edm::one::EDAnalyzer<> {
 public:
   explicit FakeGctInputTester(const edm::ParameterSet&);
-  ~FakeGctInputTester();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   // ----------member data ---------------------------
 


### PR DESCRIPTION
#### PR description:

Converted to thread friendly types. This fixes the CMS deprecation warnings.

#### PR validation:

Package compiles without CMS deprecation warnings.