### PR TITLE
Change threshold for presample mean in ECAL DQM Pedestal Quality plot [Master]

### DIFF
--- a/DQM/EcalMonitorClient/interface/PresampleClient.h
+++ b/DQM/EcalMonitorClient/interface/PresampleClient.h
@@ -18,6 +18,7 @@ namespace ecaldqm {
     float expectedMean_;
     float toleranceLow_;
     float toleranceHigh_;
+    float toleranceHighFwd_;
     float toleranceRMS_;
     float toleranceRMSFwd_;
   };

--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -7,6 +7,7 @@ minChannelEntries = 6
 expectedMean = 200.0
 toleranceLow = 25.0
 toleranceHigh = 40.0
+toleranceHighFwd = 100.0
 toleranceRMS = 3.0
 toleranceRMSFwd = 6.0
 
@@ -16,6 +17,7 @@ ecalPresampleClient = cms.untracked.PSet(
         expectedMean = cms.untracked.double(expectedMean),
         toleranceLow = cms.untracked.double(toleranceLow),
         toleranceHigh = cms.untracked.double(toleranceHigh),
+	toleranceHighFwd = cms.untracked.double(toleranceHighFwd),
         toleranceRMS = cms.untracked.double(toleranceRMS),
         toleranceRMSFwd = cms.untracked.double(toleranceRMSFwd)
     ),
@@ -96,14 +98,14 @@ ecalPresampleClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHighFwd) + ') for forward region, or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         Quality = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sPedestalOnlineClient/%(prefix)sPOT pedestal quality G12 %(sm)s'),
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('Crystal'),
-            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+            description = cms.untracked.string('Summary of the presample data quality. A channel is red if presample mean is outside the range (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHigh) + '), or (' + str(expectedMean - toleranceLow) + ', ' + str(expectedMean + toleranceHighFwd) + ') for forward region, or RMS is greater than ' + str(toleranceRMS) + '. RMS threshold is ' + str(toleranceRMSFwd) + ' in the forward region (|eta| > 2.1). Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
         ErrorsSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sPOT pedestal quality errors summary G12'),

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -16,6 +16,7 @@ namespace ecaldqm {
         expectedMean_(0.),
         toleranceLow_(0.),
         toleranceHigh_(0.),
+        toleranceHighFwd_(0.),
         toleranceRMS_(0.),
         toleranceRMSFwd_(0.) {
     qualitySummaries_.insert("Quality");
@@ -27,6 +28,7 @@ namespace ecaldqm {
     expectedMean_ = _params.getUntrackedParameter<double>("expectedMean");
     toleranceLow_ = _params.getUntrackedParameter<double>("toleranceLow");
     toleranceHigh_ = _params.getUntrackedParameter<double>("toleranceHigh");
+    toleranceHighFwd_ = _params.getUntrackedParameter<double>("toleranceHighFwd");
     toleranceRMS_ = _params.getUntrackedParameter<double>("toleranceRMS");
     toleranceRMSFwd_ = _params.getUntrackedParameter<double>("toleranceRMSFwd");
   }
@@ -65,9 +67,12 @@ namespace ecaldqm {
       bool doMask(meQuality.maskMatches(id, mask, statusManager_, GetTrigTowerMap()));
 
       double rmsThresh(toleranceRMS_);
+      double meanThreshHigh(toleranceHigh_);
 
-      if (isForward(id))
+      if (isForward(id)) {
         rmsThresh = toleranceRMSFwd_;
+        meanThreshHigh = toleranceHighFwd_;
+      }
 
       double entries(pItr->getBinEntries());
       double entriesLS(pLSItr->getBinEntries());
@@ -91,7 +96,7 @@ namespace ecaldqm {
       meRMSMap.setBinContent(getEcalDQMSetupObjects(), id, rms);
       meRMSMapAllByLumi.setBinContent(getEcalDQMSetupObjects(), id, rmsLS);
 
-      if (((mean > expectedMean_ + toleranceHigh_) || (mean < expectedMean_ - toleranceLow_)) || rms > rmsThresh) {
+      if (((mean > expectedMean_ + meanThreshHigh) || (mean < expectedMean_ - toleranceLow_)) || rms > rmsThresh) {
         qItr->setBinContent(doMask ? kMBad : kBad);
         meQualitySummary.setBinContent(getEcalDQMSetupObjects(), id, doMask ? kMBad : kBad);
         if (!doMask)


### PR DESCRIPTION

#### PR description:

This PR changes the threshold for presample mean in the forward region of ECAL in the Pedestal Quality plot. This removes the many red spots which populate the forward region in the pedestal quality and consequently, the global quality plots of ECAL DQM.

#### PR validation:

Validated by running the standard online Ecal DQM configuration and checking the output on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
Backport to 12_4_X: https://github.com/cms-sw/cmssw/pull/39944
Backport to 12_5_X: https://github.com/cms-sw/cmssw/pull/39943
