### PR TITLE
[12.5.X] EMTF DQM fix to remove duplicate x-axis bin labels

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2EMTF.cc
+++ b/DQM/L1TMonitor/src/L1TStage2EMTF.cc
@@ -58,14 +58,14 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
   //cscOccupancy designed to match the cscDQM plot
   cscDQMOccupancy = ibooker.book2D("cscDQMOccupancy", "CSC Chamber Occupancy", 42, 1, 43, 20, 0, 20);
-  cscDQMOccupancy->setAxisTitle("10#circ Chamber (N=neighbor)", 1);
+  cscDQMOccupancy->setAxisTitle("10#circ Chamber (Ni = Neighbor of Sector i)", 1);
   int count = 0;
   for (int xbin = 1; xbin < 43; ++xbin) {
     cscDQMOccupancy->setBinLabel(xbin, std::to_string(xbin - count), 1);
     if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
       ++xbin;
       ++count;
-      cscDQMOccupancy->setBinLabel(xbin, "N", 1);
+      cscDQMOccupancy->setBinLabel(xbin, "N" + std::to_string(count), 1);
     }
   }
   for (int ybin = 1; ybin <= 10; ++ybin) {
@@ -107,10 +107,10 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   }
 
   rpcHitOccupancy = ibooker.book2D("rpcHitOccupancy", "RPC Chamber Occupancy", 42, 1, 43, 12, 0, 12);
-  rpcHitOccupancy->setAxisTitle("Sector (N=neighbor)", 1);
+  rpcHitOccupancy->setAxisTitle("Sector (Ni = Neighbor of Sector i)", 1);
   for (int bin = 1; bin <= 6; ++bin) {
     rpcHitOccupancy->setBinLabel(bin * 7 - 6, std::to_string(bin), 1);
-    rpcHitOccupancy->setBinLabel(bin * 7, "N", 1);
+    rpcHitOccupancy->setBinLabel(bin * 7, "N" + std::to_string(bin), 1);
     rpcHitOccupancy->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
     rpcHitOccupancy->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1], 2);
   }
@@ -135,14 +135,14 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   gemHitBX->setBinLabel(2, "GE+1/1", 2);
 
   gemHitOccupancy = ibooker.book2D("gemHitOccupancy", "GEM Chamber Occupancy", 42, 1, 43, 2, 0, 2);
-  gemHitOccupancy->setAxisTitle("10#circ Chambers (N=neighbor)", 1);
+  gemHitOccupancy->setAxisTitle("10#circ Chambers (Ni = Neighbor of Sector i)", 1);
   count = 0;
   for (int xbin = 1; xbin < 43; ++xbin) {
     gemHitOccupancy->setBinLabel(xbin, std::to_string(xbin - count), 1);
     if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
       ++xbin;
       ++count;
-      gemHitOccupancy->setBinLabel(xbin, "N", 1);
+      gemHitOccupancy->setBinLabel(xbin, "N" + std::to_string(count), 1);
     }
   }
 
@@ -409,7 +409,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
                          24,
                          0,
                          24);  // 8* (0-2) phi part + (0-7) eta part
-      gemChamberVFATBX[hist][bx - 1]->setAxisTitle("Chamber, " + label, 1);
+      gemChamberVFATBX[hist][bx - 1]->setAxisTitle("Chamber, (Ni = Neighbor of Sector i), " + label, 1);
       gemChamberVFATBX[hist][bx - 1]->setAxisTitle("VFAT #", 2);
 
       for (int bin = 1; bin <= 24; bin++)
@@ -421,23 +421,24 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
         if (bin == 2 || bin == 9 || bin == 16 || bin == 23 || bin == 30 || bin == 37) {
           ++bin;
           ++count;
-          gemChamberVFATBX[hist][bx - 1]->setBinLabel(bin, "N", 1);
+          gemChamberVFATBX[hist][bx - 1]->setBinLabel(bin, "N" + std::to_string(count), 1);
         }
       }
+      gemChamberVFATBX[hist][bx - 1]->getTH2F()->GetXaxis()->SetCanExtend(false);
     }
   }
   // CSC LCT and RPC Hit Timing
   ibooker.setCurrentFolder(monitorDir + "/Timing");
 
   cscTimingTot = ibooker.book2D("cscTimingTotal", "CSC Total BX ", 42, 1, 43, 20, 0, 20);
-  cscTimingTot->setAxisTitle("10#circ Chamber (N=neighbor)", 1);
+  cscTimingTot->setAxisTitle("10#circ Chamber, (Ni = Neighbor of Sector i)", 1);
 
   rpcHitTimingTot = ibooker.book2D("rpcHitTimingTot", "RPC Chamber Occupancy ", 42, 1, 43, 12, 0, 12);
