### PR TITLE
[`DQMOffline/Alignment`] Improvements on di-muon mass bias plots

### DIFF
--- a/DQMOffline/Alignment/BuildFile.xml
+++ b/DQMOffline/Alignment/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="FWCore/Framework"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
+<use name="PhysicsTools/TagAndProbe"/>
 <use name="RecoVertex/KalmanVertexFit"/>
 <use name="RecoVertex/VertexPrimitives"/>
 <use name="RecoVertex/VertexTools"/>

--- a/DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h
+++ b/DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h
@@ -79,8 +79,8 @@ namespace DiLepPlotHelp {
             titlePostfix = fmt::sprintf("%s^{-} #eta;%s^{+} #eta", sed, sed);
             break;
           case xAxis::DELTA_ETA:
-            xmin = -4.;
-            xmax = 4.;
+            xmin = -hpar.getParameter<double>("maxDeltaEta");
+            xmax = hpar.getParameter<double>("maxDeltaEta");
             namePostfix = m_flav ? "EEDeltEta" : "MuMuDeltaEta";
             titlePostfix = fmt::sprintf("%s^{-}%s^{+} #Delta#eta;%s^{+}%s^{-} #Delta#eta", sed, sed, sed, sed);
             break;

--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -30,6 +30,9 @@ namespace diMuonMassBias {
     // getters
     const Measurement1D getBias() { return m_bias; }
     const Measurement1D getWidth() { return m_width; }
+    const bool isInvalid() {
+      return (m_bias.value() == 0.f && m_bias.error() == 0.f && m_width.value() == 0.f && m_width.error() == 0.f);
+    }
 
   private:
     Measurement1D m_bias;

--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -82,6 +82,7 @@ private:
   // data members
   const std::string TopFolder_;
   const bool fitBackground_;
+  const bool useRooCMSShape_;
   const bool debugMode_;
 
   float meanConfig_[3];  /* parmaeters for the fit: mean */

--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -80,11 +80,12 @@ private:
   /// book MEs
   void bookMEs(DQMStore::IBooker& ibooker);
   void getMEsToHarvest(DQMStore::IGetter& igetter);
-  diMuonMassBias::fitOutputs fitVoigt(TH1* hist, const bool& fitBackground = false) const;
+  diMuonMassBias::fitOutputs fitLineShape(TH1* hist, const bool& fitBackground = false) const;
 
   // data members
   const std::string TopFolder_;
   const bool fitBackground_;
+  const bool useRooCBShape_;
   const bool useRooCMSShape_;
   const bool debugMode_;
 

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -170,7 +170,7 @@ ALCARECOTkAlJpsiMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiM
     muonTracks = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     decayMotherName = 'J/#psi',
-    DiMuMassConfig = dict(ymin = 2.7 ,ymax = 3.4))
+    DiMuMassConfig = dict(ymin = 2.7 ,ymax = 3.4, maxDeltaEta = 1.3))
 
 ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARECOTkAlJpsiMuMuTkAlDQM + ALCARECOTkAlJpsiMuMuVtxDQM + ALCARECOTkAlJpsiMassBiasDQM)
 
@@ -240,7 +240,7 @@ ALCARECOTkAlUpsilonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.
     muonTracks = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     decayMotherName = '#Upsilon',
-    DiMuMassConfig = dict(ymin = 8.9 ,ymax = 9.9))
+    DiMuMassConfig = dict(ymin = 8.9 ,ymax = 9.9, maxDeltaEta = 1.6))
 
 ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + ALCARECOTkAlUpsilonMuMuTkAlDQM + ALCARECOTkAlUpsilonMuMuVtxDQM + ALCARECOTkAlUpsilonMassBiasDQM)
 

