### PR TITLE
Removed unused deprecated header from TauRegionalPixelSeedGenerator.h

### DIFF
--- a/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
+++ b/RecoTauTag/HLTProducers/src/TauRegionalPixelSeedGenerator.h
@@ -4,7 +4,6 @@
 //
 // Class:           TauRegionalPixelSeedGenerator
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/InputTag.h"


### PR DESCRIPTION
#### PR description:

Part of campaign to remove deprecated headers.

#### PR validation:

Code compiles.