### PR TITLE
Allow to run smearing sequence separate from GEN step

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1406,7 +1406,7 @@ class ConfigBuilder(object):
                     elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
                         self._options.inlineObjets+=','+name
 
-            if stepSpec == self.GENDefaultSeq or stepSpec == 'pgen_genonly':
+            if stepSpec == self.GENDefaultSeq or stepSpec == 'pgen_genonly' or stepSpec == 'pgen_smear':
                 if 'ProductionFilterSequence' in genModules and ('generator' in genModules):
                     self.productionFilterSequence = 'ProductionFilterSequence'
                 elif 'generator' in genModules:

--- a/Configuration/StandardSequences/python/Generator_cff.py
+++ b/Configuration/StandardSequences/python/Generator_cff.py
@@ -59,8 +59,10 @@ from SimPPS.Configuration.GenPPS_cff import *
 pgen = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer")+VertexSmearing+GenSmeared+GeneInfo+genJetMET, PPSTransportTask)
 
 # sequence for bare generator result only, without vertex smearing and analysis objects added
-
 pgen_genonly = cms.Sequence(cms.SequencePlaceholder("randomEngineStateProducer"))
+
+# only vertex smearing and analysis objects
+pgen_smear = cms.Sequence(VertexSmearing+GenSmeared+GeneInfo+genJetMET, PPSTransportTask)
 
 fixGenInfoTask = cms.Task(GeneInfoTask, genJetMETTask)
 fixGenInfo = cms.Sequence(fixGenInfoTask)


### PR DESCRIPTION
#### PR description:
Following the presentation on **GEN-only samples for Computing** at O&C meeting https://indico.cern.ch/event/1212283/, this PR proposes the mininal addition to allow to run gen and smearing separately. Basically, we need 
- a sequence of smearing + later tasks (this PR)
- to keep transient `unsmeared` collection from GEN-only step, and feed it to smearing step. (part of the cmsDriver. We may create eventcontent for this)

The test with following cmsDriver runs fine, but validation/comments from GEN experts are needed to confirm this possibility.

#### PR validation:
Run with the following cmsDriver:

(1) Run genonly, keep transient `unsmeared` collection. I choose the processName to be GENONLY, so that we can use GEN in later step.
`cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN:pgen_genonly -n 50 --conditions auto:phase2_realistic_T21 --beamspot HLLHC14TeV --datatier GEN --eventcontent GEN --geometry Extended2026D88 --era Phase2C17I13M9 --python step0_cfg.py --nThreads 8 --nStreams=3 --no_exec --fileout file:step0.root --customise_commands "from IOMC.RandomEngine.RandomServiceHelper import RandomNumberServiceHelper ; randSvc = RandomNumberServiceHelper(process.RandomNumberGeneratorService) ; randSvc.populate() \n process.source.firstLuminosityBlock = cms.untracked.uint32(55555)" --mc --processName GENONLY --outputCommands "keep *"`

(2) Run smearing+later sequence
`cmsDriver.py -s GEN:pgen_smear,SIM -n 50 --conditions auto:phase2_realistic_T21 --beamspot HLLHC14TeV --datatier GEN-SIM --eventcontent RAWSIM --geometry Extended2026D88 --era Phase2C17I13M9 --python step1_cfg.py --nThreads 8 --nStreams=3 --no_exec --fileout file:step0.root --customise_commands "from IOMC.RandomEngine.RandomServiceHelper import RandomNumberServiceHelper ; randSvc = RandomNumberServiceHelper(process.RandomNumberGeneratorService) ; randSvc.populate()" --mc --filein file:step0.root --fileout file:step1.root`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
To be decide after we converge on this PR.
