### PR TITLE
Fixing bug in HLTriggerJSONMonitoring L1 and prescale module idenfication : 12_5_X

### DIFF
--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -232,12 +232,15 @@ std::shared_ptr<HLTriggerJSONMonitoringData::run> HLTriggerJSONMonitoring::globa
     for (auto i = 0u; i < triggersSize; ++i) {
       rundata->posL1s[i] = -1;
       rundata->posPre[i] = -1;
-      auto const& moduleLabels = rundata->hltConfig.moduleLabels(i);
+      auto const trigNameIndx = rundata->indicesOfTriggerPaths[i];
+      auto const& moduleLabels = rundata->hltConfig.moduleLabels(trigNameIndx);
       for (auto j = 0u; j < moduleLabels.size(); ++j) {
-        auto const& label = rundata->hltConfig.moduleType(moduleLabels[j]);
-        if (label == "HLTL1TSeed")
+        auto const& moduleLabel = moduleLabels[j];
+        auto const& moduleType = rundata->hltConfig.moduleType(moduleLabel);
+        //the logic here is that it finds the first non ignored HLTL1TSeed module, ignored modules have - at the start of their name
+        if (rundata->posL1s[i] == -1 && moduleLabel.rfind('-', 0) != 0 && moduleType == "HLTL1TSeed") {
           rundata->posL1s[i] = j;
-        else if (label == "HLTPrescaler")
+        } else if (moduleType == "HLTPrescaler")
           rundata->posPre[i] = j;
       }
     }


### PR DESCRIPTION
#### PR description:

HLTriggerJSONMonitoring is how the HLT reports path rates to OMS. It was updated in Jun (https://github.com/cms-sw/cmssw/pull/38418) to better support DatasetPaths.

In doing so a bug was introduced in that if a path is after a dataset path, the wrong L1 and prescale module will be identified.

Additionally the logic was improved to only consider the first seed module and also to disregard ignored modules. This fixes problems in some paths which have additional L1 seed modules which are ignored as they want to use this data later in the path.

Credit goes to Adelina Lintuluoto (@alintulu) for spotting this issue in the hilton tests.

#### PR validation:

validation in : https://github.com/cms-sw/cmssw/pull/39779

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported 
backport of https://github.com/cms-sw/cmssw/pull/39779  as its needed to fix a bug in monitoring at P5


