### PR TITLE
Migration ::JetCorrector to reco::JetCorrector, trivial cases

### DIFF
--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -52,9 +52,6 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-// JetCorrection
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 // ROOT
 #include "TLorentzVector.h"
 
@@ -248,8 +245,6 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
 
     // Jet Correction
     int countJet = 0;
-    // const JetCorrector* pfcorrector =
-    // JetCorrector::getJetCorrector(PFJetCorService_,iSetup);
 
     for (edm::View<reco::Jet>::const_iterator jet = pfjets.begin(), jetEnd = pfjets.end(); jet != jetEnd; ++jet) {
       if (jet->pt() < jetPtMins_[icoll])

--- a/DQM/Physics/src/FSQDQM.cc
+++ b/DQM/Physics/src/FSQDQM.cc
@@ -51,9 +51,6 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-// JetCorrection
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 // Substructure
 #include "RecoJets/JetAlgorithms/interface/CATopJetHelper.h"
 #include "DataFormats/BTauReco/interface/CATopJetTagInfo.h"

--- a/DQM/Physics/src/SMPDQM.h
+++ b/DQM/Physics/src/SMPDQM.h
@@ -47,7 +47,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "TLorentzVector.h"

--- a/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons.h
@@ -53,7 +53,6 @@
 // include the centrality variables
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "RecoJets/JetProducers/interface/JetIDHelper.h"
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons_matching.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer_HeavyIons_matching.h
@@ -54,7 +54,6 @@
 // include the centrality variables
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "RecoJets/JetProducers/interface/JetIDHelper.h"
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"

--- a/DQMOffline/Trigger/plugins/HLTInclusiveVBFSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTInclusiveVBFSource.cc
@@ -26,8 +26,6 @@
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 #include <cmath>
 #include "TH1F.h"
 #include "TProfile.h"

--- a/RecoJets/JetAnalyzers/src/myFastSimVal.cc
+++ b/RecoJets/JetAnalyzers/src/myFastSimVal.cc
@@ -15,7 +15,6 @@
 // #include "FWCore/Framework/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TFile.h>
@@ -702,9 +701,6 @@ void myFastSimVal::analyze(const Event& evt, const EventSetup& es) {
   EtaOk10 = 0;
   EtaOk13 = 0;
   EtaOk40 = 0;
-
-  //  const JetCorrector* corrector =
-  //    JetCorrector::getJetCorrector (JetCorrectionService, es);
 
   double highestPt;
   double nextPt;

--- a/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
+++ b/RecoMET/METFilters/plugins/EcalDeadCellDeltaRFilter.cc
@@ -62,7 +62,6 @@
 
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
 #include "DataFormats/METReco/interface/PFMETCollection.h"

--- a/Validation/RecoJets/plugins/JetTester_HeavyIons.h
+++ b/Validation/RecoJets/plugins/JetTester_HeavyIons.h
@@ -60,7 +60,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "RecoJets/JetProducers/interface/JetMatchingTools.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"


### PR DESCRIPTION
#### PR description:

These are the trivial cases where the header is included but JetCorrector is not used or the code using it is commented out. Only delete header includes and comments.

This is part of an effort to finish the migration from ::JetCorrector to reco::JetCorrector that started in 2014, ::JetCorrector has been deprecated since then.

#### PR validation:

These changes are trivial enough that if it compiles it should validate it.
