### PR TITLE
New Vertex Clustering in Blocks and Weighted Mean Estimator

### DIFF
--- a/Configuration/ProcessModifiers/python/vertexInBlocks_cff.py
+++ b/Configuration/ProcessModifiers/python/vertexInBlocks_cff.py
@@ -3,3 +3,4 @@ import FWCore.ParameterSet.Config as cms
 # This modifier enables, in the primary vertex producer,
 # - da clustering for PV in blocks
 vertexInBlocks =  cms.Modifier()
+

--- a/Configuration/ProcessModifiers/python/vertexInBlocks_cff.py
+++ b/Configuration/ProcessModifiers/python/vertexInBlocks_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
 # This modifier enables, in the primary vertex producer,
-# - vertex fitting with weighted mean
-weightedVertexing = cms.Modifier()
+# - da clustering for PV in blocks
+vertexInBlocks =  cms.Modifier()

--- a/Configuration/ProcessModifiers/python/weightedVertexing_cff.py
+++ b/Configuration/ProcessModifiers/python/weightedVertexing_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier enables, in the primary vertex producer,
+# - track clustering in blocks
+# - vertex fitting with weighted mean
+weightedVertexing = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -81,3 +81,5 @@ The offsets currently in use are:
 * 0.302: FastSim Run-3 trackingOnly validation
 * 0.303: FastSim Run-3 MB for mixing
 * 0.9001: Sonic Triton
+* 0.278: Weighted Vertexing in Blocks
+* 0.279: Weighted Vertexing in Blocks and tracking only wf

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -460,6 +460,25 @@ upgradeWFs['vectorHits'] = UpgradeWorkflow_vectorHits(
     offset = 0.9,
 )
 
