### PR TITLE
PPS pixel improvement of error debugging

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -506,7 +506,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
   int lumiId = event.getLuminosityBlock().id().luminosityBlock();
   if (lumiId < 0)
     lumiId = 0;
-  verbosity = 3;
+
   int RPactivity[RPotsTotalNumber], RPdigiSize[RPotsTotalNumber];
   int pixRPTracks[RPotsTotalNumber];
 
@@ -701,9 +701,11 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
       int idet = getDet(ds_error.id);
       if (idet != DetId::VeryForward) {
 	if(idet == 15){ //dummy det id: store in a plot with fed info
+	  
 	  for (DetSet<CTPPSPixelDataError>::const_iterator dit = ds_error.begin(); dit != ds_error.end(); ++dit) {
 	    h2ErrorCode->Fill(dit->errorType(), dit->fedId());
 	  }
+	  continue;
 	}
         if (verbosity > 1)
           LogPrint("CTPPSPixelDQMSource") << "not CTPPS: ds_error.id" << ds_error.id;

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigis", ""),
+    tagRPixError = cms.untracked.InputTag("ctppsPixelDigis", ""),
     tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
@@ -16,6 +17,7 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
 
 ctppsPixelDQMOfflineSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigis", ""),
+    tagRPixError = cms.untracked.InputTag("ctppsPixelDigis", ""),
     tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout: 220_fr_hr; 210_fr_hr

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -189,7 +189,7 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical dcol and/or pxid "
-          << "fedId=" << fedId << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid << " detId=" << iD;
+          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid << " detId=" << iD;
 
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
@@ -198,7 +198,7 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical col and/or row "
-          << "fedId=" << fedId << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
+          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -145,17 +145,19 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (mit == m_Mapping.end()) {
       if (nlink >= maxLinkIndex) {
         m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
-	edm::LogError("CTPPSPixelDataFormatter") << " Invalid linkId ";
+        edm::LogError("CTPPSPixelDataFormatter") << " Invalid linkId ";
       } else if ((nroc - 1) >= maxRocIndex) {
-// if RocId wrong try to recover at least plane id 
-	CTPPSPixelFramePosition fPosDummyROC(fedId, FMC, nlink, 0);
-	mit = m_Mapping.find(fPosDummyROC);
-	if(mit != m_Mapping.end()) iD = (*mit).second.iD;
+        // if RocId wrong try to recover at least plane id
+        CTPPSPixelFramePosition fPosDummyROC(fedId, FMC, nlink, 0);
+        mit = m_Mapping.find(fPosDummyROC);
+        if (mit != m_Mapping.end())
+          iD = (*mit).second.iD;
         m_ErrorCheck.conversionError(fedId, iD, InvalidROCId, ww, errors);
-	edm::LogError("CTPPSPixelDataFormatter") << " Invalid ROC Id " << convroc << " in nlink "<< nlink << " of FED " << fedId << " in DetId " << iD;
+        edm::LogError("CTPPSPixelDataFormatter")
+            << " Invalid ROC Id " << convroc << " in nlink " << nlink << " of FED " << fedId << " in DetId " << iD;
       } else {
         m_ErrorCheck.conversionError(fedId, iD, Unknown, ww, errors);
-	edm::LogError("CTPPSPixelDataFormatter") << " Error unknown ";
+        edm::LogError("CTPPSPixelDataFormatter") << " Error unknown ";
       }
       continue;  //skip word
     }
@@ -189,16 +191,17 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical dcol and/or pxid "
-          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid << " detId=" << iD;
+          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " dcol=" << dcol
+          << " pxid=" << pxid << " detId=" << iD;
 
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;
     }
     if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW)) {
-      edm::LogError("CTPPSPixelDataFormatter")
-          << " unphysical col and/or row "
-          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
+      edm::LogError("CTPPSPixelDataFormatter") << " unphysical col and/or row "
+                                               << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc
+                                               << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -145,10 +145,17 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (mit == m_Mapping.end()) {
       if (nlink >= maxLinkIndex) {
         m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
+	edm::LogError("CTPPSPixelDataFormatter") << " Invalid linkId ";
       } else if ((nroc - 1) >= maxRocIndex) {
+// if RocId wrong try to recover at least plane id 
+	CTPPSPixelFramePosition fPosDummyROC(fedId, FMC, nlink, 0);
+	mit = m_Mapping.find(fPosDummyROC);
+	if(mit != m_Mapping.end()) iD = (*mit).second.iD;
         m_ErrorCheck.conversionError(fedId, iD, InvalidROCId, ww, errors);
+	edm::LogError("CTPPSPixelDataFormatter") << " Invalid ROC Id " << convroc << " in nlink "<< nlink << " of FED " << fedId << " in DetId " << iD;
       } else {
         m_ErrorCheck.conversionError(fedId, iD, Unknown, ww, errors);
+	edm::LogError("CTPPSPixelDataFormatter") << " Error unknown ";
       }
       continue;  //skip word
     }
@@ -182,7 +189,7 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical dcol and/or pxid "
-          << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
+          << "fedId=" << fedId << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid << " detId=" << iD;
 
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
@@ -191,8 +198,7 @@ void CTPPSPixelDataFormatter::interpretRawData(
     if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW)) {
       edm::LogError("CTPPSPixelDataFormatter")
           << " unphysical col and/or row "
-          << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " col=" << col << " row=" << row;
-
+          << "fedId=" << fedId << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;


### PR DESCRIPTION
#### PR description:

This PR is intended to improve the information used for error debugging of PPS pixel detector.
Two DQM plots are added to show the error reported during the data unpacking process.
A slight change in the data unpacker is implemented as well to send out more information in case of errors. 

#### PR validation:

Private validation on Run3 data

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport foreseen.

@grzanka 
