### PR TITLE
Removed unnecessary deprecated header from VertexProducer.cc

### DIFF
--- a/L1Trigger/VertexFinder/plugins/VertexProducer.cc
+++ b/L1Trigger/VertexFinder/plugins/VertexProducer.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/L1Trigger/interface/Vertex.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

This is part of a cleanup campaign for FWCore/Framework/interface/EDProducer.h.

#### PR validation:

Code compiles.