### PR TITLE
Add ppEra_Run3_pp_on_PbPb_approxSiStripClusters scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -104,6 +104,10 @@ def customisePostEra_Run3_pp_on_PbPb(process):
     customisePostEra_Run3(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters(process):
+    customisePostEra_Run3_pp_on_PbPb(process)
+    return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:
This PR adds a new scenario `ppEra_Run3_pp_on_PbPb_approxSiStripClusters`, based on Era `Run3_pp_on_PbPb_approxSiStripClusters` introduced in #39863.
This scenario allows to run Repacking and Prompt reconstruction in Tier0 on the RawPrime data that will be produced during the HI test run (scheduled for November 17-18<sup>th</sup>).

#### PR validation:
Run the following commands on the streamer files produced by HLT in the dry-run with CMSSW_12_5_2 and announced in [this CMSTalk thread](https://cms-talk.web.cern.ch/t/weekly-jointops-meeting-on-monday-oct-31st-13-00-cern-time-hybrid/16804/7):
 - `python3 $CMSSW_BASE/src/Configuration/DataProcessing/test/RunRepack.py --lfn file:run360991_ls0112_streamPhysicsHITestRawPrime.dat`
 - `python3 $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run3_pp_on_PbPb_approxSiStripClusters --reco --aod --dqmio --global-tag 124X_dataRun3_Prompt_v6 --lfn file:write_PrimDS1_RAW.root`
 - `python3 $CMSSW_BASE/src/Configuration/DataProcessing/test/RunDQMHarvesting.py --scenario ppEra_Run3_pp_on_PbPb_approxSiStripClusters --global-tag 124X_dataRun3_Prompt_v6 --lfn file:output_inDQMIO.root --run 360991 --dataset=/A/B/C --dqmio`

Minimal recipe to reproduce the input file:
```
cmsrel CMSSW_12_5_2
cd CMSSW_12_5_2/src
cmsenv
cat /eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/FOG/HIonTest/run360991/streamPhysicsHITestRawPrime/data/run360991_ls0000_streamPhysicsHITestRawPrime_hilton-c2f13-20-04.ini /eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/FOG/HIonTest/run360991/streamPhysicsHITestRawPrime/data/run360991_ls0112_streamPhysicsHITestRawPrime_hilton-c2f13-20-04.dat > run360991_ls0112_streamPhysicsHITestRawPrime.dat
```
Inpecting the DQM output the SiStrip and Tracking properties seems to be filled correctly (thanks @mmusich for double checking!):
<img width="1359" alt="Schermata 2022-11-07 alle 10 26 35" src="https://user-images.githubusercontent.com/7822641/200275206-5c498cc5-56c5-4640-91f9-eba02ae9fd62.png">

FYI @mandrenguyen @cms-sw/alca-l2 

#### Backport:
Not a backport, but a 12_5_X backport will be provided soon.