### PR TITLE
Run3-alca231 Update some of the defaults for Muon analysis code in HCalAlCaRecoProducers and HcalCalibAlgos

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
@@ -173,7 +173,7 @@ AlCaHcalHBHEMuonProducer::AlCaHcalHBHEMuonProducer(const edm::ParameterSet& iCon
       isItPreRecHit_(iConfig.getUntrackedParameter<bool>("isItPreRecHit", false)),
       writeRespCorr_(iConfig.getUntrackedParameter<bool>("writeRespCorr", false)),
       fileInCorr_(iConfig.getUntrackedParameter<std::string>("fileInCorr", "")),
-      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 4)),
+      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 7)),
       mergedDepth_((!isItPreRecHit_) || (collapseDepth_)),
       nRun_(0),
       nAll_(0),
@@ -964,7 +964,7 @@ void AlCaHcalHBHEMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.addUntracked<bool>("isItPreRecHit", false);
   desc.addUntracked<bool>("writeRespCorr", false);
   desc.addUntracked<std::string>("fileInCorr", "");
-  desc.addUntracked<int>("maxDepth", 4);
+  desc.addUntracked<int>("maxDepth", 7);
   descriptions.add("alcaHcalHBHEMuonProducer", desc);
 }
 

--- a/Calibration/HcalCalibAlgos/macros/HBHEMuonHighEta.C
+++ b/Calibration/HcalCalibAlgos/macros/HBHEMuonHighEta.C
@@ -50,8 +50,8 @@ private:
   TTree *fChain;   //!pointer to the analyzed TTree or TChain
   Int_t fCurrent;  //!current Tree number in a TChain
 
-  static const int maxDepthHB_ = 7;
-  static const int maxDepthHE_ = 4;
+  static const int maxDepthHB_ = 4;
+  static const int maxDepthHE_ = 7;
 
   // Fixed size dimensions of array or collections stored in the TTree if any.
   // Declaration of leaf types

--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonAnalyzer.cc
@@ -95,6 +95,7 @@ private:
   const edm::InputTag labelEBRecHit_, labelEERecHit_, labelHBHERecHit_;
   const std::string labelVtx_, labelMuon_, fileInCorr_;
   const std::vector<std::string> triggers_;
+  const double pMinMuon_;
   const int verbosity_, useRaw_;
   const bool unCorrect_, collapseDepth_, isItPlan1_;
   const bool ignoreHECorr_, isItPreRecHit_;
@@ -180,6 +181,7 @@ HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig)
       labelMuon_(iConfig.getParameter<std::string>("labelMuon")),
       fileInCorr_(iConfig.getUntrackedParameter<std::string>("fileInCorr", "")),
       triggers_(iConfig.getParameter<std::vector<std::string>>("triggers")),
+      pMinMuon_(iConfig.getParameter<double>("pMinMuon")),
       verbosity_(iConfig.getUntrackedParameter<int>("verbosity", 0)),
       useRaw_(iConfig.getParameter<int>("useRaw")),
       unCorrect_(iConfig.getParameter<bool>("unCorrect")),
@@ -189,7 +191,7 @@ HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig)
       isItPreRecHit_(iConfig.getUntrackedParameter<bool>("isItPreRecHit", false)),
       getCharge_(iConfig.getParameter<bool>("getCharge")),
       writeRespCorr_(iConfig.getUntrackedParameter<bool>("writeRespCorr", false)),
-      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 4)),
+      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 7)),
       modnam_(iConfig.getUntrackedParameter<std::string>("moduleName", "")),
       procnm_(iConfig.getUntrackedParameter<std::string>("processName", "")),
       tok_trigRes_(consumes<edm::TriggerResults>(hlTriggerResults_)),
@@ -246,7 +248,7 @@ HcalHBHEMuonAnalyzer::HcalHBHEMuonAnalyzer(const edm::ParameterSet& iConfig)
   edm::LogVerbatim("HBHEMuon") << "Flags used: UseRaw " << useRaw_ << " GetCharge " << getCharge_ << " UnCorrect "
                                << unCorrect_ << " IgnoreHECorr " << ignoreHECorr_ << " CollapseDepth " << collapseDepth_
                                << ":" << mergedDepth_ << " IsItPlan1 " << isItPlan1_ << " IsItPreRecHit "
-                               << isItPreRecHit_ << " UseMyCorr " << useMyCorr_;
+                               << isItPreRecHit_ << " UseMyCorr " << useMyCorr_ << " pMinMuon " << pMinMuon_;
 }
 
 //
@@ -296,12 +298,12 @@ void HcalHBHEMuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
   edm::LogVerbatim("HBHEMuon") << "Run " << runNumber_ << " Event " << eventNumber_ << " Lumi " << lumiNumber_ << " BX "
                                << bxNumber_ << std::endl;
 #endif
