### PR TITLE
HLT Tau DQM from MiniAOD

### DIFF
--- a/DQMOffline/Trigger/BuildFile.xml
+++ b/DQMOffline/Trigger/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TauReco"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/PatCandidates"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
@@ -11,6 +11,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
 //Plotters
 #include "DQMOffline/Trigger/interface/HistoWrapper.h"
@@ -43,6 +44,8 @@ private:
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
   edm::InputTag triggerEventSrc_;
   edm::EDGetTokenT<trigger::TriggerEvent> triggerEventToken_;
+  edm::InputTag miniAODTriggerObjectSrc;
+  edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> miniAODTriggerObjectToken;
 
   // For path plotters
   const std::string pathRegex_;

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -2,6 +2,7 @@
 #ifndef DQMOffline_Trigger_HLTTauDQMPath_h
 #define DQMOffline_Trigger_HLTTauDQMPath_h
 
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
 #include <tuple>
@@ -118,6 +119,9 @@ public:
 
   // Get objects associated to a filter, i is the "internal" index
   void getFilterObjects(const trigger::TriggerEvent& triggerEvent, size_t i, std::vector<Object>& retval) const;
+  void getFilterObjects(const pat::TriggerObjectStandAloneCollection& triggerObjects,
+                        size_t i,
+                        std::vector<Object>& retval) const;
 
   // i = filter index
   bool offlineMatching(size_t i,

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
@@ -38,9 +38,425 @@ public:
 
   void bookHistograms(HistoWrapper &iWrapper, DQMStore::IBooker &iBooker);
 
+  template <class T>
   void analyze(const edm::TriggerResults &triggerResults,
-               const trigger::TriggerEvent &triggerEvent,
-               const HLTTauDQMOfflineObjects &refCollection);
+               const T &triggerEvent,
+               const HLTTauDQMOfflineObjects &refCollection) {
+    std::vector<HLTTauDQMPath::Object> triggerObjs;
+    std::vector<HLTTauDQMPath::Object> matchedTriggerObjs;
+    HLTTauDQMOfflineObjects matchedOfflineObjs;
+
+    // Events per filter
+    const int lastPassedFilter = hltPath_.lastPassedFilter(triggerResults);
+    int lastMatchedFilter = -1;
+    int lastMatchedMETFilter = -1;
+    int lastMatchedElectronFilter = -1;
+    int lastMatchedMuonFilter = -1;
+    int lastMatchedTauFilter = -1;
+    int firstMatchedMETFilter = -1;
+
+    if (doRefAnalysis_) {
+      double matchDr = hltPath_.isFirstFilterL1Seed() ? l1MatchDr_ : hltMatchDr_;
+      for (int i = 0; i <= lastPassedFilter; ++i) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear();
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, i, triggerObjs);
+        //std::cout << "Filter name " << hltPath_.getFilterName(i) << " nobjs " << triggerObjs.size() << " " << "ref size " << refCollection.taus.size() << std::endl;
+        bool matched =
+            hltPath_.offlineMatching(i, triggerObjs, refCollection, matchDr, matchedTriggerObjs, matchedOfflineObjs);
+        //std::cout << "  offline matching: " << matched << " " << matchedTriggerObjs.size() << std::endl;
+        matchDr = hltMatchDr_;
+        if (!matched)
+          break;
+
+        if (hAcceptedEvents_)
+          hAcceptedEvents_->Fill(i + 0.5);
+        lastMatchedFilter = i;
+        if (hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length())
+          lastMatchedMETFilter = i;
+        if (hltPath_.getFilterType(i) == "HLTMuonL3PreFilter" || hltPath_.getFilterType(i) == "HLTMuonIsoFilter")
+          lastMatchedMuonFilter = i;
+        if (hltPath_.getFilterName(i).find("hltEle") < hltPath_.getFilterName(i).length())
+          lastMatchedElectronFilter = i;
+        if (hltPath_.getFilterName(i).find("hltPFTau") < hltPath_.getFilterName(i).length() ||
+            hltPath_.getFilterName(i).find("hltHpsPFTau") < hltPath_.getFilterName(i).length() ||
+            hltPath_.getFilterName(i).find("hltDoublePFTau") < hltPath_.getFilterName(i).length() ||
+            hltPath_.getFilterName(i).find("hltHpsDoublePFTau") < hltPath_.getFilterName(i).length())
+          lastMatchedTauFilter = i;
+        if (firstMatchedMETFilter < 0 && hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length())
+          firstMatchedMETFilter = i;
+      }
+    } else {
+      for (int i = 0; i <= lastPassedFilter; ++i) {
+        if (hAcceptedEvents_)
+          hAcceptedEvents_->Fill(i + 0.5);
+      }
+    }
+
+    // Efficiency plots
+    if (doRefAnalysis_ && lastMatchedFilter >= 0) {
+      // L2 taus
+      if (hltPath_.hasL2Taus()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL2TauIndex()) {
+          for (const LV &tau : refCollection.taus) {
+            if (hL2TrigTauEtEffDenom_)
+              hL2TrigTauEtEffDenom_->Fill(tau.pt());
+            if (hL2TrigTauHighEtEffDenom_)
+              hL2TrigTauHighEtEffDenom_->Fill(tau.pt());
+            if (hL2TrigTauEtaEffDenom_)
+              hL2TrigTauEtaEffDenom_->Fill(tau.eta());
+            if (hL2TrigTauPhiEffDenom_)
+              hL2TrigTauPhiEffDenom_->Fill(tau.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL2TauFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2TauFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL2TauFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &tau : matchedOfflineObjs.taus) {
+              if (hL2TrigTauEtEffNum_)
+                hL2TrigTauEtEffNum_->Fill(tau.pt());
+              if (hL2TrigTauHighEtEffNum_)
+                hL2TrigTauHighEtEffNum_->Fill(tau.pt());
+              if (hL2TrigTauEtaEffNum_)
+                hL2TrigTauEtaEffNum_->Fill(tau.eta());
+              if (hL2TrigTauPhiEffNum_)
+                hL2TrigTauPhiEffNum_->Fill(tau.phi());
+            }
+          }
+        }
+      }
+
+      // L3 taus
+      if (hltPath_.hasL3Taus()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL3TauIndex()) {
+          for (const LV &tau : refCollection.taus) {
+            if (hL3TrigTauEtEffDenom_)
+              hL3TrigTauEtEffDenom_->Fill(tau.pt());
+            if (hL3TrigTauHighEtEffDenom_)
+              hL3TrigTauHighEtEffDenom_->Fill(tau.pt());
+            if (hL3TrigTauEtaEffDenom_)
+              hL3TrigTauEtaEffDenom_->Fill(tau.eta());
+            if (hL3TrigTauPhiEffDenom_)
+              hL3TrigTauPhiEffDenom_->Fill(tau.phi());
+            if (hL3TrigTauEtaPhiEffDenom_)
+              hL3TrigTauEtaPhiEffDenom_->Fill(tau.eta(), tau.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL3TauFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL3TauFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL3TauFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &tau : matchedOfflineObjs.taus) {
+              if (hL3TrigTauEtEffNum_)
+                hL3TrigTauEtEffNum_->Fill(tau.pt());
+              if (hL3TrigTauHighEtEffNum_)
+                hL3TrigTauHighEtEffNum_->Fill(tau.pt());
+              if (hL3TrigTauEtaEffNum_)
+                hL3TrigTauEtaEffNum_->Fill(tau.eta());
+              if (hL3TrigTauPhiEffNum_)
+                hL3TrigTauPhiEffNum_->Fill(tau.phi());
+              if (hL3TrigTauEtaPhiEffNum_)
+                hL3TrigTauEtaPhiEffNum_->Fill(tau.eta(), tau.phi());
+            }
+          }
+        }
+      }
+
+      // L2 Electrons
+      if (hltPath_.hasL2Electrons()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL2ElectronIndex()) {
+          for (const LV &electron : refCollection.electrons) {
+            if (hL2TrigElectronEtEffDenom_)
+              hL2TrigElectronEtEffDenom_->Fill(electron.pt());
+            if (hL2TrigElectronEtaEffDenom_)
+              hL2TrigElectronEtaEffDenom_->Fill(electron.eta());
+            if (hL2TrigElectronPhiEffDenom_)
+              hL2TrigElectronPhiEffDenom_->Fill(electron.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL2ElectronFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2ElectronFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL2ElectronFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &electron : matchedOfflineObjs.electrons) {
+              if (hL2TrigElectronEtEffNum_)
+                hL2TrigElectronEtEffNum_->Fill(electron.pt());
+              if (hL2TrigElectronEtaEffNum_)
+                hL2TrigElectronEtaEffNum_->Fill(electron.eta());
+              if (hL2TrigElectronPhiEffNum_)
+                hL2TrigElectronPhiEffNum_->Fill(electron.phi());
+            }
+          }
+        }
+      }
+
+      // L3 electron
+      if (hltPath_.hasL3Electrons()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL3ElectronIndex()) {
+          for (const LV &electron : refCollection.electrons) {
+            if (hL3TrigElectronEtEffDenom_)
+              hL3TrigElectronEtEffDenom_->Fill(electron.pt());
+            if (hL3TrigElectronEtaEffDenom_)
+              hL3TrigElectronEtaEffDenom_->Fill(electron.eta());
+            if (hL3TrigElectronPhiEffDenom_)
+              hL3TrigElectronPhiEffDenom_->Fill(electron.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL3ElectronFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL3ElectronFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL3ElectronFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &electron : matchedOfflineObjs.electrons) {
+              if (hL3TrigElectronEtEffNum_)
+                hL3TrigElectronEtEffNum_->Fill(electron.pt());
+              if (hL3TrigElectronEtaEffNum_)
+                hL3TrigElectronEtaEffNum_->Fill(electron.eta());
+              if (hL3TrigElectronPhiEffNum_)
+                hL3TrigElectronPhiEffNum_->Fill(electron.phi());
+            }
+          }
+        }
+      }
+
+      // L2 Muons
+      if (hltPath_.hasL2Muons()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL2MuonIndex()) {
+          for (const LV &muon : refCollection.muons) {
+            if (hL2TrigMuonEtEffDenom_)
+              hL2TrigMuonEtEffDenom_->Fill(muon.pt());
+            if (hL2TrigMuonEtaEffDenom_)
+              hL2TrigMuonEtaEffDenom_->Fill(muon.eta());
+            if (hL2TrigMuonPhiEffDenom_)
+              hL2TrigMuonPhiEffDenom_->Fill(muon.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL2MuonFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2MuonFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL2MuonFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &muon : matchedOfflineObjs.muons) {
+              if (hL2TrigMuonEtEffNum_)
+                hL2TrigMuonEtEffNum_->Fill(muon.pt());
+              if (hL2TrigMuonEtaEffNum_)
+                hL2TrigMuonEtaEffNum_->Fill(muon.eta());
+              if (hL2TrigMuonPhiEffNum_)
+                hL2TrigMuonPhiEffNum_->Fill(muon.phi());
+            }
+          }
+        }
+      }
+
+      // L3 muon
+      if (hltPath_.hasL3Muons()) {
+        // Denominators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL3MuonIndex()) {
+          for (const LV &muon : refCollection.muons) {
+            if (hL3TrigMuonEtEffDenom_)
+              hL3TrigMuonEtEffDenom_->Fill(muon.pt());
+            if (hL3TrigMuonEtaEffDenom_)
+              hL3TrigMuonEtaEffDenom_->Fill(muon.eta());
+            if (hL3TrigMuonPhiEffDenom_)
+              hL3TrigMuonPhiEffDenom_->Fill(muon.phi());
+          }
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL3MuonFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL3MuonFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL3MuonFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            for (const LV &muon : matchedOfflineObjs.muons) {
+              if (hL3TrigMuonEtEffNum_)
+                hL3TrigMuonEtEffNum_->Fill(muon.pt());
+              if (hL3TrigMuonEtaEffNum_)
+                hL3TrigMuonEtaEffNum_->Fill(muon.eta());
+              if (hL3TrigMuonPhiEffNum_)
+                hL3TrigMuonPhiEffNum_->Fill(muon.phi());
+            }
+          }
+        }
+      }
+
+      // L2 CaloMET
+      if (hltPath_.hasL2CaloMET()) {
+        // Denominators
+        if (static_cast<size_t>(firstMatchedMETFilter) >= hltPath_.getFirstFilterBeforeL2CaloMETIndex()) {
+          if (hL2TrigMETEtEffDenom_)
+            hL2TrigMETEtEffDenom_->Fill(refCollection.met[0].pt());
+        }
+
+        // Numerators
+        if (static_cast<size_t>(lastMatchedMETFilter) >= hltPath_.getLastL2CaloMETFilterIndex()) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2CaloMETFilterIndex(), triggerObjs);
+          bool matched = hltPath_.offlineMatching(hltPath_.getLastL2CaloMETFilterIndex(),
+                                                  triggerObjs,
+                                                  refCollection,
+                                                  hltMatchDr_,
+                                                  matchedTriggerObjs,
+                                                  matchedOfflineObjs);
+          if (matched) {
+            if (hL2TrigMETEtEffNum_)
+              hL2TrigMETEtEffNum_->Fill(matchedOfflineObjs.met[0].pt());
+          }
+        }
+      }
+    }
+
+    if (hltPath_.fired(triggerResults)) {
+      triggerObjs.clear();
+      matchedTriggerObjs.clear();
+      matchedOfflineObjs.clear();
+
+      if (lastMatchedMETFilter >= 0)
+        hltPath_.getFilterObjects(triggerEvent, lastMatchedMETFilter, triggerObjs);
+      if (lastMatchedMuonFilter >= 0)
+        hltPath_.getFilterObjects(triggerEvent, lastMatchedMuonFilter, triggerObjs);
+      if (lastMatchedElectronFilter >= 0)
+        hltPath_.getFilterObjects(triggerEvent, lastMatchedElectronFilter, triggerObjs);
+
+      if (lastMatchedTauFilter >= 0)
+        hltPath_.getFilterObjects(triggerEvent, lastMatchedTauFilter, triggerObjs);
+      if (doRefAnalysis_) {
+        bool matched = hltPath_.offlineMatching(
+            lastPassedFilter, triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+        if (matched) {
+          // Di-object invariant mass
+          if (hMass_) {
+            const int ntaus = hltPath_.getFilterNTaus(lastPassedFilter);
+            if (ntaus == 2 && hltPath_.getFilterNElectrons(lastMatchedElectronFilter) == 0 &&
+                hltPath_.getFilterNMuons(lastMatchedMuonFilter) == 0) {
+              // Di-tau (matchedOfflineObjs are already sorted)
+              if (hMass_)
+                hMass_->Fill((matchedOfflineObjs.taus[0] + matchedOfflineObjs.taus[1]).M());
+            }
+            // Electron+tau
+            else if (ntaus == 1 && hltPath_.getFilterNElectrons(lastPassedFilter) == 1) {
+              if (hMass_)
+                hMass_->Fill((matchedOfflineObjs.taus[0] + matchedOfflineObjs.electrons[0]).M());
+            }
+            // Muon+tau
+            else if (ntaus == 1 && hltPath_.getFilterNMuons(lastPassedFilter) == 1) {
+              if (hMass_)
+                hMass_->Fill((matchedOfflineObjs.taus[0] + matchedOfflineObjs.muons[0]).M());
+            }
+            // Tau+MET
+            if (hltPath_.getFilterNTaus(lastPassedFilter) == 1 && hltPath_.getFilterMET(lastMatchedMETFilter) == 1) {
+              double taupt = matchedOfflineObjs.taus[0].Pt();
+              double tauphi = matchedOfflineObjs.taus[0].Phi();
+              double met = matchedOfflineObjs.met[0].Pt();
+              double metphi = matchedOfflineObjs.met[0].Phi();
+              double mT = sqrt(2 * taupt * met * (1 - cos(tauphi - metphi)));
+
+              if (hMass_)
+                hMass_->Fill(mT);
+            }
+          }
+        }
+
+        // Triggered object kinematics
+        for (const HLTTauDQMPath::Object &obj : triggerObjs) {
+          if (obj.id == trigger::TriggerTau) {
+            if (hTrigTauEt_)
+              hTrigTauEt_->Fill(obj.object.pt());
+            if (hTrigTauEta_)
+              hTrigTauEta_->Fill(obj.object.eta());
+            if (hTrigTauPhi_)
+              hTrigTauPhi_->Fill(obj.object.phi());
+          }
+          if (obj.id == trigger::TriggerElectron || obj.id == trigger::TriggerPhoton) {
+            if (hTrigElectronEt_)
+              hTrigElectronEt_->Fill(obj.object.pt());
+            if (hTrigElectronEta_)
+              hTrigElectronEta_->Fill(obj.object.eta());
+            if (hTrigElectronPhi_)
+              hTrigElectronPhi_->Fill(obj.object.phi());
+          }
+          if (obj.id == trigger::TriggerMuon) {
+            if (hTrigMuonEt_)
+              hTrigMuonEt_->Fill(obj.object.pt());
+            if (hTrigMuonEta_)
+              hTrigMuonEta_->Fill(obj.object.eta());
+            if (hTrigMuonPhi_)
+              hTrigMuonPhi_->Fill(obj.object.phi());
+          }
+          if (obj.id == trigger::TriggerMET) {
+            if (hTrigMETEt_)
+              hTrigMETEt_->Fill(obj.object.pt());
+            if (hTrigMETPhi_)
+              hTrigMETPhi_->Fill(obj.object.phi());
+          }
+        }
+      }
+    }
+  }
 
   const HLTTauDQMPath *getPathObject() const { return &hltPath_; }
 

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h
@@ -7,7 +7,9 @@
 
 #include <vector>
 
