### PR TITLE
Update GMT Barrel limit

### DIFF
--- a/DataFormats/L1TMuonPhase2/interface/Constants.h
+++ b/DataFormats/L1TMuonPhase2/interface/Constants.h
@@ -70,10 +70,11 @@ namespace Phase2L1GMT {
   const float maxTanl_ = 8.0;
   const float maxZ0_ = 30.;
   const float maxD0_ = 15.4;
-  const int barrelLimit0_ = 181 / 4;
-  const int barrelLimit1_ = 160 / 4;
-  const int barrelLimit2_ = 140 / 4;
-  const int barrelLimit3_ = 110 / 4;
+  // Updated barrelLimit according to Karol, https://indico.cern.ch/event/1113802/#1-phase2-gmt-performance-and-i
+  const int barrelLimit0_ = 1.4 / 0.00076699039 / 8;
+  const int barrelLimit1_ = 1.1 / 0.00076699039 / 8;
+  const int barrelLimit2_ = 0.95 / 0.00076699039 / 8;
+  const int barrelLimit3_ = 0.95 / 0.00076699039 / 8;
   const int barrelLimit4_ = 0;
 
   // LSB


### PR DESCRIPTION
#### PR description:
Update the GMT Barrel Limit according to https://indico.cern.ch/event/1113802/contributions/4680319/attachments/2375735/4058290/220119%20Phase2GMT%20and%20NN.pdf

The muon ID will need to be tuned, which will come later.

Local PR:  https://github.com/cms-l1t-offline/cmssw/pull/1052

#### PR validation:
Basic formatting checks after the changes were made.