+# WeightedMeanFitter vertexing workflows
+class UpgradeWorkflow_weightedVertex(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        stepDict[stepName][k] = merge([{'--procModifiers': 'weightedVertexing'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment=="TTbar_14TeV" and ('2026' or '2022') in key
+upgradeWFs['vectorHits'] = UpgradeWorkflow_vectorHits(
+    steps = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    PU = [
+        'RecoGlobal',
+        'HARVESTGlobal'
+    ],
+    suffix = '_weightedVertex',
+    offset = 0.278,
+)
+
 # Special TICL Pattern recognition Workflows
 class UpgradeWorkflow_ticl_clue3D(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -263,9 +263,12 @@ class UpgradeWorkflow_trackingOnly(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
+
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="TTbar_13" or fragment=="TTbar_14TeV") and hasHarvest and self.condition_(fragment, stepList, key, hasHarvest)
         return result
+
+
 
 upgradeWFs['trackingOnly'] = UpgradeWorkflow_trackingOnly(
     steps = [
@@ -493,7 +496,7 @@ class UpgradeWorkflow_weightedVertex(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         # temporarily remove trigger & downstream steps
         if 'Reco' in step:
-            mod = {'--procModifiers': 'weightedVertexing', '--datatier':'GEN-SIM-RECO,DQMIO',
+            mod = {'--procModifiers': 'weightedVertexing,vertexInBlocks', '--datatier':'GEN-SIM-RECO,DQMIO',
             '--eventcontent':'RECOSIM,DQM'}
             stepDict[stepName][k] = merge([mod,self.step3, stepDict[step][k]])
         if 'HARVEST' in step:
@@ -511,19 +514,7 @@ class UpgradeWorkflow_weightedVertex(UpgradeWorkflow):
         return result
 
 
-upgradeWFs['weightedVertex'] = UpgradeWorkflow_weightedVertex(
-    # steps = [
-    #     'Reco',
-    #     'RecoGlobal',
-    #     'RecoNano',
-    #     'RecoFakeHLT',
-    # ],
-    # PU = [
-    #     'Reco',
-    #     'RecoGlobal',
-    #     'RecoNano',
-    #     'RecoFakeHLT',
-    # ],
+upgradeWFs['weightedVertex'] = UpgradeWorkflow_weightedVertex( 
     suffix = '_weightedVertex',
     offset = 0.278,
 )

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -240,7 +240,7 @@ upgradeWFs['DigiNoHLT'] = UpgradeWorkflow_DigiNoHLT(
 
 # some commonalities among tracking WFs
 class UpgradeWorkflowTracking(UpgradeWorkflow):
-    # skip the PU argument since PU workflows never used here
+
     def __init__(self, steps, PU, suffix, offset):
         # always include some steps that will be skipped
         steps = steps + ["ALCA","Nano"]

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -15,11 +15,11 @@ from RecoJets.JetProducers.caloJetsForTrk_cff import *
 
 unsortedOfflinePrimaryVertices=offlinePrimaryVertices.clone()
 offlinePrimaryVertices=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices", 
+    vertices="unsortedOfflinePrimaryVertices",
     particles="trackRefsForJetsBeforeSorting"
 )
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices:WithBS", 
+    vertices="unsortedOfflinePrimaryVertices:WithBS",
     particles="trackRefsForJetsBeforeSorting"
 )
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(
@@ -93,3 +93,7 @@ phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimary
 phase2_timing_layer.toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
 phase2_timing_layer.toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")
 
+from Configuration.ProcesssModifiers.weightedVertexing_cff import weightedVertexing
+#don't want to mess up with phase2_timing_layer
+(weightedVertexing & ~phase2_timing_layer).toModify(offlinePrimaryVertices.TkClusParameters.TkDAClusParameters, runInBlocks = True, block_size = cms.uint32(512), overlap_frac = 0.5)
+(weightedVertexing & ~phase2_timing_layer).toModify(offlinePrimaryVerticesWithBS.TkClusParameters.TkDAClusParameters, runInBlocks = True, block_size = cms.uint32(512), overlap_frac = 0.5)

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -93,7 +93,19 @@ phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimary
 phase2_timing_layer.toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
 phase2_timing_layer.toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")
 
-from Configuration.ProcesssModifiers.weightedVertexing_cff import weightedVertexing
-#don't want to mess up with phase2_timing_layer
-(weightedVertexing & ~phase2_timing_layer).toModify(offlinePrimaryVertices.TkClusParameters.TkDAClusParameters, runInBlocks = True, block_size = cms.uint32(512), overlap_frac = 0.5)
-(weightedVertexing & ~phase2_timing_layer).toModify(offlinePrimaryVerticesWithBS.TkClusParameters.TkDAClusParameters, runInBlocks = True, block_size = cms.uint32(512), overlap_frac = 0.5)
+# from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
+# #don't want to mess up with phase2_timing_layer
+# offlinePrimaryVerticesWeighted = offlinePrimaryVertices.clone(
+#     TkClusParameters.TkDAClusParameters.runInBlocks = True,
+#     TkClusParameters.TkDAClusParameters.block_size = 512,
+#     TkClusParameters.TkDAClusParameters.overlap_frac = 0.5
+# )
+#
+# offlinePrimaryVerticesWeightedWithBS = offlinePrimaryVerticesWithBS.clone(
+#     TkClusParameters.TkDAClusParameters.runInBlocks = True,
+#     TkClusParameters.TkDAClusParameters.block_size = 512,
+#     TkClusParameters.TkDAClusParameters.overlap_frac = 0.5
+# )
+#
+# (weightedVertexing & ~phase2_timing_layer).toReplaceWith(offlinePrimaryVertices, offlinePrimaryVerticesWeightedWithBS.clone())
+# (weightedVertexing & ~phase2_timing_layer).toReplaceWith(offlinePrimaryVerticesWithBS, offlinePrimaryVerticesWeighted.clone())

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -15,11 +15,11 @@ from RecoJets.JetProducers.caloJetsForTrk_cff import *
 
 unsortedOfflinePrimaryVertices=offlinePrimaryVertices.clone()
 offlinePrimaryVertices=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices",
+    vertices="unsortedOfflinePrimaryVertices", 
     particles="trackRefsForJetsBeforeSorting"
 )
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(
-    vertices="unsortedOfflinePrimaryVertices:WithBS",
+    vertices="unsortedOfflinePrimaryVertices:WithBS", 
     particles="trackRefsForJetsBeforeSorting"
 )
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(
@@ -93,19 +93,3 @@ phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimary
 phase2_timing_layer.toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
 phase2_timing_layer.toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")
 
-# from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
-# #don't want to mess up with phase2_timing_layer
-# offlinePrimaryVerticesWeighted = offlinePrimaryVertices.clone(
-#     TkClusParameters.TkDAClusParameters.runInBlocks = True,
-#     TkClusParameters.TkDAClusParameters.block_size = 512,
-#     TkClusParameters.TkDAClusParameters.overlap_frac = 0.5
-# )
-#
-# offlinePrimaryVerticesWeightedWithBS = offlinePrimaryVerticesWithBS.clone(
-#     TkClusParameters.TkDAClusParameters.runInBlocks = True,
-#     TkClusParameters.TkDAClusParameters.block_size = 512,
-#     TkClusParameters.TkDAClusParameters.overlap_frac = 0.5
-# )
-#
-# (weightedVertexing & ~phase2_timing_layer).toReplaceWith(offlinePrimaryVertices, offlinePrimaryVerticesWeightedWithBS.clone())
-# (weightedVertexing & ~phase2_timing_layer).toReplaceWith(offlinePrimaryVerticesWithBS, offlinePrimaryVerticesWeighted.clone())

--- a/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h
@@ -176,6 +176,7 @@ public:
       const std::vector<reco::TransientTrack> &tracks) const override;
 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &tracks) const;
+  std::vector<TransientVertex> vertices_in_blocks(const std::vector<reco::TransientTrack> &tracks) const;
 
   track_t fill(const std::vector<reco::TransientTrack> &tracks) const;
 
@@ -222,6 +223,10 @@ private:
 
   double sel_zrange_;
   const double zrange_min_ = 0.1;  // smallest z-range to be included in a tracks cluster list
+
+  bool runInBlocks_;
+  unsigned int block_size_;
+  double overlap_frac_;
 };
 
 //#ifndef DAClusterizerInZ_vect_h

--- a/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h
@@ -41,6 +41,7 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
 //#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
@@ -95,4 +96,5 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float> > trkTimeResosToken;
 
   bool f4D;
+  bool weightFit;
 };

--- a/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
@@ -1,0 +1,282 @@
+#ifndef RecoVertex_PrimaryVertexProducer_WeightedMeanFitter_h
+#define RecoVertex_PrimaryVertexProducer_WeightedMeanFitter_h
+
+#include <vector>
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace WeightedMeanFitter {
+
+  constexpr float startError = 20.0;
+  constexpr float precision = 1e-24;
+  constexpr float corr_x = 1.2;
+  constexpr float corr_z = 1.4;
+  constexpr int maxIterations = 50;
+
+  std::pair<GlobalPoint, double> nearestPoint(const GlobalPoint& vertex, reco::Track iclus){
+      double ox = iclus.vx();
+      double oy = iclus.vy();
+      double oz = iclus.vz();
+
+      double vx = iclus.px();
+      double vy = iclus.py();
+      double vz = iclus.pz();
+
+      double opx = vertex.x() - ox;
+      double opy = vertex.y() - oy;
+      double opz = vertex.z() - oz;
+
+      double vnorm2 = (vx*vx + vy*vy + vz*vz);
+      double t = (vx * opx + vy * opy + vz * opz) / (vnorm2);
+
+      GlobalPoint p(ox + t * vx, oy + t * vy, oz + t * vz);
+      return std::pair<GlobalPoint, double>(p, std::sqrt( std::pow( p.x() - vertex.x() , 2) + std::pow( p.y() - vertex.y() , 2) + std::pow( p.z() - vertex.z() , 2) ));
+  }
+
+  TransientVertex weightedMeanOutlierRejection(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus){
+       float x=0., y=0., z=0.;
+       float s_wx=0., s_wz=0.;
+       float s2_wx=0., s2_wz=0.;
+       float wx=0., wz=0., chi2=0.;
+       float ndof_x = 0.;
+
+       AlgebraicSymMatrix33 err;
+       err(0,0) = 2 * 2;
+       err(1,1) = 2 * 2;
+       err(2,2) = startError * startError; // error is 20 cm, so cov -> is 20 ^ 2
+       for (const auto& p : points){
+
+              wx = p.second.x() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.x(),2);
+
+              wz = p.second.z() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.z(),2);
+
+             x += p.first.x() * wx;
+             y += p.first.y() * wx;
+             z += p.first.z() * wz;
+
+             s_wx += wx;
+             s_wz += wz;
+       }
+
+       if ( s_wx == 0. || s_wz == 0. ){
+          edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning \n";
+          return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
+       }
+
+       x /= s_wx;
+       y /= s_wx;
+       z /= s_wz;
+
+      float old_x, old_y, old_z;
+
+      float xpull;
+      int niter = 0;
+      float mu = 3.;
+
+      float err_x, err_z;
+
+      err_x = 1. / s_wx;
+      err_z = 1. / s_wz;
+
+      while ((niter++) < 2){
+          old_x = x;
+          old_y = y;
+          old_z = z;
+          s_wx = 0; s_wz = 0; s2_wx = 0; s2_wz = 0;
+          x = 0; y = 0; z = 0;
+
+          for (unsigned int i = 0; i < (unsigned int) points.size(); i++){
+              std::pair<GlobalPoint, double> p = nearestPoint(GlobalPoint(old_x, old_y, old_z), (iclus)[i].track());
+
+              wx =  points[i].second.x() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.x(), 2);
+              wz =  points[i].second.z() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.z(),2);
+
+              xpull = 0.;
+
+              if ( std::pow(p.first.x() - old_x, 2) / (wx + err_x) < mu*mu && std::pow(p.first.y() - old_y, 2) / (wx + err_x) < mu*mu && std::pow(p.first.z() - old_z, 2) / (wz + err_z) < mu*mu)  xpull = 1.;
+
+              ndof_x += xpull;
+
+              wx = xpull / wx;
+              wz = xpull / wz;
+
+              x += wx * p.first.x();
+              y += wx * p.first.y();
+              z += wz * p.first.z();
+
+              s_wx += wx;
+              s_wz += wz;
+
+              s2_wx += wx * xpull;
+              s2_wz += wz * xpull;
+          }
+
+          if ( s_wx == 0. || s_wz == 0. ){
+              edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed" << s_wx << " , " << " , " << s_wz << "\n";
+              return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
+          }
+          x /= s_wx;
+          y /= s_wx;
+          z /= s_wz;
+
+          err_x = (s2_wx / std::pow(s_wx, 2));
+          err_z = (s2_wz / std::pow(s_wz, 2));
+
+          if (std::abs(x - old_x) < (precision/1.) && std::abs(y - old_y) < (precision/1.) && std::abs(z - old_z) < (precision/1.)){
+              break;
+          }
+      }
+
+       err(0,0) = err_x * corr_x * corr_x;
+       err(1,1) = err_x * corr_x * corr_x;
+       err(2,2) = err_z * corr_z * corr_z;
+
+
+       float dist = 0;
+       for (const auto& p : points){
+          wx = p.second.x();
+          wx =  wx <= precision ? precision : wx;
+
+          wz = p.second.z();
+          wz =  wz <= precision ? precision : wz;
+
+          dist =  std::pow(p.first.x() - x, 2) / ( std::pow(wx, 2) +  err(0,0) );
+          dist += std::pow(p.first.y() - y, 2) / ( std::pow(wx, 2) +  err(1,1) );
+          dist += std::pow(p.first.z() - z, 2) / ( std::pow(wz, 2) +  err(2,2) );
+          chi2 += dist;
+       }
+       TransientVertex v(GlobalPoint(x,y,z), err, iclus, chi2, (int) ndof_x);
+       return v;
+  }
+
+  TransientVertex weightedMeanOutlierRejectionVarianceAsError(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus){
+       float x=0, y=0, z=0, s_wx=0, s_wy=0, s_wz=0, s2_wx=0, s2_wy=0, s2_wz=0, wx=0, wy=0, wz=0, chi2=0;
+       float ndof_x = 0;
+       AlgebraicSymMatrix33 err;
+       err(0,0) = 2 * 2;
+       err(1,1) = 2 * 2;
+       err(2,2) = startError * startError; // error is 20 cm, so cov -> is 20 ^ 2
+
+       for (const auto& p : points){
+              wx = p.second.x();
+              wx = wx <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(wx,2);
+
+              wz = p.second.z();
+              wz = wz <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(wz,2);
+
+              x += p.first.x() * wx;
+              y += p.first.y() * wx;
+              z += p.first.z() * wz;
+
+              s_wx += wx;
+              s_wz += wz;
+       }
+
+       if ( s_wx == 0. || s_wz == 0. ){
+          edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning. \n";
+          return TransientVertex(GlobalPoint(0,0,0), err, *iclus, 0, 0);
+       }
+
+       x /= s_wx;
+       y /= s_wx;
+       z /= s_wz;
+
+      float old_x, old_y, old_z;
+      float xpull;
+      int niter = 0;
+      float mu = 3.;
+      float err_x, err_y, err_z;
+      err_x = 1. / std::sqrt(s_wx);
+      err_y = 1. / std::sqrt(s_wx);
+      err_z = 1. / std::sqrt(s_wz);
+      float s_err_x = 0, s_err_y = 0, s_err_z = 0;
+      while ((niter++) < maxIterations){
+          old_x = x;
+          old_y = y;
+          old_z = z;
+          s_wx = 0; s_wy = 0; s_wz = 0; s2_wx = 0; s2_wy = 0; s2_wz = 0;
+          x = 0; y = 0; z = 0;
+          s_err_x = 0.; s_err_y = 0.; s_err_z = 0;
+
+          for (const auto& p : points){
+              wx = p.second.x();
+              wx =  wx <= precision ? precision : wx;
+
+              wy = wx*wx + err_y*err_y;
+              wx = wx*wx + err_x*err_x;
+
+              wz = p.second.z();
+              wz =  wz <= precision ? precision : wz;
+              wz = wz*wz + err_z*err_z;
+
+              xpull  = std::pow((p.first.x() - old_x), 2) / wx;
+              xpull += std::pow((p.first.y() - old_y), 2) / wy;
+              xpull += std::pow((p.first.z() - old_z), 2) / wz;
+              xpull = 1. / (1. + std::exp(-0.5 * ((mu * mu) - xpull)));
+              ndof_x += xpull;
+
+              wx = 1. / wx;
+              wy = 1. / wy;
+              wz = 1. / wz;
+
+              wx *= xpull;
+              wy *= xpull;
+              wz *= xpull;
+
+              x += wx * p.first.x();
+              y += wy * p.first.y();
+              z += wz * p.first.z();
+
+              s_wx += wx;
+              s_wy += wy;
+              s_wz += wz;
+
+              s2_wx += wx * wx;
+              s2_wy += wy * wy;
+              s2_wz += wz * wz;
+
+            s_err_x += wx * pow(p.first.x() - old_x, 2);
+            s_err_y += wy * pow(p.first.y() - old_y, 2);
+            s_err_z += wz * pow(p.first.z() - old_z, 2);
+          }
+          if ( s_wx == 0. || s_wy == 0. || s_wz == 0. ){
+
+            edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed" << s_wx << " , " << s_wy << " , " << s_wz << "\n";
+              return TransientVertex(GlobalPoint(0,0,0), err, *iclus, 0, 0);
+          }
+          x /= s_wx;
+          y /= s_wy;
+          z /= s_wz;
+
+          err_x = std::sqrt(s_err_x / s_wx );
+          err_y = std::sqrt(s_err_y / s_wy );
+          err_z = std::sqrt(s_err_z / s_wz );
+
+          if (std::abs(x - old_x) < (precision/1.) && std::abs(y - old_y) < (precision/1.) && std::abs(z - old_z) < (precision/1.))
+              break;
+      }
+
+       err(0,0) = err_x * err_x;
+       err(1,1) = err_y * err_y;
+       err(2,2) = err_z * err_z;
+
+       float dist = 0;
+       for (const auto& p : points){
+          wx = p.second.x();
+          wx =  wx <= precision ? precision : wx;
+
+          wz = p.second.z();
+          wz =  wz <= precision ? precision : wz;
+
+          dist =  std::pow(p.first.x() - x, 2) / ( std::pow(wx, 2) + std::pow( err(0,0), 2) );
+          dist += std::pow(p.first.y() - y, 2) / ( std::pow(wx, 2) + std::pow( err(1,1), 2) );
+          dist += std::pow(p.first.z() - z, 2) / ( std::pow(wz, 2) + std::pow( err(2,2), 2) );
+          chi2 += dist;
+       }
+       TransientVertex v(GlobalPoint(x,y,z), err, *iclus, chi2, (int) ndof_x);
+       return v;
+  }
+
+};
+
+#endif

--- a/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
@@ -15,7 +15,7 @@ namespace WeightedMeanFitter {
   constexpr float corr_z = 1.4;
   constexpr int maxIterations = 50;
 
-  std::pair<GlobalPoint, double> nearestPoint(const GlobalPoint& vertex, reco::Track iclus){
+  inline std::pair<GlobalPoint, double> nearestPoint(const GlobalPoint& vertex, reco::Track iclus){
       double ox = iclus.vx();
       double oy = iclus.vy();
       double oz = iclus.vz();
@@ -35,7 +35,7 @@ namespace WeightedMeanFitter {
       return std::pair<GlobalPoint, double>(p, std::sqrt( std::pow( p.x() - vertex.x() , 2) + std::pow( p.y() - vertex.y() , 2) + std::pow( p.z() - vertex.z() , 2) ));
   }
 
-  TransientVertex weightedMeanOutlierRejection(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus){
+  inline TransientVertex weightedMeanOutlierRejection(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus){
        float x=0., y=0., z=0.;
        float s_wx=0., s_wz=0.;
        float s2_wx=0., s2_wz=0.;
@@ -154,7 +154,7 @@ namespace WeightedMeanFitter {
 
 
 
-TransientVertex weightedMeanOutlierRejectionBeamSpot(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus, const reco::BeamSpot& beamSpot){
+inline TransientVertex weightedMeanOutlierRejectionBeamSpot(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus, const reco::BeamSpot& beamSpot){
      float x=0., y=0., z=0.;
      float s_wx=0., s_wz=0.;
      float s2_wx=0., s2_wz=0.;
@@ -303,7 +303,7 @@ TransientVertex weightedMeanOutlierRejectionBeamSpot(const std::vector<std::pair
      return v;
 }
 
-  TransientVertex weightedMeanOutlierRejectionVarianceAsError(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus){
+  inline TransientVertex weightedMeanOutlierRejectionVarianceAsError(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus){
        float x=0, y=0, z=0, s_wx=0, s_wy=0, s_wz=0, s2_wx=0, s2_wy=0, s2_wz=0, wx=0, wy=0, wz=0, chi2=0;
        float ndof_x = 0;
        AlgebraicSymMatrix33 err;

--- a/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
@@ -298,8 +298,7 @@ namespace WeightedMeanFitter {
       err_y = (s2_wy / std::pow(s_wy, 2));
       err_z = (s2_wz / std::pow(s_wz, 2));
 
-      if (std::abs(x - old_x) < (precision / 1.) && std::abs(y - old_y) < (precision / 1.) &&
-          std::abs(z - old_z) < (precision / 1.)) {
+      if (std::abs(x - old_x) < (precision) && std::abs(y - old_y) < (precision) && std::abs(z - old_z) < (precision)) {
         break;
       }
     }
@@ -331,9 +330,8 @@ namespace WeightedMeanFitter {
           chi2 = 0;
     float ndof_x = 0;
     AlgebraicSymMatrix33 err;
-    err(0, 0) = startError / 10 * startError / 10;
-    err(1, 1) = startError / 10 * startError / 10;
     err(2, 2) = startError * startError;  // error is 20 cm, so cov -> is 20 ^ 2
+    err(0, 0) = err(1, 1) = err(2, 2) / 100.;
 
     for (const auto& p : points) {
       wx = p.second.x();
@@ -367,7 +365,7 @@ namespace WeightedMeanFitter {
     err_x = 1. / std::sqrt(s_wx);
     err_y = 1. / std::sqrt(s_wx);
     err_z = 1. / std::sqrt(s_wz);
-    float s_err_x = 0, s_err_y = 0, s_err_z = 0;
+    float s_err_x = 0., s_err_y = 0., s_err_z = 0.;
     while ((niter++) < maxIterations) {
       old_x = x;
       old_y = y;
@@ -383,7 +381,7 @@ namespace WeightedMeanFitter {
       z = 0;
       s_err_x = 0.;
       s_err_y = 0.;
-      s_err_z = 0;
+      s_err_z = 0.;
 
       for (const auto& p : points) {
         wx = p.second.x();
@@ -448,7 +446,7 @@ namespace WeightedMeanFitter {
     err(1, 1) = err_y * err_y;
     err(2, 2) = err_z * err_z;
 
-    float dist = 0;
+    float dist = 0.f;
     for (const auto& p : points) {
       wx = p.second.x();
       wx = wx <= precision ? precision : wx;

--- a/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/WeightedMeanFitter.h
@@ -5,202 +5,214 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 
 namespace WeightedMeanFitter {
 
   constexpr float startError = 20.0;
   constexpr float precision = 1e-24;
   constexpr float corr_x = 1.2;
-  constexpr float corr_x_bs = 1.0; // corr_x for beam spot 
+  constexpr float corr_x_bs = 1.0;  // corr_x for beam spot
   constexpr float corr_z = 1.4;
   constexpr int maxIterations = 50;
 
-  inline std::pair<GlobalPoint, double> nearestPoint(const GlobalPoint& vertex, reco::Track iclus){
-      double ox = iclus.vx();
-      double oy = iclus.vy();
-      double oz = iclus.vz();
+  inline std::pair<GlobalPoint, double> nearestPoint(const GlobalPoint& vertex, reco::Track iclus) {
+    double ox = iclus.vx();
+    double oy = iclus.vy();
+    double oz = iclus.vz();
 
-      double vx = iclus.px();
-      double vy = iclus.py();
-      double vz = iclus.pz();
+    double vx = iclus.px();
+    double vy = iclus.py();
+    double vz = iclus.pz();
 
-      double opx = vertex.x() - ox;
-      double opy = vertex.y() - oy;
-      double opz = vertex.z() - oz;
+    double opx = vertex.x() - ox;
+    double opy = vertex.y() - oy;
+    double opz = vertex.z() - oz;
 
-      double vnorm2 = (vx*vx + vy*vy + vz*vz);
-      double t = (vx * opx + vy * opy + vz * opz) / (vnorm2);
+    double vnorm2 = (vx * vx + vy * vy + vz * vz);
+    double t = (vx * opx + vy * opy + vz * opz) / (vnorm2);
 
-      GlobalPoint p(ox + t * vx, oy + t * vy, oz + t * vz);
-      return std::pair<GlobalPoint, double>(p, std::sqrt( std::pow( p.x() - vertex.x() , 2) + std::pow( p.y() - vertex.y() , 2) + std::pow( p.z() - vertex.z() , 2) ));
+    GlobalPoint p(ox + t * vx, oy + t * vy, oz + t * vz);
+    return std::pair<GlobalPoint, double>(
+        p,
+        std::sqrt(std::pow(p.x() - vertex.x(), 2) + std::pow(p.y() - vertex.y(), 2) + std::pow(p.z() - vertex.z(), 2)));
   }
 
-  inline TransientVertex weightedMeanOutlierRejection(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus){
-       float x=0., y=0., z=0.;
-       float s_wx=0., s_wz=0.;
-       float s2_wx=0., s2_wz=0.;
-       float wx=0., wz=0., chi2=0.;
-       float ndof_x = 0.;
+  inline TransientVertex weightedMeanOutlierRejection(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points,
+                                                      std::vector<reco::TransientTrack> iclus) {
+    float x = 0., y = 0., z = 0.;
+    float s_wx = 0., s_wz = 0.;
+    float s2_wx = 0., s2_wz = 0.;
+    float wx = 0., wz = 0., chi2 = 0.;
+    float ndof_x = 0.;
 
-       AlgebraicSymMatrix33 err;
-       err(0,0) = startError/10 * startError/10;
-       err(1,1) = startError/10 * startError/10;
-       err(2,2) = startError * startError; // error is 20 cm, so cov -> is 20 ^ 2
-       for (const auto& p : points){
+    AlgebraicSymMatrix33 err;
+    err(0, 0) = startError / 10 * startError / 10;
+    err(1, 1) = startError / 10 * startError / 10;
+    err(2, 2) = startError * startError;  // error is 20 cm, so cov -> is 20 ^ 2
+    for (const auto& p : points) {
+      wx = p.second.x() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(p.second.x(), 2);
 
-              wx = p.second.x() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.x(),2);
+      wz = p.second.z() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(p.second.z(), 2);
 
-              wz = p.second.z() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.z(),2);
+      x += p.first.x() * wx;
+      y += p.first.y() * wx;
+      z += p.first.z() * wz;
 
-             x += p.first.x() * wx;
-             y += p.first.y() * wx;
-             z += p.first.z() * wz;
+      s_wx += wx;
+      s_wz += wz;
+    }
 
-             s_wx += wx;
-             s_wz += wz;
-       }
+    if (s_wx == 0. || s_wz == 0.) {
+      edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning\n";
+      return TransientVertex(GlobalPoint(0, 0, 0), err, iclus, 0, 0);
+    }
 
-       if ( s_wx == 0. || s_wz == 0. ){
-          edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning \n";
-          return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
-       }
+    x /= s_wx;
+    y /= s_wx;
+    z /= s_wz;
 
-       x /= s_wx;
-       y /= s_wx;
-       z /= s_wz;
+    float old_x, old_y, old_z;
 
-      float old_x, old_y, old_z;
+    float xpull;
+    int niter = 0;
+    float mu = 3.;
 
-      float xpull;
-      int niter = 0;
-      float mu = 3.;
+    float err_x, err_z;
 
-      float err_x, err_z;
+    err_x = 1. / s_wx;
+    err_z = 1. / s_wz;
 
-      err_x = 1. / s_wx;
-      err_z = 1. / s_wz;
+    while ((niter++) < 2) {
+      old_x = x;
+      old_y = y;
+      old_z = z;
+      s_wx = 0;
+      s_wz = 0;
+      s2_wx = 0;
+      s2_wz = 0;
+      x = 0;
+      y = 0;
+      z = 0;
+      ndof_x = 0;
 
-      while ((niter++) < 2){
-          old_x = x;
-          old_y = y;
-          old_z = z;
-          s_wx = 0; s_wz = 0; s2_wx = 0; s2_wz = 0;
-          x = 0; y = 0; z = 0;
-          ndof_x = 0;
+      for (unsigned int i = 0; i < (unsigned int)points.size(); i++) {
+        std::pair<GlobalPoint, double> p = nearestPoint(GlobalPoint(old_x, old_y, old_z), (iclus)[i].track());
 
-          for (unsigned int i = 0; i < (unsigned int) points.size(); i++){
-              std::pair<GlobalPoint, double> p = nearestPoint(GlobalPoint(old_x, old_y, old_z), (iclus)[i].track());
+        wx = points[i].second.x() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.x(), 2);
+        wz = points[i].second.z() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.z(), 2);
 
-              wx =  points[i].second.x() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.x(), 2);
-              wz =  points[i].second.z() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.z(),2);
+        xpull = 0.;
 
-              xpull = 0.;
+        if (std::pow(p.first.x() - old_x, 2) / (wx + err_x) < mu * mu &&
+            std::pow(p.first.y() - old_y, 2) / (wx + err_x) < mu * mu &&
+            std::pow(p.first.z() - old_z, 2) / (wz + err_z) < mu * mu)
+          xpull = 1.;
 
-              if ( std::pow(p.first.x() - old_x, 2) / (wx + err_x) < mu*mu && std::pow(p.first.y() - old_y, 2) / (wx + err_x) < mu*mu && std::pow(p.first.z() - old_z, 2) / (wz + err_z) < mu*mu)  xpull = 1.;
+        ndof_x += xpull;
 
-              ndof_x += xpull;
+        wx = xpull / wx;
+        wz = xpull / wz;
 
-              wx = xpull / wx;
-              wz = xpull / wz;
+        x += wx * p.first.x();
+        y += wx * p.first.y();
+        z += wz * p.first.z();
 
-              x += wx * p.first.x();
-              y += wx * p.first.y();
-              z += wz * p.first.z();
+        s_wx += wx;
+        s_wz += wz;
 
-              s_wx += wx;
-              s_wz += wz;
+        s2_wx += wx * xpull;
+        s2_wz += wz * xpull;
+      }
 
-              s2_wx += wx * xpull;
-              s2_wz += wz * xpull;
-          }
+      if (s_wx == 0. || s_wz == 0.) {
+        edm::LogWarning("WeightedMeanFitter")
+            << "Vertex fitting failed, either all tracks are outliers or they have a very large error\n";
+        return TransientVertex(GlobalPoint(0, 0, 0), err, iclus, 0, 0);
+      }
+      x /= s_wx;
+      y /= s_wx;
+      z /= s_wz;
 
-          if ( s_wx == 0. || s_wz == 0. ){
-              edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed" << s_wx << " , " << s_wz << "\n";
-              return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
-          }
-          x /= s_wx;
-          y /= s_wx;
-          z /= s_wz;
+      err_x = (s2_wx / std::pow(s_wx, 2));
+      err_z = (s2_wz / std::pow(s_wz, 2));
 
-          err_x = (s2_wx / std::pow(s_wx, 2));
-          err_z = (s2_wz / std::pow(s_wz, 2));
+      if (std::abs(x - old_x) < (precision / 1.) && std::abs(y - old_y) < (precision / 1.) &&
+          std::abs(z - old_z) < (precision / 1.)) {
+        break;
+      }
+    }
 
-          if (std::abs(x - old_x) < (precision/1.) && std::abs(y - old_y) < (precision/1.) && std::abs(z - old_z) < (precision/1.)){
-              break;
-          }
-       } 
-       
-       err(0,0) = err_x * corr_x * corr_x;
-       err(1,1) = err_x * corr_x * corr_x;
-       err(2,2) = err_z * corr_z * corr_z;
+    err(0, 0) = err_x * corr_x * corr_x;
+    err(1, 1) = err_x * corr_x * corr_x;
+    err(2, 2) = err_z * corr_z * corr_z;
 
+    float dist = 0;
+    for (const auto& p : points) {
+      wx = p.second.x();
+      wx = wx <= precision ? precision : wx;
 
-       float dist = 0;
-       for (const auto& p : points){
-          wx = p.second.x();
-          wx =  wx <= precision ? precision : wx;
+      wz = p.second.z();
+      wz = wz <= precision ? precision : wz;
 
-          wz = p.second.z();
-          wz =  wz <= precision ? precision : wz;
-
-          dist =  std::pow(p.first.x() - x, 2) / ( std::pow(wx, 2) +  err(0,0) );
-          dist += std::pow(p.first.y() - y, 2) / ( std::pow(wx, 2) +  err(1,1) );
-          dist += std::pow(p.first.z() - z, 2) / ( std::pow(wz, 2) +  err(2,2) );
-          chi2 += dist;
-       }
-       TransientVertex v(GlobalPoint(x,y,z), err, iclus, chi2, (int) ndof_x);
-       return v;
+      dist = std::pow(p.first.x() - x, 2) / (std::pow(wx, 2) + err(0, 0));
+      dist += std::pow(p.first.y() - y, 2) / (std::pow(wx, 2) + err(1, 1));
+      dist += std::pow(p.first.z() - z, 2) / (std::pow(wz, 2) + err(2, 2));
+      chi2 += dist;
+    }
+    TransientVertex v(GlobalPoint(x, y, z), err, iclus, chi2, (int)ndof_x);
+    return v;
   }
 
+  inline TransientVertex weightedMeanOutlierRejectionBeamSpot(
+      const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points,
+      std::vector<reco::TransientTrack> iclus,
+      const reco::BeamSpot& beamSpot) {
+    float x = 0., y = 0., z = 0.;
+    float s_wx = 0., s_wz = 0.;
+    float s2_wx = 0., s2_wz = 0.;
+    float wx = 0., wz = 0., chi2 = 0.;
+    float wy = 0., s_wy = 0., s2_wy = 0.;
+    float ndof_x = 0.;
 
+    AlgebraicSymMatrix33 err;
+    err(0, 0) = startError / 10 * startError / 10;
+    err(1, 1) = startError / 10 * startError / 10;
+    err(2, 2) = startError * startError;  // error is 20 cm, so cov -> is 20 ^ 2
 
-inline TransientVertex weightedMeanOutlierRejectionBeamSpot(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<reco::TransientTrack> iclus, const reco::BeamSpot& beamSpot){
-     float x=0., y=0., z=0.;
-     float s_wx=0., s_wz=0.;
-     float s2_wx=0., s2_wz=0.;
-     float wx=0., wz=0., chi2=0.;
-     float wy=0., s_wy=0., s2_wy=0.;
-     float ndof_x = 0.; 
+    GlobalError bse(beamSpot.rotatedCovariance3D());
+    GlobalPoint bsp(Basic3DVector<float>(beamSpot.position()));
 
-     AlgebraicSymMatrix33 err;
-     err(0,0) = startError/10 * startError/10;
-     err(1,1) = startError/10 * startError/10;
-     err(2,2) = startError * startError; // error is 20 cm, so cov -> is 20 ^ 2
+    for (const auto& p : points) {
+      wx = p.second.x() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(p.second.x(), 2);
+      wy = p.second.y() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(p.second.y(), 2);
 
-     GlobalError bse(beamSpot.rotatedCovariance3D());
-     GlobalPoint bsp(Basic3DVector<float>(beamSpot.position()));
-   
-     for (const auto& p : points){ 
+      wz = p.second.z() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(p.second.z(), 2);
 
-            wx = p.second.x() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.x(),2);
-            wy = p.second.y() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.y(),2);
+      x += p.first.x() * wx;
+      y += p.first.y() * wy;
+      z += p.first.z() * wz;
 
-            wz = p.second.z() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(p.second.z(),2);
+      s_wx += wx;
+      s_wy += wy;
+      s_wz += wz;
+    }
 
-           x += p.first.x() * wx;
-           y += p.first.y() * wy;
-           z += p.first.z() * wz;
+    if (s_wx == 0. || s_wy == 0. || s_wz == 0.) {
+      edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning\n";
+      return TransientVertex(GlobalPoint(0, 0, 0), err, iclus, 0, 0);
+    }
+    // use the square of covariance element to increase it's weight: it will be the most important
+    wx = bse.cxx() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(bse.cxx(), 2);
+    wy = bse.cyy() <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(bse.cyy(), 2);
 
-           s_wx += wx;
-           s_wy += wy;
-           s_wz += wz;
-     }
+    x += bsp.x() * wx;
+    y += bsp.y() * wy;
 
-     if ( s_wx == 0. || s_wy == 0. ||s_wz == 0. ){
-        edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning \n";
-        return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
-     }
-    // use the square of covariance element to increase it's weight: it will be the most important 
-     wx = bse.cxx() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(bse.cxx(),2);
-     wy = bse.cyy() <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(bse.cyy(),2);
+    x /= (s_wx + wx);
+    y /= (s_wy + wy);
+    z /= s_wz;
 
-     x += bsp.x() * wx;
-     y += bsp.y() * wy;
-     
-     x /= (s_wx + wx);     
-     y /= (s_wy + wy);     
-     z /= s_wz;  
- 
     float old_x, old_y, old_z;
 
     float xpull;
@@ -213,224 +225,246 @@ inline TransientVertex weightedMeanOutlierRejectionBeamSpot(const std::vector<st
     err_y = 1. / s_wy;
     err_z = 1. / s_wz;
 
-    while ((niter++) < 2){
-        old_x = x;
-        old_y = y;
-        old_z = z;
-        s_wx = 0; s_wz = 0; s2_wx = 0; s2_wz = 0;
+    while ((niter++) < 2) {
+      old_x = x;
+      old_y = y;
+      old_z = z;
+      s_wx = 0;
+      s_wz = 0;
+      s2_wx = 0;
+      s2_wz = 0;
 
-        s_wy = 0; s2_wy = 0;
+      s_wy = 0;
+      s2_wy = 0;
 
-        x = 0; y = 0; z = 0;
-        ndof_x = 0; 
+      x = 0;
+      y = 0;
+      z = 0;
+      ndof_x = 0;
 
-        for (unsigned int i = 0; i < (unsigned int) points.size(); i++){ 
-            std::pair<GlobalPoint, double> p = nearestPoint(GlobalPoint(old_x, old_y, old_z), (iclus)[i].track());
+      for (unsigned int i = 0; i < (unsigned int)points.size(); i++) {
+        std::pair<GlobalPoint, double> p = nearestPoint(GlobalPoint(old_x, old_y, old_z), (iclus)[i].track());
 
-            wx =  points[i].second.x() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.x(), 2);
-            wy =  points[i].second.y() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.y(), 2);
+        wx = points[i].second.x() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.x(), 2);
+        wy = points[i].second.y() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.y(), 2);
 
-            wz =  points[i].second.z() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.z(),2);
-            
- 
-            xpull = 0.;
-            if ( std::pow(p.first.x() - old_x, 2) / (wx + err_x) < mu*mu && std::pow(p.first.y() - old_y, 2) / (wy + err_y) < mu*mu && std::pow(p.first.z() - old_z, 2) / (wz + err_z) < mu*mu)  xpull = 1.;
+        wz = points[i].second.z() <= precision ? std::pow(precision, 2) : std::pow(points[i].second.z(), 2);
 
-            ndof_x += xpull;
+        xpull = 0.;
+        if (std::pow(p.first.x() - old_x, 2) / (wx + err_x) < mu * mu &&
+            std::pow(p.first.y() - old_y, 2) / (wy + err_y) < mu * mu &&
+            std::pow(p.first.z() - old_z, 2) / (wz + err_z) < mu * mu)
+          xpull = 1.;
 
-            wx = xpull / wx;
-            wy = xpull / wy;
-            wz = xpull / wz;
+        ndof_x += xpull;
 
-            x += wx * p.first.x();
-            y += wy * p.first.y();
-            z += wz * p.first.z();
+        wx = xpull / wx;
+        wy = xpull / wy;
+        wz = xpull / wz;
 
-            s_wx += wx;
-            s_wy += wy;
-            s_wz += wz;
+        x += wx * p.first.x();
+        y += wy * p.first.y();
+        z += wz * p.first.z();
 
-            s2_wx += wx * xpull;
-            s2_wy += wy * xpull;
-            s2_wz += wz * xpull;
-        }
+        s_wx += wx;
+        s_wy += wy;
+        s_wz += wz;
 
-        if ( s_wx == 0. || s_wy == 0. || s_wz == 0. ){
-            edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed" << s_wx << " , " << s_wy << " , " << s_wz << "\n";
-            return TransientVertex(GlobalPoint(0,0,0), err, iclus, 0, 0);
-        }
-        wx = bse.cxx() <=  std::pow(precision,2) ? 1. / std::pow(precision,2) : 1. / bse.cxx();
-        wy = bse.cyy() <=  std::pow(precision,2) ? 1. / std::pow(precision,2) : 1. / bse.cyy();
-
-        x += bsp.x() * wx;
-        y += bsp.y() * wy;
-        s_wx  += wx;
-        s2_wx += wx;
-        s_wy  += wy;
-        s2_wy += wy;
-        
-        x /= s_wx;     
-        y /= s_wy;     
-        z /= s_wz;
-
-        err_x = (s2_wx / std::pow(s_wx, 2));
-        err_y = (s2_wy / std::pow(s_wy, 2));
-        err_z = (s2_wz / std::pow(s_wz, 2));
-
-        if (std::abs(x - old_x) < (precision/1.) && std::abs(y - old_y) < (precision/1.) && std::abs(z - old_z) < (precision/1.)){
-            break;
-        }
-    }
-     err(0,0) = err_x * corr_x_bs * corr_x_bs;
-     err(1,1) = err_y * corr_x_bs * corr_x_bs;
-     err(2,2) = err_z * corr_z * corr_z;
-
-
-     float dist = 0; 
-     for (const auto& p : points){ 
-        wx = p.second.x();
-        wx =  wx <= precision ? precision : wx;
-
-        wz = p.second.z();
-        wz =  wz <= precision ? precision : wz;
-
-        dist =  std::pow(p.first.x() - x, 2) / ( std::pow(wx, 2) +  err(0,0) );
-        dist += std::pow(p.first.y() - y, 2) / ( std::pow(wx, 2) +  err(1,1) );
-        dist += std::pow(p.first.z() - z, 2) / ( std::pow(wz, 2) +  err(2,2) ); 
-        chi2 += dist;
-     }
-     TransientVertex v(GlobalPoint(x,y,z), err, iclus, chi2, (int) ndof_x);
-     return v;
-}
-
-  inline TransientVertex weightedMeanOutlierRejectionVarianceAsError(const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points, std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus){
-       float x=0, y=0, z=0, s_wx=0, s_wy=0, s_wz=0, s2_wx=0, s2_wy=0, s2_wz=0, wx=0, wy=0, wz=0, chi2=0;
-       float ndof_x = 0;
-       AlgebraicSymMatrix33 err;
-       err(0,0) = startError/10 * startError/10;
-       err(1,1) = startError/10 * startError/10;
-       err(2,2) = startError * startError; // error is 20 cm, so cov -> is 20 ^ 2
-
-       for (const auto& p : points){
-              wx = p.second.x();
-              wx = wx <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(wx,2);
-
-              wz = p.second.z();
-              wz = wz <=  precision ? 1. / std::pow(precision,2) : 1. / std::pow(wz,2);
-
-              x += p.first.x() * wx;
-              y += p.first.y() * wx;
-              z += p.first.z() * wz;
-
-              s_wx += wx;
-              s_wz += wz;
-       }
-
-       if ( s_wx == 0. || s_wz == 0. ){
-          edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning. \n";
-          return TransientVertex(GlobalPoint(0,0,0), err, *iclus, 0, 0);
-       }
-
-       x /= s_wx;
-       y /= s_wx;
-       z /= s_wz;
-
-      float old_x, old_y, old_z;
-      float xpull;
-      int niter = 0;
-      float mu = 3.;
-      float err_x, err_y, err_z;
-      err_x = 1. / std::sqrt(s_wx);
-      err_y = 1. / std::sqrt(s_wx);
-      err_z = 1. / std::sqrt(s_wz);
-      float s_err_x = 0, s_err_y = 0, s_err_z = 0;
-      while ((niter++) < maxIterations){
-          old_x = x;
-          old_y = y;
-          old_z = z;
-          s_wx = 0; s_wy = 0; s_wz = 0; s2_wx = 0; s2_wy = 0; s2_wz = 0;
-          x = 0; y = 0; z = 0;
-          s_err_x = 0.; s_err_y = 0.; s_err_z = 0;
-
-          for (const auto& p : points){
-              wx = p.second.x();
-              wx =  wx <= precision ? precision : wx;
-
-              wy = wx*wx + err_y*err_y;
-              wx = wx*wx + err_x*err_x;
-
-              wz = p.second.z();
-              wz =  wz <= precision ? precision : wz;
-              wz = wz*wz + err_z*err_z;
-
-              xpull  = std::pow((p.first.x() - old_x), 2) / wx;
-              xpull += std::pow((p.first.y() - old_y), 2) / wy;
-              xpull += std::pow((p.first.z() - old_z), 2) / wz;
-              xpull = 1. / (1. + std::exp(-0.5 * ((mu * mu) - xpull)));
-              ndof_x += xpull;
-
-              wx = 1. / wx;
-              wy = 1. / wy;
-              wz = 1. / wz;
-
-              wx *= xpull;
-              wy *= xpull;
-              wz *= xpull;
-
-              x += wx * p.first.x();
-              y += wy * p.first.y();
-              z += wz * p.first.z();
-
-              s_wx += wx;
-              s_wy += wy;
-              s_wz += wz;
-
-              s2_wx += wx * wx;
-              s2_wy += wy * wy;
-              s2_wz += wz * wz;
-
-            s_err_x += wx * pow(p.first.x() - old_x, 2);
-            s_err_y += wy * pow(p.first.y() - old_y, 2);
-            s_err_z += wz * pow(p.first.z() - old_z, 2);
-          }
-          if ( s_wx == 0. || s_wy == 0. || s_wz == 0. ){
-
-            edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed" << s_wx << " , " << s_wy << " , " << s_wz << "\n";
-              return TransientVertex(GlobalPoint(0,0,0), err, *iclus, 0, 0);
-          }
-          x /= s_wx;
-          y /= s_wy;
-          z /= s_wz;
-
-          err_x = std::sqrt(s_err_x / s_wx );
-          err_y = std::sqrt(s_err_y / s_wy );
-          err_z = std::sqrt(s_err_z / s_wz );
-
-          if (std::abs(x - old_x) < (precision/1.) && std::abs(y - old_y) < (precision/1.) && std::abs(z - old_z) < (precision/1.))
-              break;
+        s2_wx += wx * xpull;
+        s2_wy += wy * xpull;
+        s2_wz += wz * xpull;
       }
 
-       err(0,0) = err_x * err_x;
-       err(1,1) = err_y * err_y;
-       err(2,2) = err_z * err_z;
+      if (s_wx == 0. || s_wy == 0. || s_wz == 0.) {
+        edm::LogWarning("WeightedMeanFitter")
+            << "Vertex fitting failed, either all tracks are outliers or they have a very large error\n";
+        return TransientVertex(GlobalPoint(0, 0, 0), err, iclus, 0, 0);
+      }
+      wx = bse.cxx() <= std::pow(precision, 2) ? 1. / std::pow(precision, 2) : 1. / bse.cxx();
+      wy = bse.cyy() <= std::pow(precision, 2) ? 1. / std::pow(precision, 2) : 1. / bse.cyy();
 
-       float dist = 0;
-       for (const auto& p : points){
-          wx = p.second.x();
-          wx =  wx <= precision ? precision : wx;
+      x += bsp.x() * wx;
+      y += bsp.y() * wy;
+      s_wx += wx;
+      s2_wx += wx;
+      s_wy += wy;
+      s2_wy += wy;
 
-          wz = p.second.z();
-          wz =  wz <= precision ? precision : wz;
+      x /= s_wx;
+      y /= s_wy;
+      z /= s_wz;
 
-          dist =  std::pow(p.first.x() - x, 2) / ( std::pow(wx, 2) + std::pow( err(0,0), 2) );
-          dist += std::pow(p.first.y() - y, 2) / ( std::pow(wx, 2) + std::pow( err(1,1), 2) );
-          dist += std::pow(p.first.z() - z, 2) / ( std::pow(wz, 2) + std::pow( err(2,2), 2) );
-          chi2 += dist;
-       }
-       TransientVertex v(GlobalPoint(x,y,z), err, *iclus, chi2, (int) ndof_x);
-       return v;
+      err_x = (s2_wx / std::pow(s_wx, 2));
+      err_y = (s2_wy / std::pow(s_wy, 2));
+      err_z = (s2_wz / std::pow(s_wz, 2));
+
+      if (std::abs(x - old_x) < (precision / 1.) && std::abs(y - old_y) < (precision / 1.) &&
+          std::abs(z - old_z) < (precision / 1.)) {
+        break;
+      }
+    }
+    err(0, 0) = err_x * corr_x_bs * corr_x_bs;
+    err(1, 1) = err_y * corr_x_bs * corr_x_bs;
+    err(2, 2) = err_z * corr_z * corr_z;
+
+    float dist = 0;
+    for (const auto& p : points) {
+      wx = p.second.x();
+      wx = wx <= precision ? precision : wx;
+
+      wz = p.second.z();
+      wz = wz <= precision ? precision : wz;
+
+      dist = std::pow(p.first.x() - x, 2) / (std::pow(wx, 2) + err(0, 0));
+      dist += std::pow(p.first.y() - y, 2) / (std::pow(wx, 2) + err(1, 1));
+      dist += std::pow(p.first.z() - z, 2) / (std::pow(wz, 2) + err(2, 2));
+      chi2 += dist;
+    }
+    TransientVertex v(GlobalPoint(x, y, z), err, iclus, chi2, (int)ndof_x);
+    return v;
   }
 
-};
+  inline TransientVertex weightedMeanOutlierRejectionVarianceAsError(
+      const std::vector<std::pair<GlobalPoint, GlobalPoint>>& points,
+      std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus) {
+    float x = 0, y = 0, z = 0, s_wx = 0, s_wy = 0, s_wz = 0, s2_wx = 0, s2_wy = 0, s2_wz = 0, wx = 0, wy = 0, wz = 0,
+          chi2 = 0;
+    float ndof_x = 0;
+    AlgebraicSymMatrix33 err;
+    err(0, 0) = startError / 10 * startError / 10;
+    err(1, 1) = startError / 10 * startError / 10;
+    err(2, 2) = startError * startError;  // error is 20 cm, so cov -> is 20 ^ 2
+
+    for (const auto& p : points) {
+      wx = p.second.x();
+      wx = wx <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(wx, 2);
+
+      wz = p.second.z();
+      wz = wz <= precision ? 1. / std::pow(precision, 2) : 1. / std::pow(wz, 2);
+
+      x += p.first.x() * wx;
+      y += p.first.y() * wx;
+      z += p.first.z() * wz;
+
+      s_wx += wx;
+      s_wz += wz;
+    }
+
+    if (s_wx == 0. || s_wz == 0.) {
+      edm::LogWarning("WeightedMeanFitter") << "Vertex fitting failed at beginning\n";
+      return TransientVertex(GlobalPoint(0, 0, 0), err, *iclus, 0, 0);
+    }
+
+    x /= s_wx;
+    y /= s_wx;
+    z /= s_wz;
+
+    float old_x, old_y, old_z;
+    float xpull;
+    int niter = 0;
+    float mu = 3.;
+    float err_x, err_y, err_z;
+    err_x = 1. / std::sqrt(s_wx);
+    err_y = 1. / std::sqrt(s_wx);
+    err_z = 1. / std::sqrt(s_wz);
+    float s_err_x = 0, s_err_y = 0, s_err_z = 0;
+    while ((niter++) < maxIterations) {
+      old_x = x;
+      old_y = y;
+      old_z = z;
+      s_wx = 0;
+      s_wy = 0;
+      s_wz = 0;
+      s2_wx = 0;
+      s2_wy = 0;
+      s2_wz = 0;
+      x = 0;
+      y = 0;
+      z = 0;
+      s_err_x = 0.;
+      s_err_y = 0.;
+      s_err_z = 0;
+
+      for (const auto& p : points) {
+        wx = p.second.x();
+        wx = wx <= precision ? precision : wx;
+
+        wy = wx * wx + err_y * err_y;
+        wx = wx * wx + err_x * err_x;
+
+        wz = p.second.z();
+        wz = wz <= precision ? precision : wz;
+        wz = wz * wz + err_z * err_z;
+
+        xpull = std::pow((p.first.x() - old_x), 2) / wx;
+        xpull += std::pow((p.first.y() - old_y), 2) / wy;
+        xpull += std::pow((p.first.z() - old_z), 2) / wz;
+        xpull = 1. / (1. + std::exp(-0.5 * ((mu * mu) - xpull)));
+        ndof_x += xpull;
+
+        wx = 1. / wx;
+        wy = 1. / wy;
+        wz = 1. / wz;
+
+        wx *= xpull;
+        wy *= xpull;
+        wz *= xpull;
+
+        x += wx * p.first.x();
+        y += wy * p.first.y();
+        z += wz * p.first.z();
+
+        s_wx += wx;
+        s_wy += wy;
+        s_wz += wz;
+
+        s2_wx += wx * wx;
+        s2_wy += wy * wy;
+        s2_wz += wz * wz;
+
+        s_err_x += wx * pow(p.first.x() - old_x, 2);
+        s_err_y += wy * pow(p.first.y() - old_y, 2);
+        s_err_z += wz * pow(p.first.z() - old_z, 2);
+      }
+      if (s_wx == 0. || s_wy == 0. || s_wz == 0.) {
+        edm::LogWarning("WeightedMeanFitter")
+            << "Vertex fitting failed, either all tracks are outliers or they have a very large error\n";
+        return TransientVertex(GlobalPoint(0, 0, 0), err, *iclus, 0, 0);
+      }
+      x /= s_wx;
+      y /= s_wy;
+      z /= s_wz;
+
+      err_x = std::sqrt(s_err_x / s_wx);
+      err_y = std::sqrt(s_err_y / s_wy);
+      err_z = std::sqrt(s_err_z / s_wz);
+
+      if (std::abs(x - old_x) < (precision / 1.) && std::abs(y - old_y) < (precision / 1.) &&
+          std::abs(z - old_z) < (precision / 1.))
+        break;
+    }
+
+    err(0, 0) = err_x * err_x;
+    err(1, 1) = err_y * err_y;
+    err(2, 2) = err_z * err_z;
+
+    float dist = 0;
+    for (const auto& p : points) {
+      wx = p.second.x();
+      wx = wx <= precision ? precision : wx;
+
+      wz = p.second.z();
+      wz = wz <= precision ? precision : wz;
+
+      dist = std::pow(p.first.x() - x, 2) / (std::pow(wx, 2) + std::pow(err(0, 0), 2));
+      dist += std::pow(p.first.y() - y, 2) / (std::pow(wx, 2) + std::pow(err(1, 1), 2));
+      dist += std::pow(p.first.z() - z, 2) / (std::pow(wz, 2) + std::pow(err(2, 2), 2));
+      chi2 += dist;
+    }
+    TransientVertex v(GlobalPoint(x, y, z), err, *iclus, chi2, (int)ndof_x);
+    return v;
+  }
+
+};  // namespace WeightedMeanFitter
 
 #endif

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -238,7 +238,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
                    points.push_back(p2);
             }
 
-           v = WeightedMeanFitter::weightedMeanOutlierRejection(points, *iclus);
+           v = WeightedMeanFitter::weightedMeanOutlierRejectionBeamSpot(points, *iclus, beamSpot);
            if ((v.positionError().matrix())(2,2) != (WeightedMeanFitter::startError*WeightedMeanFitter::startError)) pvs.push_back(v);
         }
         else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -60,13 +60,13 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
   }
 
   if (f4D) {
-    trkTimesToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
-    trkTimeResosToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
+    trkTimesToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
+    trkTimeResosToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
   }
 
   // select and configure the vertex fitters
   std::vector<edm::ParameterSet> vertexCollections =
-      conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+      conf.getParameter<std::vector<edm::ParameterSet>>("vertexCollections");
 
   for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
        algoconf != vertexCollections.end();
@@ -165,8 +165,8 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   std::vector<reco::TransientTrack> t_tks;
 
   if (f4D) {
-    edm::Handle<edm::ValueMap<float> > trackTimesH;
-    edm::Handle<edm::ValueMap<float> > trackTimeResosH;
+    edm::Handle<edm::ValueMap<float>> trackTimesH;
+    edm::Handle<edm::ValueMap<float>> trackTimeResosH;
     iEvent.getByToken(trkTimesToken, trackTimesH);
     iEvent.getByToken(trkTimeResosToken, trackTimeResosH);
     t_tks = (*theB).build(tks, beamSpot, *(trackTimesH.product()), *(trackTimeResosH.product()));
@@ -183,7 +183,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   std::vector<reco::TransientTrack>&& seltks = theTrackFilter->select(t_tks);
 
   // clusterize tracks in Z
-  std::vector<std::vector<reco::TransientTrack> >&& clusters = theTrackClusterizer->clusterize(seltks);
+  std::vector<std::vector<reco::TransientTrack>>&& clusters = theTrackClusterizer->clusterize(seltks);
 
   if (fVerbose) {
     std::cout << " clustering returned  " << clusters.size() << " clusters  from " << seltks.size()
@@ -196,7 +196,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     reco::VertexCollection& vColl = (*result);
 
     std::vector<TransientVertex> pvs;
-    for (std::vector<std::vector<reco::TransientTrack> >::const_iterator iclus = clusters.begin();
+    for (std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus = clusters.begin();
          iclus != clusters.end();
          iclus++) {
       double sumwt = 0.;
@@ -221,43 +221,43 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
       }
 
       TransientVertex v;
-      if(algorithm->fitter)
-      {if (algorithm->useBeamConstraint && validBS && (iclus->size() > 1)) {
-        v = algorithm->fitter->vertex(*iclus, beamSpot);
-      } else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {
-        v = algorithm->fitter->vertex(*iclus);
-      }  // else: no fit ==> v.isValid()=False
-      }else if(weightFit)
-      {
+      if (algorithm->fitter) {
+        if (algorithm->useBeamConstraint && validBS && (iclus->size() > 1)) {
+          v = algorithm->fitter->vertex(*iclus, beamSpot);
+        } else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {
+          v = algorithm->fitter->vertex(*iclus);
+        }  // else: no fit ==> v.isValid()=False
+      } else if (weightFit) {
         std::vector<std::pair<GlobalPoint, GlobalPoint>> points;
         if (algorithm->useBeamConstraint && validBS && (iclus->size() > 1)) {
-            for (const auto& itrack : *iclus){
-                   GlobalPoint p =  itrack.stateAtBeamLine().trackStateAtPCA().position();
-                   GlobalPoint err(itrack.stateAtBeamLine().transverseImpactParameter().error(), itrack.stateAtBeamLine().transverseImpactParameter().error(), itrack.track().dzError());
-                   std::pair<GlobalPoint, GlobalPoint> p2(p, err);
-                   points.push_back(p2);
-            }
+          for (const auto& itrack : *iclus) {
+            GlobalPoint p = itrack.stateAtBeamLine().trackStateAtPCA().position();
+            GlobalPoint err(itrack.stateAtBeamLine().transverseImpactParameter().error(),
+                            itrack.stateAtBeamLine().transverseImpactParameter().error(),
+                            itrack.track().dzError());
+            std::pair<GlobalPoint, GlobalPoint> p2(p, err);
+            points.push_back(p2);
+          }
 
-           v = WeightedMeanFitter::weightedMeanOutlierRejectionBeamSpot(points, *iclus, beamSpot);
-           if ((v.positionError().matrix())(2,2) != (WeightedMeanFitter::startError*WeightedMeanFitter::startError)) pvs.push_back(v);
-        }
-        else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {
-           for (const auto& itrack : *iclus){
-                   GlobalPoint p = itrack.impactPointState().globalPosition();
-                   GlobalPoint err(itrack.track().dxyError(), itrack.track().dxyError(), itrack.track().dzError());
-                   std::pair<GlobalPoint, GlobalPoint> p2(p, err);
-                   points.push_back(p2);
-           }
+          v = WeightedMeanFitter::weightedMeanOutlierRejectionBeamSpot(points, *iclus, beamSpot);
+          if ((v.positionError().matrix())(2, 2) != (WeightedMeanFitter::startError * WeightedMeanFitter::startError))
+            pvs.push_back(v);
+        } else if (!(algorithm->useBeamConstraint) && (iclus->size() > 1)) {
+          for (const auto& itrack : *iclus) {
+            GlobalPoint p = itrack.impactPointState().globalPosition();
+            GlobalPoint err(itrack.track().dxyError(), itrack.track().dxyError(), itrack.track().dzError());
+            std::pair<GlobalPoint, GlobalPoint> p2(p, err);
+            points.push_back(p2);
+          }
 
-           v = WeightedMeanFitter::weightedMeanOutlierRejection(points, *iclus);
-           if ((v.positionError().matrix())(2,2) != (WeightedMeanFitter::startError*WeightedMeanFitter::startError)) pvs.push_back(v); //FIX with constants
+          v = WeightedMeanFitter::weightedMeanOutlierRejection(points, *iclus);
+          if ((v.positionError().matrix())(2, 2) != (WeightedMeanFitter::startError * WeightedMeanFitter::startError))
+            pvs.push_back(v);  //FIX with constants
         }
-      }
-      else
+      } else
         throw VertexException(
-            "PrimaryVertexProducer: Something went wrong. You are not using the weighted mean fit and no algorithm was selected.");
-
-
+            "PrimaryVertexProducer: Something went wrong. You are not using the weighted mean fit and no algorithm was "
+            "selected.");
 
       // 4D vertices: add timing information
       if (f4D and v.isValid()) {
@@ -281,8 +281,8 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
           std::cout << "Invalid fitted vertex,  cluster size=" << (*iclus).size() << std::endl;
         }
       }
-      
-      //for weightFit we have already pushed it above (no timing infomration anyway) 
+
+      //for weightFit we have already pushed it above (no timing infomration anyway)
       if (v.isValid() && not weightFit && (v.degreesOfFreedom() >= algorithm->minNdof) &&
           (!validBS || (*(algorithm->vertexSelector))(v, beamVertexState)))
         pvs.push_back(v);
@@ -347,7 +347,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         std::cout << std::endl;
       }
     }
-  
+
     iEvent.put(std::move(result), algorithm->label);
   }
 }

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -8,15 +8,15 @@ offlinePrimaryVertices = cms.EDProducer(
     verbose = cms.untracked.bool(False),
     TrackLabel = cms.InputTag("generalTracks"),
     beamSpotLabel = cms.InputTag("offlineBeamSpot"),
-    
+
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
         maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(4.0), 
-        maxD0Error = cms.double(1.0), 
-        maxDzError = cms.double(1.0), 
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
         minPt = cms.double(0.0),
         maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
@@ -41,11 +41,11 @@ offlinePrimaryVertices = cms.EDProducer(
                )
       ]
     ),
-    
+
     isRecoveryIteration = cms.bool(False),
     recoveryVtxCollection = cms.InputTag("")
 
-                                        
+
 )
 
 # This customization is needed in the trackingLowPU era to be able to
@@ -59,9 +59,10 @@ trackingLowPU.toModify(offlinePrimaryVertices,
 
 
 # higher eta cut for the phase 2 tracker
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker 
-phase2_tracker.toModify(offlinePrimaryVertices, 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(offlinePrimaryVertices,
                         TkFilterParameters = dict(maxEta = 4.0))
+
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
@@ -69,8 +70,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                TkFilterParameters = dict(
                    algorithm="filterWithThreshold",
                    maxD0Significance = 2.0,
-                   maxD0Error = 10.0, 
-                   maxDzError = 10.0, 
+                   maxD0Error = 10.0,
+                   maxDzError = 10.0,
                    minPixelLayersWithHits=3,
                    minPt = 0.7,
                    trackQuality = "highPurity",
@@ -79,13 +80,13 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                    minPtTight = cms.double(1.0)
                ),
                TkClusParameters = cms.PSet(
-                 algorithm = cms.string("gap"),
-                 TkGapClusParameters = cms.PSet(
-                   zSeparation = cms.double(1.0)        
-                 )
+            algorithm = cms.string("gap"),
+            TkGapClusParameters = cms.PSet(
+                zSeparation = cms.double(1.0)
+                )
+            )
                )
-)
-    
+
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
@@ -93,8 +94,8 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          minPixelLayersWithHits = 1,
          minSiliconLayersWithHits = 3,
          maxD0Significance = 7.0,
-         maxD0Error = 10.0, 
-         maxDzError = 10.0, 
+         maxD0Error = 10.0,
+         maxDzError = 10.0,
          maxEta = 2.5
      ),
      vertexCollections = {
@@ -102,4 +103,3 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          1: dict(chi2cutoff = 4.0, minNdof = -2.0),
      }
 )
-

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -48,6 +48,27 @@ offlinePrimaryVertices = cms.EDProducer(
 
 )
 
+from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
+weightedVertexing.toModify(offlinePrimaryVertices,
+    vertexCollections = cms.VPSet(
+     [cms.PSet(label=cms.string(""),
+               algorithm=cms.string("WeightedMeanFitter"),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(0.0),
+               useBeamConstraint = cms.bool(False),
+               maxDistanceToBeam = cms.double(1.0)
+               ),
+      cms.PSet(label=cms.string("WithBS"),
+               algorithm = cms.string('WeightedMeanFitter'),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(2.0),
+               useBeamConstraint = cms.bool(True),
+               maxDistanceToBeam = cms.double(1.0),
+               )
+      ]
+    )
+)
+
 # This customization is needed in the trackingLowPU era to be able to
 # produce vertices also in the cases in which the pixel detector is
 # not included in data-taking, like it was the case for "Quiet Beam"

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -8,15 +8,15 @@ offlinePrimaryVertices = cms.EDProducer(
     verbose = cms.untracked.bool(False),
     TrackLabel = cms.InputTag("generalTracks"),
     beamSpotLabel = cms.InputTag("offlineBeamSpot"),
-
+    
     TkFilterParameters = cms.PSet(
         algorithm=cms.string('filter'),
         maxNormalizedChi2 = cms.double(10.0),
         minPixelLayersWithHits=cms.int32(2),
         minSiliconLayersWithHits = cms.int32(5),
-        maxD0Significance = cms.double(4.0),
-        maxD0Error = cms.double(1.0),
-        maxDzError = cms.double(1.0),
+        maxD0Significance = cms.double(4.0), 
+        maxD0Error = cms.double(1.0), 
+        maxDzError = cms.double(1.0), 
         minPt = cms.double(0.0),
         maxEta = cms.double(2.4),
         trackQuality = cms.string("any")
@@ -41,34 +41,32 @@ offlinePrimaryVertices = cms.EDProducer(
                )
       ]
     ),
-
+    
     isRecoveryIteration = cms.bool(False),
     recoveryVtxCollection = cms.InputTag("")
 
-
+                                        
 )
 
 from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
 weightedVertexing.toModify(offlinePrimaryVertices,
-    vertexCollections = cms.VPSet(
-     [cms.PSet(label=cms.string(""),
-               algorithm=cms.string("WeightedMeanFitter"),
-               chi2cutoff = cms.double(2.5),
-               minNdof=cms.double(0.0),
-               useBeamConstraint = cms.bool(False),
-               maxDistanceToBeam = cms.double(1.0)
-               ),
-      cms.PSet(label=cms.string("WithBS"),
-               algorithm = cms.string('WeightedMeanFitter'),
-               chi2cutoff = cms.double(2.5),
-               minNdof=cms.double(2.0),
-               useBeamConstraint = cms.bool(True),
-               maxDistanceToBeam = cms.double(1.0),
-               )
-      ]
-    )
-)
-
+                           vertexCollections = cms.VPSet(
+                           [cms.PSet(label=cms.string(""),
+                                     algorithm=cms.string("WeightedMeanFitter"),
+                                     chi2cutoff = cms.double(2.5),
+                                     minNdof=cms.double(0.0),
+                                     useBeamConstraint = cms.bool(False),
+                                     maxDistanceToBeam = cms.double(1.0)
+                           ),
+                           cms.PSet(label=cms.string("WithBS"),
+                                     algorithm = cms.string('WeightedMeanFitter'),
+                                     minNdof=cms.double(0.0),
+                                     chi2cutoff = cms.double(2.5),
+                                     useBeamConstraint = cms.bool(False),
+                                     maxDistanceToBeam = cms.double(1.0)
+                                     )
+                           ]
+                           ))
 # This customization is needed in the trackingLowPU era to be able to
 # produce vertices also in the cases in which the pixel detector is
 # not included in data-taking, like it was the case for "Quiet Beam"
