### PR TITLE
Changing abs(eta) cut for tracks in ALCARECOEcalESAlign_cff.py

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_cff.py
+++ b/Calibration/EcalAlCaRecoProducers/python/ALCARECOEcalESAlign_cff.py
@@ -14,7 +14,7 @@ ALCARECOEcalESAlignHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clon
 
 esSelectedTracks = cms.EDFilter("TrackSelector",
                                 src = cms.InputTag('generalTracks'),
-                                cut = cms.string("abs(eta)>1.7 && abs(eta)<2.3 && pt>1 && numberOfValidHits>=10")
+                                cut = cms.string("abs(eta)>1.65 && pt>1 && numberOfValidHits>=10")
                                 )
 
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi


### PR DESCRIPTION
Loosen the abs(eta) cut for the tracks
- lower abs(eta) change from 1.7 to 1.65.
- remove the higher abs(eta) cut

#### PR description:

Change the abs(eta) cut of the track.

- Lower cut change to 1.65
- Remove higher cut

#### PR validation:

Current abs(eta) cut decrease statistic in high eta region of the Preshower. Loosening the eta cut is proposed to increase the hits statistic. Hits occupancy issue can be seen in the plots in my cernbox[1]

[1]https://cernbox.cern.ch/s/FmTTfZvdBRXxKRW
