### PR TITLE
Moved BasicToPFJet to global::EDProducer

### DIFF
--- a/RecoJets/JetProducers/plugins/BasicToPFJet.cc
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.cc
@@ -36,15 +36,13 @@ BasicToPFJet::BasicToPFJet(const edm::ParameterSet& PSet)
   produces<reco::PFJetCollection>();
 }
 
-BasicToPFJet::~BasicToPFJet() {}
-
 void BasicToPFJet::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag(""));
   descriptions.add("BasicToPFJet", desc);
 }
 
-void BasicToPFJet::produce(edm::Event& Event, const edm::EventSetup& EventSetup) {
+void BasicToPFJet::produce(edm::StreamID, edm::Event& Event, const edm::EventSetup& EventSetup) const {
   //first get the basic jet collection
   edm::Handle<reco::BasicJetCollection> BasicJetColl;
   Event.getByToken(inputToken_, BasicJetColl);

--- a/RecoJets/JetProducers/plugins/BasicToPFJet.h
+++ b/RecoJets/JetProducers/plugins/BasicToPFJet.h
@@ -2,17 +2,16 @@
 #define RecoJets_JetProducers_BasicToPFJet_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 
-class BasicToPFJet : public edm::EDProducer {
+class BasicToPFJet : public edm::global::EDProducer<> {
 public:
   explicit BasicToPFJet(const edm::ParameterSet& PSet);
-  ~BasicToPFJet() override;
-  void produce(edm::Event& event, const edm::EventSetup& EventSetup) override;
+  void produce(edm::StreamID, edm::Event& event, const edm::EventSetup& EventSetup) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:


### PR DESCRIPTION
#### PR description:

This fixes the CMS deprecation warnings.

#### PR validation:

The package compiles without issuing CMS deprecation warnings.