-class HLTTauDQMPath;
+#include "DQMOffline/Trigger/interface/HLTTauDQMPath.h"
+
+//class HLTTauDQMPath;
 namespace edm {
   class TriggerResults;
 }
@@ -28,9 +30,47 @@ public:
   void setPathObjects(const std::vector<const HLTTauDQMPath*>& pathObjects) { pathObjects_ = pathObjects; }
   void bookHistograms(HistoWrapper& iWrapper, DQMStore::IBooker& iBooker);
 
+  template <class T>
   void analyze(const edm::TriggerResults& triggerResults,
-               const trigger::TriggerEvent& triggerEvent,
-               const HLTTauDQMOfflineObjects& refCollection);
+               const T& triggerEvent,  //trigger::TriggerEvent& triggerEvent,
+               const HLTTauDQMOfflineObjects& refCollection) {
+    if (doRefAnalysis_) {
+      std::vector<HLTTauDQMPath::Object> triggerObjs;
+      std::vector<HLTTauDQMPath::Object> matchedTriggerObjs;
+      HLTTauDQMOfflineObjects matchedOfflineObjs;
+
+      for (size_t i = 0; i < pathObjects_.size(); ++i) {
+        const HLTTauDQMPath* path = pathObjects_[i];
+        const int lastFilter = path->filtersSize() - 1;
+
+        if (path->goodOfflineEvent(lastFilter, refCollection)) {
+          if (all_events)
+            all_events->Fill(i + 0.5);
+        }
+        if (path->fired(triggerResults)) {
+          triggerObjs.clear();
+          matchedTriggerObjs.clear();
+          matchedOfflineObjs.clear();
+          path->getFilterObjects(triggerEvent, lastFilter, triggerObjs);
+          if (path->offlineMatching(
+                  lastFilter, triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs)) {
+            if (accepted_events)
+              accepted_events->Fill(i + 0.5);
+          }
+        }
+      }
+    } else {
+      for (size_t i = 0; i < pathObjects_.size(); ++i) {
+        const HLTTauDQMPath* path = pathObjects_[i];
+        if (all_events)
+          all_events->Fill(i + 0.5);
+        if (path->fired(triggerResults)) {
+          if (accepted_events)
+            accepted_events->Fill(i + 0.5);
+        }
+      }
+    }
+  }
 
 private:
   const double hltMatchDr_;

