### PR TITLE
Run3-sim132 Use token rather than label in some of te classes in FastSimulation/Tracking

### DIFF
--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -1,4 +1,5 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
@@ -72,7 +73,7 @@ TrackingLayer TrackingLayer::createFromDetId(const DetId& detId, const TrackerTo
     throw cms::Exception("FastSimulation/Tracking")
         << "Cannot determine seeding layer from DetId:" << trackerTopology.print(detId).c_str() << std::endl;
   }
-  //std::cout<<"LayerSpec::createFromDetId: "<<trackerTopology.print(detId).c_str()<<", parsed="<<seedingLayer.print().c_str()<<std::endl;
+  edm::LogVerbatim("TrackingLayer") << "LayerSpec::createFromDetId: " << trackerTopology.print(detId).c_str() << ", parsed=" << trackingLayer._layerNumber;
   return trackingLayer;
 }
 
@@ -168,7 +169,7 @@ TrackingLayer TrackingLayer::createFromString(std::string layerSpecification) {
         << "no case sensitive name of ['BPix','FPix','TIB','MTIB','TID','MTID','TOB','TEC','MTEC'] matches '"
         << layerSpecification.c_str() << "'";
   }
-  //std::cout<<"LayerSpec::createFromString: "<<layerSpecification.c_str()<<", parsed="<<seedingLayer.print().c_str()<<std::endl;
+  edm::LogVerbatim("TrackingLayer")  << "LayerSpec::createFromString: " << layerSpecification.c_str() << ", parsed=" << trackingLayer._layerNumber;
 
   return trackingLayer;
 }

--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -73,7 +73,8 @@ TrackingLayer TrackingLayer::createFromDetId(const DetId& detId, const TrackerTo
     throw cms::Exception("FastSimulation/Tracking")
         << "Cannot determine seeding layer from DetId:" << trackerTopology.print(detId).c_str() << std::endl;
   }
-  edm::LogVerbatim("TrackingLayer") << "LayerSpec::createFromDetId: " << trackerTopology.print(detId).c_str() << ", parsed=" << trackingLayer._layerNumber;
+  edm::LogVerbatim("TrackingLayer") << "LayerSpec::createFromDetId: " << trackerTopology.print(detId).c_str()
+                                    << ", parsed=" << trackingLayer._layerNumber;
   return trackingLayer;
 }
 
@@ -169,7 +170,8 @@ TrackingLayer TrackingLayer::createFromString(std::string layerSpecification) {
         << "no case sensitive name of ['BPix','FPix','TIB','MTIB','TID','MTID','TOB','TEC','MTEC'] matches '"
         << layerSpecification.c_str() << "'";
   }
-  edm::LogVerbatim("TrackingLayer")  << "LayerSpec::createFromString: " << layerSpecification.c_str() << ", parsed=" << trackingLayer._layerNumber;
+  edm::LogVerbatim("TrackingLayer") << "LayerSpec::createFromString: " << layerSpecification.c_str()
+                                    << ", parsed=" << trackingLayer._layerNumber;
 
   return trackingLayer;
 }

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -44,8 +44,8 @@ public:
 private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken;
   const edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken;
-  const edm::EDGetTokenT<std::vector<SimTrack> > tokSimTrack_;
-  const edm::EDGetTokenT<std::vector<SimVertex> > tokSimVertex_;
+  const edm::EDGetTokenT<std::vector<SimTrack>> tokSimTrack_;
+  const edm::EDGetTokenT<std::vector<SimVertex>> tokSimVertex_;
 
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
@@ -80,8 +80,8 @@ private:
 testGeneralTracks::testGeneralTracks(const edm::ParameterSet& p)
     : geomToken(esConsumes()),
       pdtToken(esConsumes()),
-      tokSimTrack_(consumes<std::vector<SimTrack> >(edm::InputTag("fastSimProducer"))),
-      tokSimVertex_(consumes<std::vector<SimVertex> >(edm::InputTag("fastSimProducer"))),
+      tokSimTrack_(consumes<std::vector<SimTrack>>(edm::InputTag("fastSimProducer"))),
+      tokSimVertex_(consumes<std::vector<SimVertex>>(edm::InputTag("fastSimProducer"))),
       mySimEvent(2, static_cast<FSimEvent*>(0)),
       h0(2, static_cast<MonitorElement*>(0)),
       TracksvsEtaP(2, static_cast<MonitorElement*>(0)),
@@ -157,8 +157,8 @@ void testGeneralTracks::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   std::unique_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
 
