### PR TITLE
Fix trigger matching issues in L1Trigger DQMOffline

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -87,7 +87,7 @@ goodPFJetsForL1T = cms.EDFilter(
 from L1Trigger.L1TNtuples.L1TPFMetNoMuProducer_cfi import l1tPFMetNoMu
 
 l1tPFMetNoMuForDQM = l1tPFMetNoMu.clone(
-    pfMETCollection= 'pfMETT1',
+    pfMETCollection= 'pfMet',  ## Was 'pfMETT1', threw errors - AWB 2022.09.28
     muonCollection= 'muons'
 )
 

--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -101,19 +101,19 @@ namespace dqmoffline {
                                              const std::string triggerProcess) {
       std::vector<edm::InputTag> results;
       for (auto trigger : triggers) {
-	// For some reason various modules now come *after* "hltBoolEnd"
-	// Really just want module one index before "hltBoolEnd" - AWB 2022.09.28
-	unsigned int moduleIndex = 999999;
-	for (int ii = 0; ii < int(hltConfig.size(trigger)); ii++) {
-	  if (hltConfig.moduleLabels(trigger)[ii] == "hltBoolEnd") {
-	    moduleIndex = ii - 1;
-	    break;
-	  }
-	}
-	if (moduleIndex == 999999) {
-	  edm::LogError("L1TCommon") << " Found no module label in trigger " << trigger << std::endl;
-	  continue;
-	}
+        // For some reason various modules now come *after* "hltBoolEnd"
+        // Really just want module one index before "hltBoolEnd" - AWB 2022.09.28
+        unsigned int moduleIndex = 999999;
+        for (int ii = 0; ii < int(hltConfig.size(trigger)); ii++) {
+          if (hltConfig.moduleLabels(trigger)[ii] == "hltBoolEnd") {
+            moduleIndex = ii - 1;
+            break;
+          }
+        }
+        if (moduleIndex == 999999) {
+          edm::LogError("L1TCommon") << " Found no module label in trigger " << trigger << std::endl;
+          continue;
+        }
         const std::vector<std::string> &modules(hltConfig.moduleLabels(trigger));
         std::string module(modules[moduleIndex]);
         edm::InputTag filterInputTag = edm::InputTag(module, "", triggerProcess);

--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -101,8 +101,19 @@ namespace dqmoffline {
                                              const std::string triggerProcess) {
       std::vector<edm::InputTag> results;
       for (auto trigger : triggers) {
-        unsigned int hltIndexOffset(2);
-        unsigned int moduleIndex = hltConfig.size(trigger) - hltIndexOffset;
+	// For some reason various modules now come *after* "hltBoolEnd"
+	// Really just want module one index before "hltBoolEnd" - AWB 2022.09.28
+	unsigned int moduleIndex = 999999;
+	for (int ii = 0; ii < int(hltConfig.size(trigger)); ii++) {
+	  if (hltConfig.moduleLabels(trigger)[ii] == "hltBoolEnd") {
+	    moduleIndex = ii - 1;
+	    break;
+	  }
+	}
+	if (moduleIndex == 999999) {
+	  edm::LogError("L1TCommon") << " Found no module label in trigger " << trigger << std::endl;
+	  continue;
+	}
         const std::vector<std::string> &modules(hltConfig.moduleLabels(trigger));
         std::string module(modules[moduleIndex]);
         edm::InputTag filterInputTag = edm::InputTag(module, "", triggerProcess);

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -201,7 +201,8 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
       if (tmpName.Contains(tNamePattern)) {
         tIndex = int(ipath);
         m_trigIndices.push_back(tIndex);
-        if (m_verbose) cout << "[L1TMuonDQMOffline:] Found trigger " << tmpName << " with index " << tIndex << endl;
+        if (m_verbose)
+          cout << "[L1TMuonDQMOffline:] Found trigger " << tmpName << " with index " << tIndex << endl;
       }
     }
     if (tIndex < 0 && m_verbose)
@@ -211,8 +212,8 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
 
 //_____________________________________________________________________
 void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetup) {
-
-  if (m_verbose) cout << "\n[L1TMuonDQMOffline:] Processing new event in analyze" << endl;
+  if (m_verbose)
+    cout << "\n[L1TMuonDQMOffline:] Processing new event in analyze" << endl;
 
   auto const propagator = m_propagatorSetup.init(eventSetup);
 
@@ -233,13 +234,15 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
   bool pass_HLT = false;
   for (const auto& tIndex : m_trigIndices) {
     if (trigResults->accept(tIndex)) {
-      if (m_verbose) cout << "[L1TMuonDQMOffline:] Fired trigger " << m_hltConfig.triggerName(tIndex) << endl;
+      if (m_verbose)
+        cout << "[L1TMuonDQMOffline:] Fired trigger " << m_hltConfig.triggerName(tIndex) << endl;
       pass_HLT = true;
       break;
     }
   }
   if (not pass_HLT) {
-    if (m_verbose) cout << "[L1TMuonDQMOffline:] Did not fire any triggers - quitting" << endl;
+    if (m_verbose)
+      cout << "[L1TMuonDQMOffline:] Did not fire any triggers - quitting" << endl;
     return;
   }
 
@@ -251,8 +254,9 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
 
   getMuonGmtPairs(gmtCands, propagator);
 
-  if (m_verbose) cout << "[L1TMuonDQMOffline:] Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
-		      <<  m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size() << " probe muons" << endl;
+  if (m_verbose)
+    cout << "[L1TMuonDQMOffline:] Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
+         << m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size() << " probe muons" << endl;
 
   vector<MuonGmtPair>::const_iterator muonGmtPairsIt = m_MuonGmtPairs.begin();
   vector<MuonGmtPair>::const_iterator muonGmtPairsEnd = m_MuonGmtPairs.end();
@@ -279,8 +283,9 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
             if (muonGmtPairsIt->gmtQual() >= qualCut) {
               std::get<2>(histoKeyRes) = qualLevel;
               m_ResolutionHistos[histoKeyRes]->Fill(varToFill);
-              if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
-				  << std::get<1>(histoKeyRes) << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
+              if (m_verbose)
+                cout << "[L1TMuonDQMOffline:] Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
+                     << std::get<1>(histoKeyRes) << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
             }
           }
         }
@@ -314,7 +319,8 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
           // Fill denominators
           if (var == kEffEta) {
             m_EfficiencyDenEtaHistos[gmtPtCut]->Fill(varToFill);
-            if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
+            if (m_verbose)
+              cout << "[L1TMuonDQMOffline:] Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
           } else {
             std::get<0>(histoKeyEffDenVar) = var;
             // Fill for the global eta and for TF eta region that the probe muon is in
@@ -322,13 +328,17 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               if (var == kEffPt) {
                 if (cutsCounter == 0) {
                   m_EfficiencyDenPtHistos[regToFill]->Fill(varToFill);
-                  if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom pT histo[" << regToFill << "] with " << varToFill << endl;
+                  if (m_verbose)
+                    cout << "[L1TMuonDQMOffline:] Filled eff denom pT histo[" << regToFill << "] with " << varToFill
+                         << endl;
                 }
               } else {
                 std::get<2>(histoKeyEffDenVar) = regToFill;
                 m_EfficiencyDenVarHistos[histoKeyEffDenVar]->Fill(varToFill);
-                if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
-				    << std::get<1>(histoKeyEffDenVar) << ", " << std::get<2>(histoKeyEffDenVar) << "] with " << varToFill << endl;
+                if (m_verbose)
+                  cout << "[L1TMuonDQMOffline:] Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
+                       << std::get<1>(histoKeyEffDenVar) << ", " << std::get<2>(histoKeyEffDenVar) << "] with "
+                       << varToFill << endl;
               }
             }
           }
@@ -339,17 +349,19 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
             if (var == kEffEta) {
               m_histoKeyEffNumEtaType histoKeyEffNumEta = {gmtPtCut, qualLevel};
               m_EfficiencyNumEtaHistos[histoKeyEffNumEta]->Fill(varToFill);
-              if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta)
-				  << ", " << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
+              if (m_verbose)
+                cout << "[L1TMuonDQMOffline:] Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta) << ", "
+                     << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
             } else {
               std::get<3>(histoKeyEffNumVar) = qualLevel;
               // Fill for the global eta and for TF eta region that the probe muon is in
               for (const auto regToFill : regsToFill) {
                 std::get<2>(histoKeyEffNumVar) = regToFill;
                 m_EfficiencyNumVarHistos[histoKeyEffNumVar]->Fill(varToFill);
-                if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
-				    << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
-				    << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
+                if (m_verbose)
+                  cout << "[L1TMuonDQMOffline:] Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
+                       << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
+                       << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
               }
             }
           }
