### PR TITLE
Fix deprecation warnings in HLTrigger/HLTanalyzers

### DIFF
--- a/HLTrigger/HLTanalyzers/plugins/HLTBitAnalyzer.h
+++ b/HLTrigger/HLTanalyzers/plugins/HLTBitAnalyzer.h
@@ -6,7 +6,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -31,12 +31,13 @@
   * \author G. Karapostoli - ULB
   */
 
-class HLTBitAnalyzer : public edm::EDAnalyzer {
+class HLTBitAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit HLTBitAnalyzer(edm::ParameterSet const& conf);
   void analyze(edm::Event const& e, edm::EventSetup const& iSetup) override;
   void endJob() override;
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
 
   //  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 

--- a/HLTrigger/HLTanalyzers/plugins/HLTGetDigi.cc
+++ b/HLTrigger/HLTanalyzers/plugins/HLTGetDigi.cc
@@ -206,7 +206,7 @@ void HLTGetDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 //
 
 // ------------ method called to produce the data  ------------
-void HLTGetDigi::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void HLTGetDigi::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   //--- L1 GCT and GT Digis ---//

--- a/HLTrigger/HLTanalyzers/plugins/HLTGetDigi.h
+++ b/HLTrigger/HLTanalyzers/plugins/HLTGetDigi.h
@@ -13,7 +13,7 @@
  */
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -59,11 +59,11 @@
 // class declaration
 //
 
-class HLTGetDigi : public edm::EDAnalyzer {
+class HLTGetDigi : public edm::global::EDAnalyzer<> {
 public:
   explicit HLTGetDigi(const edm::ParameterSet&);
   ~HLTGetDigi() override;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:


### PR DESCRIPTION
#### PR description:

- changed modules to thread-friendly types.

#### PR validation:

package compiles without issuing a CMS deprecation warning.