### PR TITLE
Make `cms::alpakatools::host()` non-`static` [12.5.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/host.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/host.h
@@ -21,7 +21,7 @@ namespace cms::alpakatools {
   }  // namespace detail
 
   // returns the alpaka host device
-  static inline alpaka::DevCpu const& host() {
+  inline alpaka::DevCpu const& host() {
     static const auto host = detail::enumerate_host();
     return host;
   }


### PR DESCRIPTION
#### PR description:

Make `cms::alpakatools::host()` non-`static` to prevent generating multiple instances of the same function-`static` variables.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #39813 to 12.5.x to ease the Alpaka migration