### PR TITLE
Add MC GT for 2022 postEE leak

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -71,6 +71,8 @@ autoCond = {
     'phase1_2022_design'           : '125X_mcRun3_2022_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
     'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v5',
+    # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
+    'phase1_2022_realistic_postEE' : '124X_mcRun3_2022_realistic_postEE_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
     'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:
As suggested by @silviodonato during the [17<sup>th</sup> Nov. 2022 PPD General meeting](https://indico.cern.ch/event/1219319/), this PR adds a new key in `autoCond`:
```
# GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
'phase1_2022_realistic_postEE' : '124X_mcRun3_2022_realistic_postEE_v1',
```
which adds to the release the MC GT (announced in [this CMSTalk post](https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-post-ee-failure-mc-deadline-oct-31/16130/5)) to be used in the `Summer22Run3EE` MC campaign ([PDMVMCPROD-71](https://its.cern.ch/jira/browse/PDMVMCPROD-71)), i.e. after the EE+ water leak.

#### PR validation:
None, as currently there is no relval set up for this campaign. 
A new relval should be added by @cms-sw/pdmv-l2

#### Backport:
Not a backport. Backports to 12_5_X and 12_4_X will be provided soon.