### PR TITLE
Fix deprecation warnings in PhysicsTools sub-system

### DIFF
--- a/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
+++ b/PhysicsTools/JetCharge/test/JetChargeAnalyzer.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -19,7 +19,7 @@
 #include <TH1.h>
 #include <string>
 
-class JetChargeAnalyzer : public edm::EDAnalyzer {
+class JetChargeAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   struct JetRefCompare {
     inline bool operator()(const edm::RefToBase<reco::Jet>& j1, const edm::RefToBase<reco::Jet>& j2) const {
@@ -46,13 +46,14 @@ private:
 };
 
 const int pdgIds[12] = {0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 21};
-const char* pdgs[12] = {"?", "u", "-u", "d", "-d", "s", "-s", "c", "-c", "b", "-b", "g"};
+const char* const pdgs[12] = {"?", "u", "-u", "d", "-d", "s", "-s", "c", "-c", "b", "-b", "g"};
 
 JetChargeAnalyzer::JetChargeAnalyzer(const edm::ParameterSet& iConfig)
     : srcToken_(consumes<JetChargeCollection>(iConfig.getParameter<edm::InputTag>("src"))),
       jetMCSrcToken_(consumes<reco::JetFlavourMatchingCollection>(iConfig.getParameter<edm::InputTag>("jetFlavour"))),
       minET_(iConfig.getParameter<double>("minET")),
       dir_(iConfig.getParameter<std::string>("dir")) {
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   TFileDirectory cwd = fs->mkdir(dir_.c_str());
   char buff[255], biff[255];

--- a/PhysicsTools/JetExamples/test/printGenJetRatio.cc
+++ b/PhysicsTools/JetExamples/test/printGenJetRatio.cc
@@ -1,6 +1,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/JetMatching/interface/JetFlavour.h"
 #include "DataFormats/JetMatching/interface/JetFlavourMatching.h"
 
-class printGenJetRatio : public edm::EDAnalyzer {
+class printGenJetRatio : public edm::one::EDAnalyzer<> {
 public:
   typedef reco::JetFloatAssociation::Container JetBCEnergyRatioCollection;
 

--- a/PhysicsTools/JetExamples/test/printJetFlavour.cc
+++ b/PhysicsTools/JetExamples/test/printJetFlavour.cc
@@ -1,6 +1,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -31,7 +31,7 @@
 #include <Math/VectorUtil.h>
 #include <TMath.h>
 
-class printJetFlavour : public edm::EDAnalyzer {
+class printJetFlavour : public edm::one::EDAnalyzer<> {
 public:
   explicit printJetFlavour(const edm::ParameterSet&);
   ~printJetFlavour(){};

--- a/PhysicsTools/JetExamples/test/printJetFlavourInfo.cc
+++ b/PhysicsTools/JetExamples/test/printJetFlavourInfo.cc
@@ -1,6 +1,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -16,7 +16,7 @@
 // system include files
 #include <memory>
 
-class printJetFlavourInfo : public edm::EDAnalyzer {
+class printJetFlavourInfo : public edm::one::EDAnalyzer<> {
 public:
   explicit printJetFlavourInfo(const edm::ParameterSet&);
   ~printJetFlavourInfo(){};

--- a/PhysicsTools/JetExamples/test/printPartonJet.cc
+++ b/PhysicsTools/JetExamples/test/printPartonJet.cc
@@ -9,7 +9,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -27,7 +27,7 @@ using namespace std;
 using namespace reco;
 using namespace edm;
 
-class printPartonJet : public edm::EDAnalyzer {
+class printPartonJet : public edm::one::EDAnalyzer<> {
 public:
   explicit printPartonJet(const edm::ParameterSet&);
   ~printPartonJet(){};

--- a/PhysicsTools/JetExamples/test/printTrackJet.cc
+++ b/PhysicsTools/JetExamples/test/printTrackJet.cc
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,7 +20,7 @@ using namespace std;
 using namespace reco;
 using namespace edm;
 
-class printTrackJet : public edm::EDAnalyzer {
+class printTrackJet : public edm::one::EDAnalyzer<> {
 public:
   explicit printTrackJet(const edm::ParameterSet&);
   ~printTrackJet(){};

--- a/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testReadMVAComputerCondDB.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,21 +21,22 @@
 
 using namespace PhysicsTools;
 
-class testReadMVAComputerCondDB : public edm::EDAnalyzer {
+class testReadMVAComputerCondDB : public edm::one::EDAnalyzer<> {
 public:
   explicit testReadMVAComputerCondDB(const edm::ParameterSet& params);
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  virtual void endJob();
+  void endJob() override;
+
+private:
+  edm::ESGetToken<Calibration::MVAComputerContainer, BTauGenericMVAJetTagComputerRcd> m_token;
 };
 
-testReadMVAComputerCondDB::testReadMVAComputerCondDB(const edm::ParameterSet& params) {}
+testReadMVAComputerCondDB::testReadMVAComputerCondDB(const edm::ParameterSet& params) : m_token(esConsumes()) {}
 
 void testReadMVAComputerCondDB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<Calibration::MVAComputerContainer> calib;
-  iSetup.get<BTauGenericMVAJetTagComputerRcd>().get(calib);
-  MVAComputer computer(&calib.product()->find("test"));
+  MVAComputer computer(&iSetup.getData(m_token).find("test"));
 
   Variable::Value values[] = {
       Variable::Value("toast", 4.4), Variable::Value("toast", 4.5), Variable::Value("test", 4.6),

--- a/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
+++ b/PhysicsTools/MVAComputer/test/testWriteMVAComputerCondDB.cc
@@ -12,7 +12,7 @@
 #include <algorithm>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -30,13 +30,13 @@
 
 using namespace PhysicsTools::Calibration;
 
-class testWriteMVAComputerCondDB : public edm::EDAnalyzer {
+class testWriteMVAComputerCondDB : public edm::one::EDAnalyzer<> {
 public:
   explicit testWriteMVAComputerCondDB(const edm::ParameterSet& params);
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  virtual void endJob();
+  void endJob() override;
 
 private:
   std::string record;


### PR DESCRIPTION
#### PR description:

- Changed to thread friendly module types
- Added esConsumes
#### PR validation:

Packages compile without issuing a CMS deprecation warning