### PR TITLE
Updates on GE21 online/offlineDQM plots with division on modules, a backport to 12_5_X

### DIFF
--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -17,6 +17,8 @@
 
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
+#include "CondFormats/DataRecord/interface/GEMChMapRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
@@ -34,6 +36,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 protected:
+  void LoadROMap(edm::EventSetup const& iSetup);
+
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override{};
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& e, edm::EventSetup const& eSetup) override;
@@ -46,9 +50,14 @@ private:
 
   const static int nNumBitDigiOcc_ = 16384;
 
+  const edm::ESGetToken<GEMChMap, GEMChMapRcd> gemChMapToken_;
+
   edm::EDGetToken tagDigi_;
 
   edm::EDGetTokenT<LumiScalersCollection> lumiScalers_;
+
+  std::map<ME4IdsKey, Int_t> mapChamberType_;
+  std::map<ME3IdsKey, Int_t> mapStripToVFAT_;
 
   MEMap3Inf mapTotalDigi_layer_;
   MEMap3Inf mapDigiWheel_layer_;

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -150,6 +150,8 @@ protected:
   std::vector<std::string> listLayer_;
   std::map<std::string, int> mapIdxLayer_;  // All indices in the following objects start at 1
   std::map<int, int> mapNumChPerChamber_;
+  std::map<int, int> mapNumModule_;
+  std::map<int, std::map<int, int>> mapIdxToChamberInOcc_;
   std::map<int, MonitorElement *> mapHistLumiFunc_;
   Bool_t bIsStatusChambersInit_;
 };
@@ -229,6 +231,39 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
       if (h2SrcVFATOcc == nullptr)
         continue;
       listOccPlots[nIdxLayer] = h2SrcVFATOcc;
