### PR TITLE
Add histogram full name if exception happens in DQMRootSource

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -194,20 +194,26 @@ struct DQMTTreeIO {
 
     void read(ULong64_t iIndex, DQMStore* dqmstore, int run, int lumi) override {
       // This will populate the fields as defined in setTree method
-      m_tree->GetEntry(iIndex);
+      try {
+        m_tree->GetEntry(iIndex);
 
-      auto key = makeKey(*m_fullName, run, lumi);
-      auto existing = dqmstore->findOrRecycle(key);
-      if (existing) {
-        // TODO: make sure there is sufficient locking here.
-        DQMMergeHelper::mergeTogether(existing->getTH1(), m_buffer);
-      } else {
-        // We make our own MEs here, to avoid a round-trip through the booking API.
-        MonitorElementData meData;
-        meData.key_ = key;
-        meData.value_.object_ = std::unique_ptr<T>((T*)(m_buffer->Clone()));
-        auto me = new MonitorElement(std::move(meData));
-        dqmstore->putME(me);
+        auto key = makeKey(*m_fullName, run, lumi);
+        auto existing = dqmstore->findOrRecycle(key);
+        if (existing) {
+          // TODO: make sure there is sufficient locking here.
+          DQMMergeHelper::mergeTogether(existing->getTH1(), m_buffer);
+        } else {
+          // We make our own MEs here, to avoid a round-trip through the booking API.
+          MonitorElementData meData;
+          meData.key_ = key;
+          meData.value_.object_ = std::unique_ptr<T>((T*)(m_buffer->Clone()));
+          auto me = new MonitorElement(std::move(meData));
+          dqmstore->putME(me);
+        }
+      } catch (cms::Exception& iExcept) {
+        using namespace std::string_literals;
+        iExcept.addContext("failed while reading "s + *m_fullName);
+        throw;
       }
     }
 


### PR DESCRIPTION
#### PR description:

This is meant to help track down any future cases of problems while merging histograms during harvesting.

#### PR validation:

Code compiles and does show full histogram name when the exception is thrown.