### PR TITLE
Allow SwitchProducer cases to declare different transient products

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -187,7 +187,9 @@ namespace edm {
                 branchKey.moduleLabel() == prod.second.switchAliasModuleLabel() and
                 branchKey.productInstanceName() == prod.second.productInstanceName()) {
               prod.second.setSwitchAliasForBranch(desc);
-              it->second.chosenBranches.push_back(prod.first);  // with moduleLabel of the Switch
+              if (!prod.second.transient()) {
+                it->second.chosenBranches.push_back(prod.first);  // with moduleLabel of the Switch
+              }
               found = true;
             }
           }
@@ -233,7 +235,7 @@ namespace edm {
         }
       };
 
-      // Check that non-chosen cases declare exactly the same branches
+      // Check that non-chosen cases declare exactly the same non-transient branches
       // Also set the alias-for branches to transient
       std::vector<bool> foundBranches;
       for (auto const& switchItem : switchMap) {
@@ -246,6 +248,32 @@ namespace edm {
           for (auto& nonConstItem : preg.productListUpdator()) {
             auto const& item = nonConstItem;
             if (item.first.moduleLabel() == caseLabel and item.first.processName() == processName) {
+              // Check that products which are not transient in the dictionary are consistent between
+              // all the cases of a SwitchProducer.
+              if (!item.second.transient()) {
+                auto range = std::equal_range(chosenBranches.begin(),
+                                              chosenBranches.end(),
+                                              BranchKey(item.first.friendlyClassName(),
+                                                        switchLabel,
+                                                        item.first.productInstanceName(),
+                                                        item.first.processName()));
+                if (range.first == range.second) {
+                  Exception ex(errors::Configuration);
+                  ex << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " with a product "
+                     << item.first << " that is not produced by the chosen case "
+                     << proc_pset.getParameter<edm::ParameterSet>(switchLabel)
+                            .getUntrackedParameter<std::string>("@chosen_case")
+                     << " and that product is not transient. "
+                     << "If the intention is to produce only a subset of the non-transient products listed below, each "
+                        "case with more non-transient products needs to be replaced with an EDAlias to only the "
+                        "necessary products, and the EDProducer itself needs to be moved to a Task.\n\n";
+                  addProductsToException(caseLabels, ex);
+                  throw ex;
+                }
+                assert(std::distance(range.first, range.second) == 1);
+                foundBranches[std::distance(chosenBranches.begin(), range.first)] = true;
+              }
+
               // Set the alias-for branch as transient so it gets fully ignored in output.
               // I tried first to implicitly drop all branches with
               // '@' in ProductSelector, but that gave problems on
@@ -255,27 +283,6 @@ namespace edm {
               // detection logic in RootFile says that the
               // SwitchProducer branches are not alias branches)
               nonConstItem.second.setTransient(true);
-
-              auto range = std::equal_range(chosenBranches.begin(),
-                                            chosenBranches.end(),
-                                            BranchKey(item.first.friendlyClassName(),
-                                                      switchLabel,
-                                                      item.first.productInstanceName(),
-                                                      item.first.processName()));
-              if (range.first == range.second) {
-                Exception ex(errors::Configuration);
-                ex << "SwitchProducer " << switchLabel << " has a case " << caseLabel << " with a product "
-                   << item.first << " that is not produced by the chosen case "
-                   << proc_pset.getParameter<edm::ParameterSet>(switchLabel)
-                          .getUntrackedParameter<std::string>("@chosen_case")
-                   << ". If the intention is to produce only a subset of the products listed below, each case with "
-                      "more products needs to be replaced with an EDAlias to only the necessary products, and the "
-                      "EDProducer itself needs to be moved to a Task.\n\n";
-                addProductsToException(caseLabels, ex);
-                throw ex;
-              }
-              assert(std::distance(range.first, range.second) == 1);
-              foundBranches[std::distance(chosenBranches.begin(), range.first)] = true;
 
               // Check that there are no BranchAliases for any of the cases
               auto const& bd = item.second;
@@ -299,10 +306,10 @@ namespace edm {
               Exception ex(errors::Configuration);
               ex << "SwitchProducer " << switchLabel << " has a case " << caseLabel
                  << " that does not produce a product " << chosenBranches[i] << " that is produced by the chosen case "
-                 << chosenLabel
-                 << ". If the intention is to produce only a subset of the products listed below, each case with more "
-                    "products needs to be replaced with an EDAlias to only the necessary products, and the "
-                    "EDProducer itself needs to be moved to a Task.\n\n";
+                 << chosenLabel << " and that product is not transient. "
+                 << "If the intention is to produce only a subset of the non-transient products listed below, each "
+                    "case with more non-transient products needs to be replaced with an EDAlias to only the "
+                    "necessary products, and the EDProducer itself needs to be moved to a Task.\n\n";
               addProductsToException(caseLabels, ex);
               throw ex;
             }

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -247,6 +247,24 @@ TEST_CASE("Configuration with different branches", s_tag) {
   }
 }
 
+TEST_CASE("Configuration with different transient branches", s_tag) {
+  const std::string test1{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(1), values = cms.VPSet())"};
+  const std::string test2{
+      "cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), transientValues = "
+      "cms.VPSet(cms.PSet(instance=cms.string('foo'),value=cms.int32(3))))"};
+
+  const std::string baseConfig1 = makeConfig(true, test1, test2);
+  const std::string baseConfig2 = makeConfig(false, test1, test2);
+
+  SECTION("Different transient branches are allowed") {
+    edm::test::TestProcessor::Config config1{baseConfig1};
+    edm::test::TestProcessor testProcessor1{config1};
+
+    edm::test::TestProcessor::Config config2{baseConfig2};
+    edm::test::TestProcessor testProcessor2{config2};
+  }
+}
+
 TEST_CASE("Configuration with different branches with EDAlias", s_tag) {
   const std::string otherprod{
       "cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = "

--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -259,9 +259,23 @@ TEST_CASE("Configuration with different transient branches", s_tag) {
   SECTION("Different transient branches are allowed") {
     edm::test::TestProcessor::Config config1{baseConfig1};
     edm::test::TestProcessor testProcessor1{config1};
+    auto event1 = testProcessor1.test();
+    REQUIRE(event1.get<edmtest::IntProduct>()->value == 2);
+
+    // It would be better if the next line of executable code would
+    // throw an exception, but that is not the current expected behavior.
+    // It would be nice to have all cases of a SwitchProducer fail if
+    // any case fails on a "get" (but it is intentional and desirable
+    // that it does not fail only because a  case declares it produces
+    // different transient products). We decided it was not worth the
+    // effort and complexity to implement this behavior (at least not yet).
+    REQUIRE(event1.get<edmtest::TransientIntProduct>("foo")->value == 3);
 
     edm::test::TestProcessor::Config config2{baseConfig2};
     edm::test::TestProcessor testProcessor2{config2};
+    auto event2 = testProcessor2.test();
+    REQUIRE(event2.get<edmtest::IntProduct>()->value == 1);
+    REQUIRE_THROWS(event2.get<edmtest::TransientIntProduct>()->value == 3);
   }
 }
 


### PR DESCRIPTION
#### PR description:

Allow SwitchProducer cases to declare different transient products. Currently we throw an exception if all cases do not declare the same produced products. With this, we allow differences for products marked as transient in their dictionary.

#### PR validation:

Extends an existing unit test to verify differences in declared transient products do not cause an exception to be thrown.
