### PR TITLE
Always keep JobReport file as XML parseable

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -427,6 +427,7 @@ namespace edm {
     edm::propagate_const<std::unique_ptr<JobReportImpl>>& impl() { return impl_; }
 
   private:
+    void temporarilyCloseXML();
     edm::propagate_const<std::unique_ptr<JobReportImpl>> impl_;
     std::mutex write_mutex;
   };


### PR DESCRIPTION
#### PR description:

Temporarily write the close element each time we finish writing to the job report file.

#### PR validation:

Code compiles and framework unit tests (where some do test xml parseability of the framework job report file) all pass.