### PR TITLE
[12_5_X] Update SiStrip and SiPixel bad components for Run 3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,17 +70,17 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '125X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v3',
+    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v3',
+    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '125X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:
Backport of #39645
This PR updates, in the Run 3 _realistic_ MC GTs, the SiPixel ([CMSTalk request](https://cms-talk.web.cern.ch/t/mc-gt-updating-sipixel-bad-components-for-2022-mc/15500)) and SiStrip ([CMSTalk request](https://cms-talk.web.cern.ch/t/mc-new-sistrip-tag-for-bad-components/15449/11)) bad components tags.

See master PR for list of updated tags and GT differences.

#### PR validation:
Tested with:
` runTheMatrix.py -l 11634.0,7.23,159.0,12434.0,12834.0 --ibeos -j 16`

#### Backport:
Backport of #39645