### PR TITLE
Run3-sim130 Use of tokens instead of labels for accessing collections in FastSimulation/Muons

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -59,7 +59,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   // Loop on L2 muons
   unsigned int imu = 0;
   unsigned int imuMax = l2muonH->size();
-  edm::LogVerbatim("FastSim") << "Found " << imuMax << " L2 muons";
+  edm::LogVerbatim("FastTSGFromL2Muon") << "Found " << imuMax << " L2 muons";
   for (; imu != imuMax; ++imu) {
     // Make a ref to l2 muon
     reco::TrackRef muRef(l2muonH, imu);
@@ -109,7 +109,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
 
   }  // End of l2 muon loop
 
-  edm::LogVerbatim("FastSim") << "Found " << result->size() << " seeds for muons";
+  edm::LogVerbatim("FastTSGFromL2Muon") << "Found " << result->size() << " seeds for muons";
 
   //put in the event
   ev.put(std::move(result));

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -1,54 +1,36 @@
+#include "FastSimulation/Muons/plugins/FastTSGFromL2Muon.h"
+
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/FastTrackerRecHit.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
-
-#include "FastSimulation/Muons/plugins/FastTSGFromL2Muon.h"
-
-//#include <TH1.h>
 
 #include <set>
 
-FastTSGFromL2Muon::FastTSGFromL2Muon(const edm::ParameterSet& cfg) {
+FastTSGFromL2Muon::FastTSGFromL2Muon(const edm::ParameterSet& cfg)
+    : thePtCut(cfg.getParameter<double>("PtCut")),
+      theL2CollectionLabel(cfg.getParameter<edm::InputTag>("MuonCollectionLabel")),
+      theSeedCollectionLabels(cfg.getParameter<std::vector<edm::InputTag> >("SeedCollectionLabels")),
+      theSimTrackCollectionLabel(cfg.getParameter<edm::InputTag>("SimTrackCollectionLabel")),
+      simTrackToken_(consumes<edm::SimTrackContainer>(theSimTrackCollectionLabel)),
+      l2TrackToken_(consumes<reco::TrackCollection>(theL2CollectionLabel)) {
   produces<L3MuonTrajectorySeedCollection>();
 
-  edm::ParameterSet serviceParameters = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
+  for (auto& seed : theSeedCollectionLabels)
+    seedToken_.emplace_back(consumes<edm::View<TrajectorySeed> >(seed));
 
-  thePtCut = cfg.getParameter<double>("PtCut");
-
-  theL2CollectionLabel = cfg.getParameter<edm::InputTag>("MuonCollectionLabel");
-  theSeedCollectionLabels = cfg.getParameter<std::vector<edm::InputTag> >("SeedCollectionLabels");
-  theSimTrackCollectionLabel = cfg.getParameter<edm::InputTag>("SimTrackCollectionLabel");
-  // useTFileService_ = cfg.getUntrackedParameter<bool>("UseTFileService",false);
   edm::ParameterSet regionBuilderPSet = cfg.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
   theRegionBuilder = std::make_unique<MuonTrackingRegionBuilder>(regionBuilderPSet, consumesCollector());
 }
 
-FastTSGFromL2Muon::~FastTSGFromL2Muon() {}
-
 void FastTSGFromL2Muon::beginRun(edm::Run const& run, edm::EventSetup const& es) {
   //region builder
-
-  /*
-  if(useTFileService_) {
-    edm::Service<TFileService> fs;
-    h_nSeedPerTrack = fs->make<TH1F>("nSeedPerTrack","nSeedPerTrack",76,-0.5,75.5);
-    h_nGoodSeedPerTrack = fs->make<TH1F>("nGoodSeedPerTrack","nGoodSeedPerTrack",75,-0.5,75.5);
-    h_nGoodSeedPerEvent = fs->make<TH1F>("nGoodSeedPerEvent","nGoodSeedPerEvent",75,-0.5,75.5);
-  } else {
-    h_nSeedPerTrack = 0;
-    h_nGoodSeedPerEvent = 0;
-    h_nGoodSeedPerTrack = 0;
-  }
-  */
 }
 
 void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
@@ -59,12 +41,10 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   theRegionBuilder->setEvent(ev, es);
 
   // Retrieve the Monte Carlo truth (SimTracks)
-  edm::Handle<edm::SimTrackContainer> theSimTracks;
-  ev.getByLabel(theSimTrackCollectionLabel, theSimTracks);
+  const edm::Handle<edm::SimTrackContainer>& theSimTracks = ev.getHandle(simTrackToken_);
 
   // Retrieve L2 muon collection
-  edm::Handle<reco::TrackCollection> l2muonH;
-  ev.getByLabel(theL2CollectionLabel, l2muonH);
+  const edm::Handle<reco::TrackCollection>& l2muonH = ev.getHandle(l2TrackToken_);
 
   // Retrieve Seed collection
   unsigned seedCollections = theSeedCollectionLabels.size();
@@ -72,14 +52,14 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
   theSeeds.resize(seedCollections);
   unsigned seed_size = 0;
   for (unsigned iseed = 0; iseed < seedCollections; ++iseed) {
-    ev.getByLabel(theSeedCollectionLabels[iseed], theSeeds[iseed]);
+    ev.getByToken(seedToken_[iseed], theSeeds[iseed]);
     seed_size += theSeeds[iseed]->size();
   }
 
   // Loop on L2 muons
   unsigned int imu = 0;
   unsigned int imuMax = l2muonH->size();
-  // std::cout << "Found " << imuMax << " L2 muons" << std::endl;
+  edm::LogVerbatim("FastSim") << "Found " << imuMax << " L2 muons";
   for (; imu != imuMax; ++imu) {
     // Make a ref to l2 muon
     reco::TrackRef muRef(l2muonH, imu);
@@ -120,12 +100,6 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
 
     }  // End loop on seed collections
 
-    // A plot
-    // if(h_nSeedPerTrack) h_nSeedPerTrack->Fill(tkSeeds.size());
-
-    // Another plot
-    // if(h_nGoodSeedPerTrack) h_nGoodSeedPerTrack->Fill(tkSeeds.size());
-
     // Now create the Muon Trajectory Seed
     unsigned int is = 0;
     unsigned int isMax = tkSeeds.size();
@@ -135,10 +109,7 @@ void FastTSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es) {
 
   }  // End of l2 muon loop
 
