### PR TITLE
Use `fp_traits_non_native` directly in eos-portable-archive

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -371,13 +371,13 @@ namespace eos {
     /** 
 		 * \brief Load floating point types.
 		 * 
-		 * We simply rely on fp_traits to set the bit pattern from the (unsigned)
+		 * We simply rely on fp_traits_non_native to set the bit pattern from the (unsigned)
 		 * integral type that was stored in the stream. Francois Mauger provided
 		 * standardized behaviour for special values like inf and NaN, that need to
 		 * be serialized in his application.
 		 *
 		 * \note by Johan Rade (author of the floating point utilities library):
-		 * Be warned that the math::detail::fp_traits<T>::type::get_bits() function 
+		 * Be warned that the math::detail::fp_traits_non_native<T,U>::get_bits() function
 		 * is *not* guaranteed to give you all bits of the floating point number. It
 		 * will give you all bits if and only if there is an integer type that has
 		 * the same size as the floating point you are copying from. It will not
@@ -397,7 +397,8 @@ namespace eos {
 		 */
     template <typename T>
     typename boost::enable_if<boost::is_floating_point<T> >::type load(T& t, dummy<3> = 0) {
-      typedef typename fp::detail::fp_traits<T>::type traits;
+      typedef typename fp::detail::size_to_precision<sizeof(T), ::std::is_floating_point<T>::value>::type precision;
+      typedef typename fp::detail::fp_traits_non_native<T, precision> traits;
 
       // if you end here there are three possibilities:
       // 1. you're serializing a long double which is not portable

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -353,13 +353,13 @@ namespace eos {
     /**
 		 * \brief Save floating point types.
 		 * 
-		 * We simply rely on fp_traits to extract the bit pattern into an (unsigned)
+		 * We simply rely on fp_traits_non_native to extract the bit pattern into an (unsigned)
 		 * integral type and store that into the stream. Francois Mauger provided
 		 * standardized behaviour for special values like inf and NaN, that need to
 		 * be serialized in his application.
 		 *
 		 * \note by Johan Rade (author of the floating point utilities library):
-		 * Be warned that the math::detail::fp_traits<T>::type::get_bits() function 
+		 * Be warned that the math::detail::fp_traits_non_native<T,U>::get_bits() function 
 		 * is *not* guaranteed to give you all bits of the floating point number. It
 		 * will give you all bits if and only if there is an integer type that has
 		 * the same size as the floating point you are copying from. It will not
@@ -379,7 +379,8 @@ namespace eos {
 		 */
     template <typename T>
     typename boost::enable_if<boost::is_floating_point<T> >::type save(const T& t, dummy<3> = 0) {
-      typedef typename fp::detail::fp_traits<T>::type traits;
+      typedef typename fp::detail::size_to_precision<sizeof(T), ::std::is_floating_point<T>::value>::type precision;
+      typedef typename fp::detail::fp_traits_non_native<T, precision> traits;
 
       // if the no_infnan flag is set we must throw here
       if (get_flags() & no_infnan && !fp::isfinite(t))


### PR DESCRIPTION
In the eos-portable-archive sources that were copy-pasted into `CondFormats/Serialization`, the boost implementation detail `fp_traits<T>::value` is used, which is expected to resolve to `fp_traits_non_native` that has the `bits` and `set_bits` attributes, which are used in the code.

But depending on the compiler flags, `fp_traits<T>::value` can also resolve to `fp_traits_native`, which doesn't have `bits` and `set_bits`. It only works when `BOOST_MATH_DISABLE_STD_FPCLASSIFY` is set.

To make the CMSSW code compile independent of the boost flags, this commit suggests to directly use `fp_traits_non_native` in exactly the same way as it is used inside `fp_traits` in the
`boost/math/special_functions/detail/fp_traits.hpp` header file from boost:

https://github.com/boostorg/math/blob/master/include/boost/math/special_functions/detail/fp_traits.hpp#L570

This PR is part of my ongoing effort of making CMSSW compile on other platforms more easily.

See also:
https://github.com/daldegam/eos-portable-archive/issues/5