### PR TITLE
Fix in SiPixelQualityESProducer to support two labelled records

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelQualityESProducer.cc
@@ -46,6 +46,7 @@ public:
 
   std::unique_ptr<SiPixelQuality> produce(const SiPixelQualityRcd& iRecord);
   std::unique_ptr<SiPixelQuality> produceWithLabel(const SiPixelQualityRcd& iRecord);
+  std::unique_ptr<SiPixelQuality> produceWithLabelRawToDigi(const SiPixelQualityRcd& iRecord);
 
 private:
   void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
@@ -66,6 +67,7 @@ private:
 
   const Tokens defaultTokens_;
   Tokens labelTokens_;
+  Tokens labelTokens_RawToDigi_;
 };
 
 //
@@ -79,9 +81,18 @@ SiPixelQualityESProducer::SiPixelQualityESProducer(const edm::ParameterSet& conf
   auto label =
       conf_.exists("siPixelQualityLabel") ? conf_.getParameter<std::string>("siPixelQualityLabel") : std::string{};
 
-  if (label == "forDigitizer" || label == "forRawToDigi") {
+  if (label == "forDigitizer") {
     labelTokens_ =
         Tokens(setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabel, edm::es::Label(label)), label);
+  }
+
+  label = conf_.exists("siPixelQualityLabel_RawToDigi")
+              ? conf_.getParameter<std::string>("siPixelQualityLabel_RawToDigi")
+              : std::string{};
+
+  if (label == "forRawToDigi") {
+    labelTokens_RawToDigi_ = Tokens(
+        setWhatProduced(this, &SiPixelQualityESProducer::produceWithLabelRawToDigi, edm::es::Label(label)), label);
   }
   findingRecord<SiPixelQualityRcd>();
 }
@@ -118,6 +129,9 @@ std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produce(const SiPixelQ
 }
 std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produceWithLabel(const SiPixelQualityRcd& iRecord) {
   return get_pointer(iRecord, labelTokens_);
+}
+std::unique_ptr<SiPixelQuality> SiPixelQualityESProducer::produceWithLabelRawToDigi(const SiPixelQualityRcd& iRecord) {
+  return get_pointer(iRecord, labelTokens_RawToDigi_);
 }
 
 void SiPixelQualityESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,

--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
     siPixelQualityLabel = cms.string(""),
+    siPixelQualityLabel_RawToDigi = cms.string("")
 )
 
 from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
 siPixelQualityRawToDigi.toModify(siPixelQualityESProducer,
-    siPixelQualityLabel = 'forRawToDigi',
+    siPixelQualityLabel_RawToDigi = 'forRawToDigi',
 )
 


### PR DESCRIPTION
#### PR description:

This PR addresses the problem with the Run3Summer22 MC campaign reported on [Jira](https://its.cern.ch/jira/browse/PDMVMCPROD-62) where production jobs were crashing when the SiPixelRawToDigi module tried to load a labelled SiPixelQuality payload. 

#### PR validation:

The code compiles and fixes the problem which was occurring in [step2](https://its.cern.ch/jira/browse/PDMVMCPROD-62?focusedCommentId=4618412&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4618412).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

If the tests are successful, the PR will be backported to 12_5_X and 12_4_X.
