### PR TITLE
Phase2TrackerDigitizer: Activating Bias Rail Inefficiency

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -25,8 +25,8 @@ PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf, edm:
                                       conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm"),
                                       iC),
       geomToken_(iC.esConsumes()),
-      addBiasRailInefficiency_(
-          conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm").getParameter<bool>("AddBiasRailInefficiency")) {
+      biasRailInefficiencyFlag_(
+          conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm").getParameter<int>("BiasRailInefficiencyFlag")) {
   if (use_LorentzAngle_DB_)
     siPhase2OTLorentzAngleToken_ = iC.esConsumes();
   pixelFlag_ = false;
@@ -37,14 +37,14 @@ PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf, edm:
                                     << "threshold in electron Barrel = " << theThresholdInE_Barrel_ << " "
                                     << theElectronPerADC_ << " " << theAdcFullScale_ << " The delta cut-off is set to "
                                     << tMax_ << " pix-inefficiency " << addPixelInefficiency_
-                                    << "Bias Rail Inefficiency " << addBiasRailInefficiency_;
+                                    << "Bias Rail Inefficiency " << biasRailInefficiencyFlag_;
 }
 PSPDigitizerAlgorithm::~PSPDigitizerAlgorithm() { LogDebug("PSPDigitizerAlgorithm") << "Algorithm deleted"; }
 //
 // -- Select the Hit for Digitization (sigScale will be implemented in future)
 //
 bool PSPDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) const {
-  if (addBiasRailInefficiency_ && isInBiasRailRegion(hit))
+  if (biasRailInefficiencyFlag_ > 0 && isInBiasRailRegion(hit))
     return false;
   double toa = hit.tof() - tCorr;
   return (toa > theTofLowerCut_ && toa < theTofUpperCut_);
@@ -68,10 +68,16 @@ bool PSPDigitizerAlgorithm::isInBiasRailRegion(const PSimHit& hit) const {
   constexpr float block_unit = implant + bRail;
   float yin = hit.entryPoint().y() + block_len;
   float yout = hit.exitPoint().y() + block_len;
-  if (std::fmod(yin, block_unit) > implant && std::fmod(yout, block_unit) > implant)
-    return true;
-  else
-    return false;
+  bool result = false;
+
+  // Flag= 1 corresponds to optimistic case when the entire trajectory is withon the bias rail region the SimHit will be rejected
+  if (biasRailInefficiencyFlag_ == 1 && (std::fmod(yin, block_unit) > implant && std::fmod(yout, block_unit) > implant))
+    result = true;
+  // Flag= 2 corresponds to pessimistic case i.e iven in a small part of the trajectory is inside the bias rain region the SimHit is rejected
+  else if (biasRailInefficiencyFlag_ == 2 &&
+           (std::fmod(yin, block_unit) > implant || std::fmod(yout, block_unit) > implant))
+    result = true;
+  return result;
 }
 //
 // -- Read Bad Channels from the Condidion DB and kill channels/module accordingly

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -68,7 +68,7 @@ bool PSPDigitizerAlgorithm::isInBiasRailRegion(const PSimHit& hit) const {
   constexpr float block_unit = implant + bRail;
   float yin = hit.entryPoint().y() + block_len;
   float yout = hit.exitPoint().y() + block_len;
-  if (std::fmod(yin, block_unit) > implant || std::fmod(yout, block_unit) > implant)
+  if (std::fmod(yin, block_unit) > implant && std::fmod(yout, block_unit) > implant)
     return true;
   else
     return false;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -22,6 +22,6 @@ public:
 private:
   edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
-  bool addBiasRailInefficiency_{false};
+  const int biasRailInefficiencyFlag_{0};
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -127,7 +127,7 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
       CellsToKill = cms.VPSet(),
-      AddBiasRailInefficiency= cms.bool(True)
+      BiasRailInefficiencyFlag = cms.int32(1) # Flag to decide BiasRail inefficiency : no inefficency(0) : inefficiency with optimistic(AND) scenario(1) : inefficiency with pessimistic(OR) scenario(2)
     ),
 #Strip in PS module
     PSSDigitizerAlgorithm = cms.PSet(

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -127,7 +127,7 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
       CellsToKill = cms.VPSet(),
-      AddBiasRailInefficiency= cms.bool(False)
+      AddBiasRailInefficiency= cms.bool(True)
     ),
 #Strip in PS module
     PSSDigitizerAlgorithm = cms.PSet(


### PR DESCRIPTION
#### PR description:
Activating the  bias rails inefficiency for PS-p modules by default as it is the intrinsic to the sensor itself. SimHits are discarded (not considered for Digitization) when the trajectory is entirely inside the bias rail region. At the moment we consider also those SimHits for which the trajectory is partly outside (optimistic scenario with 'AND' condition for Entry/Exit points of SimHits) the bias rail region. 

**Note :** the code was already integrated before we are now switching it on through a configuration parameter. 

We expect to find  less digis in PSP modules due to this inefficiency
  
At the moment we are estimating the effect of this inefficiency in L1 tracking and it is not fully optimized. We might move to a more pessimistic scenario when we shall not consider the SimHits where the the trajectory is event partly inside the bias rail region ( 'OR' condition for Entry/Exit points of SimHits)

#### PR validation and some performance updates

- [Bi-weekly modelling, simulation and performance Meeting 11/11/2022](https://indico.cern.ch/event/1201190/contributions/5140217/attachments/2547129/4386516/Phase2Digitizer_BiasRailInEff_NoiseOccu_11112022.pdf)

- [Bi-weekly modelling, simulation and performance Meeting 11/11/2022](https://indico.cern.ch/event/1201190/contributions/5135986/attachments/2546226/4384765/LST_BiasRailBadStrips_TKPhase2Simulation_221111.pdf)

- [Bi-weekly modelling, simulation and performance Meeting 27/05/2022](https://indico.cern.ch/event/1160374/contributions/4894251/attachments/2452078/4201920/L1T_DQM_Update_5_27_22.pdf)
  
**Note :** all the above validation plots are presented with the pessimistic 'OR' option

@emiglior 