### PR TITLE
Update Phase-2 Tracker and HGCAL HLT config files

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1336,6 +1336,23 @@ upgradeWFs['HLT75e33'] = UpgradeWorkflow_HLT75e33(
     offset = 0.75,
 )
 
+class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'DigiTrigger' in step:
+            stepDict[stepName][k] = merge([{'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@relval2026'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment=="TTbar_14TeV" and '2026' in key
+upgradeWFs['HLTwDIGI75e33'] = UpgradeWorkflow_HLTwDIGI75e33(
+    steps = [
+        'DigiTrigger',
+    ],
+    PU = [
+        'DigiTrigger',
+    ],
+    suffix = '_HLTwDIGI75e33',
+    offset = 0.76,
+)
+
 class UpgradeWorkflow_Neutron(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'GenSim' in step:

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
@@ -1,7 +1,4 @@
-import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms 
 
-siPhase2Clusters = cms.EDProducer("Phase2TrackerClusterizer",
-    maxClusterSize = cms.uint32(0),
-    maxNumberClusters = cms.uint32(0),
-    src = cms.InputTag("mix","Tracker")
-)
+from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import siPhase2Clusters as _siPhase2Clusters 
+siPhase2Clusters = _siPhase2Clusters.clone()

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/siPhase2Clusters_cfi.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms 
+import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import siPhase2Clusters as _siPhase2Clusters 
 siPhase2Clusters = _siPhase2Clusters.clone()

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_fC_cfi.py
@@ -1,8 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-HGCAL_noise_fC = cms.PSet(
-    doseMap = cms.string(''),
-    scaleByDose = cms.bool(False),
-    scaleByDoseAlgo = cms.uint32(0),
-    values = cms.vdouble(0.32041012, 0.384492144, 0.32041012)
-)
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCAL_noise_fC as _HGCAL_noise_fC
+HGCAL_noise_fC = _HGCAL_noise_fC.clone()

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_heback_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HGCAL_noise_heback_cfi.py
@@ -1,8 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-HGCAL_noise_heback = cms.PSet(
-    doseMap = cms.string(''),
-    noise_MIP = cms.double(0.01),
-    scaleByDose = cms.bool(False),
-    scaleByDoseAlgo = cms.uint32(0)
-)
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCAL_noise_heback as _HGCAL_noise_heback
+HGCAL_noise_heback = _HGCAL_noise_heback.clone()


### PR DESCRIPTION
#### PR description:
This is the same as the draft PR https://github.com/cms-sw/cmssw/pull/39450 without updating the DQM.

This PR updates module and pset used in Phase-2 Tracker and HGCAL HLT. The update follows what defined in
- https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
- https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPhase2Clusterizer/python/phase2TrackerClusterizer_cfi.py

To complete on PR test, and example of benefit from the new workflow, this PR also introduces a new workfow `.76` which the `DIGI` and `HLT:@relval2026` steps are running together instead of `HLT:@fake`.  The new workflow will allow us to develop Phase2 HLT DQM and sequence to be used in future Phase-2 production. 

Note that,
- We still keep `HLT:@fake2` in the main Phase-2 as the new workflow does not validate yet 
- This PR is an effort to help on validation as mentioned in https://github.com/cms-sw/cmssw/issues/39362.

#### PR validation:
Run test with the following workflows: 
- `20834.75`: To make sure that Phase-2 HLT is still running properly.
- `20834.76`: To show that `DIGI` and `HLT:@relval2026` can run together.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
None.
