### PR TITLE
Do not call methods on EcalTrigTowerConstituentsMap nullptr

### DIFF
--- a/Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h
+++ b/Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h
@@ -23,6 +23,8 @@ public:
   /// Get the tower id for this det id (or null if not known)
   EcalTrigTowerDetId towerOf(const DetId& id) const;
 
+  static EcalTrigTowerDetId barrelTowerOf(const DetId& id);
+
   /// Get the constituent detids for this tower id
   std::vector<DetId> constituentsOf(const EcalTrigTowerDetId& id) const;
 

--- a/Geometry/CaloTopology/src/EcalTrigTowerConstituentsMap.cc
+++ b/Geometry/CaloTopology/src/EcalTrigTowerConstituentsMap.cc
@@ -5,8 +5,18 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include <cassert>
 
 EcalTrigTowerConstituentsMap::EcalTrigTowerConstituentsMap() {}
+
+EcalTrigTowerDetId EcalTrigTowerConstituentsMap::barrelTowerOf(const DetId& id) {
+  assert(id.det() == DetId::Ecal && id.subdetId() == EcalBarrel);
+  //--------------------
+  // Ecal Barrel
+  //--------------------
+  EBDetId myId(id);
+  return myId.tower();
+}
 
 EcalTrigTowerDetId EcalTrigTowerConstituentsMap::towerOf(const DetId& id) const {
   if (id.det() == DetId::Ecal && id.subdetId() == EcalBarrel) {

--- a/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
+++ b/SimCalorimetry/EcalEBTrigPrimAlgos/interface/EcalEBTrigPrimTestAlgo.h
@@ -185,7 +185,8 @@ void EcalEBTrigPrimTestAlgo::fillMap(
     ;
     for (unsigned int i = 0; i < col->size(); ++i) {
       Digi samples((*col)[i]);
-      EcalTrigTowerDetId coarser = (*eTTmap_).towerOf(samples.id());
+      EcalTrigTowerDetId coarser =
+          eTTmap_ ? (*eTTmap_).towerOf(samples.id()) : EcalTrigTowerConstituentsMap::barrelTowerOf(samples.id());
       int index = getIndex(col, coarser);
       int stripnr = findStripNr(samples.id());
 

--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalTrigPrimFunctionalAlgo.h
@@ -305,7 +305,8 @@ void EcalTrigPrimFunctionalAlgo::fillMap(
     LogDebug("EcalTPG") << "Fill mapping, Collection size = " << col->size();
     for (unsigned int i = 0; i < col->size(); ++i) {
       Digi samples((*col)[i]);
-      EcalTrigTowerDetId coarser = (*eTTmap_).towerOf(samples.id());
+      EcalTrigTowerDetId coarser =
+          eTTmap_ ? (*eTTmap_).towerOf(samples.id()) : EcalTrigTowerConstituentsMap::barrelTowerOf(samples.id());
       int index = getIndex(col, coarser);
       int stripnr = findStripNr(samples.id());
 


### PR DESCRIPTION
#### PR description:

This fixes an UBSAN related error.

#### PR validation:

Code compiles and workflow 20034.0 does not generate the warning.