### PR TITLE
[GSF tracking] Add full Sylvester criterion for positive definite check

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -31,15 +31,12 @@ TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSur
   for (auto const& tsosI : predictedComponents) {
     TrajectoryStateOnSurface updatedTSOS = KFUpdator().update(tsosI, aRecHit);
 
-    double det = 0;
-    double det22 = 0;
-    double det33 = 0;
-    double det44 = 0;
-    if (updatedTSOS.isValid() && updatedTSOS.localError().valid() && updatedTSOS.localError().posDef() &&
-        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det22) && det22 > 0) &&
-        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det33) && det33 > 0) &&
-        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det44) && det44 > 0) &&
-        (updatedTSOS.curvilinearError().matrix().Det2(det)) && det > 0) {
+    if (double det;
+        updatedTSOS.isValid() && updatedTSOS.localError().valid() && updatedTSOS.localError().posDef() &&
+        (det = 0., updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det) && det > 0) &&
+        (det = 0., updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det) && det > 0) &&
+        (det = 0., updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det) && det > 0) &&
+        (det = 0., updatedTSOS.curvilinearError().matrix().Det2(det) && det > 0)) {
       result.addState(TrajectoryStateOnSurface(weights[i],
                                                updatedTSOS.localParameters(),
                                                updatedTSOS.localError(),

--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -32,7 +32,13 @@ TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSur
     TrajectoryStateOnSurface updatedTSOS = KFUpdator().update(tsosI, aRecHit);
 
     double det = 0;
+    double det22 = 0;
+    double det33 = 0;
+    double det44 = 0;
     if (updatedTSOS.isValid() && updatedTSOS.localError().valid() && updatedTSOS.localError().posDef() &&
+        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det22) && det22 > 0) &&
+        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det33) && det33 > 0) &&
+        (updatedTSOS.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det44) && det44 > 0) &&
         (updatedTSOS.curvilinearError().matrix().Det2(det)) && det > 0) {
       result.addState(TrajectoryStateOnSurface(weights[i],
                                                updatedTSOS.localParameters(),


### PR DESCRIPTION
#### PR description:
This PR proposes to add a more strict check of positive definiteness in order to avoid GSF crashes observed recently at HLT as discussed in this issue https://github.com/cms-sw/cmssw/issues/39570.

#### PR validation:

`runTheMatrix.py -l 12434.0` ran fine.

In order to check if this PR would affect HLT electron efficiency, I reran HLT on EGamma RAW data, before and after this PR, and checked trigger decisions for 1000 events. HLT menu `/online/collisions/2022/2e34/v1.4/HLT/V2` was run on `/eos/cms/tier0/store/data/Run2022E/EGamma/RAW/v1/000/359/871/00000/fcf81596-54ed-45d3-9dee-32dec392f246.root`. Trigger result was same, before and after this PR. For example:
```
HLT name | nEventPassed before PR | nEventPassed after PR
HLT_Ele32_WPTight_Gsf_v17 | 376 | 376
HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v21 | 30 | 30
```

The PR test can be done preferably by enabling profiling to see if there is any extra CPU cost for the computation of determinants of sub-matrices.

If this fix is accepted, then a backport to data-taking release cycle would be nice.