### PR TITLE
Fix deprecation warnings in DQMOffline/CalibMuon

### DIFF
--- a/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTnoiseDBValidation.h
@@ -8,7 +8,7 @@
  */
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -27,7 +27,7 @@ class DTChamberId;
 class DTStatusFlag;
 class TFile;
 
-class DTnoiseDBValidation : public edm::EDAnalyzer {
+class DTnoiseDBValidation : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
+++ b/DQMOffline/CalibMuon/interface/DTt0DBValidation.h
@@ -8,7 +8,7 @@
  */
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -29,7 +29,7 @@
 class DTT0;
 class TFile;
 
-class DTt0DBValidation : public edm::EDAnalyzer {
+class DTt0DBValidation : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQMOffline/CalibMuon/src/DTnoiseDBValidation.cc
+++ b/DQMOffline/CalibMuon/src/DTnoiseDBValidation.cc
@@ -41,6 +41,7 @@ DTnoiseDBValidation::DTnoiseDBValidation(const ParameterSet &pset)
   LogVerbatim("NoiseDBValidation") << "[DTnoiseDBValidation] Constructor called!";
 
   // Get the DQM needed services
+  usesResource("DQMStore");
   dbe_ = edm::Service<DQMStore>().operator->();
   dbe_->setCurrentFolder("DT/DtCalib/NoiseDBValidation");
 

--- a/DQMOffline/CalibMuon/src/DTt0DBValidation.cc
+++ b/DQMOffline/CalibMuon/src/DTt0DBValidation.cc
@@ -40,6 +40,7 @@ DTt0DBValidation::DTt0DBValidation(const ParameterSet &pset)
   LogVerbatim(metname_) << "[DTt0DBValidation] Constructor called!";
 
   // Get the DQM needed services
+  usesResource("DQMStore");
   dbe_ = edm::Service<DQMStore>().operator->();
   dbe_->setCurrentFolder("DT/DtCalib/InterChannelSynchDBValidation");
 


### PR DESCRIPTION
#### PR description:

Converted modules to edm::one::EDAnalyzer

#### PR validation:

Package compiles without issuing a CMS deprecation warning.