### PR TITLE
Adapt protection against zero weights or pt for SV producer [12_4_X]

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -389,7 +389,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
           reco::CandidatePtr constit = *m;
-          if (constit->pt() == 0) {
+          if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;
           }
@@ -399,8 +399,10 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
                   << "TemplatedSecondaryVertexProducer: No weights (e.g. PUPPI) given for weighted jet collection"
                   << std::endl;
             float w = (*weightsHandle)[constit];
-            fjInputs.push_back(
-                fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+            if (w > 0) {
+              fjInputs.push_back(
+                  fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+            }
           } else {
             fjInputs.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
           }
@@ -413,7 +415,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
           reco::CandidatePtr constit = *m;
-          if (constit->pt() == 0) {
+          if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;
           }
@@ -423,8 +425,10 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
                   << "TemplatedSecondaryVertexProducer: No weights (e.g. PUPPI) given for weighted jet collection"
                   << std::endl;
             float w = (*weightsHandle)[constit];
-            fjInputs.push_back(
-                fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+            if (w > 0) {
+              fjInputs.push_back(
+                  fastjet::PseudoJet(constit->px() * w, constit->py() * w, constit->pz() * w, constit->energy() * w));
+            }
           } else {
             fjInputs.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
           }


### PR DESCRIPTION
#### PR description:

This PR applies the same protective measures introduced in https://github.com/cms-sw/cmssw/pull/40081 for another producer in the `RecoBTag/SecondaryVertex` package. While we have not seen a precedent case that yields the abort signal reported in https://github.com/cms-sw/cmssw/issues/40032 coming from this particular producer (`TemplatedSecondaryVertexProducer.cc`), the logic is essentially same, so we think we should include the fixes here for safety purposes as well.

#### PR validation:

Tests have been performed for CMSSW_12_4_10_patch3 (https://cms-sw.github.io/PRWorkflow.html)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Meant for 12_4_X, as a backport of #40093 (we follow the same scheme for backports as for the BoostedDoubleSVProducer, just applied to TemplatedSecondaryVertexProducer to avoid abort signals in the future)
First backport: #40123 