### PR TITLE
simple option to rerun failed workflows from a matrix report

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -181,7 +181,12 @@ if __name__ == '__main__':
                         help='Comma separated list of workflow to be shown or ran. Possible keys are also '+str(predefinedSet.keys())+'. and wild card like muon, or mc',
                         dest='testList',
                         default=None)
-    
+
+    parser.add_argument('-f','--failed-from',
+                        help='Provide a matrix report to specify the workflows to be run again. Augments the -l option if specified already',
+                        dest='failed_from',
+                        default=None)
+
     parser.add_argument('-r','--raw',
                         help='Temporary dump the .txt needed for prodAgent interface. To be discontinued soon. Argument must be the name of the set (standard, pileup,...)',
                         dest='raw')
@@ -377,6 +382,18 @@ if __name__ == '__main__':
     opt = parser.parse_args()
     if opt.command: opt.command = ' '.join(opt.command)
     os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
+    if opt.failed_from:
+        rerunthese=[]
+        with open(opt.failed_from,'r') as report:
+            for report_line in report:
+                if 'FAILED' in report_line:
+                    to_run,_=report_line.split('_',1)
+                    rerunthese.append(to_run)
+        if opt.testList:
+            opt.testList+=','.join(['']+rerunthese)
+        else:
+            opt.testList = ','.join(rerunthese)
+
     if opt.IBEos:
       from subprocess import getstatusoutput as run_cmd
 


### PR DESCRIPTION
#### PR description:

with this one can do `runTheMatrix.py --from-failed runall-report-step123-.log` to run the workflows that failed previously

#### PR validation:

not much to validate, but turns out to be useful while fixing incrementally failures in the matrix.