### PR TITLE
fix initialization of local variables to avoid vagrind warnings

### DIFF
--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -534,8 +534,8 @@ namespace mkfit {
       MPlexQF hitsXi;
       MPlexQF propSign;
 #pragma omp simd
-      for (int n = 0; n < N_proc; ++n) {
-        if (failFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
+      for (int n = 0; n < NN; ++n) {
+        if (n >= N_proc || (failFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0)))) {
           hitsRl(n, 0, 0) = 0.f;
           hitsXi(n, 0, 0) = 0.f;
         } else {
@@ -637,8 +637,8 @@ namespace mkfit {
       MPlexQF hitsXi;
       MPlexQF propSign;
 #pragma omp simd
-      for (int n = 0; n < N_proc; ++n) {
-        if (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0)) {
+      for (int n = 0; n < NN; ++n) {
+        if (n >= N_proc || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
           hitsRl(n, 0, 0) = 0.f;
           hitsXi(n, 0, 0) = 0.f;
         } else {


### PR DESCRIPTION
#### PR description:

This PR fixes the initialization of a couple of MPlex arrays allocated on the stack. Previously they were being initialized up to N_proc, which may be smaller than the full vector width NN.  This PR ensures that any MPlex entries past N_proc are initialized to zero, since many of the propagation loops go up to NN to aid vectorization.

#### PR validation:

Reran valgrind and verified that there were no MkFit warnings.
