### PR TITLE
Remove use of legacy EDProducer from Framework tests

### DIFF
--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -179,7 +179,7 @@ class StallMonitorParser(object):
 
         self._f = f
         if numStreams == 0:
-          numStreams = numStreamsFromSource +1
+          numStreams = numStreamsFromSource +2
         self.numStreams =numStreams
         self._moduleNames = moduleNames
         self._esModuleNames = esModuleNames

--- a/FWCore/Concurrency/test/streamGrapher_stallMonitor_cfg.py
+++ b/FWCore/Concurrency/test/streamGrapher_stallMonitor_cfg.py
@@ -5,19 +5,19 @@ process = cms.Process("TRACING")
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:file_for_grapher.root"))
 
 process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(100*1000*1000))
-process.legacy1 = cms.EDProducer("BusyWaitIntLegacyProducer",ivalue = cms.int32(12), iterations = cms.uint32(3000*1000))
+process.shared1 = cms.EDProducer("BusyWaitIntOneSharedProducer",ivalue = cms.int32(12), iterations = cms.uint32(3000*1000))
 
 process.adder1 = cms.EDProducer("AddIntsProducer",
-                                labels = cms.VInputTag("a","busy1","legacy1"))
+                                labels = cms.VInputTag("a","busy1","shared1"))
 
 process.busy2 = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(7), iterations = cms.uint32(4*1000*1000))
 process.busy3 = cms.EDProducer("BusyWaitIntProducer", ivalue = cms.int32(2), iterations = cms.uint32(1000*1000))
-process.legacy2 = cms.EDProducer("BusyWaitIntLegacyProducer", ivalue=cms.int32(-1), iterations = cms.uint32(6000*1000))
+process.shared2 = cms.EDProducer("BusyWaitIntOneSharedProducer", ivalue=cms.int32(-1), iterations = cms.uint32(6000*1000))
 
 process.strt = cms.EDProducer("AddIntsProducer",
-                              labels = cms.VInputTag("busy2","busy3","legacy2","b", "adder1"))
+                              labels = cms.VInputTag("busy2","busy3","shared2","b", "adder1"))
 
-process.t = cms.Task(process.busy1, process.legacy1, process.adder1, process.busy2, process.busy3, process.legacy2)
+process.t = cms.Task(process.busy1, process.shared1, process.adder1, process.busy2, process.busy3, process.shared2)
 
 process.p = cms.Path(process.strt, process.t)
 

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -66,7 +66,6 @@
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/UnscheduledCallProducer.h"
 #include "FWCore/Framework/interface/WorkerManager.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Path.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/Framework/interface/maker/Worker.h"

--- a/FWCore/Framework/test/test_mayConsumes_deadlocking_cfg.py
+++ b/FWCore/Framework/test/test_mayConsumes_deadlocking_cfg.py
@@ -17,12 +17,14 @@ process.b = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer",
                             resourceName = cms.untracked.string("B")
                             )
 
-process.one = cms.EDProducer("IntLegacyProducer",
-                             ivalue = cms.int32(1)
+process.one = cms.EDProducer("IntOneSharedProducer",
+                             ivalue = cms.int32(1),
+                             resourceNames = cms.untracked.vstring("A", "B")
 )
 
-process.two = cms.EDProducer("IntLegacyProducer",
-                             ivalue = cms.int32(2)
+process.two = cms.EDProducer("IntOneSharedProducer",
+                             ivalue = cms.int32(2),
+                             resourceNames = cms.untracked.vstring("A", "B")
 )
            
 process.options = dict(

--- a/FWCore/Framework/test/test_no_concurrent_module_cfg.py
+++ b/FWCore/Framework/test/test_no_concurrent_module_cfg.py
@@ -12,11 +12,12 @@ process.options = dict(
 
 process.maxEvents.input = 20
 
-process.i1 = cms.EDProducer("BusyWaitIntLegacyProducer", ivalue = cms.int32(1),
-  iterations = cms.uint32(300*1000))
-process.i2 = cms.EDProducer("BusyWaitIntLegacyProducer", ivalue = cms.int32(2),
-  iterations = cms.uint32(300*1000))
-
+process.i1 = cms.EDProducer("BusyWaitIntOneSharedProducer", ivalue = cms.int32(1),
+  iterations = cms.uint32(300*1000),
+  resourceNames = cms.untracked.vstring("foo"))
+process.i2 = cms.EDProducer("BusyWaitIntOneSharedProducer", ivalue = cms.int32(2),
+  iterations = cms.uint32(300*1000),
+  resourceNames = cms.untracked.vstring("foo"))
 process.c1 = cms.EDAnalyzer("ConsumingOneSharedResourceAnalyzer",
                             valueMustMatch = cms.untracked.int32(1),
                             moduleLabel = cms.untracked.InputTag("i1"),


### PR DESCRIPTION
#### PR description:

- removed unnecessary include of `interface/EDProducer.h`
- changed unit tests using Legacy module to using a one with SharedResources.

#### PR validation:

Framework unit tests succeed.