### PR TITLE
Run3-alca234 Make a new set of PU correction factor for 2022 calibration runs

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -10,7 +10,8 @@
 //        int type = The type of data being considered
 //                   (1: Run 1 old; 2: Run1 new; 3: Run2 2016;
 //                    4: Run 2 2017; 5: Run2 2018; 6: Run3 Old;
-//                    7: Run 3 June 2021; 97: dlphin Try 3;
+//                    7: Run 3 June 2021; 8: Run3 Mahi Jan2022;
+//                    9: Run3 M0 Jan2022l; 97: dlphin Try 3;
 //                    98: dlphin Try 2; 99: dlphin Try 1)
 // double puFactorRho(type, ieta, rho, double eHcal)
 //      Returns a multiplicative factor as PU correction evaluated from rho
@@ -274,10 +275,44 @@ double puFactor(int type, int ieta, double pmom, double eHcal, double ediff, boo
       if (debug)
         std::cout << " d2p " << d2p << ":" << DELTA_CUT << " coeff " << icor << ":" << CONST_COR_COEF[icor] << ":"
                   << LINEAR_COR_COEF[icor] << ":" << SQUARE_COR_COEF[icor] << " Fac " << fac;
-    } else {  // 21pu (June, 2021)
+    } else if (type == 7) {  // 21pu (June, 2021)
       const double CONST_COR_COEF[6] = {0.989727, 0.981923, 0.97571, 0.562475, 0.467947, 0.411831};
       const double LINEAR_COR_COEF[6] = {-0.0469558, -0.125805, -0.251383, -0.0668994, -0.0964236, -0.0947158};
       const double SQUARE_COR_COEF[6] = {0, 0, 0.0399785, 0.00610104, 0.00952528, 0.0100645};
+      const int PU_IETA_1 = 7;
+      const int PU_IETA_2 = 16;
+      const int PU_IETA_3 = 25;
+      const int PU_IETA_4 = 26;
+      const int PU_IETA_5 = 27;
+      unsigned icor = (unsigned(jeta >= PU_IETA_1) + unsigned(jeta >= PU_IETA_2) + unsigned(jeta >= PU_IETA_3) +
+                       unsigned(jeta >= PU_IETA_4) + unsigned(jeta >= PU_IETA_5));
+      double deltaCut = (icor > 2) ? 1.0 : DELTA_CUT;
+      if (d2p > deltaCut)
+        fac = (CONST_COR_COEF[icor] + LINEAR_COR_COEF[icor] * d2p + SQUARE_COR_COEF[icor] * d2p * d2p);
+      if (debug)
+        std::cout << " d2p " << d2p << ":" << DELTA_CUT << " coeff " << icor << ":" << CONST_COR_COEF[icor] << ":"
+                  << LINEAR_COR_COEF[icor] << ":" << SQUARE_COR_COEF[icor] << " Fac " << fac;
+    } else if (type == 9) {  // M0 22pu (Jan, 2022)
+      const double CONST_COR_COEF[6] = {0.980941, 0.973156, 0.970749, 0.726582, 0.532628, 0.473727};
+      const double LINEAR_COR_COEF[6] = {-0.0770642, -0.178295, -0.241338, -0.122956, -0.122346, -0.112574};
+      const double SQUARE_COR_COEF[6] = {0, 0, 0.0401732, 0.00989908, 0.0108291, 0.0100508};
+      const int PU_IETA_1 = 7;
+      const int PU_IETA_2 = 16;
+      const int PU_IETA_3 = 25;
+      const int PU_IETA_4 = 26;
+      const int PU_IETA_5 = 27;
+      unsigned icor = (unsigned(jeta >= PU_IETA_1) + unsigned(jeta >= PU_IETA_2) + unsigned(jeta >= PU_IETA_3) +
+                       unsigned(jeta >= PU_IETA_4) + unsigned(jeta >= PU_IETA_5));
+      double deltaCut = (icor > 2) ? 1.0 : DELTA_CUT;
+      if (d2p > deltaCut)
+        fac = (CONST_COR_COEF[icor] + LINEAR_COR_COEF[icor] * d2p + SQUARE_COR_COEF[icor] * d2p * d2p);
+      if (debug)
+        std::cout << " d2p " << d2p << ":" << DELTA_CUT << " coeff " << icor << ":" << CONST_COR_COEF[icor] << ":"
+                  << LINEAR_COR_COEF[icor] << ":" << SQUARE_COR_COEF[icor] << " Fac " << fac;
+    } else {  // Mahi 22pu (Jan, 2022)
+      const double CONST_COR_COEF[6] = {0.995902, 0.991240, 0.981019, 0.788052, 0.597956, 0.538731};
+      const double LINEAR_COR_COEF[6] = {-0.0540563, -0.104361, -0.215936, -0.147801, -0.160845, -0.154359};
+      const double SQUARE_COR_COEF[6] = {0, 0, 0.0365911, 0.0161266, 0.0180053, 0.0184295};
       const int PU_IETA_1 = 7;
       const int PU_IETA_2 = 16;
       const int PU_IETA_3 = 25;

--- a/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
@@ -43,7 +43,7 @@
 //                               no corr.)
 //   puCorr (int)              = PU correction to be applied or not: 0 no
 //                               correction; < 0 use eDelta; > 0 rho dependent
-//                               correction (-2)
+//                               correction (-8)
 //   flag (int)                = 7 digit integer (xmlthdo) with control
 //                               information (x=3/2/1/0 for having 1000/500/50/
 //                               100 bins for response distribution in (0:5);
@@ -243,7 +243,7 @@ public:
                const std::string &prefix = "",
                const char *corrFileName = "",
                const char *rcorFileName = "",
-               int puCorr = -2,
+               int puCorr = -8,
                int flag = 1031,
                int numb = 50,
                bool datMC = true,

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -36,7 +36,7 @@
 //                               correction  (default="", no corr.)
 //   puCorr (int)              = PU correction to be applied or not: 0 no
 //                               correction; < 0 use eDelta; > 0 rho dependent
-//                               correction (-2)
+//                               correction (-8)
 //   flag (int)                = 6 digit integer (mlthdo) with control
 //                               information (m=0/1 for controlling creation
 //                               of depth depedendent histograms;
@@ -241,7 +241,7 @@ public:
                       const std::string &prefix = "",
                       const char *corrFileName = "",
                       const char *rcorFileName = "",
-                      int puCorr = -1,
+                      int puCorr = -8,
                       int flag = 101111,
                       bool dataMC = true,
                       int truncateFlag = 0,

--- a/Calibration/HcalCalibAlgos/macros/CalibTree.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibTree.C
@@ -45,7 +45,7 @@
 //                              -1 loose, -2 flexible, > 0 for systematic
 //  puCorr          (int)     = PU correction to be applied or not: 0 no
 //                              correction; < 0 use eDelta; > 0 rho dependent
-//                              correction (-5: 2018 version)
+//                              correction (-8: 2022 Mahi version)
 //  applyL1Cut      (int)     = Flag to see if closeness to L1 object to be
 //                              applied: 0 no check; 1 only to events with
 //                              datatype not equal to 1; 2 to all (1)
@@ -131,7 +131,7 @@ void Run(const char *inFileName = "Silver.root",
          int ietaMax = 25,
          int ietaTrack = -1,
          int sysmode = -1,
-         int puCorr = -5,
+         int puCorr = -8,
          int applyL1Cut = 1,
          double l1Cut = 0.5,
          int truncateFlag = 0,


### PR DESCRIPTION
#### PR description:

Make a new set of PU correction factor for 2022 calibration runs

#### PR validation:

Used this in making the IsoTrack calibration constants

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special