### PR TITLE
Problem with plotting in macros is solved

### DIFF
--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -140,9 +140,10 @@ void momentumBiasValidation(TString variable,
   std::cout << "Initializing the TTree ..." << std::endl;
   std::vector<TTree*> trees(files.size(), 0);
   EopElecVariables* track = new EopElecVariables();
-  if (!initializeTree(files, trees, track))
+  if (!initializeTree(files, trees, track)) {
     delete track;
-  return;
+    return;
+  } 
 
   // Configuring ROOT style
   std::cout << "Configuring the ROOT style ..." << std::endl;
@@ -158,6 +159,7 @@ void momentumBiasValidation(TString variable,
 
   // To save the table cut
   TFile* histo1;
+  delete histo1;
   std::string fileName;
 
   for (unsigned int ifile = 0; ifile < histos.size(); ifile++) {
@@ -280,9 +282,8 @@ void momentumBiasValidation(TString variable,
   time_t end = time(0);
   std::cout << "Done in " << static_cast<int>(difftime(end, start)) / 60 << " min and "
             << static_cast<int>(difftime(end, start)) % 60 << " sec." << std::endl;
-
-  delete track;
   delete histo1;
+  delete track;
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Problem: The execution of momentumElectronBiasValidation.C macros didn't proceed to "Configuring the ROOT style" and Plotting stage after "Initializing the TTree step". The problem was solved (l143 - l146). Warning: 'histo1' may be used uninitialized appeared and was solved by adding delete histo1 (l162).

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
