### PR TITLE
Fix deprecation warnings in  RecoMuon sub-system

### DIFF
--- a/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
+++ b/RecoMuon/DetLayers/test/MuonRecoGeometryAnalyzer.cc
@@ -3,7 +3,7 @@
  */
 
 #include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/Framework/interface/ESHandle.h>
@@ -33,11 +33,11 @@
 using namespace std;
 using namespace edm;
 
-class MuonRecoGeometryAnalyzer : public EDAnalyzer {
+class MuonRecoGeometryAnalyzer : public one::EDAnalyzer<> {
 public:
   MuonRecoGeometryAnalyzer(const ParameterSet& pset);
 
-  virtual void analyze(const Event& ev, const EventSetup& es);
+  void analyze(const Event& ev, const EventSetup& es) override;
 
   void testDTLayers(const MuonDetLayerGeometry*, const MagneticField* field);
   void testCSCLayers(const MuonDetLayerGeometry*, const MagneticField* field);
@@ -46,20 +46,21 @@ public:
 
 private:
   MeasurementEstimator* theEstimator;
+  ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord> theGeomToken;
+  ESGetToken<MagneticField, IdealMagneticFieldRecord> theMagfieldToken;
 };
 
 MuonRecoGeometryAnalyzer::MuonRecoGeometryAnalyzer(const ParameterSet& iConfig) {
   float theMaxChi2 = 25.;
   float theNSigma = 3.;
   theEstimator = new Chi2MeasurementEstimator(theMaxChi2, theNSigma);
+  theGeomToken = esConsumes();
+  theMagfieldToken = esConsumes();
 }
 
 void MuonRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
-  ESHandle<MuonDetLayerGeometry> geo;
-  es.get<MuonRecoGeometryRecord>().get(geo);
-
-  ESHandle<MagneticField> magfield;
-  es.get<IdealMagneticFieldRecord>().get(magfield);
+  ESHandle<MuonDetLayerGeometry> geo = es.getHandle(theGeomToken);
+  ESHandle<MagneticField> magfield = es.getHandle(theMagfieldToken);
   // Some printouts
 
   cout << "*** allDTLayers(): " << geo->allDTLayers().size() << endl;

--- a/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.h
+++ b/RecoMuon/L2MuonIsolationProducer/test/L2MuonIsolationAnalyzer.h
@@ -7,7 +7,7 @@
  *  \author J. Alcaraz
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/MuonIsolation/interface/Cuts.h"
 
@@ -21,19 +21,19 @@ class TFile;
 class TH1F;
 class TH2F;
 
-class L2MuonIsolationAnalyzer : public edm::EDAnalyzer {
+class L2MuonIsolationAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   L2MuonIsolationAnalyzer(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~L2MuonIsolationAnalyzer();
+  ~L2MuonIsolationAnalyzer() override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 private:
   void Puts(const char* fmt, ...);

--- a/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.h
+++ b/RecoMuon/L3MuonIsolationProducer/test/L3MuonIsolationAnalyzer.h
@@ -6,7 +6,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoMuon/MuonIsolation/interface/Cuts.h"
 
@@ -20,19 +20,19 @@ class TFile;
 class TH1F;
 class TH2F;
 
-class L3MuonIsolationAnalyzer : public edm::EDAnalyzer {
+class L3MuonIsolationAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   L3MuonIsolationAnalyzer(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~L3MuonIsolationAnalyzer();
+  ~L3MuonIsolationAnalyzer() override;
 
   // Operations
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 private:
   void Puts(const char* fmt, ...);

--- a/RecoMuon/Navigation/test/MuonNavigationTest.cc
+++ b/RecoMuon/Navigation/test/MuonNavigationTest.cc
@@ -5,7 +5,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -24,19 +24,21 @@
 //#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-class MuonNavigationTest : public edm::EDAnalyzer {
+class MuonNavigationTest : public edm::one::EDAnalyzer<> {
 public:
   explicit MuonNavigationTest(const edm::ParameterSet&);
-  ~MuonNavigationTest();
+  ~MuonNavigationTest() override;
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
+  edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord> geomToken_;
 };
 
 // constructor
 
 MuonNavigationTest::MuonNavigationTest(const edm::ParameterSet& iConfig) {
+  geomToken_ = esConsumes();
   std::cout << "Muon Navigation Printer Begin:" << std::endl;
 }
 
@@ -51,13 +53,11 @@ void MuonNavigationTest::analyze(const edm::Event& iEvent, const edm::EventSetup
   //
   // get Geometry
   //
-  edm::ESHandle<MuonDetLayerGeometry> muon;
-  iSetup.get<MuonRecoGeometryRecord>().get(muon);
-  const MuonDetLayerGeometry* mm(&(*muon));
+  const MuonDetLayerGeometry& mm = iSetup.getData(geomToken_);
 
   if (testMuon) {
-    MuonNavigationSchool school(mm);
-    MuonNavigationPrinter* printer = new MuonNavigationPrinter(mm, school);
+    MuonNavigationSchool school(&mm);
+    MuonNavigationPrinter* printer = new MuonNavigationPrinter(&mm, school);
     delete printer;
   }
   /*

--- a/RecoMuon/StandAloneMuonProducer/test/STAMuonAnalyzer.cc
+++ b/RecoMuon/StandAloneMuonProducer/test/STAMuonAnalyzer.cc
@@ -46,6 +46,9 @@ STAMuonAnalyzer::STAMuonAnalyzer(const ParameterSet& pset) {
 
   numberOfSimTracks = 0;
   numberOfRecTracks = 0;
+
+  theFieldToken = esConsumes();
+  theGeomToken = esConsumes();
 }
 
 /// Destructor
@@ -97,11 +100,8 @@ void STAMuonAnalyzer::analyze(const Event& event, const EventSetup& eventSetup) 
   Handle<reco::TrackCollection> staTracks;
   event.getByLabel(theSTAMuonLabel, staTracks);
 
-  ESHandle<MagneticField> theMGField;
-  eventSetup.get<IdealMagneticFieldRecord>().get(theMGField);
-
-  ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-  eventSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  ESHandle<MagneticField> theMGField = eventSetup.getHandle(theFieldToken);
+  ESHandle<GlobalTrackingGeometry> theTrackingGeometry = eventSetup.getHandle(theGeomToken);
 
   double recPt = 0.;
   double simPt = 0.;

--- a/RecoMuon/StandAloneMuonProducer/test/STAMuonAnalyzer.h
+++ b/RecoMuon/StandAloneMuonProducer/test/STAMuonAnalyzer.h
@@ -8,7 +8,7 @@
  */
 
 // Base Class Headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 namespace edm {
   class ParameterSet;
@@ -19,21 +19,25 @@ namespace edm {
 class TFile;
 class TH1F;
 class TH2F;
+class MagneticField;
+class IdealMagneticFieldRecord;
+class GlobalTrackingGeometry;
+class GlobalTrackingGeometryRecord;
 
-class STAMuonAnalyzer : public edm::EDAnalyzer {
+class STAMuonAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   STAMuonAnalyzer(const edm::ParameterSet &pset);
 
   /// Destructor
-  virtual ~STAMuonAnalyzer();
+  ~STAMuonAnalyzer() override;
 
   // Operations
 
-  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup);
+  void analyze(const edm::Event &event, const edm::EventSetup &eventSetup) override;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() override;
+  void endJob() override;
 
 protected:
 private:
@@ -58,5 +62,7 @@ private:
   int numberOfRecTracks;
 
   std::string theDataType;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theGeomToken;
 };
 #endif


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- added missing esConsumes

#### PR validation:

Code compiles without issuing a CMS deprecation warning.