### PR TITLE
Fix site-local-config.xml parsing when subsite tag has no element

### DIFF
--- a/FWCore/Services/test/full-site-local-config.testfile
+++ b/FWCore/Services/test/full-site-local-config.testfile
@@ -1,6 +1,6 @@
 <site-local-config>
 <site name="DUMMY">
-<subsite name="DUMMY_SUB_SITE">
+  <subsite name="DUMMY_SUB_SITE"/>
   <event-data>
     <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
   </event-data>
@@ -30,6 +30,5 @@
     <statistics-destination name="cms-udpmon-collector.cern.ch:9331" info ="dn"/>
     <timeout-in-seconds value="7200" />
   </source-config>
-</subsite>
 </site>
 </site-local-config>

--- a/FWCore/Services/test/no-source-site-local-config.testfile
+++ b/FWCore/Services/test/no-source-site-local-config.testfile
@@ -1,6 +1,6 @@
 <site-local-config>
 <site name="DUMMY">
-<subsite name="DUMMY_SUB_SITE">
+  <subsite name="DUMMY_SUB_SITE"/>
   <event-data>
     <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
   </event-data>
@@ -18,6 +18,5 @@
       <proxy url="http://cmsfrontier.dummy.foo:3128"/>
     </frontier-connect>
   </calib-data>
-</subsite>
 </site>
 </site-local-config>

--- a/FWCore/Services/test/source-site-local-config.testfile
+++ b/FWCore/Services/test/source-site-local-config.testfile
@@ -1,6 +1,6 @@
 <site-local-config>
 <site name="DUMMY">
-<subsite name="DUMMY_SUB_SITE">
+  <subsite name="DUMMY_SUB_SITE"/>
   <event-data>
     <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=dcap"/>
   </event-data>
@@ -27,6 +27,5 @@
       <protocol prefix="file"/>
     </native-protocols>
   </source-config>
-</subsite>
 </site>
 </site-local-config>


### PR DESCRIPTION
#### PR description:
This PR fixes site-local-config.xml parsing when subsite tag has no element:
\<site name=...>
  \<subsite name=.../>
 ...
\<site/>
This PR is related to https://github.com/cms-sw/cmssw/pull/37278 where subsite tag is extracted to locate storage description, storage.json. The extraction here uses subsite tag containing all elements (\<data-access>, \<local-stage-out>....).

The symbolic links in path to the storage.json is also resolved using filesystem::path::canonical


#### PR validation:

All tests in FWCore/Services/test are performed (scram b runtests)
