### PR TITLE
Fix the `ThroughputService` and `FastTimerService` DQM folders [12.5.x]

### DIFF
--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -13,6 +13,8 @@
 #include "HLTrigger/Timer/interface/processor_model.h"
 #include "ThroughputService.h"
 
+using namespace std::literals;
+
 // describe the module's configuration
 void ThroughputService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -73,6 +75,13 @@ void ThroughputService::preGlobalBeginRun(edm::GlobalContext const& gc) {
     std::string y_axis_title = fmt::sprintf("events / %g s", m_time_resolution);
     unsigned int bins = std::round(m_time_range / m_time_resolution);
     double range = bins * m_time_resolution;
+
+    // clean characters that are deemed unsafe for DQM
+    // see the definition of `s_safe` in DQMServices/Core/src/DQMStore.cc
+    auto safe_for_dqm = "/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# "s;
+    for (auto& c : m_dqm_path)
+      if (safe_for_dqm.find(c) == std::string::npos)
+        c = '_';
 
     // define a callback that can book the histograms
     auto bookTransactionCallback = [&, this](DQMStore::IBooker& booker, DQMStore::IGetter&) {

--- a/HLTrigger/Timer/plugins/ThroughputService.cc
+++ b/HLTrigger/Timer/plugins/ThroughputService.cc
@@ -44,6 +44,7 @@ ThroughputService::ThroughputService(const edm::ParameterSet& config, edm::Activ
       m_time_range(m_enable_dqm ? config.getUntrackedParameter<double>("timeRange") : 0.),
       m_time_resolution(m_enable_dqm ? config.getUntrackedParameter<double>("timeResolution") : 0.) {
   m_events.clear();  // erases all elements, but does not free internal arrays
+  registry.watchPreallocate(this, &ThroughputService::preallocate);
   registry.watchPreGlobalBeginRun(this, &ThroughputService::preGlobalBeginRun);
   registry.watchPreSourceEvent(this, &ThroughputService::preSourceEvent);
   registry.watchPostEvent(this, &ThroughputService::postEvent);


### PR DESCRIPTION
#### PR description:

Include the information about whether Simultaneous Multi Threading (SMT) is enabled or disabled after the processor model name.

Fix the DQM folder used by the `ThroughputService` to take into account the processor model name (and the SMT status) if the corresponding flag is enabled.

#### PR validation:

The processor model name and the SMT status not appear correctly in the DQM folder names for the `FastTimerService` and `ThroughputService`:

![image](https://user-images.githubusercontent.com/4069793/201712860-0c5c9183-e17c-4ef2-97b5-40b8ec5a46b8.png)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40062 to 12.5.x for data taking.