### PR TITLE
Resume stream queue later in releaseBeginRunResources

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1398,12 +1398,12 @@ namespace edm {
   }
 
   void EventProcessor::releaseBeginRunResources(unsigned int iStream) {
-    streamQueues_[iStream].resume();
     auto& status = streamRunStatus_[iStream];
     if (status->streamFinishedBeginRun()) {
       status->resetBeginResources();
       queueWhichWaitsForIOVsToFinish_.resume();
     }
+    streamQueues_[iStream].resume();
   }
 
   void EventProcessor::endRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus, WaitingTaskHolder iHolder) {


### PR DESCRIPTION
#### PR description:

Fix bug recently introduced with run concurrency PR #39673. Resume stream queue later in releaseBeginRunResources. In very rare circumstances the runStatus can be deleted before the function completes if the order is not changed. Fixes a unit test failure that showed up in the PPC architecture build.

#### PR validation:

Relies on existing tests.
