### PR TITLE
Add missing include to TransformerBase.cc

### DIFF
--- a/FWCore/Framework/src/TransformerBase.cc
+++ b/FWCore/Framework/src/TransformerBase.cc
@@ -7,6 +7,8 @@
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
+#include <optional>
+
 namespace edm {
   void TransformerBase::registerTransformImp(
       ProducerBase& iBase, EDPutToken iToken, const TypeID& id, std::string instanceName, TransformFunction iFunc) {


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/39557 broke GCC 11 IBs because of a missing include of `optional` added here.

#### PR validation:

None (edited in the web)