@@ -626,7 +638,6 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
   vector<int>::const_iterator trigIndexEnd = m_trigIndices.end();
 
   for (; trigIndexIt != trigIndexEnd; ++trigIndexIt) {
-
     const vector<string> moduleLabels(m_hltConfig.moduleLabels(*trigIndexIt));
     // For some reason various modules now come *after* "hltBoolEnd"
     // Really just want module one index before "hltBoolEnd" - AWB 2022.09.28
@@ -634,8 +645,8 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
     unsigned int moduleIndex = 999999;
     for (int ii = 0; ii < int(moduleLabels.size()); ii++) {
       if (moduleLabels[ii] == "hltBoolEnd") {
-	moduleIndex = ii - 1;
-	break;
+        moduleIndex = ii - 1;
+        break;
       }
     }
     if (moduleIndex == 999999) {
@@ -652,10 +663,12 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
 
       for (size_t iTrig = 0; iTrig < nTriggers; ++iTrig) {
         const TriggerObject trigObject = trigObjs[triggerKeys[iTrig]];
-        if (m_verbose) cout << "[L1TMuonDQMOffline:] Found trigObject with pt = " << trigObject.pt()
-			    << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
-        if (m_verbose) cout << "[L1TMuonDQMOffline:] Compare to muon with pt = " << (*mu).pt()
-			    << ", eta = " << (*mu).eta() << ", phi = " << (*mu).phi() << endl;
+        if (m_verbose)
+          cout << "[L1TMuonDQMOffline:] Found trigObject with pt = " << trigObject.pt()
+               << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
+        if (m_verbose)
+          cout << "[L1TMuonDQMOffline:] Compare to muon with pt = " << (*mu).pt() << ", eta = " << (*mu).eta()
+               << ", phi = " << (*mu).phi() << endl;
         double dRtmp = deltaR((*mu), trigObject);
         if (dRtmp < matchDeltaR)
           matchDeltaR = dRtmp;

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -155,7 +155,7 @@ L1TMuonDQMOffline::L1TMuonDQMOffline(const ParameterSet& ps)
       m_minTagProbeDR(0.5),
       m_maxHltMuonDR(0.1) {
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] ____________ Storage initialization ____________ " << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "____________ Storage initialization ____________ " << endl;
 
   for (const auto& cutsPSet : m_cutsVPSet) {
     const auto qCut = cutsPSet.getUntrackedParameter<int>("qualCut");
@@ -176,7 +176,7 @@ L1TMuonDQMOffline::~L1TMuonDQMOffline() {}
 //----------------------------------------------------------------------
 void L1TMuonDQMOffline::dqmBeginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Called beginRun." << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Called beginRun." << endl;
   bool changed = true;
   m_hltConfig.init(run, iSetup, m_trigProcess, changed);
 }
@@ -202,18 +202,18 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
         tIndex = int(ipath);
         m_trigIndices.push_back(tIndex);
         if (m_verbose)
-          cout << "[L1TMuonDQMOffline:] Found trigger " << tmpName << " with index " << tIndex << endl;
+          edm::LogInfo("L1TMuonDQMOffline") << "Found trigger " << tmpName << " with index " << tIndex << endl;
       }
     }
     if (tIndex < 0 && m_verbose)
-      cout << "[L1TMuonDQMOffline:] Warning: Could not find trigger " << (*trigNamesIt) << endl;
+      edm::LogInfo("L1TMuonDQMOffline") << "Warning: Could not find trigger " << (*trigNamesIt) << endl;
   }
 }
 
 //_____________________________________________________________________
 void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetup) {
   if (m_verbose)
-    cout << "\n[L1TMuonDQMOffline:] Processing new event in analyze" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "\nProcessing new event in analyze" << endl;
 
   auto const propagator = m_propagatorSetup.init(eventSetup);
 
@@ -235,14 +235,14 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
   for (const auto& tIndex : m_trigIndices) {
     if (trigResults->accept(tIndex)) {
       if (m_verbose)
-        cout << "[L1TMuonDQMOffline:] Fired trigger " << m_hltConfig.triggerName(tIndex) << endl;
+        edm::LogInfo("L1TMuonDQMOffline") << "Fired trigger " << m_hltConfig.triggerName(tIndex) << endl;
       pass_HLT = true;
       break;
     }
   }
   if (not pass_HLT) {
     if (m_verbose)
-      cout << "[L1TMuonDQMOffline:] Did not fire any triggers - quitting" << endl;
+      edm::LogInfo("L1TMuonDQMOffline") << "Did not fire any triggers - quitting" << endl;
     return;
   }
 
@@ -255,7 +255,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
   getMuonGmtPairs(gmtCands, propagator);
 
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
+    edm::LogInfo("L1TMuonDQMOffline") << "Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
          << m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size() << " probe muons" << endl;
 
   vector<MuonGmtPair>::const_iterator muonGmtPairsIt = m_MuonGmtPairs.begin();
@@ -284,7 +284,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               std::get<2>(histoKeyRes) = qualLevel;
               m_ResolutionHistos[histoKeyRes]->Fill(varToFill);
               if (m_verbose)
-                cout << "[L1TMuonDQMOffline:] Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
+                edm::LogInfo("L1TMuonDQMOffline") << "Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
                      << std::get<1>(histoKeyRes) << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
             }
           }
