### PR TITLE
Protection in geant4 stacking action 

### DIFF
--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -216,11 +216,11 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
       G4int subType = (nullptr != proc) ? proc->GetProcessSubType() : 0;
       if (subType == 16) {
         auto ptr = dynamic_cast<const G4GammaGeneralProcess*>(proc);
-	if(nullptr != proc) {
-	  proc = ptr->GetSelectedProcess();
-	  subType = proc->GetProcessSubType();
-	  track->SetCreatorProcess(proc);
-	}
+        if (nullptr != proc) {
+          proc = ptr->GetSelectedProcess();
+          subType = proc->GetProcessSubType();
+          track->SetCreatorProcess(proc);
+        }
       }
       LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
                                        << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -212,13 +212,15 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
     } else {
       // potentially good for tracking
       const double ke = aTrack->GetKineticEnergy();
-      auto proc = aTrack->GetCreatorProcess();
-      G4int subType = proc->GetProcessSubType();
+      const G4VProcess* proc = aTrack->GetCreatorProcess();
+      G4int subType = (nullptr != proc) ? proc->GetProcessSubType() : 0;
       if (subType == 16) {
-        auto ptr = static_cast<const G4GammaGeneralProcess*>(proc);
-        proc = ptr->GetSelectedProcess();
-        subType = proc->GetProcessSubType();
-        track->SetCreatorProcess(proc);
+        auto ptr = dynamic_cast<const G4GammaGeneralProcess*>(proc);
+	if(nullptr != proc) {
+	  proc = ptr->GetSelectedProcess();
+	  subType = proc->GetProcessSubType();
+	  track->SetCreatorProcess(proc);
+	}
       }
       LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
                                        << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()


### PR DESCRIPTION
#### PR description:
The protection in manipulation with pointers to Geant4 process object is introduced. This pointer belong to G4VProcess object, which limits current Geant4 step. This PR is needed to address the issue #40090 : crash in Geant4 tracking due to corrupted pointers in some special condition. Similar report was discussed at the recent Simulation meeting, which also concerns on StackingAction at the same place and for Run-2 simulation with the 12_6_X release. The problem is not seen for Run-3 or Phase-2 WFs, its origin is not clear, it is not frequent but should be fixed anyway. The current fix includes dynamic_cast and checks on validity of pointers.   

Any physics result should not be affected.

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO backport assumed

