### PR TITLE
change default isrptmin2fac to recover ul behavior in first run3 mc

### DIFF
--- a/Configuration/Generator/python/PSweightsPythia/PythiaPSweightsSettings_cfi.py
+++ b/Configuration/Generator/python/PSweightsPythia/PythiaPSweightsSettings_cfi.py
@@ -48,7 +48,7 @@ isr_X2XG_cNS_up isr:X2XG:cNS=2.0}',
         'UncertaintyBands:overSampleFSR = 10.0',
         'UncertaintyBands:overSampleISR = 10.0',
         'UncertaintyBands:FSRpTmin2Fac = 20',
-        'UncertaintyBands:ISRpTmin2Fac = 1'
+        'UncertaintyBands:ISRpTmin2Fac = 20' # for consistency with UL and P8.240 set to 20, to be optimized and changed for Run 3 re-MC  
         )
 )
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/40038 to 12_4 which will be used in run3 winter campaign for mc production 