### PR TITLE
Mask old b-taggers and keep only DNN taggers with Era modifier for run3.

### DIFF
--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -92,7 +92,30 @@ btagging = cms.Sequence(btaggingTask)
 
 ## modifying b-tagging task in Run3 adding ParticleNet inferece
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-_pfBTaggingTask_particleNet = pfBTaggingTask.copy()
-_pfBTaggingTask_particleNet.add( pfParticleNetAK4TaskForRECO, pfParticleNetTask )
-run3_common.toReplaceWith( pfBTaggingTask, _pfBTaggingTask_particleNet)
+_pfBTaggingTask_run3 = cms.Task(
+    # Keep all the infos and DeepCSV
+    pfImpactParameterTagInfos,
+    pfTrackCountingHighEffBJetTags,
+    pfJetProbabilityBJetTags,
+    pfJetBProbabilityBJetTags,
+
+    pfSecondaryVertexTagInfos,
+    inclusiveCandidateVertexingTask,
+    pfInclusiveSecondaryVertexFinderTagInfos,
+    pfGhostTrackVertexTagInfos,
+    pfDeepCSVTask,
+
+    softPFMuonsTagInfos,
+    softPFElectronsTagInfos,
+    pixelClusterTagInfos,
+
+    pfParticleNetAK4TaskForRECO,
+    pfParticleNetTask
+)
+_pfCTaggingTask_run3 = cms.Task(
+    inclusiveCandidateVertexingCvsLTask,
+    pfInclusiveSecondaryVertexFinderCvsLTagInfos,
+)
+run3_common.toReplaceWith( pfBTaggingTask, _pfBTaggingTask_run3 )
+run3_common.toReplaceWith( pfCTaggingTask, _pfCTaggingTask_run3 )
 


### PR DESCRIPTION
#### PR description:

Regarding the AlCa issue #58 (https://github.com/cms-AlCaDB/AlCaTools/issues/58),  old b-tagging GT records are request to be removed (starting) from 12_1_X (and so on). Due to the dependency on "BTauGenericMVAJetTagComputerRcd" and "JetTagComputerRecord", the corresponding b-tagging computers need to be masked in run3. As DNN taggers will be the only supported ones in run3, this PR masks the old taggers with Era modifier and keeps only DNN taggers like DeepCSV and particleNet. (track counting and jet probability are kept for reference as requested)

#### PR validation:

PR tested in local with runTheMatrix.py processes. However, the standard run 2 validation sequences will fail due to missing b-tagger objects.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
This PR is for run 3. Not a backport and no backport planed.
