### PR TITLE
MTD geometry and reconstruction: update locaPosition in RectangularMTDTopology and adapt cluster accordingly

### DIFF
--- a/DataFormats/FTLRecHit/interface/FTLCluster.h
+++ b/DataFormats/FTLRecHit/interface/FTLCluster.h
@@ -118,12 +118,12 @@ public:
 
   // linear average position (barycenter)
   inline float x() const {
-    auto x_pos = [this](unsigned int i) { return this->theHitOffset[i * 2] + minHitRow() + 0.5f; };
+    auto x_pos = [this](unsigned int i) { return this->theHitOffset[i * 2] + minHitRow(); };
     return weighted_mean(this->theHitENERGY, x_pos);
   }
 
   inline float y() const {
-    auto y_pos = [this](unsigned int i) { return this->theHitOffset[i * 2 + 1] + minHitCol() + 0.5f; };
+    auto y_pos = [this](unsigned int i) { return this->theHitOffset[i * 2 + 1] + minHitCol(); };
     return weighted_mean(this->theHitENERGY, y_pos);
   }
 

--- a/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
+++ b/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
@@ -54,14 +54,14 @@ LocalPoint RectangularMTDTopology::localPosition(const MeasurementPoint& mp) con
 // measuremet to local transformation for X coordinate
 float RectangularMTDTopology::localX(const float mpx) const {
   // The final position in local coordinates
-  float lpX = mpx * m_pitchx + m_xoffset;
+  float lpX = (mpx + 0.5f) * m_pitchx + m_xoffset;
 
   return lpX;
 }
 
 float RectangularMTDTopology::localY(const float mpy) const {
   // The final position in local coordinates
-  float lpY = mpy * m_pitchy + m_yoffset;
+  float lpY = (mpy + 0.5f) * m_pitchy + m_yoffset;
 
   return lpY;
 }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -198,7 +198,6 @@ BtlLocalRecoValidation::BtlLocalRecoValidation(const edm::ParameterSet& iConfig)
   btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
   btlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
   mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
