### PR TITLE
Improve cpu feature discover on ppc and aarch64

### DIFF
--- a/FWCore/Services/plugins/BuildFile.xml
+++ b/FWCore/Services/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="Utilities/XrdAdaptor"/>
 <use name="boost"/>
 <use name="gcc-atomic"/>
+<use name="cpu_features"/>
 <library file="*.cc" name="FWCoreServicesPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -266,16 +266,16 @@ namespace edm {
 
       std::string model;
 #if defined(CPU_FEATURES_ARCH_X86)
-      const auto info { GetX86Info() };
+      const auto info{GetX86Info()};
       model = info.brand_string;
 #elif defined(CPU_FEATURES_ARCH_ARM)
-      const auto info { GetArmInfo() };
+      const auto info{GetArmInfo()};
       model = fmt::format("ARM {} {} {}", info.implementer, info.architecture, info.variant);
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
-      const auto info { GetAarch64Info() };
+      const auto info{GetAarch64Info()};
       model = fmt::format("aarch64 {} {}", info.implementer, info.variant);
 #elif defined(CPU_FEATURES_ARCH_PPC)
-      const auto strings { GetPPCPlatformStrings() };
+      const auto strings{GetPPCPlatformStrings()};
       model = strings.machine;
 #endif
       return model;

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -25,7 +25,7 @@
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
 #include "cpu_features/cpuinfo_aarch64.h"
 #elif defined(CPU_FEATURES_ARCH_MIPS)
-#include "cpu_features/cpuinfo_mips.h"
+//#include "cpu_features/cpuinfo_mips.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpu_features/cpuinfo_ppc.h"
 #endif
@@ -38,6 +38,7 @@
 #include <fstream>
 #include <sstream>
 #include <set>
+#include <fmt/format.h>
 
 #ifdef __linux__
 #include <sched.h>
