### PR TITLE
Remove deprecated `exists` API in favor of `fillDescriptions` in `SiPixelQualityESProducer`

### DIFF
--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -1,9 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
-    siPixelQualityLabel = cms.string(""),
-    siPixelQualityLabel_RawToDigi = cms.string("")
-)
+from CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi import siPixelQualityESProducer
 
 from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
 siPixelQualityRawToDigi.toModify(siPixelQualityESProducer,


### PR DESCRIPTION
#### PR description:

This PR addresses issue https://github.com/cms-sw/cmssw/issues/40077

#### PR validation:

Code compiles and cmsDriver from the original [JIRA](https://its.cern.ch/jira/browse/PDMVMCPROD-62?focusedCommentId=4618412&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4618412) runs successfully.

#### Backports:

No backports are needed.
