### PR TITLE
Fix deprecation warnings in  L1TriggerConfig subsystem

### DIFF
--- a/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCTFParametersTester.h
+++ b/L1TriggerConfig/CSCTFConfigProducers/interface/L1MuCSCTFParametersTester.h
@@ -22,24 +22,25 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
-class L1GtParameters;
+class L1MuCSCTFConfiguration;
+class L1MuCSCTFConfigurationRcd;
 
 // class declaration
-class L1MuCSCTFParametersTester : public edm::EDAnalyzer {
+class L1MuCSCTFParametersTester : public edm::one::EDAnalyzer<> {
 public:
   // constructor
   explicit L1MuCSCTFParametersTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1MuCSCTFParametersTester() override;
-
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::ESGetToken<L1MuCSCTFConfiguration, L1MuCSCTFConfigurationRcd> token_;
 };
 
 #endif /*CSCTFConfigProducers_L1MuCSCTFParametersTester_h*/

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigTestAnalyzer.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigTestAnalyzer.cc
@@ -10,7 +10,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -30,17 +30,16 @@
 // class decleration
 //
 
-class CSCTFConfigTestAnalyzer : public edm::EDAnalyzer {
+class CSCTFConfigTestAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit CSCTFConfigTestAnalyzer(const edm::ParameterSet&);
-  ~CSCTFConfigTestAnalyzer() override;
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   // ----------member data ---------------------------
+  edm::ESGetToken<L1TriggerKeyList, L1TriggerKeyListRcd> keyListToken_;
+  edm::ESGetToken<L1TriggerKey, L1TriggerKeyRcd> keyToken_;
 };
 
 //
@@ -54,15 +53,8 @@ private:
 //
 // constructors and destructor
 //
-CSCTFConfigTestAnalyzer::CSCTFConfigTestAnalyzer(const edm::ParameterSet& iConfig)
-
-{
+CSCTFConfigTestAnalyzer::CSCTFConfigTestAnalyzer(const edm::ParameterSet& iConfig) : keyToken_(esConsumes()) {
   //now do what ever initialization is needed
-}
-
-CSCTFConfigTestAnalyzer::~CSCTFConfigTestAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -73,8 +65,7 @@ CSCTFConfigTestAnalyzer::~CSCTFConfigTestAnalyzer() {
 void CSCTFConfigTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  ESHandle<L1TriggerKeyList> pList;
-  iSetup.get<L1TriggerKeyListRcd>().get(pList);
+  ESHandle<L1TriggerKeyList> pList = iSetup.getHandle(keyListToken_);
 
   std::cout << "Found " << pList->tscKeyToTokenMap().size() << " TSC keys:" << std::endl;
 
@@ -100,8 +91,7 @@ void CSCTFConfigTestAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   }
 
   try {
-    ESHandle<L1TriggerKey> pKey;
-    iSetup.get<L1TriggerKeyRcd>().get(pKey);
+    ESHandle<L1TriggerKey> pKey = iSetup.getHandle(keyToken_);
 
     // std::cout << "Current TSC key = " << pKey->getTSCKey() << std::endl ;
     std::cout << "Current TSC key = " << pKey->tscKey() << std::endl;
@@ -125,12 +115,6 @@ void CSCTFConfigTestAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
     std::cout << "No L1TriggerKey found." << std::endl;
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void CSCTFConfigTestAnalyzer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void CSCTFConfigTestAnalyzer::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CSCTFConfigTestAnalyzer);

--- a/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCTFParametersTester.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCTFParametersTester.cc
@@ -21,7 +21,6 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,19 +37,9 @@
 // forward declarations
 
 // constructor(s)
-L1MuCSCTFParametersTester::L1MuCSCTFParametersTester(const edm::ParameterSet& parSet) {
-  // empty
-}
-
-// destructor
-L1MuCSCTFParametersTester::~L1MuCSCTFParametersTester() {
-  // empty
-}
+L1MuCSCTFParametersTester::L1MuCSCTFParametersTester(const edm::ParameterSet& parSet) { token_ = esConsumes(); }
 
 // loop over events
 void L1MuCSCTFParametersTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1MuCSCTFConfiguration> l1CSCTFPar;
-  evSetup.get<L1MuCSCTFConfigurationRcd>().get(l1CSCTFPar);
-
-  l1CSCTFPar->print(std::cout);
+  evSetup.getData(token_).print(std::cout);
 }

--- a/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/plugins/DTTPGParamsWriter.h
@@ -7,7 +7,7 @@
  */
 
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include <fstream>
 #include <string>
 
@@ -19,7 +19,7 @@ namespace edm {
 
 class DTChamberId;
 
-class DTTPGParamsWriter : public edm::EDAnalyzer {
+class DTTPGParamsWriter : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTTPGParamsWriter(const edm::ParameterSet &pset);

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.cc
@@ -23,10 +23,7 @@ DTConfigTester::DTConfigTester(const edm::ParameterSet &ps) {
   my_traco = ps.getUntrackedParameter<int>("traco");
   my_bti = ps.getUntrackedParameter<int>("bti");
   my_sl = ps.getUntrackedParameter<int>("sl");
-}
-
-DTConfigTester::~DTConfigTester() {
-  // cout << "DTConfigTester::~DTConfigTester()" << endl;
+  my_configToken = esConsumes();
 }
 
 void DTConfigTester::analyze(const edm::Event &e, const edm::EventSetup &es) {
@@ -36,8 +33,7 @@ void DTConfigTester::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
   using namespace edm;
 
-  ESHandle<DTConfigManager> dtConfig;
-  es.get<DTConfigManagerRcd>().get(dtConfig);
+  ESHandle<DTConfigManager> dtConfig = es.getHandle(my_configToken);
 
   cout << "\tPrint configuration :" << endl;
 

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.h
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigTester.h
@@ -19,21 +19,20 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 //
 // class decleration
 //
+class DTConfigManager;
+class DTConfigManagerRcd;
 
-class DTConfigTester : public edm::EDAnalyzer {
+class DTConfigTester : public edm::one::EDAnalyzer<> {
 public:
   //! Constructor
   explicit DTConfigTester(const edm::ParameterSet &);
-
-  //! Destructor
-  ~DTConfigTester() override;
 
   // Analyze Method
   void analyze(const edm::Event &, const edm::EventSetup &) override;
@@ -45,4 +44,6 @@ private:
   int my_traco;
   int my_bti;
   int my_sl;
+
+  edm::ESGetToken<DTConfigManager, DTConfigManagerRcd> my_configToken;
 };

--- a/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
+++ b/L1TriggerConfig/L1GeometryProducers/src/L1CaloGeometryDump.cc
@@ -22,7 +22,7 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -40,17 +40,15 @@
 // class decleration
 //
 
-class L1CaloGeometryDump : public edm::EDAnalyzer {
+class L1CaloGeometryDump : public edm::global::EDAnalyzer<> {
 public:
   explicit L1CaloGeometryDump(const edm::ParameterSet &);
-  ~L1CaloGeometryDump() override;
 
 private:
-  void beginJob() override;
-  void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
+  void analyze(edm::StreamID, const edm::Event &, const edm::EventSetup &) const override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<L1CaloGeometry, L1CaloGeometryRecord> geomToken_;
 };
 
 //
@@ -64,15 +62,8 @@ private:
 //
 // constructors and destructor
 //
-L1CaloGeometryDump::L1CaloGeometryDump(const edm::ParameterSet &iConfig)
-
-{
+L1CaloGeometryDump::L1CaloGeometryDump(const edm::ParameterSet &iConfig) : geomToken_(esConsumes()) {
   // now do what ever initialization is needed
-}
-
-L1CaloGeometryDump::~L1CaloGeometryDump() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -80,22 +71,9 @@ L1CaloGeometryDump::~L1CaloGeometryDump() {
 //
 
 // ------------ method called to for each event  ------------
-void L1CaloGeometryDump::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  using namespace edm;
-
-  ESHandle<L1CaloGeometry> pGeom;
-  iSetup.get<L1CaloGeometryRecord>().get(pGeom);
-
-  LogDebug("L1CaloGeometryDump") << *pGeom << std::endl;
+void L1CaloGeometryDump::analyze(edm::StreamID, const edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  LogDebug("L1CaloGeometryDump") << iSetup.getData(geomToken_) << std::endl;
 }
-
-// ------------ method called once each job just before starting event loop
-// ------------
-void L1CaloGeometryDump::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop
-// ------------
-void L1CaloGeometryDump::endJob() {}
 
 // define this as a plug-in
 DEFINE_FWK_MODULE(L1CaloGeometryDump);

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
@@ -17,7 +17,7 @@
 //
 #include <iostream>
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -39,25 +39,22 @@
 // class declaration
 //
 
-class L1RCTChannelMaskTester : public edm::EDAnalyzer {
+class L1RCTChannelMaskTester : public edm::one::EDAnalyzer<> {
 public:
-  explicit L1RCTChannelMaskTester(const edm::ParameterSet&) {}
-  ~L1RCTChannelMaskTester() override {}
+  explicit L1RCTChannelMaskTester(const edm::ParameterSet&) : maskToken_(esConsumes()), noisyToken_(esConsumes()) {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::ESGetToken<L1RCTChannelMask, L1RCTChannelMaskRcd> maskToken_;
+  edm::ESGetToken<L1RCTNoisyChannelMask, L1RCTNoisyChannelMaskRcd> noisyToken_;
 };
 
 void L1RCTChannelMaskTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   //
-  edm::ESHandle<L1RCTChannelMask> rctChanMask;
-  evSetup.get<L1RCTChannelMaskRcd>().get(rctChanMask);
-
-  rctChanMask->print(std::cout);
+  evSetup.getData(maskToken_).print(std::cout);
 
   if (auto maskRecord = evSetup.tryToGet<L1RCTNoisyChannelMaskRcd>()) {
-    edm::ESHandle<L1RCTNoisyChannelMask> rctNoisyChanMask;
-    maskRecord->get(rctNoisyChanMask);
-
-    rctNoisyChanMask->print(std::cout);
+    maskRecord->get(noisyToken_).print(std::cout);
   } else {
     std::cout << "\nRecord \""
               << "L1RCTNoisyChannelMaskRcd"

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTOmdsFedVectorProducer.cc
@@ -64,6 +64,8 @@ private:
   std::string connectionString;
   std::string authpath;
   std::string tableToRead;
+
+  edm::ESGetToken<RunInfo, RunInfoRcd> token_;
 };
 
 //
@@ -83,7 +85,7 @@ L1RCTOmdsFedVectorProducer::L1RCTOmdsFedVectorProducer(const edm::ParameterSet& 
       tableToRead(iConfig.getParameter<std::string>("tableToRead")) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this, "OmdsFedVector");
+  token_ = setWhatProduced(this, "OmdsFedVector").consumes();
 
   //now do what ever other initialization is needed
 }
@@ -104,9 +106,7 @@ L1RCTOmdsFedVectorProducer::ReturnType L1RCTOmdsFedVectorProducer::produce(const
   //  std::cout << "GETTING FED VECTOR FROM OMDS" << std::endl;
 
   // GETTING ALREADY-EXISTING RUNINFO OUT OF ES TO FIND OUT RUN NUMBER
-  edm::ESHandle<RunInfo> sum;
-  iRecord.get(sum);
-  const RunInfo* summary = sum.product();
+  const RunInfo* summary = &iRecord.get(token_);
   int runNumber = summary->m_run;
 
   // CREATING NEW RUNINFO WHICH WILL GET NEW FED VECTOR AND BE RETURNED

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
@@ -16,7 +16,7 @@
 //
 //
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -42,18 +42,17 @@ using std::endl;
 // class declaration
 //
 
-class L1RCTParametersTester : public edm::EDAnalyzer {
+class L1RCTParametersTester : public edm::one::EDAnalyzer<> {
 public:
-  explicit L1RCTParametersTester(const edm::ParameterSet&) {}
-  ~L1RCTParametersTester() override {}
+  explicit L1RCTParametersTester(const edm::ParameterSet&) : token_(esConsumes()) {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::ESGetToken<L1RCTParameters, L1RCTParametersRcd> token_;
 };
 
 void L1RCTParametersTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1RCTParameters> rctParam;
-  evSetup.get<L1RCTParametersRcd>().get(rctParam);
-
-  rctParam->print(std::cout);
+  evSetup.getData(token_).print(std::cout);
 }
 
 DEFINE_FWK_MODULE(L1RCTParametersTester);


### PR DESCRIPTION
#### PR description:

- converted modules to thread-friendly types
- added esConsumes

#### PR validation:

Packages compile without issuing a CMS deprecation warning.