### PR TITLE
add a `TransientTrackingRechitBuilder` for `CPEFast`

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -478,8 +478,6 @@ void PixelCPEFast::errorFromTemplates(DetParam const& theDetParam,
 LocalPoint PixelCPEFast::localPosition(DetParam const& theDetParam, ClusterParam& theClusterParamBase) const {
   ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
 
-  assert(!theClusterParam.with_track_angle);
-
   if (useErrorsFromTemplates_) {
     errorFromTemplates(theDetParam, theClusterParam, theClusterParam.theCluster->charge());
   } else {

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -62,6 +62,12 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
     ppToken_ = c.consumes(edm::ESInputTag("", pname));
   }
 
+  if (pname == "PixelCPEFast") {
+    edm::LogWarning("TkTransientTrackingRecHitBuilderESProducer")
+        << "\n\t\t WARNING!\n 'PixelCPEFast' has been chosen as PixelCPE choice.\n"
+        << " Track angles will NOT be used in the CPE estimation!\n";
+  }
+
   auto const mname = p.getParameter<std::string>("Matcher");
   if (mname != "Fake") {
     mpToken_ = c.consumes(edm::ESInputTag("", mname));

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -7,6 +7,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4MixedTriplets_cfi impor
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
+from RecoLocalTracker.SiPixelRecHits.PixelCPEFastESProducer_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -8,6 +8,9 @@ ttrhbwr =  tkTransientTrackingRecHitBuilderESProducer.clone(StripCPE = 'StripCPE
                                                             Matcher = 'StandardMatcher',
                                                             ComputeCoarseLocalPositionFromDisk = False)
 
+TTRHBuilderFast = ttrhbwr.clone(ComponentName = 'WithoutAngleFast',
+                                PixelCPE = 'PixelCPEFast')
+
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwr, 
                              Phase2StripCPE = 'Phase2StripCPE',


### PR DESCRIPTION
#### PR description:

As per request of the Tracker Alignment group, I provide a `TransientTrackingRechitBuilder` flavour for `PixelCPEFast`, as it might be useful for checking the calibration performance at the HLT pixel tracking step.
In order to avoid a run-time assertion, a line has been removed in [RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:cmssw:CPEFastTrackRefitter?expand=1#diff-0bdeee58c61562d4080fe9683b1b4e38861ec0fae050bc5cae5118ef85383bc1), while a new warning is emitted from [RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:cmssw:CPEFastTrackRefitter?expand=1#diff-977de069a65840df6e8259c8c6277b63ec5566cd6ef684660e19ff418be88b99) in order to warn the user that track angles will not be used.

#### PR validation:

Run the configuration files at this [gist](https://gist.github.com/mmusich/1bbb30be65b0a28aee6e6d60ea0ca5b5).
Also, results using this configuration will be shown at the upcoming [TK DPG meeting](https://indico.cern.ch/event/1199476/?showDate=all&showSession=9#4-update-on-hg-pcl-with-templa)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

cc:
@consuegs @antoniovagnerini 