### PR TITLE
Add missing dependence on DataFormats/MuonReco to RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
+++ b/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/MuonReco"/>
 <use name="DataFormats/GEMRecHit"/>
 <use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/GEMGeometry"/>


### PR DESCRIPTION
#### PR description:

UBSAN fails to build because of
```
/pool/condor/dir_25578/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -g -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc11/src/RecoLocalMuon/GEMCSCSegment/test/GEMCSCCoincidenceRateAnalyzer/GEMCSCCoincidenceRateAnalyzer.cc.o -o tmp/el8_amd64_gcc11/src/RecoLocalMuon/GEMCSCSegment/test/GEMCSCCoincidenceRateAnalyzer/libGEMCSCCoincidenceRateAnalyzer.so -Wl,-E -Wl,--hash-style=gnu -L/pool/condor/dir_25578/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/1b2eaa275701962dee4e708dbb2a0228/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_0_UBSAN_X_2022-11-28-1100/biglib/el8_amd64_gcc11 -L/pool/condor/dir_25578/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/1b2eaa275701962dee4e708dbb2a0228/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_0_UBSAN_X_2022-11-28-1100/lib/el8_amd64_gcc11 -L/pool/condor/dir_25578/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/1b2eaa275701962dee4e708dbb2a0228/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_0_UBSAN_X_2022-11-28-1100/external/el8_amd64_gcc11/lib -lDataFormatsGEMRecHit -lDataFormatsCSCRecHit -lDataFormatsTrackingRecHit -lGeometryCSCGeometry -lGeometryGEMGeometry -lGeometryCommonTopologies -lCondFormatsAlignment -lDataFormatsGeometryCommonDetAlgo -lGeometryRecords -lCommonToolsUtilAlgos -lCondFormatsAlignmentRecord -lDataFormatsGeometrySurface -lSimDataFormatsTrackingHit -lCommonToolsUtils -lDataFormatsCLHEP -lDataFormatsEcalDetId -lDataFormatsGeometryVector -lDataFormatsL1GlobalTrigger -lDataFormatsMuonDetId -lFWCoreFramework -lSimDataFormatsTrack -lDataFormatsDetId -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lFWCoreCommon -lFWCoreServiceRegistry -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lSimDataFormatsEncodedEventId -lTreePlayer -lGraf3d -lPostscript -lGpad -lGraf -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lThread -lMathCore -lRIO -lboost_regex -lboost_serialization -lCore -lboost_thread -lboost_date_time -lCLHEP -lpcre -lbz2 -lgsl -luuid -ltbb -llzma -lz -lfmt -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
  /pool/condor/dir_25578/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/bin/../lib/gcc/x86_64-redhat-linux-gnu/11.2.1/../../../../x86_64-redhat-linux-gnu/bin/ld: tmp/el8_amd64_gcc11/src/RecoLocalMuon/GEMCSCSegment/test/GEMCSCCoincidenceRateAnalyzer/GEMCSCCoincidenceRateAnalyzer.cc.o:(.data.rel+0x4018): undefined reference to `typeinfo for reco::Muon'
 collect2: error: ld returned 1 exit status
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_13_0_UBSAN_X_2022-11-28-1100/RecoLocalMuon/GEMCSCSegment

The dependence on `DataFormats/MuonReco` seems to have been added in https://github.com/cms-sw/cmssw/pull/39441. This PR adds the dependence explicitly. Since #39441  was merged in 12_6_X, I based this PR on the IB tag that is common between 12_6_X and 13_0_X so it can be trivially backported to 12_6_X.


#### PR validation:

None