### PR TITLE
HLT release validation and offline DQM for EXO Run 3 HLT paths (12_5_X)

### DIFF
--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -7,18 +7,7 @@ TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*"]),
-)
-
-TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*"]),
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
-)
-
-TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v*"]),
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
+    requireValidHLTPaths = False,
 )
 
 DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
@@ -26,6 +15,7 @@ DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu43NoFiltersNoVtx_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 
@@ -34,6 +24,7 @@ DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu40NoFiltersNoVtxDisplaced_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 #--------------------------------------------------
@@ -42,6 +33,7 @@ DoubleL2Mu23NoVtx_2Cha_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
@@ -49,6 +41,7 @@ DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #--------------------------------------------------
 DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
@@ -56,6 +49,7 @@ DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #--------------------------------------------------
 DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring = hltMuonmonitoring.clone(
@@ -63,6 +57,7 @@ DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring = hltMuonmonitoring.clone
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #--------------------------------------------------
 DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
@@ -70,6 +65,7 @@ DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitor
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #--------------------------------------------------
 DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
@@ -77,6 +73,7 @@ DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #--------------------------------------------------
 DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
@@ -84,6 +81,7 @@ DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
     nmuons = 2,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 
@@ -96,6 +94,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
     nelectrons = 1,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
@@ -105,6 +104,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
     eleSelection = 'pt > 43',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
@@ -114,6 +114,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
     muonSelection = 'pt > 43',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone(
@@ -122,6 +123,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clon
     nelectrons = 1,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
@@ -131,6 +133,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitorin
     eleSelection = 'pt > 38',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
@@ -140,6 +143,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitori
     muonSelection = 'pt > 38',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 #####
 
@@ -149,6 +153,7 @@ Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring = hltMuonmonitoring
     nelectrons = 1,
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring = hltMuonmonitoring.clone(
@@ -158,6 +163,7 @@ Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring = hltMuonmoni
     eleSelection = 'pt > 38',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring = hltMuonmonitoring.clone(
@@ -167,12 +173,11 @@ Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring = hltMuonmon
     muonSelection = 'pt > 38',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
     denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    requireValidHLTPaths = False,
 )
 
 exoHLTMuonmonitoring = cms.Sequence(
     TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring 
-    + TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring
-    + TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring
     + DoubleMu43NoFiltersNoVtx_monitoring
     + DoubleMu40NoFiltersNoVtxDisplaced_monitoring
     + Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/39799

This PR:

1. removes the offline DQM monitoring of two obsolete HLT paths, which are no longer in the 2022 menu: HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v and HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v
2. make it not required to have all paths be valid in the numerator and denominator, for the paths monitored in MuonMonitor_cff

The reason for the second part is because in the HLT 2022 v1.3 menu, one of the paths in the denominator was removed. As a result, the DQM plots did not get made, although they would have been fine, physics-wise. Changing this flag to false is the easiest way to have similar DQM plots with the earlier and later HLT menus, and it fixes this bug.

As a result of this PR, some DQM plots will be removed, and some will reappear.

#### PR validation:

Using the 11634.0 ttbar workflow, I have tested that the correct histograms are produced and filled in the harvested DQM file.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/39799 . A backport to 12_4_X is necessary, and this backport is to make the intermediate release cycle 12_5_X consistent. 

