### PR TITLE
Work around a segfault when a non-consumed module with Transfomer ability has been deleted

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -499,7 +499,11 @@ namespace edm {
   void TransformingProductResolver::setupUnscheduled(UnscheduledConfigurator const& iConfigure) {
     aux_ = iConfigure.auxiliary();
     worker_ = iConfigure.findWorker(branchDescription().moduleLabel());
-    index_ = worker_->transformIndex(branchDescription());
+    // worker can be missing if the corresponding module is
+    // unscheduled and none of its products are consumed
+    if (worker_) {
+      index_ = worker_->transformIndex(branchDescription());
+    }
   }
 
   ProductResolverBase::Resolution TransformingProductResolver::resolveProduct_(Principal const&,

--- a/FWCore/Integration/test/transformTest_cfg.py
+++ b/FWCore/Integration/test/transformTest_cfg.py
@@ -47,10 +47,12 @@ if args.noTransform:
     process.tester.valueMustMatch = 2
     process.t.checkTransformNotCalled = True
 
+process.nonConsumed = process.t.clone()
+
 if args.onPath:
-    process.p = cms.Path(process.t+process.tester, cms.Task(process.start))
+    process.p = cms.Path(process.t+process.tester, cms.Task(process.start, process.nonConsumed))
 else:
-    process.p = cms.Path(process.tester, cms.Task(process.start, process.t))
+    process.p = cms.Path(process.tester, cms.Task(process.start, process.t, process.nonConsumed))
 
 if args.addTracer:
     process.add_(cms.Service("Tracer"))


### PR DESCRIPTION
#### PR description:

I found out that if a non-consumed module uses the Transformer ability, the `TransformingProductResolver::setupUnscheduled()` segfaults because of `worker_` being `nullptr` (while testing privately #39428 with SwitchProducer).

(the need for this workaround is, in a sense, a consequence of cleanup in https://github.com/cms-sw/cmssw/issues/30826 not being done yet)

#### PR validation:

Framework unit tests pass