### PR TITLE
Added a module to do eta filtering for Egamma HLT candidates

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTEgammaEtaFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaEtaFilter.cc
@@ -1,0 +1,89 @@
+/** \class HLTEgammaEtaFilter
+ *
+ *
+ *  \author Abanti Ranadhir Sahasransu (VUB, Belgium)
+ *
+ */
+
+#include "HLTEgammaEtaFilter.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+
+//
+// constructors and destructor
+//
+HLTEgammaEtaFilter::HLTEgammaEtaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+  inputTag_ = iConfig.getParameter<edm::InputTag>("inputTag");
+  minEtacut_ = iConfig.getParameter<double>("minEtaCut");
+  maxEtacut_ = iConfig.getParameter<double>("maxEtaCut");
+  ncandcut_ = iConfig.getParameter<int>("ncandcut");
+  l1EGTag_ = iConfig.getParameter<edm::InputTag>("l1EGCand");
+  inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
+}
+
+void HLTEgammaEtaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("HLTEgammaL1MatchFilter"));
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
+  desc.add<double>("minEtaCut", -2.65);
+  desc.add<double>("maxEtaCut", 2.65);
+  desc.add<int>("ncandcut", 1);
+  descriptions.add("hltEgammaEtaFilter", desc);
+}
+
+HLTEgammaEtaFilter::~HLTEgammaEtaFilter() = default;
+
+// ------------ method called to produce the data  ------------
+bool HLTEgammaEtaFilter::hltFilter(edm::Event& iEvent,
+                                   const edm::EventSetup& iSetup,
+                                   trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace trigger;
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1EGTag_);
+    ;
+  }
+
+  // Ref to Candidate object to be recorded in filter object
+  edm::Ref<reco::RecoEcalCandidateCollection> ref;
+
+  // get hold of filtered candidates
+  //edm::Handle<reco::HLTFilterObjectWithRefs> recoecalcands;
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
+  iEvent.getByToken(inputToken_, PrevFilterOutput);
+
+  std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;  // vref with your specific C++ collection type
+  PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
+  if (recoecalcands.empty())
+    PrevFilterOutput->getObjects(TriggerPhoton,
+                                 recoecalcands);  //we dont know if its type trigger cluster or trigger photon
+
+  // look at all candidates,  check cuts and add to filter object
+  int n(0);
+
+  for (auto& recoecalcand : recoecalcands) {
+    ref = recoecalcand;
+
+    if (ref->eta() > minEtacut_ && ref->eta() < maxEtacut_) {
+      n++;
+      filterproduct.addObject(TriggerCluster, ref);
+    }
+  }
+
+  // filter decision
+  bool accept(n >= ncandcut_);
+
+  return accept;
+}
+
+// declare this class as a framework plugin
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTEgammaEtaFilter);

--- a/HLTrigger/Egamma/plugins/HLTEgammaEtaFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTEgammaEtaFilter.h
@@ -1,0 +1,41 @@
+#ifndef HLTEgammaEtaFilter_h
+#define HLTEgammaEtaFilter_h
+
+/** \class HLTEgammaEtaFilter
+ *
+ *  \author Abanti Ranadhir Sahasransu (VUB, Belgium)
+ *
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
+//
+// class declaration
+//
+
+class HLTEgammaEtaFilter : public HLTFilter {
+public:
+  explicit HLTEgammaEtaFilter(const edm::ParameterSet&);
+  ~HLTEgammaEtaFilter() override;
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  edm::InputTag inputTag_;  // input tag identifying product contains egammas
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
+  double minEtacut_;  // Min Eta threshold
+  double maxEtacut_;  // Max Eta threshold
+  int ncandcut_;      // number of egammas required
+
+  edm::InputTag l1EGTag_;
+};
+
+#endif  //HLTEgammaEtaFilter_h


### PR DESCRIPTION
#### PR description:

 - Added a module to do eta filtering of HLT Egamma objects
 - Necessary for an eta cut on objects in the trigger HLT_DiPhoton10Time1p2ns_v

#### PR validation:

 - Checked the functionality of the filter module and verified that the eta cuts function as intended. A basic plot is shown below.
 - The red histogram is after the eta cut while the blue histogram is before cut. An |eta|<2.15 has been applied as can be observed by comparing the plots. 
 - Code checks and code format performed

#### PR backport:

 - PR needs to be backported to CMSSW_12_4_X and 12_5_X
 - The current software at HLT is in the 12_4_X release. Hence the need for backport.
 
![Screenshot from 2022-10-19 09-12-41](https://user-images.githubusercontent.com/32368439/196621814-b7d632e2-7a4e-4cf4-a920-67620937927e.png)


