### PR TITLE
add `edm::one::SharedResources` to `DQM/SiStripMonitorClient` plugins

### DIFF
--- a/DQM/SiStripMonitorClient/plugins/SiStripAnalyser.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripAnalyser.cc
@@ -40,7 +40,8 @@ class SiStripDetCabling;
 class SiStripClassToMonitorCondData;
 class FEDRawDataCollection;
 
-class SiStripAnalyser : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class SiStripAnalyser
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::harvesting::MonitorElement MonitorElement;
   typedef dqm::harvesting::DQMStore DQMStore;
@@ -104,6 +105,7 @@ SiStripAnalyser::SiStripAnalyser(edm::ParameterSet const& ps)
       tkDetMapTokenELB_(esConsumes<edm::Transition::EndLuminosityBlock>()),
       tkDetMapTokenBR_(esConsumes<edm::Transition::BeginRun>()),
       printFaultyModuleList_{ps.getUntrackedParameter<bool>("PrintFaultyModuleList", true)} {
+  usesResource("DQMStore");
   std::string const localPath{"DQM/SiStripMonitorClient/test/loader.html"};
   std::ifstream fin{edm::FileInPath(localPath).fullPath(), std::ios::in};
   if (!fin) {

--- a/DQM/SiStripMonitorClient/plugins/SiStripCertificationInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripCertificationInfo.cc
@@ -25,7 +25,8 @@
 
 class SiStripDetCabling;
 
-class SiStripCertificationInfo : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class SiStripCertificationInfo
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::harvesting::MonitorElement MonitorElement;
   typedef dqm::harvesting::DQMStore DQMStore;
@@ -73,6 +74,7 @@ SiStripCertificationInfo::SiStripCertificationInfo(edm::ParameterSet const&)
     : detCablingToken_(esConsumes<edm::Transition::BeginRun>()),
       tTopoToken_(esConsumes<edm::Transition::EndRun>()),
       runInfoToken_(esConsumes<edm::Transition::BeginRun>()) {
+  usesResource("DQMStore");
   consumes<DQMToken, edm::InRun>(edm::InputTag("siStripOfflineAnalyser", "DQMGenerationSiStripAnalyserRun"));
   consumes<DQMToken, edm::InLumi>(edm::InputTag("siStripOfflineAnalyser", "DQMGenerationSiStripAnalyserLumi"));
 }

--- a/DQM/SiStripMonitorClient/plugins/SiStripDaqInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDaqInfo.cc
@@ -30,7 +30,7 @@
 class SiStripFedCabling;
 class TrackerTopology;
 
-class SiStripDaqInfo : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+class SiStripDaqInfo : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   typedef dqm::harvesting::MonitorElement MonitorElement;
   typedef dqm::harvesting::DQMStore DQMStore;
@@ -73,6 +73,7 @@ SiStripDaqInfo::SiStripDaqInfo(edm::ParameterSet const&)
     : fedCablingToken_{esConsumes<edm::Transition::BeginRun>()},
       tTopoToken_{esConsumes<edm::Transition::BeginRun>()},
       runInfoToken_{esConsumes<edm::Transition::BeginRun>()} {
+  usesResource("DQMStore");
   edm::LogInfo("SiStripDaqInfo") << "SiStripDaqInfo::Deleting SiStripDaqInfo ";
 }
 

--- a/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
+++ b/DQM/SiStripMonitorClient/plugins/SiStripDcsInfo.cc
@@ -32,7 +32,8 @@ class SiStripDetVOff;
 class SiStripDetCabling;
 class RunInfo;
 
-class SiStripDcsInfo : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class SiStripDcsInfo
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::harvesting::MonitorElement MonitorElement;
   typedef dqm::harvesting::DQMStore DQMStore;
@@ -98,6 +99,7 @@ SiStripDcsInfo::SiStripDcsInfo(edm::ParameterSet const& pSet)
       detVOffToken2_(esConsumes<edm::Transition::EndRun>()),
       detCablingToken_(esConsumes<edm::Transition::BeginRun>()),
       runInfoToken_(esConsumes<edm::Transition::BeginRun>()) {
+  usesResource("DQMStore");
   LogDebug("SiStripDcsInfo") << "SiStripDcsInfo::Deleting SiStripDcsInfo ";
 }
 


### PR DESCRIPTION
#### PR description:

Quick follow-up to https://github.com/cms-sw/cmssw/pull/39518. 
Declare usage of `DQMStore` as a used shared resource to the `edm::one` modules migrated in #39518, as it was done in https://github.com/cms-sw/cmssw/pull/39616.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
