### PR TITLE
[12_6_X] puppi V16 in 12.6

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -35,7 +35,6 @@ puppi = _mod.PuppiProducer.clone(
                        NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
                        DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
                        PtMaxNeutralsStartSlope = 20.,
-                       PtMaxPhotons = 20.,
                        clonePackedCands   = False, # should only be set to True for MiniAOD
                        algos          = { 
                         0: dict( 
@@ -103,5 +102,6 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(puppi, algos = [])
 
 puppiNoLep = puppi.clone(
-    puppiNoLep = True
+    puppiNoLep = True,
+    PtMaxPhotons = 20.
     )


### PR DESCRIPTION
#### PR description:

As mentioned in #39861 https://github.com/cms-sw/cmssw/pull/39861#issuecomment-1330823718 we should keep things consistent in 12.6 (regardless of what it might be used for). i.e keep puppi jets in V16 tune, aligned with downstream taggers.

Changes towards V17 should be handled consistently later on, in 13.0 most likely