### PR TITLE
Add Run 3 muon process using proper DNN b-tagger

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/displacedMuonProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/displacedMuonProducer_cff.py
@@ -88,8 +88,6 @@ patDisplacedMuons = patMuons.clone(
 patDisplacedMuons.isoDeposits = cms.PSet()
 patDisplacedMuons.isolationValues = cms.PSet()
 
-
-
 # Displaced muon task filters the displacedMuons that overlap with standard muons
 makePatDisplacedMuonsTask = cms.Task(
     filteredDisplacedMuonsTask,
@@ -97,4 +95,9 @@ makePatDisplacedMuonsTask = cms.Task(
     )
 
 makePatDisplacedMuons = cms.Sequence(makePatDisplacedMuonsTask)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(patDisplacedMuons,
+                     mvaJetTag = "pfDeepCSVJetTags:probb",
+)
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -135,14 +135,9 @@ patMuons = cms.EDProducer("PATMuonProducer",
     hltCollectionFilters = cms.vstring('*')
 )
 
-
-
-
-
-
-
-
-
-
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(patMuons,
+                     mvaJetTag = cms.InputTag("pfDeepCSVJetTags:probb"),
+)
 
 


### PR DESCRIPTION
#### PR description:

Regarding the AlCa issue https://github.com/cms-sw/cmssw/pull/58 (https://github.com/cms-AlCaDB/AlCaTools/issues/58), old b-tagging GT records are request to be removed (starting) from 12_1_X (and so on). Due to the dependency on "BTauGenericMVAJetTagComputerRcd" and "JetTagComputerRecord", the corresponding b-tagging computers need to be masked in run3. Only DNN taggers will be the only supported ones in run3. To accommodate the change, this PR changes the discriminator to "pfDeepCSVJetTag:probb" in patMuon and patDisplacedMuon with Era Modifier for Run 3.

#### PR validation:

PR tested locally with runTheMatrix with Run3 era and 125X_mcRun3_2022_realistic_Queue condition on 11603.0 and native run 3 tests 312.0, 139.001 and 13234.0.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport and no backport expected.