### PR TITLE
Mark alpaka trait constants as inline [12.5.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/traits.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/traits.h
@@ -32,37 +32,34 @@ namespace cms::alpakatools {
   // is_platform
 
   template <typename T>
-  struct is_platform
-      : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptPltf, T>::value> {};
+  using is_platform = alpaka::concepts::ImplementsConcept<alpaka::ConceptPltf, T>;
 
   template <typename T>
-  constexpr bool is_platform_v = is_platform<T>::value;
+  inline constexpr bool is_platform_v = is_platform<T>::value;
 
   // is_device
 
   template <typename T>
-  struct is_device : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptDev, T>::value> {};
+  using is_device = alpaka::concepts::ImplementsConcept<alpaka::ConceptDev, T>;
 
   template <typename T>
-  constexpr bool is_device_v = is_device<T>::value;
+  inline constexpr bool is_device_v = is_device<T>::value;
 
   // is_accelerator
 
   template <typename T>
-  struct is_accelerator
-      : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptAcc, T>::value> {};
+  using is_accelerator = alpaka::concepts::ImplementsConcept<alpaka::ConceptAcc, T>;
 
   template <typename T>
-  constexpr bool is_accelerator_v = is_accelerator<T>::value;
+  inline constexpr bool is_accelerator_v = is_accelerator<T>::value;
 
   // is_queue
 
   template <typename T>
-  struct is_queue : std::integral_constant<bool, alpaka::concepts::ImplementsConcept<alpaka::ConceptQueue, T>::value> {
-  };
+  using is_queue = alpaka::concepts::ImplementsConcept<alpaka::ConceptQueue, T>;
 
   template <typename T>
-  constexpr bool is_queue_v = is_queue<T>::value;
+  inline constexpr bool is_queue_v = is_queue<T>::value;
 
 }  // namespace cms::alpakatools
 


### PR DESCRIPTION
#### PR description:

Mark trait constants as inline, and simplify the definition of the trait types.

Fixes #39786.

#### PR validation:

GCC 11 now generates unique global symbols (`u`) instead of local data symbols (`b`) for the allocators:
```
/data/user/fwyzard/gcc11/CMSSW_12_6_0_pre3/src$ nm -C ../lib/el8_amd64_gcc11/libHeterogeneousCoreAlpakaServicesCudaAsync.so | egrep 'allocator$'
0000000000016400 u guard variable for cms::alpakatools::getHostCachingAllocator<alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt, false>, void>()::allocator
0000000000016420 u cms::alpakatools::getHostCachingAllocator<alpaka::uniform_cuda_hip::detail::QueueUniformCudaHipRt<alpaka::ApiCudaRt, false>, void>()::allocator
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #39826 to CMSSW_12_5_X to ease the migration to Alpaka.