+      mapIdxToChamberInOcc_[nIdxLayer] = {};
+      Int_t nNumModule = mapNumModule_[nIdxLayer];  // FIXME: Is this way to obtain the module number fully general?
+      // Obtaining the bin indices of chambers from their labels
+      for (Int_t i = 1; i <= h2SrcVFATOcc->getNbinsX(); i++) {
+        std::string strLabel = h2SrcVFATOcc->getTH2F()->GetXaxis()->GetBinLabel(i);
+        std::string strSrc = strLabel;
+        std::vector<int> listNumExtract;
+
+        while (!strSrc.empty()) {
+          auto nPosDigit = strSrc.find_first_of("0123456789");
+          if (nPosDigit == std::string::npos)
+            break;
+          std::stringstream ss;
+          ss << strSrc.substr(nPosDigit);
+          Int_t nExtract;
+          ss >> nExtract;
+          if (!ss.eof()) {
+            ss >> strSrc;
+          } else {
+            strSrc = "";
+          }
+          listNumExtract.push_back(nExtract);
+        }
+
+        if (listNumExtract.empty()) {  // Errneous case; but the job should not be dead
+          edm::LogError("GEMDQMHarvester") << "Error: Wrong label of GEM VFAT occupancy plot: " << strLabel;
+        } else if (listNumExtract.size() > 1 && nNumModule > 1) {
+          Int_t nCh = (listNumExtract[0] - 1) * nNumModule + listNumExtract[1];
+          mapIdxToChamberInOcc_[nIdxLayer][nCh] = i;
+        } else {
+          mapIdxToChamberInOcc_[nIdxLayer][listNumExtract[0]] = i;
+        }
+      }
     }
 
     fReportSummary = refineSummaryHistogram(strTitleSummary,
@@ -271,8 +306,8 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
   for (const auto &strSuffix : listLayer_) {
     if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
       continue;
-    //auto nNumChamber = mapNumChPerChamber_[mapIdxLayer_[strSuffix]];
-    Int_t nNumChamber = 36;
+    Int_t nIdxLayer = mapIdxLayer_[strSuffix];
+    auto nNumChamber = mapNumChPerChamber_[nIdxLayer] / mapNumModule_[nIdxLayer];
     createInactiveChannelFracHist(store, strSuffix, nNumChamber);
   }
 
@@ -329,7 +364,7 @@ void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElem
         if (strLayer.find("GE11") != std::string::npos) {
           nBinXActual = 36;
         } else if (strLayer.find("GE21") != std::string::npos) {
-          nBinXActual = 18;
+          nBinXActual = 72;
         } else if (strLayer.find("GE01") != std::string::npos) {
           nBinXActual = 36;
         }
@@ -337,6 +372,7 @@ void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElem
       listLayer_.push_back(strLayer);
       mapIdxLayer_[strLayer] = i;
       mapNumChPerChamber_[i] = nBinXActual;
+      mapNumModule_[i] = (strLayer.find("GE21") != std::string::npos ? 4 : 1);
     }
   } else {  // For others (validation and...?)
     listLayer_.push_back("");
@@ -417,8 +453,9 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
   Int_t nBinY = h2Sum->getNbinsY();
   Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
-    Int_t nBinX = (Int_t)(h2SrcStatusE->getBinContent(0, j) + 0.5);
+    Int_t nBinX = mapNumChPerChamber_[j];
     auto h2SrcOcc = listOccPlots[j];
+    auto &mapIdxOccChamber = mapIdxToChamberInOcc_[j];
     Int_t nBinYOcc = 0;
     if (h2SrcOcc != nullptr) {
       nBinYOcc = h2SrcOcc->getNbinsY();
@@ -427,8 +464,9 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
     h2Sum->setBinContent(0, j, nBinX);
     for (Int_t i = 1; i <= nBinX; i++) {
       Float_t fOcc = 0;
+      Int_t nIdxChOcc = mapIdxOccChamber[i];
       for (Int_t r = 1; r <= nBinYOcc; r++) {
-        fOcc += h2SrcOcc->getBinContent(i, r);
+        fOcc += h2SrcOcc->getBinContent(nIdxChOcc, r);
       }
 
       Float_t fStatusAll = h2SrcStatusA->getBinContent(i, j);
@@ -591,8 +629,15 @@ void GEMDQMHarvester::createLumiFuncHist(edm::Service<DQMStore> &store,
 
     h2Summary->setXTitle("Luminosity block");
     h2Summary->setYTitle("Chamber");
+    Int_t nNumModule = mapNumModule_[nIdxLayer];
     for (Int_t i = 1; i <= nNumCh; i++) {
-      h2Summary->setBinLabel(i, Form("%i", i), 2);
+      if (nNumModule <= 1) {
+        h2Summary->setBinLabel(i, Form("%i", i), 2);
+      } else {
+        Int_t nCh = (i - 1) / nNumModule + 1;
+        Int_t nModule = (i - 1) / nNumModule + 1;
+        h2Summary->setBinLabel(i, Form("%i M%i", nCh, nModule), 2);
+      }
     }
   } else {
     h2Summary = mapHistLumiFunc_[nIdxLayer];

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -3,7 +3,8 @@
 using namespace std;
 using namespace edm;
 
-GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg) {
+GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg)
+    : GEMDQMBase(cfg), gemChMapToken_(esConsumes<GEMChMap, GEMChMapRcd, edm::Transition::BeginRun>()) {
   tagDigi_ = consumes<GEMDigiCollection>(cfg.getParameter<edm::InputTag>("digisInputLabel"));
   lumiScalers_ = consumes<LumiScalersCollection>(
       cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
@@ -21,11 +22,65 @@ void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& description
   descriptions.add("GEMDigiSource", desc);
 }
 
+void GEMDigiSource::LoadROMap(edm::EventSetup const& iSetup) {
+  //if (useDBEMap_)
+  if (true) {
+    const auto& chMap = iSetup.getData(gemChMapToken_);
+    auto gemChMap = std::make_unique<GEMChMap>(chMap);
+
+    std::map<int, bool> mapCheckedType;
+    for (auto const& p : gemChMap->chamberMap()) {
+      auto& dc = p.second;
+      GEMDetId gemChId(dc.detId);
+      for (Int_t ieta = 1; ieta <= 24; ieta++) {
+        if (!gemChMap->isValidStrip(dc.chamberType, ieta, 1))
+          continue;
+        mapChamberType_[{gemChId.station(), gemChId.layer(), gemChId.chamber(), ieta}] = dc.chamberType;
+        if (mapCheckedType[dc.chamberType])
+          continue;
+        for (Int_t strip = 0; strip <= 3 * 128; strip++) {
+          if (!gemChMap->isValidStrip(dc.chamberType, ieta, strip))
+            continue;
+          auto& stripInfo = gemChMap->getChannel(dc.chamberType, ieta, strip);
+          mapStripToVFAT_[{dc.chamberType, ieta, strip}] = stripInfo.vfatAdd;
+        }
+      }
+      mapCheckedType[dc.chamberType] = true;
+    }
+  } else {
+    // no EMap in DB, using dummy
+    auto gemChMap = std::make_unique<GEMChMap>();
+    gemChMap->setDummy();
+
+    std::map<int, bool> mapCheckedType;
+    for (auto const& p : gemChMap->chamberMap()) {
+      auto& dc = p.second;
+      GEMDetId gemChId(dc.detId);
+
+      for (Int_t ieta = 1; ieta <= 24; ieta++) {
+        if (!gemChMap->isValidStrip(dc.chamberType, ieta, 1))
+          continue;
+        mapChamberType_[{gemChId.station(), gemChId.layer(), gemChId.chamber(), ieta}] = dc.chamberType;
+        if (mapCheckedType[dc.chamberType])
+          continue;
+        mapCheckedType[dc.chamberType] = true;
+        for (Int_t strip = 0; strip <= 3 * 128; strip++) {
+          if (!gemChMap->isValidStrip(dc.chamberType, ieta, strip))
+            continue;
+          auto& stripInfo = gemChMap->getChannel(dc.chamberType, ieta, strip);
+          mapStripToVFAT_[{dc.chamberType, ieta, strip}] = stripInfo.vfatAdd;
+        }
+      }
+    }
+  }
+}
+
 void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, edm::EventSetup const& iSetup) {
   initGeometry(iSetup);
   if (GEMGeometry_ == nullptr)
     return;
   loadChambers();
+  LoadROMap(iSetup);
 
   strFolderMain_ = "GEM/Digis";
 
@@ -104,12 +159,20 @@ int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
 int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
+  Int_t nNewNumCh = stationInfo.nMaxIdxChamber_ - stationInfo.nMinIdxChamber_ + 1;
+  Int_t nNewMinIdxChamber = stationInfo.nNumModules_ * (stationInfo.nMinIdxChamber_ - 1) + 1;
+  Int_t nNewMaxIdxChamber = stationInfo.nNumModules_ * stationInfo.nMaxIdxChamber_;
+
+  nNewNumCh *= stationInfo.nNumModules_;
+
+  Int_t nNumVFATPerModule = stationInfo.nMaxVFAT_ / stationInfo.nNumModules_;
+
   int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
 
-  mapTotalDigi_layer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
+  mapTotalDigi_layer_.SetBinConfX(nNewNumCh, nNewMinIdxChamber - 0.5, nNewMaxIdxChamber + 0.5);
+  mapTotalDigi_layer_.SetBinConfY(nNumVFATPerModule, -0.5);
   mapTotalDigi_layer_.bookND(bh, key);
-  mapTotalDigi_layer_.SetLabelForChambers(key, 1, -1, stationInfo.nMinIdxChamber_);
+  mapTotalDigi_layer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber, stationInfo.nNumModules_);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
@@ -139,7 +202,7 @@ int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key
   int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
   int nNumCh = stationInfo.nNumDigi_;
 
-  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta, -0.5);
+  mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta, stationInfo.nFirstStrip_ - 0.5);
   mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapDigiOccPerCh_.bookND(bh, key);
   mapDigiOccPerCh_.SetLabelForIEta(key, 2);
@@ -173,10 +236,13 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
       if (total_digi_eta.find(key3IEta) == total_digi_eta.end())
         total_digi_eta[key3IEta] = 0;
       const auto& digis_in_det = gemDigis->get(eId);
+      auto nChamberType = mapChamberType_[{gid.station(), gid.layer(), gid.chamber(), eId.ieta()}];
+      Int_t nIdxModule = getIdxModule(gid.station(), nChamberType);
+      Int_t nCh = (gid.chamber() - 1) * stationInfo.nNumModules_ + nIdxModule;
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
-        Int_t nIdxVFAT = getVFATNumberByDigi(gid.station(), eId.ieta(), d->strip());
-        mapTotalDigi_layer_.Fill(key3, gid.chamber(), nIdxVFAT);
+        Int_t nIdxVFAT = mapStripToVFAT_[{nChamberType, eId.ieta(), d->strip()}];
+        mapTotalDigi_layer_.Fill(key3, nCh, nIdxVFAT);
 
         // Filling of digi
         mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -135,7 +135,11 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapRecHitXY_layer_.SetBinHighEdgeY(fRangeRadius);
   mapRecHitXY_layer_.bookND(bh, key);
 
-  mapRecHitOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
+  Int_t nNumEta = stationInfo.nNumEtaPartitions_;
+  if (stationInfo.nNumModules_ > 1) {
+    nNumEta = stationInfo.nNumModules_;
+  }
+  mapRecHitOcc_ieta_.SetBinConfX(nNumEta);
   mapRecHitOcc_ieta_.bookND(bh, key);
   mapRecHitOcc_ieta_.SetLabelForIEta(key, 1);
 
@@ -148,14 +152,34 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   Int_t nNewNumCh = stationInfo.nMaxIdxChamber_ - stationInfo.nMinIdxChamber_ + 1;
 
   mapCLSAverage_.SetBinConfX(nNewNumCh, stationInfo.nMinIdxChamber_ - 0.5, stationInfo.nMaxIdxChamber_ + 0.5);
+  mapCLSAverage_.SetBinConfY(nNumEta, 0.5);
   mapCLSAverage_.bookND(bh, key);
   mapCLSAverage_.SetLabelForChambers(key, 1, -1, stationInfo.nMinIdxChamber_);
   mapCLSAverage_.SetLabelForIEta(key, 2);
 
   mapCLSOver5_.SetBinConfX(nNewNumCh, stationInfo.nMinIdxChamber_ - 0.5, stationInfo.nMaxIdxChamber_ + 0.5);
+  mapCLSOver5_.SetBinConfY(nNumEta, 0.5);
   mapCLSOver5_.bookND(bh, key);
   mapCLSOver5_.SetLabelForChambers(key, 1, -1, stationInfo.nMinIdxChamber_);
   mapCLSOver5_.SetLabelForIEta(key, 2);
+
+  if (keyToStation(key) == 2) {
+    if (mapCLSAverage_.isOperating()) {
+      mapCLSAverage_.FindHist(key)->setYTitle("Module");
+    }
+    if (mapCLSOver5_.isOperating()) {
+      mapCLSOver5_.FindHist(key)->setYTitle("Module");
+    }
+    for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
+      std::string strLabel = std::string(Form("M%i", i));
+      if (mapCLSAverage_.isOperating()) {
+        mapCLSAverage_.FindHist(key)->setBinLabel(i, strLabel, 2);
+      }
+      if (mapCLSOver5_.isOperating()) {
+        mapCLSOver5_.FindHist(key)->setBinLabel(i, strLabel, 2);
+      }
+    }
+  }
 
   return 0;
 }
