### PR TITLE
[12_5_X] Add ppEra_Run3_pp_on_PbPb_approxSiStripClusters scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -104,6 +104,10 @@ def customisePostEra_Run3_pp_on_PbPb(process):
     customisePostEra_Run3(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters(process):
+    customisePostEra_Run3_pp_on_PbPb(process)
+    return process
+
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:
Backport of #39998
This PR adds a new scenario `ppEra_Run3_pp_on_PbPb_approxSiStripClusters`, based on Era `Run3_pp_on_PbPb_approxSiStripClusters` introduced in #39863.
This scenario allows to run Repacking and Prompt reconstruction in Tier0 on the RawPrime data that will be produced during the HI test run (scheduled for November 17-18<sup>th</sup>).

#### PR validation:
See master PR for the validation

#### Backport:
Backport of #39998