@@ -320,7 +320,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
           if (var == kEffEta) {
             m_EfficiencyDenEtaHistos[gmtPtCut]->Fill(varToFill);
             if (m_verbose)
-              cout << "[L1TMuonDQMOffline:] Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
+              edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
           } else {
             std::get<0>(histoKeyEffDenVar) = var;
             // Fill for the global eta and for TF eta region that the probe muon is in
@@ -329,14 +329,14 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
                 if (cutsCounter == 0) {
                   m_EfficiencyDenPtHistos[regToFill]->Fill(varToFill);
                   if (m_verbose)
-                    cout << "[L1TMuonDQMOffline:] Filled eff denom pT histo[" << regToFill << "] with " << varToFill
+                    edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom pT histo[" << regToFill << "] with " << varToFill
                          << endl;
                 }
               } else {
                 std::get<2>(histoKeyEffDenVar) = regToFill;
                 m_EfficiencyDenVarHistos[histoKeyEffDenVar]->Fill(varToFill);
                 if (m_verbose)
-                  cout << "[L1TMuonDQMOffline:] Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
+                  edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
                        << std::get<1>(histoKeyEffDenVar) << ", " << std::get<2>(histoKeyEffDenVar) << "] with "
                        << varToFill << endl;
               }
@@ -350,7 +350,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               m_histoKeyEffNumEtaType histoKeyEffNumEta = {gmtPtCut, qualLevel};
               m_EfficiencyNumEtaHistos[histoKeyEffNumEta]->Fill(varToFill);
               if (m_verbose)
