### PR TITLE
allow SoA Pixel RecHits monitoring to run in Phase-2 workflows

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
@@ -61,10 +61,10 @@ private:
   MonitorElement* hFcharge;
   MonitorElement* hFsizex;
   MonitorElement* hFsizey;
-  MonitorElement* hFposXYD[2][3];
-  MonitorElement* hFchargeD[2][3];
-  MonitorElement* hFsizexD[2][3];
-  MonitorElement* hFsizeyD[2][3];
+  MonitorElement* hFposXYD[2][12];
+  MonitorElement* hFchargeD[2][12];
+  MonitorElement* hFsizexD[2][12];
+  MonitorElement* hFsizeyD[2][12];
 };
 
 //

--- a/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
@@ -5,6 +5,10 @@ from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorRecHitsSoA_cfi import *
 
 monitorpixelSoASource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA * siPixelPhase1MonitorTrackSoA * siPixelPhase1MonitorVertexSoA)
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+_monitorpixelSoARecHitsSource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA)
+phase2_tracker.toReplaceWith(monitorpixelSoASource, _monitorpixelSoARecHitsSource)
+
 #Define the sequence for GPU vs CPU validation
 #This should run:- individual monitor for the 2 collections + comparison module
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1CompareTrackSoA_cfi import *
@@ -49,8 +53,14 @@ monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRecHitsSoACPU *
                                             siPixelPhase1CompareTrackSoA *
                                             siPixelPhase1MonitorVertexSoACPU *
                                             siPixelPhase1MonitorVertexSoAGPU *
-                                            siPixelPhase1CompareVertexSoA
-)
+                                            siPixelPhase1CompareVertexSoA)
+
+monitorpixelSoACompareSourceNoTracking = cms.Sequence(siPixelPhase1MonitorRecHitsSoACPU *
+                                      	              siPixelPhase1MonitorRecHitsSoAGPU *
+                                        	      siPixelPhase1CompareRecHitsSoA)
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(monitorpixelSoACompareSource,monitorpixelSoACompareSourceNoTracking)
 
 from Configuration.ProcessModifiers.gpuValidationPixel_cff import gpuValidationPixel
 gpuValidationPixel.toReplaceWith(monitorpixelSoASource, monitorpixelSoACompareSource)

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -174,13 +174,6 @@ DQMOfflinePixelTracking = cms.Sequence( pixelTracksMonitoring *
                                         pixelPVMonitor *
                                         monitorpixelSoASource )
 
-
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-_DQMOfflinePixelTrackingNoSoA = DQMOfflinePixelTracking.copy()
-_DQMOfflinePixelTrackingNoSoA = cms.Sequence(pixelTracksMonitoring * pixelPVMonitor)
-
-phase2_tracker.toReplaceWith(DQMOfflinePixelTracking, _DQMOfflinePixelTrackingNoSoA)
-
 DQMOuterTracker = cms.Sequence( DQMOfflineDCS *
                                 OuterTrackerSource *
                                 DQMMessageLogger *


### PR DESCRIPTION
#### PR description:

Title says it all, minimal set of modifications to be able to run the SoA pixel rechits monitoring in the phase-2 workflows.
The code - even if used for Phase-2 - still resides in `DQM/SiPixelPhase1Heterogeneous` (which is a misnomer).  We plan further clean-up of the naming and extending to the tracks and vertices by using class templates once the dust settles on #38761.

#### PR validation:

Tested on `lxplus-gpu` by running  `runTheMatrix.py --what upgrade -l 20834.507 -t 4 -j 8` and checked that plots are filled correctly:

![Screenshot from 2022-10-19 14-52-39](https://user-images.githubusercontent.com/5082376/196696270-a667d564-fc34-4389-8b9e-1fda21cbd260.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

cc:
@AdrianoDee @sroychow 