### PR TITLE
fix `gcc11` compilation issues in `CompareAlignments`, post #38304 merge

### DIFF
--- a/Alignment/OfflineValidation/src/CompareAlignments.cc
+++ b/Alignment/OfflineValidation/src/CompareAlignments.cc
@@ -227,8 +227,7 @@ void CompareAlignments::MergeRootfile(TDirectory *target, TList *sourcelist, TLi
         } else if (wrongphase) {
           //nothing
         } else {
-          std::cerr << "Histogram " << key2->GetTitle() << " is not present in file " << nextsource->GetName()
-                    << std::endl;
+          std::cerr << "Histogram " << path << " is not present in file " << nextsource->GetName() << std::endl;
         }
 
         nextsource = (TFile *)sourcelist->After(nextsource);


### PR DESCRIPTION
#### PR description:

Minimal set of fixes, to avoid compilation issues with `Alignment/OfflineValidation` in `gcc11` IBs, post #38304 merge (see [IB logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_12_6_X_2022-11-08-2300/Alignment/OfflineValidation) )

#### PR validation:

`cmssw` compiles in `el8_amd64_gcc11`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

@TomasKello, please cross-check
