### PR TITLE
Fix number of aligned modules for HG PCL Tracker alignment

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -162,9 +162,8 @@ void MillePedeFileReader ::readMillePedeResultFile() {
       auto alignableIndex = alignableLabel % 10 - 1;
       std::string detLabel = getStringFromHLS(det);
 
-      countsTotal_[detLabel][alignableIndex]++;
-
       if (tokens.size() > 4 /*3*/) {
+        countsTotal_[detLabel][alignableIndex]++;  //Count aligned modules/ladders per structure
         const auto paramNum = pedeLabeler_->paramNumFromLabel(alignableLabel);
         align::StructureType type = alignable->alignableObjectId();
         align::ID id = alignable->id();


### PR DESCRIPTION
#### PR description:

With this PR an inconsistency in the derivation of the number of aligned modules is fixed. The number of aligned modules is required in the new thresholds logic used for the HG PCL alignment. Without the fix only modules, without entries in the binary files, were counted as non-aligned. Now also modules, which do not fulfill the N_hits requirement of MillePede, are counted as non-aligned.

#### PR validation:

The PR was validated by rerunning the HG PCL alignment for one recent run (360130) using the following two commands:
```
cmsDriver.py step3 -s ALCA:PromptCalibProdSiPixelAliHG --conditions 124X_dataRun3_Express_v5 --datatier ALCARECO --eventcontent ALCARECO --triggerResultsProcess RECO --dasquery="file dataset=/StreamExpress/Run2022E-TkAlMinBias-Express-v1/ALCARECO run=360130" --processName=ReALCA -n -1

cmsDriver.py step7 -s ALCAHARVEST:SiPixelAliHG --conditions 124X_dataRun3_Express_v5 --scenario pp --data --filein file:PromptCalibProdSiPixelAliHG.root
```

@mmusich, @connorpa, @antoniovagnerini, @consuegs