### PR TITLE
Convert RecoJets/JetAssociationProducers to thread friendly types

### DIFF
--- a/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.cc
+++ b/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.cc
@@ -26,16 +26,14 @@ JetSignalVertexCompatibility::JetSignalVertexCompatibility(const edm::ParameterS
     : algo(params.getParameter<double>("cut"), params.getParameter<double>("temperature")) {
   jetTracksAssocToken = consumes<JetTracksAssociationCollection>(params.getParameter<edm::InputTag>("jetTracksAssoc"));
   primaryVerticesToken = consumes<VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+  builderToken = esConsumes(edm::ESInputTag("", "TransientTrackBuilder"));
   produces<JetFloatAssociation::Container>();
 }
 
 JetSignalVertexCompatibility::~JetSignalVertexCompatibility() {}
 
 void JetSignalVertexCompatibility::produce(edm::Event &event, const edm::EventSetup &es) {
-  edm::ESHandle<TransientTrackBuilder> trackBuilder;
-  es.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
-
-  algo.resetEvent(trackBuilder.product());
+  algo.resetEvent(&es.getData(builderToken));
 
   edm::Handle<JetTracksAssociationCollection> jetTracksAssoc;
   event.getByToken(jetTracksAssocToken, jetTracksAssoc);

--- a/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.h
+++ b/RecoJets/JetAssociationProducers/src/JetSignalVertexCompatibility.h
@@ -1,7 +1,7 @@
 #ifndef JetSignalVertexCompatibility_h
 #define JetSignalVertexCompatibility_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -11,7 +11,10 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
-class JetSignalVertexCompatibility : public edm::EDProducer {
+class TransientTrackBuilder;
+class TransientTrackRecord;
+
+class JetSignalVertexCompatibility : public edm::stream::EDProducer<> {
 public:
   JetSignalVertexCompatibility(const edm::ParameterSet &params);
   ~JetSignalVertexCompatibility() override;
@@ -23,6 +26,7 @@ private:
 
   edm::EDGetTokenT<reco::JetTracksAssociationCollection> jetTracksAssocToken;
   edm::EDGetTokenT<reco::VertexCollection> primaryVerticesToken;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken;
 };
 
 #endif  // JetSignalVertexCompatibility_h

--- a/RecoJets/JetAssociationProducers/test/PileupJetAnalyzer.cc
+++ b/RecoJets/JetAssociationProducers/test/PileupJetAnalyzer.cc
@@ -3,7 +3,7 @@
 
 #include <TNtuple.h>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@
 
 using namespace reco;
 
-class PileupJetAnalyzer : public edm::EDAnalyzer {
+class PileupJetAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   PileupJetAnalyzer(const edm::ParameterSet &params);
   ~PileupJetAnalyzer();
@@ -64,6 +64,7 @@ PileupJetAnalyzer::PileupJetAnalyzer(const edm::ParameterSet &params)
   tokenSimTrack = consumes<edm::SimTrackContainer>(edm::InputTag("fastSimProducer"));
   tokenSimVertex = consumes<edm::SimVertexContainer>(edm::InputTag("fastSimProducer"));
 
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   ntuple = fs->make<TNtuple>("jets", "", "mc:tag:et:eta");
 }


### PR DESCRIPTION
#### PR description:

This fixes the CMS deprecation warnings.

#### PR validation:

The package compiles without issuing a CMS deprecation warning.