@@ -166,9 +190,26 @@ int GEMRecHitSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey k
 
   bh.getBooker()->setCurrentFolder(strFolderMain_ + "/clusterSize_" + getNameDirLayer(key3));
 
-  mapCLSPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  Int_t nNumEta = stationInfo.nNumEtaPartitions_;
+  if (stationInfo.nNumModules_ > 1) {
+    nNumEta = stationInfo.nNumModules_;
+  }
+
+  mapCLSPerCh_.SetBinConfY(nNumEta, 0.5);
   mapCLSPerCh_.bookND(bh, key);
   mapCLSPerCh_.SetLabelForIEta(key, 2);
+
+  if (keyToStation(key) == 2) {
+    if (mapCLSPerCh_.isOperating()) {
+      mapCLSPerCh_.FindHist(key)->setYTitle("Module");
+    }
+    for (Int_t i = 1; i <= stationInfo.nNumModules_; i++) {
+      std::string strLabel = std::string(Form("M%i", i));
+      if (mapCLSPerCh_.isOperating()) {
+        mapCLSPerCh_.FindHist(key)->setBinLabel(i, strLabel, 2);
+      }
+    }
+  }
 
   bh.getBooker()->setCurrentFolder(strFolderMain_);
 
@@ -198,6 +239,12 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};
       ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
 
