### PR TITLE
HCAL: Modifications to the HCAL trigger key generation scripts

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
@@ -60,6 +60,7 @@ private:
   std::vector<std::string> tags_;
   std::vector<std::string> quality_;
   std::vector<std::string> pedestals_;
+  std::vector<std::string> effpedestals_;
   std::vector<std::string> gains_;
   std::vector<std::string> respcorrs_;
 
@@ -79,6 +80,7 @@ HcalLutAnalyzer::HcalLutAnalyzer(const edm::ParameterSet& iConfig) {
   tags_ = iConfig.getParameter<std::vector<std::string> >("tags");
   quality_ = iConfig.getParameter<std::vector<std::string> >("quality");
   pedestals_ = iConfig.getParameter<std::vector<std::string> >("pedestals");
+  effpedestals_ = iConfig.getParameter<std::vector<std::string> >("effpedestals");
   gains_ = iConfig.getParameter<std::vector<std::string> >("gains");
   respcorrs_ = iConfig.getParameter<std::vector<std::string> >("respcorrs");
 
@@ -100,13 +102,13 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
   typedef std::vector<std::string> vstring;
   typedef std::map<unsigned long int, float> LUTINPUT;
 
-  static const int NVAR = 5;  //variables
+  static const int NVAR = 6;  //variables
   static const int NDET = 2;  //detectors
   static const int NDEP = 7;  //depths
   static const int NLEV = 3;  //old,new,ratio
 
-  const bool doRatio[NVAR] = {false, true, true, false, true};
-  const char* titleVar[NVAR] = {"Pedestals", "RespCorrs", "Gains", "Threshold", "LUTs"};
+  const bool doRatio[NVAR] = {false, true, true, false, true,false};
+  const char* titleVar[NVAR] = {"Pedestals", "RespCorrs", "Gains", "Threshold", "LUTs","EffPedestals"};
   const char* titleHisR[NLEV] = {"Old", "New", "Ratio"};
   const char* titleHisD[NLEV] = {"Old", "New", "Difference"};
   const char* titleDet[4] = {"HBHE", "HF", "HEP17", "HO"};
@@ -144,8 +146,8 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
     hslope[d]->SetYTitle("Lut ratio");
 
     for (int j = 0; j < NVAR; ++j) {
-      double rmin = doRatio[j] ? Ymin : -6;
-      double rmax = doRatio[j] ? Ymax : 6;
+      double rmin = doRatio[j] ? Ymin : -4;
+      double rmax = doRatio[j] ? Ymax : 4;
       r[j][d] = new TH2D(Form("r%s_%s", titleVar[j], titleDet[d]),
                          Form("%s, %s", titleVar[j], titleDet[d]),
                          83,
@@ -198,11 +200,13 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
   LUTINPUT lutgain[2];
   LUTINPUT lutresp[2];
   LUTINPUT lutpede[2];
+  LUTINPUT luteffpede[2];
 
   assert(tags_.size() == 2);
   assert(gains_.size() == 2);
   assert(respcorrs_.size() == 2);
   assert(pedestals_.size() == 2);
+  assert(effpedestals_.size() == 2);
 
   unsigned long int iraw;
   int ieta, iphi, idep;
@@ -237,6 +241,32 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
 
       HcalDetId id(subdet, ieta, iphi, idep);
       lutgain[ii].insert(LUTINPUT::value_type(id.rawId(), theval));
+    }
+
+    //Effective Pedestals
+    std::ifstream infeffped(
+        edm::FileInPath(Form("%s/EffectivePedestals/EffectivePedestals_Run%s.txt", inputDir.c_str(), effpedestals_[ii].c_str()))
+            .fullPath()
+            .c_str());
+    assert(!infeffped.fail());
+    while (!infeffped.eof()) {
+      infeffped.getline(buffer, 1024);
+      if (buffer[0] == '#')
+        continue;
+      std::istringstream(buffer) >> ieta >> iphi >> idep >> det >> val1 >> val2 >> val3 >> val4 >> wid1 >> wid2 >>
+          wid3 >> wid4 >> iraw;
+      if (det != "HB" && det != "HE" && det != "HF")
+        continue;
+
+      float theval = (val1 + val2 + val3 + val4) / 4.0;
+
+      HcalSubdetector subdet = det == "HB"   ? HcalBarrel
+                               : det == "HE" ? HcalEndcap
+                               : det == "HF" ? HcalForward
+                                             : HcalOther;
+
+      HcalDetId id(subdet, ieta, iphi, idep);
+      luteffpede[ii].insert(LUTINPUT::value_type(id.rawId(), theval));
     }
 
     //Pedestals
@@ -464,6 +494,13 @@ void HcalLutAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
     h[3][2][hbhe][idep]->Fill(ieta, iphi, xfill);
     r[3][hbhe]->Fill(ieta, xfill);
     p[3][hbhe]->Fill(ieta, xfill);
+
+    h[5][0][hbhe][idep]->Fill(ieta, iphi, luteffpede[0][iraw]);
+    h[5][1][hbhe][idep]->Fill(ieta, iphi, luteffpede[1][iraw]);
+    xfill = luteffpede[1][iraw] - luteffpede[0][iraw];
+    h[5][2][hbhe][idep]->Fill(ieta, iphi, xfill);
+    r[5][hbhe]->Fill(ieta, xfill);
+    p[5][hbhe]->Fill(ieta, xfill);
 
     size_t maxvalue = hbhe == 0 ? 1023 : 2047;
 

--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -18,7 +18,7 @@ BaseDir=${FullPath#${CMSSW_BASE}/src/}
 CondDir=conditions
 templatefile=template.py
 
-inputConditions=(ElectronicsMap LutMetadata LUTCorrs QIETypes QIEData SiPMParameters TPParameters TPChannelParameters ChannelQuality Gains Pedestals PedestalWidths RespCorrs L1TriggerObjects)
+inputConditions=(ElectronicsMap LutMetadata LUTCorrs QIETypes QIEData SiPMParameters TPParameters TPChannelParameters ChannelQuality Gains Pedestals EffectivePedestals PedestalWidths EffectivePedestalWidths RespCorrs L1TriggerObjects)
 
 
 
@@ -68,6 +68,9 @@ dump(){
     CheckParameter GlobalTag
 
     dumpCmd="cmsRun $CMSSW_RELEASE_BASE/src/CondTools/Hcal/test/runDumpHcalCond_cfg.py geometry=DB prefix="""
+    PedSTR='Pedestal'
+    PedWidthSTR='PedestalWidths'
+    EffSTR='Effective'
 
     if [ -z $frontier ]
     then
@@ -76,9 +79,23 @@ dump(){
 
     if [ ! -z $tag ]
     then
-	if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag  frontierloc=$frontier frontierlist=Hcal${record}Rcd:$tag  
-	then
-	    exit 1
+        if [[ ${record} == *"$EffSTR"* ]]; then
+	    if [[ ${record} == *"$PedWidthSTR"* ]]; then
+                if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag  frontierloc=$frontier frontierlist=HcalPedestalWidthsRcd:effective:$tag
+                then
+                    exit 1
+                fi
+	    elif [[ ${record} == *"$PedSTR"* ]]; then
+                if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag  frontierloc=$frontier frontierlist=HcalPedestalsRcd:effective:$tag
+                then
+                    exit 1
+                fi
+	    fi
+	else
+	    if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag  frontierloc=$frontier frontierlist=Hcal${record}Rcd:$tag  
+	    then
+	        exit 1
+	    fi
 	fi
     else 
 	if ! $dumpCmd dumplist=$record run=$Run globaltag=$GlobalTag 
@@ -163,6 +180,8 @@ then
 
     mkdir -p $CondDir/$Tag/Debug
     hcalLUT merge storePrepend="$flist" outputFile=$CondDir/$Tag/${Tag}.xml
+    sed -i 's:UTF-8:ISO-8859-1:g' $CondDir/$Tag/${Tag}.xml
+    sed -i '/^$/d' $CondDir/$Tag/${Tag}.xml
     mv *$Tag*.{xml,dat} $CondDir/$Tag/Debug
 
     echo "-------------------"
@@ -175,34 +194,23 @@ then
     eval $(conddb list $GlobalTag | grep -E "$(export IFS="|"; echo "${HcalInput[*]}")" | \
 	awk '{if($1~/^HcalPed/ && $2=="effective") print "tagMap["$1"+"$2"]="$3; else print "tagMap["$1"]="$3}')
 
-    PedSTR='Pedestal'
+    EffSTR='Effective'
     individualInputTags=""
     for i in ${inputConditions[@]}; do
 	t=$i
 	v=${!t}
-	if [[ -z $v ]]; then
-	    if [[ ${i} == *"$PedSTR"* ]]; then
-	        v=${tagMap[Hcal${i}Rcd]}
-		l=""
-		individualInputTags="""$individualInputTags
-    <Parameter type=\"string\" name=\"$t\" label=\"$l\">$v</Parameter>"""
-		v=${tagMap[Hcal${i}Rcd+effective]}
-		l="effective"
-	    else
-                v=${tagMap[Hcal${i}Rcd]}
-		l=""
-	    fi
-	else
-            if [[ ${i} == *"$PedSTR"* ]]; then
-		l=""
-                individualInputTags="""$individualInputTags
-    <Parameter type=\"string\" name=\"$t\" label=\"$l\">$v</Parameter>"""
-                v="${v}_effective"
+	if ! [[ -z $v ]]; then
+            if [[ ${i} == *"$EffSTR"* ]]; then
                 l="effective"
+            else
+                l=""
 	    fi
 	fi
-	individualInputTags="""$individualInputTags
+
+	if ! [[ -z $v ]]; then
+	    individualInputTags="""$individualInputTags
     <Parameter type=\"string\" name=\"$t\" label=\"$l\">$v</Parameter>"""
+        fi
     done
 
     dd=$(date +"%Y-%m-%d %H:%M:%S")
@@ -235,7 +243,7 @@ then
     mkdir -p $CondDir/$Tag/Figures
     cmsRun PlotLUT.py globaltag=$GlobalTag run=$Run \
 	inputDir=$BaseDir/$CondDir plotsDir=$CondDir/$Tag/Figures/ \
-	tags=$OldTag,$Tag gains=$runs respcorrs=$runs pedestals=$runs quality=$runs 
+	tags=$OldTag,$Tag gains=$runs respcorrs=$runs pedestals=$runs effpedestals=$runs quality=$runs 
 
 elif [ "$cmd" == "upload" ]
 then

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -38,6 +38,10 @@ process.es_ascii = cms.ESSource('HcalTextCalibrations',
 	 file   = cms.FileInPath(CONDDIR+'/Pedestals/Pedestals_Run__RUN__.txt')
       ),	
       cms.PSet(
+         object = cms.string('EffectivePedestals'),
+	 file   = cms.FileInPath(CONDDIR+'/EffectivePedestals/EffectivePedestals_Run__RUN__.txt')
+      ),	
+      cms.PSet(
          object = cms.string('Gains'),
 	 file   = cms.FileInPath(CONDDIR+'/Gains/Gains_Run__RUN__.txt')
       ),


### PR DESCRIPTION
#### PR description:

Modifications to the HCAL trigger key generation script, fixing the issue described in slide 3 [here](https://indico.cern.ch/event/1210556/#40-hcal-o2o-post-mortem-analys). This is needed so that old conditions are not accidentally updated in the online conditions in the HCAL.

Also, this PR adds the feature to create plots comparing the HCAL effective pedestals before and after a condition change. 

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport. This PR updates the "service" scripts for LUTs and Trigger key generation, so the changes do not need to be backported to 12_4_X/12_5_X
