### PR TITLE
Better array initialization in L1TrackJetEmulationProducer

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TrackJetEmulationProducer.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TrackJetEmulationProducer.h
@@ -70,10 +70,10 @@ struct TrackJetEmulationEtaPhiBin {
 
 //store important information for plots
 struct TrackJetEmulationMaxZBin {
-  int znum;    //Numbered from 0 to nzbins (16, 32, or 64) in order
-  int nclust;  //number of clusters in this bin
-  z0_intern zbincenter;
-  TrackJetEmulationEtaPhiBin *clusters;  //list of all the clusters in this bin
-  pt_intern ht;                          //sum of all cluster pTs--only the zbin with the maximum ht is stored
+  int znum = 0;    //Numbered from 0 to nzbins (16, 32, or 64) in order
+  int nclust = 0;  //number of clusters in this bin
+  z0_intern zbincenter = 0;
+  TrackJetEmulationEtaPhiBin *clusters = nullptr;  //list of all the clusters in this bin
+  pt_intern ht = 0;                                //sum of all cluster pTs--only the zbin with the maximum ht is stored
 };
 #endif

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulationProducer.cc
@@ -262,10 +262,8 @@ void L1TrackJetEmulationProducer::L2_cluster(vector<Ptr<L1TTTrackType>> L1TrkPtr
   };
 
   const int nz = zBins_ + 1;
+  //values are initialized by 0 as struct assigns default values for members
   TrackJetEmulationMaxZBin all_zBins[nz];
-  static TrackJetEmulationMaxZBin mzbtemp;
-  for (int z = 0; z < nz; ++z)
-    all_zBins[z] = mzbtemp;
 
   z0_intern zmin = convert::makeZ0(-1.0 * trkZMax_);
   z0_intern zmax = zmin + 2 * zStep_;


### PR DESCRIPTION
#### PR description:

Avoid use of static function local variable and use explicit member initialization instead.

Our static analyzer was complaining about the use of non-const function local static.

#### PR validation:

Code compiles.