### PR TITLE
Alignment Payload Inspector: support multi-IOV tag comparisons and pixel maps

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/plugins/BuildFile.xml
@@ -20,6 +20,7 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
   <use name="CondFormats/Alignment"/>
+  <use name="DQM/TrackerRemapper"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="Alignment/CommonAlignment"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>


### PR DESCRIPTION
#### PR description:

Title says it all, this PR consists of two commits:
   * d2da0bcc04c53bc8ef087702cdaf790ddcd5a5b7 provides support for multi-tag comparison summaries per partition to make plots as the one in https://github.com/cms-sw/cmssw/issues/39110#issuecomment-1271348535
   * https://github.com/cms-sw/cmssw/commit/fd7ed3446a6d400243e081a8df92f76f56101852 provides support for pixel tracker -only maps for the surface deformation parameters.

#### PR validation:

Private tests, one can e.g. produce this plot:

![image](https://user-images.githubusercontent.com/5082376/196648463-5957714a-4706-4c72-aca0-2970612232ae.png)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A