### PR TITLE
Remove CMS deprecation warnings from CheckHitPattern

### DIFF
--- a/PhysicsTools/RecoUtils/interface/CheckHitPattern.h
+++ b/PhysicsTools/RecoUtils/interface/CheckHitPattern.h
@@ -9,8 +9,6 @@
  *        if used seriously it needs to be optimized and used properly... 
  */
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "RecoVertex/VertexPrimitives/interface/VertexState.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
@@ -21,6 +19,7 @@
 class DetId;
 
 class TrackerTopology;
+class TrackerGeometry;
 
 class CheckHitPattern {
 public:
@@ -39,7 +38,7 @@ public:
   static void print(const reco::Track& track);
 
   // Create map indicating r/z values of all layers/disks.
-  void init(const edm::EventSetup& iSetup);
+  void init(const TrackerTopology* tTopo, const TrackerGeometry& geom, const TransientTrackBuilder& builder);
 
   // Return a pair<uint32, uint32> consisting of the numbers used by HitPattern to
   // identify subdetector and layer number respectively.
@@ -61,7 +60,7 @@ private:
   RZrangeMap rangeRorZ_;
 
   // Makes TransientTracks needed for vertex fitting.
-  edm::ESHandle<TransientTrackBuilder> trkTool_;
+  const TransientTrackBuilder* trkTool_ = nullptr;
 };
 
 #endif

--- a/PhysicsTools/RecoUtils/src/CheckHitPattern.cc
+++ b/PhysicsTools/RecoUtils/src/CheckHitPattern.cc
@@ -1,7 +1,6 @@
 #include "PhysicsTools/RecoUtils/interface/CheckHitPattern.h"
 
 // To get Tracker Geometry
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
@@ -18,24 +17,17 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void CheckHitPattern::init(const edm::EventSetup& iSetup) {
-  //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
-
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trkTool_);  // Needed for vertex fits
-
+void CheckHitPattern::init(const TrackerTopology* tTopo,
+                           const TrackerGeometry& geom,
+                           const TransientTrackBuilder& builder) {
+  trkTool_ = &builder;
   //
   // Note min/max radius (z) of each barrel layer (endcap disk).
   //
 
   geomInitDone_ = true;
 
-  // Get Tracker geometry
-  edm::ESHandle<TrackerGeometry> trackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
-  const TrackingGeometry::DetContainer& dets = trackerGeometry->dets();
+  const TrackingGeometry::DetContainer& dets = geom.dets();
 
   // Loop over all modules in the Tracker.
   for (unsigned int i = 0; i < dets.size(); i++) {


### PR DESCRIPTION
#### PR description:

-Replaced use of EventSetup with passing data products into call.

#### PR validation:

Code compiles without issuing a CMS deprecation warning.