### PR TITLE
Removed unused EDAnalyzer.h from L1Trigger*

### DIFF
--- a/L1Trigger/L1GctAnalyzer/interface/compareCands.h
+++ b/L1Trigger/L1GctAnalyzer/interface/compareCands.h
@@ -3,7 +3,6 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/L1GctAnalyzer/interface/compareMissingEnergySums.h
+++ b/L1Trigger/L1GctAnalyzer/interface/compareMissingEnergySums.h
@@ -6,7 +6,6 @@
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/L1GctAnalyzer/interface/compareTotalEnergySums.h
+++ b/L1Trigger/L1GctAnalyzer/interface/compareTotalEnergySums.h
@@ -6,7 +6,6 @@
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/L1GctAnalyzer/src/DumpGctDigis.cc
+++ b/L1Trigger/L1GctAnalyzer/src/DumpGctDigis.cc
@@ -6,7 +6,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/L1TGlobal/plugins/GtInputDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtInputDump.cc
@@ -16,7 +16,6 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 //#include "FWCore/ParameterSet/interface/InputTag.h"
 
 // system include files

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTRelValAnalyzer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTRelValAnalyzer.cc
@@ -3,7 +3,6 @@
 
 // user include files
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
@@ -9,7 +9,6 @@ using std::ostream;
 
 #include <iomanip>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTestAnalyzer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTTestAnalyzer.cc
@@ -3,7 +3,6 @@
 
 // user include files
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctConfigDump.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctConfigDump.cc
@@ -1,6 +1,5 @@
 #include "L1TriggerConfig/GctConfigProducers/interface/L1GctConfigDump.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTester.cc
@@ -19,9 +19,6 @@
 #include <iomanip>
 
 // user include files
-//   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAndMasksTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAndMasksTester.cc
@@ -20,9 +20,6 @@
 #include <iostream>
 
 // user include files
-//   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
@@ -20,9 +20,6 @@
 #include <iostream>
 
 // user include files
-//   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
@@ -20,9 +20,6 @@
 #include <boost/algorithm/string/erase.hpp>
 
 // user include files
-//   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
@@ -20,9 +20,6 @@
 #include <iostream>
 #include <sys/stat.h>
 
-//   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.