### PR TITLE
Removed unused EDAnalyzer.h from HLTJetMETValidation.h

### DIFF
--- a/HLTriggerOffline/JetMET/interface/HLTJetMETValidation.h
+++ b/HLTriggerOffline/JetMET/interface/HLTJetMETValidation.h
@@ -6,7 +6,6 @@
 #define HLTJetMETValidation_h
 
 #include "DataFormats/Math/interface/LorentzVector.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

The framework header is deprecated.

#### PR validation:

Code compiles.