### PR TITLE
Fix CMS deprecation warnings in  RecoTracker & RecoVertex

### DIFF
--- a/RecoTracker/DebugTools/plugins/CkfDebugger.h
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -37,14 +38,20 @@ class MagneticField;
 class Chi2MeasurementEstimator;
 class Propagator;
 class NavigationSchool;
+class TrackerDigiGeometryRecord;
+class IdealMagneticFieldRecord;
+class IdealGeometryRecord;
+class NavigationSchoolRecord;
 
 typedef TransientTrackingRecHit::ConstRecHitPointer CTTRHp;
 
 class CkfDebugger {
 public:
-  CkfDebugger(edm::EventSetup const& es, edm::ConsumesCollector&& iC);
+  CkfDebugger(edm::ConsumesCollector iC);
 
   ~CkfDebugger();
+
+  void setConditions(edm::EventSetup const& es);
 
   void printSimHits(const edm::Event& iEvent);
 
@@ -96,6 +103,11 @@ private:
   const GeometricSearchTracker* theGeomSearchTracker;
   const MeasurementEstimator* theChi2;
   const Propagator* theForwardPropagator;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  edm::ESGetToken<TrackerTopology, IdealGeometryRecord> theTopoHandToken;
+  edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> theNavToken;
+
   TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   TrackerHitAssociator* hitAssociator;
   const MeasurementTrackerEvent* theMeasurementTracker;

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicRegionalSeedGenerator.h
@@ -6,7 +6,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
@@ -10,7 +10,6 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/InputTag.h"


### PR DESCRIPTION
#### PR description:

- converted modules to thread friendly forms
- added missing esConsumes

#### PR validation:

Packages compiles without issuing a CMS deprecation warnings.