### PR TITLE
Run3-sim128 Use token rather than label for accessing collections in FastSimulation/Calorimetry

### DIFF
--- a/FastSimulation/Calorimetry/plugins/TreeWriterForEcalCorrection.cc
+++ b/FastSimulation/Calorimetry/plugins/TreeWriterForEcalCorrection.cc
@@ -20,7 +20,7 @@
 
 #include "TTree.h"
 
-class TreeWriterForEcalCorrection : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+class TreeWriterForEcalCorrection : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TreeWriterForEcalCorrection(const edm::ParameterSet&);
   ~TreeWriterForEcalCorrection() override = default;
@@ -34,21 +34,21 @@ private:
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ebf_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_eef_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_esf_;
-  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ebs_;  
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ebs_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ees_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ess_;
   TTree* tree_;
   float tree_e_, tree_eta_, tree_response_;
 };
 
-TreeWriterForEcalCorrection::TreeWriterForEcalCorrection(const edm::ParameterSet& iConfig) 
-  : tok_gen_(consumes<reco::GenParticleCollectio>(edm::InputTag("genParticles", ""))),
-    tok_ebf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEB"))),
-    tok_eef_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEE"))),
-    tok_esf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsES"))),
-    tok_ebs_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEB"))),
-    tok_ees_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"))),
-    tok_ess_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsES"))) {
+TreeWriterForEcalCorrection::TreeWriterForEcalCorrection(const edm::ParameterSet& iConfig)
+    : tok_gen_(consumes<reco::GenParticleCollectio>(edm::InputTag("genParticles", ""))),
+      tok_ebf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEB"))),
+      tok_eef_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEE"))),
+      tok_esf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsES"))),
+      tok_ebs_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEB"))),
+      tok_ees_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"))),
+      tok_ess_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsES"))) {
   usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> file;
   tree_ = file->make<TTree>("responseTree", "same info as 3dhisto");
