### PR TITLE
Add Eta cut to HLT Egamma objects  - BackportFrom126X to 125X

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTEgammaEtFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaEtFilter.cc
@@ -22,6 +22,8 @@ HLTEgammaEtFilter::HLTEgammaEtFilter(const edm::ParameterSet& iConfig) : HLTFilt
   inputTag_ = iConfig.getParameter<edm::InputTag>("inputTag");
   etcutEB_ = iConfig.getParameter<double>("etcutEB");
   etcutEE_ = iConfig.getParameter<double>("etcutEE");
+  minEtaCut_ = iConfig.getParameter<double>("minEtaCut");
+  maxEtaCut_ = iConfig.getParameter<double>("maxEtaCut");
   ncandcut_ = iConfig.getParameter<int>("ncandcut");
   l1EGTag_ = iConfig.getParameter<edm::InputTag>("l1EGCand");
   inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
@@ -34,6 +36,8 @@ void HLTEgammaEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltL1IsoRecoEcalCandidate"));
   desc.add<double>("etcutEB", 1.0);
   desc.add<double>("etcutEE", 1.0);
+  desc.add<double>("minEtaCut", -9999.0);
+  desc.add<double>("maxEtaCut", 9999.0);
   desc.add<int>("ncandcut", 1);
   descriptions.add("hltEgammaEtFilter", desc);
 }
@@ -71,6 +75,9 @@ bool HLTEgammaEtFilter::hltFilter(edm::Event& iEvent,
 
   for (auto& recoecalcand : recoecalcands) {
     ref = recoecalcand;
+
+    if ((ref->eta() < minEtaCut_) or (ref->eta() > maxEtaCut_))
+      continue;
 
     if ((fabs(ref->eta()) < 1.479 && ref->et() >= etcutEB_) || (fabs(ref->eta()) >= 1.479 && ref->et() >= etcutEE_)) {
       n++;

--- a/HLTrigger/Egamma/plugins/HLTEgammaEtFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTEgammaEtFilter.h
@@ -31,9 +31,11 @@ public:
 private:
   edm::InputTag inputTag_;  // input tag identifying product contains egammas
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
-  double etcutEB_;  // Barrel Et threshold in GeV
-  double etcutEE_;  // Endcap Et threshold in GeV
-  int ncandcut_;    // number of egammas required
+  double etcutEB_;    // Barrel Et threshold in GeV
+  double etcutEE_;    // Endcap Et threshold in GeV
+  double minEtaCut_;  // Min pseudorapidity cut
+  double maxEtaCut_;  // Max pseudorapidity cut
+  int ncandcut_;      // number of egammas required
 
   edm::InputTag l1EGTag_;
 };


### PR DESCRIPTION
#### PR description:

 - Added a module to do eta filtering of HLT Egamma objects
 - Necessary for an eta cut on objects in the trigger HLT_DiPhoton10Time1p2ns_v

#### PR validation:

 - Checked the functionality of the filter module and verified that the eta cuts function as intended. A basic plot is shown below.
 - The red histogram is after the eta cut while the blue histogram is before cut. An |eta|<2.15 has been applied as can be observed by comparing the plots. 
 - Code checks and code format performed
 - Based on advice from @Martin-Grunewald on a similar PR at https://github.com/cms-sw/cmssw/pull/39764, it was decided to change the `HLTEgammaEtFilter` class in place of adding a new class. 

#### PR backport:

 - PR needs to be backported to CMSSW_12_4_X and 12_5_X.
 - Original PR: https://github.com/cms-sw/cmssw/pull/39789
 - The current software at HLT is in the 12_4_X release. Hence the need for backporting to all releases through 12_5_X to 12_4_X.
 
![Screenshot from 2022-10-19 09-12-41](https://user-images.githubusercontent.com/32368439/196621814-b7d632e2-7a4e-4cf4-a920-67620937927e.png)