-  rpcHitTimingTot->setAxisTitle("Sector (N=neighbor)", 1);
+  rpcHitTimingTot->setAxisTitle("Sector (Ni = Neighbor of Sector i)", 1);
 
   gemHitTimingTot =
       ibooker.book2D("gemHitTimingTot", "GEM Chamber Occupancy ", 42, 1, 43, 2, 0, 2);  // Add GEM Timing Oct 27 2020
-  gemHitTimingTot->setAxisTitle("10#circ Chamber (N=neighbor)", 1);
+  gemHitTimingTot->setAxisTitle("10#circ Chamber (Ni = Neighbor of Sector i)", 1);
   const std::array<std::string, 5> nameBX{{"BXNeg1", "BXPos1", "BXNeg2", "BXPos2", "BX0"}};
   const std::array<std::string, 5> labelBX{{"BX -1", "BX +1", "BX -2", "BX +2", "BX 0"}};
 
@@ -445,7 +446,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     count = 0;
     cscLCTTiming[hist] =
         ibooker.book2D("cscLCTTiming" + nameBX[hist], "CSC Chamber Occupancy " + labelBX[hist], 42, 1, 43, 20, 0, 20);
-    cscLCTTiming[hist]->setAxisTitle("10#circ Chamber", 1);
+    cscLCTTiming[hist]->setAxisTitle("10#circ Chamber, (Ni = Neighbor of Sector i)", 1);
 
     for (int xbin = 1; xbin < 43; ++xbin) {
       cscLCTTiming[hist]->setBinLabel(xbin, std::to_string(xbin - count), 1);
@@ -454,9 +455,9 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
         ++xbin;
         ++count;
-        cscLCTTiming[hist]->setBinLabel(xbin, "N", 1);
+        cscLCTTiming[hist]->setBinLabel(xbin, "N" + std::to_string(count), 1);
         if (hist == 0)
-          cscTimingTot->setBinLabel(xbin, "N", 1);
+          cscTimingTot->setBinLabel(xbin, "N" + std::to_string(count), 1);
       }
     }
 
@@ -474,10 +475,10 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
     rpcHitTiming[hist] =
         ibooker.book2D("rpcHitTiming" + nameBX[hist], "RPC Chamber Occupancy " + labelBX[hist], 42, 1, 43, 12, 0, 12);
-    rpcHitTiming[hist]->setAxisTitle("Sector (N=neighbor)", 1);
+    rpcHitTiming[hist]->setAxisTitle("Sector, (Ni=Neighbor of Sector i )", 1);
     for (int bin = 1; bin < 7; ++bin) {
       rpcHitTiming[hist]->setBinLabel(bin * 7 - 6, std::to_string(bin), 1);
-      rpcHitTiming[hist]->setBinLabel(bin * 7, "N", 1);
+      rpcHitTiming[hist]->setBinLabel(bin * 7, "N" + std::to_string(bin), 1);
       rpcHitTiming[hist]->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
       rpcHitTiming[hist]->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1], 2);
     }
@@ -485,7 +486,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     if (hist == 0) {
       for (int bin = 1; bin < 7; ++bin) {
         rpcHitTimingTot->setBinLabel(bin * 7 - 6, std::to_string(bin), 1);
-        rpcHitTimingTot->setBinLabel(bin * 7, "N", 1);
+        rpcHitTimingTot->setBinLabel(bin * 7, "N" + std::to_string(bin), 1);
         rpcHitTimingTot->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
         rpcHitTimingTot->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1], 2);
       }
@@ -496,7 +497,7 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     // Add GEM Timing Oct 27 2020
     gemHitTiming[hist] =
         ibooker.book2D("gemHitTiming" + nameBX[hist], "GEM Chamber Occupancy " + labelBX[hist], 42, 1, 43, 2, 0, 2);
-    gemHitTiming[hist]->setAxisTitle("10#circ Chamber", 1);
+    gemHitTiming[hist]->setAxisTitle("10#circ Chamber, (Ni = Neighbor of Sector i)", 1);
     count = 0;
     for (int xbin = 1; xbin < 43; ++xbin) {
       gemHitTiming[hist]->setBinLabel(xbin, std::to_string(xbin - count), 1);
@@ -505,9 +506,9 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
         ++xbin;
         ++count;
-        gemHitTiming[hist]->setBinLabel(xbin, "N", 1);
+        gemHitTiming[hist]->setBinLabel(xbin, "N" + std::to_string(count), 1);
         if (hist == 0)
-          gemHitTimingTot->setBinLabel(xbin, "N", 1);
+          gemHitTimingTot->setBinLabel(xbin, "N" + std::to_string(count), 1);
       }
     }
 
