### PR TITLE
Add new LumiCorrectionsSummary plot for Payload Inspector

### DIFF
--- a/CondCore/LuminosityPlugins/plugins/BuildFile.xml
+++ b/CondCore/LuminosityPlugins/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<library file="LumiCorrections_PayloadInspector.cc" name="LumiCorrections_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/LuminosityPlugins/plugins/LumiCorrections_PayloadInspector.cc
+++ b/CondCore/LuminosityPlugins/plugins/LumiCorrections_PayloadInspector.cc
@@ -1,0 +1,70 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+#include "CondFormats/Luminosity/interface/LumiCorrections.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+#include "TCanvas.h"
+#include "TGraph.h"
+#include "TAxis.h"
+
+namespace {
+
+  /************************************************
+    summary class
+  *************************************************/
+
+  class LumiCorrectionsSummary : public cond::payloadInspector::PlotImage<LumiCorrections> {
+  public:
+    LumiCorrectionsSummary() : cond::payloadInspector::PlotImage<LumiCorrections>("LumiCorrections Summary") {}
+
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto tagname = tag.name;
+      auto iov = tag.iovs.front();
+
+      std::shared_ptr<LumiCorrections> payload = fetchPayload(std::get<1>(iov));
+      auto unpacked = unpack(std::get<0>(iov));
+      if (payload != nullptr) {
+        TCanvas canvas(Form("LumiCorrectionsSummary per BX Run %d Lumi %d", unpacked.first, unpacked.second),
+                       Form("LumiCorrectionsSummary per BX Run %d Lumi %d", unpacked.first, unpacked.second),
+                       1200,
+                       600);
+        canvas.cd();
+        const int nBX = 3564;
+        std::vector<float> correctionScaleFactors_ = payload->getCorrectionsBX();
+        Double_t x[nBX];
+        Double_t y[nBX];
+        for (int i = 0; i < nBX; i++) {
+          x[i] = i;
+          y[i] = correctionScaleFactors_[i];
+        }
+        TGraph* gr = new TGraph(nBX, x, y);
+        gr->SetTitle(Form("LumiCorrectionsSummary per BX Run %d Lumi %d", unpacked.first, unpacked.second));
+        gr->Draw("AP");
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {
+      auto kLowMask = 0XFFFFFFFF;
+      auto run = (since >> 32);
+      auto lumi = (since & kLowMask);
+      return std::make_pair(run, lumi);
+    }
+  };
+}  // namespace
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(LumiCorrections) { PAYLOAD_INSPECTOR_CLASS(LumiCorrectionsSummary); }

--- a/CondCore/LuminosityPlugins/test/BuildFile.xml
+++ b/CondCore/LuminosityPlugins/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="CondCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<bin file="testLumiCorrections.cpp" name="testLumiCorrections">
+</bin>

--- a/CondCore/LuminosityPlugins/test/testLumiCorrections.cpp
+++ b/CondCore/LuminosityPlugins/test/testLumiCorrections.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/LuminosityPlugins/plugins/LumiCorrections_PayloadInspector.cc"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  // LumiCorrectionsSummary
+  std::string tag = "LumiPCC_Corrections_prompt";
+  cond::Time_t start = static_cast<unsigned long long>(1545372182773899);
+  cond::Time_t end = static_cast<unsigned long long>(1545372182773899);
+
+  edm::LogPrint("testLumiCorrectionsSummaryPayloadInspector")
+      << "## Exercising LumiCorrectionsSummary plots " << std::endl;
+
+  LumiCorrectionsSummary test;
+  test.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testLumiCorrectionsSummaryPayloadInspector") << test.data() << std::endl;
+
+  Py_Finalize();
+}

--- a/CondCore/LuminosityPlugins/test/testLumiCorrections.sh
+++ b/CondCore/LuminosityPlugins/test/testLumiCorrections.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+mkdir -p $W_DIR/results
+
+if [ -f *.png ]; then    
+    rm *.png
+fi
+
+echo "Testing the Luminosity Corrections Summary plot"
+
+getPayloadData.py \
+    --plugin pluginLumiCorrections_PayloadInspector \
+    --plot plot_LumiCorrectionsSummary \
+    --tag LumiPCC_Corrections_prompt \
+    --time_type Lumi \
+    --iovs '{"start_iov": "1545372182773899", "end_iov": "1545372182773899"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/results/LuminosityCorrectionsSummary.png


### PR DESCRIPTION
#### PR description:

New class containing the plot with the luminosity corrections vs bunch crossing ID is added to the Payload Inspector module in order to visualize the luminosity corrections with the software.

#### PR validation:

Tested by running the script testLumiCorrections.sh (based on getPayloadData.py).

No backport is needed.