### PR TITLE
Converted remaining DQM modules to edm::one::EDAnalyzer

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
@@ -24,6 +24,7 @@ AlcaBeamMonitorClient::AlcaBeamMonitorClient(const ParameterSet& ps)
     : parameters_(ps),
       monitorName_(parameters_.getUntrackedParameter<string>("MonitorName", "YourSubsystemName")),
       numberOfValuesToSave_(0) {
+  usesResource("DQMStore");
   dbe_ = Service<DQMStore>().operator->();
 
   if (!monitorName_.empty())

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -12,7 +12,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -20,7 +20,8 @@
 //#include "DataFormats/VertexReco/interface/Vertex.h"
 //#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-class AlcaBeamMonitorClient : public edm::EDAnalyzer {
+class AlcaBeamMonitorClient
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -32,6 +33,7 @@ protected:
   void beginJob(void) override;
   void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override {}
   void endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -30,6 +30,7 @@ BeamConditionsMonitor::BeamConditionsMonitor(const ParameterSet& ps) : countEvt_
   bsSrc_ = parameters_.getUntrackedParameter<InputTag>("beamSpot");
   debug_ = parameters_.getUntrackedParameter<bool>("Debug");
   beamSpotToken_ = esConsumes();
+  usesResource("DQMStore");
   dbe_ = Service<DQMStore>().operator->();
 
   if (!monitorName_.empty())

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -11,7 +11,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -23,7 +23,8 @@
 // class declaration
 //
 class BeamSpotObjectsRcd;
-class BeamConditionsMonitor : public edm::EDAnalyzer {
+class BeamConditionsMonitor
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   BeamConditionsMonitor(const edm::ParameterSet&);
   ~BeamConditionsMonitor() override;

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -58,6 +58,7 @@ BeamMonitorBx::BeamMonitorBx(const ParameterSet& ps) : countBx_(0), countEvt_(0)
   fitNLumi_ = parameters_.getUntrackedParameter<int>("fitEveryNLumi", -1);
   resetFitNLumi_ = parameters_.getUntrackedParameter<int>("resetEveryNLumi", -1);
 
+  usesResource("DQMStore");
   dbe_ = Service<DQMStore>().operator->();
 
   if (!monitorName_.empty())

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -11,7 +11,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -22,7 +22,8 @@
 // class declaration
 //
 
-class BeamMonitorBx : public edm::EDAnalyzer {
+class BeamMonitorBx
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/EcalMonitorDbModule/interface/EcalBarrelMonitorDbModule.h
+++ b/DQM/EcalMonitorDbModule/interface/EcalBarrelMonitorDbModule.h
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -21,7 +21,7 @@
 
 class MonitorElementsDb;
 
-class EcalBarrelMonitorDbModule : public edm::EDAnalyzer {
+class EcalBarrelMonitorDbModule : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/EcalMonitorDbModule/plugins/EcalBarrelMonitorDbModule.cc
+++ b/DQM/EcalMonitorDbModule/plugins/EcalBarrelMonitorDbModule.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 EcalBarrelMonitorDbModule::EcalBarrelMonitorDbModule(const edm::ParameterSet &ps) {
+  usesResource("DQMStore");
   dqmStore_ = edm::Service<DQMStore>().operator->();
 
   prefixME_ = ps.getUntrackedParameter<std::string>("prefixME", "");

--- a/DQM/HLTEvF/plugins/FourVectorHLT.cc
+++ b/DQM/HLTEvF/plugins/FourVectorHLT.cc
@@ -15,6 +15,7 @@ using namespace edm;
 FourVectorHLT::FourVectorHLT(const edm::ParameterSet& iConfig) {
   LogDebug("FourVectorHLT") << "constructor....";
 
+  usesResource("DQMStore");
   dbe_ = Service<DQMStore>().operator->();
   if (!dbe_) {
     LogWarning("Status") << "unable to get DQMStore service?";

--- a/DQM/HLTEvF/plugins/FourVectorHLT.h
+++ b/DQM/HLTEvF/plugins/FourVectorHLT.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -43,7 +43,7 @@
 // class decleration
 //
 
-class FourVectorHLT : public edm::EDAnalyzer {
+class FourVectorHLT : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/SiStripCommissioningClients/interface/SiStripCommissioningOfflineClient.h
+++ b/DQM/SiStripCommissioningClients/interface/SiStripCommissioningOfflineClient.h
@@ -6,7 +6,7 @@
 #include "DQM/SiStripCommissioningClients/interface/SiStripTFile.h"
 #include "DQM/SiStripCommissioningClients/interface/SummaryPlotXmlParser.h"
 #include "DQM/SiStripCommissioningSummary/interface/SummaryPlot.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@ class TH1;
    histograms", analyzes the histograms to extract "monitorables", and
    creates summary histograms.
 */
-class SiStripCommissioningOfflineClient : public edm::EDAnalyzer {
+class SiStripCommissioningOfflineClient : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   typedef dqm::harvesting::MonitorElement MonitorElement;
   typedef dqm::harvesting::DQMStore DQMStore;
@@ -35,6 +35,7 @@ public:
   ~SiStripCommissioningOfflineClient() override;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 

--- a/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
+++ b/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
@@ -53,6 +53,7 @@ SiStripCommissioningOfflineClient::SiStripCommissioningOfflineClient(const edm::
       parameters_(pset) {
   LogTrace(mlDqmClient_) << "[SiStripCommissioningOfflineClient::" << __func__ << "]"
                          << " Constructing object...";
+  usesResource("DQMStore");
   setInputFiles(inputFiles_,
                 pset.getUntrackedParameter<std::string>("FilePath"),
                 pset.existsAs<std::string>("PartitionName") ? pset.getParameter<std::string>("PartitionName") : "",

--- a/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
+++ b/DQM/SiStripCommissioningSources/interface/SiStripCommissioningSource.h
@@ -12,7 +12,7 @@
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
@@ -31,7 +31,7 @@ class SiStripEventSummary;
 /**
    @class SiStripCommissioningSource
 */
-class SiStripCommissioningSource : public edm::EDAnalyzer {
+class SiStripCommissioningSource : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:  // ---------- Public interface ----------
   /** Map of task objects, identified through FedChanelId */
   typedef std::map<unsigned int, CommissioningTask*> TaskMap;
@@ -48,6 +48,7 @@ public:  // ---------- Public interface ----------
   ~SiStripCommissioningSource() override;
 
   void beginRun(edm::Run const&, const edm::EventSetup&) override;
+  void endRun(edm::Run const&, const edm::EventSetup&) override {}
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 

--- a/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
+++ b/DQM/SiStripCommissioningSources/src/SiStripCommissioningSource.cc
@@ -76,6 +76,7 @@ SiStripCommissioningSource::SiStripCommissioningSource(const edm::ParameterSet& 
       base_(""),
       view_(pset.getUntrackedParameter<std::string>("View", "Default")),
       parameters_(pset) {
+  usesResource("DQMStore");
   inputModuleSummaryToken_ = consumes<SiStripEventSummary>(edm::InputTag(inputModuleLabelSummary_));
   digiVirginRawToken_ = mayConsume<edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "VirginRaw"));
   digiFineDelaySelectionToken_ =

--- a/DQM/TrigXMonitorClient/interface/HLTScalersClient.h
+++ b/DQM/TrigXMonitorClient/interface/HLTScalersClient.h
@@ -42,7 +42,7 @@
 #include <utility>
 #include <vector>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -53,7 +53,8 @@
 #define MAX_PATHS 200
 #define MAX_LUMI_SEG_HLT 2400
 
-class HLTScalersClient : public edm::EDAnalyzer {
+class HLTScalersClient
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 private:
   std::ofstream textfile_;
 
@@ -133,6 +134,7 @@ public:
 
   /// End LumiBlock
   /// DQM Client Diagnostic should be performed here
+  void beginLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override {}
   void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
   // unused

--- a/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
+++ b/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
@@ -6,7 +6,7 @@
 #ifndef L1ScalersCLIENT_H
 #define L1ScalersCLIENT_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -19,7 +19,8 @@
 #define MAX_TT 80
 #define MAX_LUMI_SEG 2000
 
-class L1ScalersClient : public edm::EDAnalyzer {
+class L1ScalersClient
+    : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -44,6 +45,7 @@ public:
 
   /// End LumiBlock
   /// DQM Client Diagnostic should be performed here
+  void beginLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override {}
   void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg, const edm::EventSetup &c) override;
 
   // unused

--- a/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/HLTScalersClient.cc
@@ -81,6 +81,7 @@ HLTScalersClient::HLTScalersClient(const edm::ParameterSet &ps)
     }
   }
   // get back-end interface
+  usesResource("DQMStore");
   dbe_ = edm::Service<DQMStore>().operator->();
   dbe_->setCurrentFolder(folderName_);
 

--- a/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
+++ b/DQM/TrigXMonitorClient/src/L1ScalersClient.cc
@@ -34,6 +34,7 @@ L1ScalersClient::L1ScalersClient(const edm::ParameterSet &ps)
       first_tt(true) {
   LogDebug("Status") << "constructor";
   // get back-end interface
+  usesResource("DQMStore");
   dbe_ = edm::Service<DQMStore>().operator->();
   assert(dbe_ != nullptr);  // blammo!
   dbe_->setCurrentFolder(folderName_);


### PR DESCRIPTION
#### PR description:

This fixes the CMS deprecation warnings in the DQM subsystem.

#### PR validation:

Packages compile without issuing CMS deprecation warnings.