### PR TITLE
Implementation of  digitizer noise occupancy 

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -721,7 +721,7 @@ void Phase2TrackerDigitizerAlgorithm::pixel_inefficiency(const SubdetEfficiencie
 }
 void Phase2TrackerDigitizerAlgorithm::initializeEvent(CLHEP::HepRandomEngine& eng) {
   if (addNoise_ || addPixelInefficiency_ || fluctuateCharge_ || addThresholdSmearing_) {
-    gaussDistribution_ = std::make_unique<CLHEP::RandGaussQ>(eng, 0., theReadoutNoise_);
+    gaussDistribution_ = std::make_unique<CLHEP::RandGaussQ>(eng, 0., theNoiseInElectrons_);
   }
   // Threshold smearing with gaussian distribution:
   if (addThresholdSmearing_) {
@@ -891,8 +891,11 @@ void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* p
     add_noise(pixdet);  // generate noise
   if (addXtalk_)
     add_cross_talk(pixdet);
-  if (addNoisyPixels_)
-    add_noisy_cells(pixdet, theHIPThresholdInE / theElectronPerADC_);
+  if (addNoisyPixels_) {
+    float thresholdInNoiseUnits = 99.9;
+    if (theNoiseInElectrons_) thresholdInNoiseUnits = theThresholdInE / theNoiseInElectrons_;
+    add_noisy_cells(pixdet, thresholdInNoiseUnits);
+  }
 
   // Do only if needed
   if (addPixelInefficiency_ && !theSignal.empty()) {

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -893,7 +893,8 @@ void Phase2TrackerDigitizerAlgorithm::digitize(const Phase2TrackerGeomDetUnit* p
     add_cross_talk(pixdet);
   if (addNoisyPixels_) {
     float thresholdInNoiseUnits = 99.9;
-    if (theNoiseInElectrons_) thresholdInNoiseUnits = theThresholdInE / theNoiseInElectrons_;
+    if (theNoiseInElectrons_)
+      thresholdInNoiseUnits = theThresholdInE / theNoiseInElectrons_;
     add_noisy_cells(pixdet, thresholdInNoiseUnits);
   }
 

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 PixelDigitizerAlgorithmCommon = cms.PSet(
     ElectronPerAdc = cms.double(1500.0),
-    ReadoutNoiseInElec = cms.double(0.0),
+    ReadoutNoiseInElec = cms.double(-99.9),       # not used at the moment
     ThresholdInElectrons_Barrel = cms.double(1000.0),
     ThresholdInElectrons_Endcap = cms.double(1000.0),
     AddThresholdSmearing = cms.bool(False),
@@ -94,10 +94,10 @@ phase2TrackerDigitizer = cms.PSet(
 #Pixel in PS Module
     PSPDigitizerAlgorithm = cms.PSet(
       ElectronPerAdc = cms.double(135.0),
-      ReadoutNoiseInElec = cms.double(200.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing
+      ReadoutNoiseInElec = cms.double(-99.9),       # not used at the moment
       ThresholdInElectrons_Barrel = cms.double(6300.), #(0.4 MIP = 0.4 * 16000 e)
       ThresholdInElectrons_Endcap = cms.double(6300.), #(0.4 MIP = 0.4 * 16000 e) 
-      AddThresholdSmearing = cms.bool(True),
+      AddThresholdSmearing = cms.bool(False),
       ThresholdSmearing_Barrel = cms.double(630.0),
       ThresholdSmearing_Endcap = cms.double(630.0),
       HIPThresholdInElectrons_Barrel = cms.double(1.0e10), # very high value to avoid Over threshold bit
@@ -133,15 +133,15 @@ phase2TrackerDigitizer = cms.PSet(
     PSSDigitizerAlgorithm = cms.PSet(
       ElectronPerAdc = cms.double(135.0),
 #D.B.:the noise should be a function of strip capacitance, roughly: ReadoutNoiseInElec=500+(64*Cdet[pF]) ~= 500+(64*1.5[cm])
-      ReadoutNoiseInElec = cms.double(700.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing
-      ThresholdInElectrons_Barrel = cms.double(6300.), #(0.4 MIP = 0.4 * 16000 e)
-      ThresholdInElectrons_Endcap = cms.double(6300.), #(0.4 MIP = 0.4 * 16000 e)
-      AddThresholdSmearing = cms.bool(True),
-      ThresholdSmearing_Barrel = cms.double(630.0),
-      ThresholdSmearing_Endcap = cms.double(630.0),
+      ReadoutNoiseInElec = cms.double(-99.9),       # not used at the moment
+      ThresholdInElectrons_Barrel = cms.double(4800.), #(0.4 MIP = 0.4 * 16000 e)
+      ThresholdInElectrons_Endcap = cms.double(4800.), #(0.4 MIP = 0.4 * 16000 e)
+      AddThresholdSmearing = cms.bool(False),
+      ThresholdSmearing_Barrel = cms.double(480.0),
+      ThresholdSmearing_Endcap = cms.double(480.0),
       HIPThresholdInElectrons_Barrel = cms.double(21000.), # 1.4 MIP considered as HIP
       HIPThresholdInElectrons_Endcap = cms.double(21000.), # 1.4 MIP considered as HIP 
-      NoiseInElectrons = cms.double(700),	         # 30% of the readout noise (should be changed in future)
+      NoiseInElectrons = cms.double(1010), # threshold = 4800e, noise=4800e/4.75=1010 (4.75 sigma=>occupancy =1e-6)
       Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
       AdcFullScale = cms.int32(255),
       TofUpperCut = cms.double(12.5),
@@ -171,15 +171,15 @@ phase2TrackerDigitizer = cms.PSet(
     SSDigitizerAlgorithm = cms.PSet(
       ElectronPerAdc = cms.double(135.0),
 #D.B.:the noise should be a function of strip capacitance, roughly: ReadoutNoiseInElec=500+(64*Cdet[pF]) ~= 500+(64*1.5[cm])
-      ReadoutNoiseInElec = cms.double(1000.0),#D.B.:Fill readout noise, including all readout chain, relevant for smearing
-      ThresholdInElectrons_Barrel = cms.double(5800.), #D.B.: this should correspond to a threshold of 530mV    
-      ThresholdInElectrons_Endcap = cms.double(5800.),
-      AddThresholdSmearing = cms.bool(True),
-      ThresholdSmearing_Barrel = cms.double(580.0),#D.B.: changed (~5mV peakToPeak --> 1.76mV rms) (was 210.0)
-      ThresholdSmearing_Endcap = cms.double(580.0),#D.B.: changed (~5mV peakToPeak --> 1.76mV rms) (was 245.0)
+      ReadoutNoiseInElec = cms.double(-99.9),       # not used at the moment
+      ThresholdInElectrons_Barrel = cms.double(6000.), 
+      ThresholdInElectrons_Endcap = cms.double(6000.),
+      AddThresholdSmearing = cms.bool(False),    
+      ThresholdSmearing_Barrel = cms.double(600.0),
+      ThresholdSmearing_Endcap = cms.double(600.0),
       HIPThresholdInElectrons_Barrel = cms.double(1.0e10), # very high value to avoid Over threshold bit
       HIPThresholdInElectrons_Endcap = cms.double(1.0e10), # very high value to avoid Over threshold bit
-      NoiseInElectrons = cms.double(1000),	         # 30% of the readout noise (should be changed in future)
+      NoiseInElectrons = cms.double(1263), # threshold = 6000e, noise=6000e/4.75=1263e (4.75 sigma=>occupancy =1e-6)
       Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
       AdcFullScale = cms.int32(255),
       TofUpperCut = cms.double(12.5),


### PR DESCRIPTION
#### PR description:
 Implementation of noise occupancy in neighboring channels without containing signal Hits for strip like modules (PSS,SS) in the Phase2 Outer Tracker. The threshold cutoff for PSS and SS modules are updated to 4800e and 6000e respectively. Corresponding noise values are set as 1010e and 1263e considering the threshold to be 4.75sigmas. The add_noisy_cell method has been updated to use this cutoff. Other than this change, 
   - we have switched off threshold smearing in all types of modules. 
   - at the moment the configuration parameter ReadoutNoiseInElec is not used and kept with a dummy value for the time being

#### PR validation:

 The performance were presented in Phase2 Tracker Simulation meetings 
       https://indico.cern.ch/event/1201188/contributions/5095554/attachments/2528800/4350459/Phase2Digitizer_Noise_occupancy_14102022.pdf

https://indico.cern.ch/event/1201186/contributions/5051043/attachments/2510200/4314408/Phase2Digitizer_Noise_occupancy_16092022.pdf