--- a/DQMOffline/Trigger/interface/HLTTauDQMTagAndProbePlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMTagAndProbePlotter.h
@@ -9,6 +9,10 @@
 //#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "Math/GenVector/VectorUtil.h"
 
 namespace edm {
   class Event;
@@ -34,14 +38,93 @@ public:
                       DQMStore::IBooker &iBooker,
                       edm::Run const &iRun,
                       edm::EventSetup const &iSetup);
-
+  template <class T>
   void analyze(edm::Event const &iEvent,
                const edm::TriggerResults &triggerResults,
-               const trigger::TriggerEvent &triggerEvent,
-               const HLTTauDQMOfflineObjects &refCollection);
+               const T &triggerEvent,
+               const HLTTauDQMOfflineObjects &refCollection) {
+    std::vector<LV> offlineObjects;
+    if (xvariable == "tau")
+      offlineObjects = refCollection.taus;
+    if (xvariable == "muon")
+      offlineObjects = refCollection.muons;
+    if (xvariable == "electron")
+      offlineObjects = refCollection.electrons;
+    if (xvariable == "met")
+      offlineObjects = refCollection.met;
+
+    if (offlineObjects.size() < nOfflineObjs)
+      return;
+
+    const edm::TriggerNames &trigNames = iEvent.triggerNames(triggerResults);
+
+    for (const LV &offlineObject : offlineObjects) {
+      // Filter out events if Trigger Filtering is requested
+      bool passTrigger = false;
+      bool hltMatched = false;
+      for (size_t i = 0; i < denTriggers.size(); ++i) {
+        LV trgObject = findTrgObject(denTriggers[i], triggerEvent);
+
+        for (unsigned int hltIndex = 0; hltIndex < trigNames.size(); ++hltIndex) {
+          passTrigger = (trigNames.triggerName(hltIndex).find(denTriggers[i]) != std::string::npos &&
+                         triggerResults.wasrun(hltIndex) && triggerResults.accept(hltIndex));
+
+          if (passTrigger) {
+            double dr = ROOT::Math::VectorUtil::DeltaR(trgObject, offlineObject);
+            if (dr < 0.4)
+              hltMatched = true;
+            break;
+          }
+        }
+        if (passTrigger)
+          break;
+      }
+      if (!passTrigger)
+        return;
+      if (hltMatched)
+        return;  // do not consider offline objects which match the tag trigger
+
+      if (h_den_pt)
+        h_den_pt->Fill(offlineObject.pt());
+      if (xvariable != "met") {
+        if (h_den_eta)
+          h_den_eta->Fill(offlineObject.eta());
+        if (h_den_etaphi)
+          h_den_etaphi->Fill(offlineObject.eta(), offlineObject.phi());
+      }
+      if (h_den_phi)
+        h_den_phi->Fill(offlineObject.phi());
+
+      // applying selection for numerator
+      passTrigger = false;
+      for (size_t i = 0; i < numTriggers.size(); ++i) {
+        for (unsigned int hltIndex = 0; hltIndex < trigNames.size(); ++hltIndex) {
+          passTrigger = (trigNames.triggerName(hltIndex).find(numTriggers[i]) != std::string::npos &&
+                         triggerResults.wasrun(hltIndex) && triggerResults.accept(hltIndex));
+          if (passTrigger)
+            break;
+        }
+        if (passTrigger)
+          break;
+      }
+      if (!passTrigger)
+        return;
+      if (h_num_pt)
+        h_num_pt->Fill(offlineObject.pt());
+      if (xvariable != "met") {
+        if (h_num_eta)
+          h_num_eta->Fill(offlineObject.eta());
+        if (h_num_etaphi)
+          h_num_etaphi->Fill(offlineObject.eta(), offlineObject.phi());
+      }
+      if (h_num_phi)
+        h_num_phi->Fill(offlineObject.phi());
+    }
+  }
 
 private:
   LV findTrgObject(std::string, const trigger::TriggerEvent &);
