### PR TITLE
Protect against particles with zero weight and pt being given to njettiness [12_5_X]

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -661,8 +661,7 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
         // loop over subjet constituents and push them in the vector of FastJet constituents
         for (size_t i = 0; i < daughter->numberOfDaughters(); ++i) {
           const reco::CandidatePtr& constit = subjet->daughterPtr(i);
-
-          if (constit.isNonnull()) {
+          if (constit.isNonnull() && constit->pt() > std::numeric_limits<double>::epsilon()) {
             // Check if any values were nan or inf
             float valcheck = constit->px() + constit->py() + constit->pz() + constit->energy();
             if (edm::isNotFinite(valcheck)) {
@@ -679,10 +678,13 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
                     << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection"
                     << std::endl;
               }
-              fjParticles.push_back(
-                  fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
-            } else
+              if (w > 0) {
+                fjParticles.push_back(
+                    fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+              }
+            } else {
               fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+            }
           } else
             edm::LogWarning("MissingJetConstituent")
                 << "Jet constituent required for N-subjettiness computation is missing!";
@@ -703,10 +705,13 @@ void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
             throw cms::Exception("MissingConstituentWeight")
                 << "BoostedDoubleSVProducer: No weights (e.g. PUPPI) given for weighted jet collection" << std::endl;
           }
-          fjParticles.push_back(
-              fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
-        } else
+          if (w > 0 && daughter->pt() > std::numeric_limits<double>::epsilon()) {
+            fjParticles.push_back(
+                fastjet::PseudoJet(daughter->px() * w, daughter->py() * w, daughter->pz() * w, daughter->energy() * w));
+          }
+        } else {
           fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
+        }
       }
     } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";


### PR DESCRIPTION
#### PR description:
As discussed in issue https://github.com/cms-sw/cmssw/issues/40032 , BoostedDoubleSVProducer caused an abort signal in a reco job.
We found that there were unrealistic kinematic values in fjParticles being input to njettiness and are protecting against it by requiring a nonzero weight and pt > epsilon.

#### PR validation:
Verified that this fix solves the issues in CMSSW_12_4_10_patch3 and ran usual code check and that basic runTheMatrix workflows run in 12_5_2_patch1

@rappoccio

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Original PR: https://github.com/cms-sw/cmssw/pull/40081
First bp: https://github.com/cms-sw/cmssw/pull/40088
Backport is needed so that future reco jobs run without being stopped by this issue