### PR TITLE
Adding "hcal2" DQM to "rerecoCommon" in autoDQM.py

### DIFF
--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -180,7 +180,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
 
             'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@hcal2+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
                              'PostDQMOffline',
-                             '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
+                             '@common+@muon+@L1TMon+@hcal+@hcal2+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
 
             'rerecoSingleMuon': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma+@lumi+@L1TMuon+@L1TEgamma+@ctpps',
                                  'PostDQMOffline',

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -178,7 +178,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                              'PostDQMOffline',
                              '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma'],
 
-            'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
+            'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@hcal2+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
                              'PostDQMOffline',
                              '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
 


### PR DESCRIPTION
#### PR description:

Actual "rerecoCommon" sequence used in the data re-reco RelVals, for instance in the most recent "CMSSW_12_4_11_rerecoGTValidation" campaign
 https://cms-talk.web.cern.ch/t/new-validation-campaign-cmssw-12-4-11-rerecogtvalidation-added/17645
   -> RelMon
 https://cms-pdmv.cern.ch/relmon/?q=CMSSW_12_4_11_PromptGTvsCMSSW_12_4_11_ReRecoGT

doesn't contain the most informative HCAL folders (HcalRecHitsD and CaloTowerdD) produced by "hcal2" DQM sequence.
This small update fixes the omission, as was discussed a ~week ago with the members of 
  cms-ppd-pdmv-dev
  cms-PPD-conveners-DQM-DC

#### PR validation:

runTheMatrix.py -l limited 

#### If this PR is a backport 

it's not.