### PR TITLE
[12_4_X] RPCDqmClient crash fix for 0 LS runs

### DIFF
--- a/DQM/RPCMonitorClient/plugins/RPCDqmClient.cc
+++ b/DQM/RPCMonitorClient/plugins/RPCDqmClient.cc
@@ -48,6 +48,7 @@ RPCDqmClient::RPCDqmClient(const edm::ParameterSet& pset) {
 
   //clear counters
   lumiCounter_ = 0;
+  RPCEvents_ = nullptr;
 
   rpcGeomToken_ = esConsumes<edm::Transition::EndLuminosityBlock>();
 }


### PR DESCRIPTION
#### PR description:
To fix another RPC client crash place in online DQM when 0 LS are in the run  ([0]).

[0]  https://cmsweb.cern.ch/dqm/dqm-square-k8/api?what=get_logs&id=dqm-source-state-run359813-hostfu-c2f11-11-03-pid038886&db=production

#### PR validation:
Tested locally, to be tested at P5