### PR TITLE
Removed unused EDAnalyzer.h from METTester

### DIFF
--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -37,16 +37,14 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "TMath.h"
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
-// class METTester: public edm::EDAnalyzer {
 class METTester : public DQMEDAnalyzer {
 public:
   explicit METTester(const edm::ParameterSet &);


### PR DESCRIPTION
#### PR description:

The header is deprecated.

#### PR validation:

Code compiles.