### PR TITLE
Setting precision in GlobalVariablesProducer

### DIFF
--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -117,10 +117,9 @@ class SimpleFlatTableProducerBase : public edm::stream::EDProducer<> {
 public:
   SimpleFlatTableProducerBase(edm::ParameterSet const &params)
       : name_(params.getParameter<std::string>("name")),
-        doc_(params.existsAs<std::string>("doc") ? params.getParameter<std::string>("doc") : ""),
-        extension_(params.existsAs<bool>("extension") ? params.getParameter<bool>("extension") : false),
-        skipNonExistingSrc_(
-            params.existsAs<bool>("skipNonExistingSrc") ? params.getParameter<bool>("skipNonExistingSrc") : false),
+        doc_(params.getParameter<std::string>("doc")),
+        extension_(params.getParameter<bool>("extension")),
+        skipNonExistingSrc_(params.getParameter<bool>("skipNonExistingSrc")),
         src_(consumes<TProd>(params.getParameter<edm::InputTag>("src"))) {
     edm::ParameterSet const &varsPSet = params.getParameter<edm::ParameterSet>("variables");
     for (const std::string &vname : varsPSet.getParameterNamesForType<edm::ParameterSet>()) {
@@ -151,9 +150,9 @@ public:
     edm::ParameterSetDescription desc;
     std::string classname = ClassName<T>::name();
     desc.add<std::string>("name")->setComment("name of the branch in the flat table output for " + classname);
-    desc.addOptional<std::string>("doc")->setComment("few words of self documentation");
-    desc.addOptional<bool>("extension", false)->setComment("whether or not to extend an existing same table");
-    desc.addOptional<bool>("skipNonExistingSrc", false)
+    desc.add<std::string>("doc", "")->setComment("few words of self documentation");
+    desc.add<bool>("extension", false)->setComment("whether or not to extend an existing same table");
+    desc.add<bool>("skipNonExistingSrc", false)
         ->setComment("whether or not to skip producing the table on absent input product");
     desc.add<edm::InputTag>("src")->setComment("input collection to fill the flat table");
 

--- a/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
@@ -76,11 +76,12 @@ protected:
   class Variable {
   public:
     Variable(const std::string& aname, const edm::ParameterSet& cfg)
-      : name_(aname), doc_(cfg.getParameter<std::string>("doc")), precision_(cfg.existsAs<int>("precision") ? cfg.getParameter<int>("precision") : -1 ) {}
+        : name_(aname),
+          doc_(cfg.getParameter<std::string>("doc")),
+          precision_(cfg.existsAs<int>("precision") ? cfg.getParameter<int>("precision") : -1) {}
     virtual void fill(const edm::Event& iEvent, nanoaod::FlatTable& out) const = 0;
     virtual ~Variable() {}
-    const std::string& name() const {
-      return name_; }
+    const std::string& name() const { return name_; }
 
   protected:
     std::string name_, doc_;

--- a/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
@@ -54,7 +54,7 @@ public:
                          "int", "float", "double", "bool", "candidatescalarsum", "candidatesize", "candidatesummass"));
     variable.add<edm::InputTag>("src")->setComment("input collection for the branch");
     variable.add<std::string>("doc")->setComment("few words description of the branch content");
-    variable.addOptional<int>("precision")->setComment("precision to store the information [NOT USED IN THE CODE]");
+    variable.addOptional<int>("precision")->setComment("precision to store the information");
     edm::ParameterSetDescription variables;
     variables.setComment("a parameters set to define variable to fill the flat table");
     variables.addNode(

--- a/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
@@ -14,8 +14,7 @@
 class GlobalVariablesTableProducer : public edm::stream::EDProducer<> {
 public:
   GlobalVariablesTableProducer(edm::ParameterSet const& params)
-      : name_(params.existsAs<std::string>("name") ? params.getParameter<std::string>("name") : ""),
-        extension_(params.existsAs<bool>("extension") ? params.getParameter<bool>("extension") : false) {
+      : name_(params.getParameter<std::string>("name")), extension_(params.getParameter<bool>("extension")) {
     edm::ParameterSet const& varsPSet = params.getParameter<edm::ParameterSet>("variables");
     for (const std::string& vname : varsPSet.getParameterNamesForType<edm::ParameterSet>()) {
       const auto& varPSet = varsPSet.getParameter<edm::ParameterSet>(vname);
@@ -45,8 +44,8 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.addOptional<std::string>("name")->setComment("name of the branch in the flat table output");
-    desc.addOptional<bool>("extension", false)->setComment("whether or not to extend an existing same table");
+    desc.add<std::string>("name", "")->setComment("name of the branch in the flat table output");
+    desc.add<bool>("extension", false)->setComment("whether or not to extend an existing same table");
     edm::ParameterSetDescription variable;
     variable.ifValue(edm::ParameterDescription<std::string>(
                          "type", "int", true, edm::Comment("the c++ type of the branch in the flat table")),
@@ -54,7 +53,7 @@ public:
                          "int", "float", "double", "bool", "candidatescalarsum", "candidatesize", "candidatesummass"));
     variable.add<edm::InputTag>("src")->setComment("input collection for the branch");
     variable.add<std::string>("doc")->setComment("few words description of the branch content");
-    variable.addOptional<int>("precision")->setComment("precision to store the information");
+    variable.add<int>("precision", -1)->setComment("precision to store the information");
     edm::ParameterSetDescription variables;
     variables.setComment("a parameters set to define variable to fill the flat table");
     variables.addNode(
@@ -76,9 +75,7 @@ protected:
   class Variable {
   public:
     Variable(const std::string& aname, const edm::ParameterSet& cfg)
-        : name_(aname),
-          doc_(cfg.getParameter<std::string>("doc")),
-          precision_(cfg.existsAs<int>("precision") ? cfg.getParameter<int>("precision") : -1) {}
+        : name_(aname), doc_(cfg.getParameter<std::string>("doc")), precision_(cfg.getParameter<int>("precision")) {}
     virtual void fill(const edm::Event& iEvent, nanoaod::FlatTable& out) const = 0;
     virtual ~Variable() {}
     const std::string& name() const { return name_; }

--- a/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GlobalVariablesTableProducer.cc
@@ -76,13 +76,15 @@ protected:
   class Variable {
   public:
     Variable(const std::string& aname, const edm::ParameterSet& cfg)
-        : name_(aname), doc_(cfg.getParameter<std::string>("doc")) {}
+      : name_(aname), doc_(cfg.getParameter<std::string>("doc")), precision_(cfg.existsAs<int>("precision") ? cfg.getParameter<int>("precision") : -1 ) {}
     virtual void fill(const edm::Event& iEvent, nanoaod::FlatTable& out) const = 0;
     virtual ~Variable() {}
-    const std::string& name() const { return name_; }
+    const std::string& name() const {
+      return name_; }
 
   protected:
     std::string name_, doc_;
+    int precision_;
   };
   template <typename ValType>
   class Identity {
@@ -160,7 +162,8 @@ protected:
         : Variable(aname, cfg), src_(cc.consumes<ValType>(cfg.getParameter<edm::InputTag>("src"))) {}
     ~VariableT() override {}
     void fill(const edm::Event& iEvent, nanoaod::FlatTable& out) const override {
-      out.template addColumnValue<ColType>(this->name_, Converter::convert(iEvent.get(src_)), this->doc_);
+      out.template addColumnValue<ColType>(
+          this->name_, Converter::convert(iEvent.get(src_)), this->doc_, this->precision_);
     }
 
   protected:


### PR DESCRIPTION
#### PR description:

while going through #39796, it was noticed that precision, specified in the configuration of `GlobalVariablesProducer` was actually not used downstream. This PR includes the option to specify it.

- [x] This will have to go after #39796 to be able to modify the parameter description

#### PR validation:

running on matrix workflows yield a below percent improvement on size per event.