### PR TITLE
Switch to TICLv4 for offline HGCAL electrons and photons

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -50,10 +50,10 @@ _hgcalTracksterMapper_HGCal = cms.PSet(
     ),
     tracksterSrc = cms.InputTag("ticlTrackstersMerge"),
     clusterSrc = cms.InputTag("hgcalLayerClusters"),
-    filterByTracksterPID = cms.bool(False),
+    filterByTracksterPID = cms.bool(True),
     pid_threshold = cms.double(0.8),
     filter_on_categories = cms.vint32([0, 1]),
-    filterByTracksterIteration = cms.bool(True),
+    filterByTracksterIteration = cms.bool(False),
     filter_on_iterations = cms.vint32([0, 1]),
 )
 


### PR DESCRIPTION
#### PR description:

This PR switches to TICLv4 for offline HGCAL electrons and photons.

The following plots were obtained using these samples:
- `SingleElectron_Pt-2To200-gun/PhaseIISpring22DRMiniAOD-PU200_123X_mcRun4_realistic_v11-v1/GEN-SIM-DIGI-RAW-MINIAOD`
- `SinglePhoton_Pt-2To200-gun/PhaseIISpring22DRMiniAOD-PU200_123X_mcRun4_realistic_v11-v1/GEN-SIM-DIGI-RAW-MINIAOD`

Expected consequences:
* The electron reco efficiency should increase:
  <img src="https://user-images.githubusercontent.com/15279834/197150848-97b28949-a464-461b-8f18-f73c9ac3af78.png" width="300"> <img src="https://user-images.githubusercontent.com/15279834/197149586-a9b8bc58-39f3-4245-9d76-bf04bda7db90.png" width="300">

* The photon reco efficiency should increase:
  <img src="https://user-images.githubusercontent.com/15279834/197149626-c4bd2a76-e650-4798-81d9-c3fd6cb6c0da.png" width="300"> <img src="https://user-images.githubusercontent.com/15279834/197150486-e4677943-6a9e-4e71-a01e-e076eeb9939b.png" width="300">

* The electron mis-reco (i.e. reco electrons not $\Delta R$ matched to any gen-electron) efficiency should not change much:
  <img src="https://user-images.githubusercontent.com/15279834/197152247-819545ef-58a7-4b47-842f-598de677d23a.png" width="300">

* The photon mis-reco (i.e. reco-photons not $\Delta R$ matched to any gen-photons) efficiency should not change much:
  <img src="https://user-images.githubusercontent.com/15279834/197152703-3ee973c1-f9c4-4fdd-b2f4-fbb4d99a522d.png" width="300">

* The electron and photon energy responses (recoE/genE) should remain fairly the same.


@swagata87 @rovere @felicepantaleo