### PR TITLE
Run3-sim129 Use token rather than label for accessing collections in FastSimulation/ForwardDetectors

### DIFF
--- a/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.cc
@@ -24,7 +24,7 @@ namespace cms {
     npassed = 0;
   }
   void FastSimDataFilter::endJob() {
-    edm::LogVerbatim("FastSim") << " FastSimDataFilter: accepted " << npassed << "  out of total " << ntotal;
+    edm::LogVerbatim("FastSimDataFilter") << " FastSimDataFilter: accepted " << npassed << "  out of total " << ntotal;
   }
 
   bool FastSimDataFilter::filter(edm::Event& event, const edm::EventSetup& setup) {

--- a/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.cc
@@ -15,9 +15,9 @@
 using namespace std;
 namespace cms {
 
-  FastSimDataFilter::FastSimDataFilter(const edm::ParameterSet& conf) 
-    : tokTowers_(consumes<CaloTowerCollection>(edm::InputTag("towerMaker"))),
-      towercut(conf.getUntrackedParameter<double>("towercut", 1.4)) { }
+  FastSimDataFilter::FastSimDataFilter(const edm::ParameterSet& conf)
+      : tokTowers_(consumes<CaloTowerCollection>(edm::InputTag("towerMaker"))),
+        towercut(conf.getUntrackedParameter<double>("towercut", 1.4)) {}
 
   void FastSimDataFilter::beginJob() {
     ntotal = 0;

--- a/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.h
+++ b/FastSimulation/ForwardDetectors/plugins/FastSimDataFilter.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "DataFormats/Math/interface/Vector3D.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
 #include <vector>
 #include <utility>
@@ -22,8 +23,7 @@ namespace cms {
   class FastSimDataFilter : public edm::stream::EDFilter<> {
   public:
     FastSimDataFilter(const edm::ParameterSet& pset);
-
-    ~FastSimDataFilter() override;
+    ~FastSimDataFilter() override = default;
 
     bool filter(edm::Event&, const edm::EventSetup&) override;
     virtual void beginJob();
@@ -31,8 +31,9 @@ namespace cms {
 
   private:
     typedef math::RhoEtaPhiVector Vector;
+    const edm::EDGetTokenT<CaloTowerCollection> tokTowers_;
 
-    double towercut;
+    const double towercut;
     int ntotal, npassed;
   };
 }  // namespace cms

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -223,11 +223,8 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
   // ... set all acceptances to zero
 
-  float acc420b1, acc220b1, acc420and220b1, acc420or220b1;  // beam 1 (clockwise)
-  float acc420b2, acc220b2, acc420and220b2, acc420or220b2;  // beam 2 (anti-clockwise)
-
-  acc420b1 = acc220b1 = acc420and220b1 = acc420or220b1 = 0;
-  acc420b2 = acc220b2 = acc420and220b2 = acc420or220b2 = 0;
+  float acc420b1(0), acc220b1(0), acc420and220b1(0);  // beam 1 (clockwise)
+  float acc420b2(0), acc220b2(0), acc420and220b2(0);  // beam 2 (anti-clockwise)
 
   int nP1at220m = 0;
   int nP1at420m = 0;
@@ -280,7 +277,7 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       acc220b1 = helper220beam1.GetAcceptance(t, xi, phi);
       acc420and220b1 = helper420a220beam1.GetAcceptance(t, xi, phi);
 
-      acc420or220b1 = acc420b1 + acc220b1 - acc420and220b1;
+      float acc420or220b1 = acc420b1 + acc220b1 - acc420and220b1;
 
       edm::LogVerbatim("FastSimProtonTaggerFilter")
           << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1
@@ -319,7 +316,7 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       acc220b2 = helper220beam2.GetAcceptance(t, xi, phi);
       acc420and220b2 = helper420a220beam2.GetAcceptance(t, xi, phi);
 
-      acc420or220b2 = acc420b2 + acc220b2 - acc420and220b2;
+      float acc420or220b2 = acc420b2 + acc220b2 - acc420and220b2;
 
       edm::LogVerbatim("FastSimProtonTaggerFilter")
           << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -83,10 +83,12 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
       edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged";
       break;
     case 3:
-      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged as 220+220 or 420+420";
+      edm::LogVerbatim("FastSimProtonTaggerFilter")
+          << "Option chosen: two protons should be tagged as 220+220 or 420+420";
       break;
     case 4:
-      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged as 220+420 or 420+220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter")
+          << "Option chosen: two protons should be tagged as 220+420 or 420+220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers")
@@ -94,12 +96,13 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
   }
 
   if (((beam1mode != 4) || (beam2mode != 4)) && (beamCombiningMode > 2)) {
-    edm::LogWarning("FastSimProtonTaggerFilter") << "Warning: beamCombiningMode = " << beamCombiningMode
-                               << " only makes sence with beam1mode = beam2mode = 4";
+    edm::LogWarning("FastSimProtonTaggerFilter")
+        << "Warning: beamCombiningMode = " << beamCombiningMode << " only makes sence with beam1mode = beam2mode = 4";
   }
 
   if (((beam1mode == 0) || (beam2mode == 0)) && (beamCombiningMode > 1)) {
-    edm::LogWarning("FastSimProtonTaggerFilter") << "Warning: You ask for 2 protons while one of the beams is set to ignore";
+    edm::LogWarning("FastSimProtonTaggerFilter")
+        << "Warning: You ask for 2 protons while one of the beams is set to ignore";
   }
 
   if ((beam1mode == 0) && (beam2mode == 0)) {
@@ -279,7 +282,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
       acc420or220b1 = acc420b1 + acc220b1 - acc420and220b1;
 
-      edm::LogVerbatim("FastSimProtonTaggerFilter") << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1 << " acc420or220b1: " << acc420or220b1;
+      edm::LogVerbatim("FastSimProtonTaggerFilter")
+          << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1
+          << " acc420or220b1: " << acc420or220b1;
 
       bool res420and220 = (acc420and220b1 > acceptThreshold);
       bool res420 = (acc420b1 > acceptThreshold);
@@ -296,14 +301,14 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
         edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 220 m along beam 1, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 220 m along beam 1, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 420 m along beam 1, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 420 m along beam 1, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 220 m & 420 m  along beam 1, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 220 m & 420 m  along beam 1, pz = " << pz;
       }
     }
 
@@ -316,7 +321,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
       acc420or220b2 = acc420b2 + acc220b2 - acc420and220b2;
 
-      edm::LogVerbatim("FastSimProtonTaggerFilter") << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2 << " acc420or220b2: " << acc420or220b2;
+      edm::LogVerbatim("FastSimProtonTaggerFilter")
+          << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2
+          << " acc420or220b2: " << acc420or220b2;
 
       bool res420and220 = (acc420and220b2 > acceptThreshold);
       bool res420 = (acc420b2 > acceptThreshold);
@@ -333,14 +340,14 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
         edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 220 m along beam 2, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 220 m along beam 2, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 420 m along beam 2, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 420 m along beam 2, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
-                                      << " at 220 m & 420 m along beam 2, pz = " << pz;
+          edm::LogVerbatim("FastSimProtonTaggerFilter")
+              << "got a particle with pid" << p->pdg_id() << " at 220 m & 420 m along beam 2, pz = " << pz;
       }
     }
   }

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -33,23 +33,23 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
       beam1mode(p.getParameter<unsigned int>("beam1mode")),
       beam2mode(p.getParameter<unsigned int>("beam2mode")),
       beamCombiningMode(p.getParameter<unsigned int>("beamCombiningMode")) {
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Initializing ...";
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "ProtonTaggerFilter: Initializing ...";
 
   switch (beam1mode) {
     case 0:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: ingnore";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 1: ingnore";
       break;
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 1: 420";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 1: 220";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 and 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 1: 420 and 220";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 or 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 1: 420 or 220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers") << "Error: beam1mode cannot be " << beam1mode;
@@ -57,19 +57,19 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
 
   switch (beam2mode) {
     case 0:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: ingnore";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 2: ingnore";
       break;
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 2: 420";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 2: 220";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 and 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 2: 420 and 220";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 or 220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen for beam 2: 420 or 220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers") << "Error: beam2mode cannot be " << beam2mode;
@@ -77,16 +77,16 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
 
   switch (beamCombiningMode) {
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen: one proton is sufficient";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: one proton is sufficient";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+220 or 420+420";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged as 220+220 or 420+420";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+420 or 420+220";
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "Option chosen: two protons should be tagged as 220+420 or 420+220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers")
@@ -94,36 +94,36 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
   }
 
   if (((beam1mode != 4) || (beam2mode != 4)) && (beamCombiningMode > 2)) {
-    edm::LogWarning("FastSim") << "Warning: beamCombiningMode = " << beamCombiningMode
+    edm::LogWarning("FastSimProtonTaggerFilter") << "Warning: beamCombiningMode = " << beamCombiningMode
                                << " only makes sence with beam1mode = beam2mode = 4";
   }
 
   if (((beam1mode == 0) || (beam2mode == 0)) && (beamCombiningMode > 1)) {
-    edm::LogWarning("FastSim") << "Warning: You ask for 2 protons while one of the beams is set to ignore";
+    edm::LogWarning("FastSimProtonTaggerFilter") << "Warning: You ask for 2 protons while one of the beams is set to ignore";
   }
 
   if ((beam1mode == 0) && (beam2mode == 0)) {
-    edm::LogWarning("FastSim") << "Warning: Both beams are set to ignore.";
+    edm::LogWarning("FastSimProtonTaggerFilter") << "Warning: Both beams are set to ignore.";
   }
 
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Initialized";
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "ProtonTaggerFilter: Initialized";
 }
 
 /** initialize detector acceptance table */
 
 void ProtonTaggerFilter::beginJob() {
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Getting ready ...";
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "ProtonTaggerFilter: Getting ready ...";
 
   edm::FileInPath myDataFile("FastSimulation/ForwardDetectors/data/acceptance_420_220.root");
   std::string fullPath = myDataFile.fullPath();
 
-  edm::LogVerbatim("FastSim") << "Opening " << fullPath;
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "Opening " << fullPath;
   TFile f(fullPath.c_str());
 
   if (f.Get("description") != nullptr)
-    edm::LogVerbatim("FastSim") << "Description found: " << f.Get("description")->GetTitle();
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "Description found: " << f.Get("description")->GetTitle();
 
-  edm::LogVerbatim("FastSim") << "Reading acceptance tables @#@#%@$%@$#%@%";
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "Reading acceptance tables @#@#%@$%@$#%@%";
 
   helper420beam1.Init(f, "a420");
   helper420beam2.Init(f, "a420_b2");
@@ -136,7 +136,7 @@ void ProtonTaggerFilter::beginJob() {
 
   f.Close();
 
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Ready";
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "ProtonTaggerFilter: Ready";
 }
 
 /** Compute the detector acceptances and decide whether to filter the event */
@@ -147,9 +147,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   const edm::Handle<edm::HepMCProduct>& evtSource = iEvent.getHandle(tokGen_);
   const HepMC::GenEvent* genEvent = evtSource->GetEvent();
 
-  //edm::LogVerbatim("FastSim") << "event contains " << genEvent->particles_size() << " particles " ;
+  //edm::LogVerbatim("FastSimProtonTaggerFilter") << "event contains " << genEvent->particles_size() << " particles " ;
   if (genEvent->particles_empty()) {
-    edm::LogVerbatim("FastSim") << "empty source event";
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "empty source event";
     return false;
   }
 
@@ -163,13 +163,13 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
   if (isProduct) {
     pileUpEvent = pileUpSource->GetEvent();
-    //edm::LogVerbatim("FastSim") << "got pileup" ;
+    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "got pileup" ;
   } else {
     isPileUp = false;
-    //edm::LogVerbatim("FastSim") << "no pileup in the event" ;
+    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "no pileup in the event" ;
   }
 
-  //if (isPileUp) edm::LogVerbatim("FastSim") << "event contains " << pileUpEvent->particles_size() << " pileup particles " ;
+  //if (isPileUp) edm::LogVerbatim("FastSimProtonTaggerFilter") << "event contains " << pileUpEvent->particles_size() << " pileup particles " ;
 
   // ... some constants
 
@@ -189,14 +189,14 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
     float pz = p->momentum().pz();
     if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
       veryForwardParicles.push_back(p);
-      //edm::LogVerbatim("FastSim") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+      //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
     }
   }
 
