### PR TITLE
Bug fix, start Services in runOrQueueEventSetupForInstanceAsync

### DIFF
--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -35,6 +35,7 @@ namespace edm {
   class ParameterSet;
   class IOVSyncValue;
   class ModuleTypeResolverBase;
+  class ServiceToken;
   class WaitingTaskHolder;
   class WaitingTaskList;
 
@@ -103,6 +104,7 @@ namespace edm {
                                                 std::vector<std::shared_ptr<const EventSetupImpl>>&,
                                                 edm::SerialTaskQueue& queueWhichWaitsForIOVsToFinish,
                                                 ActivityRegistry*,
+                                                ServiceToken const&,
                                                 bool iForceCacheClear = false);
 
       // Pass in an IOVSyncValue to let the EventSetup system know which run and lumi

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1183,6 +1183,7 @@ namespace edm {
                                                            status->eventSetupImpls(),
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
+                                                           serviceToken_,
                                                            forceESCacheClearOnNewRun_);
     }) | chain::then([this, status, iSync](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
@@ -1428,7 +1429,8 @@ namespace edm {
                                                            iRunStatus->endIOVWaitingTasksEndRun(),
                                                            iRunStatus->eventSetupImplsEndRun(),
                                                            queueWhichWaitsForIOVsToFinish_,
-                                                           actReg_.get());
+                                                           actReg_.get(),
+                                                           serviceToken_);
     }) | chain::then([this, iRunStatus, ts](std::exception_ptr const* iException, auto nextTask) {
       if (iException) {
         iRunStatus->setEndingEventSetupSucceeded(false);
@@ -1632,7 +1634,8 @@ namespace edm {
                                                            status->endIOVWaitingTasks(),
                                                            status->eventSetupImpls(),
                                                            queueWhichWaitsForIOVsToFinish_,
-                                                           actReg_.get());
+                                                           actReg_.get(),
+                                                           serviceToken_);
     }) | chain::then([this, status, iRunStatus, iSync](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         //the call to doneWaiting will cause the count to decrement


### PR DESCRIPTION
#### PR description:

Bug fix related to #38801. The problem was noticed in the IBs after that pull request was merged. It didn't show up in earlier tests. This should fix the problem with the message "no ServiceRegistry has been set for this thread".

Note that a second problem with the symptom of a seg fault also showed up rarely after that PR was merged. This probably will not fix that. We are still working on a fix for that one.

#### PR validation:

This is a non-reproducible problem that does not show up every time so I am not 100% sure this will fix it. We should merge it and see what happens in the IBs.