@@ -270,11 +271,11 @@ namespace edm {
       const X86Info info = GetX86Info();
       model = info.brand_string;
 #elif defined(CPU_FEATURES_ARCH_ARM)
-      //const ArmInfo info = GetArmInfo();
-      model = "ARM";
+      const ArmInfo info = GetArmInfo();
+      model = fmt::format("ARM {} {} {}", info.implementer, info.architecture, info.variant);
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
-      //const Aarch64Info info = GetAarch64Info();
-      model = "aarch64";
+      const Aarch64Info info = GetAarch64Info();
+      model = fmt::format("aarch64 {} {}", info.implementer, info.variant);
 #elif defined(CPU_FEATURES_ARCH_MIPS)
       model = "mips";
 #elif defined(CPU_FEATURES_ARCH_PPC)

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -24,8 +24,6 @@
 #include "cpu_features/cpuinfo_arm.h"
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
 #include "cpu_features/cpuinfo_aarch64.h"
-#elif defined(CPU_FEATURES_ARCH_MIPS)
-//#include "cpu_features/cpuinfo_mips.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpu_features/cpuinfo_ppc.h"
 #endif
@@ -268,18 +266,16 @@ namespace edm {
 
       std::string model;
 #if defined(CPU_FEATURES_ARCH_X86)
-      const X86Info info = GetX86Info();
+      const auto info { GetX86Info() };
       model = info.brand_string;
 #elif defined(CPU_FEATURES_ARCH_ARM)
-      const ArmInfo info = GetArmInfo();
+      const auto info { GetArmInfo() };
       model = fmt::format("ARM {} {} {}", info.implementer, info.architecture, info.variant);
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
-      const Aarch64Info info = GetAarch64Info();
+      const auto info { GetAarch64Info() };
       model = fmt::format("aarch64 {} {}", info.implementer, info.variant);
-#elif defined(CPU_FEATURES_ARCH_MIPS)
-      model = "mips";
 #elif defined(CPU_FEATURES_ARCH_PPC)
-      const PPCPlatformStrings strings = GetPPCPlatformStrings();
+      const auto strings { GetPPCPlatformStrings() };
       model = strings.machine;
 #endif
       return model;

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -19,5 +19,6 @@
 <bin file="test_catch2_*.cc" name="testFWCoreServicesCatch2">
   <use name="catch2"/>
   <use name="clhep"/>
+  <use name="cpu_features"/>
   <use name="FWCore/Services"/>
 </bin>

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -11,7 +11,7 @@
 
 <ifrelease name="!_ASAN_">
   <bin file="TestFWCoreServicesDriver.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_sitelocalconfig.sh test_resource.sh test_zombiekiller.sh"/>
+    <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_sitelocalconfig.sh test_resource.sh test_zombiekiller.sh test_cpu.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
 </ifrelease>

--- a/FWCore/Services/test/test_CPU.py
+++ b/FWCore/Services/test/test_CPU.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.add_(cms.Service("CPU"))
+
+process.thing = cms.EDProducer("ThingProducer")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+process.p = cms.Path(process.thing)

--- a/FWCore/Services/test/test_catch2_cpu_features.cc
+++ b/FWCore/Services/test/test_catch2_cpu_features.cc
@@ -10,8 +10,6 @@
 #include "cpu_features/cpuinfo_arm.h"
 #elif defined(CPU_FEATURES_ARCH_AARCH64)
 #include "cpu_features/cpuinfo_aarch64.h"
-#elif defined(CPU_FEATURES_ARCH_MIPS)
-#include "cpu_features/cpuinfo_mips.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpu_features/cpuinfo_ppc.h"
 #endif
@@ -21,7 +19,6 @@ TEST_CASE("Test cpu_features library", "[cpu_features]") {
 
 #if defined(CPU_FEATURES_ARCH_X86)
   const X86Info info = GetX86Info();
-  //const CacheInfo cache_info = GetX86CacheInfo();
   std::cout << "arch:     "
             << "x86"
             << "\nbrand:    " << info.brand_string << "\nfamily:   " << info.family << "\nmodel:    " << info.model
@@ -40,9 +37,6 @@ TEST_CASE("Test cpu_features library", "[cpu_features]") {
             << "aarch64"
             << "\nimplementer: " << info.implementer << "\nvariant:     " << info.variant
             << "\npart:        " << info.part << "\nrevision:    " << info.revision << std::endl;
-#elif defined(CPU_FEATURES_ARCH_MIPS)
-  std::cout << "arch: "
-            << "mips" << std::endl;
 #elif defined(CPU_FEATURES_ARCH_PPC)
   const PPCPlatformStrings strings = GetPPCPlatformStrings();
   std::cout << "arch:              "

--- a/FWCore/Services/test/test_catch2_cpu_features.cc
+++ b/FWCore/Services/test/test_catch2_cpu_features.cc
@@ -1,0 +1,55 @@
+#include <iostream>
+
+#include "catch.hpp"
+
+#include "cpu_features/cpu_features_macros.h"
+
+#if defined(CPU_FEATURES_ARCH_X86)
+#include "cpu_features/cpuinfo_x86.h"
+#elif defined(CPU_FEATURES_ARCH_ARM)
+#include "cpu_features/cpuinfo_arm.h"
+#elif defined(CPU_FEATURES_ARCH_AARCH64)
+#include "cpu_features/cpuinfo_aarch64.h"
+#elif defined(CPU_FEATURES_ARCH_MIPS)
+#include "cpu_features/cpuinfo_mips.h"
+#elif defined(CPU_FEATURES_ARCH_PPC)
+#include "cpu_features/cpuinfo_ppc.h"
+#endif
+
+TEST_CASE("Test cpu_features library", "[cpu_features]") {
+  using namespace cpu_features;
+
+#if defined(CPU_FEATURES_ARCH_X86)
+  const X86Info info = GetX86Info();
+  //const CacheInfo cache_info = GetX86CacheInfo();
+  std::cout << "arch:     "
+            << "x86"
+            << "\nbrand:    " << info.brand_string << "\nfamily:   " << info.family << "\nmodel:    " << info.model
+            << "\nstepping: " << info.stepping
+            << "\nuarch:    " << GetX86MicroarchitectureName(GetX86Microarchitecture(&info)) << std::endl;
+#elif defined(CPU_FEATURES_ARCH_ARM)
+  const ArmInfo info = GetArmInfo();
+  std::cout << "arch          "
+            << "ARM"
+            << "\nimplementer:  " << info.implementer << "\narchitecture: " << info.architecture
+            << "\nvariant:      " << info.variant << "\npart:         " << info.part
+            << "\nrevision:     " << info.revision << std::endl;
+#elif defined(CPU_FEATURES_ARCH_AARCH64)
+  const Aarch64Info info = GetAarch64Info();
+  std::cout << "arch:        "
+            << "aarch64"
+            << "\nimplementer: " << info.implementer << "\nvariant:     " << info.variant
+            << "\npart:        " << info.part << "\nrevision:    " << info.revision << std::endl;
+#elif defined(CPU_FEATURES_ARCH_MIPS)
+  std::cout << "arch: "
+            << "mips" << std::endl;
+#elif defined(CPU_FEATURES_ARCH_PPC)
+  const PPCPlatformStrings strings = GetPPCPlatformStrings();
+  std::cout << "arch:              "
+            << "ppc"
+            << "\nplatform:          " << strings.platform << "\nmodel:             " << strings.model
+            << "\nmachine:           " << strings.machine << "\ncpu:               " << strings.cpu
+            << "\ninstruction:       " << strings.type.platform << "\nmicroarchitecture: " << strings.type.base_platform
+            << std::endl;
+#endif
+}

--- a/FWCore/Services/test/test_cpu.sh
+++ b/FWCore/Services/test/test_cpu.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/test_CPU.py
+
+(cmsRun -j test_CPU.xml $F1 ) || die "Failure using $F1" $?
+grep -v '""' test_CPU.xml | grep -q CPUModels || die "CPUModels not found using $F1" $?


### PR DESCRIPTION
#### PR description:

The FWCore/Services CPU plugin only reliably identifies X86-64 CPU types.  Information about other architectures is incomplete or missing due to variations in /proc/cpu, which is what we currently parse to fill in the CPU info.  See #37488 for details.  This PR adds a fallback to the google cpu_features library if the "model name" string isn't found in /proc/cpu.

#### PR validation:

I added two unit tests, one to verify that the cpu_features library is functional, and the second to verify that the CPU service sets a non-empty string for the CPUModels entry in the FJR SystemCPU PerformanceSummary.  Tested on x86-64 and aarch6 (would test on ppc but cvmfs seems to be broken ibmminsky-2 at the moment).