--- a/DQMOffline/Alignment/python/DiMuonMassBiasClient_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasClient_cfi.py
@@ -5,6 +5,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 DiMuonMassBiasClient = DQMEDHarvester("DiMuonMassBiasClient",
                                       FolderName = cms.string('DiMuonMassBiasMonitor'),
                                       fitBackground = cms.bool(False),
+                                      useRooCMSShape = cms.bool(False),
                                       debugMode = cms.bool(False),
                                       fit_par = cms.PSet(
                                           mean_par = cms.vdouble(

--- a/DQMOffline/Alignment/python/DiMuonMassBiasClient_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasClient_cfi.py
@@ -5,6 +5,7 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 DiMuonMassBiasClient = DQMEDHarvester("DiMuonMassBiasClient",
                                       FolderName = cms.string('DiMuonMassBiasMonitor'),
                                       fitBackground = cms.bool(False),
+                                      useRooCBShape = cms.bool(False),
                                       useRooCMSShape = cms.bool(False),
                                       debugMode = cms.bool(False),
                                       fit_par = cms.PSet(

--- a/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
@@ -20,10 +20,11 @@ __selectionName = 'TkAlJpsiMuMu'
 ALCARECOTkAlJpsiMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName,
     fitBackground = True,
-    useRooCMSShape = False,
+    useRooCBShape = True, # crystal-ball fit
+    useRooCMSShape = True,
     fit_par = dict(mean_par = [3.09, 2.7, 3.4],   # parameters of the mass pole
                    width_par = [1.0, 0.0, 5.0],
-                   sigma_par = [1.0, 0.0, 5.0])
+                   sigma_par = [0.01, 0.0, 5.0])
 )
 
 alcaTkAlJpsiMuMuBiasClients = cms.Sequence(ALCARECOTkAlJpsiMuMuMassBiasClient)
@@ -33,7 +34,8 @@ __selectionName = 'TkAlUpsilonMuMu'
 ALCARECOTkAlUpsilonMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName,
     fitBackground = True,
-    useRooCMSShape = False,
+    useRooCBShape = True, # crystal-ball fit
+    useRooCMSShape = True,
     fit_par = dict(mean_par = [9.46, 8.9, 9.9],  # parameters of the mass pole
                    width_par = [1.0, 0.0, 5.0],
                    sigma_par = [1.0, 0.0, 5.0])

--- a/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
@@ -23,8 +23,8 @@ ALCARECOTkAlJpsiMuMuMassBiasClient = diMuonMassBiasClient.clone(
     useRooCBShape = True, # crystal-ball fit
     useRooCMSShape = True,
     fit_par = dict(mean_par = [3.09, 2.7, 3.4],   # parameters of the mass pole
-                   width_par = [1.0, 0.0, 5.0],
-                   sigma_par = [0.01, 0.0, 5.0])
+                   width_par = [1.0, 0.0, 5.0],   # not actually used
+                   sigma_par = [0.01, 0.0, 5.0])  # width of the CB
 )
 
 alcaTkAlJpsiMuMuBiasClients = cms.Sequence(ALCARECOTkAlJpsiMuMuMassBiasClient)
@@ -34,11 +34,11 @@ __selectionName = 'TkAlUpsilonMuMu'
 ALCARECOTkAlUpsilonMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName,
     fitBackground = True,
-    useRooCBShape = True, # crystal-ball fit
-    useRooCMSShape = True,
+    useRooCBShape = True,   # crystal-ball fit
+    useRooCMSShape = False, # using the exponential is useful to model the onset of Y(2S) peak
     fit_par = dict(mean_par = [9.46, 8.9, 9.9],  # parameters of the mass pole
-                   width_par = [1.0, 0.0, 5.0],
-                   sigma_par = [1.0, 0.0, 5.0])
+                   width_par = [1.0, 0.0, 5.0],  # not actually used
+                   sigma_par = [1.0, 0.0, 5.0])  # width of the CB
 )
 
 alcaTkAlUpsilonMuMuBiasClients = cms.Sequence(ALCARECOTkAlUpsilonMuMuMassBiasClient)

--- a/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasHarvesting_cff.py
@@ -5,7 +5,12 @@ from DQMOffline.Alignment.DiMuonMassBiasClient_cfi import DiMuonMassBiasClient a
 # Z-> mm
 __selectionName = 'TkAlDiMuonAndVertex'
 ALCARECOTkAlZMuMuMassBiasClient = diMuonMassBiasClient.clone(
-    FolderName = "AlCaReco/"+__selectionName
+    FolderName = "AlCaReco/"+__selectionName,
+    fitBackground = True,
+    useRooCMSShape = True,
+    fit_par = dict(mean_par = [90., 89., 100.],    # parameters of the mass pole
+                   width_par = [2.49, 2.48, 2.50], # natural width of the Z
+                   sigma_par = [1.5, 0.0, 10.0])   # detector smearing
 )
 
 alcaTkAlZMuMuBiasClients = cms.Sequence(ALCARECOTkAlZMuMuMassBiasClient)
