### PR TITLE
Removed unused header from EcalRecHitWorkerRecover.cc

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerRecover.cc
@@ -14,7 +14,6 @@
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 #include "DataFormats/EcalDetId/interface/EcalScDetId.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
#### PR description:

This is part of a cleanup campaign for deprecated headers.

#### PR validation:

Code compiles.