### PR TITLE
track selection DNN update and relative working points

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_CKF_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_CKF_cfi.py
@@ -2,6 +2,6 @@ from PhysicsTools.TensorFlow.tfGraphDefProducer_cfi import tfGraphDefProducer as
 
 trackSelectionTf_CKF = _tfGraphDefProducer.clone(
     ComponentName = "trackSelectionTf_CKF",
-    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/CKF_2021Run3.pb"
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/CKF_Run3_12_5_0_pre5.pb"
 )
 

--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
@@ -1,7 +1,7 @@
 from PhysicsTools.TensorFlow.tfGraphDefProducer_cfi import tfGraphDefProducer as _tfGraphDefProducer
 trackSelectionTf = _tfGraphDefProducer.clone(
     ComponentName = "trackSelectionTf",
-    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFit4plus3_2021Run3.pb"
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFit_Run3_12_5_0_pre5.pb"
 )
 
 

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -247,6 +247,9 @@ pp_on_AA.toModify(lowPtQuadStep,
 )
 fastSim.toModify(lowPtQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
+((~trackingMkFitLowPtQuadStep) & trackdnn).toModify(lowPtQuadStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
+                                                    qualityCuts = [-0.33,  0.13,  0.35])
+
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -327,6 +327,9 @@ pp_on_AA.toModify(lowPtTripletStep,
 )
 fastSim.toModify(lowPtTripletStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
+((~trackingMkFitLowPtTripletStep) & trackdnn).toModify(lowPtTripletStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
+                                                    qualityCuts = [-0.23,  0.15,  0.41])
+
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -403,7 +403,7 @@ trackdnn.toReplaceWith(pixelLessStep, trackTfClassifier.clone(
 (trackdnn & fastSim).toModify(pixelLessStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 ((~trackingMkFitPixelLessStep) & trackdnn).toModify(pixelLessStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
-                                                    qualityCuts = [-0.81, -0.61, -0.17])
+                                                    qualityCuts = [-0.82, -0.61, -0.16])
 
 pp_on_AA.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
 

--- a/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
+++ b/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
@@ -1,31 +1,31 @@
 # https://indico.cern.ch/event/947686/contributions/3981867/attachments/2090510/3512658/TrackingDNN_24_8_2020.pdf
 import FWCore.ParameterSet.Config as cms
 qualityCutDictionary = cms.PSet(
-   InitialStep         =        cms.vdouble(-0.56, -0.08, 0.17),
-   LowPtQuadStep       =        cms.vdouble(-0.35, 0.13, 0.36),
-   HighPtTripletStep   =        cms.vdouble(0.41, 0.49, 0.57),
-   LowPtTripletStep    =        cms.vdouble(-0.29, 0.09, 0.36),
-   DetachedQuadStep    =        cms.vdouble(-0.63, -0.14, 0.49),
-   DetachedTripletStep =        cms.vdouble(-0.32, 0.24, 0.81),
-   PixelPairStep       =        cms.vdouble(-0.38, -0.23, 0.04),
-   MixedTripletStep    =        cms.vdouble(-0.83, -0.63, -0.38),
-   PixelLessStep       =        cms.vdouble(-0.60, -0.40, 0.02),
-   TobTecStep          =        cms.vdouble(-0.71, -0.58, -0.46), 
-   JetCoreRegionalStep =        cms.vdouble(-0.53, -0.33, 0.18)
+   InitialStep         =        cms.vdouble(-0.35,  0.1,   0.28),
+   LowPtQuadStep       =        cms.vdouble(-0.37,  0.08,  0.28),
+   HighPtTripletStep   =        cms.vdouble(0.47,   0.55,  0.62),
+   LowPtTripletStep    =        cms.vdouble(-0.26,  0.09,  0.33),
+   DetachedQuadStep    =        cms.vdouble(-0.66, -0.15,  0.46),
+   DetachedTripletStep =        cms.vdouble(-0.42,  0.16,  0.78),
+   PixelPairStep       =        cms.vdouble(-0.31, -0.13,  0.13),
+   MixedTripletStep    =        cms.vdouble(-0.86, -0.68, -0.43),
+   PixelLessStep       =        cms.vdouble(-0.64, -0.47, -0.09),
+   TobTecStep          =        cms.vdouble(-0.76, -0.65, -0.55),
+   JetCoreRegionalStep =        cms.vdouble(-0.62, -0.49,  0.02)
 )
 
 from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
 
 trackdnn_CKF.toModify(qualityCutDictionary, 
-   InitialStep         =        [-0.49, 0.08, 0.34],
-   LowPtQuadStep       =        [-0.29, 0.17, 0.39],
-   HighPtTripletStep   =        [0.5, 0.58, 0.65],
-   LowPtTripletStep    =        [-0.30, 0.06, 0.32],
-   DetachedQuadStep    =        [-0.61, -0.09, 0.51],
-   DetachedTripletStep =        [-0.38, 0.31, 0.83],
-   PixelPairStep       =        [-0.25, -0.07, 0.19],
-   MixedTripletStep    =        [-0.86, -0.57, -0.12],
-   PixelLessStep       =        [-0.81, -0.61, -0.17],
-   TobTecStep          =        [-0.67, -0.54, -0.40],
-   JetCoreRegionalStep =        [0.00, 0.03, 0.68]
+   InitialStep         =        [-0.57,  0.02,  0.3 ],
+   LowPtQuadStep       =        [-0.33,  0.13,  0.35],
+   HighPtTripletStep   =        [0.52,   0.6,   0.67],
+   LowPtTripletStep    =        [-0.23,  0.15,  0.41],
+   DetachedQuadStep    =        [-0.6,  -0.06,  0.54],
+   DetachedTripletStep =        [-0.35,  0.33,  0.84],
+   PixelPairStep       =        [-0.29, -0.1,   0.18],
+   MixedTripletStep    =        [-0.87, -0.61, -0.17],
+   PixelLessStep       =        [-0.82, -0.61, -0.16],
+   TobTecStep          =        [-0.75, -0.65, -0.53],
+   JetCoreRegionalStep =        [-0.14, -0.12,  0.63],
 )


### PR DESCRIPTION
#### PR description:

  - the track selection DNN is updated with a retraining under more recent Run3 conditions (CMSSW 12_5_0_pre5) and relative working points 
  - two trainings are performed: **mkFit for 7 iterations + CKF for the rest** and **CKF for all the iterations**
  - for the current tracking, where mkFit is used in 4 iterations + InitialStepPreSplitting (5), the first DNN is used for the 4 mkFit iterations (initial , high pt triplet, detached quad and triplet) and the iterations where both trainings use CKF (pixel pair, mixed triplet, tobtec, jetCore), while the CKF training and working points is used as a fallback for pixelLess, low pT quad and triplet, trained with mkFit in the first training.
  - the update was presented at the TRK POG -> [link](https://indico.cern.ch/event/1203304/contributions/5076116/attachments/2525202/4347565/Track%20selection%20DNN%20update%20for%20Run%203.pdf ) 

#### PR validation:

the MTV plots for TTbar and QCD high pT (1800-2400) are linked below

- default tracking
[TTbar default](http://uaf-10.t2.ucsd.edu/~legianni/DNN-PullRequest/TTMkFit5/)
[QCD default](http://uaf-10.t2.ucsd.edu/~legianni/DNN-PullRequest/QCDHighPtMkFit5/)

- pure CKF
[TTbar CKF](http://uaf-10.t2.ucsd.edu/~legianni/DNN-PullRequest/TTCKF/)
[QCD CKF](http://uaf-10.t2.ucsd.edu/~legianni/DNN-PullRequest/QCDHighPtCKF/)


NB: the cand DNN cut for mkFit high pT triplet is kept the same, as it doesn't change the performance (same as before retraining)

for testing one needs to include this PR to cms-data
https://github.com/cms-data/RecoTracker-FinalTrackSelectors/pull/12 




