### PR TITLE
Possible fix for y-axis range of fit-results plot: online DQM app BeamPixel

### DIFF
--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.cc
@@ -1554,6 +1554,7 @@ void Vx3DHLTAnalyzer::bookHistograms(DQMStore::IBooker& ibooker, Run const& iRun
   statusCounter->getTH1()->GetYaxis()->SetBinLabel(10, "MINUIT stat.");
   statusCounter->getTH1()->GetYaxis()->SetBinLabel(11, "MINUIT stat.");
   statusCounter->getTH1()->GetYaxis()->SetBinLabel(12, "MINUIT stat.");
+  statusCounter->getTH1()->GetYaxis()->SetRangeUser(-6.5, 5.5);
 
   fitResults = ibooker.book2D("A - fit results", "Results of Beam Spot Fit", 2, 0., 2., 9, 0., 9.);
   fitResults->setAxisTitle("Ongoing: bootstrapping", 1);


### PR DESCRIPTION
#### PR description:
Possible fix for y-axis range of fit-results plot
DQM application: `BeamPixel`
The plot `App. status vs Lumisection` has a y-axis which leaves one item out, basically, it's too short.
Though when testing the application locally on `lxplus` the histogram range is correct
I'm attaching the histogram output as it appears on the online DQM GUI: `FatalRootError` is outside the y-axis

#### PR validation:
I've tested that it compiles but like I said, I can not test it because it works on `lxplus`
Let's see whether the `SetRangeUser` fixes it also [online](https://cmsweb.cern.ch/dqm/online/start?runnr=360295;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=BeamPixel;focus=BeamPixel/G%20-%20vertex%20z%20fit;zoom=no;)