### PR TITLE
[L1T] Phase-2, Update Track Selection Emulation to Match Firmware

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -276,7 +276,7 @@ protected:
     return reco::deltaPhi(globalPhi, (sector * sectorWidth));
   }
 
-private:
+public:
   // ----------private member functions --------------
   unsigned int countSetBits(unsigned int n) const {
     // Adapted from: https://www.geeksforgeeks.org/count-set-bits-in-an-integer/
@@ -314,7 +314,7 @@ private:
     return (up - bins.begin() - 1);
   }
 
-  double undigitizeSignedValue(unsigned int twosValue, unsigned int nBits, double lsb) const {
+  double undigitizeSignedValue(unsigned int twosValue, unsigned int nBits, double lsb, double offset = 0.5) const {
     // Check that none of the bits above the nBits-1 bit, in a range of [0, nBits-1], are set.
     // This makes sure that it isn't possible for the value represented by `twosValue` to be
     //  any bigger than ((1 << nBits) - 1).
@@ -327,7 +327,7 @@ private:
     }
 
     // Convert to floating point value
-    return (double(digitizedValue) + 0.5) * lsb;
+    return (double(digitizedValue) + offset) * lsb;
   }
 
   // ----------member data ---------------------------

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -277,7 +277,7 @@ protected:
   }
 
 public:
-  // ----------private member functions --------------
+  // ----------public member functions --------------
   unsigned int countSetBits(unsigned int n) const {
     // Adapted from: https://www.geeksforgeeks.org/count-set-bits-in-an-integer/
     unsigned int count = 0;

--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -77,6 +77,7 @@ process.l1tVertexProducer.VertexReconstruction.VxMinTrackPt = cms.double(0.0)
 process.l1tVertexProducer.debug = options.debug
 process.l1tTrackSelectionProducer.processSimulatedTracks = cms.bool(False)
 process.l1tTrackSelectionProducer.l1VerticesEmulationInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
+process.l1tTrackSelectionProducer.debug = options.debug
 process.l1tTrackJetsEmulation.VertexInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
 process.l1tTrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("l1tVertexProducer", "l1verticesEmulation")
 process.l1tTrackerEmuEtMiss.debug = options.debug

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -113,8 +113,6 @@ private:
           TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
       ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize> ptEmulation;
       ptEmulation.V = ptEmulationBits.range();
-      //edm::LogInfo("L1TrackSelectionProducer") << "produce::Emulation track properties::ap_uint(bits) = " << ptEmulationBits.to_string(2)
-      //                                         << " ap_ufixed(bits) = " << ptEmulation.to_string(2) << " ap_ufixed(float) = " << ptEmulation.to_double();
       return ptEmulation.to_double() >= ptMin_;
     }
 
@@ -156,7 +154,10 @@ private:
     TTTrackWordAbsZ0MaxSelector(double absZ0Max) : absZ0Max_(absZ0Max) {}
     TTTrackWordAbsZ0MaxSelector(const edm::ParameterSet& cfg)
         : absZ0Max_(cfg.template getParameter<double>("absZ0Max")) {}