-  //edm::LogVerbatim("FastSim") << "# generated forward particles  : " << veryForwardParicles.size() ;
+  //edm::LogVerbatim("FastSimProtonTaggerFilter") << "# generated forward particles  : " << veryForwardParicles.size() ;
 
   if (isPileUp) {
-    //edm::LogVerbatim("FastSim") << "Adding pileup " ;
+    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "Adding pileup " ;
 
     for (HepMC::GenEvent::particle_const_iterator piter = pileUpEvent->particles_begin();
          piter != pileUpEvent->particles_end();
@@ -206,12 +206,12 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       float pz = p->momentum().pz();
       if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
         veryForwardParicles.push_back(p);
-        //edm::LogVerbatim("FastSim") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+        //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
       }
     }
   }
 
-  //edm::LogVerbatim("FastSim") << "# forward particles to be tried: " << veryForwardParicles.size() ;
+  //edm::LogVerbatim("FastSimProtonTaggerFilter") << "# forward particles to be tried: " << veryForwardParicles.size() ;
 
   // ... return false if no forward protons found
 
@@ -257,9 +257,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
     double t = (-pt * pt - mp * mp * xi * xi) / (1 - xi);  // "t"
 
-    //edm::LogVerbatim("FastSim") << " pdg_id: "  << p->pdg_id() << " eta: " << p->momentum().eta() << " e: "
+    //edm::LogVerbatim("FastSimProtonTaggerFilter") << " pdg_id: "  << p->pdg_id() << " eta: " << p->momentum().eta() << " e: "
     //          <<  p->momentum().e() ;