-  const edm::Handle<std::vector<SimTrack> >& fastSimTracks = iEvent.getHandle(tokSimTrack_);
-  const edm::Handle<std::vector<SimVertex> >& fastSimVertices = iEvent.getHandle(tokSimVertex_);
+  const edm::Handle<std::vector<SimTrack>>& fastSimTracks = iEvent.getHandle(tokSimTrack_);
+  const edm::Handle<std::vector<SimVertex>>& fastSimVertices = iEvent.getHandle(tokSimVertex_);
   mySimEvent[1]->fill(*fastSimTracks, *fastSimVertices);
 
   if (!mySimEvent[1]->nVertices())

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -42,12 +42,15 @@ public:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 private:
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken;
-  edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken;
+  const edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken;
+  const edm::EDGetTokenT<std::vector<SimTrack> > tokSimTrack_;
+  const edm::EDGetTokenT<std::vector<SimVertex> > tokSimVertex_;
 
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
-  std::vector<edm::InputTag> allTracks;
+  std::vector<edm::InputTag> allTracks_;
+  std::vector<edm::EDGetTokenT<reco::TrackCollection>> allTrackToken_;
   bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
   std::string simModuleLabel_;
@@ -77,6 +80,8 @@ private:
 testGeneralTracks::testGeneralTracks(const edm::ParameterSet& p)
     : geomToken(esConsumes()),
       pdtToken(esConsumes()),
+      tokSimTrack_(consumes<std::vector<SimTrack> >(edm::InputTag("fastSimProducer"))),
+      tokSimVertex_(consumes<std::vector<SimVertex> >(edm::InputTag("fastSimProducer"))),
       mySimEvent(2, static_cast<FSimEvent*>(0)),
       h0(2, static_cast<MonitorElement*>(0)),
       TracksvsEtaP(2, static_cast<MonitorElement*>(0)),
@@ -84,15 +89,15 @@ testGeneralTracks::testGeneralTracks(const edm::ParameterSet& p)
       HitsvsEta(2, static_cast<MonitorElement*>(0)),
       LayersvsP(2, static_cast<MonitorElement*>(0)),
       LayersvsEta(2, static_cast<MonitorElement*>(0)),
-
       Num(2, static_cast<MonitorElement*>(0)),
-
       totalNEvt(0) {
   // Let's just initialize the SimEvent's
   particleFilter_ = p.getParameter<edm::ParameterSet>("TestParticleFilter");
 
-  allTracks.push_back(p.getParameter<edm::InputTag>("Full"));
-  allTracks.push_back(p.getParameter<edm::InputTag>("Fast"));
+  allTracks_.emplace_back(p.getParameter<edm::InputTag>("Full"));
+  allTracks_.emplace_back(p.getParameter<edm::InputTag>("Fast"));
+  for (const auto& tag : allTracks_)
+    allTrackToken_.emplace_back(consumes<reco::TrackCollection>(tag));
 
   // For the full sim
   mySimEvent[0] = new FSimEvent(particleFilter_);
@@ -152,10 +157,8 @@ void testGeneralTracks::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   std::unique_ptr<edm::SimTrackContainer> nuclSimTracks(new edm::SimTrackContainer);
 
-  edm::Handle<std::vector<SimTrack> > fastSimTracks;
-  iEvent.getByLabel("fastSimProducer", fastSimTracks);
-  edm::Handle<std::vector<SimVertex> > fastSimVertices;
-  iEvent.getByLabel("fastSimProducer", fastSimVertices);
+  const edm::Handle<std::vector<SimTrack> >& fastSimTracks = iEvent.getHandle(tokSimTrack_);
+  const edm::Handle<std::vector<SimVertex> >& fastSimVertices = iEvent.getHandle(tokSimVertex_);
   mySimEvent[1]->fill(*fastSimTracks, *fastSimVertices);
 
   if (!mySimEvent[1]->nVertices())
@@ -177,9 +180,8 @@ void testGeneralTracks::analyze(const edm::Event& iEvent, const edm::EventSetup&
   std::vector<bool> firstSeed(2, static_cast<bool>(false));
   std::vector<bool> secondSeed(2, static_cast<bool>(false));
 
-  for (unsigned ievt = 0; ievt < 2; ++ievt) {
-    edm::Handle<reco::TrackCollection> tkRef0;
-    iEvent.getByLabel(allTracks[ievt], tkRef0);
+  for (unsigned ievt = 0; ievt < allTracks_.size(); ++ievt) {
+    const edm::Handle<reco::TrackCollection>& tkRef0 = iEvent.getHandle(allTrackToken_[ievt]);
     std::vector<const reco::TrackCollection*> tkColl;
     tkColl.push_back(tkRef0.product());
 


### PR DESCRIPTION
#### PR description:

Use token rather than label in some of te classes in FastSimulation/Tracking

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special