### PR TITLE
Fix CMS deprecatation warnings in  RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/DTRecHit/test/DTRecHitReader.cc
+++ b/RecoLocalMuon/DTRecHit/test/DTRecHitReader.cc
@@ -48,6 +48,8 @@ DTRecHitReader::DTRecHitReader(const ParameterSet& pset) {
   hRHitZ_W1 = new H1DRecHit("RZ_W1");
   hRHitZ_W2 = new H1DRecHit("RZ_W2");
   hRHitZ_All = new H1DRecHit("RZ_All");
+
+  dtGeomToken_ = esConsumes();
 }
 
 // Destructor
@@ -69,8 +71,8 @@ DTRecHitReader::~DTRecHitReader() {
 void DTRecHitReader::analyze(const Event& event, const EventSetup& eventSetup) {
   cout << "--- [DTRecHitReader] Event analysed #Run: " << event.id().run() << " #Event: " << event.id().event() << endl;
   // Get the DT Geometry
-  ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  ESHandle<DTGeometry> dtGeom = eventSetup.getHandle(dtGeomToken_);
+  ;
 
   // Get the rechit collection from the event
   Handle<DTRecHitCollection> dtRecHits;

--- a/RecoLocalMuon/DTRecHit/test/DTRecHitReader.h
+++ b/RecoLocalMuon/DTRecHit/test/DTRecHitReader.h
@@ -8,7 +8,7 @@
  *  \author G. Cerminara - INFN Torino
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
@@ -32,18 +32,21 @@ class TFile;
 class DTLayer;
 class DTWireId;
 
-class DTRecHitReader : public edm::EDAnalyzer {
+class DTGeometry;
+class MuonGeometryRecord;
+
+class DTRecHitReader : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   DTRecHitReader(const edm::ParameterSet& pset);
 
   /// Destructor
-  virtual ~DTRecHitReader();
+  ~DTRecHitReader() override;
 
   // Operations
 
   /// Perform the real analysis
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 protected:
 private:
@@ -74,6 +77,8 @@ private:
   std::string rootFileName;
   std::string simHitLabel;
   std::string recHitLabel;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
 };
 
 #endif

--- a/RecoLocalMuon/GEMRecHit/test/TestGEMRecHitAnalyzer.cc
+++ b/RecoLocalMuon/GEMRecHit/test/TestGEMRecHitAnalyzer.cc
@@ -42,12 +42,11 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include <DataFormats/GEMRecHit/interface/GEMRecHit.h>
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
@@ -78,7 +77,7 @@
 // class declaration
 //
 
-class TestGEMRecHitAnalyzer : public edm::EDAnalyzer {
+class TestGEMRecHitAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TestGEMRecHitAnalyzer(const edm::ParameterSet&);
   ~TestGEMRecHitAnalyzer();
@@ -89,7 +88,7 @@ private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  edm::ESHandle<GEMGeometry> gemGeom;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeom_Token;
   edm::EDGetTokenT<GEMRecHitCollection> GEMRecHit_Token;
 
   std::string rootFileName;
@@ -129,6 +128,7 @@ TestGEMRecHitAnalyzer::TestGEMRecHitAnalyzer(const edm::ParameterSet& iConfig)
 
 {
   //now do what ever initialization is needed
+  gemGeom_Token = esConsumes();
   GEMRecHit_Token = consumes<GEMRecHitCollection>(edm::InputTag("gemRecHits"));
   rootFileName = iConfig.getUntrackedParameter<std::string>("RootFileName");
   outputfile.reset(TFile::Open(rootFileName.c_str(), "RECREATE"));
@@ -417,7 +417,7 @@ TestGEMRecHitAnalyzer::~TestGEMRecHitAnalyzer() {
 
 // ------------ method called for each event  ------------
 void TestGEMRecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(gemGeom);
+  auto gemGeom = iSetup.getHandle(gemGeom_Token);
 
   // ================
   // GEM recHits

--- a/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMSegment/test/TestME0SegmentAnalyzer.cc
@@ -28,12 +28,11 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 #include <DataFormats/GEMRecHit/interface/ME0RecHitCollection.h>
@@ -51,7 +50,7 @@
 // class declaration
 //
 
-class TestME0SegmentAnalyzer : public edm::EDAnalyzer {
+class TestME0SegmentAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TestME0SegmentAnalyzer(const edm::ParameterSet&);
   ~TestME0SegmentAnalyzer();
@@ -60,7 +59,7 @@ private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
   // ----------member data ---------------------------
-  edm::ESHandle<ME0Geometry> me0Geom;
+  edm::ESGetToken<ME0Geometry, MuonGeometryRecord> me0Geom_Token;
 
   edm::EDGetTokenT<ME0SegmentCollection> ME0Segment_Token;
   edm::EDGetTokenT<ME0RecHitCollection> ME0RecHit_Token;
@@ -123,6 +122,7 @@ TestME0SegmentAnalyzer::TestME0SegmentAnalyzer(const edm::ParameterSet& iConfig)
 
 {
   //now do what ever initialization is needed
+  me0Geom_Token = esConsumes();
   ME0Segment_Token = consumes<ME0SegmentCollection>(edm::InputTag("me0Segments", "", "ME0RERECO"));
   ME0RecHit_Token = consumes<ME0RecHitCollection>(edm::InputTag("me0RecHits"));
   ME0Digi_Token = consumes<ME0DigiPreRecoCollection>(edm::InputTag("simMuonME0PseudoReDigis"));
@@ -219,7 +219,7 @@ TestME0SegmentAnalyzer::~TestME0SegmentAnalyzer() {
 
 // ------------ method called for each event  ------------
 void TestME0SegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(me0Geom);
+  auto me0Geom = iSetup.getHandle(me0Geom_Token);
 
   // ================
   // ME0 Segments

--- a/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
+++ b/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
@@ -20,7 +20,6 @@
 #include <stdio.h>
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
@@ -60,6 +59,8 @@ Double_t linearF(Double_t* x, Double_t* par) {
 
 // Constructor
 RPCRecHitReader::RPCRecHitReader(const edm::ParameterSet& pset) : _phi(0) {
+  rpcGeomToken_ = esConsumes();
+  rpcGeomBRToken_ = esConsumes<edm::Transition::BeginRun>();
   // Get the various input parameters
   fOutputFileName = pset.getUntrackedParameter<std::string>("HistOutFile");
   recHitLabel1 = pset.getUntrackedParameter<std::string>("recHitLabel1");
@@ -90,8 +91,7 @@ RPCRecHitReader::RPCRecHitReader(const edm::ParameterSet& pset) : _phi(0) {
 }
 
 void RPCRecHitReader::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeo);
+  edm::ESHandle<RPCGeometry> rpcGeo = iSetup.getHandle(rpcGeomBRToken_);
 
   RPCDetId id(region, wheel, station, sector, layer, subsector, 3);
   const RPCRoll* roll = dynamic_cast<const RPCRoll*>(rpcGeo->roll(id));
@@ -174,8 +174,7 @@ void RPCRecHitReader::analyze(const edm::Event& event, const edm::EventSetup& ev
     std::cout << " Event analysed #Run: " << event.id().run() << " #Event: " << event.id().event() << std::endl;
 
   // Get the RPC Geometry :
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  eventSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  edm::ESHandle<RPCGeometry> rpcGeom = eventSetup.getHandle(rpcGeomToken_);
 
   // Get the RecHits collection :
   edm::Handle<RPCRecHitCollection> recHits;

--- a/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.h
+++ b/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.h
@@ -7,7 +7,7 @@
  *  From D. Fortin  - UC Riverside
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,26 +35,31 @@ class TH1F;
 class TH2F;
 
 class RPCRecHit;
+class RPCGeometry;
+class MuonGeometryRecord;
 
-class RPCRecHitReader : public edm::EDAnalyzer {
+class RPCRecHitReader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   RPCRecHitReader(const edm::ParameterSet& pset);
 
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endJob();
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
+  void endJob() override;
 
   /// Destructor
-  virtual ~RPCRecHitReader();
+  ~RPCRecHitReader() override;
 
   // Operations
 
   /// Perform the real analysis
-  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   unsigned int layerRecHit(RPCRecHit);
 
 private:
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomBRToken_;
   std::string fOutputFileName;
   std::string recHitLabel1;
   std::string recHitLabel2;


### PR DESCRIPTION
#### PR description:

- converted modules to edm::one::EDAnalyzer
- added esConsumes calls

#### PR validation:

Packages compiles without issuing CMS deprecation warnings.