### PR TITLE
Fix rerecoCommon DQM sequence

### DIFF
--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -178,9 +178,9 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                              'PostDQMOffline',
                              '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma'],
 
-            'rerecoCommon': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
+            'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
                              'PostDQMOffline',
-                             '@common+@muon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
+                             '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
 
             'rerecoSingleMuon': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma+@lumi+@L1TMuon+@L1TEgamma+@ctpps',
                                  'PostDQMOffline',


### PR DESCRIPTION
#### PR description:
It was noted in [JIRA-PDMVRERECO-55](https://its.cern.ch/jira/browse/PDMVRERECO-55) that the `@rerecoCommon` DQM sequence it's broken with error:
```
----- Begin Fatal Exception 31-Oct-2022 15:04:43 CET-----------------------
An exception of category 'HCALDQM' occurred while
   [0] Processing  Event run: 355680 lumi: 1 event: 583350 stream: 0
   [1] Running path 'dqmoffline_1_step'
   [2] Calling method for module TPTask/'tpTask'
Exception Message:
TPTask::Collection HcalTrigPrimDigiCollection isn't available: valHcalTriggerPrimitiveDigis 
----- End Fatal Exception -------------------------------------------------
```
This error was already observed last year in https://github.com/dmwm/T0/pull/4619#discussion_r751207522 and a fix was implemented by @jfernan2 in https://github.com/cms-sw/cmssw/pull/35605.
However the fix was not propagated to the `@rerecoCommon` sequence, so this PR does that.

#### PR validation:
Running in CMSSW_12_4_10_patch3:
```
dasgoclient --limit 0 --query "file dataset=/ZeroBias/Run2022B-v1/RAW run in [355680]" >> ReReco-Run2022B-ZeroBias-30Oct22_pilot-00001_files.txt

cmsDriver.py RECO --conditions 124X_dataRun3_v10 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3,Configuration/DataProcessing/Utils.addMonitoring --datatier AOD,MINIAOD,DQMIO --era Run3 --eventcontent AOD,MINIAOD,DQM --filein "filelist:ReReco-Run2022B-ZeroBias-30Oct22_pilot-00001_files.txt" --fileout "file:ReReco-Run2022B-ZeroBias-30Oct22_pilot-00001.root" --nThreads 8 --number 10 --python_filename "ReReco-Run2022B-ZeroBias-30Oct22_pilot-00001_0_cfg.py" --scenario pp --step RAW2DIGI,L1Reco,RECO,PAT,DQM:@rerecoCommon --data
```
gives the crash. 
While running with this PR on top of it, the driver runs to completion.

#### Backport:
Not a backport, but 12_4_X and 12_5_X backports will be provided soon.