-    //edm::LogVerbatim("FastSim") << "pz: " << pz << " pt: " <<  pt << " xi: " << xi
+    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pz: " << pz << " pt: " <<  pt << " xi: " << xi
     //          << " t: " << t << " phi: " << phi ;
 
     if (xi < 0.0)
@@ -279,7 +279,7 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
       acc420or220b1 = acc420b1 + acc220b1 - acc420and220b1;
 
-      //edm::LogVerbatim("FastSim") << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1 << " acc420or220b1: " << acc420or220b1  ;
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1 << " acc420or220b1: " << acc420or220b1;
 
       bool res420and220 = (acc420and220b1 > acceptThreshold);
       bool res420 = (acc420b1 > acceptThreshold);
@@ -294,15 +294,15 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
         nP1at220m++;
 
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
-        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz;
+        edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 220 m along beam 1, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 420 m along beam 1, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 220 m & 420 m  along beam 1, pz = " << pz;
       }
     }
@@ -316,7 +316,7 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
       acc420or220b2 = acc420b2 + acc220b2 - acc420and220b2;
 
-      //edm::LogVerbatim("FastSim") << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2 << " acc420or220b2: " << acc420or220b2 ;
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2 << " acc420or220b2: " << acc420or220b2;
 
       bool res420and220 = (acc420and220b2 > acceptThreshold);
       bool res420 = (acc420b2 > acceptThreshold);