-                cout << "[L1TMuonDQMOffline:] Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta) << ", "
+                edm::LogInfo("L1TMuonDQMOffline") << "Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta) << ", "
                      << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
             } else {
               std::get<3>(histoKeyEffNumVar) = qualLevel;
@@ -359,7 +359,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
                 std::get<2>(histoKeyEffNumVar) = regToFill;
                 m_EfficiencyNumVarHistos[histoKeyEffNumVar]->Fill(varToFill);
                 if (m_verbose)
-                  cout << "[L1TMuonDQMOffline:] Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
+                  edm::LogInfo("L1TMuonDQMOffline") << "Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
                        << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
                        << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
               }
@@ -372,13 +372,13 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
   }
 
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Computation finished" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Computation finished" << endl;
 }
 
 //_____________________________________________________________________
 void L1TMuonDQMOffline::bookControlHistos(DQMStore::IBooker& ibooker) {
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Booking Control Plot Histos" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Booking Control Plot Histos" << endl;
 
   ibooker.setCurrentFolder(m_HistFolder + "/control_variables");
 
@@ -453,7 +453,7 @@ void L1TMuonDQMOffline::bookEfficiencyHistos(DQMStore::IBooker& ibooker) {
 
 void L1TMuonDQMOffline::bookResolutionHistos(DQMStore::IBooker& ibooker) {
   if (m_verbose)
-    cout << "[L1TMuonOffline:] Booking Resolution Plot Histos" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Booking Resolution Plot Histos" << endl;
   ibooker.setCurrentFolder(m_HistFolder + "/resolution");
 
   for (const auto var : m_resTypes) {
@@ -519,7 +519,7 @@ const reco::Vertex L1TMuonDQMOffline::getPrimaryVertex(Handle<VertexCollection>&
 //_____________________________________________________________________
 void L1TMuonDQMOffline::getTightMuons(edm::Handle<reco::MuonCollection>& muons, const Vertex& vertex) {
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Getting tight muons" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Getting tight muons" << endl;
   m_TightMuons.clear();
   MuonCollection::const_iterator muonIt = muons->begin();
   MuonCollection::const_iterator muonEnd = muons->end();
@@ -536,7 +536,7 @@ void L1TMuonDQMOffline::getTightMuons(edm::Handle<reco::MuonCollection>& muons, 
 void L1TMuonDQMOffline::getProbeMuons(Handle<edm::TriggerResults>& trigResults,
                                       edm::Handle<trigger::TriggerEvent>& trigEvent) {
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] getting probe muons" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "getting probe muons" << endl;
   m_ProbeMuons.clear();
   std::vector<const reco::Muon*> tagMuonsInHist;
 
@@ -598,7 +598,7 @@ void L1TMuonDQMOffline::getMuonGmtPairs(edm::Handle<l1t::MuonBxCollection>& gmtC
                                         PropagateToMuon const& propagator) {
   m_MuonGmtPairs.clear();
   if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Getting muon GMT pairs" << endl;
+    edm::LogInfo("L1TMuonDQMOffline") << "Getting muon GMT pairs" << endl;
 
   vector<const reco::Muon*>::const_iterator probeMuIt = m_ProbeMuons.begin();
   vector<const reco::Muon*>::const_iterator probeMuEnd = m_ProbeMuons.end();
@@ -650,7 +650,7 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
       }
     }
     if (moduleIndex == 999999) {
-      edm::LogError("L1TMuonDQMOffline") << " Found no module label in trigger " << (*trigIndexIt) << std::endl;
+      edm::LogError("L1TMuonDQMOffline") << "Found no module label in trigger " << (*trigIndexIt) << endl;
       continue;
     }
 
@@ -664,10 +664,10 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
       for (size_t iTrig = 0; iTrig < nTriggers; ++iTrig) {
         const TriggerObject trigObject = trigObjs[triggerKeys[iTrig]];
         if (m_verbose)
-          cout << "[L1TMuonDQMOffline:] Found trigObject with pt = " << trigObject.pt()
+          edm::LogInfo("L1TMuonDQMOffline") << "Found trigObject with pt = " << trigObject.pt()
                << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
         if (m_verbose)
-          cout << "[L1TMuonDQMOffline:] Compare to muon with pt = " << (*mu).pt() << ", eta = " << (*mu).eta()
+          edm::LogInfo("L1TMuonDQMOffline") << "Compare to muon with pt = " << (*mu).pt() << ", eta = " << (*mu).eta()
                << ", phi = " << (*mu).phi() << endl;
         double dRtmp = deltaR((*mu), trigObject);
         if (dRtmp < matchDeltaR)

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -256,7 +256,8 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
 
   if (m_verbose)
     edm::LogInfo("L1TMuonDQMOffline") << "Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
-         << m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size() << " probe muons" << endl;
+                                      << m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size()
+                                      << " probe muons" << endl;
 
   vector<MuonGmtPair>::const_iterator muonGmtPairsIt = m_MuonGmtPairs.begin();
   vector<MuonGmtPair>::const_iterator muonGmtPairsEnd = m_MuonGmtPairs.end();
@@ -284,8 +285,9 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               std::get<2>(histoKeyRes) = qualLevel;
               m_ResolutionHistos[histoKeyRes]->Fill(varToFill);
               if (m_verbose)
-                edm::LogInfo("L1TMuonDQMOffline") << "Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
-                     << std::get<1>(histoKeyRes) << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
+                edm::LogInfo("L1TMuonDQMOffline")
+                    << "Filled resolution histo[" << std::get<0>(histoKeyRes) << ", " << std::get<1>(histoKeyRes)
+                    << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
             }
           }
         }
@@ -320,7 +322,8 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
           if (var == kEffEta) {
             m_EfficiencyDenEtaHistos[gmtPtCut]->Fill(varToFill);
             if (m_verbose)
-              edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
+              edm::LogInfo("L1TMuonDQMOffline")
+                  << "Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
           } else {
             std::get<0>(histoKeyEffDenVar) = var;
             // Fill for the global eta and for TF eta region that the probe muon is in
@@ -329,16 +332,16 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
                 if (cutsCounter == 0) {
                   m_EfficiencyDenPtHistos[regToFill]->Fill(varToFill);
                   if (m_verbose)
-                    edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom pT histo[" << regToFill << "] with " << varToFill
-                         << endl;
+                    edm::LogInfo("L1TMuonDQMOffline")
+                        << "Filled eff denom pT histo[" << regToFill << "] with " << varToFill << endl;
                 }
               } else {
                 std::get<2>(histoKeyEffDenVar) = regToFill;
                 m_EfficiencyDenVarHistos[histoKeyEffDenVar]->Fill(varToFill);
                 if (m_verbose)
-                  edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
-                       << std::get<1>(histoKeyEffDenVar) << ", " << std::get<2>(histoKeyEffDenVar) << "] with "
-                       << varToFill << endl;
+                  edm::LogInfo("L1TMuonDQMOffline") << "Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar)
+                                                    << ", " << std::get<1>(histoKeyEffDenVar) << ", "
+                                                    << std::get<2>(histoKeyEffDenVar) << "] with " << varToFill << endl;
               }
             }
           }
@@ -350,8 +353,9 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               m_histoKeyEffNumEtaType histoKeyEffNumEta = {gmtPtCut, qualLevel};
               m_EfficiencyNumEtaHistos[histoKeyEffNumEta]->Fill(varToFill);
               if (m_verbose)
-                edm::LogInfo("L1TMuonDQMOffline") << "Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta) << ", "
-                     << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
+                edm::LogInfo("L1TMuonDQMOffline")
+                    << "Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta) << ", "
+                    << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
             } else {
               std::get<3>(histoKeyEffNumVar) = qualLevel;
               // Fill for the global eta and for TF eta region that the probe muon is in
@@ -359,9 +363,10 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
                 std::get<2>(histoKeyEffNumVar) = regToFill;
                 m_EfficiencyNumVarHistos[histoKeyEffNumVar]->Fill(varToFill);
                 if (m_verbose)
-                  edm::LogInfo("L1TMuonDQMOffline") << "Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
-                       << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
-                       << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
+                  edm::LogInfo("L1TMuonDQMOffline")
+                      << "Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
+                      << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
+                      << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
               }
             }
           }