@@ -82,8 +82,10 @@ void TreeWriterForEcalCorrection::analyze(const edm::Event& iEvent, const edm::E
   bool isFastSim = SimHitsEB.isValid();
   if (!isFastSim)
     SimHitsEB = iEvent.getHandle(tok_ebs_);
-  const edm::Handle<edm::PCaloHitContainer> SimHitsEE = isFastSim ? iEvent.getHandle(tok_eef_) : iEvent.getHandle(tok_ees_);
-  const edm::Handle<edm::PCaloHitContainer> SimHitsES = isFastSim ? iEvent.getHandle(tok_esf_) : iEvent.getHandle(tok_ess_);
+  const edm::Handle<edm::PCaloHitContainer> SimHitsEE =
+      isFastSim ? iEvent.getHandle(tok_eef_) : iEvent.getHandle(tok_ees_);
+  const edm::Handle<edm::PCaloHitContainer> SimHitsES =
+      isFastSim ? iEvent.getHandle(tok_esf_) : iEvent.getHandle(tok_ess_);
 
   // merge them into one single vector
   auto SimHits = *(SimHitsEB.product());

--- a/FastSimulation/Calorimetry/plugins/TreeWriterForEcalCorrection.cc
+++ b/FastSimulation/Calorimetry/plugins/TreeWriterForEcalCorrection.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -20,32 +20,46 @@
 
 #include "TTree.h"
 
-class TreeWriterForEcalCorrection : public edm::EDAnalyzer {
+class TreeWriterForEcalCorrection : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 public:
   explicit TreeWriterForEcalCorrection(const edm::ParameterSet&);
-  ~TreeWriterForEcalCorrection() override{};
+  ~TreeWriterForEcalCorrection() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  edm::Service<TFileService> file;
-  TTree* tree;
-  float tree_e, tree_eta, tree_response;
+  const edm::EDGetTokenT<reco::GenParticleCollectio> tok_gen_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ebf_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_eef_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_esf_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ebs_;  
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ees_;
+  const edm::EDGetTokenT<edm::PCaloHitContainer> tok_ess_;
+  TTree* tree_;
+  float tree_e_, tree_eta_, tree_response_;
 };
 
-TreeWriterForEcalCorrection::TreeWriterForEcalCorrection(const edm::ParameterSet& iConfig) {
-  tree = file->make<TTree>("responseTree", "same info as 3dhisto");
-  tree->Branch("e", &tree_e, "e/F");
-  tree->Branch("eta", &tree_eta, "eta/F");
-  tree->Branch("r", &tree_response, "r/F");
+TreeWriterForEcalCorrection::TreeWriterForEcalCorrection(const edm::ParameterSet& iConfig) 
+  : tok_gen_(consumes<reco::GenParticleCollectio>(edm::InputTag("genParticles", ""))),
+    tok_ebf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEB"))),
+    tok_eef_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsEE"))),
+    tok_esf_(consumes<edm::PCaloHitContainer>(edm::InputTag("fastSimProducer", "EcalHitsES"))),
+    tok_ebs_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEB"))),
+    tok_ees_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"))),
+    tok_ess_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsES"))) {
+  usesResource(TFileService::kSharedResource);
+  edm::Service<TFileService> file;
+  tree_ = file->make<TTree>("responseTree", "same info as 3dhisto");
+  tree_->Branch("e", &tree_e_, "e/F");
+  tree_->Branch("eta", &tree_eta_, "eta/F");
+  tree_->Branch("r", &tree_response_, "r/F");
 }
 
 void TreeWriterForEcalCorrection::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get generated particles
-  edm::Handle<reco::GenParticleCollection> GenParticles;
-  iEvent.getByLabel("genParticles", "", GenParticles);
+  const edm::Handle<reco::GenParticleCollection>& GenParticles = iEvent.getHandle(tok_gen_);
 
   // As this module is intended for single particle guns, there should be
   // exactly one generated particle.
@@ -63,23 +77,16 @@ void TreeWriterForEcalCorrection::analyze(const edm::Event& iEvent, const edm::E
   // If not, you could take the absolute value here.
 
   // get sim hits
-  edm::Handle<edm::PCaloHitContainer> SimHitsEB;
-  edm::Handle<edm::PCaloHitContainer> SimHitsEE;
-  edm::Handle<edm::PCaloHitContainer> SimHitsES;
-
+  edm::Handle<edm::PCaloHitContainer> SimHitsEB = iEvent.getHandle(tok_ebf_);
   // Finds out automatically, if this is fullsim or fastsim
-  bool isFastSim = iEvent.getByLabel("fastSimProducer", "EcalHitsEB", SimHitsEB);
-  if (isFastSim) {
-    iEvent.getByLabel("fastSimProducer", "EcalHitsEE", SimHitsEE);
-    iEvent.getByLabel("fastSimProducer", "EcalHitsES", SimHitsES);
-  } else {
-    iEvent.getByLabel("g4SimHits", "EcalHitsEB", SimHitsEB);
-    iEvent.getByLabel("g4SimHits", "EcalHitsEE", SimHitsEE);
-    iEvent.getByLabel("g4SimHits", "EcalHitsES", SimHitsES);
-  }
+  bool isFastSim = SimHitsEB.isValid();
+  if (!isFastSim)
+    SimHitsEB = iEvent.getHandle(tok_ebs_);
+  const edm::Handle<edm::PCaloHitContainer> SimHitsEE = isFastSim ? iEvent.getHandle(tok_eef_) : iEvent.getHandle(tok_ees_);
+  const edm::Handle<edm::PCaloHitContainer> SimHitsES = isFastSim ? iEvent.getHandle(tok_esf_) : iEvent.getHandle(tok_ess_);
 
   // merge them into one single vector
-  auto SimHits = *SimHitsEB;
+  auto SimHits = *(SimHitsEB.product());
   SimHits.insert(SimHits.end(), SimHitsEE->begin(), SimHitsEE->end());
   SimHits.insert(SimHits.end(), SimHitsES->begin(), SimHitsES->end());
 
@@ -90,10 +97,10 @@ void TreeWriterForEcalCorrection::analyze(const edm::Event& iEvent, const edm::E
     energyTotal += Hit.energy();
   }
 
-  tree_e = genE;
-  tree_eta = genEta;
-  tree_response = energyTotal / genE;
-  tree->Fill();
+  tree_e_ = genE;
+  tree_eta_ = genEta;
+  tree_response_ = energyTotal / genE;
+  tree_->Fill();
 }
 
 void TreeWriterForEcalCorrection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

Use token rather than label for accessing collections in FastSimulation/Calorimetry

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special