### PR TITLE
Add Run 3 patjet process with supported b-taggers

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -99,6 +99,47 @@ _patJets = _mod.PATJetProducer.clone(
     resolutions     = dict()
 )
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(_patJets,
+              jetSource = "ak4PFJetsCHS",
+              genJetMatch = "patJetGenJetMatch",
+              genPartonMatch = "patJetPartonMatch",
+              JetFlavourInfoSource = "patJetFlavourAssociation",
+              JetPartonMapSource = "patJetFlavourAssociationLegacy",
+              jetCorrFactorsSource = ["patJetCorrFactors"],
+              addBTagInfo          = True,   ## master switch
+              addDiscriminators    = True,   ## addition btag disc.
+              discriminatorSources = ["pfJetBProbabilityBJetTags",
+                                      "pfJetProbabilityBJetTags",
+                                      "pfTrackCountingHighEffBJetTags",
+                                      # DeepFlavour
+                                      'pfDeepCSVJetTags:probb',
+                                      'pfDeepCSVJetTags:probc',
+                                      'pfDeepCSVJetTags:probudsg',
+                                      'pfDeepCSVJetTags:probbb',
+                                      # New DeepFlavour (commented until available in RelVals)
+                                      #'pfDeepFlavourJetTags:probb',
+                                      #'pfDeepFlavourJetTags:probbb',
+                                      #'pfDeepFlavourJetTags:problepb',
+                                      #'pfDeepFlavourJetTags:probc',
+                                      #'pfDeepFlavourJetTags:probuds',
+                                      #'pfDeepFlavourJetTags:probg'
+                                      #'pfDeepFlavourJetTags:probuds',
+                                      #'pfDeepFlavourJetTags:probg'
+                                     ],
+              addTagInfos     = False,
+              tagInfoSources  = [],
+              # track association
+              addAssociatedTracks    = True,
+              trackAssociationSource = "ak4JetTracksAssociatorAtVertexPF",
+              # jet charge
+              addJetCharge    = True,
+              jetChargeSource = "patJetCharge",
+
+              addJetID = False,
+              jetIDMap = "ak4JetID",
+)
+
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(_patJets, 
                        jetSource = "akCs4PFJets",


### PR DESCRIPTION
#### PR description:

Regarding the AlCa issue https://github.com/cms-sw/cmssw/pull/58 (https://github.com/cms-AlCaDB/AlCaTools/issues/58), old b-tagging GT records are request to be removed (starting) from 12_1_X (and so on). Due to the dependency on "BTauGenericMVAJetTagComputerRcd" and "JetTagComputerRecord", the corresponding b-tagging computers need to be masked in run3. Only DNN taggers will be the only supported ones in run3. To accommodate the change, this PR changes the discriminator sources with Era Modifier.

#### PR validation:

PR tested locally with runTheMatrix with Run3 era and 125X_mcRun3_2022_realistic_Queue condition.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport and no backport expected.