### PR TITLE
Remove MVASelector tags for tracking in data GTs + re-snapshot frozen GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,14 +33,14 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-12 13:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-11-09 21:24:02 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v8',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v1',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v6 but with snapshot at 2022-10-04 14:22:26 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
+    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v3',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-11-09 21:24:02 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v8',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v8 but with snapshot at 2022-11-09 21:24:02 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v7',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-11-01 12:00:00 (UTC)
     'run3_data'                    : '124X_dataRun3_v11',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu


### PR DESCRIPTION
#### PR description:

Data part of https://github.com/cms-sw/cmssw/pull/40010
Here on the other hand, due to the re-snapshot we expect changes.

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v6/124X_dataRun3_HLT_frozen_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_HLT_relval_v1/125X_dataRun3_HLT_relval_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v6/124X_dataRun3_Express_frozen_v8
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v5/124X_dataRun3_Prompt_frozen_v7

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but prob should be backported to 12_4_X