### PR TITLE
[12_5_X] Fix HI rawDataInputTag for beamhlt DQM client

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -132,14 +132,10 @@ process.tcdsDigis = tcdsRawToDigi.clone()
 # Import raw to digi modules
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
-# Set rawDataRepacker (HI and live) or hltFEDSelectorTCDS+hltFEDSelectorOnlineMetaData (for all the rest)
-if (process.runType.getRunType() == process.runType.hi_run and live):
-    rawDataInputTag = "rawDataRepacker"
-    onlineMetaDataInputTag = "hltFEDSelectorOnlineMetaData"
-else:
-    # Use raw data from selected TCDS FEDs (1024, 1025) and OnlineMetaData FED (1022)
-    rawDataInputTag = "hltFEDSelectorTCDS"
-    onlineMetaDataInputTag = "hltFEDSelectorOnlineMetaData"
+# Set InputTags from selected TCDS FEDs (1024, 1025) and OnlineMetaData FED (1022)
+# NOTE: these collections MUST be added to streamDQMOnlineBeamspot for all HLT menus (both pp and HI)
+rawDataInputTag        = "hltFEDSelectorTCDS"
+onlineMetaDataInputTag = "hltFEDSelectorOnlineMetaData"
 
 process.onlineMetaDataDigis.onlineMetaDataInputLabel = onlineMetaDataInputTag
 process.scalersRawToDigi.scalersInputTag             = rawDataInputTag


### PR DESCRIPTION
#### PR description:
Backport of #40109

This PR fixes the crash observed during HeavyIon data-taking in the online DQM client `beamhlt`:
```
----- Begin Fatal Exception 18-Nov-2022 16:45:53 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 362293 lumi: 14 event: 15139921 stream: 0
   [1] Running path 'p'
   [2] Calling method for module ScalersRawToDigi/'scalersRawToDigi'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: FEDRawDataCollection
Looking for module label: rawDataRepacker
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.
----- End Fatal Exception -------------------------------------------------
```
The issue arises from the fact that the `streamDQMOnlineBeamspot` does not contain `rawDataRepacker`, but:
```
OutputModule: hltOutputDQMOnlineBeamspot
    Datasets:
         Dataset_DQMOnlineBeamspot
    Event Content:
         drop *
         keep *_hltFEDSelectorOnlineMetaData_*_*
         keep *_hltFEDSelectorTCDS_*_*
         keep edmTriggerResults_*_*_*
         keep recoTracks_hltPFMuonMergingPPOnAA_*_*
         keep recoVertexs_hltVerticesPFFilterPPOnAA_*_*
```
This PR adds the correct `rawDataInputTag` for the HI case.

#### PR validation:
None, to be tested online in P5

#### Backport:
backport of #40109