### PR TITLE
Removed unused EDAnalyzer.h header from DQMOffline

### DIFF
--- a/DQMOffline/EGamma/interface/ElectronDqmHarvesterBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmHarvesterBase.h
@@ -2,7 +2,6 @@
 #ifndef ElectronDqmHarvesterBase_h
 #define ElectronDqmHarvesterBase_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <Rtypes.h>
 #include <string>

--- a/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
+++ b/DQMOffline/JetMET/interface/ECALRecHitAnalyzer.h
@@ -13,7 +13,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
+++ b/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
@@ -18,7 +18,6 @@
 
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 
 class JetMETDQMDCSFilter {

--- a/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
+++ b/DQMOffline/JetMET/interface/SUSYDQMAnalyzer.h
@@ -7,7 +7,6 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQMOffline/JetMET/plugins/SusyPostProcessor.h
+++ b/DQMOffline/JetMET/plugins/SusyPostProcessor.h
@@ -3,7 +3,6 @@
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQMOffline/Lumi/interface/ElectronIdentifier.h
+++ b/DQMOffline/Lumi/interface/ElectronIdentifier.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"   // definitions for declaring plug-in modules
 #include "FWCore/Framework/interface/Frameworkfwd.h"  // declaration of EDM types
-#include "FWCore/Framework/interface/EDAnalyzer.h"    // EDAnalyzer class
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"  // Parameters
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"   // definitions for declaring plug-in modules
 #include "FWCore/Framework/interface/Frameworkfwd.h"  // declaration of EDM types
-#include "FWCore/Framework/interface/EDAnalyzer.h"    // EDAnalyzer class
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"  // Parameters
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/DQMOffline/Lumi/plugins/ZCountingElectrons.h
+++ b/DQMOffline/Lumi/plugins/ZCountingElectrons.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"   // definitions for declaring plug-in modules
 #include "FWCore/Framework/interface/Frameworkfwd.h"  // declaration of EDM types
-#include "FWCore/Framework/interface/EDAnalyzer.h"    // EDAnalyzer class
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"  // Parameters
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
@@ -28,7 +28,6 @@
 //#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 

--- a/DQMOffline/Trigger/interface/HLTTauCertifier.h
+++ b/DQMOffline/Trigger/interface/HLTTauCertifier.h
@@ -6,7 +6,6 @@ bachtis@hep.wisc.edu
 
 #include <memory>
 #include <unistd.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"

--- a/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMOfflineSource.h
@@ -3,7 +3,6 @@
 #ifndef DQMOffline_Trigger_HLTTauDQMOfflineSource_h
 #define DQMOffline_Trigger_HLTTauDQMOfflineSource_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/DQMOffline/Trigger/interface/JetMETHLTOfflineClient.h
+++ b/DQMOffline/Trigger/interface/JetMETHLTOfflineClient.h
@@ -20,7 +20,6 @@
 
 #include <memory>
 #include <unistd.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.