### PR TITLE
Fix alignment offline validation ROOT6.27/01 issue

### DIFF
--- a/Alignment/OfflineValidation/interface/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/interface/PlotAlignmentValidation.h
@@ -12,6 +12,7 @@
 #include "TDirectoryFile.h"
 #include "TF1.h"
 #include "TFile.h"
+#include "TFrame.h"
 #include "TGaxis.h"
 #include "TH2F.h"
 #include "THStack.h"

--- a/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
+++ b/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
@@ -1238,8 +1238,20 @@ void PlotAlignmentValidation::plotChi2(const char* inputFile) {
   } else {
     errorflag = kTRUE;
   }
-  TCanvas* normchi = new TCanvas((TCanvas*)fi1->Get("TrackerOfflineValidation/GlobalTrackVariables/h_normchi2"));
-  TCanvas* chiprob = new TCanvas((TCanvas*)fi1->Get("TrackerOfflineValidation/GlobalTrackVariables/h_chi2Prob"));
+  if (errorflag) {
+    std::cout << "PlotAlignmentValidation::plotChi2: Can't find GlobalTrackVariables given file,"
+              << " no chi^2-plots produced" << std::endl;
+    return;
+  }
+
+  auto normchi = fi1->Get<TCanvas>("TrackerOfflineValidation/GlobalTrackVariables/h_normchi2");
+  // please remove following line once bug is fixed with ROOT Version: >6.27/01
+  normchi->GetFrame()->ResetBit(kCanDelete);
+
+  auto chiprob = fi1->Get<TCanvas>("TrackerOfflineValidation/GlobalTrackVariables/h_chi2Prob");
+  // please remove following line once bug is fixed with ROOT Version: >6.27/01
+  chiprob->GetFrame()->ResetBit(kCanDelete);
+
   if (normchi == nullptr || chiprob == nullptr) {
     errorflag = kTRUE;
   }

--- a/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
+++ b/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
@@ -1229,24 +1229,19 @@ void PlotAlignmentValidation::plotChi2(const char* inputFile) {
   // Opens the file (it should be OfflineValidation(Parallel)_result.root)
   // and reads and plots the norm_chi^2 and h_chi2Prob -distributions.
 
-  Bool_t errorflag = kTRUE;
+  Bool_t errorflag = kFALSE;
   TFile* fi1 = TFile::Open(inputFile, "read");
-  TDirectoryFile* mta1 = nullptr;
-  TDirectoryFile* mtb1 = nullptr;
-  TCanvas* normchi = nullptr;
-  TCanvas* chiprob = nullptr;
   if (fi1 != nullptr) {
-    mta1 = (TDirectoryFile*)fi1->Get("TrackerOfflineValidation");
-    if (mta1 != nullptr) {
-      mtb1 = (TDirectoryFile*)mta1->Get("GlobalTrackVariables");
-      if (mtb1 != nullptr) {
-        normchi = dynamic_cast<TCanvas*>(mtb1->Get("h_normchi2"));
-        chiprob = dynamic_cast<TCanvas*>(mtb1->Get("h_chi2Prob"));
-        if (normchi != nullptr && chiprob != nullptr) {
-          errorflag = kFALSE;
-        }
-      }
+    if (fi1->GetDirectory("TrackerOfflineValidation/GlobalTrackVariables") == nullptr) {
+      errorflag = kTRUE;
     }
+  } else {
+    errorflag = kTRUE;
+  }
+  TCanvas* normchi = new TCanvas((TCanvas*)fi1->Get("TrackerOfflineValidation/GlobalTrackVariables/h_normchi2"));
+  TCanvas* chiprob = new TCanvas((TCanvas*)fi1->Get("TrackerOfflineValidation/GlobalTrackVariables/h_chi2Prob"));
+  if (normchi == nullptr || chiprob == nullptr) {
+    errorflag = kTRUE;
   }
   if (errorflag) {
     std::cout << "PlotAlignmentValidation::plotChi2: Can't find data from given file,"
@@ -1308,6 +1303,7 @@ void PlotAlignmentValidation::plotChi2(const char* inputFile) {
   chiprob->Write();
   fi3.Close();
 
+  fi1->Close();
   delete fi1;
 }
 


### PR DESCRIPTION
#### PR description:

Recasting pointer access that was in conflict with `ROOT Version: 6.27/01` and caused unit test failure.

#### PR validation:

Unit tests now successful for `el8_amd64_gcc10` and both `ROOT Version: 6.27/01` and `ROOT Version: 6.24/07`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
