### PR TITLE
Fix deprecation warnings in RecoMuon/GlobalMuonProducer

### DIFF
--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -11,7 +11,6 @@
 
 // Framework
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoMuon/GlobalMuonProducer/test/GLBMuonAnalyzer.cc
+++ b/RecoMuon/GlobalMuonProducer/test/GLBMuonAnalyzer.cc
@@ -6,7 +6,7 @@
  */
 
 // Base Class Headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 // Collaborating Class Header
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -34,20 +34,20 @@
 #include "TH1F.h"
 #include "TH2F.h"
 
-class GLBMuonAnalyzer : public edm::EDAnalyzer {
+class GLBMuonAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   GLBMuonAnalyzer(const edm::ParameterSet &pset);
 
   /// Destructor
-  virtual ~GLBMuonAnalyzer();
+  ~GLBMuonAnalyzer() override;
 
   // Operations
 
-  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup);
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 protected:
 private:
@@ -71,6 +71,9 @@ private:
   int numberOfRecTracks;
 
   std::string theDataType;
+
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMGFieldToken;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
 };
 
 using namespace std;
@@ -78,6 +81,8 @@ using namespace edm;
 
 /// Constructor
 GLBMuonAnalyzer::GLBMuonAnalyzer(const ParameterSet &pset) {
+  theMGFieldToken = esConsumes();
+  theTrackingGeometryToken = esConsumes();
   theGLBMuonLabel = pset.getUntrackedParameter<edm::InputTag>("GlobalTrackCollectionLabel");
 
   theRootFileName = pset.getUntrackedParameter<string>("rootFileName");
@@ -140,11 +145,9 @@ void GLBMuonAnalyzer::analyze(const Event &event, const EventSetup &eventSetup) 
   Handle<reco::TrackCollection> staTracks;
   event.getByLabel(theGLBMuonLabel, staTracks);
 
-  ESHandle<MagneticField> theMGField;
-  eventSetup.get<IdealMagneticFieldRecord>().get(theMGField);
+  ESHandle<MagneticField> theMGField = eventSetup.getHandle(theMGFieldToken);
 
-  ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-  eventSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  ESHandle<GlobalTrackingGeometry> theTrackingGeometry = eventSetup.getHandle(theTrackingGeometryToken);
 
   double recPt = 0.;
   double simPt = 0.;


### PR DESCRIPTION
#### PR description:

- converted legacy modules to thread friendly
- added esConsumes

#### PR validation:

Packaged compiles without issuing a CMS deprecation warning.