@@ -80,10 +78,9 @@ trackingLowPU.toModify(offlinePrimaryVertices,
 
 
 # higher eta cut for the phase 2 tracker
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(offlinePrimaryVertices,
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker 
+phase2_tracker.toModify(offlinePrimaryVertices, 
                         TkFilterParameters = dict(maxEta = 4.0))
-
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
@@ -91,8 +88,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                TkFilterParameters = dict(
                    algorithm="filterWithThreshold",
                    maxD0Significance = 2.0,
-                   maxD0Error = 10.0,
-                   maxDzError = 10.0,
+                   maxD0Error = 10.0, 
+                   maxDzError = 10.0, 
                    minPixelLayersWithHits=3,
                    minPt = 0.7,
                    trackQuality = "highPurity",
@@ -101,13 +98,13 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                    minPtTight = cms.double(1.0)
                ),
                TkClusParameters = cms.PSet(
-            algorithm = cms.string("gap"),
-            TkGapClusParameters = cms.PSet(
-                zSeparation = cms.double(1.0)
-                )
-            )
+                 algorithm = cms.string("gap"),
+                 TkGapClusParameters = cms.PSet(
+                   zSeparation = cms.double(1.0)        
+                 )
                )
-
+)
+    
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
@@ -115,8 +112,8 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          minPixelLayersWithHits = 1,
          minSiliconLayersWithHits = 3,
          maxD0Significance = 7.0,
