### PR TITLE
cleaning the folder name of the per path histograms

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -568,7 +568,7 @@ void FastTimerService::PlotsPerPath::book(dqm::reco::DQMStore::IBooker& booker,
                                           unsigned int lumisections,
                                           bool byls) {
   const std::string basedir = booker.pwd();
-  std::string folderName = basedir + "/" + prefixDir + path.name_; 
+  std::string folderName = basedir + "/" + prefixDir + path.name_;
   fixForDQM(folderName);
   booker.setCurrentFolder(folderName);
 

--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -568,7 +568,9 @@ void FastTimerService::PlotsPerPath::book(dqm::reco::DQMStore::IBooker& booker,
                                           unsigned int lumisections,
                                           bool byls) {
   const std::string basedir = booker.pwd();
-  booker.setCurrentFolder(basedir + "/" + prefixDir + path.name_);
+  std::string folderName = basedir + "/" + prefixDir + path.name_; 
+  fixForDQM(folderName);
+  booker.setCurrentFolder(folderName);
 
   total_.book(booker, "path", path.name_, ranges, lumisections, byls);
 


### PR DESCRIPTION
#### PR description:

TSG timing measurements are failing when moving from CMSSW_12_4_X with the error
```
An exception of category 'BadMonitorElementPathName' occurred while
   [0] Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)
Exception Message:
 Monitor element path name: 'merService/process TIMING paths/endpath @finalPath/path time_thread' uses unacceptable characters.
 Acceptable characters are: /ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# 
----- End Fatal Exception -------------------------------------------------
```

This was traced to https://github.com/cms-sw/cmssw/pull/38831. 

The fixes in https://github.com/cms-sw/cmssw/pull/38963 and https://github.com/cms-sw/cmssw/pull/38966 did not go far enough, the uncleaned name of the path also appears in the folder of the perpath dqm plots (which are not always run, hence the previous reporter didnt notice this).

#### PR validation:

A test HLT menu now works correct and does not throw the above error message. I should also do a bit more of a through investigation as I was debugging this on nightshift and may well have made an error ;)

