### PR TITLE
(DAQ) File based protocol update

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -45,9 +45,12 @@ DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet& ps) : DQMFileSaverBase(p
   }
 
   if (!fakeFilterUnitMode_) {
-    evf::EvFDaqDirector* daqDirector = (evf::EvFDaqDirector*)(edm::Service<evf::EvFDaqDirector>().operator->());
-    const std::string initFileName = daqDirector->getInitFilePath(streamLabel_);
+    if (!edm::Service<evf::EvFDaqDirector>().isAvailable())
+      throw cms::Exception("DQMFileSaverPB") << "EvFDaqDirector is not available";
+    std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_);
     std::ofstream file(initFileName);
+    if (!file)
+      throw cms::Exception("DQMFileSaverPB") << "Cannot create INI file: " << initFileName << " error:" << strerror(errno);
     file.close();
   }
 }

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -50,7 +50,8 @@ DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet& ps) : DQMFileSaverBase(p
     std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_);
     std::ofstream file(initFileName);
     if (!file)
-      throw cms::Exception("DQMFileSaverPB") << "Cannot create INI file: " << initFileName << " error:" << strerror(errno);
+      throw cms::Exception("DQMFileSaverPB")
+          << "Cannot create INI file: " << initFileName << " error: " << strerror(errno);
     file.close();
   }
 }

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -43,6 +43,14 @@ DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet& ps) : DQMFileSaverBase(p
   if (tag_ != "UNKNOWN") {
     streamLabel_ = "DQMLive";
   }
+
+  if (!fakeFilterUnitMode_) {
+    evf::EvFDaqDirector* daqDirector = (evf::EvFDaqDirector*)(edm::Service<evf::EvFDaqDirector>().operator->());
+    const std::string initFileName = daqDirector->getInitFilePath(streamLabel_);
+    std::ofstream file(initFileName);
+    file.close();
+  }
+
 }
 
 DQMFileSaverPB::~DQMFileSaverPB() = default;
@@ -51,13 +59,6 @@ void DQMFileSaverPB::initRun() const {
   if (!fakeFilterUnitMode_) {
     transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(streamLabel_);
     mergeType_ = edm::Service<evf::EvFDaqDirector>()->getStreamMergeType(streamLabel_, evf::MergeTypePB);
-  }
-
-  if (!fakeFilterUnitMode_) {
-    evf::EvFDaqDirector* daqDirector = (evf::EvFDaqDirector*)(edm::Service<evf::EvFDaqDirector>().operator->());
-    const std::string initFileName = daqDirector->getInitFilePath(streamLabel_);
-    std::ofstream file(initFileName);
-    file.close();
   }
 }
 

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -50,7 +50,6 @@ DQMFileSaverPB::DQMFileSaverPB(const edm::ParameterSet& ps) : DQMFileSaverBase(p
     std::ofstream file(initFileName);
     file.close();
   }
