### PR TITLE
Removed unused EDAnalyzer.h header from AnalysisJV

### DIFF
--- a/JetMETCorrections/JetVertexAssociation/test/AnalysisJV.cc
+++ b/JetMETCorrections/JetVertexAssociation/test/AnalysisJV.cc
@@ -19,7 +19,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "JetMETCorrections/JetVertexAssociation/test/AnalysisJV.h"


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.