### PR TITLE
[12_4_X] Remove hardcoded trigger bits from Lumi ALCARECOs

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECORandomHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-    HLTPaths = cms.vstring("AlCa_LumiPixelsCounts_Random_v*"),
-    eventSetupPathsKey='',
-    TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
-    andOr = cms.bool(True), # choose logical OR between Triggerbits
-    throw = cms.bool(False) # tolerate triggers stated above, but not available
+   # HLTPaths = ["AlCa_LumiPixelsCounts_Random_v*"],
+    eventSetupPathsKey='AlCaPCCRandom',
+    TriggerResultsTag = ("TriggerResults","","HLT"),
+    andOr = True, # choose logical OR between Triggerbits
+    throw = False # tolerate triggers stated above, but not available
 )
 
 

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-    HLTPaths = cms.vstring("AlCa_LumiPixelsCounts_ZeroBias_v*"),
-    eventSetupPathsKey='',
-    TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
-    andOr = cms.bool(True), # choose logical OR between Triggerbits
-    throw = cms.bool(False) # tolerate triggers stated above, but not available
+   #HLTPaths = ["AlCa_LumiPixelsCounts_ZeroBias_v*"],
+    eventSetupPathsKey='AlCaPCCZeroBias',
+    TriggerResultsTag = ("TriggerResults","","HLT"),
+    andOr = True, # choose logical OR between Triggerbits
+    throw = False # tolerate triggers stated above, but not available
 )
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCIntegrator_cfi import alcaPCCIntegrator

--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -51,7 +51,7 @@ def buildList(pdList, matrix):
 
 # Update the lists anytime a new PD is added to the matrix
 autoAlca = { 'allForPrompt'         : buildList(['Charmonium', 'Commissioning', 'DoubleMuParked', 'DoubleMuon', 'DoubleMuonLowMass', 'EGamma', 'HLTPhysics', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuOnia', 'MuOniaParked', 'NoBPTX', 'SingleMuon', 'ZeroBias'], AlCaRecoMatrix),
-             'allForExpress'        : buildList(['StreamExpress', 'ALCALumiPixelsCountsExpress'], AlCaRecoMatrix),
+             'allForExpress'        : buildList(['StreamExpress'], AlCaRecoMatrix),
              'allForExpressHI'      : buildList(['StreamExpressHI'], AlCaRecoMatrix),
              'allForPromptCosmics'  : buildList(['Cosmics'], AlCaRecoMatrix),
              'allForExpressCosmics' : buildList(['ExpressCosmics'], AlCaRecoMatrix) }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,10 +37,10 @@ autoCond = {
     'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
     'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v8',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v4',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v6 but with snapshot at 2022-10-04 14:22:26 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 23:00:00 (UTC)
     'run3_data'                    : '124X_dataRun3_v9',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu


### PR DESCRIPTION
#### PR description:

 Remove hardcoded trigger bits from AlCaRecos and include it as a key in the alcareco trigger bits tag in "ALCARECOAlCaPCCZeroBias" and "ALCARECOAlCaPCCRandom"

Two GTs were created to be included in this PR, with the correct AlCaRecoTriggerBits tag.
1- 124X_dataRun3_Express_frozen_v6 :
GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v6 but with snapshot at 2022-10-04 14:22:26 (UTC)
Here is the link of difference of GT, old vs new : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v4/124X_dataRun3_Express_frozen_v6

2- 124X_dataRun3_Prompt_frozen_v5 :
GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
Here is the link of difference of GT, old vs new : [https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v4/124X_dataRun3_Prompt_frozen_v](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v4/124X_dataRun3_Prompt_frozen_v5)  


backport of #39519

