### PR TITLE
Phase2-hgx329B Remove reference to FastTimeGeometry from Fireworks - this is an obsolete reference, never used and never will be

### DIFF
--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -16,7 +16,6 @@ class CaloGeometryRecord;
 class GlobalTrackingGeometry;
 class GlobalTrackingGeometryRecord;
 class TrackerGeometry;
-class FastTimeGeometry;
 class IdealGeometryRecord;
 class FWRecoGeometry;
 class FWRecoGeometryRecord;
@@ -59,13 +58,9 @@ private:
   void writeTrackerParametersXML(FWRecoGeometry&);
 
   edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_trackingGeomToken;
-  edm::ESGetToken<FastTimeGeometry, IdealGeometryRecord> m_ftlBarrelGeomToken;
-  edm::ESGetToken<FastTimeGeometry, IdealGeometryRecord> m_ftlEndcapGeomToken;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_caloGeomToken;
   const GlobalTrackingGeometry* m_trackingGeom = nullptr;
   const CaloGeometry* m_caloGeom = nullptr;
-  const FastTimeGeometry* m_ftlBarrelGeom = nullptr;
-  const FastTimeGeometry* m_ftlEndcapGeom = nullptr;
   const TrackerGeometry* m_trackerGeom = nullptr;
 
   unsigned int m_current;

--- a/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "Geometry/Records/interface/FastTimeGeometryRecord.h"
 
 class FWRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -12,7 +12,6 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
-#include "Geometry/HGCalGeometry/interface/FastTimeGeometry.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -114,10 +113,6 @@ FWRecoGeometryESProducer::FWRecoGeometryESProducer(const edm::ParameterSet& pset
   if (m_tracker or m_muon or m_gem) {
     m_trackingGeomToken = cc.consumes();
   }
-  if (m_timing) {
-    m_ftlBarrelGeomToken = cc.consumes(edm::ESInputTag{"", "FastTimeBarrel"});
-    m_ftlEndcapGeomToken = cc.consumes(edm::ESInputTag{"", "SFBX"});
-  }
   if (m_calo) {
     m_caloGeomToken = cc.consumes();
   }
@@ -157,12 +152,6 @@ std::unique_ptr<FWRecoGeometry> FWRecoGeometryESProducer::produce(const FWRecoGe
   if (m_calo) {
     m_caloGeom = &record.get(m_caloGeomToken);
     addCaloGeometry(*fwRecoGeometry);
-  }
-
-  if (m_timing) {
-    m_ftlBarrelGeom = &record.getRecord<CaloGeometryRecord>().get(m_ftlBarrelGeomToken);
-    m_ftlEndcapGeom = &record.getRecord<CaloGeometryRecord>().get(m_ftlEndcapGeomToken);
-    addFTLGeometry(*fwRecoGeometry);
   }
 
   fwRecoGeometry->idToName.resize(m_current + 1);
@@ -638,18 +627,8 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
 }
 
 void FWRecoGeometryESProducer::addFTLGeometry(FWRecoGeometry& fwRecoGeometry) {
-  // do the barrel
-  for (const auto& detid : m_ftlBarrelGeom->getValidDetIds()) {
-    unsigned int id = insert_id(detid.rawId(), fwRecoGeometry);
-    const auto& cor = m_ftlBarrelGeom->getCorners(detid);
-    fillPoints(id, cor.begin(), cor.end(), fwRecoGeometry);
-  }
-  // do the endcap
-  for (const auto& detid : m_ftlEndcapGeom->getValidDetIds()) {
-    unsigned int id = insert_id(detid.rawId(), fwRecoGeometry);
-    const auto& cor = m_ftlEndcapGeom->getCorners(detid);
-    fillPoints(id, cor.begin(), cor.end(), fwRecoGeometry);
-  }
+  // do the barrel (do for BTL)
+  // do the endcap (do for ETL)
 }
 
 unsigned int FWRecoGeometryESProducer::insert_id(unsigned int rawid, FWRecoGeometry& fwRecoGeometry) {


### PR DESCRIPTION
#### PR description:

Remove reference to FastTimeGeometry from Fireworks - this is an obsolete reference, never used and never will be. A few variables and methods are left for future implementation of BTL and ETL geometries

#### PR validation:

No reference was found which uses the deleted code

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special