@@ -331,15 +331,15 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
         nP2at220m++;
 
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
-        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz;
+        edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 220 m along beam 2, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 420 m along beam 2, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+          edm::LogVerbatim("FastSimProtonTaggerFilter") << "got a particle with pid" << p->pdg_id()
                                       << " at 220 m & 420 m along beam 2, pz = " << pz;
       }
     }
@@ -353,13 +353,13 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   bool p2at420m = (nP2at420m > 0) ? true : false;
 
   if ((nP1at220m > 1) && (beam1mode != 1))
-    edm::LogVerbatim("FastSim") << " !!! " << nP1at220m << " proton(s) from beam 1 at 220 m";
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! " << nP1at220m << " proton(s) from beam 1 at 220 m";
   if ((nP1at420m > 1) && (beam1mode != 2))
-    edm::LogVerbatim("FastSim") << " !!! " << nP1at420m << " proton(s) from beam 1 at 420 m";
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! " << nP1at420m << " proton(s) from beam 1 at 420 m";
   if ((nP2at220m > 1) && (beam2mode != 1))
-    edm::LogVerbatim("FastSim") << " !!! " << nP2at220m << " proton(s) from beam 2 at 220 m";
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! " << nP2at220m << " proton(s) from beam 2 at 220 m";
   if ((nP2at420m > 1) && (beam2mode != 2))
-    edm::LogVerbatim("FastSim") << " !!! " << nP2at420m << " proton(s) from beam 2 at 420 m";
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << " !!! " << nP2at420m << " proton(s) from beam 2 at 420 m";
 
   // ... make a decision based on requested filter configuration
 
@@ -384,8 +384,8 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   if ((beam2mode == 4) && (p2at220m || p2at420m))
     p2accepted = true;
 
