### PR TITLE
add plugin to produce `FEDRawDataCollection` excluding a list of FEDs

### DIFF
--- a/EventFilter/Utilities/plugins/BuildFile.xml
+++ b/EventFilter/Utilities/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
   <use name="EventFilter/Utilities"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Sources"/>
   <use name="FWCore/Utilities"/>

--- a/EventFilter/Utilities/plugins/EvFFEDExcluder.cc
+++ b/EventFilter/Utilities/plugins/EvFFEDExcluder.cc
@@ -1,0 +1,49 @@
+#include <memory>
+#include <algorithm>
+
+#include "EvFFEDExcluder.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+evf::EvFFEDExcluder::EvFFEDExcluder(edm::ParameterSet const& config)
+    : rawDataToken_(consumes(config.getParameter<edm::InputTag>("src"))),
+      fedIds_([](std::vector<unsigned int> const& fedsToExclude) {
+        // ret = all FED Ids except those to be excluded (i.e. fedsToExclude)
+        std::vector<unsigned int> ret;
+        auto const maxSize = FEDNumbering::lastFEDId() + 1;
+        ret.reserve(maxSize);
+        // loop on all FED IDs: [0, FEDNumbering::lastFEDId]
+        for (auto fedId = 0u; fedId < maxSize; ++fedId) {
+          // keep only fedIds not present in fedsToExclude
+          if (std::find(fedsToExclude.begin(), fedsToExclude.end(), fedId) == fedsToExclude.end())
+            ret.emplace_back(fedId);
+        }
+        ret.shrink_to_fit();
+        return ret;
+      }(config.getParameter<std::vector<unsigned int>>("fedsToExclude"))) {
+  produces<FEDRawDataCollection>();
+}
+
+void evf::EvFFEDExcluder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("source"));
+  desc.add<std::vector<unsigned int>>("fedsToExclude", {});
+  descriptions.add("EvFFEDExcluder", desc);
+}
+
+void evf::EvFFEDExcluder::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&) const {
+  auto out = std::make_unique<FEDRawDataCollection>();
+  auto const rawDataHandle = event.getHandle(rawDataToken_);
+
+  for (auto const fedId : fedIds_)
+    if (rawDataHandle->FEDData(fedId).size() > 0)
+      out->FEDData(fedId) = rawDataHandle->FEDData(fedId);
+
+  event.put(std::move(out));
+}

--- a/EventFilter/Utilities/plugins/EvFFEDExcluder.h
+++ b/EventFilter/Utilities/plugins/EvFFEDExcluder.h
@@ -1,0 +1,27 @@
+#ifndef EventFilter_Utilities_EvFFEDExcluder_h
+#define EventFilter_Utilities_EvFFEDExcluder_h
+
+#include <vector>
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+class FEDRawDataCollection;
+
+namespace evf {
+
+  class EvFFEDExcluder : public edm::global::EDProducer<> {
+  public:
+    explicit EvFFEDExcluder(edm::ParameterSet const&);
+    ~EvFFEDExcluder() override = default;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const final;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    edm::EDGetTokenT<FEDRawDataCollection> const rawDataToken_;
+    std::vector<unsigned int> const fedIds_;
+  };
+
+}  // namespace evf
+
+#endif  // EventFilter_Utilities_EvFFEDExcluder_h

--- a/EventFilter/Utilities/plugins/modules.cc
+++ b/EventFilter/Utilities/plugins/modules.cc
@@ -5,6 +5,7 @@
 #include "EventFilter/Utilities/plugins/DaqFakeReader.h"
 #include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
 #include "EventFilter/Utilities/plugins/EvFFEDSelector.h"
+#include "EventFilter/Utilities/plugins/EvFFEDExcluder.h"
 #include "EventFilter/Utilities/plugins/ExceptionGenerator.h"
 #include "EventFilter/Utilities/plugins/RawEventFileWriterForBU.h"
 #include "EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h"
@@ -26,6 +27,7 @@ DEFINE_FWK_SERVICE(EvFBuildingThrottle);
 DEFINE_FWK_SERVICE(EvFDaqDirector);
 DEFINE_FWK_MODULE(ExceptionGenerator);
 DEFINE_FWK_MODULE(EvFFEDSelector);
