### PR TITLE
Removed unneeded include of EDAnalyzer.h from DQM

### DIFF
--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -4,7 +4,6 @@
 #include "CalibFormats/CastorObjects/interface/CastorDbService.h"
 #include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQM/DTMonitorModule/interface/DTCalibValidation.h
+++ b/DQM/DTMonitorModule/interface/DTCalibValidation.h
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/DTMonitorModule/interface/DTCalibValidationFromMuons.h
+++ b/DQM/DTMonitorModule/interface/DTCalibValidationFromMuons.h
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.h
@@ -15,7 +15,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"

--- a/DQM/DTMonitorModule/src/DTEfficiencyTask.h
+++ b/DQM/DTMonitorModule/src/DTEfficiencyTask.h
@@ -18,7 +18,6 @@
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/DTMonitorModule/src/DTNoiseTask.h
+++ b/DQM/DTMonitorModule/src/DTNoiseTask.h
@@ -9,7 +9,6 @@
 
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.h
@@ -17,7 +17,6 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"

--- a/DQM/DTMonitorModule/src/DTRunConditionVar.h
+++ b/DQM/DTMonitorModule/src/DTRunConditionVar.h
@@ -22,7 +22,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.h
@@ -18,7 +18,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/EcalMonitorDbModule/interface/MonitorElementsDb.h
+++ b/DQM/EcalMonitorDbModule/interface/MonitorElementsDb.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESPedestalTask.h
@@ -1,7 +1,6 @@
 #ifndef ESPedestalTask_H
 #define ESPedestalTask_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESRawDataTask.h
@@ -1,7 +1,6 @@
 #ifndef ESRawDataTask_H
 #define ESRawDataTask_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESTimingTask.h
@@ -1,7 +1,6 @@
 #ifndef ESTimingTask_H
 #define ESTimingTask_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/DQM/EcalPreshowerMonitorModule/interface/ESTrendTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESTrendTask.h
@@ -1,7 +1,6 @@
 #ifndef ESTrendTask_H
 #define ESTrendTask_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/DQM/HLTEvF/plugins/FourVectorHLT.cc
+++ b/DQM/HLTEvF/plugins/FourVectorHLT.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/HcalCommon/interface/HcalCommonHeaders.h
+++ b/DQM/HcalCommon/interface/HcalCommonHeaders.h
@@ -43,7 +43,6 @@
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"

--- a/DQM/L1TMonitor/interface/L1TDTTF.h
+++ b/DQM/L1TMonitor/interface/L1TDTTF.h
@@ -12,7 +12,6 @@
 #include <string>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"

--- a/DQM/L1TMonitor/interface/L1TObjectsTiming.h
+++ b/DQM/L1TMonitor/interface/L1TObjectsTiming.h
@@ -25,7 +25,6 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 

--- a/DQM/L1TMonitor/interface/L1TdeCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTF.h
@@ -5,7 +5,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h
+++ b/DQM/L1TMonitorClient/interface/L1EmulatorErrorFlagClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TCSCTFClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TCSCTFClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TDTTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TDTTPGClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TEventInfoClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TEventInfoClient.h
@@ -30,7 +30,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TGCTClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TGCTClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TGMTClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TGMTClient.h
@@ -1,7 +1,6 @@
 #ifndef DQM_L1TMONITORCLIENT_L1TGMTCLIENT_H
 #define DQM_L1TMONITORCLIENT_L1TGMTCLIENT_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TOccupancyClient.h
@@ -5,7 +5,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"

--- a/DQM/L1TMonitorClient/interface/L1TOccupancyClientHistogramService.h
+++ b/DQM/L1TMonitorClient/interface/L1TOccupancyClientHistogramService.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TRPCTFClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TRPCTFClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TTestsSummary.h
+++ b/DQM/L1TMonitorClient/interface/L1TTestsSummary.h
@@ -5,7 +5,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeCSCTPGShowerClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeGEMTPGClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TdeStage2RegionalShowerClient.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 

--- a/DQM/Physics/src/CentralityDQM.cc
+++ b/DQM/Physics/src/CentralityDQM.cc
@@ -15,7 +15,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // Centrality
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 using namespace edm;

--- a/DQM/Physics/src/CentralitypADQM.cc
+++ b/DQM/Physics/src/CentralitypADQM.cc
@@ -15,7 +15,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // Centrality
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 using namespace edm;

--- a/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/SiStripFineDelayTLA.h
@@ -1,7 +1,6 @@
 #ifndef CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTLA_h
 #define CalibTracker_SiSitripLorentzAngle_SiStripFineDelayTLA_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -16,7 +16,6 @@ Monitoring source for general quantities related to tracks.
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.