### PR TITLE
JetCorrector migration in DQM/Physics

### DIFF
--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc
@@ -1,5 +1,6 @@
 #include "DQM/Physics/src/SingleTopTChannelLeptonDQM.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
@@ -13,6 +14,8 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
 using namespace std;
 namespace SingleTopTChannelLepton {
 
@@ -107,7 +110,8 @@ namespace SingleTopTChannelLepton {
       // jetCorrector is optional; in case it's not found
       // the InputTag will remain empty
       if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
+        jetCorrector_ =
+            iC.consumes<reco::JetCorrector>(edm::InputTag(jetExtras.getParameter<std::string>("jetCorrector")));
       }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
@@ -507,28 +511,19 @@ namespace SingleTopTChannelLepton {
 
     // load jet
     // corrector if configured such
-    const JetCorrector* corrector = nullptr;
-    if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex()) {
-      // check whether a jet correcto is in the event setup or not
-      if (setup.find(edm::eventsetup::EventSetupRecordKey::makeKey<JetCorrectionsRecord>())) {
-        corrector = &setup.getData(jetCorrector_);
-        ;
+    const reco::JetCorrector* corrector = nullptr;
+    if (!jetCorrector_.isUninitialized()) {
+      // check whether a jet corrector is in the event or not
+      edm::Handle<reco::JetCorrector> correctorHandle = event.getHandle(jetCorrector_);
+      if (correctorHandle.isValid()) {
+        corrector = correctorHandle.product();
       } else {
         edm::LogVerbatim("SingleTopTChannelLeptonDQM")
             << "\n"
             << "-----------------------------------------------------------------"
                "-------------------- \n"
-            << " No JetCorrectionsRecord available from EventSetup:\n"
+            << " No JetCorrector available from Event:\n"
             << "  - Jets will not be corrected.\n"
-            << "  - If you want to change this add the following lines to your "
-               "cfg file:\n"
-            << "\n"
-            << "  ## load jet corrections\n"
-            << "  "
-               "process.load(\"JetMETCorrections.Configuration."
-               "JetCorrectionServicesAllAlgos_cff\") \n"
-            << "  process.prefer(\"ak5CaloL2L3\")\n"
-            << "\n"
             << "-----------------------------------------------------------------"
                "-------------------- \n";
       }

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -12,7 +12,6 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -163,7 +162,7 @@ namespace SingleTopTChannelLepton {
     /// extra selection on muons
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
     /// jetCorrector
-    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
+    edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
 

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -16,8 +16,6 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 using namespace std;
 namespace SingleTopTChannelLepton_miniAOD {
 
@@ -112,11 +110,6 @@ namespace SingleTopTChannelLepton_miniAOD {
     // empty
     if (cfg.existsAs<edm::ParameterSet>("jetExtras")) {
       edm::ParameterSet jetExtras = cfg.getParameter<edm::ParameterSet>("jetExtras");
-      // jetCorrector is optional; in case it's not found
-      // the InputTag will remain empty
-      if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
-      }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
         edm::ParameterSet jetID = jetExtras.getParameter<edm::ParameterSet>("jetID");

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.h
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -116,8 +115,6 @@ namespace SingleTopTChannelLepton_miniAOD {
     /// extra selection on muons
     std::unique_ptr<StringCutObjectSelector<pat::Muon> > muonSelect_;
 
-    /// jetCorrector
-    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets

--- a/DQM/Physics/src/TopDiLeptonOfflineDQM.h
+++ b/DQM/Physics/src/TopDiLeptonOfflineDQM.h
@@ -12,11 +12,11 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 /**
    \class   MonitorEnsemble TopDQMHelpers.h
    "DQM/Physics/interface/TopDQMHelpers.h"
@@ -159,7 +159,7 @@ namespace TopDiLeptonOffline {
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate, true> > muonSelect_;
 
     /// jetCorrector
-    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
+    edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets

--- a/DQM/Physics/src/TopSingleLeptonDQM.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM.h
@@ -10,7 +10,6 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -120,7 +119,6 @@ namespace TopSingleLepton {
 
     /// electronId label
     edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
-    edm::EDGetTokenT<reco::JetCorrector> mJetCorrector;
 
     /// electronId pattern we expect the following pattern:
     ///  0: fails
@@ -155,7 +153,7 @@ namespace TopSingleLepton {
     std::unique_ptr<StringCutObjectSelector<reco::PFCandidate> > muonSelect_;
 
     /// jetCorrector
-    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
+    edm::EDGetTokenT<reco::JetCorrector> jetCorrector_;
 
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -16,8 +16,6 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 using namespace std;
 namespace TopSingleLepton_miniAOD {
 
@@ -112,11 +110,6 @@ namespace TopSingleLepton_miniAOD {
     // empty
     if (cfg.existsAs<edm::ParameterSet>("jetExtras")) {
       edm::ParameterSet jetExtras = cfg.getParameter<edm::ParameterSet>("jetExtras");
-      // jetCorrector is optional; in case it's not found
-      // the InputTag will remain empty
-      if (jetExtras.existsAs<std::string>("jetCorrector")) {
-        jetCorrector_ = iC.esConsumes(edm::ESInputTag("", jetExtras.getParameter<std::string>("jetCorrector")));
-      }
       // read jetID information if it exists
       if (jetExtras.existsAs<edm::ParameterSet>("jetID")) {
         edm::ParameterSet jetID = jetExtras.getParameter<edm::ParameterSet>("jetID");

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.h
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -116,8 +115,6 @@ namespace TopSingleLepton_miniAOD {
     /// extra selection on muons
     std::unique_ptr<StringCutObjectSelector<pat::Muon> > muonSelect_;
 
-    /// jetCorrector
-    edm::ESGetToken<JetCorrector, JetCorrectionsRecord> jetCorrector_;
     /// jetID as an extra selection type
     edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
     /// extra jetID selection on calo jets


### PR DESCRIPTION
#### PR description:

This is part of the migration from getting the deprecated ::JetCorrector class from the EventSetup to getting the   new reco::JetCorrector from the Event. This migration has been in progress since 2014 and is nearly complete. There are only a few cases left that need migrating. We want to finish this soon and delete the deprecated header file and related code. This is related to the consumes migration and will improve multi-threading performance.

This PR handles the remaining cases in the package DQM/Physics. I need some help with this from DQM if possible.

First question. Is this code still used? If not, I would rather delete it entirely than continue maintaining dead code.

The existing code has what appears to be a bug. See for example, https://cmssdt.cern.ch/dxr/CMSSW/source/DQM/Physics/src/SingleTopTChannelLeptonDQM.cc#511

The following conditional always evaluates to false.

```
if (!jetCorrector_.isInitialized() && jetCorrector_.hasValidIndex())
```

So the code inside that conditional  that uses the deprecated JetCorrector class is never actually executed. From the history, it appears this is not intentional. If it was intentional, I could just delete the related code fragments, not modify the behavior, and complete the migration. If you want this, please let me know.

In the PR, I have migrated the C++ code to use the new interface in reco::JetCorrector. I need help, because I do not know how to test this code. I also do not know how to verify that the configurations are correct and reading the correct JetCorrector objects. Is there a DQM expert who could help with this? Which tests should I run? I am willing to do a little more work on this, but need some help and/or direction.

There are no unit tests. I've run the limited runTheMatrix.py tests, but I do not know if they use this code or not. If I know what tests to run, then I will try to run them. There may be implications for changing histograms and needing to update comparison reference histograms and DQM experts would need to handle that.

I am a Core expert, not a DQM expert so help from DQM on this migration would be appreciated.

Note the old JetCorrectors for the EventSetup are no longer supported. I'm not sure that they would run without exceptions even if the existing bug was fixed.

#### PR validation:

It compiles and builds. There are no unit tests. Limited runTheMatrix tests pass, but I do not know if those execute this code.
