### PR TITLE
Fix warning message about `PixelCPEFast` in `TkTransientTrackingRecHitBuilderESProducer`

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -360,6 +360,10 @@ def getSequence(process, collection,
     ## put the sequence together ##
     ###############################
 
+    if "Fast" in TTRHBuilder:
+        print("PixelCPEFast has been chosen, here we must include CUDAService first")
+        process.load('HeterogeneousCore.CUDAServices.CUDAService_cfi')
+
     modules = []
     src = collection
     prevsrc = None


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/40003, which added the `TransientTrackingRechitBuilder` flavour for `PixelCPEFast`.
In that PR a new warning was emitted from `TkTransientTrackingRecHitBuilderESProducer` in order to warn the user that track angles will not be used, but since that was implemented in the constructor or the class, the message ended up being emitted every time the `TransientTrackingRecHitBuilder_cfi` was loaded, leading to the misleading message that `PixelCPEFast` was used in the track fit, even when in fact it was not (logs from recent IB relvals show that the message is present in each one of them, see e.g. [wf 1.0](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc10/CMSSW_13_0_X_2022-11-28-2300/pyRelValMatrixLogs/run/1.0_ProdMinBias+ProdMinBias+DIGIPROD1+RECOPROD1/step3_ProdMinBias+ProdMinBias+DIGIPROD1+RECOPROD1.log#/17) or [wf 250408.0](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc10/CMSSW_13_0_X_2022-11-28-2300/pyRelValMatrixLogs/run/250408.0_QCD_FlatPt_15_3000HS_13+FS_QCD_FlatPt_15_3000HS_13_PRMXUP15_PU25+HARVESTUP15FS+MINIAODMCUP15FS/step1_QCD_FlatPt_15_3000HS_13+FS_QCD_FlatPt_15_3000HS_13_PRMXUP15_PU25+HARVESTUP15FS+MINIAODMCUP15FS.log#/24) ).
This PR fixes the problem by moving the `LogWarning` from the class constructor to the `produce` method, such that it is emitted only if the ES products are actually consumed by the downstream modules.
I profit of this PR (in commit 6bcc614a6bdb47af5780b6e49d8e4d1414c5c48e) to automatically supply a service needed in case of the `PixelCPEFast` choice in tracker alignment common refitting sequence. 

#### PR validation:

Tested with this branch that the spurious messages in relvals are removed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will need to be backported to the 12.6.X cycle.