+  LV findTrgObject(std::string, const pat::TriggerObjectStandAloneCollection &);
 
   const int nbinsPt_;
   const double ptmin_, ptmax_;

--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -24,6 +24,7 @@
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 #include "DataFormats/TauReco/interface/TauDiscriminatorContainer.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
 
 // ELECTRON includes
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
@@ -32,12 +33,15 @@
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+
 // MUON includes
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "TLorentzVector.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
 
 //Photon Includes
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
@@ -46,6 +50,7 @@
 //MET Includes
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
 
 #include <memory>
 
@@ -68,15 +73,23 @@ private:
   using LorentzVector = math::XYZTLorentzVectorD;
   using LorentzVectorCollection = std::vector<LorentzVector>;
 
+  std::string PFTauType;
+  bool isMiniAODTau;
   edm::EDGetTokenT<reco::PFTauCollection> PFTaus_;
   std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator>> PFTauDis_;
   std::vector<edm::EDGetTokenT<reco::TauDiscriminatorContainer>> PFTauDisCont_;
   std::vector<std::string> PFTauDisContWPs_;
   edm::ProcessHistoryID phID_;
+
+  edm::EDGetTokenT<edm::View<pat::Tau>> MiniAODTauToken;
+  std::vector<std::string> MiniAODTauDiscriminators;
+
   bool doPFTaus_;
   double ptMinPFTau_, etaMinPFTau_, etaMaxPFTau_, phiMinPFTau_, phiMaxPFTau_;
 
   edm::EDGetTokenT<reco::GsfElectronCollection> Electrons_;