@@ -15,7 +20,8 @@ __selectionName = 'TkAlJpsiMuMu'
 ALCARECOTkAlJpsiMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName,
     fitBackground = True,
-    fit_par = dict(mean_par = [3.09, 2.7, 3.4],
+    useRooCMSShape = False,
+    fit_par = dict(mean_par = [3.09, 2.7, 3.4],   # parameters of the mass pole
                    width_par = [1.0, 0.0, 5.0],
                    sigma_par = [1.0, 0.0, 5.0])
 )
@@ -27,7 +33,8 @@ __selectionName = 'TkAlUpsilonMuMu'
 ALCARECOTkAlUpsilonMuMuMassBiasClient = diMuonMassBiasClient.clone(
     FolderName = "AlCaReco/"+__selectionName,
     fitBackground = True,
-    fit_par = dict(mean_par = [9.46, 8.9, 9.9],
+    useRooCMSShape = False,
+    fit_par = dict(mean_par = [9.46, 8.9, 9.9],  # parameters of the mass pole
                    width_par = [1.0, 0.0, 5.0],
                    sigma_par = [1.0, 0.0, 5.0])
 )

--- a/DQMOffline/Alignment/python/DiMuonMassBiasMonitor_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonMassBiasMonitor_cfi.py
@@ -13,6 +13,8 @@ DiMuonMassBiasMonitor = DQMEDAnalyzer('DiMuonMassBiasMonitor',
                                           yUnits = cms.string('[GeV]'),
                                           NxBins = cms.int32(24),
                                           NyBins = cms.int32(50),
+                                          # defaults for the Z->mm decay
                                           ymin = cms.double(65.),
-                                          ymax = cms.double(115.)
+                                          ymax = cms.double(115.),
+                                          maxDeltaEta =  cms.double(3.7),
                                       ))