-    bool operator()(const L1Track& t) const { return std::abs(t.getZ0()) <= absZ0Max_; }
+    bool operator()(const L1Track& t) const {
+      double floatZ0 = t.undigitizeSignedValue(t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+      return std::abs(floatZ0) <= absZ0Max_;
+    }
 
   private:
     double absZ0Max_;
@@ -263,7 +264,7 @@ private:
           deltaZMax_(cfg.template getParameter<double>("deltaZMax")) {}
     bool operator()(const L1Track& t, const l1t::Vertex& v) const {
       size_t etaIndex =
-          std::lower_bound(deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(t.momentum().eta())) -
+          std::upper_bound(deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(t.momentum().eta())) -
           deltaZMaxEtaBounds_.begin() - 1;
       if (etaIndex > deltaZMax_.size() - 1)
         etaIndex = deltaZMax_.size() - 1;
@@ -281,12 +282,21 @@ private:
         : deltaZMaxEtaBounds_(cfg.template getParameter<double>("deltaZMaxEtaBounds")),
           deltaZMax_(cfg.template getParameter<double>("deltaZMax")) {}
     bool operator()(const L1Track& t, const l1t::VertexWord& v) const {
+      TTTrack_TrackWord::tanl_t etaEmulationBits = t.getTanlWord();
+      ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize> etaEmulation;
+      etaEmulation.V = etaEmulationBits.range();
       size_t etaIndex =
-          std::lower_bound(deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(t.momentum().eta())) -
+          std::upper_bound(deltaZMaxEtaBounds_.begin(), deltaZMaxEtaBounds_.end(), std::abs(etaEmulation.to_double())) -
           deltaZMaxEtaBounds_.begin() - 1;
       if (etaIndex > deltaZMax_.size() - 1)
         etaIndex = deltaZMax_.size() - 1;
-      return std::abs(v.z0() - t.getZ0()) <= deltaZMax_[etaIndex];
+      l1t::VertexWord::vtxz0_t fixedTkZ0 = t.undigitizeSignedValue(t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+
+      ap_uint<TrackBitWidths::kPtSize> ptEmulationBits = t.getTrackWord()(
+      TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
+      ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize> ptEmulation;
+      ptEmulation.V = ptEmulationBits.range();
+      return std::abs(v.z0() - fixedTkZ0.to_double()) <= deltaZMax_[etaIndex];
     }
 
   private:
@@ -496,9 +506,11 @@ void L1TrackSelectionProducer::printTrackInfo(edm::LogInfo& log, const L1Track& 
     TTTrack_TrackWord::tanl_t etaEmulationBits = track.getTanlWord();
     ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize> etaEmulation;
     etaEmulation.V = etaEmulationBits.range();
-    log << "\t\t(" << ptEmulation.to_double() << ", " << etaEmulation.to_double() << ", " << track.getPhi() << ", "
+    double floatTkZ0 = track.undigitizeSignedValue(track.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+    double floatTkPhi = track.undigitizeSignedValue(track.getPhiBits(), TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0, 0.0);
+    log << "\t\t(" << ptEmulation.to_double() << ", " << etaEmulation.to_double() << ", " << floatTkPhi << ", "
         << track.getNStubs() << ", " << track.getBendChi2() << ", " << track.getChi2RZ() << ", " << track.getChi2RPhi()
-        << ", " << track.getZ0() << ")\n";
+        << ", " << floatTkZ0 << ")\n";
   }
 }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -155,7 +155,8 @@ private:
     TTTrackWordAbsZ0MaxSelector(const edm::ParameterSet& cfg)
         : absZ0Max_(cfg.template getParameter<double>("absZ0Max")) {}
     bool operator()(const L1Track& t) const {
-      double floatZ0 = t.undigitizeSignedValue(t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+      double floatZ0 = t.undigitizeSignedValue(
+          t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
       return std::abs(floatZ0) <= absZ0Max_;
     }
 
@@ -290,10 +291,11 @@ private:
           deltaZMaxEtaBounds_.begin() - 1;
       if (etaIndex > deltaZMax_.size() - 1)
         etaIndex = deltaZMax_.size() - 1;
-      l1t::VertexWord::vtxz0_t fixedTkZ0 = t.undigitizeSignedValue(t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+      l1t::VertexWord::vtxz0_t fixedTkZ0 = t.undigitizeSignedValue(
+          t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
 
       ap_uint<TrackBitWidths::kPtSize> ptEmulationBits = t.getTrackWord()(
-      TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
+          TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
       ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize> ptEmulation;
       ptEmulation.V = ptEmulationBits.range();
       return std::abs(v.z0() - fixedTkZ0.to_double()) <= deltaZMax_[etaIndex];
@@ -506,8 +508,10 @@ void L1TrackSelectionProducer::printTrackInfo(edm::LogInfo& log, const L1Track& 
     TTTrack_TrackWord::tanl_t etaEmulationBits = track.getTanlWord();
     ap_fixed<TrackBitWidths::kEtaSize, TrackBitWidths::kEtaMagSize> etaEmulation;
     etaEmulation.V = etaEmulationBits.range();
-    double floatTkZ0 = track.undigitizeSignedValue(track.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
-    double floatTkPhi = track.undigitizeSignedValue(track.getPhiBits(), TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0, 0.0);
+    double floatTkZ0 = track.undigitizeSignedValue(
+        track.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
+    double floatTkPhi = track.undigitizeSignedValue(
+        track.getPhiBits(), TTTrack_TrackWord::TrackBitWidths::kPhiSize, TTTrack_TrackWord::stepPhi0, 0.0);
     log << "\t\t(" << ptEmulation.to_double() << ", " << etaEmulation.to_double() << ", " << floatTkPhi << ", "
         << track.getNStubs() << ", " << track.getBendChi2() << ", " << track.getChi2RZ() << ", " << track.getChi2RPhi()
         << ", " << floatTkZ0 << ")\n";

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -294,10 +294,6 @@ private:
       l1t::VertexWord::vtxz0_t fixedTkZ0 = t.undigitizeSignedValue(
           t.getZ0Bits(), TTTrack_TrackWord::TrackBitWidths::kZ0Size, TTTrack_TrackWord::stepZ0, 0.0);
 
-      ap_uint<TrackBitWidths::kPtSize> ptEmulationBits = t.getTrackWord()(
-          TTTrack_TrackWord::TrackBitLocations::kRinvMSB - 1, TTTrack_TrackWord::TrackBitLocations::kRinvLSB);
-      ap_ufixed<TrackBitWidths::kPtSize, TrackBitWidths::kPtMagSize> ptEmulation;
-      ptEmulation.V = ptEmulationBits.range();
       return std::abs(v.z0() - fixedTkZ0.to_double()) <= deltaZMax_[etaIndex];
     }
 


### PR DESCRIPTION
#### PR description:

Updates the TrackSelection outputs to better match the firmware. Care is taken to make sure that no undigitization rounding errors are incurred before the comparisons selecting the tracks are made.

#### PR validation:

The outputs of this PR now match the firmware outputs. Also the standard scram checks were performed

Porting of local https://github.com/cms-l1t-offline/cmssw/pull/1055