-  //if (p1accepted) edm::LogVerbatim("FastSim") << "proton 1 accepted" ;
-  //if (p2accepted) edm::LogVerbatim("FastSim") << "proton 2 accepted" ;
+  //if (p1accepted) edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 1 accepted" ;
+  //if (p2accepted) edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 2 accepted" ;
 
   switch (beamCombiningMode) {
     case 1:  // ... either of two protons

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -27,30 +27,29 @@
 
 /** read (and verify) parameters */
 
-ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p) 
-  : tokGen_(consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"))),
-    tokPile_(consumes<edm::HepMCProduct>(edm::InputTag("famosPileUp", "PileUpEvents"))),
-    beam1mode(p.getParameter<unsigned int>("beam1mode")),
-    beam2mode(p.getParameter<unsigned int>("beam2mode")),
-    beamCombiningMode(p.getParameter<unsigned int>("beamCombiningMode")) {
-
+ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
+    : tokGen_(consumes<edm::HepMCProduct>(edm::InputTag("generatorSmeared"))),
+      tokPile_(consumes<edm::HepMCProduct>(edm::InputTag("famosPileUp", "PileUpEvents"))),
+      beam1mode(p.getParameter<unsigned int>("beam1mode")),
+      beam2mode(p.getParameter<unsigned int>("beam2mode")),
+      beamCombiningMode(p.getParameter<unsigned int>("beamCombiningMode")) {
   edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Initializing ...";
 
   switch (beam1mode) {
     case 0:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: ingnore" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: ingnore";
       break;
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 220";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 and 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 and 220";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 or 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 1: 420 or 220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers") << "Error: beam1mode cannot be " << beam1mode;
@@ -58,19 +57,19 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
 
   switch (beam2mode) {
     case 0:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: ingnore" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: ingnore";
       break;
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 220";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 and 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 and 220";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 or 220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen for beam 2: 420 or 220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers") << "Error: beam2mode cannot be " << beam2mode;
@@ -78,16 +77,16 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
 
   switch (beamCombiningMode) {
     case 1:
-      edm::LogVerbatim("FastSim") << "Option chosen: one proton is sufficient" ;
+      edm::LogVerbatim("FastSim") << "Option chosen: one proton is sufficient";
       break;
     case 2:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged" ;
+      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged";
       break;
     case 3:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+220 or 420+420" ;
+      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+220 or 420+420";
       break;
     case 4:
-      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+420 or 420+220" ;
+      edm::LogVerbatim("FastSim") << "Option chosen: two protons should be tagged as 220+420 or 420+220";
       break;
     default:
       throw cms::Exception("FastSimulation/ProtonTaggers")
@@ -96,35 +95,35 @@ ProtonTaggerFilter::ProtonTaggerFilter(edm::ParameterSet const& p)
 
   if (((beam1mode != 4) || (beam2mode != 4)) && (beamCombiningMode > 2)) {
     edm::LogWarning("FastSim") << "Warning: beamCombiningMode = " << beamCombiningMode
-              << " only makes sence with beam1mode = beam2mode = 4" ;
+                               << " only makes sence with beam1mode = beam2mode = 4";
   }
 
   if (((beam1mode == 0) || (beam2mode == 0)) && (beamCombiningMode > 1)) {
-     edm::LogWarning("FastSim") << "Warning: You ask for 2 protons while one of the beams is set to ignore" ;
+    edm::LogWarning("FastSim") << "Warning: You ask for 2 protons while one of the beams is set to ignore";
   }
 
   if ((beam1mode == 0) && (beam2mode == 0)) {
-     edm::LogWarning("FastSim") << "Warning: Both beams are set to ignore." ;
+    edm::LogWarning("FastSim") << "Warning: Both beams are set to ignore.";
   }
 
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Initialized" ;
+  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Initialized";
 }
 
 /** initialize detector acceptance table */
 
 void ProtonTaggerFilter::beginJob() {
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Getting ready ..." ;
+  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Getting ready ...";
 
   edm::FileInPath myDataFile("FastSimulation/ForwardDetectors/data/acceptance_420_220.root");
   std::string fullPath = myDataFile.fullPath();
 
-  edm::LogVerbatim("FastSim") << "Opening " << fullPath ;
+  edm::LogVerbatim("FastSim") << "Opening " << fullPath;
   TFile f(fullPath.c_str());
 
   if (f.Get("description") != nullptr)
-    edm::LogVerbatim("FastSim") << "Description found: " << f.Get("description")->GetTitle() ;
+    edm::LogVerbatim("FastSim") << "Description found: " << f.Get("description")->GetTitle();
 
-  edm::LogVerbatim("FastSim") << "Reading acceptance tables @#@#%@$%@$#%@%" ;
+  edm::LogVerbatim("FastSim") << "Reading acceptance tables @#@#%@$%@$#%@%";
 
   helper420beam1.Init(f, "a420");
   helper420beam2.Init(f, "a420_b2");
@@ -137,20 +136,20 @@ void ProtonTaggerFilter::beginJob() {
 
   f.Close();
 
-  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Ready" ;
+  edm::LogVerbatim("FastSim") << "ProtonTaggerFilter: Ready";
 }
 
 /** Compute the detector acceptances and decide whether to filter the event */
 
 bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   // ... get generated event
-  
+
   const edm::Handle<edm::HepMCProduct>& evtSource = iEvent.getHandle(tokGen_);
   const HepMC::GenEvent* genEvent = evtSource->GetEvent();
 
   //edm::LogVerbatim("FastSim") << "event contains " << genEvent->particles_size() << " particles " ;
   if (genEvent->particles_empty()) {
-    edm::LogVerbatim("FastSim") << "empty source event" ;
+    edm::LogVerbatim("FastSim") << "empty source event";
     return false;
   }
 
@@ -295,14 +294,16 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
         nP1at220m++;
 
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
-        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz ;
+        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 220 m along beam 1, pz = " << pz ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 220 m along beam 1, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 420 m along beam 1, pz = " << pz ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 420 m along beam 1, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 220 m & 420 m  along beam 1, pz = " << pz
-                    ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 220 m & 420 m  along beam 1, pz = " << pz;
       }
     }
 
@@ -330,14 +331,16 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
         nP2at220m++;
 
       if ((p->pdg_id() != 2212) && (res220 || res420 || res420and220)) {
-        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz ;
+        edm::LogVerbatim("FastSim") << " !!! P got proton 1 at 420 m: pz = " << pz;
         if (res220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 220 m along beam 2, pz = " << pz ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 220 m along beam 2, pz = " << pz;
         if (res420)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 420 m along beam 2, pz = " << pz ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 420 m along beam 2, pz = " << pz;
         if (res420and220)
-          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id() << " at 220 m & 420 m along beam 2, pz = " << pz
-                    ;
+          edm::LogVerbatim("FastSim") << "got a particle with pid" << p->pdg_id()
+                                      << " at 220 m & 420 m along beam 2, pz = " << pz;
       }
     }
   }
@@ -350,13 +353,13 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   bool p2at420m = (nP2at420m > 0) ? true : false;
 
   if ((nP1at220m > 1) && (beam1mode != 1))
-    edm::LogVerbatim("FastSim") << " !!! " << nP1at220m << " proton(s) from beam 1 at 220 m" ;
+    edm::LogVerbatim("FastSim") << " !!! " << nP1at220m << " proton(s) from beam 1 at 220 m";
   if ((nP1at420m > 1) && (beam1mode != 2))
-    edm::LogVerbatim("FastSim") << " !!! " << nP1at420m << " proton(s) from beam 1 at 420 m" ;
+    edm::LogVerbatim("FastSim") << " !!! " << nP1at420m << " proton(s) from beam 1 at 420 m";
   if ((nP2at220m > 1) && (beam2mode != 1))
-    edm::LogVerbatim("FastSim") << " !!! " << nP2at220m << " proton(s) from beam 2 at 220 m" ;
+    edm::LogVerbatim("FastSim") << " !!! " << nP2at220m << " proton(s) from beam 2 at 220 m";
   if ((nP2at420m > 1) && (beam2mode != 2))
-    edm::LogVerbatim("FastSim") << " !!! " << nP2at420m << " proton(s) from beam 2 at 420 m" ;
+    edm::LogVerbatim("FastSim") << " !!! " << nP2at420m << " proton(s) from beam 2 at 420 m";
 
   // ... make a decision based on requested filter configuration
 

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -174,8 +174,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   }
 
 #ifdef EDM_ML_DEBUG
-  if (isPileUp) 
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << "event contains " << pileUpEvent->particles_size() << " pileup particles " ;
+  if (isPileUp)
+    edm::LogVerbatim("FastSimProtonTaggerFilter")
+        << "event contains " << pileUpEvent->particles_size() << " pileup particles ";
 #endif
   // ... some constants
 
@@ -196,17 +197,17 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
     if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
       veryForwardParicles.push_back(p);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status();
 #endif
     }
   }
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# generated forward particles  : " << veryForwardParicles.size() ;
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# generated forward particles  : " << veryForwardParicles.size();
 #endif
   if (isPileUp) {
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << "Adding pileup " ;
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "Adding pileup ";
 #endif
     for (HepMC::GenEvent::particle_const_iterator piter = pileUpEvent->particles_begin();
          piter != pileUpEvent->particles_end();
@@ -217,14 +218,14 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
         veryForwardParicles.push_back(p);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+        edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status();
 #endif
       }
     }
   }
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# forward particles to be tried: " << veryForwardParicles.size() ;
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# forward particles to be tried: " << veryForwardParicles.size();
 #endif
   // ... return false if no forward protons found
 
