### PR TITLE
Remove use of deprecated header from RecoMuon subsystem

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
@@ -13,7 +13,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
@@ -10,7 +10,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
@@ -20,7 +20,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMuon/MuonIsolation/plugins/MuPFIsoEmbedder.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuPFIsoEmbedder.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -36,7 +36,7 @@
 // class declaration
 //
 
-class MuPFIsoEmbedder : public edm::EDProducer {
+class MuPFIsoEmbedder : public edm::stream::EDProducer<> {
 public:
   explicit MuPFIsoEmbedder(const edm::ParameterSet&);
   ~MuPFIsoEmbedder() override;
@@ -80,6 +80,7 @@ MuPFIsoEmbedder::MuPFIsoEmbedder(const edm::ParameterSet& iConfig)
 MuPFIsoEmbedder::~MuPFIsoEmbedder() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
+  delete helper_;
 }
 
 //

--- a/RecoMuon/MuonIsolationProducers/test/IsolationExample.cc
+++ b/RecoMuon/MuonIsolationProducers/test/IsolationExample.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -16,13 +16,10 @@
 
 using namespace std;
 
-class IsolationExample : public edm::EDAnalyzer {
+class IsolationExample : public edm::one::EDAnalyzer<> {
 public:
   IsolationExample(const edm::ParameterSet& conf);
-  ~IsolationExample();
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::InputTag theMuonTag;
@@ -44,10 +41,6 @@ IsolationExample::IsolationExample(const edm::ParameterSet& conf)
       theEventCount(0) {
   LogDebug("IsolationExample") << " CTOR" << endl;
 }
-
-IsolationExample::~IsolationExample() {}
-
-void IsolationExample::beginJob() {}
 
 void IsolationExample::analyze(const edm::Event& ev, const edm::EventSetup& es) {
   static const std::string metname = "IsolationExample";

--- a/RecoMuon/MuonIsolationProducers/test/MuIsoDepositAnalyzer.cc
+++ b/RecoMuon/MuonIsolationProducers/test/MuIsoDepositAnalyzer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -15,13 +15,10 @@
 
 using namespace std;
 
-class MuIsoDepositAnalyzer : public edm::EDAnalyzer {
+class MuIsoDepositAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   MuIsoDepositAnalyzer(const edm::ParameterSet& conf);
-  ~MuIsoDepositAnalyzer();
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   edm::InputTag theMuonLabel;
@@ -35,10 +32,6 @@ MuIsoDepositAnalyzer::MuIsoDepositAnalyzer(const edm::ParameterSet& conf)
       theEventCount(0) {
   LogDebug("MuIsoDepositAnalyzer") << " CTOR" << endl;
 }
-
-MuIsoDepositAnalyzer::~MuIsoDepositAnalyzer() {}
-
-void MuIsoDepositAnalyzer::beginJob() {}
 
 void MuIsoDepositAnalyzer::analyze(const edm::Event& ev, const edm::EventSetup& es) {
   LogDebug("MuIsoDepositAnalyzer::analyze") << " ============== analysis of event: " << ++theEventCount;


### PR DESCRIPTION
#### PR description:

- changed remaining modules to thread-friendly types
- removed commented out deprecated headers

This is part of the campaign to remove use of `FWCore/Framework/interface/EDProducer.h`

#### PR validation:

Packages compile without CMS deprecation warnings.