### PR TITLE
Fixing bug in HLTriggerJSONMonitoring L1 and prescale module idenfication

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -232,12 +232,15 @@ std::shared_ptr<HLTriggerJSONMonitoringData::run> HLTriggerJSONMonitoring::globa
     for (auto i = 0u; i < triggersSize; ++i) {
       rundata->posL1s[i] = -1;
       rundata->posPre[i] = -1;
-      auto const& moduleLabels = rundata->hltConfig.moduleLabels(i);
+      auto const trigNameIndx = rundata->indicesOfTriggerPaths[i];
+      auto const& moduleLabels = rundata->hltConfig.moduleLabels(trigNameIndx);
       for (auto j = 0u; j < moduleLabels.size(); ++j) {
-        auto const& label = rundata->hltConfig.moduleType(moduleLabels[j]);
-        if (label == "HLTL1TSeed")
+        auto const& moduleLabel = moduleLabels[j];
+        auto const& moduleType = rundata->hltConfig.moduleType(moduleLabel);
+        //the logic here is that it finds the first non ignored HLTL1TSeed module, ignored modules have - at the start of their name
+        if (rundata->posL1s[i] == -1 && moduleLabel.rfind('-', 0) != 0 && moduleType == "HLTL1TSeed") {
           rundata->posL1s[i] = j;
-        else if (label == "HLTPrescaler")
+        } else if (moduleType == "HLTPrescaler")
           rundata->posPre[i] = j;
       }
     }


### PR DESCRIPTION
#### PR description:

HLTriggerJSONMonitoring is how the HLT reports path rates to OMS.  It was updated in Jun (https://github.com/cms-sw/cmssw/pull/38418) to better support DatasetPaths.

In doing so a bug was introduced in that if a path is after a dataset path, the wrong L1 and prescale module will be identified. 

Additionally the logic was improved to only consider the first seed module and also to disregard ignored modules. This fixes problems in some paths which have additional L1 seed modules which are ignored as they want to use this data later in the path.  

Credit goes to Adelina Lintuluoto  (@alintulu) for spotting this issue  in the hilton tests. 

#### PR validation:

Testing a menu which had the bug rates output with and without the patch (these paths are after a dataset path)


pre fix -> post fix 
```
< HLT_SingleEle8_v1                                                      500           500              0 
< HLT_SingleEle8_SingleEGL1_v1                                           500           500              9 
---
> HLT_SingleEle8_v1                                                       19             0              0 
> HLT_SingleEle8_SingleEGL1_v1                                            17            17              9 
```
and for the second bug  with paths which have multiple L1 seed modules
```
< HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_v2                19            59              2 
< HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75_v2                16            48              1 
< HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_CrossL1_v2             0             5              0 
< HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_CrossL1_v2             0             5              0 
< HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75_CrossL1_v2             0             5              0 
---
> HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_v2                59            59              2 
> HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75_v2                48            48              1 
> HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_CrossL1_v2             5             5              0 
> HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_CrossL1_v2             5             5              0 
> HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75_CrossL1_v2             5             5              0 
```

you can see how it goes from impossible values to the  correct values (cant have more objects passing prescaler than L1 seed module for a correctly designed path)


