### PR TITLE
Add Service type in an exception message from ServiceRegistry

### DIFF
--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -61,9 +61,10 @@ namespace edm {
     template <typename T>
     T& get() const {
       if (nullptr == manager_.get()) {
-        Exception::throwThis(errors::NotFound,
-                             "Service"
-                             " no ServiceRegistry has been set for this thread");
+        Exception::throwThis(
+            errors::NotFound,
+            "No ServiceRegistry has been set for this thread. Tried to get a Service with compiler type name ",
+            typeid(T).name());
       }
       return manager_->template get<T>();
     }
@@ -72,8 +73,9 @@ namespace edm {
     bool isAvailable() const {
       if (nullptr == manager_.get()) {
         Exception::throwThis(errors::NotFound,
-                             "Service"
-                             " no ServiceRegistry has been set for this thread");
+                             "No ServiceRegistry has been set for this thread. Tried to ask availability of a Service "
+                             "with compiler type name ",
+                             typeid(T).name());
       }
       return manager_->template isAvailable<T>();
     }

--- a/FWCore/ServiceRegistry/interface/ServiceRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistry.h
@@ -23,6 +23,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/ServiceRegistry/interface/ServicesManager.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 // system include files
 #include <vector>
@@ -61,10 +62,10 @@ namespace edm {
     template <typename T>
     T& get() const {
       if (nullptr == manager_.get()) {
-        Exception::throwThis(
-            errors::NotFound,
-            "No ServiceRegistry has been set for this thread. Tried to get a Service with compiler type name ",
-            typeid(T).name());
+        auto demangled = typeDemangle(typeid(T).name());
+        Exception::throwThis(errors::NotFound,
+                             "No ServiceRegistry has been set for this thread. Tried to get a Service ",
+                             demangled.c_str());
       }
       return manager_->template get<T>();
     }
@@ -72,10 +73,10 @@ namespace edm {
     template <typename T>
     bool isAvailable() const {
       if (nullptr == manager_.get()) {
+        auto demangled = typeDemangle(typeid(T).name());
         Exception::throwThis(errors::NotFound,
-                             "No ServiceRegistry has been set for this thread. Tried to ask availability of a Service "
-                             "with compiler type name ",
-                             typeid(T).name());
+                             "No ServiceRegistry has been set for this thread. Tried to ask availability of a Service ",
+                             demangled.c_str());
       }
       return manager_->template isAvailable<T>();
     }

--- a/FWCore/ServiceRegistry/interface/ServicesManager.h
+++ b/FWCore/ServiceRegistry/interface/ServicesManager.h
@@ -24,6 +24,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMakerBase.h"
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Utilities/interface/TypeIDBase.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -80,9 +81,10 @@ namespace edm {
           //do on demand building of the service
           if (nullptr == type2Maker_.get() ||
               type2Maker_->end() == (itFoundMaker = type2Maker_->find(TypeIDBase(typeid(T))))) {
+            auto demangled = typeDemangle(typeid(T).name());
             Exception::throwThis(errors::NotFound,
                                  "Service Request unable to find requested service with compiler type name '",
-                                 typeid(T).name(),
+                                 demangled.c_str(),
                                  "'.\n");
           } else {
             const_cast<ServicesManager&>(*this).createServiceFor(itFoundMaker->second);


### PR DESCRIPTION
#### PR description:

This PR adds the Service type as part of the exception message when a ServiceRegistry has not been set for the current thread. This information could help debugging semi-rare failures in HLT tests that were reported in https://github.com/cms-sw/cmssw/pull/38801#issuecomment-1267976632 .

#### PR validation:

Code compiles