+      Int_t nEtaModule = eId.ieta();
+      if (gid.station() == 2) {
+        nEtaModule = getIdxModule(2, 24 - (nEtaModule - 1) / 4);
+      }
+      ME4IdsKey key4IEtaMod{gid.region(), gid.station(), gid.layer(), nEtaModule};
+
       if (total_rechit_layer.find(key3) == total_rechit_layer.end())
         total_rechit_layer[key3] = 0;
 
@@ -211,7 +258,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
         mapRecHitXY_layer_.Fill(key3, recHitGP.x(), recHitGP.y());
 
         // Filling of RecHit (iEta)
-        mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
+        mapRecHitOcc_ieta_.Fill(key3, nEtaModule);
 
         // Filling of RecHit (phi)
         Float_t fPhi = recHitGP.phi();
@@ -227,10 +274,10 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
         Int_t nCLS = hit->clusterSize();
         Int_t nCLSCutOff = std::min(nCLS, nCLSMax_);  // For overflow
         mapCLSRecHit_ieta_.Fill(key3AbsReIEta, nCLSCutOff);
-        mapCLSPerCh_.Fill(key4Ch, nCLSCutOff, eId.ieta());
-        mapCLSAverage_.Fill(key3, (Double_t)chamber, (Double_t)eId.ieta(), nCLS);
+        mapCLSPerCh_.Fill(key4Ch, nCLSCutOff, nEtaModule);
+        mapCLSAverage_.Fill(key3, (Double_t)chamber, (Double_t)nEtaModule, nCLS);
         if (nCLS > 5)
