### PR TITLE
Removed unnecessary deprecated header from L3MuonProducer.cc

### DIFF
--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -10,7 +10,6 @@
 
 // Framework
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Part of campaign to remove deprecated headers.

#### PR validation:

Code compiles.