### PR TITLE
Improve the SoA accessors and optimisations

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -66,8 +66,9 @@ Serialization of Eigen data is not yet supported.
 The template shared by layouts and parameters are:
 - Byte aligment (defaulting to the nVidia GPU cache line size (128 bytes))
 - Alignment enforcement (`relaxed` or `enforced`). When enforced, the alignment will be checked at construction
-  time, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
-  intrinsic).
+  time.~~, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
+  intrinsic).~~ It turned out that hinting `nvcc` for alignement removed the benefit of more important `__restrict__`
+  hinting. The `__builtin_assume_aligned` is hence currently not use.
 
 In addition, the views also provide access parameters:
 - Restrict qualify: add restrict hints to read accesses, so that the compiler knows it can relax accesses to the

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -287,19 +287,19 @@ namespace cms::soa {
 
     SOA_HOST_DEVICE SOA_INLINE Ref operator()() {
       // Ptr type will add the restrict qualifyer if needed
-      Ptr col = alignedCol();
+      Ptr col = col_;
       return col[idx_];
     }
 
     SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
       // PtrToConst type will add the restrict qualifyer if needed
-      PtrToConst col = alignedCol();
+      PtrToConst col = col_();
       return col[idx_];
     }
 
-    SOA_HOST_DEVICE SOA_INLINE Ptr operator&() { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE Ptr operator&() { return &col_[idx_]; }
 
-    SOA_HOST_DEVICE SOA_INLINE PtrToConst operator&() const { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE PtrToConst operator&() const { return &col_[idx_]; }
 
     /* This was an attempt to implement the syntax
      *
@@ -318,7 +318,7 @@ namespace cms::soa {
 
     template <typename T2>
     SOA_HOST_DEVICE SOA_INLINE Ref operator=(const T2& v) {
-      return alignedCol()[idx_] = v;
+      return col_[idx_] = v;
     }
     */
 
@@ -327,13 +327,6 @@ namespace cms::soa {
     static constexpr auto valueSize = sizeof(T);
 
   private:
-    SOA_HOST_DEVICE SOA_INLINE Ptr alignedCol() const {
-      if constexpr (ALIGNMENT) {
-        return reinterpret_cast<Ptr>(__builtin_assume_aligned(col_, ALIGNMENT));
-      }
-      return reinterpret_cast<Ptr>(col_);
-    }
-
     size_type idx_;
     T* col_;
   };
@@ -437,11 +430,11 @@ namespace cms::soa {
 
     SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
       // Ptr type will add the restrict qualifyer if needed
-      PtrToConst col = alignedCol();
+      PtrToConst col = col_;
       return col[idx_];
     }
 
-    SOA_HOST_DEVICE SOA_INLINE const T* operator&() const { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE const T* operator&() const { return &col_[idx_]; }
 
     /* This was an attempt to implement the syntax
      *
@@ -461,13 +454,6 @@ namespace cms::soa {
     static constexpr auto valueSize = sizeof(T);
 
   private:
-    SOA_HOST_DEVICE SOA_INLINE PtrToConst alignedCol() const {
-      if constexpr (ALIGNMENT) {
-        return reinterpret_cast<PtrToConst>(__builtin_assume_aligned(col_, ALIGNMENT));
-      }
-      return reinterpret_cast<PtrToConst>(col_);
-    }
-
     size_type idx_;
     const T* col_;
   };

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -612,7 +612,7 @@ namespace cms::soa {
         : params_(params) {}
     SOA_HOST_DEVICE SOA_INLINE const T* operator()() const { return params_.addr_; }
     using NoParamReturnType = const T*;
-    SOA_HOST_DEVICE SOA_INLINE T operator()(size_type index) const { return params_.addr_[index]; }
+    SOA_HOST_DEVICE SOA_INLINE T const& operator()(size_type index) const { return params_.addr_[index]; }
 
   private:
     SoAConstParametersImpl<SoAColumnType::column, T> params_;
@@ -638,8 +638,8 @@ namespace cms::soa {
   struct SoAColumnAccessorsImpl<T, SoAColumnType::scalar, SoAAccessType::constAccess> {
     SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAConstParametersImpl<SoAColumnType::scalar, T>& params)
         : params_(params) {}
-    SOA_HOST_DEVICE SOA_INLINE T operator()() const { return *params_.addr_; }
-    using NoParamReturnType = T;
+    SOA_HOST_DEVICE SOA_INLINE T const& operator()() const { return *params_.addr_; }
+    using NoParamReturnType = T const&;
     SOA_HOST_DEVICE SOA_INLINE void operator()(size_type index) const {
       assert(false && "Indexed access impossible for SoA scalars.");
     }
@@ -667,8 +667,8 @@ namespace cms::soa {
   struct SoAColumnAccessorsImpl<T, SoAColumnType::eigen, SoAAccessType::constAccess> {
     SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAConstParametersImpl<SoAColumnType::eigen, T>& params)
         : params_(params) {}
-    SOA_HOST_DEVICE SOA_INLINE const typename T::Scalar* operator()() const { return params_.addr_; }
-    using NoParamReturnType = typename T::Scalar*;
+    SOA_HOST_DEVICE SOA_INLINE typename T::Scalar const* operator()() const { return params_.addr_; }
+    using NoParamReturnType = typename T::Scalar const*;
     //SOA_HOST_DEVICE SOA_INLINE T operator()(size_type index) const { return params_.addr_[index]; }
 
   private:

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -581,17 +581,6 @@
         throw std::runtime_error("In " #CLASS "::" #CLASS ": unexpected end pointer.");                                \
     }                                                                                                                  \
                                                                                                                        \
-    /* Range checker conditional to the macro _DO_RANGECHECK */                                                        \
-    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
-    void rangeCheck(size_type index) const {                                                                           \
-      if constexpr (_DO_RANGECHECK) {                                                                                  \
-        if (index >= elements_) {                                                                                      \
-          printf("In " #CLASS "::rangeCheck(): index out of range: %zu with elements: %zu\n", index, elements_);       \
-          assert(false);                                                                                               \
-        }                                                                                                              \
-      }                                                                                                                \
-    }                                                                                                                  \
-                                                                                                                       \
     /* Data members */                                                                                                 \
     std::byte* mem_;                                                                                                   \
     size_type elements_;                                                                                               \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -389,7 +389,11 @@ namespace cms::soa {
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                          \
   LOCAL_NAME(size_type index) {                                                                                        \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
+      if (index >= base_type::elements_)                                                                               \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #LOCAL_NAME "(size_type index)")                       \
+    }                                                                                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
                 template RestrictQualifier<restrictQualify>(const_cast_SoAParametersImpl(                              \
@@ -423,7 +427,11 @@ namespace cms::soa {
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
                 template RestrictQualifier<restrictQualify>::ParamReturnType                                           \
   LOCAL_NAME(size_type index) const {                                                                                  \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
+      if (index >= elements_)                                                                                          \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in const " #LOCAL_NAME "(size_type index)")                         \
+    }                                                                                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
                 template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);             \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -92,6 +92,16 @@ namespace cms::soa {
       typename BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(ParametersTypeOf_, LAYOUT_MEMBER);           \
   constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME) =                                   \
       BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(ColumnTypeOf_, LAYOUT_MEMBER);                        \
+  using BOOST_PP_CAT(ConstAccessorOf_, LOCAL_NAME) =                                                                   \
+    typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                            \
+        template ColumnType<BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                             \
+            cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
+                template RestrictQualifier<restrictQualify> ;                                                          \
+  using BOOST_PP_CAT(MutableAccessorOf_, LOCAL_NAME) =                                                                 \
+    typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                            \
+        template ColumnType<BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                             \
+            cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
+                template RestrictQualifier<restrictQualify> ;                                                          \
   SOA_HOST_DEVICE SOA_INLINE                                                                                           \
   const auto BOOST_PP_CAT(parametersOf_, LOCAL_NAME)() const {                                                         \
     return CAST(parent_.BOOST_PP_CAT(LOCAL_NAME, Parameters_));                                                        \
@@ -364,18 +374,26 @@ namespace cms::soa {
   SOA_HOST_DEVICE SOA_INLINE                                                                                           \
   typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::mutableAccess>::NoParamReturnType                                                 \
+            cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
+                 template RestrictQualifier<restrictQualify>::NoParamReturnType                                        \
   LOCAL_NAME() {                                                                                                       \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::mutableAccess>(const_cast_SoAParametersImpl(                                      \
-                base_type:: BOOST_PP_CAT(LOCAL_NAME, Parameters_)))();                                                 \
+            cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
+                template RestrictQualifier<restrictQualify>(const_cast_SoAParametersImpl(                              \
+                    base_type:: BOOST_PP_CAT(LOCAL_NAME, Parameters_)))();                                             \
   }                                                                                                                    \
-  SOA_HOST_DEVICE SOA_INLINE auto& LOCAL_NAME(size_type index) {                                                       \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+  typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::mutableAccess>(const_cast_SoAParametersImpl(                                      \
-                base_type:: BOOST_PP_CAT(LOCAL_NAME, Parameters_)))(index);                                            \
+            cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
+                 template RestrictQualifier<restrictQualify>::ParamReturnType                                          \
+  LOCAL_NAME(size_type index) {                                                                                        \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
+                template RestrictQualifier<restrictQualify>(const_cast_SoAParametersImpl(                              \
+                    base_type:: BOOST_PP_CAT(LOCAL_NAME, Parameters_)))(index);                                        \
   }
 // clang-format on
 
@@ -391,16 +409,24 @@ namespace cms::soa {
   SOA_HOST_DEVICE SOA_INLINE                                                                                           \
   typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::constAccess>::NoParamReturnType                                                   \
+            cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
+                template RestrictQualifier<restrictQualify>::NoParamReturnType                                         \
   LOCAL_NAME() const {                                                                                                 \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))();                            \
+            cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
+                template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))();                  \
   }                                                                                                                    \
-  SOA_HOST_DEVICE SOA_INLINE auto const& LOCAL_NAME(size_type index) const {                                           \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+  typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
-            cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);                       \
+            cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
+                template RestrictQualifier<restrictQualify>::ParamReturnType                                           \
+  LOCAL_NAME(size_type index) const {                                                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
+                template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);             \
   }
 // clang-format on
 

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -388,12 +388,16 @@ namespace cms::soa {
 // clang-format off
 #define _DECLARE_VIEW_SOA_CONST_ACCESSOR_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                                  \
   /* Column or scalar */                                                                                               \
-  SOA_HOST_DEVICE SOA_INLINE auto LOCAL_NAME() const {                                                                 \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+  typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::constAccess>::NoParamReturnType                                                   \
+  LOCAL_NAME() const {                                                                                                 \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))();                            \
   }                                                                                                                    \
-  SOA_HOST_DEVICE SOA_INLINE auto LOCAL_NAME(size_type index) const {                                                  \
+  SOA_HOST_DEVICE SOA_INLINE auto const& LOCAL_NAME(size_type index) const {                                           \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);                       \

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -101,7 +101,7 @@ using RangeCheckingHostDeviceView =
 
 // We expect to just run one thread.
 __global__ void rangeCheckKernel(RangeCheckingHostDeviceView soa) {
-  printf("About to fail range-check in CUDA thread: %d\n", threadIdx.x);
+  printf("About to fail range-check (operator[]) in CUDA thread: %d\n", threadIdx.x);
   [[maybe_unused]] auto si = soa[soa.metadata().size()];
   printf("Fail: range-check failure should have stopped the kernel.\n");
 }
@@ -250,10 +250,23 @@ int main(void) {
         soa1viewRangeChecking(h_soahdLayout);
     // This should throw an exception
     [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
-    std::cout << "Fail: expected range-check exception not caught on the host." << std::endl;
+    std::cout << "Fail: expected range-check exception (operator[]) not caught on the host." << std::endl;
     assert(false);
   } catch (const std::out_of_range&) {
-    std::cout << "Pass: expected range-check exception successfully caught on the host." << std::endl;
+    std::cout << "Pass: expected range-check exception (operator[]) successfully caught on the host." << std::endl;
+  }
+
+  try {
+    // Get a view like the default, except for range checking
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>
+        soa1viewRangeChecking(h_soahdLayout);
+    // This should throw an exception
+    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
+    std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host." << std::endl;
+    assert(false);
+  } catch (const std::out_of_range&) {
+    std::cout << "Pass: expected range-check exception (view-level index access) successfully caught on the host."
+              << std::endl;
   }
 
   // Validation of range checking in a kernel

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -88,6 +88,25 @@ public:
                  reinterpret_cast<intptr_t>(view.metadata().addressOf_r());
     }
 
+    assert(view.metadata().addressOf_x() == view.x());
+    assert(view.metadata().addressOf_x() == &view.x(0));
+    assert(view.metadata().addressOf_x() == &view[0].x());
+    assert(view.metadata().addressOf_y() == view.y());
+    assert(view.metadata().addressOf_y() == &view.y(0));
+    assert(view.metadata().addressOf_y() == &view[0].y());
+    assert(view.metadata().addressOf_z() == view.z());
+    assert(view.metadata().addressOf_z() == &view.z(0));
+    assert(view.metadata().addressOf_z() == &view[0].z());
+    assert(view.metadata().addressOf_id() == view.id());
+    assert(view.metadata().addressOf_id() == &view.id(0));
+    assert(view.metadata().addressOf_id() == &view[0].id());
+    assert(view.metadata().addressOf_m() == view.m());
+    //assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0,0));    // view.m(0) does not seem to be supported for Eigen columns ?
+    assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
+    assert(view.metadata().addressOf_r() == &view.r());
+    //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index
+    //assert(view.metadata().addressOf_r() == &view[0].r());                // cannot access a scalar via a SoA row-like accessor
+
     const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
     assert(view.r() == 1.);
     for (int32_t i = 0; i < view.metadata().size(); ++i) {

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -48,6 +48,29 @@ namespace {
     column.print(out);
     return out;
   }
+
+  template <typename T>
+  void checkViewAddresses(T const& view) {
+    assert(view.metadata().addressOf_x() == view.x());
+    assert(view.metadata().addressOf_x() == &view.x(0));
+    assert(view.metadata().addressOf_x() == &view[0].x());
+    assert(view.metadata().addressOf_y() == view.y());
+    assert(view.metadata().addressOf_y() == &view.y(0));
+    assert(view.metadata().addressOf_y() == &view[0].y());
+    assert(view.metadata().addressOf_z() == view.z());
+    assert(view.metadata().addressOf_z() == &view.z(0));
+    assert(view.metadata().addressOf_z() == &view[0].z());
+    assert(view.metadata().addressOf_id() == view.id());
+    assert(view.metadata().addressOf_id() == &view.id(0));
+    assert(view.metadata().addressOf_id() == &view[0].id());
+    assert(view.metadata().addressOf_m() == view.m());
+    assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0, 0));
+    assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
+    assert(view.metadata().addressOf_r() == &view.r());
+    //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index
+    //assert(view.metadata().addressOf_r() == &view[0].r());                // cannot access a scalar via a SoA row-like accessor
+  }
+
 }  // namespace
 
 class TestAlpakaAnalyzer : public edm::stream::EDAnalyzer<> {
@@ -58,6 +81,8 @@ public:
   void analyze(edm::Event const& event, edm::EventSetup const&) override {
     portabletest::TestHostCollection const& product = event.get(token_);
     auto const& view = product.const_view();
+    auto& mview = product.view();
+    auto const& cmview = product.view();
 
     {
       edm::LogInfo msg("TestAlpakaAnalyzer");
@@ -88,24 +113,9 @@ public:
                  reinterpret_cast<intptr_t>(view.metadata().addressOf_r());
     }
 
-    assert(view.metadata().addressOf_x() == view.x());
-    assert(view.metadata().addressOf_x() == &view.x(0));
-    assert(view.metadata().addressOf_x() == &view[0].x());
-    assert(view.metadata().addressOf_y() == view.y());
-    assert(view.metadata().addressOf_y() == &view.y(0));
-    assert(view.metadata().addressOf_y() == &view[0].y());
-    assert(view.metadata().addressOf_z() == view.z());
-    assert(view.metadata().addressOf_z() == &view.z(0));
-    assert(view.metadata().addressOf_z() == &view[0].z());
-    assert(view.metadata().addressOf_id() == view.id());
-    assert(view.metadata().addressOf_id() == &view.id(0));
-    assert(view.metadata().addressOf_id() == &view[0].id());
-    assert(view.metadata().addressOf_m() == view.m());
-    assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0, 0));
-    assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
-    assert(view.metadata().addressOf_r() == &view.r());
-    //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index
-    //assert(view.metadata().addressOf_r() == &view[0].r());                // cannot access a scalar via a SoA row-like accessor
+    checkViewAddresses(view);
+    checkViewAddresses(mview);
+    checkViewAddresses(cmview);
 
     const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
     assert(view.r() == 1.);

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -101,7 +101,7 @@ public:
     assert(view.metadata().addressOf_id() == &view.id(0));
     assert(view.metadata().addressOf_id() == &view[0].id());
     assert(view.metadata().addressOf_m() == view.m());
-    //assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0,0));    // view.m(0) does not seem to be supported for Eigen columns ?
+    assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0, 0));
     assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
     assert(view.metadata().addressOf_r() == &view.r());
     //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index


### PR DESCRIPTION
#### PR description:

These changes fix various issues with the SoA accessors:
  - return const scalars by const reference instead of by value, which would break non-trivially copiable types;
  - remove the `__builtin_assume_aligned` compiler hints from the SoA fields, as it breaks the `__restrict__` optimizations in nvcc;
  - add support for SoA view-level indexed access of Eigen columns;
  - add range checking to SoA view-level indexed accessors.

Extend the tests to check the access by (const) reference, the access to Eigen SoA columns, and the improved range checking.

#### PR validation:

Fixes a simple test provided by @borzari .

The updated unit test passes all checks.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW 12.5.x to ease the migration to Alpaka.