### PR TITLE
PPS pixel: fixing sim unitid

### DIFF
--- a/SimG4CMS/PPS/src/PPSPixelOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSPixelOrganization.cc
@@ -28,7 +28,7 @@ PPSPixelOrganization ::PPSPixelOrganization()
 
 uint32_t PPSPixelOrganization ::unitID(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  G4VPhysicalVolume* physVol = touch->GetVolume(0);
+  G4VPhysicalVolume* physVol = touch->GetVolume(1);
   int coNum = physVol->GetCopyNo();
   edm::LogVerbatim("PPSPixelSim") << "PPSPixelSim: PhysVol= " << physVol->GetName() << " coNum=" << coNum;
   currentPlane_ = coNum - 1;


### PR DESCRIPTION
#### PR description:
This PR fixes a bug in the determination of the UnitId assigned to the sensitive detectors of PPS pixel planes.

#### PR validation:
The bug prevented the creation of hits in PPS pixel planes but the first. With the bug fix the simHits are present in all the planes. Tests done with particle guns.

