### PR TITLE
add era-dependent switch on the AlCaRecoTriggerBit key for SiPixel ALCARECO producers

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonLoose_cff.py
@@ -32,3 +32,9 @@ scalerForSiPixelCalSingleMuonLoose = CalibTracker.SiStripCommon.prescaleEvent_cf
 seqALCARECOSiPixelCalSingleMuonLoose = cms.Sequence(ALCARECOSiPixelCalSingleMuonLooseHLTFilter+
                                                     scalerForSiPixelCalSingleMuonLoose+
                                                     ALCARECOSiPixelCalSingleMuonLoose)
+
+## customizations for the pp_on_AA eras
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(ALCARECOSiPixelCalSingleMuonLooseHLTFilter,
+                  eventSetupPathsKey='SiPixelCalSingleMuonHI'
+)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -96,3 +96,8 @@ seqALCARECOSiPixelCalSingleMuonTight = cms.Sequence(offlineBeamSpot+
                                                     ALCARECOSiPixelCalSingleMuonTight+
                                                     trackDistances +
                                                     ALCARECOSiPixelCalSingleMuonTightOffTrackClusters)
+## customizations for the pp_on_AA eras
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(ALCARECOSiPixelCalSingleMuonTightHLTFilter,
+                  eventSetupPathsKey='SiPixelCalSingleMuonHI'
+)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuon_cff.py
@@ -24,3 +24,9 @@ ALCARECOSiPixelCalSingleMuon.etaMax = 3.5
 # Loose Sequence
 ##################################################################
 seqALCARECOSiPixelCalSingleMuon = cms.Sequence(ALCARECOSiPixelCalSingleMuonHLTFilter+ALCARECOSiPixelCalSingleMuon)
+
+## customizations for the pp_on_AA eras
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(ALCARECOSiPixelCalSingleMuonHLTFilter,
+                  eventSetupPathsKey='SiPixelCalSingleMuonHI'
+)


### PR DESCRIPTION
#### PR description:

Title says it all, as suggested by @malbouis 

#### PR validation:

ongoing, will probably require an update of the trigger bits in the Global Tag

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

will have to be backported to CMSSW_12_5_X (for the HI data-taking)
