### PR TITLE
loosen check on ntuplet size in `GPUCACell::find_ntuplets` [`12_5_X`]

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -290,7 +290,7 @@ public:
 
     auto doubletId = this - cells;
     tmpNtuplet.push_back_unsafe(doubletId);
-    assert(tmpNtuplet.size() <= 4);
+    assert(tmpNtuplet.size() <= 5);
 
     bool last = true;
     for (unsigned int otherCell : outerNeighbors()) {
@@ -331,7 +331,7 @@ public:
       }
     }
     tmpNtuplet.pop_back();
-    assert(tmpNtuplet.size() < 4);
+    assert(tmpNtuplet.size() < 5);
   }
 
   // Cell status management


### PR DESCRIPTION
backport of #39780

#### PR description:

This PR implements a suggestion from @fwyzard and @VinInn to fix the last outstanding issue of those described in #38453.

It loosens an `assert` check used (on CPU) in the building of pixel-track candidates at HLT.

#### PR validation:

None beyond the checks done for #39780.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#39780
