### PR TITLE
[L1T] Fix mva ntuple variable

### DIFF
--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -1506,7 +1506,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_chi2rphi = iterL1Track->chi2XYRed();
       float tmp_trk_chi2rz = iterL1Track->chi2ZRed();
       float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
-      float tmp_trk_MVA1 = -99.9;  //update with actual MVA when available
+      float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
           stubRefs = iterL1Track->getStubRefs();
@@ -1699,7 +1699,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       float tmp_trk_chi2rphi = iterL1Track->chi2XYRed();
       float tmp_trk_chi2rz = iterL1Track->chi2ZRed();
       float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
-      float tmp_trk_MVA1 = -99.9;  //update when actual MVA is available
+      float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
           stubRefs = iterL1Track->getStubRefs();
@@ -2149,8 +2149,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrk_chi2rphi = matchedTracks.at(i_track)->chi2XYRed();
         tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
         tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
-        tmp_matchtrk_MVA1 = -99.9;  //update when MVA is available
-        tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
+        tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
+	tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();
         tmp_matchtrk_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
 
@@ -2321,8 +2321,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrkExt_chi2rphi = matchedTracks.at(i_track)->chi2XYRed();
         tmp_matchtrkExt_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
         tmp_matchtrkExt_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
-        tmp_matchtrkExt_MVA = -99.9;  //update when MVA is available
-        tmp_matchtrkExt_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
+        tmp_matchtrkExt_MVA = matchedTracks.at(i_track)->trkMVA1();
+	tmp_matchtrkExt_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrkExt_seed = (int)matchedTracks.at(i_track)->trackSeedType();
         tmp_matchtrkExt_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
 

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2150,7 +2150,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
         tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
         tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
-	tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
+        tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();
         tmp_matchtrk_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
 
@@ -2322,7 +2322,7 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
         tmp_matchtrkExt_chi2rz = matchedTracks.at(i_track)->chi2ZRed();
         tmp_matchtrkExt_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
         tmp_matchtrkExt_MVA = matchedTracks.at(i_track)->trkMVA1();
-	tmp_matchtrkExt_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
+        tmp_matchtrkExt_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
         tmp_matchtrkExt_seed = (int)matchedTracks.at(i_track)->trackSeedType();
         tmp_matchtrkExt_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
 


### PR DESCRIPTION
#### PR description:
The ntuple was filling the track mva variable with -99 as a default until the mva variable was ready to be used. We have now replaced the -99 to the actual mva variable. This is a very minor change.

- Local PR: [https://github.com/cms-l1t-offline/cmssw/pull/1046](https://github.com/cms-l1t-offline/cmssw/pull/1046)

#### PR validation:
This works correctly when running the ntuple. Basic formatting checks after the changes were made.