+DEFINE_FWK_MODULE(EvFFEDExcluder);
 DEFINE_FWK_MODULE(EvFOutputModule);
 DEFINE_FWK_MODULE(DaqFakeReader);
 DEFINE_FWK_INPUT_SOURCE(FedRawDataInputSource);

--- a/EventFilter/Utilities/test/testEvFFEDSelectors.py
+++ b/EventFilter/Utilities/test/testEvFFEDSelectors.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TEST')
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing('analysis')
+options.setDefault('inputFiles', [
+  'root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/Run2022B_HLTPhysics0_run355558/cd851cf4-0fca-4d76-b80e-1d33e1371929.root',
+])
+options.setDefault('maxEvents', 10)
+options.parseArguments()
+
+# set max number of input events
+process.maxEvents.input = options.maxEvents
+
+# initialize MessageLogger and output report
+process.options.wantSummary = False
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 100 # only report every 100th event start
+process.MessageLogger.cerr.enableStatistics = False # enable "MessageLogger Summary" message
+process.MessageLogger.cerr.threshold = 'INFO' # change to 'WARNING' not to show INFO-level messages
+## enable reporting of INFO-level messages (default is limit=0, i.e. no messages reported)
+#process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+#    reportEvery = cms.untracked.int32(1), # every event!
+#    limit = cms.untracked.int32(-1)       # no limit!
+#)
+
+###
+### Source (input file)
+###
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(options.inputFiles)
+)
+print('process.source.fileNames =', process.source.fileNames)
+
+###
+### Path (FEDRAWData producers)
+###
+_siStripFEDs = [foo for foo in range(50, 489+1)]
+
+from EventFilter.Utilities.EvFFEDSelector_cfi import EvFFEDSelector as _EvFFEDSelector
+process.rawDataSiStripV1 = _EvFFEDSelector.clone(
+  inputTag = 'rawDataCollector',
+  fedList = _siStripFEDs,
+)
+
+from EventFilter.Utilities.EvFFEDExcluder_cfi import EvFFEDExcluder as _EvFFEDExcluder
+process.rawDataSiStripV2 = _EvFFEDExcluder.clone(
+  src = 'rawDataCollector',
+  fedsToExclude = [foo for foo in range(4096+1) if foo not in _siStripFEDs],
+)
+
+process.rawDataSelectionPath = cms.Path(
+    process.rawDataSiStripV1
+  + process.rawDataSiStripV2
+)
+
+###
+### EndPath (output file)
+###
+process.rawDataOutputModule = cms.OutputModule('PoolOutputModule',
+    fileName = cms.untracked.string('file:tmp.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep FEDRawDataCollection_*_*_*',
+        'keep edmTriggerResults_*_*_*',
+        'keep triggerTriggerEvent_*_*_*',
+    )
+)
+
+process.outputEndPath = cms.EndPath( process.rawDataOutputModule )


### PR DESCRIPTION
#### PR description:

This PR aims to introduce a producer that, given a `FEDRawDataCollection`, produces a new one _excluding_ a certain list of FEDs. This new plugin is, in a way, the counterpart of `EvFFEDSelector`, which instead requires the list of FEDs to keep.

One use case for this plugin is HIon's "RawPrime", which includes a `FEDRawDataCollection` without SiStrip FEDs (right now, an hard-coded list of "all FEDs but the SiStrip ones" is used in a `EvFFEDSelector`; it would arguably be better to have a `EvFFEDExcluder` with the list of SiStrip FEDs).

This was discussed in https://github.com/cms-sw/cmssw/pull/39863#discussion_r1006485795 and https://github.com/cms-sw/cmssw/pull/39863#discussion_r1013955672.

Names (e.g. "excluder") are tentative. I chose different names for the plugin's parameters with respect to `EvFFEDSelector` (`InputTag -> src`, `fedList -> fedsToExclude`) thinking that this reduces the chance of using `EvFFEDExcluder` instead of `EvFFEDSelector` (or viceversa) by mistake.

A cfg file is added to `test/` for testing purposes (if not useful, it can be removed).

No changes expected, as this PR is basically insensitive to PR tests.

_Note_ : no backports are planned. The intention is simply to add this new plugin for development purposes (could be useful in 2023).

FYI: @mmusich

#### PR validation:

Checks based on `testEvFFEDSelectors.py`.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A