### PR TITLE
[12_4_X] EMTF Primitive Conversion LUT update

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
@@ -75,15 +75,16 @@ unsigned int ConditionHelper::get_pc_lut_version() const {
   // because of rigid CondFormats naming conventions - AWB 02.06.17
   // std::cout << "    - Getting proper PC LUT version from ConditionHelper: version = " << params_->PhiMatchWindowSt1_ << std::endl;
   // return params_->PhiMatchWindowSt1_;
-
   // Hack until we figure out why the database is returning "0" for 2017 data - AWB 04.08.17
   // std::cout << "    - Getting hacked PC LUT version from ConditionHelper: version = " << (params_->firmwareVersion_ >= 50000) << std::endl;
   if (params_->firmwareVersion_ < 50000) {  // For 2016
     return 0;
   } else if (params_->firmwareVersion_ < 1537467271) {  // From the beginning of 2017
     return 1;                                           // Corresponding to FW timestamps before Sept. 20, 2018
-  } else {
+  } else if (params_->firmwareVersion_ < 1664468309){   // Corresponds to September 29, 2022. The firmware got deployed on October 6, 2022.
     return 2;  // Starting September 26, 2018 with run 323556 (data only, not in MC)
+  } else {
+    return 3;  // Starting October 6, 2022 with run 359924 (data only, not in MC)
   }
 }
 

--- a/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
@@ -81,8 +81,9 @@ unsigned int ConditionHelper::get_pc_lut_version() const {
     return 0;
   } else if (params_->firmwareVersion_ < 1537467271) {  // From the beginning of 2017
     return 1;                                           // Corresponding to FW timestamps before Sept. 20, 2018
-  } else if (params_->firmwareVersion_ < 1664468309){   // Corresponds to September 29, 2022. The firmware got deployed on October 6, 2022.
-    return 2;  // Starting September 26, 2018 with run 323556 (data only, not in MC)
+  } else if (params_->firmwareVersion_ <
+             1664468309) {  // Corresponds to September 29, 2022. The firmware got deployed on October 6, 2022.
+    return 2;               // Starting September 26, 2018 with run 323556 (data only, not in MC)
   } else {
     return 3;  // Starting October 6, 2022 with run 359924 (data only, not in MC)
   }

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -25,6 +25,8 @@ void SectorProcessorLUT::read(bool pc_lut_data, int pc_lut_version) {
     coord_lut_dir = "ph_lut_v2";  // Beginning of 2017, improved alignment from ideal CMS geometry (MC)
   else if (pc_lut_version == 2 && pc_lut_data)
     coord_lut_dir = "ph_lut_v3_data";  // Update in September 2017 from ReReco alignment, data only
+  else if (pc_lut_version == 3 && pc_lut_data)
+    coord_lut_dir = "ph_lut_Run3_2022_data";  // Update in October 2022 from Run 3 2022 alignment, data only
   else if (pc_lut_version == 2)
     coord_lut_dir = "ph_lut_v2";  // MC still uses ideal CMS aligment
   else if (pc_lut_version == -1 && pc_lut_data)


### PR DESCRIPTION
#### PR description:

This is a backport of https://github.com/cms-sw/cmssw/pull/39822

This PR adds options to use the new primitive conversion LUTs in the EMTF emulator. The LUTs were deployed at P5 on October 6th, but they are not used in the emulator yet. 

This PR needs the LUTs in https://github.com/cms-data/L1Trigger-L1TMuon/pull/23 to work.

We see improvement in EMTF performance at P5 with these new LUTs, so changes to muon efficiencies etc are expected when testing the re-emulation workflows from recent runs (after October 6th). Otherwise this PR shouldn't change anything in the emulator.

This PR should be backported to 12_4 if there is an opportunity to run this at P5 to improve data/emulator comparisons in DQM. If data taking with 12_5 is expected we should also backport it there. 

This has no effect on MC production so MC campaigns do not matter for the purpose of this PR.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated with the workflow from https://github.com/cms-sw/cmssw/pull/39822#issuecomment-1290545788 since the regular test workflows are not useful for this PR. 

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

https://github.com/cms-sw/cmssw/pull/39822


<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
