### PR TITLE
Removed commented out deprecated header in L1TMuonCPPFDigiProducer

### DIFF
--- a/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
+++ b/L1Trigger/L1TMuonCPPF/plugins/L1TMuonCPPFDigiProducer.h
@@ -12,7 +12,6 @@
 // User include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

This helps with the work of removing the header from CMSSW.

#### PR validation:

Code compiles.