### PR TITLE
[12_5_X] Update Run3 offline and offline_relval GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -41,10 +41,10 @@ autoCond = {
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-10-20 10:08:23 (UTC)
-    'run3_data'                    : '124X_dataRun3_v10',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-11-01 12:00:00 (UTC)
+    'run3_data'                    : '124X_dataRun3_v11',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '125X_dataRun3_relval_v3',
+    'run3_data_relval'             : '125X_dataRun3_relval_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -41,10 +41,10 @@ autoCond = {
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 23:00:00 (UTC)
-    'run3_data'                    : '124X_dataRun3_v9',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-10-20 10:08:23 (UTC)
+    'run3_data'                    : '124X_dataRun3_v10',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '125X_dataRun3_relval_v1',
+    'run3_data_relval'             : '125X_dataRun3_relval_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-10-20 10:08:23 (UTC)
     'run3_data'                    : '124X_dataRun3_v10',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '125X_dataRun3_relval_v2',
+    'run3_data_relval'             : '125X_dataRun3_relval_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
Backport of #39823

This PR updates the offline GT (`auto:run3_data`) with the latest conditions to be used for the 2022ABCD re-reco (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/call-for-update-of-conditions-in-offline-data-gt/13784/3)). The offline relval GT (`auto:run3_data_relval`) is updated as well to be even with the offline GT.

GT differences:
- **Run 3 data (offline)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v9/124X_dataRun3_v11

- **Run 3 data RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_relval_v1/125X_dataRun3_relval_v4

- Diff between new offline and new offline_relval GTs
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v11/125X_dataRun3_relval_v4

#### PR validation:
Successfully ran:
`runTheMatrix.py -l 139.001 --ibeos -j 4`
which consumes the relval GT.

#### Backport:
Backport of #39823