### PR TITLE
[12.5.X] use ibeos protocol for DQM/Integration unit tests (online DQM unit tests)

### DIFF
--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -102,7 +102,7 @@ for ls in range(options.minLumi, options.maxLumi+1):
     secFiles.extend(sec)
 
     # Get last eventsPerLumi of events in this file
-    command = "edmFileUtil --catalog file:/cvmfs/cms-ib.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=xrootd --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0]
+    command = "edmFileUtil --catalog file:/cvmfs/cms-ib.cern.ch/SITECONF/local/PhEDEx/storage.xml?protocol=ibeos --events %s | tail -n +9 | head -n -5 | awk '{ print $3 }'" % read[0]
     print(command)
     events = subprocess.check_output(command, shell=True)
     events = events.split(b'\n')


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/39669#

#### PR description:

Title says it all, from suggestion at https://github.com/cms-sw/cmssw/issues/39669#issuecomment-1287484400

#### PR validation:

Run successfully `scram b runtests use-ibeos` with the fix

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to at least 12.4.X
