### PR TITLE
Remove unused EDAnalyzer.h in Reco* packages

### DIFF
--- a/RecoEgamma/ElectronIdentification/plugins/plugins.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/plugins.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "PhysicsTools/SelectorUtils/interface/VersionedIdProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
+++ b/RecoMuon/TrackingTools/src/MuonSegmentMatcher.cc
@@ -12,7 +12,6 @@
 #include "RecoMuon/TrackingTools/interface/MuonSegmentMatcher.h"
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.