### PR TITLE
Improve unprotected areas of GSF code to avoid segfault

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfTrajectorySmoother.cc
+++ b/TrackingTools/GsfTracking/src/GsfTrajectorySmoother.cc
@@ -129,6 +129,10 @@ Trajectory GsfTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     if (theMerger)
       predTsos = theMerger->merge(predTsos);
 
+    if (!predTsos.isValid()) {
+      return Trajectory();
+    }
+
     if ((*itm).recHit()->isValid()) {
       //update
       currTsos = updator()->update(predTsos, *(*itm).recHit());
@@ -204,6 +208,9 @@ Trajectory GsfTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     if (theMerger)
       currTsos = theMerger->merge(currTsos);
 
+    if (!currTsos.isValid()) {
+      return Trajectory();
+    }
     dump(currTsos, "currTsos", "GsfTrackFitters");
   }
 


### PR DESCRIPTION
#### PR description:
This PR fixes a crash in prompt reco in run number `361971` as reported in https://github.com/cms-sw/cmssw/issues/39987#issuecomment-1316832648. 

In Run3, by now, there were at least 3 instances of crashes in prompt reco due to Gsf, to the best of my knowledge. Apparently the error-messages looks similar, but they needed different fixes. To fix this particular crash, we need some extra protection against edge-cases, in `GsfTrajectorySmoother`. 

#### PR validation:

Checked that the reported crash in run `361971` gets solved.
`runTheMatrix.py -l 12434.0` ran fine.

I intend to backport it to 12_4_X and 12_5_X soon. 