### PR TITLE
Add option to cut H<a+bE+cE*E

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTFilteredObjProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTFilteredObjProducer.h
@@ -72,18 +72,17 @@ public:
             compFunc(std::less<float>()) {}
 
       bool operator()(const reco::RecoEcalCandidate& cand, float value) const {
-	if(!doAnd) {
-	  if (compFunc(value, cut))
-	    return true;
-	  else {
-	    float energyInv = useEt ? 1. / cand.et() : 1. / cand.energy();
-	    return compFunc(value * energyInv, cutOverE) || compFunc(value * energyInv * energyInv, cutOverE2);
-	  }
-	}
-	else {
-	  float energy = useEt ? cand.et() : cand.energy();
-	  return compFunc(value, cut + cutOverE*energy + cutOverE2*energy*energy);
-	}
+        if (!doAnd) {
+          if (compFunc(value, cut))
+            return true;
+          else {
+            float energyInv = useEt ? 1. / cand.et() : 1. / cand.energy();
+            return compFunc(value * energyInv, cutOverE) || compFunc(value * energyInv * energyInv, cutOverE2);
+          }
+        } else {
+          float energy = useEt ? cand.et() : cand.energy();
+          return compFunc(value, cut + cutOverE * energy + cutOverE2 * energy * energy);
+        }
       }
     };
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTFilteredObjProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTFilteredObjProducer.h
@@ -60,6 +60,7 @@ public:
       float cutOverE;
       float cutOverE2;
       bool useEt;
+      bool doAnd;
       std::function<bool(float, float)> compFunc;
 
       CutValues(const edm::ParameterSet& pset)
@@ -67,15 +68,22 @@ public:
             cutOverE(pset.getParameter<double>("cutOverE")),
             cutOverE2(pset.getParameter<double>("cutOverE2")),
             useEt(pset.getParameter<bool>("useEt")),
+            doAnd(pset.getParameter<bool>("doAnd")),
             compFunc(std::less<float>()) {}
 
       bool operator()(const reco::RecoEcalCandidate& cand, float value) const {
-        if (compFunc(value, cut))
-          return true;
-        else {
-          float energyInv = useEt ? 1. / cand.et() : 1. / cand.energy();
-          return compFunc(value * energyInv, cutOverE) || compFunc(value * energyInv * energyInv, cutOverE2);
-        }
+	if(!doAnd) {
+	  if (compFunc(value, cut))
+	    return true;
+	  else {
+	    float energyInv = useEt ? 1. / cand.et() : 1. / cand.energy();
+	    return compFunc(value * energyInv, cutOverE) || compFunc(value * energyInv * energyInv, cutOverE2);
+	  }
+	}
+	else {
+	  float energy = useEt ? cand.et() : cand.energy();
+	  return compFunc(value, cut + cutOverE*energy + cutOverE2*energy*energy);
+	}
       }
     };
 
@@ -129,9 +137,11 @@ void EgammaHLTFilteredObjProducer<OutCollType>::fillDescriptions(edm::Configurat
   regionCutsDesc.add<double>("cutOverE", -1);
   regionCutsDesc.add<double>("cutOverE2", -1);
   regionCutsDesc.add<bool>("useEt", false);
+  regionCutsDesc.add<bool>("doAnd", false);
   edm::ParameterSet cutDefaults;
   cutDefaults.addParameter<double>("cutOverE", 0.2);
   cutDefaults.addParameter<double>("useEt", false);
+  cutDefaults.addParameter<double>("doAnd", false);
 
   cutsDesc.add<edm::ParameterSetDescription>("barrelCut", regionCutsDesc);
   cutsDesc.add<edm::ParameterSetDescription>("endcapCut", regionCutsDesc);


### PR DESCRIPTION
#### PR description:

Adds an option to change the H/E cut to take the form H<a+bE+cE^2 for constants a, b, c. 
  This will be needed for Egamma objects in upcoming changes to the Scouting trigger.
  Default behavior stays unchanged.
  - No changes in output 
  - No external dependencies
  - slides presented to TSG on the change in Scouting: https://indico.cern.ch/event/1186562/contributions/4992593/attachments/2489115/4274414/electronScouting_22-08-03.pdf 
  In particular, slide 10 shows the physics motivation--large increase in low-pT scouting electron signal reconstruction efficiency resulting from changing this cut.

#### PR validation:

Tested with scram b code-checks and scram b code-format. Further tests performed locally showing expected behavior of the code changes--namely, when doAnd is set to true with non-zero values for cut and cutOverE specified, all resulting scouting electrons in the collection obey H < cutOverE*E + cut and the number of these electrons is reasonable.
