### PR TITLE
Adding HZZ electron ID mva score to miniAOD for Run3

### DIFF
--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -7,6 +7,7 @@ import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso
 import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V1_cff as ele_fall17_noIso_v1
 import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff as ele_fall17_iso_v2
 import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_noIso_V2_cff as ele_fall17_noIso_v2
+import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Summer18UL_ID_ISO_cff as ele_summer18UL_hzz
 
 
 #photon mva ids
@@ -44,6 +45,7 @@ for ele_mva_cff in [
           ele_fall17_noIso_v1,
           ele_fall17_iso_v2,
           ele_fall17_noIso_v2,
+          ele_summer18UL_hzz
         ]:
 
     setup_mva(egamma_modifications[0].electron_config,


### PR DESCRIPTION
#### PR description:

This PR includes only the addition of a variable for HZZ electron ID mva score to miniAOD for Run3. 
Up to now, in Run3 miniAOD samples we were only storing HZZ ID decision, and not the mva scores. While, for Run3 nanoAOD, we are storing also HZZ mva scores. This is causing inconsistency between the mini and nano AODs. The main problem is that if any analysis team wants to use HZZ ID in Run3 but with a different cut, can't do that in miniAOD but only in nanoAOD. 
This PR solves that discrepancy. We have plan to retrain HZZ electron mva ID using Run3 samples, but it will take time to converge. Until then the Run2 UL HZZ ID is good enough to be used.

#### PR validation:

- Tested with `runTheMatrix.py -l 12434.0 ` and verified that the new variable is added correctly

@swagata87 pls follow

