### PR TITLE
improve logging of `addOnTests`

### DIFF
--- a/Utilities/ReleaseScripts/scripts/addOnTests.py
+++ b/Utilities/ReleaseScripts/scripts/addOnTests.py
@@ -13,7 +13,6 @@ scriptPath = os.path.dirname( os.path.abspath(sys.argv[0]) )
 if scriptPath not in sys.path:
     sys.path.append(scriptPath)
 
-
 class testit(Thread):
     def __init__(self,dirName, commandList):
         Thread.__init__(self)
@@ -24,44 +23,34 @@ class testit(Thread):
         self.nfail=[]
         self.npass=[]
 
-        return
-
     def run(self):
+        try:
+            os.makedirs(self.dirName)
+        except:
+            pass
 
-        startime='date %s' %time.asctime()
-        exitCodes = []
+        with open(self.dirName+'/cmdLog', 'w') as clf:
+            clf.write(f'# {self.dirName}\n')
 
-        for command in self.commandList:
+            for cmdIdx, command in enumerate(self.commandList):
+                clf.write(f'\n{command}\n')
 
-            if not os.path.exists(self.dirName):
-                os.makedirs(self.dirName)
+                time_start = time.time()
+                exitcode = os.system(f'cd {self.dirName} && {command} > step{cmdIdx+1}.log 2>&1')
+                time_elapsed_sec = round(time.time() - time_start)
 
-            commandbase = command.replace(' ','_').replace('/','_')
-            logfile='%s.log' % commandbase[:150].replace("'",'').replace('"','').replace('../','')
-
-            executable = 'cd '+self.dirName+'; '+command+' > '+logfile+' 2>&1'
-
-            ret = os.system(executable)
-            exitCodes.append( ret )
-
-        endtime='date %s' %time.asctime()
-        tottime='%s-%s'%(endtime,startime)
-
-        for i in range(len(self.commandList)):
-            command = self.commandList[i]
-            exitcode = exitCodes[i]
-            if exitcode != 0:
-                log='%s : FAILED - time: %s s - exit: %s\n' %(command,tottime,exitcode)
-                self.report+='%s\n'%log
-                self.nfail.append(1)
-                self.npass.append(0)
-            else:
-                log='%s : PASSED - time: %s s - exit: %s\n' %(command,tottime,exitcode)
-                self.report+='%s\n'%log
-                self.nfail.append(0)
-                self.npass.append(1)
-
-        return
+                timelog = f'elapsed time: {time_elapsed_sec} sec (ended on {time.asctime()})'
+                logline = f'[{self.dirName}:{cmdIdx+1}] {command} : '
+                if exitcode != 0:
+                    logline += 'FAILED'
+                    self.nfail.append(1)
+                    self.npass.append(0)
+                else:
+                    logline += 'PASSED'
+                    self.nfail.append(0)
+                    self.npass.append(1)
+                logline += f' - {timelog} - exit: {exitcode}'
+                self.report += logline+'\n\n'
 
 class StandardTester(object):
 
@@ -95,25 +84,25 @@ class StandardTester(object):
                 }
 
         hltTests = {}
-        hltFlag_data = ' realData=True  globalTag=@ inputFiles=@ '
-        hltFlag_mc   = ' realData=False globalTag=@ inputFiles=@ '
+        hltFlag_data = 'realData=True globalTag=@ inputFiles=@'
+        hltFlag_mc = 'realData=False globalTag=@ inputFiles=@'
         from Configuration.HLT.addOnTestsHLT import addOnTestsHLT
         hltTestsToAdd = addOnTestsHLT()
         for key in hltTestsToAdd:
             if '_data_' in key:
                 hltTests[key] = [hltTestsToAdd[key][0],
-                                 'cmsRun '+self.file2Path(hltTestsToAdd[key][1])+hltFlag_data,
+                                 'cmsRun '+self.file2Path(hltTestsToAdd[key][1])+' '+hltFlag_data,
                                  hltTestsToAdd[key][2]]
             elif '_mc_' in key:
                 hltTests[key] = [hltTestsToAdd[key][0],
-                                 'cmsRun '+self.file2Path(hltTestsToAdd[key][1])+hltFlag_mc,
+                                 'cmsRun '+self.file2Path(hltTestsToAdd[key][1])+' '+hltFlag_mc,
                                  hltTestsToAdd[key][2]]
             else:
                 hltTests[key] = [hltTestsToAdd[key][0],
                                  'cmsRun '+self.file2Path(hltTestsToAdd[key][1]),
                                  hltTestsToAdd[key][2]]
 
-        self.commands={}
+        self.commands = {}
         for dirName, command in lines.items():
             self.commands[dirName] = command
 


### PR DESCRIPTION
#### PR description:

This PR is alternative to #36423.

The issue is that different "addon" tests can produce log files with the same basename. When one of these tests fails, the `cmsbuild` bot has trouble identifying which test failed (see https://github.com/cms-sw/cmssw/pull/40011#issuecomment-1306810543 for an example).

The (potential) fix in #36423 is minimal but fragile. This PR is more invasive, and changes the names of the `addOnTests` logs in order to make them unique by construction.

With this PR, a "addon" test `XYZ` with N steps creates log files named `XYZ/step{1,..,N}.log`. In addition, a text file named `cmdLog` with the list of steps is added to every addon sub-directory `XYZ`. Lines in the main log file of the `addOnTests` have the following format
```
[hlt_data_PRef:1] cmsDriver.py RelVal -s L1REPACK:Full --data --scenario=pp -n 10 --conditions auto:run3_hlt_PRef --relval 9000,50 --datatier "RAW" --customise=HLTrigger/Configuration/CustomConfigs.L1T --era Run3 --eventcontent RAW --fileout file:RelVal_Raw_PRef_DATA.root --filein root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/Run2022B_HLTPhysics0_run355558/cd851cf4-0fca-4d76-b80e-1d33e1371929.root : PASSED - elapsed time: 26 sec (ended on Tue Nov  8 23:34:13 2022) - exit: 0

[hlt_data_PRef:2] cmsRun /work/missiroli_m/test/tsg/storm/devel_addOnTestsLogFileName/CMSSW_12_6_0_pre4/src/HLTrigger/Configuration/test/OnLine_HLT_PRef.py realData=True globalTag=@ inputFiles=@ : PASSED - elapsed time: 56 sec (ended on Tue Nov  8 23:35:10 2022) - exit: 0

[hlt_data_PRef:3] cmsDriver.py RelVal -s HLT:PRef,RAW2DIGI,L1Reco,RECO --data --scenario=pp -n 10 --conditions auto:run3_data_PRef --relval 9000,50 --datatier "RAW-HLT-RECO" --eventcontent FEVTDEBUGHLT --customise=HLTrigger/Configuration/CustomConfigs.L1THLT --customise=HLTrigger/Configuration/CustomConfigs.HLTRECO --customise=HLTrigger/Configuration/CustomConfigs.customiseGlobalTagForOnlineBeamSpot --era Run3 --processName=HLTRECO --filein file:RelVal_Raw_PRef_DATA.root --fileout file:RelVal_Raw_PRef_DATA_HLT_RECO.root : PASSED - elapsed time: 84 sec (ended on Tue Nov  8 23:36:35 2022) - exit: 0
```
The first bit, i.e. `[test:N]`, is added for clarity, and to allow the bot to find the correct log file without ambiguities.

The way elapsed time is reported for every given addon test is also updated.

This PR requires https://github.com/cms-sw/cms-bot/pull/1879.

#### PR validation:

`addOnTests.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
