### PR TITLE
Fixed deprecation warnings in  RecoMuon/GlobalTrackingTools

### DIFF
--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -14,7 +14,6 @@
 // user include files
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"

--- a/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
+++ b/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,23 +26,23 @@
 
 #define MAX_THR 1e7
 
-class DYTTuner : public edm::EDAnalyzer {
+class DYTTuner : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit DYTTuner(const edm::ParameterSet&);
-  ~DYTTuner();
+  ~DYTTuner() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
   virtual double doIntegral(std::vector<double>&, DetId&);
   virtual void writePlots();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   typedef edm::ValueMap<reco::DYTInfo> DYTestimators;
   edm::Service<cond::service::PoolDBOutputService> poolDbService;


### PR DESCRIPTION
#### PR description:

- removed unused deprecated header include.
- converted legacy module to one::EDAnalyzer

#### PR validation:

Package compiles without issuing a CMS deprecation warning.