### PR TITLE
Protect against particles with zero weight and pt being given as input to njettiness

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -662,7 +662,7 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
         for (size_t i = 0; i < daughter->numberOfDaughters(); ++i) {
           const reco::CandidatePtr& constit = subjet->daughterPtr(i);
 
-          if (constit.isNonnull()) {
+          if (constit.isNonnull() && constit->pt() > std::numeric_limits<double>::epsilon()) {
             // Check if any values were nan or inf
             float valcheck = constit->px() + constit->py() + constit->pz() + constit->energy();
             if (edm::isNotFinite(valcheck)) {
@@ -679,10 +679,13 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
                     << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection"
                     << std::endl;
               }
-              fjParticles.push_back(
-                  fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
-            } else
+              if (w > 0) {
+                fjParticles.push_back(
+                    fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+              }
+            } else {
               fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+            }
           } else
             edm::LogWarning("MissingJetConstituent")
                 << "Jet constituent required for N-subjettiness computation is missing!";
@@ -703,10 +706,13 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
             throw cms::Exception("MissingConstituentWeight")
                 << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection" << std::endl;
           }
-          fjParticles.push_back(
-              fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
-        } else
+          if (w > 0 && daughter->pt() > std::numeric_limits<double>::epsilon()) {
+            fjParticles.push_back(
+                fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
+          }
+        } else {
           fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
+        }
       }
     } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";


### PR DESCRIPTION
#### PR description:

As discussed in issue #40032 , BoostedDoubleSVProducer caused an abort signal in a reco job.
We found that there were unrealistic kinematic values in fjParticles being input to njettiness and are protecting against it by requiring a nonzero weight and pt > epsilon.

#### PR validation:

Verified that this fix solves the issues in CMSSW_12_4_10_patch3. In current build (12_6_0_pre4) ran usual code check and that basic runTheMatrix workflows run.

@rappoccio 