-          mapCLSOver5[key4IEta][chamber] = true;
+          mapCLSOver5[key4IEtaMod][chamber] = true;
       }
     }
   }

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -82,12 +82,14 @@ int GEMDQMBase::loadChambers() {
 
       const int station_number = station->station();
       const int num_superchambers = (station_number == 1 ? 36 : 18);
+      const int num_mod = getNumModule(station->station());
       const int max_vfat = getMaxVFAT(station->station());  // the number of VFATs per GEMEtaPartition
       const int num_etas = getNumEtaPartitions(station);    // the number of eta partitions per GEMChamber
       const int num_vfat = num_etas * max_vfat;             // the number of VFATs per GEMChamber
+      const int strip1st = (station_number == 2 ? 1 : 0);   // the index of the first strip
       const int num_digi = GEMeMap::maxChan_;               // the number of digis (channels) per VFAT
 
-      nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers);
+      nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers * num_mod);
 
       Int_t nMinIdxChamber = 1048576;
       Int_t nMaxIdxChamber = -1048576;
@@ -108,8 +110,10 @@ int GEMDQMBase::loadChambers() {
                                               station_number,
                                               layer_number,
                                               num_superchambers,
+                                              num_mod,
                                               num_etas,
                                               num_vfat,
+                                              strip1st,
                                               num_digi,
                                               nMinIdxChamber,
                                               nMaxIdxChamber);
@@ -166,7 +170,7 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
     auto label =
         Form("GE%+i1-%cL%i;%s", region * keyToStation(key), (region > 0 ? 'P' : 'M'), keyToLayer(key), strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
-    Int_t nNumCh = mapStationInfo_[key].nNumChambers_;
+    Int_t nNumCh = mapStationInfo_[key].nNumChambers_ * mapStationInfo_[key].nNumModules_;
     h2Res->setBinContent(0, i, nNumCh);
   }
 

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -36,7 +36,7 @@ public:
   };
 
   GEMOHStatus() {}
