### PR TITLE
Skip invalid channels in the GPU HCAL RecHit producer [12.4.x]

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalCPURecHitsProducer.cc
@@ -103,14 +103,18 @@ void HcalCPURecHitsProducer::produce(edm::Event& event, edm::EventSetup const& s
     // did not set size with ctor as there is no setter for did
     recHitsLegacy->reserve(tmpRecHits_.did.size());
     for (uint32_t i = 0; i < tmpRecHits_.did.size(); i++) {
+      // skip bad channels
+      if (tmpRecHits_.chi2[i] < 0)
+        continue;
+
+      // build a legacy rechit with the computed detid and MAHI energy
       recHitsLegacy->emplace_back(HcalDetId{tmpRecHits_.did[i]},
                                   tmpRecHits_.energy[i],
                                   0  // timeRising
       );
-
-      // update newly pushed guy
-      (*recHitsLegacy)[i].setChiSquared(tmpRecHits_.chi2[i]);
-      (*recHitsLegacy)[i].setRawEnergy(tmpRecHits_.energyM0[i]);
+      // update the legacy rechit with the Chi2 and M0 values
+      recHitsLegacy->back().setChiSquared(tmpRecHits_.chi2[i]);
+      recHitsLegacy->back().setRawEnergy(tmpRecHits_.energyM0[i]);
     }
 
     // put the legacy collection


### PR DESCRIPTION
#### PR description:

This PR consistes of two parts:
  - the GPU code now marks as invalid (setting chi² = -9999.) the HCAL channels for which it cannot determine the SOI;
  - the CPU code that converts from SoA to legacy format now skips all invalid channels.

See h#39693 for a discussion on the underlying issues.

#### PR validation:

Tested on top of CMSSW_12_4_10 over the events that caused the HLT to crash in runs 357898, 359998, and 360295.
Without these changes the original crash can be reproduced in multiple files:
```
----- Begin Fatal Exception 14-Oct-2022 20:27:30 CEST-----------------------
An exception of category 'Conditions not found' occurred while
   [0] Processing  Event run: 360295 lumi: 174 event: 264575349 stream: 7
   [1] Running path 'Path'
   [2] Calling method for module CaloTowersCreator/'hltTowerMakerForAll'
Exception Message:
Unavailable Conditions of type HcalChannelQuality for cell (0x0) 
----- End Fatal Exception -------------------------------------------------
```

With these changes the HLT jobs run to completion on almost all those files (barring one that is affected by a different, ECAL-related crash).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #39738 for data taking.