### PR TITLE
Replacing jet b-tagger with 'pfDeepCSVJetTags:probb' for Run 3.

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 hltHiggsValidator = DQMEDAnalyzer('HLTHiggsValidator',
@@ -446,3 +447,16 @@ hltHiggsValidator = DQMEDAnalyzer('HLTHiggsValidator',
         minCandidates = cms.uint32(2),
         ), 
 )
+
+hltHiggsValidator_run3 = hltHiggsValidator.clone()
+hltHiggsValidator_run3.VBFHbb_0btag.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.VBFHbb_1btag.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.VBFHbb_2btag.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.ZnnHbb.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.X4b.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.AHttH.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.MSSMHbb.jetTagLabel = "pfDeepCSVJetTags:probb"
+hltHiggsValidator_run3.MSSMHbbmu.jetTagLabel = "pfDeepCSVJetTags:probb"
+
+run3_common.toReplaceWith( hltHiggsValidator, hltHiggsValidator_run3)
+

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from copy import deepcopy
 
@@ -54,6 +56,11 @@ SUSYoHLToEleHToBTagSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient
         ),
                                                                   resolution = cms.vstring('')
                                                                   )
+
+SUSY_HLT_Ele_HT_BTag_SingleLep_run3 = SUSY_HLT_Ele_HT_BTag_SingleLepton.clone()
+SUSY_HLT_Ele_HT_BTag_SingleLep_run3.hltJetTags = 'hltDeepCombinedSecondaryVertexBJetTagsCalo'
+SUSY_HLT_Ele_HT_BTag_SingleLep_run3.jetTagCollection = 'pfDeepCSVJetTags:probb'
+run3_common.toReplaceWith( SUSY_HLT_Ele_HT_BTag_SingleLepton, SUSY_HLT_Ele_HT_BTag_SingleLep_run3 )
 
 # fastsim has no conversion collection (yet)
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from copy import deepcopy
 
@@ -54,4 +56,9 @@ SUSYoHLToMuHToBTagSingleLeptonPOSTPROCESSING = DQMEDHarvester('DQMGenericClient'
         ),
                                                                  resolution = cms.vstring('')
                                                                  )
+
+SUSY_HLT_Mu_HT_BTag_SingleLep_run3 = SUSY_HLT_Mu_HT_BTag_SingleLepton.clone()
+SUSY_HLT_Mu_HT_BTag_SingleLep_run3.hltJetTags = 'hltDeepCombinedSecondaryVertexBJetTagsCalo'
+SUSY_HLT_Mu_HT_BTag_SingleLep_run3.jetTagCollection = 'pfDeepCSVJetTags:probb'
+run3_common.toReplaceWith( SUSY_HLT_Mu_HT_BTag_SingleLepton, SUSY_HLT_Mu_HT_BTag_SingleLep_run3 )
 


### PR DESCRIPTION
#### PR description:

Regarding the AlCa issue https://github.com/cms-sw/cmssw/pull/58 (https://github.com/cms-AlCaDB/AlCaTools/issues/58), old b-tagging GT records are request to be removed (starting) from 12_1_X (and so on). Only DNN taggers will be the only supported ones in run3. This PR is to accommodate the changes for HLT monitors on Higgs and SUSY BSM.

#### PR validation:

PR tested locally with runTheMatrix with Run3 era and 125X_mcRun3_2022_realistic_Queue condition.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport and no backport expected.

PS. As the performance of the b-taggers are different, the cut values may need to re-optimized and the corresponding relval distributions are expected to be changed.