### PR TITLE
Migration from deprecated ::JetCorrector class, NoPileUpPFMEtDataProducer

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.cc
@@ -167,12 +167,15 @@ void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& 
   auto jetInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
   auto pfCandInfos = std::make_unique<reco::PUSubMETCandInfoCollection>();
 
-  const JetCorrector* jetEnOffsetCorrector = nullptr;
+  // const JetCorrector* jetEnOffsetCorrector = nullptr;
   if (!jetEnOffsetCorrLabel_.empty()) {
-    jetEnOffsetCorrector = JetCorrector::getJetCorrector(jetEnOffsetCorrLabel_, es);
-    if (!jetEnOffsetCorrector)
-      throw cms::Exception("NoPileUpPFMEtDataProducer::produce")
-          << "Failed to access Jet corrections for = " << jetEnOffsetCorrLabel_ << " !!\n";
+    throw cms::Exception("NoPileUpPFMEtDataProducer::produce")
+        << "Failed to access Jet corrections for = " << jetEnOffsetCorrLabel_ << " !!\n"
+        << "During the migration from the deprecated ::JetCorrector to the\n"
+        << "new reco::JetCorrector class, this module was never completely migrated.\n"
+        << "The usage of the deprecated class was removed and replaced by this exception.\n"
+        << "To use the new reco::JetCorrector class, someone must do the work\n"
+        << "to implement and test usage of reco::JetCollector in this class.\n";
   }
 
   size_t numJets = jets->size();
@@ -207,8 +210,10 @@ void NoPileUpPFMEtDataProducer::produce(edm::Event& evt, const edm::EventSetup& 
                                   ? (jet->neutralEmEnergy() + jet->neutralHadronEnergy()) / jetEnergy_uncorrected
                                   : -1.;
     jetInfo.setChargedEnFrac((1 - jetNeutralEnFrac));
-    jetInfo.setOffsetEnCorr(
-        (jetEnOffsetCorrector) ? rawJet.energy() * (1. - jetEnOffsetCorrector->correction(rawJet, evt, es)) : 0.);
+    // jetInfo.setOffsetEnCorr(
+    //     (jetEnOffsetCorrector) ? rawJet.energy() * (1. - jetEnOffsetCorrector->correction(rawJet, evt, es)) : 0.);
+    jetInfo.setOffsetEnCorr(0.);
+
     jetInfo.setMEtSignObj(pfMEtSignInterface_->compResolution(&(*jet)));
 
     jetInfos->push_back(jetInfo);

--- a/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.h
+++ b/RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.h
@@ -36,8 +36,6 @@
 #include "DataFormats/METReco/interface/PUSubMETDataFwd.h"
 #include "DataFormats/METReco/interface/SigInputObj.h"  //PH: preserve 5_3_x dependence
 
-#include "JetMETCorrections/Objects/interface/JetCorrector.h"
-
 class NoPileUpPFMEtDataProducer : public edm::stream::EDProducer<> {
 public:
   NoPileUpPFMEtDataProducer(const edm::ParameterSet&);


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to complete the migration of the deprecated ::JetCorrector class to the newer reco::JetCorrector class in RecoMET/METPUSubtraction/plugins/NoPileUpPFMEtDataProducer.h. This migration is now to the point that there are 5 pull requests under review and when they are merged all uses of the deprecated  JetCorrector will have been removed. This migration started in 2014. I am working on a future PR that will remove the deprecated JetCorrector.h header file and then any code including it will fail to compile.

I am open to modifying this PR and accomplishing this migration in a different way. Just let me know what you want.

The existing behavior of the module is that if one configures the parameter "jetEnOffsetCorrLabel" to be a non-empty string, then the function JetCorrector::getJetCorrector is called. When that is called the Framework EventSetup code will always throw an exception. This has been the behavior of the module since 12_3_0, about 1 year. In its current state, the PR modifies the module so that it will detect the non-empty string and then immediately and directly throw an exception. This accomplishes 3 things:

1. Preserves existing behavior
2. Allows a RECO expert to make further changes at their convenience.
3. Removes the dependence on the deprecated class so I can delete it.

Here are a couple alternative approaches we could use in this PR:

- This module is referenced in only 2 cff files in CMSSW (based on a "git grep" search). The cff files put them in a Sequence. The Sequences are not referenced anywhere in CMSSW. It appears nothing runs this code. Possibly this is dead code? If you ask, I would be happy to delete this module instead of modifying it. This code was developed in 2014 and looks like serious code that was at some point useful. I do not know whether or not it is worth keeping now.
- It would easy for me to convert the C++ code to use the new reco::JetCorrector. I would be happy to do that as long as RECO would be responsible for testing and modifying configurations and selecting which corrections to use. I'll also run a test and debug errors in my changes if you can tell me how, but I don't want or know how to develop a new test.

I am also happy to just close this PR and let RECO handle this directly, although we really want to complete this migration soon.

#### PR validation:

This just throws if the affected code is executed.
