### PR TITLE
Add TTID integrity error plots for ECAL DQM [Master]

### DIFF
--- a/DQM/EcalMonitorClient/interface/IntegrityClient.h
+++ b/DQM/EcalMonitorClient/interface/IntegrityClient.h
@@ -23,6 +23,7 @@ namespace ecaldqm {
     void setTokens(edm::ConsumesCollector&) override;
 
     float errFractionThreshold_;
+    int processedEvents;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/IntegrityClient_cfi.py
@@ -18,7 +18,8 @@ ecalIntegrityClient = cms.untracked.PSet(
         ChId = ecalIntegrityTask.MEs.ChId,
         TowerId = ecalIntegrityTask.MEs.TowerId,
         BXSRP = ecalRawDataTask.MEs.BXSRP,
-        BXTCC = ecalRawDataTask.MEs.BXTCC
+        BXTCC = ecalRawDataTask.MEs.BXTCC,
+	NumEvents = ecalOccupancyTask.MEs.NEvents
     ),
     MEs = cms.untracked.PSet(
         QualitySummary = cms.untracked.PSet(
@@ -41,6 +42,13 @@ ecalIntegrityClient = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('Map of channel status as given by the Ecal Channel Status Record. LEGEND:<br/>0: Channel ok,<br/>1: DAC settings problem, pedestal not in the design range,<br/>2: Channel with no laser, ok elsewhere,<br/>3: Noisy,<br/>4: Very noisy,<br/>5-7: Reserved for more categories of noisy channels,<br/>8: Channel at fixed gain 6 (or 6 and 1),<br/>9: Channel at fixed gain 1,<br/>10: Channel at fixed gain 0 (dead of type this),<br/>11: Non-responding isolated channel (dead of type other),<br/>12: Channel and one or more neigbors not responding (e.g.: in a dead VFE 5x1 channel),<br/>13: Channel in TT with no data link, TP data ok,<br/>14: Channel in TT with no data link and no TP data.')
-        )
+       ),
+	TowerIdNormalized = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sIntegrityTask/TTId/%(prefix)sIT TTId Normalized %(sm)s'),
+            kind = cms.untracked.string('TH2F'),
+            otype = cms.untracked.string('SM'),
+            btype = cms.untracked.string('SuperCrystal'),
+            description = cms.untracked.string('TTID errors normalized by total no.of processed events per run.')
+       )
     )
 )

--- a/DQM/EcalMonitorTasks/python/IntegrityTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/IntegrityTask_cfi.py
@@ -70,6 +70,21 @@ ecalIntegrityTask = cms.untracked.PSet(
             otype = cms.untracked.string('SM'),
             btype = cms.untracked.string('SuperCrystal'),
             description = cms.untracked.string('')
+        ),
+        TTIDTotal = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sIntegrityTask/%(prefix)sIT weighted TTID errors'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('DCC'),
+            description = cms.untracked.string('Total number of TTID errors for each FED. Histogram filled weighted by no.of crystals per tower to be compatible with the other integrity errors which are binned by crystals.')
+        ),
+        TTIDByLumi = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sIntegrityTask/%(prefix)sIT weighted TTID errors by lumi'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            btype = cms.untracked.string('DCC'),
+	    perLumi = cms.untracked.bool(True),
+            description = cms.untracked.string('Total number of TTID errors for each FED in this lumi section. Histogram filled weighted by no.of crystals per tower to be compatible with the other integrity errors which are binned by crystals.')
         )
     )
 )

--- a/DQM/EcalMonitorTasks/src/IntegrityTask.cc
+++ b/DQM/EcalMonitorTasks/src/IntegrityTask.cc
@@ -13,6 +13,7 @@ namespace ecaldqm {
     if (ByLumiResetSwitch) {
       MEs_.at("MapByLumi").reset(GetElectronicsMap());
       MEs_.at("ByLumi").reset(GetElectronicsMap());
+      MEs_.at("TTIDByLumi").reset(GetElectronicsMap());
     }
   }
 
@@ -78,6 +79,8 @@ namespace ecaldqm {
     MESet& meByLumi(MEs_.at("ByLumi"));
     MESet& meTotal(MEs_.at("Total"));
     MESet& meTrendNErrors(MEs_.at("TrendNErrors"));
+    MESet& meTTIDTotal(MEs_.at("TTIDTotal"));
+    MESet& meTTIDByLumi(MEs_.at("TTIDByLumi"));
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id) {
       set->fill(getEcalDQMSetupObjects(), id);
@@ -90,6 +93,11 @@ namespace ecaldqm {
         nCrystals = 25.;
       meByLumi.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
       meTotal.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
+
+      if (_collection == kTowerIdErrors) {
+        meTTIDByLumi.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
+        meTTIDTotal.fill(getEcalDQMSetupObjects(), dccid, nCrystals);
+      }
       // Fill Integrity Errors Map with tower errors for this lumi
       // Since binned by crystal for compatibility with channel errors,
       // fill with constituent channels of tower


### PR DESCRIPTION
#### PR description:

This PR adds the following plots to monitor the TTID integrity errors in ECAL DQM:
1. Total TTID errors per FED for the whole run.
2. TTID errors per FED per lumisection.
3. TTID errors for each supermodule normalized by the no.of events processed.

#### PR validation:

This was validated by running the online DQM workflow and testing the plots on a test DQM GUI.
Also validated by running the runtheMatrix workflow 136.874

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the master PR.
Backports are made to 12_5_X https://github.com/cms-sw/cmssw/pull/40073 and 12_4_X https://github.com/cms-sw/cmssw/pull/40074
