### PR TITLE
Remove commented unnecessary code from DigiAccumulatorMixModFactory.h

### DIFF
--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -29,6 +29,5 @@ namespace edm {
 }  // namespace edm
 
 #define DEFINE_DIGI_ACCUMULATOR(type) DEFINE_EDM_PLUGIN(edm::DigiAccumulatorMixModPluginFactory, type, #type)
-//DEFINE_EDM_PLUGIN (edm::DigiAccumulatorMixModPluginFactory,type,#type); DEFINE_FWK_PSET_DESC_FILLER(type)
 
 #endif


### PR DESCRIPTION
#### PR description:

As far as I can tell, the commented out part has never been used. My motivation is to remove confusing entries from `git grep DEFINE_FWK_PSET_DESC_FILLER`.

#### PR validation:

None