### PR TITLE
Deal with cases in which file is a nullptr in DQMRootSource.cc

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -485,7 +485,7 @@ std::shared_ptr<edm::FileBlock> DQMRootSource::readFile_() {
   m_openFiles.reserve(numFiles);
 
   for (auto& fileitem : m_catalog.fileCatalogItems()) {
-    TFile* file;
+    TFile* file = nullptr;
     std::string pfn;
     std::string lfn;
     std::list<std::string> exInfo;
@@ -550,7 +550,7 @@ std::shared_ptr<edm::FileBlock> DQMRootSource::readFile_() {
       }
     }  //end loop over names of the file
 
-    if (!isGoodFile && m_skipBadFiles)
+    if (!file || (!isGoodFile && m_skipBadFiles))
       continue;
 
     std::unique_ptr<std::string> guid{file->Get<std::string>(kCmsGuid)};


### PR DESCRIPTION
#### PR description:

As hinted by the static analyzer, see also https://github.com/cms-sw/cmssw/pull/39852#issuecomment-1294603711, there is a logic error in the code of DQMRootSource.cc ([this line](https://github.com/cms-sw/cmssw/compare/master...perrotta:dealWithMissingFiles?expand=1#diff-065460daed6dfa882871be4c6dcc28e8c6fc38c622382b3cbdaaf3be78a0d7ebL556)) when `file = nullptr`

If I understand correctly the logic behind, this PR should be the fix for it

I write a PR instead of a github issue because in this case it looks faster to me. But please @Dr15Jones and/or @cms-sw/dqm-l2  comment here if you think that the fix is correct, or if you suggest something else instead

#### PR validation:

It builds.
If the fix is correct, there should be no differences in outputs