-  const edm::Handle<edm::TriggerResults> _Triggers = iEvent.getHandle(tok_trigRes_);
+  const edm::Handle<edm::TriggerResults>& _Triggers = iEvent.getHandle(tok_trigRes_);
 #ifdef EDM_ML_DEBUG
   if ((verbosity_ / 10000) % 10 > 0)
     edm::LogVerbatim("HBHEMuon") << "Size of all triggers " << all_triggers_.size();
 #endif
-  int Ntriggers = all_triggers_.size();
+  int Ntriggers = static_cast<int>(all_triggers_.size());
 #ifdef EDM_ML_DEBUG
   if ((verbosity_ / 10000) % 10 > 0)
     edm::LogVerbatim("HBHEMuon") << "Size of HLT MENU: " << _Triggers->size();
@@ -311,7 +313,7 @@ void HcalHBHEMuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
     std::vector<int> index;
     for (int i = 0; i < Ntriggers; i++) {
       index.push_back(triggerNames_.triggerIndex(all_triggers_[i]));
-      int triggerSize = int(_Triggers->size());
+      int triggerSize = static_cast<int>(_Triggers->size());
 #ifdef EDM_ML_DEBUG
       if ((verbosity_ / 10000) % 10 > 0)
         edm::LogVerbatim("HBHEMuon") << "outside loop " << index[i] << "\ntriggerSize " << triggerSize;
@@ -339,14 +341,14 @@ void HcalHBHEMuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
   const HcalDbService* conditions = &iSetup.getData(tok_dbservice_);
 
   // Relevant blocks from iEvent
-  const edm::Handle<reco::VertexCollection> vtx = iEvent.getHandle(tok_Vtx_);
+  const edm::Handle<reco::VertexCollection>& vtx = iEvent.getHandle(tok_Vtx_);
 
   edm::Handle<EcalRecHitCollection> barrelRecHitsHandle = iEvent.getHandle(tok_EB_);
   edm::Handle<EcalRecHitCollection> endcapRecHitsHandle = iEvent.getHandle(tok_EE_);
 
   edm::Handle<HBHERecHitCollection> hbhe = iEvent.getHandle(tok_HBHE_);
 
-  const edm::Handle<reco::MuonCollection> _Muon = iEvent.getHandle(tok_Muon_);
+  const edm::Handle<reco::MuonCollection>& _Muon = iEvent.getHandle(tok_Muon_);
 
   // require a good vertex
   math::XYZPoint pvx;
@@ -495,7 +497,7 @@ void HcalHBHEMuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
       if (RecMuon.innerTrack().isNonnull()) {
         const reco::Track* pTrack = (RecMuon.innerTrack()).get();
         spr::propagatedTrackID trackID = spr::propagateCALO(pTrack, geo_, bField, (((verbosity_ / 100) % 10 > 0)));
-        if ((RecMuon.p() > 10.0) && (trackID.okHCAL))
+        if ((RecMuon.p() > pMinMuon_) && (trackID.okHCAL))
           accept = true;
 
         ecalDetId.push_back((trackID.detIdECAL)());
@@ -1064,17 +1066,18 @@ void HcalHBHEMuonAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<std::string>("labelMuon", "muons");
   std::vector<std::string> trig = {"HLT_IsoMu17", "HLT_IsoMu20", "HLT_IsoMu24", "HLT_IsoMu27", "HLT_Mu45", "HLT_Mu50"};
   desc.add<std::vector<std::string>>("triggers", trig);
+  desc.add<double>("pMinMuon", 10.0);
   desc.addUntracked<int>("verbosity", 0);
   desc.add<int>("useRaw", 0);
-  desc.add<bool>("unCorrect", false);
-  desc.add<bool>("getCharge", false);
+  desc.add<bool>("unCorrect", true);
+  desc.add<bool>("getCharge", true);
   desc.add<bool>("collapseDepth", false);
   desc.add<bool>("isItPlan1", false);
   desc.addUntracked<bool>("ignoreHECorr", false);
   desc.addUntracked<bool>("isItPreRecHit", false);
   desc.addUntracked<std::string>("moduleName", "");
   desc.addUntracked<std::string>("processName", "");
-  desc.addUntracked<int>("maxDepth", 4);
+  desc.addUntracked<int>("maxDepth", 7);
   desc.addUntracked<std::string>("fileInCorr", "");
   desc.addUntracked<bool>("writeRespCorr", false);
   descriptions.add("hcalHBHEMuon", desc);

--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonHighEtaAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHEMuonHighEtaAnalyzer.cc
@@ -272,10 +272,10 @@ void HcalHBHEMuonHighEtaAnalyzer::fillDescriptions(edm::ConfigurationDescription
   desc.add<double>("etaMin", 2.0);
   desc.add<double>("emaxNearPThreshold", 10.0);
   desc.add<bool>("analyzeMuon", true);
-  desc.add<bool>("unCorrect", false);
+  desc.add<bool>("unCorrect", true);
   desc.add<bool>("collapseDepth", false);
   desc.add<bool>("isItPlan1", false);
-  desc.add<bool>("getCharge", false);
+  desc.add<bool>("getCharge", true);
   desc.add<int>("useRaw", 0);
   desc.add<int>("verbosity", 0);
   desc.addUntracked<std::string>("fileInCorr", "");
@@ -372,7 +372,7 @@ void HcalHBHEMuonHighEtaAnalyzer::analyze(const edm::Event& iEvent, const edm::E
   conditions_ = &iSetup.getData(tok_dbservice_);
 
   // Relevant blocks from iEvent
-  const edm::Handle<reco::VertexCollection> vtx = iEvent.getHandle(tok_Vtx_);
+  const edm::Handle<reco::VertexCollection>& vtx = iEvent.getHandle(tok_Vtx_);
 
   iEvent.getByToken(tok_EB_, barrelRecHitsHandle_);
   iEvent.getByToken(tok_EE_, endcapRecHitsHandle_);
@@ -495,7 +495,7 @@ void HcalHBHEMuonHighEtaAnalyzer::beginRun(edm::Run const& iRun, edm::EventSetup
 }
 
 bool HcalHBHEMuonHighEtaAnalyzer::analyzeMuon(const edm::Event& iEvent, math::XYZPoint& leadPV) {
-  const edm::Handle<reco::MuonCollection> _Muon = iEvent.getHandle(tok_Muon_);
+  const edm::Handle<reco::MuonCollection>& _Muon = iEvent.getHandle(tok_Muon_);
   bool accept = false;
 
   if (_Muon.isValid()) {

--- a/Calibration/HcalCalibAlgos/plugins/HcalHBHENewMuonAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalHBHENewMuonAnalyzer.cc
@@ -84,7 +84,7 @@ private:
 HcalHBHENewMuonAnalyzer::HcalHBHENewMuonAnalyzer(const edm::ParameterSet& iConfig)
     : labelHBHEMuonVar_(iConfig.getParameter<edm::InputTag>("hbheMuonLabel")),
       useRaw_(iConfig.getParameter<int>("useRaw")),
-      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 4)),
+      maxDepth_(iConfig.getUntrackedParameter<int>("maxDepth", 7)),
       tokHBHEMuonVar_(consumes<HcalHBHEMuonVariablesCollection>(labelHBHEMuonVar_)) {
   usesResource(TFileService::kSharedResource);
   //now do what ever initialization is needed
@@ -316,7 +316,7 @@ void HcalHBHENewMuonAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& d
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("hbheMuonLabel", edm::InputTag("alcaHcalHBHEMuonProducer", "hbheMuon"));
   desc.add<int>("useRaw", 0);
-  desc.addUntracked<int>("maxDepth", 4);
+  desc.addUntracked<int>("maxDepth", 7);
   descriptions.add("hcalHBHEMuonAnalysis", desc);
 }
 

--- a/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
@@ -97,7 +97,7 @@ HcalHBHEMuonSimAnalyzer::HcalHBHEMuonSimAnalyzer(const edm::ParameterSet& iConfi
       eeLabel_(iConfig.getParameter<std::string>("EECollection")),
       hcLabel_(iConfig.getParameter<std::string>("HCCollection")),
       verbosity_(iConfig.getUntrackedParameter<int>("Verbosity", 0)),
-      maxDepth_(iConfig.getUntrackedParameter<int>("MaxDepth", 4)),
+      maxDepth_(iConfig.getUntrackedParameter<int>("MaxDepth", 7)),
       etaMax_(iConfig.getUntrackedParameter<double>("EtaMax", 3.0)),
       tMinE_(iConfig.getUntrackedParameter<double>("TimeMinCutECAL", -500.)),
       tMaxE_(iConfig.getUntrackedParameter<double>("TimeMaxCutECAL", 500.)),
@@ -401,7 +401,7 @@ void HcalHBHEMuonSimAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<std::string>("EECollection", "EcalHitsEE");
   desc.add<std::string>("HCCollection", "HcalHits");
   desc.addUntracked<int>("Verbosity", 0);
-  desc.addUntracked<int>("MaxDepth", 4);
+  desc.addUntracked<int>("MaxDepth", 7);
   desc.addUntracked<double>("EtaMax", 3.0);
   desc.addUntracked<double>("TimeMinCutECAL", -500.);
   desc.addUntracked<double>("TimeMaxCutECAL", 500.);


### PR DESCRIPTION
#### PR description:

Update some of the defaults for Muon analysis code in HCalAlCaRecoProducers and HcalCalibAlgos. The defaults were setup for Run2 (2017). Now the defaults refer to RUn3 operation. Also a new parameter is added (threshold of muon momentum to be saved)

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special