### PR TITLE
Enable Puppi photon protection for jets

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -35,6 +35,7 @@ puppi = _mod.PuppiProducer.clone(
                        NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
                        DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
                        PtMaxNeutralsStartSlope = 20.,
+                       PtMaxPhotons = 20.,
                        clonePackedCands   = False, # should only be set to True for MiniAOD
                        algos          = { 
                         0: dict( 
@@ -102,6 +103,5 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(puppi, algos = [])
 
 puppiNoLep = puppi.clone(
-    puppiNoLep = True,
-    PtMaxPhotons = 20.
+    puppiNoLep = True
     )


### PR DESCRIPTION
#### PR description:

Enable protection of photons in PUPPI jets, i.e. give all PF photons with pT>20 a weight of 1. This is already used in PUPPI MET computation, now added also to jets for consistency. The impact of this change is at less than % level to jet response, resolution, efficiency and purity.

Summary at JME meeting and comparisons:
https://indico.cern.ch/event/1188360/#4-puppi-tuning-neutral-pt-prot
https://indico.cern.ch/event/1209020/#63-puppi-tuning-in-run3

Aim for CMSSW_12_6_0 "Run3 Re-MiniAOD".

#### PR validation:

scram b runtests
runTheMatrix - l 25.0
No differences observed on 10 events.
Expect tiny difference to only show up in higher pt, like JetHT and QCD_flat samples.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport foreseen.

@nurfikri89