### PR TITLE
Removed unnecessary include of deprecated header in DTLowQMatching

### DIFF
--- a/L1Trigger/L1TTwinMux/interface/DTLowQMatching.h
+++ b/L1Trigger/L1TTwinMux/interface/DTLowQMatching.h
@@ -21,7 +21,6 @@
 #include "L1Trigger/L1TTwinMux/interface/L1MuTMChambPhContainer.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"


### PR DESCRIPTION
#### PR description:

Removed unused header as part of cleanup of `FWCore/Framework/interface/EDProducer.h`.

#### PR validation:

Code compiles.