-         maxD0Error = 10.0,
-         maxDzError = 10.0,
+         maxD0Error = 10.0, 
+         maxDzError = 10.0, 
          maxEta = 2.5
      ),
      vertexCollections = {
@@ -124,3 +121,4 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          1: dict(chi2cutoff = 4.0, minNdof = -2.0),
      }
 )
+

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -62,7 +62,7 @@ weightedVertexing.toModify(offlinePrimaryVertices,
                                      algorithm = cms.string('WeightedMeanFitter'),
                                      minNdof=cms.double(0.0),
                                      chi2cutoff = cms.double(2.5),
-                                     useBeamConstraint = cms.bool(False),
+                                     useBeamConstraint = cms.bool(True),
                                      maxDistanceToBeam = cms.double(1.0)
                                      )
                            ]

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -9,14 +9,17 @@ DA_vectParameters = cms.PSet(
         delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
         convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
         Tmin = cms.double(2.0),           # end of vertex splitting
-        Tpurge = cms.double(2.0),         # cleaning 
-        Tstop = cms.double(0.5),          # end of annealing 
-        vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions        
-        d0CutOff = cms.double(3.),        # downweight high IP tracks 
-        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)       
+        Tpurge = cms.double(2.0),         # cleaning
+        Tstop = cms.double(0.5),          # end of annealing
+        vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
+        d0CutOff = cms.double(3.),        # downweight high IP tracks
+        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
         uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
