### PR TITLE
[12.4.X] add `ExhumeGeneratorFilter` to `ConcurrentLumisDisable`

### DIFF
--- a/Configuration/Generator/python/concurrentLumisDisable.py
+++ b/Configuration/Generator/python/concurrentLumisDisable.py
@@ -3,6 +3,7 @@ noConcurrentLumiGenerators = [
     "AMPTGeneratorFilter",
     "BeamHaloProducer",
     "CosMuoGenProducer",
+    "ExhumeGeneratorFilter",
     "Herwig7GeneratorFilter",
     "HydjetGeneratorFilter",
     "Hydjet2GeneratorFilter",


### PR DESCRIPTION
#### PR description:

Follow the suggest in https://github.com/cms-sw/cmssw/pull/39041#issuecomment-1222396640, `ExhumeGeneratorFilter` is added to the `ConcurrentLumisDisable`

#### PR validation:

Compare Generator config file from workflow 11725 with 8 threads,
Without PR:
`process.options.eventSetup.numberOfConcurrentIOVs = 1`
With PR:
`process.options.numberOfConcurrentLuminosityBlocks = 1`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/39143