--- a/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
@@ -125,9 +125,16 @@ void DiMuonMassBiasClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGett
       edm::LogPrint("DiMuonMassBiasClient") << "dealing with key: " << key << std::endl;
     TH2F* bareHisto = ME->getTH2F();
     for (int bin = 1; bin <= ME->getNbinsX(); bin++) {
+      const auto& xaxis = bareHisto->GetXaxis();
+      const auto& low_edge = xaxis->GetBinLowEdge(bin);
+      const auto& high_edge = xaxis->GetBinUpEdge(bin);
+
       if (debugMode_)
-        edm::LogPrint("DiMuonMassBiasClient") << "dealing with bin: " << bin << std::endl;
+        edm::LogPrint("DiMuonMassBiasClient") << "dealing with bin: " << bin << " range: (" << std::setprecision(2)
+                                              << low_edge << "," << std::setprecision(2) << high_edge << ")";
       TH1D* Proj = bareHisto->ProjectionY(Form("%s_proj_%i", key.c_str(), bin), bin, bin);
+      Proj->SetTitle(Form("%s, bin: %i (%.2f,%.2f)", Proj->GetTitle(), bin, low_edge, high_edge));
+
       diMuonMassBias::fitOutputs results = fitVoigt(Proj);
 
       if (results.isInvalid()) {

--- a/DQMOffline/Alignment/src/DiMuonMassBiasMonitor.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasMonitor.cc
@@ -298,6 +298,7 @@ void DiMuonMassBiasMonitor::fillDescriptions(edm::ConfigurationDescriptions& des
     psDiMuMass.add<int>("NyBins", 50);
     psDiMuMass.add<double>("ymin", 65.);
     psDiMuMass.add<double>("ymax", 115.);
+    psDiMuMass.add<double>("maxDeltaEta", 3.7);
     desc.add<edm::ParameterSetDescription>("DiMuMassConfig", psDiMuMass);
   }
 

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
@@ -101,21 +101,27 @@ process.dqmsave_step = cms.Path(process.DQMSaver)
 if (options.resonance == 'Z'):
     print('',30*"#",'\n # will harvest Z file \n',30*"#")
     _folderName = cms.string('AlCaReco/TkAlDiMuonAndVertex')
-    _doBkgFit = cms.bool(False)
-    _fitPar =  cms.PSet(mean_par = cms.vdouble(90.,60.,120.),
-                        width_par = cms.vdouble(5.0,0.0,120.0),
-                        sigma_par = cms.vdouble(5.0,0.0,120.0))
+    _doBkgFit = cms.bool(True)
+    _useRooCBShape = cms.bool(False)
+    _useRooCMSShape = cms.bool(True)
+    _fitPar =  cms.PSet(mean_par = cms.vdouble(90.,80.,100.),
+                        width_par = cms.vdouble(2.49,2.48,2.50),
+                        sigma_par = cms.vdouble(1.5,0.,10.))
 elif (options.resonance == 'Jpsi'):
     print('',30*"#",'\n # will harvest J/psi file \n',30*"#")
     _folderName =  cms.string('AlCaReco/TkAlJpsiMuMu')
     _doBkgFit = cms.bool(True)
+    _useRooCBShape = cms.bool(True)
+    _useRooCMSShape = cms.bool(True)
     _fitPar =  cms.PSet(mean_par = cms.vdouble(3.09, 2.7, 3.4),
-                        width_par = cms.vdouble(1.0, 0.0, 5.0),
-                        sigma_par = cms.vdouble(1.0, 0.0, 5.0))
+                        width_par = cms.vdouble(0.001, 0.0, 5e-3),
+                        sigma_par = cms.vdouble(0.1, 0.0, 5.0))
 elif (options.resonance == 'Upsilon'):
     print('',30*"#",'\n # will harvest Upsilon file \n',30*"#")
     _folderName =  cms.string('AlCaReco/TkAlUpsilonMuMu')
     _doBkgFit = cms.bool(True)
+    _useRooCBShape = cms.bool(True)
+    _useRooCMSShape = cms.bool(False)
     _fitPar =  cms.PSet(mean_par = cms.vdouble(9.46, 8.9, 9.9),
                         width_par = cms.vdouble(1.0, 0.0, 5.0),
                         sigma_par = cms.vdouble(1.0, 0.0, 5.0))
@@ -126,6 +132,8 @@ process.DiMuonMassBiasClient = cms.EDProducer("DiMuonMassBiasClient",
                                               fitBackground = _doBkgFit,
                                               debugMode = cms.bool(True),
                                               fit_par = _fitPar,
+                                              useRooCBShape = _useRooCBShape,
+                                              useRooCMSShape = _useRooCMSShape,
                                               MEtoHarvest = cms.vstring(
                                                   'DiMuMassVsMuMuPhi',
                                                   'DiMuMassVsMuMuEta',

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
@@ -114,8 +114,8 @@ elif (options.resonance == 'Jpsi'):
     _useRooCBShape = cms.bool(True)
     _useRooCMSShape = cms.bool(True)
     _fitPar =  cms.PSet(mean_par = cms.vdouble(3.09, 2.7, 3.4),
-                        width_par = cms.vdouble(0.001, 0.0, 5e-3),
-                        sigma_par = cms.vdouble(0.1, 0.0, 5.0))
+                        width_par = cms.vdouble(1.0, 0.0, 5.0),
+                        sigma_par = cms.vdouble(0.01, 0.0, 5.0))
 elif (options.resonance == 'Upsilon'):
     print('',30*"#",'\n # will harvest Upsilon file \n',30*"#")
     _folderName =  cms.string('AlCaReco/TkAlUpsilonMuMu')


### PR DESCRIPTION
#### PR description:

The purpose of this PR is improve the di-muon mass bias monitoring in the `DQMOffline/Alignment`.
Points addressed:
   * add provision to use `RooCMSShape` as a background shape
   * allow configurable `maxDeltaEta` parameter in `DiMuonMassBiasMonitor`
   * improve fit and plotting limits in `DiMuonMassBiasMonitor` and Client
   * add provisions for Crystal-ball fits in `DiMuonMassBiasClient`
   
#### PR validation:

Tested with the unit tests of this package: `scram b runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but should be backported to the data-taking release.