-        uniquetrkminp = cms.double(0.0)   # minimal a priori track weight for counting unique tracks
+        uniquetrkminp = cms.double(0.0),   # minimal a priori track weight for counting unique tracks
+        runInBlocks = cms.bool(False),
+        block_size = cms.int32(5122),
+        overlap_frac = cms.double(0.5)
         )
 )
 
@@ -43,11 +46,11 @@ DA2D_vectParameters = cms.PSet(
         delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
         convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
         Tmin = cms.double(4.0),           # end of vertex splitting
-        Tpurge = cms.double(4.0),         # cleaning 
-        Tstop = cms.double(2.0),          # end of annealing 
+        Tpurge = cms.double(4.0),         # cleaning
+        Tstop = cms.double(2.0),          # end of annealing
         vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
         vertexSizeTime = cms.double(0.008),
-        d0CutOff = cms.double(3.),        # downweight high IP tracks 
+        d0CutOff = cms.double(3.),        # downweight high IP tracks
         dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
         dtCutOff = cms.double(4.),        # outlier rejection after freeze-out (T<Tmin)
         t0Max = cms.double(1.0),          # outlier rejection for use of timing information

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -16,13 +16,21 @@ DA_vectParameters = cms.PSet(
         dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
         uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
-        uniquetrkminp = cms.double(0.0),   # minimal a priori track weight for counting unique tracks
-        runInBlocks = cms.bool(False),
-        block_size = cms.int32(5122),
-        overlap_frac = cms.double(0.5)
+        uniquetrkminp = cms.double(0.0),  # minimal a priori track weight for counting unique tracks
+        runInBlocks = cms.bool(False),    # activate the DA running in blocks of z sorted tracks
+        block_size = cms.uint32(10000),   # block size in tracks
+        overlap_frac = cms.double(0.0)    # overlap between consecutive blocks (blocks_size*overlap_frac)
         )
 )
 