@@ -268,8 +269,10 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
     double t = (-pt * pt - mp * mp * xi * xi) / (1 - xi);  // "t"
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << " pdg_id: "  << p->pdg_id() << " eta: " << p->momentum().eta() << " e: " <<  p->momentum().e() ;
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << "pz: " << pz << " pt: " <<  pt << " xi: " << xi << " t: " << t << " phi: " << phi ;
+    edm::LogVerbatim("FastSimProtonTaggerFilter")
+        << " pdg_id: " << p->pdg_id() << " eta: " << p->momentum().eta() << " e: " << p->momentum().e();
+    edm::LogVerbatim("FastSimProtonTaggerFilter")
+        << "pz: " << pz << " pt: " << pt << " xi: " << xi << " t: " << t << " phi: " << phi;
 #endif
     if (xi < 0.0)
       xi = -10.0;
@@ -399,9 +402,9 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
 #ifdef EDM_ML_DEBUG
   if (p1accepted)
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 1 accepted" ;
-  if (p2accepted) 
-    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 2 accepted" ;
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 1 accepted";
+  if (p2accepted)
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 2 accepted";
 #endif
   switch (beamCombiningMode) {
     case 1:  // ... either of two protons

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.cc
@@ -22,8 +22,9 @@
 
 //#include "CLHEP/Random/RandGaussQ.h"
 
-#include <iostream>
 #include <list>
+
+//#define EDM_ML_DEBUG
 
 /** read (and verify) parameters */
 
@@ -172,8 +173,10 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
     //edm::LogVerbatim("FastSimProtonTaggerFilter") << "no pileup in the event" ;
   }
 
