### PR TITLE
duplicated hcalDepthTowerSumEt in GsfElectron.h

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -560,7 +560,7 @@ namespace reco {
     float hcalTowerSumEt(const IsolationVariables &iv, int depth) const {
       if (iv.pre7DepthHcal) {
         if (depth == 0)
-          return iv.hcalDepth1TowerSumEt + iv.hcalDepth1TowerSumEt;
+          return iv.hcalDepth1TowerSumEt + iv.hcalDepth2TowerSumEt;
         else if (depth == 1)
           return iv.hcalDepth1TowerSumEt;
         else if (depth == 2)
@@ -577,7 +577,7 @@ namespace reco {
     float hcalTowerSumEtBc(const IsolationVariables &iv, int depth) const {
       if (iv.pre7DepthHcal) {
         if (depth == 0)
-          return iv.hcalDepth1TowerSumEtBc + iv.hcalDepth1TowerSumEtBc;
+          return iv.hcalDepth1TowerSumEtBc + iv.hcalDepth2TowerSumEtBc;
         else if (depth == 1)
           return iv.hcalDepth1TowerSumEtBc;
         else if (depth == 2)


### PR DESCRIPTION
#### PR description:
There was a typo due to which the same variable (hcalDepth1TowerSumEt) was added to itself instead of with hcalDepth2TowerSumEt. 

#### PR validation:
The change is just in one line of the header file (GsfElectron.h) which was pointed (and possibly validated) in the following thread:
https://cms-talk.web.cern.ch/t/duplicated-codes-in-gsfelectron-h/16202

@swagata87, please let me know in case further checks are to be performed. 
