### PR TITLE
Deal with late parents in HydjetHadronizer

### DIFF
--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -368,14 +368,18 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
                              << std::endl;
 
     if (hyjets.khj[2][ihy] == 0) {
-      primary_particle[ihy] = build_hyjet(ihy, ihy + 1);
+      if (primary_particle[ihy] == nullptr) {
+        primary_particle[ihy] = build_hyjet(ihy, ihy + 1);
+      }
       if (!sub_vertices)
         LogError("Hydjet_array") << "##### HYDJET2: Vertex not initialized!";
       else
         sub_vertices->add_particle_out(primary_particle[ihy]);
       LogDebug("Hydjet_array") << " ---> " << ihy + 1 << std::endl;
     } else {
-      particle[ihy] = build_hyjet(ihy, ihy + 1);
+      if (particle[ihy] == nullptr) {
+        particle[ihy] = build_hyjet(ihy, ihy + 1);
+      }
       int mid = hyjets.khj[2][ihy] - hjoffset + index[isub];
       int mid_t = mid;
       while (((mid + 1) < ihy) && (std::abs(hyjets.khj[1][mid]) < 100) &&
@@ -389,6 +393,16 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
 
       if (!mother) {
         mother = particle[mid];
+        if (!mother) {
+          if (mid > ihy) {
+            mother = build_hyjet(mid, mid + 1);
+            if (hyjets.khj[2][mid] != 0) {
+              particle[mid] = mother;
+            }
+          } else {
+            assert(false);
+          }
+        }
         primary_particle[mid] = mother;
       }
 


### PR DESCRIPTION
#### PR description:

There were cases where parent particles were later in the list than their children. This lead to segmentation faults. This change creates those parents when needed and avoids causing them to be created later.

#### PR validation:

I was able to catch the segmentation fault in the debugger and found that the ID for the parent was larger than the child. This meant the parent had not yet been made which lead to the crash. After making this change, I ran the job 4 times and saw no further crashes. Previously the same job would crash > 50% of the time.