@@ -523,13 +524,13 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     count = 0;
     cscLCTTimingFrac[hist] = ibooker.book2D(
         "cscLCTTimingFrac" + nameBX[hist], "CSC Chamber Occupancy " + labelBX[hist], 42, 1, 43, 20, 0, 20);
-    cscLCTTimingFrac[hist]->setAxisTitle("10#circ Chambers", 1);
+    cscLCTTimingFrac[hist]->setAxisTitle("10#circ Chambers, (Ni = Neighbor of Sector i)", 1);
     for (int xbin = 1; xbin < 43; ++xbin) {
       cscLCTTimingFrac[hist]->setBinLabel(xbin, std::to_string(xbin - count), 1);
       if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
         ++xbin;
         ++count;
-        cscLCTTimingFrac[hist]->setBinLabel(xbin, "N", 1);
+        cscLCTTimingFrac[hist]->setBinLabel(xbin, "N" + std::to_string(count), 1);
       }
     }
     for (int ybin = 1; ybin <= 10; ++ybin) {
@@ -540,10 +541,10 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
     rpcHitTimingFrac[hist] = ibooker.book2D(
         "rpcHitTimingFrac" + nameBX[hist], "RPC Chamber Fraction in " + labelBX[hist], 42, 1, 43, 12, 0, 12);
-    rpcHitTimingFrac[hist]->setAxisTitle("Sector (N=neighbor)", 1);
+    rpcHitTimingFrac[hist]->setAxisTitle("Sector, (Ni = Neighbor of Sector i)", 1);
     for (int bin = 1; bin < 7; ++bin) {
       rpcHitTimingFrac[hist]->setBinLabel(bin * 7 - 6, std::to_string(bin), 1);
-      rpcHitTimingFrac[hist]->setBinLabel(bin * 7, "N", 1);
+      rpcHitTimingFrac[hist]->setBinLabel(bin * 7, "N" + std::to_string(bin), 1);
       rpcHitTimingFrac[hist]->setBinLabel(bin, "RE-" + rpc_label[bin - 1], 2);
       rpcHitTimingFrac[hist]->setBinLabel(13 - bin, "RE+" + rpc_label[bin - 1], 2);
     }
@@ -551,14 +552,14 @@ void L1TStage2EMTF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     // Add GEM Timing Oct 27 2020
     gemHitTimingFrac[hist] =
         ibooker.book2D("gemHitTimingFrac" + nameBX[hist], "GEM Chamber Occupancy " + labelBX[hist], 42, 1, 43, 2, 0, 2);
-    gemHitTimingFrac[hist]->setAxisTitle("10#circ Chambers", 1);
+    gemHitTimingFrac[hist]->setAxisTitle("10#circ Chambers, (Ni = Neighbor of Sector i)", 1);
     count = 0;
     for (int xbin = 1; xbin < 43; ++xbin) {
       gemHitTimingFrac[hist]->setBinLabel(xbin, std::to_string(xbin - count), 1);
       if (xbin == 2 || xbin == 9 || xbin == 16 || xbin == 23 || xbin == 30 || xbin == 37) {
         ++xbin;
         ++count;
-        gemHitTimingFrac[hist]->setBinLabel(xbin, "N", 1);
+        gemHitTimingFrac[hist]->setBinLabel(xbin, "N" + std::to_string(count), 1);
       }
     }
     gemHitTimingFrac[hist]->setBinLabel(1, "GE-1/1", 2);


### PR DESCRIPTION
resolves #39936

#### PR description:

Changed DQM plot neighbor labels to avoid duplicates. This meant relabeling DQM plots such as cscDQMOccupancy among others. Chambers with the label "N" became labeled "N1", "N2" ... depending on which sector they preceded.

Change implemented in response to https://github.com/cms-sw/cmssw/issues/39936, in which it was discovered that histogram merging is dependent on bin labels in newer ROOT versions, and therefore cannot be duplicate (https://github.com/cms-sw/cmssw/pull/25569)

The flag gemChamberBXVFAT.CanExtend was also set to false for consistency with other plots.

#### PR validation:

First, the issue outlined in https://github.com/cms-sw/cmssw/issues/39936 was recreated using the PSet in /afs/cern.ch/user/c/cmst0/public/PausedJobs/HIReplay2022/job_244/job/WMTaskSpace/cmsRun1. Then, the plot labels were changed and new DQMIO files were made with DQMRootOutputModule. These files substituted the input files used in https://github.com/cms-sw/cmssw/issues/39936 and the merge was successful.

ROOT files were also created using DQMFileSaverPB to view the plots and ensure that the labels were correct.

This change will also be backported to release CMSSW_12_5_X and 12_5_1_patch1,

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/39952