### PR TITLE
MTD geometry: fix BTL numbering scheme for DD4hep+Geant4 extra level in path

### DIFF
--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -22,7 +22,7 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   uint32_t zside(999), rodCopy(0), runitCopy(0), modCopy(0), modtyp(0), crystal(0);
 
   bool isDD4hepOK(false);
-  if (nLevels == kBTLcrystalLevel+1) {
+  if (nLevels == kBTLcrystalLevel + 1) {
     if (baseNumber.getLevelName(9) == "world_volume_1") {
       isDD4hepOK = true;
     }

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -21,7 +21,14 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
   uint32_t zside(999), rodCopy(0), runitCopy(0), modCopy(0), modtyp(0), crystal(0);
 
-  if (nLevels == kBTLcrystalLevel) {
+  bool isDD4hepOK(false);
+  if (nLevels == kBTLcrystalLevel+1) {
+    if (baseNumber.getLevelName(9) == "world_volume_1") {
+      isDD4hepOK = true;
+    }
+  }
+
+  if (nLevels == kBTLcrystalLevel || isDD4hepOK) {
     LogDebug("MTDGeom") << baseNumber.getLevelName(0) << ", " << baseNumber.getLevelName(1) << ", "
                         << baseNumber.getLevelName(2) << ", " << baseNumber.getLevelName(3) << ", "
                         << baseNumber.getLevelName(4) << ", " << baseNumber.getLevelName(5) << ", "

--- a/RecoMTD/DetLayers/src/MTDDetLayerGeometry.cc
+++ b/RecoMTD/DetLayers/src/MTDDetLayerGeometry.cc
@@ -28,11 +28,17 @@ MTDDetLayerGeometry::MTDDetLayerGeometry() {}
 MTDDetLayerGeometry::~MTDDetLayerGeometry() {}
 
 void MTDDetLayerGeometry::buildLayers(const MTDGeometry* geo, const MTDTopology* mtopo) {
+  bool abort(false);
   if (geo == nullptr) {
-    LogWarning("MTDDetLayers") << "No MTD geometry is available.";
+    LogError("MTDDetLayers") << "No MTD geometry is available.";
+    abort = true;
   }
   if (mtopo == nullptr) {
-    LogWarning("MTDDetLayers") << "No MTD topology  is available.";
+    LogError("MTDDetLayers") << "No MTD topology  is available.";
+    abort = true;
+  }
+  if (abort) {
+    throw cms::Exception("MTDDetLayers") << "No complete MTD geometry available, aborting.";
   }
 
   // Build BTL layers


### PR DESCRIPTION
#### PR description:

This PR provide a fix for the crash observed in wf 20834.911 after the integration of #39670 . The use of DD4hep within Geant4 adds effectively one more level in the volume stack, which breaks the logic of the BTL numbering scheme as updated. For this reason an extra protection is added, to address this specific case. 

At the same time also the static analyser issue https://github.com/cms-sw/cmssw/pull/39670#pullrequestreview-1152996566 is addressed.

#### PR validation:

Test workflows 20834.0, 20834.911 and 23634.911 are correctly executed. Unit tests pass.