### PR TITLE
Fix CMS deprecation warning in  L1Trigger subsystem

### DIFF
--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrack.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrack.h
@@ -32,8 +32,6 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/Framework/interface/EventSetup.h>
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackAssParam.h"
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTAddressArray.h"
 #include "L1Trigger/DTTrackFinder/interface/L1MuDTTrackSegPhi.h"
@@ -162,9 +160,6 @@ public:
 
   /// set eta track segments used to form the muon candidate
   void setTSeta(const std::vector<const L1MuDTTrackSegEta*>& tsList);
-
-  /// convert  pt value in GeV to pt code
-  unsigned int triggerScale(float value, const edm::EventSetup& c) const;
 
   /// assignment operator
   L1MuDTTrack& operator=(const L1MuDTTrack&);

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrack.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrack.cc
@@ -166,19 +166,6 @@ void L1MuDTTrack::setTSeta(const vector<const L1MuDTTrackSegEta*>& tsList) {
 }
 
 //
-// convert pt value in GeV to pt code
-//
-unsigned int L1MuDTTrack::triggerScale(float value, const edm::EventSetup& c) const {
-  const float eps = 1.e-5;  // add an epsilon so that setting works with low edge value
-
-  edm::ESHandle<L1MuTriggerPtScale> theTriggerScales;
-  c.get<L1MuTriggerPtScaleRcd>().get(theTriggerScales);
-  unsigned int t_Scale = theTriggerScales->getPtScale()->getPacked(value + eps);
-
-  return t_Scale;
-}
-
-//
 // Assignment operator
 //
 L1MuDTTrack& L1MuDTTrack::operator=(const L1MuDTTrack& track) {

--- a/L1Trigger/DTTrigger/interface/DTTrigTest.h
+++ b/L1Trigger/DTTrigger/interface/DTTrigTest.h
@@ -17,7 +17,7 @@
 #define L1Trigger_DTTrigger_DTTrigTest_h
 
 // Framework related headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,7 +29,7 @@
 #include "TTree.h"
 #include "TFile.h"
 
-class DTTrigTest : public edm::EDAnalyzer {
+class DTTrigTest : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   //! Constructor
   DTTrigTest(const edm::ParameterSet& pset);
@@ -46,6 +46,7 @@ public:
 
   //! Create DTTrig instance and TUs
   void beginRun(const edm::Run& iRun, const edm::EventSetup& iEventSetup) override;
+  void endRun(const edm::Run& iRun, const edm::EventSetup& iEventSetup) override {}
 
   //! Analyze function executed on all the events
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iEventSetup) override;

--- a/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.h
+++ b/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.h
@@ -20,11 +20,11 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class CompareToObjectMapRecord : public edm::EDAnalyzer {
+class CompareToObjectMapRecord : public edm::one::EDAnalyzer<> {
 public:
   explicit CompareToObjectMapRecord(const edm::ParameterSet &pset);
   ~CompareToObjectMapRecord() override;

--- a/L1Trigger/L1GctAnalyzer/interface/DumpGctDigis.h
+++ b/L1Trigger/L1GctAnalyzer/interface/DumpGctDigis.h
@@ -17,7 +17,7 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -31,7 +31,7 @@
 // class decleration
 //
 
-class DumpGctDigis : public edm::EDAnalyzer {
+class DumpGctDigis : public edm::one::EDAnalyzer<> {
 public:
   explicit DumpGctDigis(const edm::ParameterSet&);
   ~DumpGctDigis() override;

--- a/L1Trigger/L1GctAnalyzer/interface/GctFibreAnalyzer.h
+++ b/L1Trigger/L1GctAnalyzer/interface/GctFibreAnalyzer.h
@@ -19,7 +19,7 @@ Description: Analyzer individual fibre channels from the source card.
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -29,7 +29,7 @@ Description: Analyzer individual fibre channels from the source card.
 // Gct fibre data format
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctFibreWord.h"
 
-class GctFibreAnalyzer : public edm::EDAnalyzer {
+class GctFibreAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit GctFibreAnalyzer(const edm::ParameterSet&);
   ~GctFibreAnalyzer() override;

--- a/L1Trigger/L1GctAnalyzer/interface/GctTimingAnalyzer.h
+++ b/L1Trigger/L1GctAnalyzer/interface/GctTimingAnalyzer.h
@@ -19,7 +19,7 @@ Description: Analyse the timing of all of the GCT pipelines
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,7 +33,7 @@ Description: Analyse the timing of all of the GCT pipelines
 #include <iostream>
 #include <fstream>
 
-class GctTimingAnalyzer : public edm::EDAnalyzer {
+class GctTimingAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit GctTimingAnalyzer(const edm::ParameterSet&);
   ~GctTimingAnalyzer() override;

--- a/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
+++ b/L1Trigger/L1GctAnalyzer/src/GctErrorAnalyzer.cc
@@ -21,7 +21,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -54,7 +54,7 @@ Implementation:
 // class declaration
 //
 
-class GctErrorAnalyzer : public edm::EDAnalyzer {
+class GctErrorAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   GctErrorAnalyzer() = delete;
   GctErrorAnalyzer(const GctErrorAnalyzer &) = delete;
@@ -330,6 +330,7 @@ GctErrorAnalyzer::GctErrorAnalyzer(const edm::ParameterSet &iConfig)
       useSys_(iConfig.getUntrackedParameter<std::string>("useSys", "P5")) {
   //now do what ever initialization is needed
   //make the root file
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
 
   //to try to make this look more elegant

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsWriter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloParamsWriter.cc
@@ -1,6 +1,6 @@
 // L1TCaloParamsWriter
 //
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class L1TCaloParamsWriter : public edm::EDAnalyzer {
+class L1TCaloParamsWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit L1TCaloParamsWriter(const edm::ParameterSet&) {}
   ~L1TCaloParamsWriter() override {}

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiReader.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiReader.cc
@@ -4,7 +4,7 @@
  *  \authors: Vadim Khotilovich
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-class GEMPadDigiReader : public edm::EDAnalyzer {
+class GEMPadDigiReader : public edm::one::EDAnalyzer<> {
 public:
   explicit GEMPadDigiReader(const edm::ParameterSet& pset);
 

--- a/L1Trigger/L1TMuonEndCap/test/tools/ComparePtLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/ComparePtLUT.cc
@@ -6,7 +6,7 @@
 #include "TFile.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,10 +16,10 @@
 #include "helper.h"
 #include "progress_bar.h"
 
-class ComparePtLUT : public edm::EDAnalyzer {
+class ComparePtLUT : public edm::one::EDAnalyzer<> {
 public:
   explicit ComparePtLUT(const edm::ParameterSet&);
-  virtual ~ComparePtLUT();
+  ~ComparePtLUT() override;
 
 private:
   //virtual void beginJob();
@@ -28,7 +28,7 @@ private:
   //virtual void beginRun(const edm::Run&, const edm::EventSetup&);
   //virtual void endRun(const edm::Run&, const edm::EventSetup&);
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   void compareLUTs();
 

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
@@ -14,7 +14,7 @@
 #include "TTree.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,19 +42,19 @@ typedef L1TMuon::TriggerPrimitiveCollection TriggerPrimitiveCollection;
 
 #include "helper.h"
 
-class MakeAngleLUT : public edm::EDAnalyzer {
+class MakeAngleLUT : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit MakeAngleLUT(const edm::ParameterSet&);
-  virtual ~MakeAngleLUT();
+  ~MakeAngleLUT() override;
 
 private:
   //virtual void beginJob();
   //virtual void endJob();
 
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   void generateLUTs();
 

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeCoordLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeCoordLUT.cc
@@ -8,7 +8,7 @@
 #include "TTree.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,19 +29,19 @@
 
 #include "helper.h"
 
-class MakeCoordLUT : public edm::EDAnalyzer {
+class MakeCoordLUT : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit MakeCoordLUT(const edm::ParameterSet&);
-  virtual ~MakeCoordLUT();
+  ~MakeCoordLUT() override;
 
 private:
   //virtual void beginJob();
   //virtual void endJob();
 
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   // Generate LUTs
   void generateLUTs();
@@ -101,6 +101,7 @@ private:
   bool done_;
 
   /// Event setup
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> theCSCGeometryToken_;
   const CSCGeometry* theCSCGeometry_;
 
   /// Constants
@@ -144,7 +145,8 @@ MakeCoordLUT::MakeCoordLUT(const edm::ParameterSet& iConfig)
       outdir_(iConfig.getParameter<std::string>("outdir")),
       please_validate_(iConfig.getParameter<bool>("please_validate")),
       verbose_sector_(2),
-      done_(false) {
+      done_(false),
+      theCSCGeometryToken_(esConsumes()) {
   // Zero multi-dimensional arrays
   memset(ph_init, 0, sizeof(ph_init));
   memset(ph_init_full, 0, sizeof(ph_init_full));
@@ -170,8 +172,7 @@ MakeCoordLUT::~MakeCoordLUT() {}
 
 void MakeCoordLUT::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   /// Geometry setup
-  edm::ESHandle<CSCGeometry> cscGeometryHandle;
-  iSetup.get<MuonGeometryRecord>().get(cscGeometryHandle);
+  edm::ESHandle<CSCGeometry> cscGeometryHandle = iSetup.getHandle(theCSCGeometryToken_);
   if (!cscGeometryHandle.isValid()) {
     std::cout << "ERROR: Unable to get MuonGeometryRecord!" << std::endl;
   } else {

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakePtLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakePtLUT.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,10 +15,10 @@
 #include "helper.h"
 #include "progress_bar.h"
 
-class MakePtLUT : public edm::EDAnalyzer {
+class MakePtLUT : public edm::one::EDAnalyzer<> {
 public:
   explicit MakePtLUT(const edm::ParameterSet&);
-  virtual ~MakePtLUT();
+  ~MakePtLUT() override;
 
 private:
   //virtual void beginJob();
@@ -27,7 +27,7 @@ private:
   //virtual void beginRun(const edm::Run&, const edm::EventSetup&);
   //virtual void endRun(const edm::Run&, const edm::EventSetup&);
 
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   void makeLUT();
 


### PR DESCRIPTION
#### PR description:

- converted modules on one::EDAnalyzer
- added esConsumes as needed

#### PR validation:

Code compiles without generating a CMS deprecation warning.