### PR TITLE
Catch case where parent index is bad in Hydjet

### DIFF
--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -341,7 +341,7 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
   vector<int> index(nsub_);
 
   while (ihy < hyjets.nhj) {
-    constexpr int kMaxMultiplicity = 50000;
+    constexpr int kMaxMultiplicity = 200000;
     isub = std::floor((hyjets.khj[2][ihy] / kMaxMultiplicity));
     int hjoffset = isub * kMaxMultiplicity;
 

--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -368,18 +368,14 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
                              << std::endl;
 
     if (hyjets.khj[2][ihy] == 0) {
-      if (primary_particle[ihy] == nullptr) {
-        primary_particle[ihy] = build_hyjet(ihy, ihy + 1);
-      }
+      primary_particle[ihy] = build_hyjet(ihy, ihy + 1);
       if (!sub_vertices)
         LogError("Hydjet_array") << "##### HYDJET2: Vertex not initialized!";
       else
         sub_vertices->add_particle_out(primary_particle[ihy]);
       LogDebug("Hydjet_array") << " ---> " << ihy + 1 << std::endl;
     } else {
-      if (particle[ihy] == nullptr) {
-        particle[ihy] = build_hyjet(ihy, ihy + 1);
-      }
+      particle[ihy] = build_hyjet(ihy, ihy + 1);
       int mid = hyjets.khj[2][ihy] - hjoffset + index[isub];
       int mid_t = mid;
       while (((mid + 1) < ihy) && (std::abs(hyjets.khj[1][mid]) < 100) &&
@@ -393,16 +389,6 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
 
       if (!mother) {
         mother = particle[mid];
-        if (!mother) {
-          if (mid > ihy) {
-            mother = build_hyjet(mid, mid + 1);
-            if (hyjets.khj[2][mid] != 0) {
-              particle[mid] = mother;
-            }
-          } else {
-            assert(false);
-          }
-        }
         primary_particle[mid] = mother;
       }
 

--- a/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
+++ b/GeneratorInterface/HydjetInterface/src/HydjetHadronizer.cc
@@ -341,8 +341,9 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
   vector<int> index(nsub_);
 
   while (ihy < hyjets.nhj) {
-    isub = std::floor((hyjets.khj[2][ihy] / 50000));
-    int hjoffset = isub * 50000;
+    constexpr int kMaxMultiplicity = 50000;
+    isub = std::floor((hyjets.khj[2][ihy] / kMaxMultiplicity));
+    int hjoffset = isub * kMaxMultiplicity;
 
     if (isub != isub_l) {
       sub_vertices = new HepMC::GenVertex(HepMC::FourVector(0, 0, 0, 0), isub);
@@ -360,10 +361,10 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
       stab++;
     LogDebug("Hydjet_array") << ihy << " MULTin ev.:" << hyjets.nhj << " SubEv.#" << isub << " Part #" << ihy + 1
                              << ", PDG: " << hyjets.khj[1][ihy] << " (st. " << convertStatus(hyjets.khj[0][ihy])
-                             << ") mother=" << hyjets.khj[2][ihy] - (isub * 50000) + index[isub] + 1 << " ("
+                             << ") mother=" << hyjets.khj[2][ihy] - (isub * kMaxMultiplicity) + index[isub] + 1 << " ("
                              << hyjets.khj[2][ihy] << "), childs ("
-                             << hyjets.khj[3][ihy] - (isub * 50000) + index[isub] + 1 << "-"
-                             << hyjets.khj[4][ihy] - (isub * 50000) + index[isub] + 1 << "), vtx ("
+                             << hyjets.khj[3][ihy] - (isub * kMaxMultiplicity) + index[isub] + 1 << "-"
+                             << hyjets.khj[4][ihy] - (isub * kMaxMultiplicity) + index[isub] + 1 << "), vtx ("
                              << hyjets.vhj[0][ihy] << "," << hyjets.vhj[1][ihy] << "," << hyjets.vhj[2][ihy] << ") "
                              << std::endl;
 
@@ -377,6 +378,12 @@ bool HydjetHadronizer::get_particles(HepMC::GenEvent* evt) {
     } else {
       particle[ihy] = build_hyjet(ihy, ihy + 1);
       int mid = hyjets.khj[2][ihy] - hjoffset + index[isub];
+      if (mid > ihy) {
+        throw cms::Exception("BadHydjetParent") << "Parent ID " << mid << " is greater than child id " << ihy
+                                                << " this is not allowed.\n When this happened in the past it was "
+                                                   "caused the sub event multiplicity being > "
+                                                << kMaxMultiplicity << " which caused an offset overflow.";
+      }
       int mid_t = mid;
       while (((mid + 1) < ihy) && (std::abs(hyjets.khj[1][mid]) < 100) &&
              (hyjets.khj[3][mid + 1] - hjoffset + index[isub] <= ihy))


### PR DESCRIPTION
#### PR description:

- Parent index should not be larger than child index for hydjet. This occurred when there was a high multiplicity which is causing an index overflow in the Fortran code.
- Now throw an exception when parent index is larger than child index. This is much preferred over the segmentation fault happening now.

#### PR validation:

Ran a job which before change would have a segmentation fault but after change throws exception and ends cleanly.