### PR TITLE
Run3-gex142A Use tokenss rather than labels in accessing collections in Alignment/CommonAlignmentMonitor

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -102,6 +102,7 @@ private:
   const edm::ESGetToken<AlignmentErrorsExtended, CSCAlignmentErrorExtendedRcd> esTokenCSCAPE_;
   const edm::ESGetToken<Alignments, GEMAlignmentRcd> esTokenGEMAl_;
   const edm::ESGetToken<AlignmentErrorsExtended, GEMAlignmentErrorExtendedRcd> esTokenGEMAPE_;
+  const edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackToken_;
   bool m_firstEvent;
 };
 
@@ -134,7 +135,8 @@ AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& 
       esTokenCSCAl_(esConsumes()),
       esTokenCSCAPE_(esConsumes()),
       esTokenGEMAl_(esConsumes()),
-      esTokenGEMAPE_(esConsumes()) {
+      esTokenGEMAPE_(esConsumes()),
+      trajTrackToken_(consumes<TrajTrackAssociationCollection>(m_tjTag)) {
   edm::ConsumesCollector consumeCollector = consumesCollector();
   std::vector<std::string> monitors = iConfig.getUntrackedParameter<std::vector<std::string>>("monitors");
 
@@ -213,8 +215,7 @@ void AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
   }
 
   // Retrieve trajectories and tracks from the event
-  edm::Handle<TrajTrackAssociationCollection> trajTracksMap;
-  iEvent.getByLabel(m_tjTag, trajTracksMap);
+  const edm::Handle<TrajTrackAssociationCollection>& trajTracksMap = iEvent.getHandle(trajTrackToken_);
 
   // Form pairs of trajectories and tracks
   ConstTrajTrackPairCollection trajTracks;

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
@@ -34,7 +34,7 @@
 class AlignmentMonitorMuonSystemMap1D : public AlignmentMonitorBase {
 public:
   AlignmentMonitorMuonSystemMap1D(const edm::ParameterSet &cfg, edm::ConsumesCollector iC);
-  ~AlignmentMonitorMuonSystemMap1D() override {}
+  ~AlignmentMonitorMuonSystemMap1D() override = default;
 
   void book() override;
 
@@ -54,23 +54,25 @@ private:
   const MuonResidualsFromTrack::BuilderToken m_esTokenBuilder;
 
   // parameters
-  edm::InputTag m_muonCollectionTag;
-  double m_minTrackPt;
-  double m_maxTrackPt;
-  double m_minTrackP;
-  double m_maxTrackP;
-  double m_maxDxy;
-  int m_minTrackerHits;
-  double m_maxTrackerRedChi2;
-  bool m_allowTIDTEC;
-  int m_minNCrossedChambers;
-  int m_minDT13Hits;
-  int m_minDT2Hits;
-  int m_minCSCHits;
-  bool m_doDT;
-  bool m_doCSC;
-  bool m_useStubPosition;
-  bool m_createNtuple;
+  const edm::InputTag m_muonCollectionTag;
+  const double m_minTrackPt;
+  const double m_maxTrackPt;
+  const double m_minTrackP;
+  const double m_maxTrackP;
+  const double m_maxDxy;
+  const int m_minTrackerHits;
+  const double m_maxTrackerRedChi2;
+  const bool m_allowTIDTEC;
+  const int m_minNCrossedChambers;
+  const int m_minDT13Hits;
+  const int m_minDT2Hits;
+  const int m_minCSCHits;
+  const bool m_doDT;
+  const bool m_doCSC;
+  const bool m_useStubPosition;
+  const bool m_createNtuple;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
   // counter
   long m_counter_event;
@@ -173,7 +175,9 @@ AlignmentMonitorMuonSystemMap1D::AlignmentMonitorMuonSystemMap1D(const edm::Para
       m_doDT(cfg.getParameter<bool>("doDT")),
       m_doCSC(cfg.getParameter<bool>("doCSC")),
       m_useStubPosition(cfg.getParameter<bool>("useStubPosition")),
-      m_createNtuple(cfg.getParameter<bool>("createNtuple")) {
+      m_createNtuple(cfg.getParameter<bool>("createNtuple")),
+      bsToken_(iC.consumes<reco::BeamSpot>(m_beamSpotTag)),
+      muonToken_(iC.consumes<reco::MuonCollection>(m_muonCollectionTag)) {
   if (m_createNtuple) {
     edm::Service<TFileService> fs;
     m_cscnt = fs->make<TTree>("mualNtuple", "mualNtuple");
@@ -266,8 +270,7 @@ void AlignmentMonitorMuonSystemMap1D::event(const edm::Event &iEvent,
                                             const ConstTrajTrackPairCollection &trajtracks) {
   m_counter_event++;
 
-  edm::Handle<reco::BeamSpot> beamSpot;
-  iEvent.getByLabel(m_beamSpotTag, beamSpot);
+  const edm::Handle<reco::BeamSpot> &beamSpot = iEvent.getHandle(bsToken_);
 
   const GlobalTrackingGeometry *globalGeometry = &iSetup.getData(m_esTokenGBTGeom);
   const DetIdAssociator *muonDetIdAssociator_ = &iSetup.getData(m_esTokenDetId);
@@ -296,8 +299,7 @@ void AlignmentMonitorMuonSystemMap1D::event(const edm::Event &iEvent,
       }  // end if track has acceptable momentum
     }    // end loop over tracks
   } else {
-    edm::Handle<reco::MuonCollection> muons;
-    iEvent.getByLabel(m_muonCollectionTag, muons);
+    const edm::Handle<reco::MuonCollection> &muons = iEvent.getHandle(muonToken_);
 
     for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
       if (!(muon->isTrackerMuon() && muon->innerTrack().isNonnull()))

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
@@ -52,21 +52,24 @@ private:
   const MuonResidualsFromTrack::BuilderToken m_esTokenBuilder;
 
   // parameters
-  edm::InputTag m_muonCollectionTag;
-  double m_minTrackPt;
-  double m_minTrackP;
-  int m_minTrackerHits;
-  double m_maxTrackerRedChi2;
-  bool m_allowTIDTEC;
-  bool m_minNCrossedChambers;
-  double m_maxDxy;
-  int m_minDT13Hits;
-  int m_minDT2Hits;
-  int m_minCSCHits;
-  int m_layer;
-  std::string m_propagator;
-  bool m_doDT;
-  bool m_doCSC;
+  const edm::InputTag m_muonCollectionTag;
+  const double m_minTrackPt;
+  const double m_minTrackP;
+  const int m_minTrackerHits;
+  const double m_maxTrackerRedChi2;
+  const bool m_allowTIDTEC;
+  const bool m_minNCrossedChambers;
+  const double m_maxDxy;
+  const int m_minDT13Hits;
+  const int m_minDT2Hits;
+  const int m_minCSCHits;
+  const int m_layer;
+  const std::string m_propagator;
+  const bool m_doDT;
+  const bool m_doCSC;
+
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
   enum { kDeltaX = 0, kDeltaDxDz, kNumComponents };
 
@@ -104,7 +107,9 @@ AlignmentMonitorMuonVsCurvature::AlignmentMonitorMuonVsCurvature(const edm::Para
       m_layer(cfg.getParameter<int>("layer")),
       m_propagator(cfg.getParameter<std::string>("propagator")),
       m_doDT(cfg.getParameter<bool>("doDT")),
-      m_doCSC(cfg.getParameter<bool>("doCSC")) {}
+      m_doCSC(cfg.getParameter<bool>("doCSC")),
+      bsToken_(iC.consumes<reco::BeamSpot>(m_beamSpotTag)),
+      muonToken_(iC.consumes<reco::MuonCollection>(m_muonCollectionTag)) {}
 
 void AlignmentMonitorMuonVsCurvature::book() {
   // DT
@@ -196,8 +201,7 @@ void AlignmentMonitorMuonVsCurvature::book() {
 void AlignmentMonitorMuonVsCurvature::event(const edm::Event &iEvent,
                                             const edm::EventSetup &iSetup,
                                             const ConstTrajTrackPairCollection &trajtracks) {
-  edm::Handle<reco::BeamSpot> beamSpot;
-  iEvent.getByLabel(m_beamSpotTag, beamSpot);
+  const edm::Handle<reco::BeamSpot> &beamSpot = iEvent.getHandle(bsToken_);
 
   const GlobalTrackingGeometry *globalGeometry = &iSetup.getData(m_esTokenGBTGeom);
   const DetIdAssociator *muonDetIdAssociator_ = &iSetup.getData(m_esTokenDetId);
@@ -219,8 +223,7 @@ void AlignmentMonitorMuonVsCurvature::event(const edm::Event &iEvent,
       }  // end if track pT is within range
     }    // end loop over tracks
   } else {
-    edm::Handle<reco::MuonCollection> muons;
-    iEvent.getByLabel(m_muonCollectionTag, muons);
+    const edm::Handle<reco::MuonCollection> &muons = iEvent.getHandle(muonToken_);
 
     for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
       if (!(muon->isTrackerMuon() && muon->innerTrack().isNonnull()))

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
@@ -52,19 +52,22 @@ private:
   const MuonResidualsFromTrack::BuilderToken m_esTokenBuilder;
 
   // parameters
-  edm::InputTag m_muonCollectionTag;
-  double m_minTrackPt;
-  double m_minTrackP;
-  double m_maxDxy;
-  int m_minTrackerHits;
-  double m_maxTrackerRedChi2;
-  bool m_allowTIDTEC;
-  bool m_minNCrossedChambers;
-  int m_minDT13Hits;
-  int m_minDT2Hits;
-  int m_minCSCHits;
-  bool m_doDT;
-  bool m_doCSC;
+  const edm::InputTag m_muonCollectionTag;
+  const double m_minTrackPt;
+  const double m_minTrackP;
+  const double m_maxDxy;
+  const int m_minTrackerHits;
+  const double m_maxTrackerRedChi2;
+  const bool m_allowTIDTEC;
+  const bool m_minNCrossedChambers;
+  const int m_minDT13Hits;
+  const int m_minDT2Hits;
+  const int m_minCSCHits;
+  const bool m_doDT;
+  const bool m_doCSC;
+
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
   // wheel, sector, stationdiff
   TProfile *m_dt13_resid[5][12][3];
@@ -135,7 +138,9 @@ AlignmentMonitorSegmentDifferences::AlignmentMonitorSegmentDifferences(const edm
       m_minDT2Hits(cfg.getParameter<int>("minDT2Hits")),
       m_minCSCHits(cfg.getParameter<int>("minCSCHits")),
       m_doDT(cfg.getParameter<bool>("doDT")),
-      m_doCSC(cfg.getParameter<bool>("doCSC")) {}
+      m_doCSC(cfg.getParameter<bool>("doCSC")),
+      bsToken_(iC.consumes<reco::BeamSpot>(m_beamSpotTag)),
+      muonToken_(iC.consumes<reco::MuonCollection>(m_muonCollectionTag)) {}
 
 void AlignmentMonitorSegmentDifferences::book() {
   char name[225], pos[228], neg[228];
@@ -371,8 +376,7 @@ void AlignmentMonitorSegmentDifferences::book() {
 void AlignmentMonitorSegmentDifferences::event(const edm::Event &iEvent,
                                                const edm::EventSetup &iSetup,
                                                const ConstTrajTrackPairCollection &trajtracks) {
-  edm::Handle<reco::BeamSpot> beamSpot;
-  iEvent.getByLabel(m_beamSpotTag, beamSpot);
+  const edm::Handle<reco::BeamSpot> &beamSpot = iEvent.getHandle(bsToken_);
 
   const GlobalTrackingGeometry *globalGeometry = &iSetup.getData(m_esTokenGBTGeom);
   const DetIdAssociator *muonDetIdAssociator_ = &iSetup.getData(m_esTokenDetId);
@@ -394,8 +398,7 @@ void AlignmentMonitorSegmentDifferences::event(const edm::Event &iEvent,
       }
     }  // end loop over tracks
   } else {
-    edm::Handle<reco::MuonCollection> muons;
-    iEvent.getByLabel(m_muonCollectionTag, muons);
+    const edm::Handle<reco::MuonCollection> &muons = iEvent.getHandle(muonToken_);
 
     for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
       if (!(muon->isTrackerMuon() && muon->innerTrack().isNonnull()))

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTracksFromTrajectories.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTracksFromTrajectories.cc
@@ -44,8 +44,9 @@ public:
 private:
   MuonServiceProxy *theMuonServiceProxy;
   MuonUpdatorAtVertex *theMuonUpdatorAtVertex;
-  bool m_vertexConstraint;
-  edm::InputTag m_beamSpot;
+  const bool m_vertexConstraint;
+  const edm::InputTag m_beamSpot;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
 
   TH1F *m_diMuon_Z;
   TH1F *m_diMuon_Zforward;
@@ -100,7 +101,8 @@ AlignmentMonitorTracksFromTrajectories::AlignmentMonitorTracksFromTrajectories(c
                                                                                edm::ConsumesCollector iC)
     : AlignmentMonitorBase(cfg, iC, "AlignmentMonitorTracksFromTrajectories"),
       m_vertexConstraint(cfg.getParameter<bool>("vertexConstraint")),
-      m_beamSpot(cfg.getParameter<edm::InputTag>("beamSpot")) {
+      m_beamSpot(cfg.getParameter<edm::InputTag>("beamSpot")),
+      bsToken_(iC.consumes<reco::BeamSpot>(m_beamSpot)) {
   theMuonServiceProxy = new MuonServiceProxy(cfg.getParameter<edm::ParameterSet>("ServiceParameters"));
   theMuonUpdatorAtVertex = new MuonUpdatorAtVertex(cfg.getParameter<edm::ParameterSet>("MuonUpdatorAtVertexParameters"),
                                                    theMuonServiceProxy);
@@ -152,8 +154,7 @@ void AlignmentMonitorTracksFromTrajectories::event(const edm::Event &iEvent,
                                                    const ConstTrajTrackPairCollection &tracks) {
   theMuonServiceProxy->update(iSetup);
 
-  edm::Handle<reco::BeamSpot> beamSpot;
-  iEvent.getByLabel(m_beamSpot, beamSpot);
+  const edm::Handle<reco::BeamSpot> &beamSpot = iEvent.getHandle(bsToken_);
 
   GlobalVector p1, p2;
   double e1 = 0.;

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -15,7 +15,6 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h"
 
 #include "DataFormats/Alignment/interface/AlignmentClusterFlag.h"
-#include "DataFormats/Alignment/interface/AliClusterValueMap.h"
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -34,7 +33,9 @@ AlignmentStats::AlignmentStats(const edm::ParameterSet &iConfig)
       keepHitPopulation_(iConfig.getParameter<bool>("keepHitStats")),
       statsTreeName_(iConfig.getParameter<string>("TrkStatsFileName")),
       hitsTreeName_(iConfig.getParameter<string>("HitStatsFileName")),
-      prescale_(iConfig.getParameter<uint32_t>("TrkStatsPrescale")) {
+      prescale_(iConfig.getParameter<uint32_t>("TrkStatsPrescale")),
+      trackToken_(consumes<reco::TrackCollection>(src_)),
+      mapToken_(consumes<AliClusterValueMap>(overlapAM_)) {
   //sanity checks
 
   //init
@@ -87,12 +88,10 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
 
   //take trajectories and tracks to loop on
   // edm::Handle<TrajTrackAssociationCollection> TrackAssoMap;
-  edm::Handle<reco::TrackCollection> Tracks;
-  iEvent.getByLabel(src_, Tracks);
+  const edm::Handle<reco::TrackCollection> &Tracks = iEvent.getHandle(trackToken_);
 
   //take overlap HitAssomap
-  edm::Handle<AliClusterValueMap> hMap;
-  iEvent.getByLabel(overlapAM_, hMap);
+  const edm::Handle<AliClusterValueMap> &hMap = iEvent.getHandle(mapToken_);
   const AliClusterValueMap &OverlapMap = *hMap;
 
   // Initialise

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.h
@@ -11,6 +11,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/Alignment/interface/AliClusterValueMap.h"
 
 // #include <Riostream.h>
 #include <fstream>
@@ -39,13 +41,17 @@ private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esTokenTkGeo_;
 
   //////inputs from config file
-  edm::InputTag src_;
-  edm::InputTag overlapAM_;
-  bool keepTrackStats_;
-  bool keepHitPopulation_;
-  std::string statsTreeName_;
-  std::string hitsTreeName_;
-  uint32_t prescale_;
+  const edm::InputTag src_;
+  const edm::InputTag overlapAM_;
+  const bool keepTrackStats_;
+  const bool keepHitPopulation_;
+  const std::string statsTreeName_;
+  const std::string hitsTreeName_;
+  const uint32_t prescale_;
+
+  const edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+  const edm::EDGetTokenT<AliClusterValueMap> mapToken_;
+
   //////
   uint32_t tmpPresc_;
 


### PR DESCRIPTION
#### PR description:

Use tokens rather than labels in accessing collections in Alignment/CommonAlignmentMonitor

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special