### PR TITLE
Protect against particles with zero weight and pt being given as input to njettiness BACKPORT

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -661,9 +661,8 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
         // loop over subjet constituents and push them in the vector of FastJet constituents
         for (size_t i = 0; i < daughter->numberOfDaughters(); ++i) {
           const reco::CandidatePtr& constit = subjet->daughterPtr(i);
-
-          if (constit.isNonnull()) {
-            // Check if any values were nan or inf
+	  if (constit.isNonnull() && constit->pt() > std::numeric_limits<double>::epsilon() ) {
+	    // Check if any values were nan or inf
             float valcheck = constit->px() + constit->py() + constit->pz() + constit->energy();
             if (edm::isNotFinite(valcheck)) {
               edm::LogWarning("FaultyJetConstituent")
@@ -679,10 +678,12 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
                     << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection"
                     << std::endl;
               }
-              fjParticles.push_back(
-                  fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
-            } else
-              fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+	      if ( w > 0 ) {
+		fjParticles.push_back(fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+	      }
+	    } else {
+	      fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+	    }
           } else
             edm::LogWarning("MissingJetConstituent")
                 << "Jet constituent required for N-subjettiness computation is missing!";
@@ -703,10 +704,12 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
             throw cms::Exception("MissingConstituentWeight")
                 << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection" << std::endl;
           }
-          fjParticles.push_back(
-              fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
-        } else
+	  if ( w > 0 && daughter->pt() > std::numeric_limits<double>::epsilon() ) {
+	    fjParticles.push_back(fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
+	  }
+        } else {
           fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
+	}
       }
     } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";


### PR DESCRIPTION
#### PR description:
As discussed in issue https://github.com/cms-sw/cmssw/issues/40032 , BoostedDoubleSVProducer caused an abort signal in a reco job.
We found that there were unrealistic kinematic values in fjParticles being input to njettiness and are protecting against it by requiring a nonzero weight and pt > epsilon.

#### PR validation:

Verified that this fix solves the issues in CMSSW_12_4_10_patch3 and ran usual code check and that basic runTheMatrix workflows run.

@rappoccio

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR: https://github.com/cms-sw/cmssw/pull/40081
Backport is needed so that the reco jobs being stopped can be run