-  GEMOHStatus(const GEMOptoHybrid& oh) {
+  GEMOHStatus(const GEMOptoHybrid& oh, int chamberType) : chamberType_(chamberType) {
     Errors error{0};
     error.EvtF = oh.evtF();
     error.InF = oh.inF();
@@ -77,8 +77,10 @@ public:
   uint32_t vfatMask() const { return vfatMask_; }
   uint32_t zsMask() const { return zsMask_; }
   uint32_t existVFATs() const { return existVFATs_; }
+  int chamberType() const { return chamberType_; }
 
 private:
+  int chamberType_;
   uint16_t errors_;
   uint8_t warnings_;
   uint32_t missingVFATs_;

--- a/DataFormats/GEMDigi/interface/GEMVFATStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMVFATStatus.h
@@ -28,7 +28,7 @@ public:
   };
 
   GEMVFATStatus() {}
-  GEMVFATStatus(const GEMAMC& amc, const GEMOptoHybrid& oh, const GEMVFAT& vfat, bool readMultiBX) {
+  GEMVFATStatus(const GEMAMC& amc, const GEMOptoHybrid& oh, const GEMVFAT& vfat, int chamberType, bool readMultiBX) : chamberType_(chamberType){
     Errors error{0};
     Warnings warn{0};
 
@@ -64,8 +64,10 @@ public:
   bool isBad() const { return errors_ != 0; }
   uint8_t errors() const { return errors_; }
   uint8_t warnings() const { return warnings_; }
+  int chamberType() const { return chamberType_; }
 
 private:
+  int chamberType_;
   uint16_t vfatPosition_;
   uint8_t errors_;
   uint8_t warnings_;

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -61,9 +61,10 @@
 <class name="MuonDigiCollection<uint16_t,GEMAMCStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<uint16_t,GEMAMCStatus> >" splitLevel="0"/>
 
-<class name="GEMOHStatus" ClassVersion="4">
+<class name="GEMOHStatus" ClassVersion="5">
  <version ClassVersion="3" checksum="1715607020"/>
  <version ClassVersion="4" checksum="442197271"/>
+ <version ClassVersion="5" checksum="3896553455"/>
 </class>
 <class name="std::vector<GEMOHStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMOHStatus> >"/>
@@ -71,9 +72,10 @@
 <class name="MuonDigiCollection<GEMDetId,GEMOHStatus>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMOHStatus> >" splitLevel="0"/>
 
-<class name="GEMVFATStatus" ClassVersion="4">
+<class name="GEMVFATStatus" ClassVersion="5">
  <version ClassVersion="3" checksum="2994917778"/>
  <version ClassVersion="4" checksum="2298275534"/>
+ <version ClassVersion="5" checksum="272057922"/>
 </class>
 <class name="std::vector<GEMVFATStatus>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVFATStatus> >"/>

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -172,7 +172,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
         GEMDetId cId(geb_dc.detId);
         int chamberType = geb_dc.chamberType;
 
-        GEMOHStatus st_oh(optoHybrid);
+        GEMOHStatus st_oh(optoHybrid, chamberType);
         if (st_oh.isBad()) {
           LogDebug("GEMRawToDigiModule") << st_oh;
           if (keepDAQStatus_) {
@@ -195,7 +195,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
             continue;
           }
 
-          GEMVFATStatus st_vfat(amc, optoHybrid, vfat, readMultiBX_);
+          GEMVFATStatus st_vfat(amc, optoHybrid, vfat, chamberType, readMultiBX_);
           if (st_vfat.isBad()) {
             LogDebug("GEMRawToDigiModule") << st_vfat;
             if (keepDAQStatus_) {


### PR DESCRIPTION
#### PR description:

This PR provides massive updates on GE21 onlineDQM/offlineDQM plots. This work is focusing on the division of GE21 information by modules (M1-M4). It is necessary because of the electronic configuration of GE21 chambers.

It is also included that the module information is propagated to the GEM unpacker in a better way, which is done by @yeckang.

#### PR validation:

Tests are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=361054 dataset=/ExpressPhysics/Run2022F-Express-v1/FEVT` and `runTheMatrix.py -l limited -i all --ibeos` since it makes effects on P5 and reconstruction

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of #39985 to 12_5_X.

@jshlee @watson-ij @seungjin-yang @yeckang 
