### PR TITLE
[L1T] bug-fix: rename l1ctLayer1 objects

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/DeregionizerProducer.cc
@@ -173,7 +173,7 @@ void DeregionizerProducer::setRefs_(l1t::PFCandidate &pf, const l1ct::PuppiObjEm
 void DeregionizerProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // DeregionizerProducer
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("RegionalPuppiCands", edm::InputTag("l1ctLayer1", "PuppiRegional"));
+  desc.add<edm::InputTag>("RegionalPuppiCands", edm::InputTag("l1tLayer1", "PuppiRegional"));
   desc.add<unsigned int>("nPuppiFinalBuffer", 128);
   desc.add<unsigned int>("nPuppiPerClk", 6);
   desc.add<unsigned int>("nPuppiFirstBuffers", 12);

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ctLayer1_dumpFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ctLayer1_dumpFiles_cfg.py
@@ -64,7 +64,7 @@ process.runPF.associate(process.l1tLayer1TaskInputsTask)
 
 
 for det in "Barrel", "Barrel9", "HGCal", "HGCalNoTK", "HF":
-    l1pf = getattr(process, 'l1ctLayer1'+det)
+    l1pf = getattr(process, 'l1tLayer1'+det)
     l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
 
 process.source.fileNames  = [ '/store/cmst3/group/l1tr/gpetrucc/11_1_0/NewInputs110X/110121.done/TTbar_PU200/inputs110X_%d.root' % i for i in (1,3,7,8,9) ]

--- a/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
@@ -220,7 +220,7 @@ void HPSPFTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("minSeedJetPt", 30.0);
   desc.add<double>("maxChargedRelIso", 1.0);
   desc.add<double>("minSeedChargedPFCandPt", 5.0);
-  desc.add<edm::InputTag>("srcL1PFCands", edm::InputTag("l1ctLayer1", "PF"));
+  desc.add<edm::InputTag>("srcL1PFCands", edm::InputTag("l1tLayer1", "PF"));
   desc.add<double>("stripSizeEta", 0.05);
   desc.add<double>("maxLeadChargedPFCandEta", 2.4);
   desc.add<double>("deltaRCleaning", 0.4);


### PR DESCRIPTION
#### PR description:

This PR renames the l1ctLayer1 objects to l1tLayer1 objects. These occurrences were forgotten in the wide renaming of L1 modules. 
It was spotted in this PR https://github.com/cms-sw/cmssw/pull/39451 to 12_5
