### PR TITLE
 HCAL: Modifications to the HCAL trigger key generation scripts

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/test/PlotLUT.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/PlotLUT.py
@@ -10,6 +10,7 @@ options.register('tags',	'', VarParsing.VarParsing.multiplicity.list, VarParsing
 options.register('gains',	'', VarParsing.VarParsing.multiplicity.list, VarParsing.VarParsing.varType.string, '') 
 options.register('respcorrs',	'', VarParsing.VarParsing.multiplicity.list, VarParsing.VarParsing.varType.string, '') 
 options.register('pedestals',	'', VarParsing.VarParsing.multiplicity.list, VarParsing.VarParsing.varType.string, '') 
+options.register('effpedestals','', VarParsing.VarParsing.multiplicity.list, VarParsing.VarParsing.varType.string, '')
 options.register('quality',	'', VarParsing.VarParsing.multiplicity.list, VarParsing.VarParsing.varType.string, '') 
 options.parseArguments()
 
@@ -30,6 +31,7 @@ process.plot  = cms.EDAnalyzer("HcalLutAnalyzer",
     gains     = cms.vstring(options.gains),
     respcorrs = cms.vstring(options.respcorrs),
     pedestals = cms.vstring(options.pedestals),
+    effpedestals = cms.vstring(options.effpedestals),                               
     quality   = cms.vstring(options.quality),
     Zmin      = cms.double(0),
     Zmax      = cms.double(10),

--- a/CaloOnlineTools/HcalOnlineDb/test/template.py
+++ b/CaloOnlineTools/HcalOnlineDb/test/template.py
@@ -38,6 +38,10 @@ process.es_ascii = cms.ESSource('HcalTextCalibrations',
 	 file   = cms.FileInPath(CONDDIR+'/Pedestals/Pedestals_Run__RUN__.txt')
       ),	
       cms.PSet(
+         object = cms.string('EffectivePedestals'),
+	 file   = cms.FileInPath(CONDDIR+'/EffectivePedestals/EffectivePedestals_Run__RUN__.txt')
+      ),	
+      cms.PSet(
          object = cms.string('Gains'),
 	 file   = cms.FileInPath(CONDDIR+'/Gains/Gains_Run__RUN__.txt')
       ),


### PR DESCRIPTION
#### PR description:

This PR adds the feature to create plots comparing the HCAL effective pedestals before and after a condition change.

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport. This PR updates the "service" scripts for LUTs and Trigger key generation, so the changes do not need to be backported to 12_4_X/12_5_X