### PR TITLE
Fix ASAN error in HydjetHadronizer

### DIFF
--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -349,6 +349,9 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
       evt->add_vertex(sub_vertices);
       if (!evt->signal_process_vertex())
         evt->set_signal_process_vertex(sub_vertices);
+      if (isub >= static_cast<int>(index.size())) {
+        index.resize(isub + 1);
+      }
       index[isub] = ihy - 1;
       isub_l = isub;
     }


### PR DESCRIPTION
#### PR description:

Make sure caching std::vector is large enough.

#### PR validation:

Code compiles.
Machines at FNAL cannot run ASAN so this is a guess as to the underlying problem.