### PR TITLE
Fixed CMS deprecation warnings in SimPPS/RPDigiProducer

### DIFF
--- a/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.cc
@@ -9,7 +9,9 @@
 RPDetDigitizer::RPDetDigitizer(const edm::ParameterSet &params,
                                CLHEP::HepRandomEngine &eng,
                                RPDetId det_id,
-                               const edm::EventSetup &iSetup)
+                               const CTPPSRPAlignmentCorrectionsData *alignments,
+                               const CTPPSGeometry &geom)
+
     : det_id_(det_id) {
   verbosity_ = params.getParameter<int>("RPVerbosity");
   numStrips_ = RPTopology().DetStripNo();
@@ -24,7 +26,8 @@ RPDetDigitizer::RPDetDigitizer(const edm::ParameterSet &params,
   theRPPileUpSignals = std::make_unique<RPPileUpSignals>(params, det_id_);
   theRPVFATSimulator = std::make_unique<RPVFATSimulator>(params, det_id_);
   theRPHitChargeConverter = std::make_unique<RPHitChargeConverter>(params, eng, det_id_);
-  theRPDisplacementGenerator = std::make_unique<RPDisplacementGenerator>(params, det_id_, iSetup);
+  theRPDisplacementGenerator = std::make_unique<RPDisplacementGenerator>(
+      params.getParameter<bool>("RPDisplacementOn"), det_id_, alignments, geom);
 }
 
 void RPDetDigitizer::run(const std::vector<PSimHit> &input,

--- a/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.h
+++ b/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.h
@@ -2,6 +2,8 @@
 #define SimPPS_RPDigiProducer_RP_DET_DIGITIZER_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/CTPPSDigi/interface/TotemRPDigi.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
@@ -20,13 +22,16 @@
 namespace CLHEP {
   class HepRandomEngine;
 }
+class CTPPSRPAlignmentCorrectionsData;
+class CTPPSGeometry;
 
 class RPDetDigitizer {
 public:
   RPDetDigitizer(const edm::ParameterSet &params,
                  CLHEP::HepRandomEngine &eng,
                  RPDetId det_id,
-                 const edm::EventSetup &iSetup);
+                 const CTPPSRPAlignmentCorrectionsData *alignments,
+                 const CTPPSGeometry &geom);
   void run(const std::vector<PSimHit> &input,
            const std::vector<int> &input_links,
            std::vector<TotemRPDigi> &output_digi,

--- a/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.h
+++ b/SimPPS/RPDigiProducer/plugins/RPDetDigitizer.h
@@ -2,8 +2,6 @@
 #define SimPPS_RPDigiProducer_RP_DET_DIGITIZER_H
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/CTPPSDigi/interface/TotemRPDigi.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 

--- a/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
@@ -1,9 +1,5 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/Records/interface/VeryForwardMisalignedGeometryRecord.h"
-#include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 #include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
 #include "DataFormats/CTPPSDetId/interface/TotemRPDetId.h"
@@ -16,24 +12,27 @@
 using namespace std;
 using namespace edm;
 
-RPDisplacementGenerator::RPDisplacementGenerator(const edm::ParameterSet &ps,
+RPDisplacementGenerator::RPDisplacementGenerator(bool iIsOn,
                                                  RPDetId _detId,
-                                                 const edm::EventSetup &iSetup)
+                                                 const CTPPSRPAlignmentCorrectionsData *alignments,
+                                                 const CTPPSGeometry &geom)
     : detId_(_detId) {
-  isOn_ = ps.getParameter<bool>("RPDisplacementOn");
+  isOn_ = iIsOn;  //ps.getParameter<bool>("RPDisplacementOn");
 
   // read the alignment correction
+  /*
   ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
   if (auto rec = iSetup.tryToGet<VeryForwardMisalignedGeometryRecord>()) {
     iSetup.get<VeryForwardMisalignedGeometryRecord>().get(alignments);
   }
+  */
 
   unsigned int decId = rawToDecId(detId_);
 
   math::XYZVectorD S_m;
   RotationMatrix R_m;
 
-  if (alignments.isValid()) {
+  if (alignments) {
     const CTPPSRPAlignmentCorrectionData &ac = alignments->getFullSensorCorrection(decId);
     S_m = ac.getTranslation();
     R_m = ac.getRotationMatrix();
@@ -41,9 +40,9 @@ RPDisplacementGenerator::RPDisplacementGenerator(const edm::ParameterSet &ps,
     isOn_ = false;
 
   // transform shift and rotation to the local coordinate frame
-  ESHandle<CTPPSGeometry> geom;
-  iSetup.get<VeryForwardRealGeometryRecord>().get(geom);
-  const DetGeomDesc *g = geom->sensor(detId_);
+  //ESHandle<CTPPSGeometry> geom;
+  //iSetup.get<VeryForwardRealGeometryRecord>().get(geom);
+  const DetGeomDesc *g = geom.sensor(detId_);
   const RotationMatrix &R_l = g->rotation();
   rotation_ = R_l.Inverse() * R_m.Inverse() * R_l;
   shift_ = R_l.Inverse() * R_m.Inverse() * S_m;

--- a/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.cc
@@ -17,15 +17,7 @@ RPDisplacementGenerator::RPDisplacementGenerator(bool iIsOn,
                                                  const CTPPSRPAlignmentCorrectionsData *alignments,
                                                  const CTPPSGeometry &geom)
     : detId_(_detId) {
-  isOn_ = iIsOn;  //ps.getParameter<bool>("RPDisplacementOn");
-
-  // read the alignment correction
-  /*
-  ESHandle<CTPPSRPAlignmentCorrectionsData> alignments;
-  if (auto rec = iSetup.tryToGet<VeryForwardMisalignedGeometryRecord>()) {
-    iSetup.get<VeryForwardMisalignedGeometryRecord>().get(alignments);
-  }
-  */
+  isOn_ = iIsOn;
 
   unsigned int decId = rawToDecId(detId_);
 
@@ -40,8 +32,6 @@ RPDisplacementGenerator::RPDisplacementGenerator(bool iIsOn,
     isOn_ = false;
 
   // transform shift and rotation to the local coordinate frame
-  //ESHandle<CTPPSGeometry> geom;
-  //iSetup.get<VeryForwardRealGeometryRecord>().get(geom);
   const DetGeomDesc *g = geom.sensor(detId_);
   const RotationMatrix &R_l = g->rotation();
   rotation_ = R_l.Inverse() * R_m.Inverse() * R_l;

--- a/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.h
+++ b/SimPPS/RPDigiProducer/plugins/RPDisplacementGenerator.h
@@ -6,11 +6,6 @@
 #include <Math/Rotation3D.h>
 #include <map>
 
-namespace edm {
-  class ParameterSet;
-  class EventSetup;
-}  // namespace edm
-
 class PSimHit;
 
 /**
@@ -22,16 +17,21 @@ class PSimHit;
  *
  * PSimHit points are given in the "local Det frame" (PSimHit.h)
  */
+class CTPPSRPAlignmentCorrectionsData;
+class CTPPSGeometry;
 
 class RPDisplacementGenerator {
 public:
   using RotationMatrix = ROOT::Math::Rotation3D;
   using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 
-  RPDisplacementGenerator(const edm::ParameterSet &, RPDetId, const edm::EventSetup &);
+  RPDisplacementGenerator(bool iIsOn,
+                          RPDetId,
+                          const CTPPSRPAlignmentCorrectionsData* alignments,
+                          const CTPPSGeometry& geom);
 
   /// returns displaced PSimHit
-  PSimHit displace(const PSimHit &);
+  PSimHit displace(const PSimHit&);
 
   static uint32_t rawToDecId(uint32_t raw);
 
@@ -47,7 +47,7 @@ private:
   bool isOn_;
 
   /// displaces a point
-  Local3DPoint displacePoint(const Local3DPoint &);
+  Local3DPoint displacePoint(const Local3DPoint&);
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

- handle esConsumes
- refactored to move EventSetup get to producer
- convert module to thread-friendly type

#### PR validation:

Packages compiles without issuing a CMS deprecation warning.