### PR TITLE
Nano: fix matching between pat trigger objects and L1 objects

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
@@ -120,6 +120,8 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
     for (const auto &sel : sels_) {
       if (sel.match(obj) && (sel.skipObjectsNotPassingQualityBits ? (int(sel.qualityBits(obj)) > 0) : true)) {
         selected.emplace_back(&obj, &sel);
+        // cave canem: the object will be taken by whichever selection it matches first, so it
+        // depends on the order of the selections in the VPSet
         break;
       }
     }
@@ -250,6 +252,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
         const auto &seed = l1obj.first;
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l1cut(seed)) {
+          best = dr2;
           l1pt[i] = seed.pt();
           l1iso[i] = l1obj.second;
           l1charge[i] = seed.charge();
@@ -262,6 +265,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
         const auto &seed = l1obj.first;
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l1cut_2(seed)) {
+          best = dr2;
           l1pt_2[i] = seed.pt();
         }
       }
@@ -271,6 +275,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
       for (const auto &seed : trigObjs) {
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l2cut(seed)) {
+          best = dr2;
           l2pt[i] = seed.pt();
         }
       }


### PR DESCRIPTION
#### PR description:

Fix bug with matching between PAT trigger objects and L1 objects reported in #39809.

#### PR validation:

Ran with `runTheMatrix.py --what nano --site "" --command "--number 10"`. Differences in trigger object L1/L2 branches are expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will backport to 124X. Similarly to #39309, #39230 and #39818, this will introduce some differences wrt previously produced nanoV10 samples (both when running in 126X and 124X), but we (XPOG) think the gain of fixing those in prompt nano outweights the cost of introducing these differences. Further, more cleanup on the TriggerObjectTableProducer is planned.