-
 }
 
 DQMFileSaverPB::~DQMFileSaverPB() = default;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -91,6 +91,7 @@ namespace evf {
     std::string getMergedDatChecksumFilePath(const unsigned int ls, std::string const& stream) const;
     std::string getOpenInitFilePath(std::string const& stream) const;
     std::string getInitFilePath(std::string const& stream) const;
+    std::string getInitTempFilePath(std::string const& stream) const;
     std::string getOpenProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
     std::string getProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
     std::string getMergedProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
@@ -186,7 +187,7 @@ namespace evf {
     std::string getStreamMergeType(std::string const& stream, MergeType defaultType);
     static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
     bool inputThrottled();
-    bool lumisectionDiscarded(uint32_t ls);
+    bool lumisectionDiscarded(unsigned int ls);
 
   private:
     bool bumpFile(unsigned int& ls,

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -185,6 +185,7 @@ namespace evf {
     std::string getStreamMergeType(std::string const& stream, MergeType defaultType);
     static struct flock make_flock(short type, short whence, off_t start, off_t len, pid_t pid);
     bool inputThrottled();
+    bool lumisectionDiscarded(uint32_t ls);
 
   private:
     bool bumpFile(unsigned int& ls,

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -286,6 +286,7 @@ namespace evf {
     std::unique_ptr<boost::asio::ip::tcp::socket> socket_;
 
     std::string input_throttled_file_;
+    std::string discard_ls_filestem_;
   };
 }  // namespace evf
 

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -120,6 +120,7 @@ namespace evf {
     void unlockInitLock();
     void setFMS(evf::FastMonitoringService* fms) { fms_ = fms; }
     bool isSingleStreamThread() { return nStreams_ == 1 && nThreads_ == 1; }
+    unsigned int numConcurrentLumis() const { return nConcurrentLumis_; }
     void lockFULocal();
     void unlockFULocal();
     void lockFULocal2();
@@ -264,6 +265,7 @@ namespace evf {
 
     unsigned int nStreams_ = 0;
     unsigned int nThreads_ = 0;
+    unsigned int nConcurrentLumis_ = 0;
 
     bool readEolsDefinition_ = true;
     unsigned int eolsNFilesIndex_ = 1;

--- a/EventFilter/Utilities/interface/FFFNamingSchema.h
+++ b/EventFilter/Utilities/interface/FFFNamingSchema.h
@@ -59,6 +59,13 @@ namespace fffnaming {
     return ss.str();
   }
 
+  inline std::string initTempFileNameWithPid(const unsigned int run, const unsigned int ls, std::string const& stream) {
+    std::stringstream ss;
+    runLumiPrefixFill(ss, run, ls);
+    ss << "_" << stream << "_pid" << std::setfill('0') << std::setw(5) << getpid() << ".initemp";
+    return ss.str();
+  }
+
   inline std::string initFileNameWithInstance(const unsigned int run,
                                               const unsigned int ls,
                                               std::string const& stream,

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -318,7 +318,8 @@ namespace evf {
     const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath(streamLabel_);
     std::ofstream file(iniFileName);
     if (!file)
-      throw cms::Exception("GlobalEvFOutputModule") << "can not create " << iniFileName << ": " << strerror(errno);
+      throw cms::Exception("GlobalEvFOutputModule")
+          << "can not create " << iniFileName << "error: " << strerror(errno);
     file.close();
 
     edm::LogInfo("GlobalEvFOutputModule") << "Constructor created initemp file -: " << iniFileName;
@@ -385,7 +386,8 @@ namespace evf {
     uint32_t adlera = 1, adlerb = 0;
     std::ifstream src(openIniFileName, std::ifstream::binary);
     if (!src)
-      throw cms::Exception("GlobalEvFOutputModule") << "can not read back " << openIniFileName << ": " << strerror(errno);
+      throw cms::Exception("GlobalEvFOutputModule")
+          << "can not read back " << openIniFileName << " error: " << strerror(errno);
 
     //allocate buffer to write INI file
     std::unique_ptr<char[]> outBuf = std::make_unique<char[]>(1024 * 1024);

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -315,7 +315,7 @@ namespace evf {
     //output initemp file. This lets hltd know number of streams early on
     const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_) + "temp";
     FILE* src = fopen(iniFileName.c_str(), "w");
-    if (src==NULL)
+    if (src==nullptr)
       throw cms::Exception("GlobalEvFOutputModule")
           << "can not create " << iniFileName << ":" << strerror(errno);
     fclose(src);

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -318,8 +318,7 @@ namespace evf {
     const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath(streamLabel_);
     std::ofstream file(iniFileName);
     if (!file)
-      throw cms::Exception("GlobalEvFOutputModule")
-          << "can not create " << iniFileName << "error: " << strerror(errno);
+      throw cms::Exception("GlobalEvFOutputModule") << "can not create " << iniFileName << "error: " << strerror(errno);
     file.close();
 
     edm::LogInfo("GlobalEvFOutputModule") << "Constructor created initemp file -: " << iniFileName;

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -63,9 +63,9 @@ namespace evf {
       throttledCheck();
       discardedCheck();
       if (discarded_) {
-          incAccepted();
-          msg.reset();
-          return;
+        incAccepted();
+        msg.reset();
+        return;
       }
       auto group = iHolder.group();
       writeQueue_.push(*group, [holder = std::move(iHolder), msg = msg.release(), this]() {
@@ -89,16 +89,16 @@ namespace evf {
         usleep(100000);
         counter++;
         if (edm::Service<evf::EvFDaqDirector>()->lumisectionDiscarded(ls_)) {
-           edm::LogWarning("FedRawDataInputSource") << "Detected that the lumisection is discarded -: " << ls_;
-           discarded_ = true;
+          edm::LogWarning("FedRawDataInputSource") << "Detected that the lumisection is discarded -: " << ls_;
+          discarded_ = true;
         }
       }
     }
 
     inline void discardedCheck() {
       if (!discarded_ && edm::Service<evf::EvFDaqDirector>()->lumisectionDiscarded(ls_)) {
-         edm::LogWarning("FedRawDataInputSource") << "Detected that the lumisection is discarded -: " << ls_;
-         discarded_ = true;
+        edm::LogWarning("FedRawDataInputSource") << "Detected that the lumisection is discarded -: " << ls_;
+        discarded_ = true;
       }
     }
 
@@ -196,7 +196,6 @@ namespace evf {
   GlobalEvFOutputJSONDef::GlobalEvFOutputJSONDef(std::string const& streamLabel, bool writeJsd) {
     std::string baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
     LogDebug("GlobalEvFOutputModule") << "writing .dat files to -: " << baseRunDir;
-
 
     outJsonDef_.setDefaultGroup("data");
     outJsonDef_.addLegendItem("Processed", "integer", jsoncollector::DataPointDefinition::SUM);
@@ -315,9 +314,8 @@ namespace evf {
     //output initemp file. This lets hltd know number of streams early on
     const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath(streamLabel_) + "temp";
     FILE* src = fopen(iniFileName.c_str(), "w");
-    if (src==nullptr)
-      throw cms::Exception("GlobalEvFOutputModule")
-          << "can not create " << iniFileName << ":" << strerror(errno);
+    if (src == nullptr)
+      throw cms::Exception("GlobalEvFOutputModule") << "can not create " << iniFileName << ":" << strerror(errno);
     fclose(src);
     edm::LogInfo("GlobalEvFOutputModule") << "Constructor initemp stream -: " << iniFileName;
 
@@ -344,7 +342,6 @@ namespace evf {
   }
 
   std::shared_ptr<GlobalEvFOutputJSONDef> GlobalEvFOutputModule::globalBeginRun(edm::RunForOutput const& run) const {
-
     //create run Cache holding JSON file writer and variables
     auto jsonDef = std::make_unique<GlobalEvFOutputJSONDef>(streamLabel_, false);
     jsonDef->updateDestination(streamLabel_);
@@ -465,7 +462,8 @@ namespace evf {
       jsonWriter.errorEvents_.value() = fms_->getEventsProcessedForLumi(iLB.luminosityBlock(), &abortFlag);
       jsonWriter.processed_.value() = 0;
       jsonWriter.accepted_.value() = 0;
-      edm::LogInfo("GlobalEvFOutputModule") << "Output suppressed, setting error events for LS -: "<<iLB.luminosityBlock();
+      edm::LogInfo("GlobalEvFOutputModule")
+          << "Output suppressed, setting error events for LS -: " << iLB.luminosityBlock();
     }
 
     if (abortFlag) {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -156,11 +156,9 @@ namespace evf {
     ss = std::stringstream();
     ss << getpid();
     pid_ = ss.str();
-
   }
 
   void EvFDaqDirector::initRun() {
-
     // check if base dir exists or create it accordingly
     int retval = mkdir(base_dir_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (retval != 0 && errno != EEXIST) {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -448,6 +448,10 @@ namespace evf {
     return run_dir_ + "/" + fffnaming::initFileNameWithPid(run_, 0, stream);
   }
 
+  std::string EvFDaqDirector::getInitTempFilePath(std::string const& stream) const {
+    return run_dir_ + "/" + fffnaming::initTempFileNameWithPid(run_, 0, stream);
+  }
+
   std::string EvFDaqDirector::getOpenProtocolBufferHistogramFilePath(const unsigned int ls,
                                                                      std::string const& stream) const {
     return run_dir_ + "/open/" + fffnaming::protocolBufferHistogramFileNameWithPid(run_, ls, stream);
@@ -2069,7 +2073,7 @@ namespace evf {
     return (stat(input_throttled_file_.c_str(), &buf) == 0);
   }
 
-  bool EvFDaqDirector::lumisectionDiscarded(uint32_t ls) {
+  bool EvFDaqDirector::lumisectionDiscarded(unsigned int ls) {
     struct stat buf;
     return (stat((discard_ls_filestem_ + std::to_string(ls)).c_str(), &buf) == 0);
   }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -325,6 +325,7 @@ namespace evf {
 
     nThreads_ = bounds.maxNumberOfStreams();
     nStreams_ = bounds.maxNumberOfThreads();
+    nConcurrentLumis_ = bounds.maxNumberOfConcurrentLuminosityBlocks();
   }
 
   void EvFDaqDirector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -143,9 +143,7 @@ namespace evf {
         edm::LogWarning("EvFDaqDirector") << "Bad lexical cast in parsing: " << std::string(fileBrokerUseLockParamPtr);
       }
     }
-  }
 
-  void EvFDaqDirector::initRun() {
     std::stringstream ss;
     ss << "run" << std::setfill('0') << std::setw(6) << run_;
     run_string_ = ss.str();
@@ -158,6 +156,10 @@ namespace evf {
     ss = std::stringstream();
     ss << getpid();
     pid_ = ss.str();
+
+  }
+
+  void EvFDaqDirector::initRun() {
 
     // check if base dir exists or create it accordingly
     int retval = mkdir(base_dir_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -154,6 +154,7 @@ namespace evf {
     run_nstring_ = ss.str();
     run_dir_ = base_dir_ + "/" + run_string_;
     input_throttled_file_ = run_dir_ + "/input_throttle";
+    discard_ls_filestem_ = run_dir_ + "/discard_ls";
     ss = std::stringstream();
     ss << getpid();
     pid_ = ss.str();
@@ -2065,6 +2066,11 @@ namespace evf {
   bool EvFDaqDirector::inputThrottled() {
     struct stat buf;
     return (stat(input_throttled_file_.c_str(), &buf) == 0);
+  }
+
+  bool EvFDaqDirector::lumisectionDiscarded(uint32_t ls) {
+    struct stat buf;
+    return (stat((discard_ls_filestem_ + std::to_string(ls)).c_str(), &buf) == 0);
   }
 
 }  // namespace evf

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -849,7 +849,7 @@ void FedRawDataInputSource::readSupervisor() {
           break;
 
         unsigned int nConcurrentLumis = daqDirector_->numConcurrentLumis();
-        unsigned int nOtherLumis = nConcurrentLumis > 0 ? nConcurrentLumis  - 1 : 0;
+        unsigned int nOtherLumis = nConcurrentLumis > 0 ? nConcurrentLumis - 1 : 0;
         unsigned int checkLumiStart = currentLumiSection > nOtherLumis ? currentLumiSection - nOtherLumis : 1;
         bool hasDiscardedLumi = false;
         for (unsigned int i = checkLumiStart; i <= currentLumiSection; i++) {
@@ -859,7 +859,8 @@ void FedRawDataInputSource::readSupervisor() {
             break;
           }
         }
-        if (hasDiscardedLumi) break;
+        if (hasDiscardedLumi)
+          break;
 
         setMonStateSup(inThrottled);
 

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -847,7 +847,22 @@ void FedRawDataInputSource::readSupervisor() {
       while (daqDirector_->inputThrottled()) {
         if (quit_threads_.load(std::memory_order_relaxed) || edm::shutdown_flag.load(std::memory_order_relaxed))
           break;
+
+        unsigned int nConcurrentLumis = daqDirector_->numConcurrentLumis();
+        unsigned int nOtherLumis = nConcurrentLumis > 0 ? nConcurrentLumis  - 1 : 0;
+        unsigned int checkLumiStart = currentLumiSection > nOtherLumis ? currentLumiSection - nOtherLumis : 1;
+        bool hasDiscardedLumi = false;
+        for (unsigned int i = checkLumiStart; i <= currentLumiSection; i++) {
+          if (daqDirector_->lumisectionDiscarded(i)) {
+            edm::LogWarning("FedRawDataInputSource") << "Source detected that the lumisection is discarded -: " << i;
+            hasDiscardedLumi = true;
+            break;
+          }
+        }
+        if (hasDiscardedLumi) break;
+
         setMonStateSup(inThrottled);
+
         if (!(counter % 50))
           edm::LogWarning("FedRawDataInputSource") << "Input throttled detected, reading files is paused...";
         usleep(100000);

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -153,8 +153,9 @@ HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(edm::ParameterSet const& config
     //output initemp file. This lets hltd know number of streams early
     std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath("streamHLTRates");
     std::ofstream file(initFileName);
-    if (!file) 
-      throw cms::Exception("HLTriggerJsonMonitoring") << "Cannot create INITEMP file: " << initFileName << " error:" << strerror(errno);
+    if (!file)
+      throw cms::Exception("HLTriggerJsonMonitoring")
+          << "Cannot create INITEMP file: " << initFileName << " error: " << strerror(errno);
     file.close();
   }
 }

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -157,7 +157,6 @@ HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(edm::ParameterSet const& config
   }
 }
 
-
 // validate the configuration and optionally fill the default values
 void HLTriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -148,7 +148,15 @@ private:
 // constructor
 HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(edm::ParameterSet const& config)
     : triggerResults_(config.getParameter<edm::InputTag>("triggerResults")),
-      triggerResultsToken_(consumes(triggerResults_)) {}
+      triggerResultsToken_(consumes(triggerResults_)) {
+  if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
+    //output initemp file. This lets hltd know number of streams early
+    const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath("streamHLTRates") + "temp";
+    std::ofstream file(iniFileName);
+    file.close();
+  }
+}
+
 
 // validate the configuration and optionally fill the default values
 void HLTriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -151,8 +151,10 @@ HLTriggerJSONMonitoring::HLTriggerJSONMonitoring(edm::ParameterSet const& config
       triggerResultsToken_(consumes(triggerResults_)) {
   if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
     //output initemp file. This lets hltd know number of streams early
-    const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath("streamHLTRates") + "temp";
-    std::ofstream file(iniFileName);
+    std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath("streamHLTRates");
+    std::ofstream file(initFileName);
+    if (!file) 
+      throw cms::Exception("HLTriggerJsonMonitoring") << "Cannot create INITEMP file: " << initFileName << " error:" << strerror(errno);
     file.close();
   }
 }

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -166,8 +166,9 @@ L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(edm::ParameterSet const& config
     //output initemp file. This lets hltd know number of streams early
     std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath("streamL1Rates");
     std::ofstream file(initFileName);
-    if (!file) 
-      throw cms::Exception("L1TriggerJsonMonitoring") << "Cannot create INITEMP file: " << initFileName << " error:" << strerror(errno);
+    if (!file)
+      throw cms::Exception("L1TriggerJsonMonitoring")
+          << "Cannot create INITEMP file: " << initFileName << " error: " << strerror(errno);
     file.close();
   }
 }

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -162,14 +162,12 @@ L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(edm::ParameterSet const& config
     : level1Results_(config.getParameter<edm::InputTag>("L1Results")),
       level1ResultsToken_(consumes<GlobalAlgBlkBxCollection>(level1Results_)),
       l1tUtmTriggerMenuRcdToken_(esConsumes<edm::Transition::BeginRun>()) {
-
   if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
     //output initemp file. This lets hltd know number of streams early
     const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath("streamL1Rates") + "temp";
     std::ofstream file(iniFileName);
     file.close();
   }
-
 }
 
 // validate the configuration and optionally fill the default values

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -164,8 +164,10 @@ L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(edm::ParameterSet const& config
       l1tUtmTriggerMenuRcdToken_(esConsumes<edm::Transition::BeginRun>()) {
   if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
     //output initemp file. This lets hltd know number of streams early
-    const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath("streamL1Rates") + "temp";
-    std::ofstream file(iniFileName);
+    std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitTempFilePath("streamL1Rates");
+    std::ofstream file(initFileName);
+    if (!file) 
+      throw cms::Exception("L1TriggerJsonMonitoring") << "Cannot create INITEMP file: " << initFileName << " error:" << strerror(errno);
     file.close();
   }
 }

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -161,7 +161,16 @@ constexpr const std::array<const char*, 16> L1TriggerJSONMonitoring::tcdsTrigger
 L1TriggerJSONMonitoring::L1TriggerJSONMonitoring(edm::ParameterSet const& config)
     : level1Results_(config.getParameter<edm::InputTag>("L1Results")),
       level1ResultsToken_(consumes<GlobalAlgBlkBxCollection>(level1Results_)),
-      l1tUtmTriggerMenuRcdToken_(esConsumes<edm::Transition::BeginRun>()) {}
+      l1tUtmTriggerMenuRcdToken_(esConsumes<edm::Transition::BeginRun>()) {
+
+  if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
+    //output initemp file. This lets hltd know number of streams early
+    const std::string iniFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath("streamL1Rates") + "temp";
+    std::ofstream file(iniFileName);
+    file.close();
+  }
+
+}
 
 // validate the configuration and optionally fill the default values
 void L1TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

Two changes are implemented for the file-based output protocol:

Early "initemp" file marker:
* A file marker is created in constructor (.initemp of .ini depending on the stream type and content availability at construction). From 12_6_X, as noticed in tests, beginRun (or globalBeginRun) in GlobalEvFOutputModule can be called after event processing in the source starts, so creating such markers at beginRun is no longer sufficient. Marker needs to be created early for hltd daemon to know which streams are in the run, and therefore wait for output completion until lumisection can be closed in the merging system. Standard INI file is still created with information from beginRun, except in case of DQMHistograms where it is empty, so creation was moved to constructor.

* Changes are implemented in the GlobalEvFOutputModule (data streams), DQMFileSaverPB (DQMHistograms stream) and L1/HLTriggerJsonMonitoring (L1/HLTRates streams). **Note:** in combination with correspoding changes in hltd, this patch is **required** for CMSSW_12_6_X being used in the HLT environment, as collecting output doesn't work with current version of the sw.

Discard LS:
* appearance of a file marker in hltd run directory will trigger discard of specific LS data locally in CMSSW. Motivation for this is freeing space in temporary ramdisks in HLT to allow data processing to be unblocked. With concurrent lumisections (N = 2 by default in HLT), LS potentially doesn't get closed until N new lumisections are queued, so a range of several lumisections is checked by the input source. In the output module, a new file marker check (this is a fast file operation done in ramdisk) is performed before each event is written. Discarding is implemented only for the data streams, since special streams are negligible in size.

#### PR validation:
Tested and verified in a small DAQ cluster providing environment (services) analogous to a production BU-FU setup.