### PR TITLE
[TsosGaussianStateConversions] Require GSF states to be positive definite [12_6_X]

### DIFF
--- a/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
+++ b/TrackingTools/GsfTracking/src/TsosGaussianStateConversions.cc
@@ -40,12 +40,15 @@ namespace GaussianStateConversions {
     std::vector<TrajectoryStateOnSurface> components;
     components.reserve(singleStates.size());
     for (auto const& ic : singleStates) {
-      components.emplace_back((*ic).weight(),
-                              LocalTrajectoryParameters((*ic).mean(), pzSign, charged),
-                              LocalTrajectoryError((*ic).covariance()),
-                              surface,
-                              field,
-                              side);
+      //require states to be positive-definite
+      if (double det = 0; (*ic).covariance().Det2(det) && det > 0) {
+        components.emplace_back((*ic).weight(),
+                                LocalTrajectoryParameters((*ic).mean(), pzSign, charged),
+                                LocalTrajectoryError((*ic).covariance()),
+                                surface,
+                                field,
+                                side);
+      }
     }
     return TrajectoryStateOnSurface((BasicTrajectoryState*)new BasicMultiTrajectoryState(components));
   }


### PR DESCRIPTION
#### PR description:

This PR is to solve a crash in prompt-reco that led to a paused job as reported in https://cms-talk.web.cern.ch/t/logic-error-in-reco-job-for-run-360888-dataset-parkingdoublemuonlowmass2/16641, and discussed in https://github.com/cms-sw/cmssw/issues/39570. 

It was checked, from 12_4_X, that this patch cures the crash in low-pT electron reconstruction.

#### PR validation:
`runTheMatrix.py -l 12434.0` ran fine.

From 12_4_X, it was checked that [Base] and [Base+thisPR] leads to same number of electrons, photons and low-pT electrons to be reconstructed, with same pT spectra. This check was made by running on 200 raw events on this file: `/eos/cms/tier0/store/data/Run2022F/EGamma/RAW/v1/000/361/197/00000/76bd97fa-4ad6-4d85-b941-014e3ed27f9c.root`

Tagging @francescobrivio as this week's ORM.

Backport of this PR might be necessary. 