### PR TITLE
Fix `SiPixelRawToClusterGPUKernel` for spurious ROCs [12.5.x]

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -352,8 +352,6 @@ namespace pixelgpudetails {
 
       uint32_t link = sipixelconstants::getLink(ww);  // Extract link
       uint32_t roc = sipixelconstants::getROC(ww);    // Extract ROC in link
-      pixelgpudetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
-      uint32_t rawId = detId.rawId;
 
       uint8_t errorType = checkROC<debug>(ww, fedId, link, cablingMap);
       skipROC = (roc < pixelgpudetails::maxROCIndex) ? false : (errorType != 0);
@@ -366,7 +364,11 @@ namespace pixelgpudetails {
       // check for spurious channels
       if (roc > MAX_ROC or link > MAX_LINK) {
         if constexpr (debug) {
-          printf("spurious roc %d found on link %d, detector %d (index %d)\n", roc, link, rawId, gIndex);
+          printf("spurious roc %d found on link %d, detector %d (index %d)\n",
+                 roc,
+                 link,
+                 getRawId(cablingMap, fedId, link, 1).rawId,
+                 gIndex);
         }
         continue;
       }
@@ -381,9 +383,10 @@ namespace pixelgpudetails {
       if (skipROC)
         continue;
 
+      pixelgpudetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
+      uint32_t rawId = detId.rawId;
       uint32_t layer = 0;
       int side = 0, panel = 0, module = 0;
-
       bool barrel = isBarrel(rawId);
       if (barrel) {
         layer = (rawId >> pixelgpudetails::layerStartBit) & pixelgpudetails::layerMask;


### PR DESCRIPTION
#### PR description:

Make the implementation of the pixel unpacker running on GPU skip spurious ROCs similar to the legacy version of the unpacker.

Fixes an HLT crash that has been happening more or less regularly for the past two months.

See #39045 for more details on the problem, investigation, and tests.

Also, changes the `debug` function parameter to a template parameter, to enable or disable the printouts at compile time.

#### PR validation:

Running the HLT over the error stream files does not crash any more.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #39711 to 12.5.x for data taking.