### PR TITLE
Fix remaining CMS deprecation warnings in Reco* subsystems

### DIFF
--- a/RecoCaloTools/Selectors/test/TestCaloSelectors.cc
+++ b/RecoCaloTools/Selectors/test/TestCaloSelectors.cc
@@ -5,29 +5,28 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include <iostream>
 
-class TestCaloSelectors : public edm::EDAnalyzer {
+class TestCaloSelectors : public edm::one::EDAnalyzer<> {
 public:
-  TestCaloSelectors(const edm::ParameterSet& ps) : inputTag_(ps.getParameter<edm::InputTag>("inputTag")) {}
-  virtual void analyze(const edm::Event& evt, const edm::EventSetup& es);
+  TestCaloSelectors(const edm::ParameterSet& ps)
+      : token_(consumes(ps.getParameter<edm::InputTag>("inputTag"))), caloToken_(esConsumes()) {}
+  void analyze(const edm::Event& evt, const edm::EventSetup& es) override;
 
 private:
-  edm::InputTag inputTag_;
+  edm::EDGetTokenT<HBHERecHitCollection> token_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloToken_;
 };
 
 void TestCaloSelectors::analyze(const edm::Event& evt, const edm::EventSetup& c) {
-  edm::Handle<HBHERecHitCollection> hbhe;
-  evt.getByLabel(inputTag_, hbhe);
-  edm::ESHandle<CaloGeometry> pG;
-  c.get<CaloGeometryRecord>().get(pG);
+  edm::ESHandle<CaloGeometry> pG = c.getHandle(caloToken_);
 
-  const HBHERecHitCollection& mhbhe = *hbhe;
+  const HBHERecHitCollection& mhbhe = evt.get(token_);
 
   double maxEt = -1;
   GlobalPoint pMax;

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
@@ -21,7 +21,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -36,7 +36,7 @@ Implementation:
 
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h"
 
-class testEcalClusterFunctions : public edm::EDAnalyzer {
+class testEcalClusterFunctions : public edm::one::EDAnalyzer<> {
 public:
   explicit testEcalClusterFunctions(const edm::ParameterSet&);
   ~testEcalClusterFunctions() override = default;

--- a/RecoEgamma/EgammaElectronProducers/test/GEDValueMapAnalyzer.cc
+++ b/RecoEgamma/EgammaElectronProducers/test/GEDValueMapAnalyzer.cc
@@ -3,19 +3,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include <iostream>
 
-class GEDValueMapAnalyzer : public edm::EDAnalyzer {
+class GEDValueMapAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   GEDValueMapAnalyzer(const edm::ParameterSet&);
-  ~GEDValueMapAnalyzer();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& c) override;
 
 private:
   edm::InputTag inputTagValueMapElectrons_;
@@ -26,10 +24,6 @@ GEDValueMapAnalyzer::GEDValueMapAnalyzer(const edm::ParameterSet& iConfig) {
   inputTagPFCandidates_ = iConfig.getParameter<edm::InputTag>("PFCandidates");
   inputTagValueMapElectrons_ = iConfig.getParameter<edm::InputTag>("ElectronValueMap");
 }
-
-GEDValueMapAnalyzer::~GEDValueMapAnalyzer() { ; }
-
-void GEDValueMapAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
 
 void GEDValueMapAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::PFCandidateCollection> pfCandidatesH;

--- a/RecoEgamma/EgammaIsolationAlgos/test/TestEgammaTowerIso.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/test/TestEgammaTowerIso.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -7,16 +7,13 @@
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
-struct TestEgammaTowerIsolation : public edm::EDAnalyzer {
+struct TestEgammaTowerIsolation : public edm::one::EDAnalyzer<> {
   explicit TestEgammaTowerIsolation(const edm::ParameterSet&) {}
-  ~TestEgammaTowerIsolation() {}
 
   //  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void beginJob() {}
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string towerLabel = "towerMaker";
 };

--- a/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
+++ b/RecoHI/HiEgammaAlgos/test/patTest/PATHIPhotonTestModule.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -51,15 +51,14 @@ namespace edm {
 // class decleration
 //
 
-class PATHIPhotonTestModule : public edm::EDAnalyzer {
+class PATHIPhotonTestModule : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PATHIPhotonTestModule(const edm::ParameterSet&);
-  ~PATHIPhotonTestModule();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
 
   // ----------member data ---------------------------
   edm::InputTag photons_;
@@ -67,16 +66,15 @@ private:
   enum TestMode { TestRead, TestWrite, TestExternal };
   TestMode mode_;
   TNtuple* datatemp;
-  edm::Service<TFileService> fs;
 };
 
 //
 // constructors and destructor
 //
 PATHIPhotonTestModule::PATHIPhotonTestModule(const edm::ParameterSet& iConfig)
-    : photons_(iConfig.getParameter<edm::InputTag>("photons")) {}
-
-PATHIPhotonTestModule::~PATHIPhotonTestModule() {}
+    : photons_(iConfig.getParameter<edm::InputTag>("photons")) {
+  usesResource(TFileService::kSharedResource);
+}
 
 // ------------ method called to for each event  ------------
 void PATHIPhotonTestModule::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -130,6 +128,7 @@ void PATHIPhotonTestModule::analyze(const edm::Event& iEvent, const edm::EventSe
 
 // ------------ method called once each job just before starting event loop  ------------
 void PATHIPhotonTestModule::beginJob() {
+  edm::Service<TFileService> fs;
   datatemp = fs->make<TNtuple>("gammas",
                                "photon candidate info",
                                "et:"

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.h
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.h
@@ -10,7 +10,7 @@
  *  \Original author G. Cerminara - CERN
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
@@ -18,20 +18,19 @@
 #include <vector>
 #include <string>
 
-class ProducePFCalibrationObject : public edm::EDAnalyzer {
+class ProducePFCalibrationObject : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   /// Constructor
   ProducePFCalibrationObject(const edm::ParameterSet&);
 
   /// Destructor
-  virtual ~ProducePFCalibrationObject();
+  ~ProducePFCalibrationObject() override;
 
   // Operations
-  //   virtual void beginJob();
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& eSetup);
+  void beginRun(const edm::Run& run, const edm::EventSetup& eSetup) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& eSetup) override {}
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) {}
-  virtual void endJob() {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override {}
 
 protected:
 private:

--- a/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
+++ b/RecoParticleFlow/PFProducer/test/PFIsoReader.cc
@@ -23,10 +23,6 @@ PFIsoReader::PFIsoReader(const edm::ParameterSet& iConfig) {
   inputTagPhotonIsoDeposits_ = iConfig.getParameter<std::vector<edm::InputTag> >("PhotonIsoDeposits");
 }
 
-PFIsoReader::~PFIsoReader() { ; }
-
-void PFIsoReader::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
-
 void PFIsoReader::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::PFCandidateCollection> pfCandidatesH;
   bool found = iEvent.getByLabel(inputTagPFCandidates_, pfCandidatesH);

--- a/RecoParticleFlow/PFProducer/test/PFIsoReader.h
+++ b/RecoParticleFlow/PFProducer/test/PFIsoReader.h
@@ -1,6 +1,6 @@
 #ifndef RECOPARTICLEFLOW_PFISOREADER_H
 #define RECOPARTICLEFLOW_PFISOREADER_H
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
@@ -8,12 +8,10 @@
 #include <string>
 #include <map>
 
-class PFIsoReader : public edm::EDAnalyzer {
+class PFIsoReader : public edm::one::EDAnalyzer<> {
 public:
   explicit PFIsoReader(const edm::ParameterSet&);
-  ~PFIsoReader();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& c) override;
 
 private:
   typedef std::vector<edm::Handle<edm::ValueMap<reco::IsoDeposit> > > IsoDepositMaps;

--- a/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.cc
+++ b/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.cc
@@ -23,10 +23,6 @@ PFSuperClusterReader::PFSuperClusterReader(const edm::ParameterSet& iConfig) {
   inputTagPFCandidates_ = iConfig.getParameter<edm::InputTag>("PFCandidate");
 }
 
-PFSuperClusterReader::~PFSuperClusterReader() { ; }
-
-void PFSuperClusterReader::beginRun(edm::Run const&, edm::EventSetup const&) { ; }
-
 void PFSuperClusterReader::analyze(const edm::Event& iEvent, const edm::EventSetup& c) {
   edm::Handle<reco::GsfTrackCollection> gsfTracksH;
   bool found = iEvent.getByLabel(inputTagGSFTracks_, gsfTracksH);

--- a/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.h
+++ b/RecoParticleFlow/PFProducer/test/PFSuperClusterReader.h
@@ -1,6 +1,6 @@
 #ifndef RECOPARTICLEFLOW_PFSUPERCLUSTERREADER_H
 #define RECOPARTICLEFLOW_PFSUPERCLUSTERREADER_H
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
@@ -11,12 +11,10 @@
 #include <string>
 #include <map>
 
-class PFSuperClusterReader : public edm::EDAnalyzer {
+class PFSuperClusterReader : public edm::one::EDAnalyzer<> {
 public:
   explicit PFSuperClusterReader(const edm::ParameterSet&);
-  ~PFSuperClusterReader();
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& c);
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
 
 private:
   edm::InputTag inputTagGSFTracks_;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -27,6 +27,8 @@ class TrackerGeometry;
 class TransientTrackingRecHitBuilder;
 class TransientRecHitRecord;
 class TripletFilter;
+class ClusterShapeHitFilter;
+class CkfComponentsRecord;
 
 #include <vector>
 
@@ -56,6 +58,7 @@ private:
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_magfieldToken;
   edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> m_ttrhBuilderToken;
   edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> m_msmakerToken;
+  edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> m_clusterFilterToken;
 
   void getTracker(const edm::EventSetup& es);
   GlobalPoint getGlobalPosition(const TrackingRecHit* recHit);

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/TripletFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/TripletFilter.h
@@ -6,9 +6,6 @@
 
 #include <vector>
 
-namespace edm {
-  class EventSetup;
-}
 class TrackingRecHit;
 class ClusterShapeHitFilter;
 class TrackerTopology;
@@ -16,16 +13,16 @@ class SiPixelClusterShapeCache;
 
 class TripletFilter {
 public:
-  TripletFilter(const edm::EventSetup& es);
-  ~TripletFilter();
+  explicit TripletFilter(const ClusterShapeHitFilter* iFilter) : theFilter(iFilter) {}
+  ~TripletFilter() = default;
   bool checkTrack(const std::vector<const TrackingRecHit*>& recHits,
                   const std::vector<LocalVector>& localDirs,
                   const TrackerTopology* tTopo,
-                  const SiPixelClusterShapeCache& clusterShapeCache);
+                  const SiPixelClusterShapeCache& clusterShapeCache) const;
   bool checkTrack(const std::vector<const TrackingRecHit*>& recHits,
                   const std::vector<GlobalVector>& globalDirs,
                   const TrackerTopology* tTopo,
-                  const SiPixelClusterShapeCache& clusterShapeCache);
+                  const SiPixelClusterShapeCache& clusterShapeCache) const;
 
 private:
   const ClusterShapeHitFilter* theFilter;

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -15,6 +15,7 @@
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 #undef Debug
 
@@ -28,6 +29,7 @@ PixelTripletLowPtGenerator::PixelTripletLowPtGenerator(const edm::ParameterSet& 
       m_magfieldToken(iC.esConsumes()),
       m_ttrhBuilderToken(iC.esConsumes(edm::ESInputTag("", cfg.getParameter<string>("TTRHBuilder")))),
       m_msmakerToken(iC.esConsumes()),
+      m_clusterFilterToken(iC.esConsumes(edm::ESInputTag("", "ClusterShapeHitFilter"))),
       theTracker(nullptr),
       theClusterShapeCacheToken(
           iC.consumes<SiPixelClusterShapeCache>(cfg.getParameter<edm::InputTag>("clusterShapeCacheSrc"))) {
@@ -51,7 +53,7 @@ void PixelTripletLowPtGenerator::getTracker(const edm::EventSetup& es) {
   }
 
   if (!theFilter) {
-    theFilter = std::make_unique<TripletFilter>(es);
+    theFilter = std::make_unique<TripletFilter>(&es.getData(m_clusterFilterToken));
   }
 }
 

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TripletFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TripletFilter.cc
@@ -3,37 +3,20 @@
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/HitInfo.h"
 
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
 using namespace std;
 
 /*****************************************************************************/
-TripletFilter::TripletFilter(const edm::EventSetup& es) {
-  // Get cluster shape hit filter
-  edm::ESHandle<ClusterShapeHitFilter> shape;
-  es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter", shape);
-  theFilter = shape.product();
-}
-
-/*****************************************************************************/
-TripletFilter::~TripletFilter() {}
-
-/*****************************************************************************/
 bool TripletFilter::checkTrack(const vector<const TrackingRecHit*>& recHits,
                                const vector<LocalVector>& localDirs,
                                const TrackerTopology* tTopo,
-                               const SiPixelClusterShapeCache& clusterShapeCache) {
+                               const SiPixelClusterShapeCache& clusterShapeCache) const {
   bool ok = true;
 
   vector<LocalVector>::const_iterator localDir = localDirs.begin();
@@ -62,7 +45,7 @@ bool TripletFilter::checkTrack(const vector<const TrackingRecHit*>& recHits,
 bool TripletFilter::checkTrack(const vector<const TrackingRecHit*>& recHits,
                                const vector<GlobalVector>& globalDirs,
                                const TrackerTopology* tTopo,
-                               const SiPixelClusterShapeCache& clusterShapeCache) {
+                               const SiPixelClusterShapeCache& clusterShapeCache) const {
   bool ok = true;
 
   vector<GlobalVector>::const_iterator globalDir = globalDirs.begin();

--- a/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimpleTBAnalyzer.h
+++ b/RecoTBCalo/EcalSimpleTBAnalysis/interface/EcalSimpleTBAnalyzer.h
@@ -16,7 +16,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,7 +35,7 @@
 #include <map>
 //#include<stl_pair>
 
-class EcalSimpleTBAnalyzer : public edm::EDAnalyzer {
+class EcalSimpleTBAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalSimpleTBAnalyzer(const edm::ParameterSet&);
   ~EcalSimpleTBAnalyzer() override;

--- a/RecoTBCalo/ZDCTBAnalysis/src/ZdcTBAnalyzer.cc
+++ b/RecoTBCalo/ZDCTBAnalysis/src/ZdcTBAnalyzer.cc
@@ -1,7 +1,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <memory>
 
-class ZdcTBAnalyzer : public edm::EDAnalyzer {
+class ZdcTBAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit ZdcTBAnalyzer(const edm::ParameterSet&);
   ~ZdcTBAnalyzer() override;


### PR DESCRIPTION
#### PR description:

- converted modules to thread-friendly types
- added missing esConsumes

#### PR validation:

Code compiles without issuing CMS deprecation warnings.