### PR TITLE
fix Run-3 data input for tests on HIon HLT menu

### DIFF
--- a/HLTrigger/Configuration/test/cmsDriver.csh
+++ b/HLTrigger/Configuration/test/cmsDriver.csh
@@ -45,7 +45,7 @@ set InputLHCRawGRun3 = root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/co
 set InputLHCRawHIon1 = root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW-RECO/HIRun2015_HIHardProbes_run263689/HighPtJet-PromptReco-v1/1802CD9A-DDB8-E511-9CF9-02163E0138CA.root
 # DAS name: /store/hidata/HIRun2018A/HIHardProbes/RAW/v1/000/326/479/00000/853DBE29-53BA-9A44-9FDD-58E4E9064EB1.root
 set InputLHCRawHIon2 = root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/HIRun2018A_HIHardProbes_run326479/0E2CC5D5-9D87-7348-9219-B00CD718C847.root
-set InputLHCRawHIon3 = $InputLHCRawGRun2 #!! UPDATE once 2022 HIon RAW data is available
+set InputLHCRawHIon3 = $InputLHCRawGRun3 #!! UPDATE once 2022 HIon RAW data is available
 set InputLHCRawPIon2 = $InputLHCRawGRun2
 set InputLHCRawPRef2 = $InputLHCRawGRun2
 set InputLHCRawPIon3 = $InputLHCRawGRun3


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced in #39770, where the input EDM file used to test the HLT HIon menu with Run-3 data was unintentionally changed. The issue was spotted by @Martin-Grunewald .

This fix is needed for the HLT-Validation tests that run in IBs. It will be backported as part of #39772 and #39773.

PRs tests are not sensitive to this change.

#### PR validation:

TSG tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_12_4_X`
`CMSSW_12_5_X`