-  //if (isPileUp) edm::LogVerbatim("FastSimProtonTaggerFilter") << "event contains " << pileUpEvent->particles_size() << " pileup particles " ;
-
+#ifdef EDM_ML_DEBUG
+  if (isPileUp) 
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "event contains " << pileUpEvent->particles_size() << " pileup particles " ;
+#endif
   // ... some constants
 
   const double mp = 0.938272029;      // just a proton mass
@@ -192,15 +195,19 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
     float pz = p->momentum().pz();
     if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
       veryForwardParicles.push_back(p);
-      //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+#endif
     }
   }
 
-  //edm::LogVerbatim("FastSimProtonTaggerFilter") << "# generated forward particles  : " << veryForwardParicles.size() ;
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# generated forward particles  : " << veryForwardParicles.size() ;
+#endif
   if (isPileUp) {
-    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "Adding pileup " ;
-
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "Adding pileup " ;
+#endif
     for (HepMC::GenEvent::particle_const_iterator piter = pileUpEvent->particles_begin();
          piter != pileUpEvent->particles_end();
          ++piter) {
@@ -209,13 +216,16 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       float pz = p->momentum().pz();
       if (((pz > pzCut) || (pz < -pzCut)) && ((p->status() == 0) || (p->status() == 1))) {
         veryForwardParicles.push_back(p);
-        //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+#ifdef EDM_ML_DEBUG
+        edm::LogVerbatim("FastSimProtonTaggerFilter") << "pdgid: " << p->pdg_id() << " status: " << p->status() ;
+#endif
       }
     }
   }
 
-  //edm::LogVerbatim("FastSimProtonTaggerFilter") << "# forward particles to be tried: " << veryForwardParicles.size() ;
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("FastSimProtonTaggerFilter") << "# forward particles to be tried: " << veryForwardParicles.size() ;
+#endif
   // ... return false if no forward protons found
 
   if (veryForwardParicles.empty())
@@ -257,11 +267,10 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
 
     double t = (-pt * pt - mp * mp * xi * xi) / (1 - xi);  // "t"
 
-    //edm::LogVerbatim("FastSimProtonTaggerFilter") << " pdg_id: "  << p->pdg_id() << " eta: " << p->momentum().eta() << " e: "
-    //          <<  p->momentum().e() ;
-    //edm::LogVerbatim("FastSimProtonTaggerFilter") << "pz: " << pz << " pt: " <<  pt << " xi: " << xi
-    //          << " t: " << t << " phi: " << phi ;
-
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << " pdg_id: "  << p->pdg_id() << " eta: " << p->momentum().eta() << " e: " <<  p->momentum().e() ;
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "pz: " << pz << " pt: " <<  pt << " xi: " << xi << " t: " << t << " phi: " << phi ;
+#endif
     if (xi < 0.0)
       xi = -10.0;
     if (xi > 1.0)
