### PR TITLE
Fix use of duplicate bin names in DQM/L1TMonitor

### DIFF
--- a/DQM/L1TMonitor/src/L1GtHwValidation.cc
+++ b/DQM/L1TMonitor/src/L1GtHwValidation.cc
@@ -644,8 +644,8 @@ void L1GtHwValidation::bookHistograms(DQMStore::IBooker& ibooker,
   m_gtErrorFlag = ibooker.book1D("GTErrorFlag", "L1 GT error flag for data versus emulator comparison", 5, 0., 5);
 
   m_gtErrorFlag->setBinLabel(1, "Agree", 1);
-  m_gtErrorFlag->setBinLabel(2, "", 1);
-  m_gtErrorFlag->setBinLabel(3, "", 1);
+  m_gtErrorFlag->setBinLabel(2, "2", 1);
+  m_gtErrorFlag->setBinLabel(3, "3", 1);
   m_gtErrorFlag->setBinLabel(4, "Data only", 1);
   m_gtErrorFlag->setBinLabel(5, "Emul only", 1);
 

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -1966,9 +1966,17 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& run, c
   if (!perLSsaving_)
     fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS", 108, 0, 108, 2, 0, 2);
 
+  std::map<unsigned int, unsigned int> repeats;
+  for (unsigned int i = 0; i < 108; ++i) {
+    repeats[crateFED[i]] = 0;
+  }
   for (unsigned int i = 0; i < 108; ++i) {
     char fed[10];
-    sprintf(fed, "%d", crateFED[i]);
+    if (0 == repeats[crateFED[i]]++) {
+      sprintf(fed, "%d", crateFED[i]);
+    } else {
+      sprintf(fed, "%d_%d", crateFED[i], repeats[crateFED[i]]);
+    }
     fedVectorMonitorRUN_->setBinLabel(i + 1, fed);
     if (!perLSsaving_)
       fedVectorMonitorLS_->setBinLabel(i + 1, fed);


### PR DESCRIPTION
#### PR description:

ROOT appears to be enforcing that user defined bin names for histograms must be unique.
This fixes the failures in the integration builds of workflow 4.6.

#### PR validation:

Now when running workflow 4.6 step3 the jobs succeed.