### PR TITLE
HcalDQM: Add protection to collection non-exist case for GPUTask

### DIFF
--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -202,8 +202,8 @@ namespace hcaldqm {
         {fADC_256_4, -0.5},
         {fEtlog2, 0.},
         {fDiffRatio, -2.5},
-        {fCPUenergy, -1},
-        {fGPUenergy, -1},
+        {fCPUenergy, 0},
+        {fGPUenergy, 0},
     };
     const std::map<ValueQuantityType, double> max_value = {
         {fN, 1000},
@@ -333,8 +333,8 @@ namespace hcaldqm {
         {fADC_256_4, 64},
         {fEtlog2, 9},
         {fDiffRatio, 50},
-        {fCPUenergy, 1005},
-        {fGPUenergy, 1005},
+        {fCPUenergy, 1000},
+        {fGPUenergy, 1000},
     };
     class ValueQuantity : public Quantity {
     public:

--- a/DQM/HcalCommon/interface/ValueQuantity.h
+++ b/DQM/HcalCommon/interface/ValueQuantity.h
@@ -202,8 +202,8 @@ namespace hcaldqm {
         {fADC_256_4, -0.5},
         {fEtlog2, 0.},
         {fDiffRatio, -2.5},
-        {fCPUenergy, 0},
-        {fGPUenergy, 0},
+        {fCPUenergy, -1},
+        {fGPUenergy, -1},
     };
     const std::map<ValueQuantityType, double> max_value = {
         {fN, 1000},
@@ -333,8 +333,8 @@ namespace hcaldqm {
         {fADC_256_4, 64},
         {fEtlog2, 9},
         {fDiffRatio, 50},
-        {fCPUenergy, 1000},
-        {fGPUenergy, 1000},
+        {fCPUenergy, 1005},
+        {fGPUenergy, 1005},
     };
     class ValueQuantity : public Quantity {
     public:

--- a/DQM/HcalTasks/plugins/DigiTask.cc
+++ b/DQM/HcalTasks/plugins/DigiTask.cc
@@ -790,7 +790,7 @@ DigiTask::DigiTask(edm::ParameterSet const& ps)
       lumiCache->EvtCntLS == 1) {  // Reset the bin for _cCapid_BadvsFEDvsLSmod60 at the beginning of each new LS
     for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
       HcalElectronicsId eid = HcalElectronicsId(*it);
-      _cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 50, 0);
+      _cCapid_BadvsFEDvsLSmod60.setBinContent(eid, _currentLS % 60, 0);
     }
   }
 

--- a/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
@@ -96,24 +96,9 @@ HcalGPUComparisonTask::HcalGPUComparisonTask(edm::ParameterSet const& ps)
   auto const chbhe_ref = e.getHandle(tokHBHE_ref_);
   auto const chbhe_target = e.getHandle(tokHBHE_target_);
 
-  if (not(chbhe_ref.isValid() and chbhe_target.isValid())) {
-    if (chbhe_target.isValid()) {
-      edm::LogWarning("HcalGPUComparisonTask")
-          << "The CPU HBHERecHitCollection " << tagHBHE_ref_.encode() << " is not available";
-
-      for (auto const& rh : *chbhe_target)
-        energyGPUvsCPU_subdet_.fill(rh.id(), -0.5, rh.energy());
-    } else if (chbhe_ref.isValid()) {
-      edm::LogWarning("HcalGPUComparisonTask")
-          << "The GPU HBHERecHitCollection " << tagHBHE_target_.encode() << " is not available";
-
-      for (auto const& rh : *chbhe_ref)
-        energyGPUvsCPU_subdet_.fill(rh.id(), rh.energy(), -0.5);
-    } else {
-      edm::LogWarning("HcalGPUComparisonTask")
-          << "Neither CPU nor GPU RecHit Collection available, will not fill this event.";
-    }
-
+  if (not(chbhe_ref.isValid() or chbhe_target.isValid())) {
+    edm::LogWarning("HcalGPUComparisonTask")
+        << "Either CPU or GPU RecHit Collection is available, will not fill this event.";
     return;
   }
 

--- a/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
@@ -96,9 +96,9 @@ HcalGPUComparisonTask::HcalGPUComparisonTask(edm::ParameterSet const& ps)
   auto const chbhe_ref = e.getHandle(tokHBHE_ref_);
   auto const chbhe_target = e.getHandle(tokHBHE_target_);
 
-  if (not(chbhe_ref.isValid() or chbhe_target.isValid())) {
+  if (not(chbhe_ref.isValid() and chbhe_target.isValid())) {
     edm::LogWarning("HcalGPUComparisonTask")
-        << "Either CPU or GPU RecHit Collection is available, will not fill this event.";
+        << "Either CPU or GPU RecHit Collection is unavailable, will not fill this event.";
     return;
   }
 

--- a/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
+++ b/DQM/HcalTasks/plugins/HcalGPUComparisonTask.cc
@@ -131,7 +131,7 @@ HcalGPUComparisonTask::HcalGPUComparisonTask(edm::ParameterSet const& ps)
     if (mRecHitEnergy.find(did) == mRecHitEnergy.end())
       mRecHitEnergy.insert(std::make_pair(did, energy));
     else
-      edm::LogError("HcalGPUComparisonTask") << "Duplicate Rechit from the same HcalDetId" << std::endl;
+      edm::LogError("HcalGPUComparisonTask") << "Duplicate Rechit from the same HcalDetId";
     ;
   }
 
@@ -160,14 +160,14 @@ HcalGPUComparisonTask::HcalGPUComparisonTask(edm::ParameterSet const& ps)
     } else {
       if (energy > 2.)
         edm::LogError("HcalGPUComparisonTask")
-            << "Energetic GPU Rechit exist, but not reconstructed by CPU. DetId = " << did << std::endl;
+            << "Energetic GPU Rechit exist, but not reconstructed by CPU. DetId = " << did;
     }
   }
   if (!mRecHitEnergy.empty()) {
     for (auto const& rhpair : mRecHitEnergy) {
       if (rhpair.second > 2.)
         edm::LogError("HcalGPUComparisonTask")
-            << "Energetic CPU Rechit exist, but not reconstructed by GPU. DetId = " << rhpair.first << std::endl;
+            << "Energetic CPU Rechit exist, but not reconstructed by GPU. DetId = " << rhpair.first;
     }
   }
 }

--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -102,8 +102,8 @@ process.load('DQM.HcalTasks.HcalQualityTests')
 #	New Style Modules
 #-------------------------------------
 oldsubsystem = subsystem
-process.hcalGPUComparisonTask.tagHBHE_ref = "hltHbherecoFromGPU"
-process.hcalGPUComparisonTask.tagHBHE_target = "hltHbherecoLegacy"
+process.hcalGPUComparisonTask.tagHBHE_ref = "hltHbherecoLegacy"
+process.hcalGPUComparisonTask.tagHBHE_target = "hltHbherecoFromGPU"
 process.hcalGPUComparisonTask.runkeyVal = runType
 process.hcalGPUComparisonTask.runkeyName = runTypeName
 


### PR DESCRIPTION
#### PR description:
Regarding issue #40115, this PR corrects the reference&target name mixing in the hcalgpu task, adds some conditions to the collections non-exist case instead of throwing out fetal exception, and correct a minor numeric error in the DigiTask that should mod the LS by 60, instead of 50. 


#### PR validation:
Tested with `cmsRun DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py runInputDir=/afs/cern.ch/work/l/lowang/DQM_Dev/CMSSW_12_6_X_2022-11-17-2300/src/ runNumber=362217 runkey=hi_run` and shows no problems. 
