### PR TITLE
[12_5_X] PPS: fixing sim unitid

### DIFF
--- a/SimG4CMS/PPS/src/PPSPixelOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSPixelOrganization.cc
@@ -28,7 +28,7 @@ PPSPixelOrganization ::PPSPixelOrganization()
 
 uint32_t PPSPixelOrganization ::unitID(const G4Step* aStep) {
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
-  G4VPhysicalVolume* physVol = touch->GetVolume(0);
+  G4VPhysicalVolume* physVol = touch->GetVolume(1);
   int coNum = physVol->GetCopyNo();
   edm::LogVerbatim("PPSPixelSim") << "PPSPixelSim: PhysVol= " << physVol->GetName() << " coNum=" << coNum;
   currentPlane_ = coNum - 1;


### PR DESCRIPTION
#### PR description:
This is a backport of #39807. It may be not necessary be used for PPS simulation but better to merge this fix, which should not affect anything else.

#### PR validation:
private

