### PR TITLE
Accept const session in TF interface.

### DIFF
--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -118,6 +118,8 @@ namespace tensorflow {
                   const std::vector<std::string>& outputNames,
                   std::vector<Tensor>* outputs,
                   const thread::ThreadPoolOptions& threadPoolOptions) {
+    // TF takes a non-const session in the run call which is, however, thread-safe and logically
+    // const, thus const_cast is consistent
     run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPoolOptions);
   }
 
@@ -136,6 +138,8 @@ namespace tensorflow {
                   const std::vector<std::string>& outputNames,
                   std::vector<Tensor>* outputs,
                   thread::ThreadPoolInterface* threadPool) {
+    // TF takes a non-const session in the run call which is, however, thread-safe and logically
+    // const, thus const_cast is consistent
     run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPool);
   }
 
@@ -154,6 +158,8 @@ namespace tensorflow {
                   const std::vector<std::string>& outputNames,
                   std::vector<Tensor>* outputs,
                   const std::string& threadPoolName = "no_threads") {
+    // TF takes a non-const session in the run call which is, however, thread-safe and logically
+    // const, thus const_cast is consistent
     run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPoolName);
   }
 
@@ -170,6 +176,8 @@ namespace tensorflow {
                   const std::vector<std::string>& outputNames,
                   std::vector<Tensor>* outputs,
                   const std::string& threadPoolName = "no_threads") {
+    // TF takes a non-const session in the run call which is, however, thread-safe and logically
+    // const, thus const_cast is consistent
     run(const_cast<Session*>(session), outputNames, outputs, threadPoolName);
   }
 

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -1,6 +1,5 @@
 /*
  * TensorFlow interface helpers.
- * Based on TensorFlow C++ API 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger
@@ -100,6 +99,9 @@ namespace tensorflow {
   // closes a session, calls its destructor, resets the pointer, and returns true on success
   bool closeSession(Session*& session);
 
+  // version of the function above that accepts a const session
+  bool closeSession(const Session*& session);
+
   // run the session with inputs and outputNames, store output tensors, and control the underlying
   // thread pool using threadPoolOptions
   // used for thread scheduling with custom thread pool options
@@ -110,6 +112,15 @@ namespace tensorflow {
            std::vector<Tensor>* outputs,
            const thread::ThreadPoolOptions& threadPoolOptions);
 
+  // version of the function above that accepts a const session
+  inline void run(const Session* session,
+                  const NamedTensorList& inputs,
+                  const std::vector<std::string>& outputNames,
+                  std::vector<Tensor>* outputs,
+                  const thread::ThreadPoolOptions& threadPoolOptions) {
+    run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPoolOptions);
+  }
+
   // run the session with inputs and outputNames, store output tensors, and control the underlying
   // thread pool
   // throws a cms exception when not successful
@@ -118,6 +129,15 @@ namespace tensorflow {
            const std::vector<std::string>& outputNames,
            std::vector<Tensor>* outputs,
            thread::ThreadPoolInterface* threadPool);
+
+  // version of the function above that accepts a const session
+  inline void run(const Session* session,
+                  const NamedTensorList& inputs,
+                  const std::vector<std::string>& outputNames,
+                  std::vector<Tensor>* outputs,
+                  thread::ThreadPoolInterface* threadPool) {
+    run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPool);
+  }
 
   // run the session with inputs and outputNames, store output tensors, and control the underlying
   // thread pool using a threadPoolName ("no_threads", "tbb", or "tensorflow")
@@ -128,6 +148,15 @@ namespace tensorflow {
            std::vector<Tensor>* outputs,
            const std::string& threadPoolName = "no_threads");
 
+  // version of the function above that accepts a const session
+  inline void run(const Session* session,
+                  const NamedTensorList& inputs,
+                  const std::vector<std::string>& outputNames,
+                  std::vector<Tensor>* outputs,
+                  const std::string& threadPoolName = "no_threads") {
+    run(const_cast<Session*>(session), inputs, outputNames, outputs, threadPoolName);
+  }
+
   // run the session without inputs but only outputNames, store output tensors, and control the
   // underlying thread pool using a threadPoolName ("no_threads", "tbb", or "tensorflow")
   // throws a cms exception when not successful
@@ -135,6 +164,14 @@ namespace tensorflow {
            const std::vector<std::string>& outputNames,
            std::vector<Tensor>* outputs,
            const std::string& threadPoolName = "no_threads");
+
+  // version of the function above that accepts a const session
+  inline void run(const Session* session,
+                  const std::vector<std::string>& outputNames,
+                  std::vector<Tensor>* outputs,
+                  const std::string& threadPoolName = "no_threads") {
+    run(const_cast<Session*>(session), outputNames, outputs, threadPoolName);
+  }
 
 }  // namespace tensorflow
 

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -1,6 +1,5 @@
 /*
  * TensorFlow interface helpers.
- * Based on TensorFlow C++ API 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger
@@ -208,6 +207,16 @@ namespace tensorflow {
     session = nullptr;
 
     return status.ok();
+  }
+
+  bool closeSession(const Session*& session) {
+    auto s = const_cast<Session*>(session);
+    bool state = closeSession(s);
+
+    // reset the pointer
+    session = nullptr;
+
+    return state;
   }
 
   void run(Session* session,

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -16,6 +16,12 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
+<bin name="testTFConstSession" file="testRunner.cpp,testConstSession.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
 <bin name="testTFThreadPools" file="testRunner.cpp,testThreadPools.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>

--- a/PhysicsTools/TensorFlow/test/testAOT.cc
+++ b/PhysicsTools/TensorFlow/test/testAOT.cc
@@ -1,6 +1,5 @@
 /*
  * TensorFlow AOT test
- * Based on TensorFlow 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger

--- a/PhysicsTools/TensorFlow/test/testConstSession.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSession.cc
@@ -1,5 +1,5 @@
 /*
- * Tests for loading graphs via the converted protobuf files.
+ * Tests for working with constant sessions.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger
@@ -12,8 +12,8 @@
 
 #include "testBase.h"
 
-class testGraphLoading : public testBase {
-  CPPUNIT_TEST_SUITE(testGraphLoading);
+class testConstSession : public testBase {
+  CPPUNIT_TEST_SUITE(testConstSession);
   CPPUNIT_TEST(checkAll);
   CPPUNIT_TEST_SUITE_END();
 
@@ -22,11 +22,11 @@ public:
   void checkAll() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
+CPPUNIT_TEST_SUITE_REGISTRATION(testConstSession);
 
-std::string testGraphLoading::pyScript() const { return "createconstantgraph.py"; }
+std::string testConstSession::pyScript() const { return "createconstantgraph.py"; }
 
-void testGraphLoading::checkAll() {
+void testConstSession::checkAll() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   // load the graph
@@ -35,11 +35,8 @@ void testGraphLoading::checkAll() {
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef);
+  const tensorflow::Session* session = tensorflow::createSession(graphDef);
   CPPUNIT_ASSERT(session != nullptr);
-
-  // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});
@@ -49,20 +46,9 @@ void testGraphLoading::checkAll() {
   }
   tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
   scale.scalar<float>()() = 1.0;
-
   std::vector<tensorflow::Tensor> outputs;
-  tensorflow::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
-  if (!status.ok()) {
-    std::cout << status.ToString() << std::endl;
-    CPPUNIT_ASSERT(false);
-  }
 
-  // check the output
-  CPPUNIT_ASSERT(outputs.size() == 1);
-  std::cout << outputs[0].DebugString() << std::endl;
-  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
-
-  // run again using the convenience helper
+  // run using the convenience helper
   outputs.clear();
   tensorflow::run(session, {{"input", input}, {"scale", scale}}, {"output"}, &outputs);
   CPPUNIT_ASSERT(outputs.size() == 1);

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -1,6 +1,5 @@
 /*
  * HelloWorld test of the TensorFlow interface.
- * Based on TensorFlow 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
@@ -1,6 +1,5 @@
 /*
  * Tests for loading meta graphs via the SavedModel interface.
- * Based on TensorFlow 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger

--- a/PhysicsTools/TensorFlow/test/testThreadPools.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPools.cc
@@ -1,6 +1,5 @@
 /*
  * Tests for running inference using custom thread pools.
- * Based on TensorFlow 2.1.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger


### PR DESCRIPTION
#### PR description

This PR adds five new functions to the TensorFlow interface in PhysicsTools that accept `const` sessions, four of which are related to performing model inference and one function handles the session deletion. There's also an additional test case that covers the handling of const sessions.

With this PR, there is no need for them to be stored once per stream module instance, but they can rather be moved to global caches (as is the case for tf graphs at the moment), reducing copies in memory.

The latter changes are not contained in this PR, but are subject to a future one(s). For completeness, in the following there are three lists of files where they'd need to happen (with the latter one being optional) and I can open a dedicated PR for them once _this_ one is merged (or a separate PR per subsystem, depending on what's easier to sign off on).

###### Move sessions to global cache

- L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
- RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
- RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
- RecoTauTag/RecoTau/plugins/DeepTauId.cc
- RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc


###### Remove now obsolete `const_cast`'s

- RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
- RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
- RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
- RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
- RecoHGCal/TICL/plugins/TrackstersMergeProducerV3.cc
- RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
- RecoTracker/MkFit/plugins/MkFitOutputConverter.cc


###### Use const session (only if needed)

- DQM/DTMonitorClient/src/DTOccupancyTestML.cc
- L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorAutoEncoderImpl.cc
- L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
- PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
- RecoEcal/EgammaCoreTools/src/DeepSCGraphEvaluation.cc
- RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc


#### PR validation

I added test cases for handling const sessions.


@valsdav @yongbinfeng @jeongeun @jpata @clacaputo 