-  // std::cout << "Found " << result->size() << " seeds for muons" << std::endl;
-
-  // And yet another plot
-  // if(h_nGoodSeedPerEvent) h_nGoodSeedPerEvent->Fill(result->size());
+  edm::LogVerbatim("FastSim") << "Found " << result->size() << " seeds for muons";
 
   //put in the event
   ev.put(std::move(result));

--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.h
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
 
 #include <vector>
 namespace edm {
@@ -17,7 +18,6 @@ class MuonServiceProxy;
 class MuonTrackingRegionBuilder;
 class RectangularEtaPhiTrackingRegion;
 class SimTrack;
-//class TH1F;
 
 //
 // generate seeds corresponding to L2 muons
@@ -26,7 +26,7 @@ class SimTrack;
 class FastTSGFromL2Muon : public edm::stream::EDProducer<> {
 public:
   FastTSGFromL2Muon(const edm::ParameterSet& cfg);
-  ~FastTSGFromL2Muon() override;
+  ~FastTSGFromL2Muon() override = default;
   void beginRun(edm::Run const& run, edm::EventSetup const& es) override;
   void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
@@ -37,18 +37,16 @@ private:
              const SimTrack& theSimTrack);
 
 private:
-  edm::InputTag theSimTrackCollectionLabel;
-  edm::InputTag theL2CollectionLabel;
-  std::vector<edm::InputTag> theSeedCollectionLabels;
+  const double thePtCut;
+  const edm::InputTag theL2CollectionLabel;
+  const std::vector<edm::InputTag> theSeedCollectionLabels;
+  const edm::InputTag theSimTrackCollectionLabel;
 
-  // bool useTFileService_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> l2TrackToken_;
+  std::vector<edm::EDGetTokenT<edm::View<TrajectorySeed> > > seedToken_;
 
   MuonServiceProxy* theService;
-  double thePtCut;
   std::unique_ptr<MuonTrackingRegionBuilder> theRegionBuilder;
-
-  // TH1F* h_nSeedPerTrack;
-  // TH1F* h_nGoodSeedPerTrack;
-  // TH1F* h_nGoodSeedPerEvent;
 };
 #endif


### PR DESCRIPTION
#### PR description:

Use of tokens instead of labels for accessing collections in FastSimulation/Muons

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special