### PR TITLE
change default of `resetPSCountersEachLumiSec` to `false` in L1T emulator

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -265,8 +265,8 @@ namespace l1t {
     int m_uGtBoardNumber;
     bool m_uGtFinalBoard;
 
-    //whether we reset the prescales each lumi or not
-    bool m_resetPSCountersEachLumiSec = true;
+    // whether we reset the prescales each lumi or not
+    bool m_resetPSCountersEachLumiSec = false;
 
     // start the PS counter from a random value between [1,PS] instead of PS
     bool m_semiRandomInitialPSCounters = false;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -68,8 +68,17 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
   // switch for muon showers in Run-3
   desc.add<bool>("useMuonShowers", false);
-  desc.add<bool>("resetPSCountersEachLumiSec", true);
+
+  // disables resetting the prescale counters each lumisection (needed for offline)
+  //  originally, the L1T firmware applied the reset of prescale counters at the end of every LS;
+  //  this reset was disabled in the L1T firmware starting from run-362658 (November 25th, 2022), see
+  //  https://github.com/cms-sw/cmssw/pull/37395#issuecomment-1323437044
+  desc.add<bool>("resetPSCountersEachLumiSec", false);
+
+  // initialise prescale counters with a semi-random value in the range [0, prescale*10^precision - 1];
+  // if false, the prescale counters are initialised to zero
   desc.add<bool>("semiRandomInitialPSCounters", false);
+
   // These parameters have well defined  default values and are not currently
   // part of the L1T/HLT interface.  They can be cleaned up or updated at will:
   desc.add<bool>("ProduceL1GtDaqRecord", true);

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -186,12 +186,15 @@ private:
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;
   edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_l1GtPrescaleVetosToken;
 
-  //disables reseting the prescale counters each lumisection (needed for offline)
+  // disables resetting the prescale counters each lumisection (needed for offline)
   bool m_resetPSCountersEachLumiSec;
-  // start the PS counter from a random value between [1,PS] instead of PS
+
+  // initialise prescale counters with a semi-random value in the range [0, prescale*10^precision - 1];
+  // if false, the prescale counters are initialised to zero
   bool m_semiRandomInitialPSCounters;
+
   // switch to load muon showers in the global board
   bool m_useMuonShowers;
 };
 
-#endif /*L1TGlobalProducer_h*/
+#endif  // L1TGlobalProducer_h

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -1137,7 +1137,7 @@ std::vector<l1t::GlobalBoard::PrescaleCounter> l1t::GlobalBoard::prescaleCounter
   return out;
 }
 
-// initializer prescale counters using a semi-random value between [0, prescale value * 10 ^ precision - 1]
+// initialises prescale counters with a semi-random value in the range [0, prescale*10^precision - 1]
 std::vector<l1t::GlobalBoard::PrescaleCounter> l1t::GlobalBoard::prescaleCountersWithSemirandomInitialCounter(
     std::vector<double> const& prescaleFactorsAlgoTrig, edm::Event const& iEvent) {
   // pick a (semi)random number seeding based on run, lumi, event numbers,


### PR DESCRIPTION
#### PR description:

This PR changes the default of the option `resetPSCountersEachLumiSec` from `true` to `false` in the L1T emulator.

This is done to match the behaviour of the latest L1T firmware (see https://github.com/cms-sw/cmssw/pull/37395#issuecomment-1323437044).

As far as I understand, this change does not (or, will not) have any impact on online workflows (the instance of the L1T emulator running inside the HLT menu does not apply L1T prescales). It only affects offline workflows (e.g. offline trigger studies).

Since the `resetPSCountersEachLumiSec` switch already exists in earlier releases (and users can set it as needed in offline studies), there is no need to backport this PR.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A