@@ -277,12 +286,12 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       acc220b1 = helper220beam1.GetAcceptance(t, xi, phi);
       acc420and220b1 = helper420a220beam1.GetAcceptance(t, xi, phi);
 
+#ifdef EDM_ML_DEBUG
       float acc420or220b1 = acc420b1 + acc220b1 - acc420and220b1;
-
       edm::LogVerbatim("FastSimProtonTaggerFilter")
           << "+acc420b1: " << acc420b1 << " acc220b1: " << acc220b1 << " acc420and220b1: " << acc420and220b1
           << " acc420or220b1: " << acc420or220b1;
-
+#endif
       bool res420and220 = (acc420and220b1 > acceptThreshold);
       bool res420 = (acc420b1 > acceptThreshold);
       bool res220 = (acc220b1 > acceptThreshold);
@@ -316,12 +325,12 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
       acc220b2 = helper220beam2.GetAcceptance(t, xi, phi);
       acc420and220b2 = helper420a220beam2.GetAcceptance(t, xi, phi);
 
+#ifdef EDM_ML_DEBUG
       float acc420or220b2 = acc420b2 + acc220b2 - acc420and220b2;
-
       edm::LogVerbatim("FastSimProtonTaggerFilter")
           << "+acc420b2: " << acc420b2 << " acc220b2: " << acc220b2 << " acc420and220b2: " << acc420and220b2
           << " acc420or220b2: " << acc420or220b2;
-
+#endif
       bool res420and220 = (acc420and220b2 > acceptThreshold);
       bool res420 = (acc420b2 > acceptThreshold);
       bool res220 = (acc220b2 > acceptThreshold);
@@ -388,9 +397,12 @@ bool ProtonTaggerFilter::filter(edm::Event& iEvent, const edm::EventSetup& es) {
   if ((beam2mode == 4) && (p2at220m || p2at420m))
     p2accepted = true;
 
-  //if (p1accepted) edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 1 accepted" ;
-  //if (p2accepted) edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 2 accepted" ;
-
+#ifdef EDM_ML_DEBUG
+  if (p1accepted)
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 1 accepted" ;
+  if (p2accepted) 
+    edm::LogVerbatim("FastSimProtonTaggerFilter") << "proton 2 accepted" ;
+#endif
   switch (beamCombiningMode) {
     case 1:  // ... either of two protons
       if (p1accepted || p2accepted)

--- a/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.h
+++ b/FastSimulation/ForwardDetectors/plugins/ProtonTaggerFilter.h
@@ -27,6 +27,7 @@
 
 #include "FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.h"
 
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "HepMC/GenEvent.h"
 
 #include "TFile.h"
@@ -37,26 +38,30 @@ public:
   explicit ProtonTaggerFilter(edm::ParameterSet const& p);
 
   /// empty destructor
-  ~ProtonTaggerFilter() override;
+  ~ProtonTaggerFilter() override = default;
 
   /// startup function of the EDFilter
   virtual void beginJob();
 
   /// endjob function of the EDFilter
-  virtual void endJob();
+  virtual void endJob() {}
 
   /// decide if the event is accepted by the proton taggers
   bool filter(edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  /// tokens to access the collections
+  const edm::EDGetTokenT<edm::HepMCProduct> tokGen_;
+  const edm::EDGetTokenT<edm::HepMCProduct> tokPile_;
+
   /// choose which of the detectors (FP420/TOTEM/both) will be used for beam 1
-  unsigned int beam1mode;
+  const unsigned int beam1mode;
 
   /// choose which of the detectors (FP420/TOTEM/both) will be used for beam 2
-  unsigned int beam2mode;
+  const unsigned int beam2mode;
 
   /// choose how to combine data from the two beams (ask for 1/2 proton)
-  unsigned int beamCombiningMode;
+  const unsigned int beamCombiningMode;
 
   /// Objects which actually compute the acceptance (one per detector or combination of detectors)
   AcceptanceTableHelper helper420beam1;


### PR DESCRIPTION
#### PR description:

Use tokens rather than labels for accessing collections in FastSimulation/ForwardDetectors

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special