### PR TITLE
GE21 recHits in GEM onlineDQM, a backport to 12_4_X

### DIFF
--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -41,6 +41,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.keepDAQStatus = True
 
+process.gemRecHits.ge21Off = cms.bool(False)
+
 process.GEMDigiSource.runType = "online"
 process.GEMRecHitSource.runType = "online"
 process.GEMDAQStatusSource.runType = "online"


### PR DESCRIPTION
#### PR description:

With this PR GE21 recHits are generated and drawn in the GEM onlineDQM. It makes effect only on the onlineDQM system, not on any other places, such as muon reconstruction.

#### PR validation:

Test are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of #39860 to 12_4_X.

@jshlee @watson-ij @seungjin-yang