@@ -665,10 +670,10 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
         const TriggerObject trigObject = trigObjs[triggerKeys[iTrig]];
         if (m_verbose)
           edm::LogInfo("L1TMuonDQMOffline") << "Found trigObject with pt = " << trigObject.pt()
-               << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
+                                            << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
         if (m_verbose)
           edm::LogInfo("L1TMuonDQMOffline") << "Compare to muon with pt = " << (*mu).pt() << ", eta = " << (*mu).eta()
-               << ", phi = " << (*mu).phi() << endl;
+                                            << ", phi = " << (*mu).phi() << endl;
         double dRtmp = deltaR((*mu), trigObject);
         if (dRtmp < matchDeltaR)
           matchDeltaR = dRtmp;

--- a/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TMuonDQMOffline.cc
@@ -201,6 +201,7 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
       if (tmpName.Contains(tNamePattern)) {
         tIndex = int(ipath);
         m_trigIndices.push_back(tIndex);
+        if (m_verbose) cout << "[L1TMuonDQMOffline:] Found trigger " << tmpName << " with index " << tIndex << endl;
       }
     }
     if (tIndex < 0 && m_verbose)
@@ -210,6 +211,9 @@ void L1TMuonDQMOffline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
 
 //_____________________________________________________________________
 void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetup) {
+
+  if (m_verbose) cout << "\n[L1TMuonDQMOffline:] Processing new event in analyze" << endl;
+
   auto const propagator = m_propagatorSetup.init(eventSetup);
 
   Handle<reco::MuonCollection> muons;
@@ -225,6 +229,20 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
   edm::Handle<trigger::TriggerEvent> trigEvent;
   iEvent.getByToken(m_trigInputTag, trigEvent);
 
+  // Only process event if at least one trigger fired
+  bool pass_HLT = false;
+  for (const auto& tIndex : m_trigIndices) {
+    if (trigResults->accept(tIndex)) {
+      if (m_verbose) cout << "[L1TMuonDQMOffline:] Fired trigger " << m_hltConfig.triggerName(tIndex) << endl;
+      pass_HLT = true;
+      break;
+    }
+  }
+  if (not pass_HLT) {
+    if (m_verbose) cout << "[L1TMuonDQMOffline:] Did not fire any triggers - quitting" << endl;
+    return;
+  }
+
   const auto nVtx = getNVertices(vertex);
   const Vertex primaryVertex = getPrimaryVertex(vertex, beamSpot);
 
@@ -233,8 +251,8 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
 
   getMuonGmtPairs(gmtCands, propagator);
 
-  if (m_verbose)
-    cout << "[L1TMuonDQMOffline:] Computing efficiencies" << endl;
+  if (m_verbose) cout << "[L1TMuonDQMOffline:] Computing efficiencies with " << m_MuonGmtPairs.size() << " muonGmtPairs, "
+		      <<  m_TightMuons.size() << " tight muons, " << m_ProbeMuons.size() << " probe muons" << endl;
 
   vector<MuonGmtPair>::const_iterator muonGmtPairsIt = m_MuonGmtPairs.begin();
   vector<MuonGmtPair>::const_iterator muonGmtPairsEnd = m_MuonGmtPairs.end();
@@ -261,6 +279,8 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
             if (muonGmtPairsIt->gmtQual() >= qualCut) {
               std::get<2>(histoKeyRes) = qualLevel;
               m_ResolutionHistos[histoKeyRes]->Fill(varToFill);
+              if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled resolution histo[" << std::get<0>(histoKeyRes) << ", "
+				  << std::get<1>(histoKeyRes) << ", " << std::get<2>(histoKeyRes) << "] with " << varToFill << endl;
             }
           }
         }
