### PR TITLE
[12_5_X] Nano: fix matching between pat trigger objects and L1 objects

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/TriggerObjectTableProducer.cc
@@ -121,6 +121,8 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
     for (const auto &sel : sels_) {
       if (sel.match(obj) && (sel.skipObjectsNotPassingQualityBits ? (int(sel.qualityBits(obj)) > 0) : true)) {
         selected.emplace_back(&obj, &sel);
+        // cave canem: the object will be taken by whichever selection it matches first, so it
+        // depends on the order of the selections in the VPSet
         break;
       }
     }
@@ -254,6 +256,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
         const auto &seed = l1obj.first;
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l1cut(seed)) {
+          best = dr2;
           l1pt[i] = seed.pt();
           l1iso[i] = l1obj.second;
           l1charge[i] = seed.charge();
@@ -266,6 +269,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
         const auto &seed = l1obj.first;
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l1cut_2(seed)) {
+          best = dr2;
           l1pt_2[i] = seed.pt();
         }
       }
@@ -275,6 +279,7 @@ void TriggerObjectTableProducer::produce(edm::Event &iEvent, const edm::EventSet
       for (const auto &seed : *src) {
         float dr2 = deltaR2(seed, obj);
         if (dr2 < best && sel.l2cut(seed)) {
+          best = dr2;
           l2pt[i] = seed.pt();
         }
       }


### PR DESCRIPTION
#### PR description:

Fix bug with matching between PAT trigger objects and L1 objects reported in #39809.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/39893, as requested in https://github.com/cms-sw/cmssw/pull/39932#issuecomment-1299654854