### PR TITLE
mkfit pixelLess-specific DNN training

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
@@ -3,5 +3,9 @@ trackSelectionTf = _tfGraphDefProducer.clone(
     ComponentName = "trackSelectionTf",
     FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFit_Run3_12_5_0_pre5.pb"
 )
+trackSelectionTfPLess = _tfGraphDefProducer.clone(
+    ComponentName = "trackSelectionTfPLess",
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFitPixelLessOnly_Run3_12_5_0_pre5.pb"
+)
 
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -397,6 +397,7 @@ from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
 trackdnn.toReplaceWith(pixelLessStep, trackTfClassifier.clone(
+    mva         = dict(tfDnnLabel  = 'trackSelectionTfPLess'),
     src         = 'pixelLessStepTracks',
     qualityCuts = qualityCutDictionary.PixelLessStep.value()
 ))

--- a/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
+++ b/RecoTracker/IterativeTracking/python/dnnQualityCuts.py
@@ -9,7 +9,7 @@ qualityCutDictionary = cms.PSet(
    DetachedTripletStep =        cms.vdouble(-0.42,  0.16,  0.78),
    PixelPairStep       =        cms.vdouble(-0.31, -0.13,  0.13),
    MixedTripletStep    =        cms.vdouble(-0.86, -0.68, -0.43),
-   PixelLessStep       =        cms.vdouble(-0.64, -0.47, -0.09),
+   PixelLessStep       =        cms.vdouble(-0.80, -0.69, -0.40),
    TobTecStep          =        cms.vdouble(-0.76, -0.65, -0.55),
    JetCoreRegionalStep =        cms.vdouble(-0.62, -0.49,  0.02)
 )


### PR DESCRIPTION
#### PR description:

This is a follow up PR to https://github.com/cms-sw/cmssw/pull/39715, where track selection DNNs were updated. The weights are already included in https://github.com/cms-data/RecoTracker-FinalTrackSelectors

This PR introduces a pixelLess specific DNN with its tuned working points for mkFit workflows. The DNN is not loaded nor called by default as the pixelLess iteration now uses CKF tracking. 

No changes are expected when testing the PR.

The PR can be useful for testing the impact of reintroducing the mkFit pixelLess iteration into the default tracking.

#### PR validation:

the improvements brought to the pixelLess DNN iteration in PU and no PU samples are described in this presentation
https://indico.cern.ch/event/1213630/#3-dnn-tracking-classification

