### PR TITLE
Allow SwitchProducer case-EDProducers to produce different transient products

### DIFF
--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -230,20 +230,12 @@ TEST_CASE("Configuration with different branches", s_tag) {
   const std::string baseConfig1 = makeConfig(true, test1, test2);
   const std::string baseConfig2 = makeConfig(false, test1, test2);
 
-  SECTION("Different branches are not allowed") {
+  SECTION("Different branches are allowed") {
     edm::test::TestProcessor::Config config1{baseConfig1};
-    REQUIRE_THROWS_WITH(
-        edm::test::TestProcessor(config1),
-        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case") &&
-            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
-            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
+    edm::test::TestProcessor testProcessor1(config1);
 
     edm::test::TestProcessor::Config config2{baseConfig2};
-    REQUIRE_THROWS_WITH(
-        edm::test::TestProcessor(config2),
-        Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case") &&
-            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
-            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
+    edm::test::TestProcessor testProcessor2(config2);
   }
 }
 
@@ -261,20 +253,12 @@ TEST_CASE("Configuration with different branches with EDAlias", s_tag) {
   const std::string baseConfig1 = makeConfig(true, test1, test2, otherprod, othername);
   const std::string baseConfig2 = makeConfig(false, test1, test2, otherprod, othername);
 
-  SECTION("Different branches are not allowed") {
+  SECTION("Different branches are allowed") {
     edm::test::TestProcessor::Config config1{baseConfig1};
-    REQUIRE_THROWS_WITH(
-        edm::test::TestProcessor(config1),
-        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case") &&
-            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
-            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
+    edm::test::TestProcessor testProcessor1(config1);
 
     edm::test::TestProcessor::Config config2{baseConfig2};
-    REQUIRE_THROWS_WITH(
-        edm::test::TestProcessor(config2),
-        Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case") &&
-            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
-            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
+    edm::test::TestProcessor testProcessor2(config2);
   }
 }
 

--- a/FWCore/Integration/test/testSwitchProducerTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTask_cfg.py
@@ -7,7 +7,8 @@ class SwitchProducerTest(cms.SwitchProducer):
         super(SwitchProducerTest,self).__init__(
             dict(
                 test1 = lambda accelerators: (True, -10),
-                test2 = lambda accelerators: (enableTest2, -9)
+                test2 = lambda accelerators: (enableTest2, -9),
+                test3 = lambda accelerators: (True, -11)
             ), **kargs)
 
 process = cms.Process("PROD1")
@@ -48,9 +49,11 @@ process.intProducer = SwitchProducerTest(
     test2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
 )
 # Test also existence of another SwitchProducer here
+# Note that test3 exists only to show it is allowed for different cases to have different products
 process.intProducerOther = SwitchProducerTest(
     test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1")),
-    test2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
+    test2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2")),
+    test3 = cms.EDProducer("ToyDoubleProducer", dvalue = cms.double(1.0))
 )
 # SwitchProducer with an alias
 process.intProducerAlias = SwitchProducerTest(


### PR DESCRIPTION
#### PR description:

Allow SwitchProducer case-EDProducers to produce different transient products. This is simply a matter of removing code that checked whether they were the same and threw an exception if they were not.

#### PR validation:

Modifies existing tests to demonstrate an exception is no longer thrown if the products of different cases are not the same.
