### PR TITLE
Make two function-static variables const

### DIFF
--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -31,7 +31,7 @@ namespace edm {
   namespace eventsetup {
 
     static const ComponentDescription* dummyDescription() {
-      static ComponentDescription s_desc;
+      static const ComponentDescription s_desc;
       return &s_desc;
     }
 

--- a/FWCore/Framework/src/ExceptionActions.cc
+++ b/FWCore/Framework/src/ExceptionActions.cc
@@ -8,23 +8,17 @@
 
 namespace edm {
   namespace exception_actions {
-    namespace {
-      struct ActionNames {
-        ActionNames() : table_(LastCode + 1) {
-          table_[IgnoreCompletely] = "IgnoreCompletely";
-          table_[Rethrow] = "Rethrow";
-          table_[SkipEvent] = "SkipEvent";
-          table_[FailPath] = "FailPath";
-        }
-
-        typedef std::vector<char const*> Table;
-        Table table_;
-      };
-    }  // namespace
-
     char const* actionName(ActionCodes code) {
-      static ActionNames tab;
-      return static_cast<unsigned int>(code) < tab.table_.size() ? tab.table_[code] : "UnknownAction";
+      static constexpr std::array<char const*, LastCode> tab = []() constexpr {
+        std::array<char const*, LastCode> table{};
+        table[IgnoreCompletely] = "IgnoreCompletely";
+        table[Rethrow] = "Rethrow";
+        table[SkipEvent] = "SkipEvent";
+        table[FailPath] = "FailPath";
+        return table;
+      }
+      ();
+      return static_cast<unsigned int>(code) < tab.size() ? tab[code] : "UnknownAction";
     }
   }  // namespace exception_actions
 


### PR DESCRIPTION
#### PR description:

This PR makes two function-static variables const to silence static analyzer warnings (that caught my eye in the tests of another PR). In one of them I also simplified the static variable to be `std::array` instead of `std::vector`.

#### PR validation:

Code compiles