+from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
+weightedVertexing.toModify(DA_vectParameters,
+    TkDAClusParameters = dict(
+    runInBlocks = True,
+    block_size = 512,
+    overlap_frac = 0.5
+    )
+)
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(DA_vectParameters,
      TkDAClusParameters = dict(

--- a/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
+++ b/RecoVertex/PrimaryVertexProducer/python/TkClusParameters_cff.py
@@ -9,11 +9,11 @@ DA_vectParameters = cms.PSet(
         delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
         convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
         Tmin = cms.double(2.0),           # end of vertex splitting
-        Tpurge = cms.double(2.0),         # cleaning
-        Tstop = cms.double(0.5),          # end of annealing
-        vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
-        d0CutOff = cms.double(3.),        # downweight high IP tracks
-        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
+        Tpurge = cms.double(2.0),         # cleaning 
+        Tstop = cms.double(0.5),          # end of annealing 
+        vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions        
+        d0CutOff = cms.double(3.),        # downweight high IP tracks 
+        dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)       
         zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
         uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
         uniquetrkminp = cms.double(0.0),  # minimal a priori track weight for counting unique tracks
@@ -23,14 +23,21 @@ DA_vectParameters = cms.PSet(
         )
 )
 
-from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
-weightedVertexing.toModify(DA_vectParameters,
+from Configuration.ProcessModifiers.vertexInBlocks_cff import vertexInBlocks
+vertexInBlocks.toModify(DA_vectParameters,
     TkDAClusParameters = dict(
     runInBlocks = True,
-    block_size = 512,
+    block_size = 128,
     overlap_frac = 0.5
     )
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+(phase2_tracker & vertexInBlocks).toModify(DA_vectParameters,
+        TkDAClusParameters = dict(
+        block_size = 512,
+        overlap_frac = 0.5))
+
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(DA_vectParameters,
      TkDAClusParameters = dict(
@@ -54,11 +61,11 @@ DA2D_vectParameters = cms.PSet(
         delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
         convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
         Tmin = cms.double(4.0),           # end of vertex splitting
-        Tpurge = cms.double(4.0),         # cleaning
-        Tstop = cms.double(2.0),          # end of annealing
+        Tpurge = cms.double(4.0),         # cleaning 
+        Tstop = cms.double(2.0),          # end of annealing 
         vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
         vertexSizeTime = cms.double(0.008),
-        d0CutOff = cms.double(3.),        # downweight high IP tracks
+        d0CutOff = cms.double(3.),        # downweight high IP tracks 
         dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
         dtCutOff = cms.double(4.),        # outlier rejection after freeze-out (T<Tmin)
         t0Max = cms.double(1.0),          # outlier rejection for use of timing information

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -989,6 +989,12 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
             });
 
   unsigned int nBlocks = (unsigned int)std::floor(sorted_tracks.size() / (block_size_ * (1 - overlap_frac_)));
+  if (nBlocks < 1) {
+    nBlocks = 1;
+    edm::LogWarning("DAClusterizerinZ_vect")
+        << "Warning nBlocks was 0 with ntracks = " << sorted_tracks.size() << " block_size = " << block_size_
+        << " and overlap fraction = " << overlap_frac_ << ". Setting nBlocks = 1";
+  }
   for (unsigned int block = 0; block < nBlocks; block++) {
     vector<reco::TransientTrack> block_tracks;
     unsigned int begin = (unsigned int)(block * block_size_ * (1 - overlap_frac_));

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -43,49 +43,52 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   convergence_mode_ = conf.getParameter<int>("convergence_mode");
   delta_lowT_ = conf.getParameter<double>("delta_lowT");
   delta_highT_ = conf.getParameter<double>("delta_highT");
+  runInBlocks_ = conf.getParameter<bool>("runInBlocks");
+  block_size_ = conf.getParameter<unsigned int>("block_size");
+  overlap_frac_ = conf.getParameter<double>("overlap_frac");
 
 #ifdef DEBUG
-  std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
   std::cout << "DAClusterizerInZ_vect: uniquetrkminp = " << uniquetrkminp_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: zmerge = " << zmerge_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: Tmin = " << Tmin << std::endl;
-  std::cout << "DAClusterizerinZ_vect: Tpurge = " << Tpurge << std::endl;
-  std::cout << "DAClusterizerinZ_vect: Tstop = " << Tstop << std::endl;
-  std::cout << "DAClusterizerinZ_vect: vertexSize = " << vertexSize_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: coolingFactor = " << coolingFactor_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: d0CutOff = " << d0CutOff_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: dzCutOff = " << dzCutOff_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: zmerge = " << zmerge_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: Tmin = " << Tmin << std::endl;
+  std::cout << "DAClusterizerInZ_vect: Tpurge = " << Tpurge << std::endl;
+  std::cout << "DAClusterizerInZ_vect: Tstop = " << Tstop << std::endl;
+  std::cout << "DAClusterizerInZ_vect: vertexSize = " << vertexSize_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: coolingFactor = " << coolingFactor_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: d0CutOff = " << d0CutOff_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: dzCutOff = " << dzCutOff_ << std::endl;
   std::cout << "DAClusterizerInZ_vect: zrange = " << sel_zrange_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: convergence mode = " << convergence_mode_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: delta_highT = " << delta_highT_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: delta_lowT = " << delta_lowT_ << std::endl;
-  std::cout << "DAClusterizerinZ_vect: DEBUGLEVEL " << DEBUGLEVEL << std::endl;
+  std::cout << "DAClusterizerInZ_vect: convergence mode = " << convergence_mode_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: delta_highT = " << delta_highT_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: delta_lowT = " << delta_lowT_ << std::endl;
+  std::cout << "DAClusterizerInZ_vect: DEBUGLEVEL " << DEBUGLEVEL << std::endl;
 #endif
 
   if (convergence_mode_ > 1) {
-    edm::LogWarning("DAClusterizerinZ_vect")
+    edm::LogWarning("DAClusterizerInZ_vect")
         << "DAClusterizerInZ_vect: invalid convergence_mode " << convergence_mode_ << "  reset to default " << 0;
     convergence_mode_ = 0;
   }
 
   if (Tmin == 0) {
     betamax_ = 1.0;
-    edm::LogWarning("DAClusterizerinZ_vect")
+    edm::LogWarning("DAClusterizerInZ_vect")
         << "DAClusterizerInZ_vect: invalid Tmin " << Tmin << "  reset to default " << 1. / betamax_;
   } else {
     betamax_ = 1. / Tmin;
   }
 
   if ((Tpurge > Tmin) || (Tpurge == 0)) {
-    edm::LogWarning("DAClusterizerinZ_vect")
+    edm::LogWarning("DAClusterizerInZ_vect")
         << "DAClusterizerInZ_vect: invalid Tpurge " << Tpurge << "  set to " << Tmin;
     Tpurge = Tmin;
   }
   betapurge_ = 1. / Tpurge;
 
   if ((Tstop > Tpurge) || (Tstop == 0)) {
-    edm::LogWarning("DAClusterizerinZ_vect")
+    edm::LogWarning("DAClusterizerInZ_vect")
         << "DAClusterizerInZ_vect: invalid Tstop " << Tstop << "  set to  " << max(1., Tpurge);
     Tstop = max(1., Tpurge);
   }
@@ -171,11 +174,13 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
   // prepare track data for clustering
   track_t tks;
   double sumtkwt = 0.;
+
   for (auto it = tracks.begin(); it != tracks.end(); it++) {
     if (!(*it).isValid())
       continue;
     double t_tkwt = 1.;
     double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
+
     if (std::fabs(t_z) > 1000.)
       continue;
     auto const& t_mom = (*it).stateAtBeamLine().trackStateAtPCA().momentum();
@@ -186,14 +191,16 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
                          std::pow(t_mom.z(), 2) / std::pow(t_mom.perp2(), 2)  // beam spot width
                    + std::pow(vertexSize_, 2);  // intrinsic vertex size, safer for outliers and short lived decays
     t_dz2 = 1. / t_dz2;
+
     if (edm::isNotFinite(t_dz2) || t_dz2 < std::numeric_limits<double>::min())
       continue;
     if (d0CutOff_ > 0) {
       Measurement1D atIP = (*it).stateAtBeamLine().transverseImpactParameter();  // error contains beamspot
       t_tkwt = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
                                     std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
+
       if (edm::isNotFinite(t_tkwt) || t_tkwt < std::numeric_limits<double>::epsilon()) {
-        edm::LogWarning("DAClusterizerinZ_vect") << "rejected track t_tkwt " << t_tkwt;
+        edm::LogWarning("DAClusterizerInZ_vect") << "rejected track t_tkwt " << t_tkwt;
         continue;  // usually is > 0.99
       }
     }
@@ -222,7 +229,7 @@ void DAClusterizerInZ_vect::set_vtx_range(double beta, track_t& gtracks, vertex_
   const unsigned int nt = gtracks.getSize();
 
   if (nv == 0) {
-    edm::LogWarning("DAClusterizerinZ_vect") << "empty cluster list in set_vtx_range";
+    edm::LogWarning("DAClusterizerInZ_vect") << "empty cluster list in set_vtx_range";
     return;
   }
 
@@ -289,7 +296,6 @@ double DAClusterizerInZ_vect::update(
   if (rho0 > 0) {
     Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);  // cut-off
   }
-
   // define kernels
   auto kernel_calc_exp_arg_range = [beta](const unsigned int itrack,
                                           track_t const& tracks,
@@ -434,6 +440,7 @@ unsigned int DAClusterizerInZ_vect::thermalize(
     if (delta_sum_range > zrange_min_) {
       for (unsigned int k = 0; k < v.getSize(); k++) {
         if (std::abs(v.zvtx_vec[k] - z0[k]) > zrange_min_) {
+
           set_vtx_range(beta, tks, v);
           delta_sum_range = 0;
           z0 = v.zvtx_vec;
@@ -786,10 +793,10 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   thermalize(beta, tks, y, delta_highT_);
 
+
   // annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
 
   double betafreeze = betamax_ * sqrt(coolingFactor_);
-
   while (beta < betafreeze) {
     while (merge(y, tks, beta)) {
       update(beta, tks, y, rho0, false);
@@ -798,6 +805,8 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
     beta = beta / coolingFactor_;
     thermalize(beta, tks, y, delta_highT_);
+
+
   }
 
 #ifdef DEBUG
@@ -920,11 +929,13 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   set_vtx_range(beta, tks, y);
   const unsigned int nv = y.getSize();
+  //std::cout << "ivtxO,z" << std::endl;
   for (unsigned int k = 0; k < nv; k++) {
     if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
       y.rho[k] = 0;
       y.zvtx[k] = 0;
     }
+
   }
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
@@ -942,6 +953,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
     for (auto k = kmin; k < kmax; k++) {
       tks.sum_Z[i] += y.rho[k] * y.exp[k];
     }
+
     const double invZ = tks.sum_Z[i] > 1e-100 ? 1. / tks.sum_Z[i] : 0.0;
 
     for (auto k = kmin; k < kmax; k++) {
@@ -955,6 +967,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   }  // track loop
 
+  //
   GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
   for (unsigned int k = 0; k < nv; k++) {
     if (!vtx_track_indices[k].empty()) {
@@ -971,10 +984,317 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
   return clusters;
 }
 
+vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<reco::TransientTrack>& tracks) const {
+  //unsigned int block_size_ = 512;
+  vector<reco::TransientTrack> sorted_tracks;
+  vector<pair<float, float>> vertices_tot; // z, rho for each vertex
+  for (unsigned int i=0; i< tracks.size();i++){
+    sorted_tracks.push_back(tracks[i]);
+  }
+  double rho0, beta;
+  std::sort(sorted_tracks.begin(), sorted_tracks.end(),
+    [](const reco::TransientTrack & a, const reco::TransientTrack & b) -> bool
+    {
+        return (a.stateAtBeamLine().trackStateAtPCA()).position().z() < (b.stateAtBeamLine().trackStateAtPCA()).position().z();
+    });
+
+    unsigned int nBlocks = (unsigned int) std::floor(sorted_tracks.size() / ( block_size_ * (1 - overlap_frac_)));
+  for (unsigned int block=0; block < nBlocks; block++) {
+    vector<reco::TransientTrack> block_tracks;
+    unsigned int begin = (unsigned int) (block * block_size_ * (1 - overlap_frac_));
+    unsigned int end = (unsigned int) std::min(begin + block_size_, (unsigned int) sorted_tracks.size());
+    //for (unsigned int i = block * block_size_; i < (block + 1) * block_size_ && i < sorted_tracks.size(); i++) {
+    for (unsigned int i = begin; i < end ; i++) {
+      block_tracks.push_back(sorted_tracks[i]);
+    }
+    if (block_tracks.size() == 0) {
+      continue;
+    }
+
+    #ifdef DEBUG
+      std::cout<< "Running vertices_in_blocks on" << std::endl;
+      std::cout<< "- block no." << block << " on " << nBlocks << " blocks "<< std::endl;
+      std::cout<< "- block track size: " << sorted_tracks.size() << " - block size: " << block_size_ << std::endl;
+    #endif
+    track_t&& tks = fill(block_tracks);
+    tks.extractRaw();
+
+    rho0 = 0.0;  // start with no outlier rejection
+
+    vertex_t y;  // the vertex prototypes
+
+    // initialize:single vertex at infinite temperature
+    y.addItem(0, 1.0);
+    clear_vtx_range(tks, y);
+
+    // estimate first critical temperature
+    beta = beta0(betamax_, tks, y);
+  #ifdef DEBUG
+    if (DEBUGLEVEL > 0)
+      std::cout << "Beta0 is " << beta << std::endl;
+  #endif
+
+    thermalize(beta, tks, y, delta_highT_);
+
+    // annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
+
+    double betafreeze = betamax_ * sqrt(coolingFactor_);
+    while (beta < betafreeze) {
+      while (merge(y, tks, beta)) {
+        update(beta, tks, y, rho0, false);
+      }
+      split(beta, tks, y);
+
+      beta = beta / coolingFactor_;
+      thermalize(beta, tks, y, delta_highT_);
+
+
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "last round of splitting" << std::endl;
+    }
+  #endif
+
+    set_vtx_range(beta, tks, y);
+    update(beta, tks, y, rho0, false);
+
+    while (merge(y, tks, beta)) {
+      set_vtx_range(beta, tks, y);
+      update(beta, tks, y, rho0, false);
+    }
+
+    unsigned int ntry = 0;
+    double threshold = 1.0;
+    while (split(beta, tks, y, threshold) && (ntry++ < 10)) {
+      thermalize(beta, tks, y, delta_highT_, rho0);  // rho0 = 0. here
+      while (merge(y, tks, beta)) {
+        update(beta, tks, y, rho0, false);
+      }
+
+      // relax splitting a bit to reduce multiple split-merge cycles of the same cluster
+      threshold *= 1.1;
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "turning on outlier rejection at T=" << 1 / beta << std::endl;
+    }
+  #endif
+
+    // switch on outlier rejection at T=Tmin
+    if (dzCutOff_ > 0) {
+      rho0 = y.getSize() > 1 ? 1. / y.getSize() : 1.;
+      for (unsigned int a = 0; a < 5; a++) {
+        update(beta, tks, y, a * rho0 / 5.);  // adiabatic turn-on
+      }
+    }
+
+    thermalize(beta, tks, y, delta_lowT_, rho0);
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "merging with outlier rejection at T=" << 1 / beta << std::endl;
+    }
+    if (DEBUGLEVEL > 2)
+      dump(beta, y, tks, 2, rho0);
+  #endif
+
+    // merge again  (some cluster split by outliers collapse here)
+    while (merge(y, tks, beta)) {
+      set_vtx_range(beta, tks, y);
+      update(beta, tks, y, rho0, false);
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "after merging with outlier rejection at T=" << 1 / beta << std::endl;
+    }
+    if (DEBUGLEVEL > 2)
+      dump(beta, y, tks, 2, rho0);
+  #endif
+
+    // go down to the purging temperature (if it is lower than tmin)
+    while (beta < betapurge_) {
+      beta = min(beta / coolingFactor_, betapurge_);
+      thermalize(beta, tks, y, delta_lowT_, rho0);
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "purging at T=" << 1 / beta << std::endl;
+    }
+  #endif
+
+    // eliminate insignificant vertices, this is more restrictive at higher T
+    while (purge(y, tks, rho0, beta)) {
+      thermalize(beta, tks, y, delta_lowT_, rho0);
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "last cooling T=" << 1 / beta << std::endl;
+    }
+  #endif
+
+    // optionally cool some more without doing anything, to make the assignment harder
+    while (beta < betastop_) {
+      beta = min(beta / coolingFactor_, betastop_);
+      thermalize(beta, tks, y, delta_lowT_, rho0);
+    }
+
+  #ifdef DEBUG
+    verify(y, tks);
+    if (DEBUGLEVEL > 0) {
+      std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
+                << "stop cooling at T=" << 1 / beta << std::endl;
+    }
+    if (DEBUGLEVEL > 2)
+      dump(beta, y, tks, 2, rho0);
+  #endif
+
+
+    for (unsigned int ivertex = 0; ivertex < y.getSize(); ivertex++) {
+      if (y.zvtx_vec[ivertex]!=0 && y.rho_vec[ivertex]!=0) {
+        vertices_tot.push_back(pair(y.zvtx_vec[ivertex], y.rho_vec[ivertex]));
+        #ifdef DEBUG
+          std::cout << "Found new vertex " << y.zvtx_vec[ivertex] << " , " << y.rho_vec[ivertex] << std::endl;
+        #endif
+      }
+    }
+
+  }
+
+  std::sort(vertices_tot.begin(), vertices_tot.end(), [](const pair<float, float> & a, const pair<float, float> & b) -> bool
+    {
+        return a.first < b.first;
+    });
+
+  // reassign tracks to vertices
+  track_t&& tracks_tot = fill(tracks);
+  const unsigned int nv = vertices_tot.size();
+  const unsigned int nt = tracks_tot.getSize();
+
+
+  for (auto itrack = 0U; itrack < nt; ++itrack) {
+    double zrange = max(sel_zrange_ / sqrt(beta * tracks_tot.dz2[itrack]), zrange_min_);
+
+    double zmin = tracks_tot.zpca[itrack] - zrange;
+    unsigned int kmin = min(nv - 1, tracks_tot.kmin[itrack]);
+    // find the smallest vertex_z that is larger than zmin
+    if (vertices_tot[kmin].first > zmin) {
+      while ((kmin > 0) && (vertices_tot[kmin - 1].first > zmin)) {
+        kmin--;
+      }
+    } else {
+      while ((kmin < (nv - 1)) && (vertices_tot[kmin].first < zmin)) {
+        kmin++;
+      }
+    }
+
+    double zmax = tracks_tot.zpca[itrack] + zrange;
+    unsigned int kmax = min(nv - 1, tracks_tot.kmax[itrack] - 1);
+    // note: kmax points to the last vertex in the range, while gtracks.kmax points to the entry BEHIND the last vertex
+    // find the largest vertex_z that is smaller than zmax
+    if (vertices_tot[kmax].first < zmax) {
+      while ((kmax < (nv - 1)) && (vertices_tot[kmax + 1].first < zmax)) {
+        kmax++;
+      }
+    } else {
+      while ((kmax > 0) && (vertices_tot[kmax].first > zmax)) {
+        kmax--;
+      }
+    }
+
+    if (kmin <= kmax) {
+      tracks_tot.kmin[itrack] = kmin;
+      tracks_tot.kmax[itrack] = kmax + 1;
+    } else {
+      tracks_tot.kmin[itrack] = max(0U, min(kmin, kmax));
+      tracks_tot.kmax[itrack] = min(nv, max(kmin, kmax) + 1);
+    }
+
+  }
+
+
+
+  double mintrkweight_ = 0.5;
+  rho0 = nv > 1 ? 1./nv : 1.;
+  const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
+
+  std::vector<std::vector<unsigned int> > vtx_track_indices(nv);
+  for (unsigned int i = 0; i < nt; i++) {
+    const auto kmin = tracks_tot.kmin[i];
+    const auto kmax = tracks_tot.kmax[i];
+    double p_max = -1;
+    unsigned int iMax = 10000;
+    float sum_Z = z_sum_init;
+    for (auto k = kmin; k < kmax; k++) {
+      float v_exp = local_exp(-beta * Eik(tracks_tot.zpca[i], vertices_tot[k].first, tracks_tot.dz2[i]));
+      sum_Z += vertices_tot[k].second * v_exp;
+    }
+    double invZ = sum_Z > 1e-100 ? 1. / sum_Z : 0.0;
+    for (auto k = kmin; k < kmax; k++) {
+      float v_exp = local_exp(-beta * Eik(tracks_tot.zpca[i], vertices_tot[k].first, tracks_tot.dz2[i]));
+      double p = vertices_tot[k].second * v_exp * invZ;
+      if (p > p_max && p > mintrkweight_) {
+        p_max = p;
+        iMax = k;
+      }
+    }
+    if (iMax < vtx_track_indices.size()) vtx_track_indices[iMax].push_back(i);
+
+  }
+  #ifdef DEBUG
+    for (auto itrack = 0U; itrack < nt; ++itrack) {
+          std::cout << "itrack " << itrack << " , " << tracks_tot.kmin[itrack] << " , " << tracks_tot.kmax[itrack] << std::endl;
+    }
+  #endif
+
+  vector<TransientVertex> clusters;
+
+  GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
+  for (unsigned int k = 0; k < nv; k++) {
+    if (!vtx_track_indices[k].empty()) {
+      GlobalPoint pos(0, 0, vertices_tot[k].first);
+      vector<reco::TransientTrack> vertexTracks;
+      for (auto i : vtx_track_indices[k]) {
+        vertexTracks.push_back(*(tracks_tot.tt[i]));
+        #ifdef DEBUG
+          std::cout << y.zvtx[k] << "," << (*tks.tt[i]).stateAtBeamLine().trackStateAtPCA().position().z() << std::endl;
+        #endif
+      }
+      TransientVertex v(pos, dummyError, vertexTracks, 0);
+      clusters.push_back(v);
+    }
+  }
+  
+  return clusters;
+}
+
 vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
     const vector<reco::TransientTrack>& tracks) const {
   vector<vector<reco::TransientTrack> > clusters;
-  vector<TransientVertex>&& pv = vertices(tracks);
+
+  vector<TransientVertex> pv;
+  if(runInBlocks_ and (block_size_ < tracks.size())) //doesn't bother if low number of tracks
+    pv = vertices_in_blocks(tracks);
+  else
+    pv = vertices(tracks);
 
 #ifdef DEBUG
   if (DEBUGLEVEL > 0) {
@@ -1010,7 +1330,7 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
     }
   }
   clusters.emplace_back(std::move(aCluster));
-
+  
   return clusters;
 }
 
@@ -1184,4 +1504,8 @@ void DAClusterizerInZ_vect::fillPSetDescription(edm::ParameterSetDescription& de
   desc.add<double>("uniquetrkweight", 0.8);
   desc.add<double>("uniquetrkminp", 0.0);
   desc.add<double>("zrange", 4.0);
+  desc.add<bool>("runInBlocks",false);
+  desc.add<unsigned int>("block_size", 512);
+  desc.add<double>("overlap_frac", 0.5);
+
 }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -1007,7 +1007,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     for (unsigned int i = begin; i < end ; i++) {
       block_tracks.push_back(sorted_tracks[i]);
     }
-    if (block_tracks.size() == 0) {
+    if (block_tracks.empty()) {
       continue;
     }
 

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -48,47 +48,47 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   overlap_frac_ = conf.getParameter<double>("overlap_frac");
 
 #ifdef DEBUG
-  std::cout << "DAClusterizerInZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
   std::cout << "DAClusterizerInZ_vect: uniquetrkminp = " << uniquetrkminp_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: zmerge = " << zmerge_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: Tmin = " << Tmin << std::endl;
-  std::cout << "DAClusterizerInZ_vect: Tpurge = " << Tpurge << std::endl;
-  std::cout << "DAClusterizerInZ_vect: Tstop = " << Tstop << std::endl;
-  std::cout << "DAClusterizerInZ_vect: vertexSize = " << vertexSize_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: coolingFactor = " << coolingFactor_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: d0CutOff = " << d0CutOff_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: dzCutOff = " << dzCutOff_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: zmerge = " << zmerge_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: Tmin = " << Tmin << std::endl;
+  std::cout << "DAClusterizerinZ_vect: Tpurge = " << Tpurge << std::endl;
+  std::cout << "DAClusterizerinZ_vect: Tstop = " << Tstop << std::endl;
+  std::cout << "DAClusterizerinZ_vect: vertexSize = " << vertexSize_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: coolingFactor = " << coolingFactor_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: d0CutOff = " << d0CutOff_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: dzCutOff = " << dzCutOff_ << std::endl;
   std::cout << "DAClusterizerInZ_vect: zrange = " << sel_zrange_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: convergence mode = " << convergence_mode_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: delta_highT = " << delta_highT_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: delta_lowT = " << delta_lowT_ << std::endl;
-  std::cout << "DAClusterizerInZ_vect: DEBUGLEVEL " << DEBUGLEVEL << std::endl;
+  std::cout << "DAClusterizerinZ_vect: convergence mode = " << convergence_mode_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: delta_highT = " << delta_highT_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: delta_lowT = " << delta_lowT_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: DEBUGLEVEL " << DEBUGLEVEL << std::endl;
 #endif
 
   if (convergence_mode_ > 1) {
-    edm::LogWarning("DAClusterizerInZ_vect")
+    edm::LogWarning("DAClusterizerinZ_vect")
         << "DAClusterizerInZ_vect: invalid convergence_mode " << convergence_mode_ << "  reset to default " << 0;
     convergence_mode_ = 0;
   }
 
   if (Tmin == 0) {
     betamax_ = 1.0;
-    edm::LogWarning("DAClusterizerInZ_vect")
+    edm::LogWarning("DAClusterizerinZ_vect")
         << "DAClusterizerInZ_vect: invalid Tmin " << Tmin << "  reset to default " << 1. / betamax_;
   } else {
     betamax_ = 1. / Tmin;
   }
 
   if ((Tpurge > Tmin) || (Tpurge == 0)) {
-    edm::LogWarning("DAClusterizerInZ_vect")
+    edm::LogWarning("DAClusterizerinZ_vect")
         << "DAClusterizerInZ_vect: invalid Tpurge " << Tpurge << "  set to " << Tmin;
     Tpurge = Tmin;
   }
   betapurge_ = 1. / Tpurge;
 
   if ((Tstop > Tpurge) || (Tstop == 0)) {
-    edm::LogWarning("DAClusterizerInZ_vect")
+    edm::LogWarning("DAClusterizerinZ_vect")
         << "DAClusterizerInZ_vect: invalid Tstop " << Tstop << "  set to  " << max(1., Tpurge);
     Tstop = max(1., Tpurge);
   }
@@ -174,13 +174,11 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
   // prepare track data for clustering
   track_t tks;
   double sumtkwt = 0.;
-
   for (auto it = tracks.begin(); it != tracks.end(); it++) {
     if (!(*it).isValid())
       continue;
     double t_tkwt = 1.;
     double t_z = ((*it).stateAtBeamLine().trackStateAtPCA()).position().z();
-
     if (std::fabs(t_z) > 1000.)
       continue;
     auto const& t_mom = (*it).stateAtBeamLine().trackStateAtPCA().momentum();
@@ -191,16 +189,14 @@ DAClusterizerInZ_vect::track_t DAClusterizerInZ_vect::fill(const vector<reco::Tr
                          std::pow(t_mom.z(), 2) / std::pow(t_mom.perp2(), 2)  // beam spot width
                    + std::pow(vertexSize_, 2);  // intrinsic vertex size, safer for outliers and short lived decays
     t_dz2 = 1. / t_dz2;
-
     if (edm::isNotFinite(t_dz2) || t_dz2 < std::numeric_limits<double>::min())
       continue;
     if (d0CutOff_ > 0) {
       Measurement1D atIP = (*it).stateAtBeamLine().transverseImpactParameter();  // error contains beamspot
       t_tkwt = 1. / (1. + local_exp(std::pow(atIP.value() / atIP.error(), 2) -
                                     std::pow(d0CutOff_, 2)));  // reduce weight for high ip tracks
-
       if (edm::isNotFinite(t_tkwt) || t_tkwt < std::numeric_limits<double>::epsilon()) {
-        edm::LogWarning("DAClusterizerInZ_vect") << "rejected track t_tkwt " << t_tkwt;
+        edm::LogWarning("DAClusterizerinZ_vect") << "rejected track t_tkwt " << t_tkwt;
         continue;  // usually is > 0.99
       }
     }
@@ -229,7 +225,7 @@ void DAClusterizerInZ_vect::set_vtx_range(double beta, track_t& gtracks, vertex_
   const unsigned int nt = gtracks.getSize();
 
   if (nv == 0) {
-    edm::LogWarning("DAClusterizerInZ_vect") << "empty cluster list in set_vtx_range";
+    edm::LogWarning("DAClusterizerinZ_vect") << "empty cluster list in set_vtx_range";
     return;
   }
 
@@ -296,6 +292,7 @@ double DAClusterizerInZ_vect::update(
   if (rho0 > 0) {
     Z_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);  // cut-off
   }
+
   // define kernels
   auto kernel_calc_exp_arg_range = [beta](const unsigned int itrack,
                                           track_t const& tracks,
@@ -440,7 +437,6 @@ unsigned int DAClusterizerInZ_vect::thermalize(
     if (delta_sum_range > zrange_min_) {
       for (unsigned int k = 0; k < v.getSize(); k++) {
         if (std::abs(v.zvtx_vec[k] - z0[k]) > zrange_min_) {
-
           set_vtx_range(beta, tks, v);
           delta_sum_range = 0;
           z0 = v.zvtx_vec;
@@ -476,7 +472,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t& y, track_t& tks, double& beta) const
     return false;
 
   // merge the smallest distance clusters first
-  std::vector<std::pair<double, unsigned int> > critical;
+  std::vector<std::pair<double, unsigned int>> critical;
   for (unsigned int k = 0; (k + 1) < nv; k++) {
     if (std::fabs(y.zvtx[k + 1] - y.zvtx[k]) < zmerge_) {
       critical.push_back(make_pair(std::fabs(y.zvtx[k + 1] - y.zvtx[k]), k));
@@ -485,7 +481,7 @@ bool DAClusterizerInZ_vect::merge(vertex_t& y, track_t& tks, double& beta) const
   if (critical.empty())
     return false;
 
-  std::stable_sort(critical.begin(), critical.end(), std::less<std::pair<double, unsigned int> >());
+  std::stable_sort(critical.begin(), critical.end(), std::less<std::pair<double, unsigned int>>());
 
   for (unsigned int ik = 0; ik < critical.size(); ik++) {
     unsigned int k = critical[ik].second;
@@ -657,7 +653,7 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
 
   // avoid left-right biases by splitting highest Tc first
 
-  std::vector<std::pair<double, unsigned int> > critical;
+  std::vector<std::pair<double, unsigned int>> critical;
   for (unsigned int k = 0; k < nv; k++) {
     double Tc = 2 * y.swE[k] / y.sw[k];
     if (beta * Tc > threshold) {
@@ -667,7 +663,7 @@ bool DAClusterizerInZ_vect::split(const double beta, track_t& tks, vertex_t& y, 
   if (critical.empty())
     return false;
 
-  std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int> >());
+  std::stable_sort(critical.begin(), critical.end(), std::greater<std::pair<double, unsigned int>>());
 
   bool split = false;
   const unsigned int nt = tks.getSize();
@@ -793,10 +789,10 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   thermalize(beta, tks, y, delta_highT_);
 
-
   // annealing loop, stop when T<Tmin  (i.e. beta>1/Tmin)
 
   double betafreeze = betamax_ * sqrt(coolingFactor_);
+
   while (beta < betafreeze) {
     while (merge(y, tks, beta)) {
       update(beta, tks, y, rho0, false);
@@ -805,8 +801,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
     beta = beta / coolingFactor_;
     thermalize(beta, tks, y, delta_highT_);
-
-
   }
 
 #ifdef DEBUG
@@ -929,17 +923,15 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   set_vtx_range(beta, tks, y);
   const unsigned int nv = y.getSize();
-  //std::cout << "ivtxO,z" << std::endl;
   for (unsigned int k = 0; k < nv; k++) {
     if (edm::isNotFinite(y.rho[k]) || edm::isNotFinite(y.zvtx[k])) {
       y.rho[k] = 0;
       y.zvtx[k] = 0;
     }
-
   }
 
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
-  std::vector<std::vector<unsigned int> > vtx_track_indices(nv);
+  std::vector<std::vector<unsigned int>> vtx_track_indices(nv);
   for (unsigned int i = 0; i < nt; i++) {
     const auto kmin = tks.kmin[i];
     const auto kmax = tks.kmax[i];
@@ -953,7 +945,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
     for (auto k = kmin; k < kmax; k++) {
       tks.sum_Z[i] += y.rho[k] * y.exp[k];
     }
-
     const double invZ = tks.sum_Z[i] > 1e-100 ? 1. / tks.sum_Z[i] : 0.0;
 
     for (auto k = kmin; k < kmax; k++) {
@@ -967,7 +958,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 
   }  // track loop
 
-  //
   GlobalError dummyError(0.01, 0, 0.01, 0., 0., 0.01);
   for (unsigned int k = 0; k < nv; k++) {
     if (!vtx_track_indices[k].empty()) {
@@ -985,37 +975,36 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
 }
 
 vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<reco::TransientTrack>& tracks) const {
-  //unsigned int block_size_ = 512;
   vector<reco::TransientTrack> sorted_tracks;
-  vector<pair<float, float>> vertices_tot; // z, rho for each vertex
-  for (unsigned int i=0; i< tracks.size();i++){
+  vector<pair<float, float>> vertices_tot;  // z, rho for each vertex
+  for (unsigned int i = 0; i < tracks.size(); i++) {
     sorted_tracks.push_back(tracks[i]);
   }
   double rho0, beta;
-  std::sort(sorted_tracks.begin(), sorted_tracks.end(),
-    [](const reco::TransientTrack & a, const reco::TransientTrack & b) -> bool
-    {
-        return (a.stateAtBeamLine().trackStateAtPCA()).position().z() < (b.stateAtBeamLine().trackStateAtPCA()).position().z();
-    });
+  std::sort(sorted_tracks.begin(),
+            sorted_tracks.end(),
+            [](const reco::TransientTrack& a, const reco::TransientTrack& b) -> bool {
+              return (a.stateAtBeamLine().trackStateAtPCA()).position().z() <
+                     (b.stateAtBeamLine().trackStateAtPCA()).position().z();
+            });
 
-    unsigned int nBlocks = (unsigned int) std::floor(sorted_tracks.size() / ( block_size_ * (1 - overlap_frac_)));
-  for (unsigned int block=0; block < nBlocks; block++) {
+  unsigned int nBlocks = (unsigned int)std::floor(sorted_tracks.size() / (block_size_ * (1 - overlap_frac_)));
+  for (unsigned int block = 0; block < nBlocks; block++) {
     vector<reco::TransientTrack> block_tracks;
-    unsigned int begin = (unsigned int) (block * block_size_ * (1 - overlap_frac_));
-    unsigned int end = (unsigned int) std::min(begin + block_size_, (unsigned int) sorted_tracks.size());
-    //for (unsigned int i = block * block_size_; i < (block + 1) * block_size_ && i < sorted_tracks.size(); i++) {
-    for (unsigned int i = begin; i < end ; i++) {
+    unsigned int begin = (unsigned int)(block * block_size_ * (1 - overlap_frac_));
+    unsigned int end = (unsigned int)std::min(begin + block_size_, (unsigned int)sorted_tracks.size());
+    for (unsigned int i = begin; i < end; i++) {
       block_tracks.push_back(sorted_tracks[i]);
     }
     if (block_tracks.empty()) {
       continue;
     }
 
-    #ifdef DEBUG
-      std::cout<< "Running vertices_in_blocks on" << std::endl;
-      std::cout<< "- block no." << block << " on " << nBlocks << " blocks "<< std::endl;
-      std::cout<< "- block track size: " << sorted_tracks.size() << " - block size: " << block_size_ << std::endl;
-    #endif
+#ifdef DEBUG
+    std::cout << "Running vertices_in_blocks on" << std::endl;
+    std::cout << "- block no." << block << " on " << nBlocks << " blocks " << std::endl;
+    std::cout << "- block track size: " << sorted_tracks.size() << " - block size: " << block_size_ << std::endl;
+#endif
     track_t&& tks = fill(block_tracks);
     tks.extractRaw();
 
@@ -1029,10 +1018,10 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
 
     // estimate first critical temperature
     beta = beta0(betamax_, tks, y);
-  #ifdef DEBUG
+#ifdef DEBUG
     if (DEBUGLEVEL > 0)
       std::cout << "Beta0 is " << beta << std::endl;
-  #endif
+#endif
 
     thermalize(beta, tks, y, delta_highT_);
 
@@ -1047,18 +1036,16 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
 
       beta = beta / coolingFactor_;
       thermalize(beta, tks, y, delta_highT_);
-
-
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
 
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
                 << "last round of splitting" << std::endl;
     }
-  #endif
+#endif
 
     set_vtx_range(beta, tks, y);
     update(beta, tks, y, rho0, false);
@@ -1080,13 +1067,13 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       threshold *= 1.1;
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
                 << "turning on outlier rejection at T=" << 1 / beta << std::endl;
     }
-  #endif
+#endif
 
     // switch on outlier rejection at T=Tmin
     if (dzCutOff_ > 0) {
@@ -1098,7 +1085,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
 
     thermalize(beta, tks, y, delta_lowT_, rho0);
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
@@ -1106,7 +1093,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     }
     if (DEBUGLEVEL > 2)
       dump(beta, y, tks, 2, rho0);
-  #endif
+#endif
 
     // merge again  (some cluster split by outliers collapse here)
     while (merge(y, tks, beta)) {
@@ -1114,7 +1101,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       update(beta, tks, y, rho0, false);
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
@@ -1122,7 +1109,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     }
     if (DEBUGLEVEL > 2)
       dump(beta, y, tks, 2, rho0);
-  #endif
+#endif
 
     // go down to the purging temperature (if it is lower than tmin)
     while (beta < betapurge_) {
@@ -1130,26 +1117,26 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       thermalize(beta, tks, y, delta_lowT_, rho0);
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
                 << "purging at T=" << 1 / beta << std::endl;
     }
-  #endif
+#endif
 
     // eliminate insignificant vertices, this is more restrictive at higher T
     while (purge(y, tks, rho0, beta)) {
       thermalize(beta, tks, y, delta_lowT_, rho0);
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
                 << "last cooling T=" << 1 / beta << std::endl;
     }
-  #endif
+#endif
 
     // optionally cool some more without doing anything, to make the assignment harder
     while (beta < betastop_) {
@@ -1157,7 +1144,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       thermalize(beta, tks, y, delta_lowT_, rho0);
     }
 
-  #ifdef DEBUG
+#ifdef DEBUG
     verify(y, tks);
     if (DEBUGLEVEL > 0) {
       std::cout << "DAClusterizerInZSubCluster_vect::vertices :"
@@ -1165,30 +1152,26 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     }
     if (DEBUGLEVEL > 2)
       dump(beta, y, tks, 2, rho0);
-  #endif
-
+#endif
 
     for (unsigned int ivertex = 0; ivertex < y.getSize(); ivertex++) {
-      if (y.zvtx_vec[ivertex]!=0 && y.rho_vec[ivertex]!=0) {
+      if (y.zvtx_vec[ivertex] != 0 && y.rho_vec[ivertex] != 0) {
         vertices_tot.push_back(pair(y.zvtx_vec[ivertex], y.rho_vec[ivertex]));
-        #ifdef DEBUG
-          std::cout << "Found new vertex " << y.zvtx_vec[ivertex] << " , " << y.rho_vec[ivertex] << std::endl;
-        #endif
+#ifdef DEBUG
+        std::cout << "Found new vertex " << y.zvtx_vec[ivertex] << " , " << y.rho_vec[ivertex] << std::endl;
+#endif
       }
     }
-
   }
 
-  std::sort(vertices_tot.begin(), vertices_tot.end(), [](const pair<float, float> & a, const pair<float, float> & b) -> bool
-    {
-        return a.first < b.first;
-    });
+  std::sort(vertices_tot.begin(),
+            vertices_tot.end(),
+            [](const pair<float, float>& a, const pair<float, float>& b) -> bool { return a.first < b.first; });
 
   // reassign tracks to vertices
   track_t&& tracks_tot = fill(tracks);
   const unsigned int nv = vertices_tot.size();
   const unsigned int nt = tracks_tot.getSize();
-
 
   for (auto itrack = 0U; itrack < nt; ++itrack) {
     double zrange = max(sel_zrange_ / sqrt(beta * tracks_tot.dz2[itrack]), zrange_min_);
@@ -1227,16 +1210,13 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       tracks_tot.kmin[itrack] = max(0U, min(kmin, kmax));
       tracks_tot.kmax[itrack] = min(nv, max(kmin, kmax) + 1);
     }
-
   }
 
-
-
   double mintrkweight_ = 0.5;
-  rho0 = nv > 1 ? 1./nv : 1.;
+  rho0 = nv > 1 ? 1. / nv : 1.;
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
 
-  std::vector<std::vector<unsigned int> > vtx_track_indices(nv);
+  std::vector<std::vector<unsigned int>> vtx_track_indices(nv);
   for (unsigned int i = 0; i < nt; i++) {
     const auto kmin = tracks_tot.kmin[i];
     const auto kmax = tracks_tot.kmax[i];
@@ -1256,14 +1236,15 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
         iMax = k;
       }
     }
-    if (iMax < vtx_track_indices.size()) vtx_track_indices[iMax].push_back(i);
-
+    if (iMax < vtx_track_indices.size())
+      vtx_track_indices[iMax].push_back(i);
   }
-  #ifdef DEBUG
-    for (auto itrack = 0U; itrack < nt; ++itrack) {
-          std::cout << "itrack " << itrack << " , " << tracks_tot.kmin[itrack] << " , " << tracks_tot.kmax[itrack] << std::endl;
-    }
-  #endif
+#ifdef DEBUG
+  for (auto itrack = 0U; itrack < nt; ++itrack) {
+    std::cout << "itrack " << itrack << " , " << tracks_tot.kmin[itrack] << " , " << tracks_tot.kmax[itrack]
+              << std::endl;
+  }
+#endif
 
   vector<TransientVertex> clusters;
 
@@ -1274,24 +1255,24 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
       vector<reco::TransientTrack> vertexTracks;
       for (auto i : vtx_track_indices[k]) {
         vertexTracks.push_back(*(tracks_tot.tt[i]));
-        #ifdef DEBUG
-          std::cout << y.zvtx[k] << "," << (*tks.tt[i]).stateAtBeamLine().trackStateAtPCA().position().z() << std::endl;
-        #endif
+#ifdef DEBUG
+        std::cout << y.zvtx[k] << "," << (*tks.tt[i]).stateAtBeamLine().trackStateAtPCA().position().z() << std::endl;
+#endif
       }
       TransientVertex v(pos, dummyError, vertexTracks, 0);
       clusters.push_back(v);
     }
   }
-  
+
   return clusters;
 }
 
-vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
+vector<vector<reco::TransientTrack>> DAClusterizerInZ_vect::clusterize(
     const vector<reco::TransientTrack>& tracks) const {
-  vector<vector<reco::TransientTrack> > clusters;
+  vector<vector<reco::TransientTrack>> clusters;
 
   vector<TransientVertex> pv;
-  if(runInBlocks_ and (block_size_ < tracks.size())) //doesn't bother if low number of tracks
+  if (runInBlocks_ and (block_size_ < tracks.size()))  //doesn't bother if low number of tracks
     pv = vertices_in_blocks(tracks);
   else
     pv = vertices(tracks);
@@ -1330,7 +1311,7 @@ vector<vector<reco::TransientTrack> > DAClusterizerInZ_vect::clusterize(
     }
   }
   clusters.emplace_back(std::move(aCluster));
-  
+
   return clusters;
 }
 
@@ -1504,8 +1485,7 @@ void DAClusterizerInZ_vect::fillPSetDescription(edm::ParameterSetDescription& de
   desc.add<double>("uniquetrkweight", 0.8);
   desc.add<double>("uniquetrkminp", 0.0);
   desc.add<double>("zrange", 4.0);
-  desc.add<bool>("runInBlocks",false);
+  desc.add<bool>("runInBlocks", false);
   desc.add<unsigned int>("block_size", 512);
   desc.add<double>("overlap_frac", 0.5);
-
 }

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -48,7 +48,7 @@ DAClusterizerInZ_vect::DAClusterizerInZ_vect(const edm::ParameterSet& conf) {
   overlap_frac_ = conf.getParameter<double>("overlap_frac");
 
 #ifdef DEBUG
-  std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight_ << std::endl;
+  std::cout << "DAClusterizerinZ_vect: mintrkweight = " << mintrkweight << std::endl;
   std::cout << "DAClusterizerinZ_vect: uniquetrkweight = " << uniquetrkweight_ << std::endl;
   std::cout << "DAClusterizerInZ_vect: uniquetrkminp = " << uniquetrkminp_ << std::endl;
   std::cout << "DAClusterizerinZ_vect: zmerge = " << zmerge_ << std::endl;
@@ -950,7 +950,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices(const vector<reco::Trans
     for (auto k = kmin; k < kmax; k++) {
       double p = y.rho[k] * y.exp[k] * invZ;
       if (p > mintrkweight_) {
-        // assign  track i -> vertex k (hard, mintrkweight_ should be >= 0.5 here
+        // assign  track i -> vertex k (hard, mintrkweight should be >= 0.5 here
         vtx_track_indices[k].push_back(i);
         break;
       }
@@ -1212,7 +1212,6 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     }
   }
 
-  double mintrkweight_ = 0.5;
   rho0 = nv > 1 ? 1. / nv : 1.;
   const auto z_sum_init = rho0 * local_exp(-beta * dzCutOff_ * dzCutOff_);
 
@@ -1221,14 +1220,14 @@ vector<TransientVertex> DAClusterizerInZ_vect::vertices_in_blocks(const vector<r
     const auto kmin = tracks_tot.kmin[i];
     const auto kmax = tracks_tot.kmax[i];
     double p_max = -1;
-    unsigned int iMax = 10000;
+    unsigned int iMax = 10000;  //just a "big" number w.r.t. number of vertices
     float sum_Z = z_sum_init;
     for (auto k = kmin; k < kmax; k++) {
       float v_exp = local_exp(-beta * Eik(tracks_tot.zpca[i], vertices_tot[k].first, tracks_tot.dz2[i]));
       sum_Z += vertices_tot[k].second * v_exp;
     }
     double invZ = sum_Z > 1e-100 ? 1. / sum_Z : 0.0;
-    for (auto k = kmin; k < kmax; k++) {
+    for (auto k = kmin; k < kmax && invZ != 0.0; k++) {
       float v_exp = local_exp(-beta * Eik(tracks_tot.zpca[i], vertices_tot[k].first, tracks_tot.dz2[i]));
       double p = vertices_tot[k].second * v_exp * invZ;
       if (p > p_max && p > mintrkweight_) {


### PR DESCRIPTION
Vast majority of the work from @giorgiopizz.

This PR proposes the addition of a new track clusterizer and a new 3D position estimator for the `PrimaryVertexProducer`:

- the new clusterizer sorts the tracks in the z coordinate, splits them in blocks of same size (set by default to `512`) with a fixed overlap fraction between blocks (set by default to `0.5`) and performs independently the Determistin Annealing along all the blocks. The block size and the overlap fraction are made configurable parameters.

- the new estimator iteratively estimates the vertex 3D coordinates and errors using the weighted mean of tracks impact point at the beamspot position and uncertainty. The iterations includes an outlier rejection to improve the performance. 

This PR **does not** introduce the new vertexing as default but add these options to the `PrimaryVertexProducer`. The new clustering and vertexing are used only in case the (new) processes modifiers `vertexInBlocks` and  `weightedVertexing` are added to the process. Two workflows are added to the matrix to test this setups: `*.278` which runs the full reco with the weighted vertexing and the `*.279` which runs `trackingOnly` wfs. A version of the algorithm for BS constrained vertexing is also added.

### Samples for validation

- Phase1: `/RelValTTbar_14TeV/CMSSW_12_5_0_pre5-PU_125X_mcRun3_2022_realistic_v3-v2/`
- Phase2: `/RelValTTbar_14TeV/CMSSW_12_4_0_pre3-PU_123X_mcRun4_realistic_v11_2026D88PU200-v1/`

### Computational Performance

Here the timing performance for various working points evaluated on `fu-c2a02-37-01` machine at P5 (`8 threads 8 streams`).

`PrimaryVertexProducer` cpu time for Phase1/Phase2 samples for different `block_size`s and `overlap_frac`s:

<p align=center>
<img width="300" src="https://user-images.githubusercontent.com/16901146/195576720-878dfcf3-9b46-4bec-93ca-e1876299f742.png">       <img width="300"  src="https://user-images.githubusercontent.com/16901146/195577060-f90d569d-352d-4eb2-85f8-199b45646126.png"> 
</p>

`PrimaryVertexProducer` speed up w.r.t the current producer for Phase1/Phase2 samples for different `block_size`s and `overlap_frac`s:

<p align=center>
<img width="300" alt="phase1_speedup" src="https://user-images.githubusercontent.com/16901146/195577817-c741e795-3741-4dcf-8caa-50a6818a8cfd.png">         <img width="300" alt="phase2_speedup" src="https://user-images.githubusercontent.com/16901146/195577498-b1bc347b-88be-40ab-be64-c167afbba8cc.png">
</p>

### Physics Performance

 - Phase1 validation plots (from MTV), with the `overlap_frac=0.5` and  `block_size=128` [here](https://adiflori.web.cern.ch/adiflori/phase1_vertices/plots_vertex.html).  
 - Phase2 validation plots for `block_size=128,256,512` (in all plots `cpu` stands for the current algorithm version):
   - [plots](https://adiflori.web.cern.ch/adiflori/cpu_vertexing/plots/phase2/mtv_0p15/) for  `overlap_frac=0.15`;  
   - [plots](https://adiflori.web.cern.ch/adiflori/cpu_vertexing/plots/phase2/mtv_0p25/) for  `overlap_frac=0.25`;  
   - [plots](https://adiflori.web.cern.ch/adiflori/cpu_vertexing/plots/phase2/mtv_0p50/) for  `overlap_frac=0.50`.  
 - Phase2 [different contributions](https://gpizzati.web.cern.ch/pv/plots_approval_t2/all/ ): find here a collection of results that shows the different contributions of the new clusterizer and the new estimator altogether and decoupled.

### Further references and readings

https://indico.cern.ch/event/1175120/#2-offloading-deterministic-ann
https://indico.cern.ch/event/1206394/#47-dp-note-approval-primary-ve
https://indico.cern.ch/event/1152032/#4-offloading-deterministic-ann