@@ -294,6 +314,7 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
           // Fill denominators
           if (var == kEffEta) {
             m_EfficiencyDenEtaHistos[gmtPtCut]->Fill(varToFill);
+            if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom eta histo[" << gmtPtCut << "] with " << varToFill << endl;
           } else {
             std::get<0>(histoKeyEffDenVar) = var;
             // Fill for the global eta and for TF eta region that the probe muon is in
@@ -301,10 +322,13 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
               if (var == kEffPt) {
                 if (cutsCounter == 0) {
                   m_EfficiencyDenPtHistos[regToFill]->Fill(varToFill);
+                  if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom pT histo[" << regToFill << "] with " << varToFill << endl;
                 }
               } else {
                 std::get<2>(histoKeyEffDenVar) = regToFill;
                 m_EfficiencyDenVarHistos[histoKeyEffDenVar]->Fill(varToFill);
+                if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff denom histo[" << std::get<0>(histoKeyEffDenVar) << ", "
+				    << std::get<1>(histoKeyEffDenVar) << ", " << std::get<2>(histoKeyEffDenVar) << "] with " << varToFill << endl;
               }
             }
           }
@@ -315,12 +339,17 @@ void L1TMuonDQMOffline::analyze(const Event& iEvent, const EventSetup& eventSetu
             if (var == kEffEta) {
               m_histoKeyEffNumEtaType histoKeyEffNumEta = {gmtPtCut, qualLevel};
               m_EfficiencyNumEtaHistos[histoKeyEffNumEta]->Fill(varToFill);
+              if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff num eta histo[" << std::get<0>(histoKeyEffNumEta)
+				  << ", " << std::get<1>(histoKeyEffNumEta) << "] with " << varToFill << endl;
             } else {
               std::get<3>(histoKeyEffNumVar) = qualLevel;
               // Fill for the global eta and for TF eta region that the probe muon is in
               for (const auto regToFill : regsToFill) {
                 std::get<2>(histoKeyEffNumVar) = regToFill;
                 m_EfficiencyNumVarHistos[histoKeyEffNumVar]->Fill(varToFill);
+                if (m_verbose) cout << "[L1TMuonDQMOffline:] Filled eff num histo[" << std::get<0>(histoKeyEffNumVar) << ", "
+				    << std::get<1>(histoKeyEffNumVar) << ", " << std::get<2>(histoKeyEffNumVar) << ", "
+				    << std::get<3>(histoKeyEffNumVar) << "] with " << varToFill << endl;
               }
             }
           }
@@ -597,16 +626,36 @@ double L1TMuonDQMOffline::matchHlt(edm::Handle<TriggerEvent>& triggerEvent, cons
   vector<int>::const_iterator trigIndexEnd = m_trigIndices.end();
 
   for (; trigIndexIt != trigIndexEnd; ++trigIndexIt) {
+
     const vector<string> moduleLabels(m_hltConfig.moduleLabels(*trigIndexIt));
-    const unsigned moduleIndex = m_hltConfig.size((*trigIndexIt)) - 2;
+    // For some reason various modules now come *after* "hltBoolEnd"
+    // Really just want module one index before "hltBoolEnd" - AWB 2022.09.28
+    // const unsigned moduleIndex = m_hltConfig.size((*trigIndexIt)) - 2;
+    unsigned int moduleIndex = 999999;
+    for (int ii = 0; ii < int(moduleLabels.size()); ii++) {
+      if (moduleLabels[ii] == "hltBoolEnd") {
+	moduleIndex = ii - 1;
+	break;
+      }
+    }
+    if (moduleIndex == 999999) {
+      edm::LogError("L1TMuonDQMOffline") << " Found no module label in trigger " << (*trigIndexIt) << std::endl;
+      continue;
+    }
+
     const unsigned hltFilterIndex = triggerEvent->filterIndex(InputTag(moduleLabels[moduleIndex], "", m_trigProcess));
 
     if (hltFilterIndex < triggerEvent->sizeFilters()) {
       const Keys triggerKeys(triggerEvent->filterKeys(hltFilterIndex));
       const Vids triggerVids(triggerEvent->filterIds(hltFilterIndex));
       const unsigned nTriggers = triggerVids.size();
+
       for (size_t iTrig = 0; iTrig < nTriggers; ++iTrig) {
         const TriggerObject trigObject = trigObjs[triggerKeys[iTrig]];
+        if (m_verbose) cout << "[L1TMuonDQMOffline:] Found trigObject with pt = " << trigObject.pt()
+			    << ", eta = " << trigObject.eta() << ", phi = " << trigObject.phi() << endl;
+        if (m_verbose) cout << "[L1TMuonDQMOffline:] Compare to muon with pt = " << (*mu).pt()
+			    << ", eta = " << (*mu).eta() << ", phi = " << (*mu).phi() << endl;
         double dRtmp = deltaR((*mu), trigObject);
         if (dRtmp < matchDeltaR)
           matchDeltaR = dRtmp;


### PR DESCRIPTION
#### PR description:

Fixed issue in L1T Offline DQM preventing HLT objects from being found, which leads to empty Muon and EGamma efficiency plots.  Tested in l1t-integration here:
https://github.com/cms-l1t-offline/cmssw/pull/1051

#### PR validation:

cmsDriver.py step2 --conditions 124X_dataRun3_Prompt_v4 --data --datatier RECO,DQMIO --era Run3 --eventcontent RECO,DQM --filein file:/eos/cms/store/data/Run2022C/Muon/RAW/v1/000/356/570/00000/a76e1b83-d169-4db6-8009-96d7b76ee22c.root --fileout file:step2.root --nStreams 2 --nThreads 8 --no_exec --number 10 --process RECO --python_filename step_2L1T_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM:@L1TMuon

cmsDriver.py step3 --conditions 124X_dataRun3_Prompt_v4 --data --era Run3 --filein file:step2_inDQM.root --fileout file:step3.root --filetype DQM --nStreams 2 --no_exec --number 10 --python_filename step_3_cfg.py --scenario pp --step HARVESTING:DQMHarvestL1TMuon

Also can run the above replacing "L1TMuon" with "L1TEgamma", and with the following input file:
/eos/cms/store/data/Run2022C/EGamma/RAW/v1/000/356/570/00000/aa8267bc-e993-4ed2-920e-6349cc460523.root