-
 }
 
 BtlLocalRecoValidation::~BtlLocalRecoValidation() {}

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -42,6 +42,9 @@
 
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
+#include "RecoLocalFastTime/Records/interface/MTDCPERecord.h"
+#include "RecoLocalFastTime/FTLClusterizer/interface/MTDClusterParameterEstimator.h"
+
 #include "MTDHit.h"
 
 class BtlLocalRecoValidation : public DQMEDAnalyzer {
@@ -72,8 +75,9 @@ private:
   edm::EDGetTokenT<FTLClusterCollection> btlRecCluToken_;
   edm::EDGetTokenT<MTDTrackingDetSetVector> mtdTrackingHitToken_;
 
-  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
-  edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
+  const edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  const edm::ESGetToken<MTDClusterParameterEstimator, MTDCPERecord> cpeToken_;
 
   // --- histograms declaration
 
@@ -183,7 +187,10 @@ BtlLocalRecoValidation::BtlLocalRecoValidation(const edm::ParameterSet& iConfig)
       hitMinEnergy_(iConfig.getParameter<double>("HitMinimumEnergy")),
       optionalPlots_(iConfig.getParameter<bool>("optionalPlots")),
       uncalibRecHitsPlots_(iConfig.getParameter<bool>("UncalibRecHitsPlots")),
-      hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")) {
+      hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")),
+      mtdgeoToken_(esConsumes<MTDGeometry, MTDDigiGeometryRecord>()),
+      mtdtopoToken_(esConsumes<MTDTopology, MTDTopologyRcd>()),
+      cpeToken_(esConsumes<MTDClusterParameterEstimator, MTDCPERecord>(edm::ESInputTag("", "MTDCPEBase"))) {
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
   if (uncalibRecHitsPlots_)
     btlUncalibRecHitsToken_ =
@@ -192,8 +199,6 @@ BtlLocalRecoValidation::BtlLocalRecoValidation(const edm::ParameterSet& iConfig)
   btlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
   mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
 
-  mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
-  mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
 }
 
 BtlLocalRecoValidation::~BtlLocalRecoValidation() {}
@@ -209,6 +214,8 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
   const MTDTopology* topology = topologyHandle.product();
+
+  auto const& cpe = iSetup.getData(cpeToken_);
 
   auto btlRecHitsHandle = makeValid(iEvent.getHandle(btlRecHitsToken_));
   auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
@@ -350,8 +357,10 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(genericDet->topology());
       const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
+      MTDClusterParameterEstimator::ReturnType tuple = cpe.getParameters(cluster, *genericDet);
+
       // --- Cluster position in the module reference frame
-      Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
+      LocalPoint local_point(std::get<0>(tuple));
       const auto& global_point = genericDet->toGlobal(local_point);
 
       meCluEnergy_->Fill(cluster.energy());

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -1,6 +1,8 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/MTDGeometryBuilder"/>
+<use name="RecoLocalFastTime/Records"/>
+<use name="RecoLocalFastTime/FTLClusterizer"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/TrackReco"/>

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -39,6 +39,9 @@
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
+#include "RecoLocalFastTime/Records/interface/MTDCPERecord.h"
+#include "RecoLocalFastTime/FTLClusterizer/interface/MTDClusterParameterEstimator.h"
+
 #include "MTDHit.h"
 
 class EtlLocalRecoValidation : public DQMEDAnalyzer {
@@ -70,8 +73,9 @@ private:
   edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
   edm::EDGetTokenT<MTDTrackingDetSetVector> mtdTrackingHitToken_;
 
-  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
-  edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
+  const edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  const edm::ESGetToken<MTDClusterParameterEstimator, MTDCPERecord> cpeToken_;
 
   // --- histograms declaration
 
@@ -153,7 +157,10 @@ EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
       hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")),
       optionalPlots_(iConfig.getParameter<bool>("optionalPlots")),
       uncalibRecHitsPlots_(iConfig.getParameter<bool>("UncalibRecHitsPlots")),
-      hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")) {
+      hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")),
+      mtdgeoToken_(esConsumes<MTDGeometry, MTDDigiGeometryRecord>()),
+      mtdtopoToken_(esConsumes<MTDTopology, MTDTopologyRcd>()),
+      cpeToken_(esConsumes<MTDClusterParameterEstimator, MTDCPERecord>(edm::ESInputTag("", "MTDCPEBase"))) {
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
   if (uncalibRecHitsPlots_)
     etlUncalibRecHitsToken_ =
@@ -162,8 +169,6 @@ EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
   mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
 
-  mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
-  mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
 }
 
 EtlLocalRecoValidation::~EtlLocalRecoValidation() {}
@@ -179,6 +184,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
   const MTDTopology* topology = topologyHandle.product();
+
+  auto const& cpe = iSetup.getData(cpeToken_);
 
   bool topo1Dis = false;
   bool topo2Dis = false;
@@ -371,10 +378,11 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         throw cms::Exception("EtlLocalRecoValidation")
             << "GeographicalID: " << std::hex << cluId << " is invalid!" << std::dec << std::endl;
       }
-      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(genericDet->topology());
-      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-      Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
+      MTDClusterParameterEstimator::ReturnType tuple = cpe.getParameters(cluster, *genericDet);
+
+      // --- Cluster position in the module reference frame
+      LocalPoint local_point(std::get<0>(tuple));
       const auto& global_point = genericDet->toGlobal(local_point);
 
       int idet = 999;

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -168,7 +168,6 @@ EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
   etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
   mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
-
 }
 
 EtlLocalRecoValidation::~EtlLocalRecoValidation() {}


### PR DESCRIPTION
#### PR description:

The ```locaPosition```, ```localX``` and ```localY``` methods of ```RectangularMTDTopology``` do not provide, as naively expected, the center of a pixel as its reference position, but its left-bottom corner. This is counterintuitive and forces to some odd coding in the clustering algorithm. It is compensated by a shift by 0.5 pixel in the calculation of the cluster x and y coordinates in the corresponding DataFormat. In order to have a clean situation, the shift is moved from the cluster position calculation to the basic topology code itself.

This should have no net impact, given the limited use of these methods, and the fact that its use inside the BTL clustering is effectively dummy so far. In preparation of a further PR which updates the clustering code, I propose initially this update.

With the occasion, I update the local reconstruction validation code to properly use the cluster parameter estimator code to extract the position, without replicating its methods (which are going to change in next developments).

#### PR validation:

The code was tested with single muon workflow 20903 (scenario D88), showing that the cluster resolution and pull remains consistent with the existing result. The shift in tracking hits position printed from debug statements looks consistent with the  proposed update of reference position.