+  edm::EDGetTokenT<edm::View<pat::Electron>> MiniAODElectronToken;
+
   bool doElectrons_;
   edm::EDGetTokenT<reco::TrackCollection> e_ctfTrackCollection_;
   edm::InputTag e_ctfTrackCollectionSrc_;
@@ -99,6 +112,7 @@ private:
   double ptMinPhoton_;
 
   edm::EDGetTokenT<reco::MuonCollection> Muons_;
+  edm::EDGetTokenT<edm::View<pat::Muon>> MiniAODMuonToken;
   bool doMuons_;
   double ptMinMuon_;
 
@@ -112,6 +126,7 @@ private:
   double towerIsol_;
 
   edm::EDGetTokenT<reco::CaloMETCollection> MET_;
+  edm::EDGetTokenT<edm::View<pat::MET>> MiniAODMETToken;
   bool doMET_;
   double ptMinMET_;
 

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
@@ -11,6 +11,12 @@ HLTTauDQMOffline = cms.Sequence(TauRefProducer
                                 +hltTauOfflineMonitor_TagAndProbe
                                 )
 
+HLTTauDQMOfflineMiniAOD = cms.Sequence(MiniAODTauRefProducer
+                                +hltTauOfflineMonitor_MiniAODTaus
+                                +hltTauOfflineMonitor_MiniAODInclusive
+                                +hltTauOfflineMonitor_MiniAODTagAndProbe
+                                )
+
 HLTTauDQMOfflineHarvesting = cms.Sequence(HLTTauPostSeq)
 
 HLTTauDQMOfflineQuality = cms.Sequence(hltTauOfflineQualityTests)

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -271,7 +271,7 @@ hltTauOfflineMonitor_TagAndProbe = hltTauOfflineMonitor_PFTaus.clone(
 )
 
 hltTauOfflineMonitor_MiniAODTaus = hltTauOfflineMonitor_PFTaus.clone(
-    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger"),
     Matching = cms.PSet(
         doMatching            = cms.untracked.bool(True),
         matchFilters          = cms.untracked.VPSet(
@@ -296,11 +296,11 @@ hltTauOfflineMonitor_MiniAODTaus = hltTauOfflineMonitor_PFTaus.clone(
 )
 
 hltTauOfflineMonitor_MiniAODInclusive = hltTauOfflineMonitor_Inclusive.clone(
-    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger"),
 )
 
 hltTauOfflineMonitor_MiniAODTagAndProbe = hltTauOfflineMonitor_TagAndProbe.clone(
-    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger"),
     Matching = cms.PSet(
         doMatching            = cms.untracked.bool(True),
         matchFilters          = cms.untracked.VPSet(

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -5,22 +5,22 @@ hltTauDQMofflineProcess = "HLT"
 #Ref Objects-------------------------------------------------------------------------------------------------------
 TauRefProducer = cms.EDProducer("HLTTauRefProducer",
 
-                    PFTaus = cms.untracked.PSet(
-                            PFTauDiscriminatorContainers  = cms.untracked.VInputTag(),
-                            PFTauDiscriminatorContainerWPs  = cms.untracked.vstring(),
-                            PFTauDiscriminators = cms.untracked.VInputTag(
+                    Taus = cms.untracked.PSet(
+                            TauCollection = cms.untracked.InputTag("hpsPFTauProducer"),
+                            TauDiscriminatorContainers  = cms.untracked.VInputTag(),
+                            TauDiscriminatorContainerWPs  = cms.untracked.vstring(),
+                            TauDiscriminators = cms.untracked.VInputTag(
                                     cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
                                     cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
                                     cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"),
                                     cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection")
                             ),
-                            doPFTaus = cms.untracked.bool(True),
+                            doTaus = cms.untracked.bool(True),
                             ptMin = cms.untracked.double(15.0),
                             etaMin = cms.untracked.double(-2.5),
                             etaMax = cms.untracked.double(2.5),
                             phiMin = cms.untracked.double(-3.15),
                             phiMax = cms.untracked.double(3.15),
-                            PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
                             ),
                     Electrons = cms.untracked.PSet(
                             ElectronCollection = cms.untracked.InputTag("gedGsfElectrons"),
@@ -72,6 +72,21 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                     PhiMin = cms.untracked.double(-3.15),
                     PhiMax = cms.untracked.double(3.15)
                   )
+
+MiniAODTauRefProducer = TauRefProducer.clone(
+    Taus = TauRefProducer.Taus.clone(
+        TauCollection = cms.untracked.InputTag("slimmedTaus"),
+        TauDiscriminators = cms.untracked.VInputTag(
+            cms.InputTag("decayModeFinding"),
+            cms.InputTag("byMediumDeepTau2017v2p1VSjet"),
+            cms.InputTag("byVVLooseDeepTau2017v2p1VSe"),
+            cms.InputTag("byTightDeepTau2017v2p1VSmu"),
+        ),
+    ),
+    MET = TauRefProducer.MET.clone(
+        METCollection = cms.untracked.InputTag("slimmedMETs"),
+    )
+)
 
 #----------------------------------MONITORS--------------------------------------------------------------------------
 kEverything = 0
@@ -142,8 +157,8 @@ def TriggerSelectionParameters(hltpaths):
 
 hltTauOfflineMonitor_TagAndProbe = hltTauOfflineMonitor_PFTaus.clone(
     DQMBaseFolder = "HLT/TAU/TagAndProbe",
-    Matching = cms.PSet(                                                                                                                                                                             
-        doMatching            = cms.untracked.bool(True),                                                                                                                                            
+    Matching = cms.PSet(
+        doMatching            = cms.untracked.bool(True),
         matchFilters          = cms.untracked.VPSet(                                                                                                                                                 
                                     cms.untracked.PSet(                                                                                                                                              
                                         FilterName        = cms.untracked.InputTag("TauRefProducer","PFTaus"),
@@ -253,4 +268,58 @@ hltTauOfflineMonitor_TagAndProbe = hltTauOfflineMonitor_PFTaus.clone(
             denominator = TriggerSelectionParameters(cms.vstring('HLT_Ele35_WPTight_Gsf_v*'))
         )
     )
+)
+
+hltTauOfflineMonitor_MiniAODTaus = hltTauOfflineMonitor_PFTaus.clone(
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+    Matching = cms.PSet(
+        doMatching            = cms.untracked.bool(True),
+        matchFilters          = cms.untracked.VPSet(
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","PFTaus"),
+                                        matchObjectID     = cms.untracked.int32(15),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","Electrons"),
+                                        matchObjectID     = cms.untracked.int32(11),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","Muons"),
+                                        matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","MET"),
+                                        matchObjectID     = cms.untracked.int32(0),
+                                    ),
+                                ),
+    ),
+)
+
+hltTauOfflineMonitor_MiniAODInclusive = hltTauOfflineMonitor_Inclusive.clone(
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+)
+
+hltTauOfflineMonitor_MiniAODTagAndProbe = hltTauOfflineMonitor_TagAndProbe.clone(
+    MiniAODTriggerObjectSrc = cms.untracked.InputTag("slimmedPatTrigger", "", "PAT"),
+    Matching = cms.PSet(
+        doMatching            = cms.untracked.bool(True),
+        matchFilters          = cms.untracked.VPSet(
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","PFTaus"),
+                                        matchObjectID     = cms.untracked.int32(15),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","Electrons"),
+                                        matchObjectID     = cms.untracked.int32(11),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","Muons"),
+                                        matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("MiniAODTauRefProducer","MET"),
+                                        matchObjectID     = cms.untracked.int32(0),
+                                    ),
+                                ),
+    ),
 )

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -579,6 +579,15 @@ void HLTTauDQMPath::getFilterObjects(const trigger::TriggerEvent& triggerEvent,
   }
 }
 
+void HLTTauDQMPath::getFilterObjects(const pat::TriggerObjectStandAloneCollection& triggerObjects,
+                                     size_t i,
+                                     std::vector<Object>& retval) const {
+  for (pat::TriggerObjectStandAlone trigObject : triggerObjects) {
+    if (trigObject.hasFilterLabel(getFilterName(i)))
+      retval.emplace_back(Object{trigObject.triggerObject(), trigObject.filterIds()[i]});
+  }
+}
+
 bool HLTTauDQMPath::offlineMatching(size_t i,
                                     const std::vector<Object>& triggerObjects,
                                     const HLTTauDQMOfflineObjects& offlineObjects,

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -435,7 +435,7 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
 }
 
 HLTTauDQMPathPlotter::~HLTTauDQMPathPlotter() = default;
-
+/*
 void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
                                    const trigger::TriggerEvent& triggerEvent,
                                    const HLTTauDQMOfflineObjects& refCollection) {
@@ -855,3 +855,4 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
     }
   }
 }
+*/

--- a/DQMOffline/Trigger/src/HLTTauDQMPathSummaryPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathSummaryPlotter.cc
@@ -1,5 +1,4 @@
 #include "DQMOffline/Trigger/interface/HLTTauDQMPathSummaryPlotter.h"
-#include "DQMOffline/Trigger/interface/HLTTauDQMPath.h"
 
 HLTTauDQMPathSummaryPlotter::HLTTauDQMPathSummaryPlotter(const edm::ParameterSet& pset,
                                                          bool doRefAnalysis,
@@ -33,7 +32,7 @@ void HLTTauDQMPathSummaryPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStor
 
   iBooker.setCurrentFolder(triggerTag());
 }
-
+/*
 void HLTTauDQMPathSummaryPlotter::analyze(const edm::TriggerResults& triggerResults,
                                           const trigger::TriggerEvent& triggerEvent,
                                           const HLTTauDQMOfflineObjects& refCollection) {
@@ -74,3 +73,4 @@ void HLTTauDQMPathSummaryPlotter::analyze(const edm::TriggerResults& triggerResu
     }
   }
 }
+*/

--- a/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
@@ -101,7 +101,7 @@ LV HLTTauDQMTagAndProbePlotter::findTrgObject(std::string pathName, const trigge
 
 LV HLTTauDQMTagAndProbePlotter::findTrgObject(std::string pathName,
                                               const pat::TriggerObjectStandAloneCollection& triggerObjects) {
-  for (pat::TriggerObjectStandAlone trigObject : triggerObjects) {
+  for (const pat::TriggerObjectStandAlone& trigObject : triggerObjects) {
     // Unpack trigger names into indices
     //trigObject.unpackPathNames(names);
     if (trigObject.hasPathName(pathName)) {

--- a/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMTagAndProbePlotter.cc
@@ -99,6 +99,20 @@ LV HLTTauDQMTagAndProbePlotter::findTrgObject(std::string pathName, const trigge
   return LV(0, 0, 0, 0);
 }
 
+LV HLTTauDQMTagAndProbePlotter::findTrgObject(std::string pathName,
+                                              const pat::TriggerObjectStandAloneCollection& triggerObjects) {
+  for (pat::TriggerObjectStandAlone trigObject : triggerObjects) {
+    // Unpack trigger names into indices
+    //trigObject.unpackPathNames(names);
+    if (trigObject.hasPathName(pathName)) {
+      const unsigned moduleIndex = moduleLabels.size() - 2;
+      if (trigObject.hasFilterLabel(moduleLabels[moduleIndex]))
+        return LV(trigObject.px(), trigObject.py(), trigObject.pz(), trigObject.energy());
+    }
+  }
+  return LV(0, 0, 0, 0);
+}
+/*
 void HLTTauDQMTagAndProbePlotter::analyze(edm::Event const& iEvent,
                                           const edm::TriggerResults& triggerResults,
                                           const trigger::TriggerEvent& triggerEvent,
@@ -182,3 +196,4 @@ void HLTTauDQMTagAndProbePlotter::analyze(edm::Event const& iEvent,
       h_num_phi->Fill(offlineObject.phi());
   }
 }
+*/

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
@@ -17,22 +17,21 @@ TauMCProducer  = cms.EDProducer("HLTTauMCProducer",
 
 #Create LorentzVectors for offline objects
 TauRelvalRefProducer = cms.EDProducer("HLTTauRefProducer",
-
-                                PFTaus = cms.untracked.PSet(
-                                   PFTauDiscriminators = cms.untracked.VInputTag(
+                                Taus = cms.untracked.PSet(
+                                   TauCollection = cms.untracked.InputTag("hpsPFTauProducer"),
+                                   TauDiscriminators = cms.untracked.VInputTag(
                                                     cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
                                    ),
-                                   PFTauDiscriminatorContainers = cms.untracked.VInputTag(
+                                   TauDiscriminatorContainers = cms.untracked.VInputTag(
                                                     cms.InputTag("hpsPFTauBasicDiscriminators")
                                    ),
-                                   PFTauDiscriminatorContainerWPs =  cms.untracked.vstring("ByLooseCombinedIsolationDBSumPtCorr3Hits"),
+                                   TauDiscriminatorContainerWPs =  cms.untracked.vstring("ByLooseCombinedIsolationDBSumPtCorr3Hits"),
                                    doPFTaus = cms.untracked.bool(True),
                                    ptMin = cms.untracked.double(15.0),
                                    etaMin = cms.untracked.double(-2.5),
                                    etaMax = cms.untracked.double(2.5),
                                    phiMin = cms.untracked.double(-3.15),
                                    phiMax = cms.untracked.double(3.15),
-                                   PFTauProducer = cms.untracked.InputTag("hpsPFTauProducer")
                                    ),
                                 Electrons = cms.untracked.PSet(
                                    ElectronCollection = cms.untracked.InputTag("gsfElectrons"),

--- a/HLTriggerOffline/Tau/test/runHLTTauValidationDQMOfflineMiniAOD_cfg.py
+++ b/HLTriggerOffline/Tau/test/runHLTTauValidationDQMOfflineMiniAOD_cfg.py
@@ -1,0 +1,79 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTVAL")
+
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+#process.MessageLogger.categories.append("HLTTauDQMOffline")
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+#'/store/data/Run2018C/SingleMuon/RAW-RECO/ZMu-PromptReco-v2/000/319/756/00000/FEF9093D-3C8B-E811-8048-FA163EC8DFDC.root'
+#	'file:step3.root'
+#        'file:/afs/cern.ch/work/s/slehti/Validation/TauTriggerValidation/step2_RAW2DIGI_L1Reco_RECO_0.root'
+#        '/store/mc/Run3Winter22MiniAOD/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/MINIAODSIM/122X_mcRun3_2021_realistic_v9_ext1-v1/2830000/006d687f-44da-49f0-b0c0-f46b8600731f.root'
+        'file:/eos/user/b/ballmond/DQM/forSami_MiniAOD/step2_RAW2DIGI_L1Reco_RECO_PAT_0.root'
+    )
+)
+
+# Set GlobalTag (automatically)
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
+
+#Load DQM Services
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+
+#Reconfigure Environment and saver
+#process.dqmEnv.subSystemFolder = cms.untracked.string('HLT/HLTTAU')
+#process.DQM.collectorPort = 9091
+#process.DQM.collectorHost = cms.untracked.string('pcwiscms10')
+
+process.dqmSaver.saveByRun = cms.untracked.int32(-1)
+process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
+process.dqmSaver.workflow = cms.untracked.string('/A/N/C')
+process.dqmSaver.forceRunNumber = cms.untracked.int32(123)
+
+
+#Load the Validation
+process.load("DQMOffline.Trigger.HLTTauDQMOffline_cff")
+process.hltTauOfflineMonitor_PFTaus.PlotLevel = cms.untracked.int32(1)
+process.hltTauOfflineMonitor_Inclusive.PlotLevel = cms.untracked.int32(1)
+process.hltTauOfflineMonitor_TagAndProbe.PlotLevel = cms.untracked.int32(1)
+
+#Load The Post processor
+process.load("DQMOffline.Trigger.HLTTauPostProcessor_cfi")
+#process.load("DQMOffline.Trigger.HLTTauQualityTester_cfi")
+
+
+#Define the Paths
+process.validation = cms.Path(process.HLTTauDQMOfflineMiniAOD)
+#process.validation = cms.Path(process.HLTTauVal)
+
+#process.postProcess = cms.EndPath(process.HLTTauPostVal+process.hltTauRelvalQualityTests+process.dqmSaver)
+process.postProcess = cms.EndPath(process.HLTTauPostSeq+process.dqmSaver)
+#process.postProcess = cms.EndPath(process.dqmSaver)
+process.schedule =cms.Schedule(process.validation,process.postProcess)
+
+
+
+process.output = cms.OutputModule("PoolOutputModule",
+   outputCommands = cms.untracked.vstring(
+       "keep *",
+   ),
+   fileName = cms.untracked.string("CMSSW.root")
+)     
+process.out_step = cms.EndPath(process.output)
+process.schedule =cms.Schedule(process.validation,process.postProcess,process.out_step)
+

--- a/HLTriggerOffline/Tau/test/runHLTTauValidationDQMOffline_cfg.py
+++ b/HLTriggerOffline/Tau/test/runHLTTauValidationDQMOffline_cfg.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTVAL")
+
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+#process.MessageLogger.categories.append("HLTTauDQMOffline")
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+#'/store/data/Run2018C/SingleMuon/RAW-RECO/ZMu-PromptReco-v2/000/319/756/00000/FEF9093D-3C8B-E811-8048-FA163EC8DFDC.root'
+#	'file:step3.root'
+#        'file:/afs/cern.ch/work/s/slehti/Validation/TauTriggerValidation/step2_RAW2DIGI_L1Reco_RECO_0.root'
+        'file:/eos/user/b/ballmond/DQM/forSami_RECO/step2_RAW2DIGI_L1Reco_RECO_0.root'
+    )
+)
+
+# Set GlobalTag (automatically)
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
+
+#Load DQM Services
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+
+#Reconfigure Environment and saver
+#process.dqmEnv.subSystemFolder = cms.untracked.string('HLT/HLTTAU')
+#process.DQM.collectorPort = 9091
+#process.DQM.collectorHost = cms.untracked.string('pcwiscms10')
+
+process.dqmSaver.saveByRun = cms.untracked.int32(-1)
+process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
+process.dqmSaver.workflow = cms.untracked.string('/A/N/C')
+process.dqmSaver.forceRunNumber = cms.untracked.int32(123)
+
+
+#Load the Validation
+process.load("DQMOffline.Trigger.HLTTauDQMOffline_cff")
+process.hltTauOfflineMonitor_PFTaus.PlotLevel = cms.untracked.int32(1)
+process.hltTauOfflineMonitor_Inclusive.PlotLevel = cms.untracked.int32(1)
+process.hltTauOfflineMonitor_TagAndProbe.PlotLevel = cms.untracked.int32(1)
+
+#Load The Post processor
+process.load("DQMOffline.Trigger.HLTTauPostProcessor_cfi")
+#process.load("DQMOffline.Trigger.HLTTauQualityTester_cfi")
+
+
+#Define the Paths
+process.validation = cms.Path(process.HLTTauDQMOffline)
+#process.validation = cms.Path(process.HLTTauVal)
+
+#process.postProcess = cms.EndPath(process.HLTTauPostVal+process.hltTauRelvalQualityTests+process.dqmSaver)
+process.postProcess = cms.EndPath(process.HLTTauPostSeq+process.dqmSaver)
+#process.postProcess = cms.EndPath(process.dqmSaver)
+process.schedule =cms.Schedule(process.validation,process.postProcess)
+
+
+
+process.output = cms.OutputModule("PoolOutputModule",
+   outputCommands = cms.untracked.vstring(
+       "keep *",
+   ),
+   fileName = cms.untracked.string("CMSSW.root")
+)     
+#process.out_step = cms.EndPath(process.output)
+#process.schedule =cms.Schedule(process.validation,process.postProcess,process.out_step)
+


### PR DESCRIPTION
#### PR description:
Adding support for running HLT Tau DQM on MiniAOD (PAT) samples so that a larger set of tau discriminators is available for the reference object selection.

#### PR validation:
Checked that the reference objects are the same for RECO and MiniAOD input.
