### PR TITLE
Run3-hcx336 Backport #39920 to 12_5_X to protect against wrong ieta values which happens for wrong mixing of signal and PU SIM results

### DIFF
--- a/CondFormats/GeometryObjects/interface/HcalParameters.h
+++ b/CondFormats/GeometryObjects/interface/HcalParameters.h
@@ -5,8 +5,8 @@
 
 class HcalParameters {
 public:
-  HcalParameters(void) {}
-  ~HcalParameters(void) {}
+  HcalParameters(void) = default;
+  ~HcalParameters(void) = default;
 
   struct LayerItem {
     unsigned int layer;
@@ -63,6 +63,7 @@ public:
   std::vector<LayerItem> layerGroupEtaSim, layerGroupEtaRec;
   int topologyMode;
 
+  uint32_t etaMaxHBHE() const { return static_cast<uint32_t>(etagroup.size()); }
   COND_SERIALIZABLE;
 };
 

--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -160,8 +160,13 @@ std::pair<double, double> HcalDDDRecConstants::getEtaPhi(const int& subdet, cons
 }
 
 HcalDDDRecConstants::HcalID HcalDDDRecConstants::getHCID(int subdet, int keta, int iphi, int lay, int idepth) const {
-  int ieta = (keta > 0) ? keta : -keta;
+  uint32_t ieta = (keta > 0) ? keta : -keta;
   int zside = (keta > 0) ? 1 : -1;
+  if ((ieta > hpar->etaMaxHBHE()) &&
+      ((subdet == static_cast<int>(HcalOuter)) || (subdet == static_cast<int>(HcalBarrel)) ||
+       (subdet == static_cast<int>(HcalEndcap))))
+    throw cms::Exception("HcalDDDRecConstants")
+        << "getHCID: receives an eta value " << ieta << " outside the limit (1:" << hpar->etaMaxHBHE() << ")";
   int eta(ieta), phi(iphi), depth(idepth);
   if ((subdet == static_cast<int>(HcalOuter)) ||
       ((subdet == static_cast<int>(HcalBarrel)) && (lay > maxLayerHB_ + 1))) {


### PR DESCRIPTION
#### PR description:

Backport #39920 to CMSSW_12_5_X in order to protect against wrong ieta values which happens for wrong mixing of signal and PU SIM results

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport a fix given in the master branch in PR #39920