### PR TITLE
isrptmin2fac option for PS weights in Pythia 8.306 

### DIFF
--- a/Configuration/Generator/python/PSweightsPythia/PythiaPSweightsSettings_cfi.py
+++ b/Configuration/Generator/python/PSweightsPythia/PythiaPSweightsSettings_cfi.py
@@ -48,7 +48,7 @@ isr_X2XG_cNS_up isr:X2XG:cNS=2.0}',
         'UncertaintyBands:overSampleFSR = 10.0',
         'UncertaintyBands:overSampleISR = 10.0',
         'UncertaintyBands:FSRpTmin2Fac = 20',
-        'UncertaintyBands:ISRpTmin2Fac = 1'
+        'UncertaintyBands:ISRpTmin2Fac = 20' # for consistency with UL and P8.240 set to 20, to be optimized and changed for Run 3 re-MC  
         )
 )
 


### PR DESCRIPTION
Due to a bug in P8.240 the initialization of isrptmin2fac happened via the setting of fsrptmin2fac. As the performance of the PS weights was tuned 5 years ago with the wrong setting and accepted, we plan to use the same for the first MC round of Run3 as additional validation would further delay the start. 

#### PR validation:
I was asked to initiate the process. Validation is running. Feedback will follow later today. 
 
The PR will be back-ported to 12_4. 

@smrenna @Saptaparna @menglu21 @bbilin  
