### PR TITLE
[TkAl] Fix EoP Validation plotting macros

### DIFF
--- a/Alignment/OfflineValidation/macros/momentumBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumBiasValidation.C
@@ -29,6 +29,10 @@ namespace eop {
 
   vector<Double_t> extractgausparams(TH1F *histo, TString option1 = "0", TString option2 = "");
   vector<Double_t> extractgausparams(TH1F *histo, TString option1, TString option2) {
+    if (histo->GetEntries() < 10) {
+      return {0., 0., 0., 0.};
+    }
+
     TF1 *f1 = new TF1("f1", "gaus");
     f1->SetRange(0., 2.);
     histo->Fit("f1", "QR0L");
@@ -70,258 +74,235 @@ namespace eop {
     params.push_back(upLim);
     return params;
   }
-}  // namespace eop
 
-void momentumBiasValidation(
-    TString variable = "eta",
-    TString path = "/scratch/hh/current/cms/user/henderle/",
-    TString alignmentWithLabel =
-        "EOP_TBDkbMinBias_2011.root=Summer 2011\\EOP_TBD_2011.root=no bows\\EOP_TBDfrom0T_2011.root=from 0T, no "
-        "bows\\EOP_plain_2011.root=no mass constraint",
-    bool verbose = false,
-    Double_t givenMin = 0.,
-    Double_t givenMax = 0.) {
-  time_t start = time(0);
+  void momentumBiasValidation(
+      TString variable = "eta",
+      TString path = "/scratch/hh/current/cms/user/henderle/",
+      TString alignmentWithLabel =
+          "EOP_TBDkbMinBias_2011.root=Summer 2011\\EOP_TBD_2011.root=no bows\\EOP_TBDfrom0T_2011.root=from 0T, no "
+          "bows\\EOP_plain_2011.root=no mass constraint",
+      bool verbose = false,
+      Double_t givenMin = 0.,
+      Double_t givenMax = 0.) {
+    time_t start = time(0);
 
-  // give radius at which the misalignment is calculated (arbitrary)
-  Double_t radius = 1.;
+    // give radius at which the misalignment is calculated (arbitrary)
+    Double_t radius = 1.;
 
-  // configure style
-  gROOT->cd();
-  gROOT->SetStyle("Plain");
-  if (verbose) {
-    std::cout << "\n all formerly produced control plots in ./controlEOP/ deleted.\n" << std::endl;
-    gROOT->ProcessLine(".!if [ -d controlEOP ]; then rm controlEOP/control_eop*.eps; else mkdir controlEOP; fi");
-  }
-  gStyle->SetPadBorderMode(0);
-  gStyle->SetOptStat(0);
-  gStyle->SetTitleFont(42, "XYZ");
-  gStyle->SetLabelFont(42, "XYZ");
-  gStyle->SetEndErrorSize(5);
-  gStyle->SetLineStyleString(2, "80 20");
-  gStyle->SetLineStyleString(3, "40 18");
-  gStyle->SetLineStyleString(4, "20 16");
-
-  // create canvas
-  TCanvas *c = new TCanvas("c", "Canvas", 0, 0, 1150, 880);
-  TCanvas *ccontrol = new TCanvas("ccontrol", "controlCanvas", 0, 0, 600, 300);
-
-  // create angular binning
-  TString binVar;
-  if (variable == "eta")
-    binVar = "track_eta";
-  else if (variable == "phi" || variable == "phi1" || variable == "phi2" || variable == "phi3")
-    binVar = "track_phi";
-  else {
-    std::cout << "variable can be eta or phi" << std::endl;
-    std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" << std::endl;
-  }
-
-  Int_t numberOfBins = 0;
-  Double_t startbin = 0.;
-  Double_t lastbin = 0.;
-  if (binVar == "track_eta") {
-    // tracks beyond abs(eta)=1.65 do not have radii > 99cm (cut value).
-    startbin = -1.65;
-    lastbin = 1.65;
-    numberOfBins = 18;  // ~ outermost TEC
-    //startbin = -.917; lastbin = .917; numberOfBins = 10;// ~ outermost TOB
-    //startbin = -1.28; lastbin = 1.28; numberOfBins = 14;// ~ innermost TOB
-  }
-  if (binVar == "track_phi") {
-    startbin = -TMath::Pi();
-    lastbin = TMath::Pi();
-    numberOfBins = 18;
-  }
-  Double_t binsize = (lastbin - startbin) / numberOfBins;
-  vector<Double_t> binningstrvec;
-  vector<Double_t> zBinning_;
-  for (Int_t i = 0; i <= numberOfBins; i++) {
-    binningstrvec.push_back(startbin + i * binsize);
-    zBinning_.push_back(radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(startbin + i * binsize)))));
-  }
-
-  // create energy binning
-  Int_t startStep = 0;
-  const Int_t NumberOFSteps = 2;
-  Double_t steparray[NumberOFSteps + 1] = {50, 58, 80};  //data 2 steps
-  //const Int_t NumberOFSteps = 6;Double_t steparray[NumberOFSteps+1] = {50,55,60,65,70,75,80};//mc 6 steps
-
-  vector<Double_t> steps;
-  vector<TString> stepstrg;
-  Char_t tmpstep[10];
-  for (Int_t ii = 0; ii <= NumberOFSteps; ii++) {
-    steps.push_back(steparray[ii]);
-    sprintf(tmpstep, "%1.1fGeV", steparray[ii]);
-    stepstrg.push_back(tmpstep);
-  }
-
-  // read files
-  vector<TFile *> file;
-  vector<TString> label;
-
-  TObjArray *fileLabelPairs = alignmentWithLabel.Tokenize("\\");
-  for (Int_t i = 0; i < fileLabelPairs->GetEntries(); ++i) {
-    TObjArray *singleFileLabelPair = TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
-
-    if (singleFileLabelPair->GetEntries() == 2) {
-      file.push_back(new TFile(path + (TString(singleFileLabelPair->At(0)->GetName()))));
-      label.push_back(singleFileLabelPair->At(1)->GetName());
-    } else {
-      std::cout << "Please give file name and legend entry in the following form:\n"
-                << " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
+    // configure style
+    gROOT->cd();
+    gROOT->SetStyle("Plain");
+    if (verbose) {
+      std::cout << "\n all formerly produced control plots in ./controlEOP/ deleted.\n" << std::endl;
+      gROOT->ProcessLine(".!if [ -d controlEOP ]; then rm controlEOP/control_eop*.eps; else mkdir controlEOP; fi");
     }
-  }
-  cout << "number of files: " << file.size() << endl;
+    gStyle->SetPadBorderMode(0);
+    gStyle->SetOptStat(0);
+    gStyle->SetTitleFont(42, "XYZ");
+    gStyle->SetLabelFont(42, "XYZ");
+    gStyle->SetEndErrorSize(5);
+    gStyle->SetLineStyleString(2, "80 20");
+    gStyle->SetLineStyleString(3, "40 18");
+    gStyle->SetLineStyleString(4, "20 16");
 
-  // create trees
-  vector<TTree *> tree;
-  EopVariables *track = new EopVariables();
+    // create canvas
+    TCanvas *c = new TCanvas("c", "Canvas", 0, 0, 1150, 880);
+    TCanvas *ccontrol = new TCanvas("ccontrol", "controlCanvas", 0, 0, 600, 300);
 
-  for (unsigned int i = 0; i < file.size(); i++) {
-    tree.push_back((TTree *)file[i]->Get("energyOverMomentumTree/EopTree"));
-    tree[i]->SetMakeClass(1);
-    tree[i]->SetBranchAddress("EopVariables", &track);
-    tree[i]->SetBranchAddress("track_outerRadius", &(track->track_outerRadius));
-    tree[i]->SetBranchAddress("track_chi2", &track->track_chi2);
-    tree[i]->SetBranchAddress("track_normalizedChi2", &track->track_normalizedChi2);
-    tree[i]->SetBranchAddress("track_p", &track->track_p);
-    tree[i]->SetBranchAddress("track_pt", &track->track_pt);
-    tree[i]->SetBranchAddress("track_ptError", &track->track_ptError);
-    tree[i]->SetBranchAddress("track_theta", &track->track_theta);
-    tree[i]->SetBranchAddress("track_eta", &track->track_eta);
-    tree[i]->SetBranchAddress("track_phi", &track->track_phi);
-    tree[i]->SetBranchAddress("track_emc1", &track->track_emc1);
-    tree[i]->SetBranchAddress("track_emc3", &track->track_emc3);
-    tree[i]->SetBranchAddress("track_emc5", &track->track_emc5);
-    tree[i]->SetBranchAddress("track_hac1", &track->track_hac1);
-    tree[i]->SetBranchAddress("track_hac3", &track->track_hac3);
-    tree[i]->SetBranchAddress("track_hac5", &track->track_hac5);
-    tree[i]->SetBranchAddress("track_maxPNearby", &track->track_maxPNearby);
-    tree[i]->SetBranchAddress("track_EnergyIn", &track->track_EnergyIn);
-    tree[i]->SetBranchAddress("track_EnergyOut", &track->track_EnergyOut);
-    tree[i]->SetBranchAddress("distofmax", &track->distofmax);
-    tree[i]->SetBranchAddress("track_charge", &track->track_charge);
-    tree[i]->SetBranchAddress("track_nHits", &track->track_nHits);
-    tree[i]->SetBranchAddress("track_nLostHits", &track->track_nLostHits);
-    tree[i]->SetBranchAddress("track_innerOk", &track->track_innerOk);
-  }
+    // create angular binning
+    TString binVar;
+    if (variable == "eta")
+      binVar = "track_eta";
+    else if (variable == "phi" || variable == "phi1" || variable == "phi2" || variable == "phi3")
+      binVar = "track_phi";
+    else {
+      std::cout << "variable can be eta or phi" << std::endl;
+      std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" << std::endl;
+    }
 
-  // create histogram vectors
-
-  // basic histograms
-  vector<TH1F *> histonegative;
-  vector<TH1F *> histopositive;
-  vector<TH2F *> Energynegative;
-  vector<TH2F *> Energypositive;
-  vector<TH1F *> xAxisBin;
-  vector<Int_t> selectedTracks;
-  // intermediate histograms
-  vector<TH1F *> fithisto;
-  vector<TH1F *> combinedxAxisBin;
-  // final histograms
-  vector<TGraphErrors *> overallGraph;
-  vector<TH1F *> overallhisto;
-
-  // book histograms
-  // basic histograms
-  for (UInt_t i = 0; i < NumberOFSteps * numberOfBins * file.size(); i++) {
-    Char_t histochar[20];
-    sprintf(histochar, "%i", i + 1);
-    TString histostrg = histochar;
-    TString lowEnergyBorder = stepstrg[i % NumberOFSteps];
-    TString highEnergyBorder = stepstrg[i % NumberOFSteps + 1];
-    if (binVar == "track_eta")
-      histonegative.push_back(
-          new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E < " + highEnergyBorder, 50, 0, 2));
-    else
-      histonegative.push_back(
-          new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E_{T} < " + highEnergyBorder, 50, 0, 2));
-    histopositive.push_back(new TH1F("histopositive" + histostrg, "histopositive" + histostrg, 50, 0, 2));
-    Energynegative.push_back(
-        new TH2F("Energynegative" + histostrg, "Energynegative" + histostrg, 5000, 0, 500, 50, 0, 2));
-    Energypositive.push_back(
-        new TH2F("Energypositive" + histostrg, "Energypositive" + histostrg, 5000, 0, 500, 50, 0, 2));
-    xAxisBin.push_back(new TH1F("xAxisBin" + histostrg, "xAxisBin" + histostrg, 1000, -500, 500));
-    selectedTracks.push_back(0);
-    Energynegative[i]->Sumw2();
-    Energypositive[i]->Sumw2();
-    xAxisBin[i]->Sumw2();
-    histonegative[i]->Sumw2();
-    histopositive[i]->Sumw2();
-    histonegative[i]->SetLineColor(kGreen);
-    histopositive[i]->SetLineColor(kRed);
-  }
-  // intermediate histograms
-  for (UInt_t i = 0; i < numberOfBins * file.size(); i++) {
-    Char_t histochar[20];
-    sprintf(histochar, "%i", i + 1);
-    TString histostrg = histochar;
-    fithisto.push_back(new TH1F("fithisto" + histostrg, "fithisto" + histostrg, NumberOFSteps, 0, NumberOFSteps));
-    combinedxAxisBin.push_back(
-        new TH1F("combinedxAxisBin" + histostrg, "combinedxAxisBin" + histostrg, NumberOFSteps, 0, NumberOFSteps));
-  }
-  // final histograms
-  for (UInt_t i = 0; i < file.size(); i++) {
-    TString cnt;
-    cnt += i;
+    Int_t numberOfBins = 0;
+    Double_t startbin = 0.;
+    Double_t lastbin = 0.;
     if (binVar == "track_eta") {
-      overallhisto.push_back(new TH1F("overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, &zBinning_.front()));
-      overallGraph.push_back(new TGraphErrors(overallhisto.back()));
-    } else {
-      overallhisto.push_back(new TH1F(
-          "overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, startbin, startbin + numberOfBins * binsize));
-      overallGraph.push_back(new TGraphErrors(overallhisto.back()));
+      // tracks beyond abs(eta)=1.65 do not have radii > 99cm (cut value).
+      startbin = -1.65;
+      lastbin = 1.65;
+      numberOfBins = 18;  // ~ outermost TEC
+      //startbin = -.917; lastbin = .917; numberOfBins = 10;// ~ outermost TOB
+      //startbin = -1.28; lastbin = 1.28; numberOfBins = 14;// ~ innermost TOB
     }
-  }
+    if (binVar == "track_phi") {
+      startbin = -TMath::Pi();
+      lastbin = TMath::Pi();
+      numberOfBins = 18;
+    }
+    Double_t binsize = (lastbin - startbin) / numberOfBins;
+    vector<Double_t> binningstrvec;
+    vector<Double_t> zBinning_;
+    for (Int_t i = 0; i <= numberOfBins; i++) {
+      binningstrvec.push_back(startbin + i * binsize);
+      zBinning_.push_back(radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(startbin + i * binsize)))));
+    }
 
-  // fill basic histograms
-  Long64_t nevent;
-  Int_t usedtracks;
-  for (UInt_t isample = 0; isample < file.size(); isample++) {
-    usedtracks = 0;
-    nevent = (Long64_t)tree[isample]->GetEntries();
-    cout << nevent << " tracks in sample " << isample + 1 << endl;
-    for (Long64_t ientry = 0; ientry < nevent; ++ientry) {
-      tree[isample]->GetEntry(ientry);
-      for (Int_t i = 0; i < numberOfBins; i++) {
-        for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
-          Double_t lowerEcut = steps[iStep];
-          Double_t upperEcut = steps[iStep + 1];
-          Double_t lowcut = binningstrvec[i];
-          Double_t highcut = binningstrvec[i + 1];
-          // track selection
-          if (track->track_nHits >= 13 && track->track_nLostHits == 0 && track->track_outerRadius > 99. &&
-              track->track_normalizedChi2 < 5. && track->track_EnergyIn < 1. && track->track_EnergyOut < 8. &&
-              track->track_hac3 > lowerEcut && track->track_hac3 < upperEcut) {
-            if (binVar == "track_eta") {
-              if (track->track_eta >= lowcut && track->track_eta < highcut) {
-                usedtracks++;
-                selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]++;
-                xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                    radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(track->track_eta)))));
-                if (track->track_charge < 0) {
-                  histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                      (track->track_hac3) / track->track_p);
-                  Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                      track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
-                }
-                if (track->track_charge > 0) {
-                  histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                      (track->track_hac3) / track->track_p);
-                  Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                      track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
-                }
-              }
-            } else if (binVar == "track_phi") {
-              if ((variable == "phi1" && track->track_eta < -0.9) ||
-                  (variable == "phi2" && TMath::Abs(track->track_eta) < 0.9) ||
-                  (variable == "phi3" && track->track_eta > 0.9) || variable == "phi")
-                if (track->track_phi >= lowcut && track->track_phi < highcut) {
+    // create energy binning
+    Int_t startStep = 0;
+    const Int_t NumberOFSteps = 2;
+    Double_t steparray[NumberOFSteps + 1] = {50, 58, 80};  //data 2 steps
+    //const Int_t NumberOFSteps = 6;Double_t steparray[NumberOFSteps+1] = {50,55,60,65,70,75,80};//mc 6 steps
+
+    vector<Double_t> steps;
+    vector<TString> stepstrg;
+    Char_t tmpstep[10];
+    for (Int_t ii = 0; ii <= NumberOFSteps; ii++) {
+      steps.push_back(steparray[ii]);
+      sprintf(tmpstep, "%1.1fGeV", steparray[ii]);
+      stepstrg.push_back(tmpstep);
+    }
+
+    // read files
+    vector<TFile *> file;
+    vector<TString> label;
+
+    TObjArray *fileLabelPairs = alignmentWithLabel.Tokenize("\\");
+    for (Int_t i = 0; i < fileLabelPairs->GetEntries(); ++i) {
+      TObjArray *singleFileLabelPair = TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
+
+      if (singleFileLabelPair->GetEntries() == 2) {
+        file.push_back(new TFile(path + (TString(singleFileLabelPair->At(0)->GetName()))));
+        label.push_back(singleFileLabelPair->At(1)->GetName());
+      } else {
+        std::cout << "Please give file name and legend entry in the following form:\n"
+                  << " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
+      }
+    }
+    cout << "number of files: " << file.size() << endl;
+
+    // create trees
+    vector<TTree *> tree;
+    EopVariables *track = new EopVariables();
+
+    for (unsigned int i = 0; i < file.size(); i++) {
+      tree.push_back((TTree *)file[i]->Get("energyOverMomentumTree/EopTree"));
+      tree[i]->SetMakeClass(1);
+      tree[i]->SetBranchAddress("EopVariables", &track);
+      tree[i]->SetBranchAddress("track_outerRadius", &(track->track_outerRadius));
+      tree[i]->SetBranchAddress("track_chi2", &track->track_chi2);
+      tree[i]->SetBranchAddress("track_normalizedChi2", &track->track_normalizedChi2);
+      tree[i]->SetBranchAddress("track_p", &track->track_p);
+      tree[i]->SetBranchAddress("track_pt", &track->track_pt);
+      tree[i]->SetBranchAddress("track_ptError", &track->track_ptError);
+      tree[i]->SetBranchAddress("track_theta", &track->track_theta);
+      tree[i]->SetBranchAddress("track_eta", &track->track_eta);
+      tree[i]->SetBranchAddress("track_phi", &track->track_phi);
+      tree[i]->SetBranchAddress("track_emc1", &track->track_emc1);
+      tree[i]->SetBranchAddress("track_emc3", &track->track_emc3);
+      tree[i]->SetBranchAddress("track_emc5", &track->track_emc5);
+      tree[i]->SetBranchAddress("track_hac1", &track->track_hac1);
+      tree[i]->SetBranchAddress("track_hac3", &track->track_hac3);
+      tree[i]->SetBranchAddress("track_hac5", &track->track_hac5);
+      tree[i]->SetBranchAddress("track_maxPNearby", &track->track_maxPNearby);
+      tree[i]->SetBranchAddress("track_EnergyIn", &track->track_EnergyIn);
+      tree[i]->SetBranchAddress("track_EnergyOut", &track->track_EnergyOut);
+      tree[i]->SetBranchAddress("distofmax", &track->distofmax);
+      tree[i]->SetBranchAddress("track_charge", &track->track_charge);
+      tree[i]->SetBranchAddress("track_nHits", &track->track_nHits);
+      tree[i]->SetBranchAddress("track_nLostHits", &track->track_nLostHits);
+      tree[i]->SetBranchAddress("track_innerOk", &track->track_innerOk);
+    }
+
+    // create histogram vectors
+
+    // basic histograms
+    vector<TH1F *> histonegative;
+    vector<TH1F *> histopositive;
+    vector<TH2F *> Energynegative;
+    vector<TH2F *> Energypositive;
+    vector<TH1F *> xAxisBin;
+    vector<Int_t> selectedTracks;
+    // intermediate histograms
+    vector<TH1F *> fithisto;
+    vector<TH1F *> combinedxAxisBin;
+    // final histograms
+    vector<TGraphErrors *> overallGraph;
+    vector<TH1F *> overallhisto;
+
+    // book histograms
+    // basic histograms
+    for (UInt_t i = 0; i < NumberOFSteps * numberOfBins * file.size(); i++) {
+      Char_t histochar[20];
+      sprintf(histochar, "%i", i + 1);
+      TString histostrg = histochar;
+      TString lowEnergyBorder = stepstrg[i % NumberOFSteps];
+      TString highEnergyBorder = stepstrg[i % NumberOFSteps + 1];
+      if (binVar == "track_eta")
+        histonegative.push_back(
+            new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E < " + highEnergyBorder, 50, 0, 2));
+      else
+        histonegative.push_back(
+            new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E_{T} < " + highEnergyBorder, 50, 0, 2));
+      histopositive.push_back(new TH1F("histopositive" + histostrg, "histopositive" + histostrg, 50, 0, 2));
+      Energynegative.push_back(
+          new TH2F("Energynegative" + histostrg, "Energynegative" + histostrg, 5000, 0, 500, 50, 0, 2));
+      Energypositive.push_back(
+          new TH2F("Energypositive" + histostrg, "Energypositive" + histostrg, 5000, 0, 500, 50, 0, 2));
+      xAxisBin.push_back(new TH1F("xAxisBin" + histostrg, "xAxisBin" + histostrg, 1000, -500, 500));
+      selectedTracks.push_back(0);
+      Energynegative[i]->Sumw2();
+      Energypositive[i]->Sumw2();
+      xAxisBin[i]->Sumw2();
+      histonegative[i]->Sumw2();
+      histopositive[i]->Sumw2();
+      histonegative[i]->SetLineColor(kGreen);
+      histopositive[i]->SetLineColor(kRed);
+    }
+    // intermediate histograms
+    for (UInt_t i = 0; i < numberOfBins * file.size(); i++) {
+      Char_t histochar[20];
+      sprintf(histochar, "%i", i + 1);
+      TString histostrg = histochar;
+      fithisto.push_back(new TH1F("fithisto" + histostrg, "fithisto" + histostrg, NumberOFSteps, 0, NumberOFSteps));
+      combinedxAxisBin.push_back(
+          new TH1F("combinedxAxisBin" + histostrg, "combinedxAxisBin" + histostrg, NumberOFSteps, 0, NumberOFSteps));
+    }
+    // final histograms
+    for (UInt_t i = 0; i < file.size(); i++) {
+      TString cnt;
+      cnt += i;
+      if (binVar == "track_eta") {
+        overallhisto.push_back(new TH1F("overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, &zBinning_.front()));
+        overallGraph.push_back(new TGraphErrors(overallhisto.back()));
+      } else {
+        overallhisto.push_back(new TH1F(
+            "overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, startbin, startbin + numberOfBins * binsize));
+        overallGraph.push_back(new TGraphErrors(overallhisto.back()));
+      }
+    }
+
+    // fill basic histograms
+    Long64_t nevent;
+    Int_t usedtracks;
+    for (UInt_t isample = 0; isample < file.size(); isample++) {
+      usedtracks = 0;
+      nevent = (Long64_t)tree[isample]->GetEntries();
+      cout << nevent << " tracks in sample " << isample + 1 << endl;
+      for (Long64_t ientry = 0; ientry < nevent; ++ientry) {
+        tree[isample]->GetEntry(ientry);
+        for (Int_t i = 0; i < numberOfBins; i++) {
+          for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
+            Double_t lowerEcut = steps[iStep];
+            Double_t upperEcut = steps[iStep + 1];
+            Double_t lowcut = binningstrvec[i];
+            Double_t highcut = binningstrvec[i + 1];
+            // track selection
+            if (track->track_nHits >= 13 && track->track_nLostHits == 0 && track->track_outerRadius > 99. &&
+                track->track_normalizedChi2 < 5. && track->track_EnergyIn < 1. && track->track_EnergyOut < 8. &&
+                track->track_hac3 > lowerEcut && track->track_hac3 < upperEcut) {
+              if (binVar == "track_eta") {
+                if (track->track_eta >= lowcut && track->track_eta < highcut) {
                   usedtracks++;
                   selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]++;
                   xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
-                      track->track_phi);
+                      radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(track->track_eta)))));
                   if (track->track_charge < 0) {
                     histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
                         (track->track_hac3) / track->track_p);
@@ -335,331 +316,365 @@ void momentumBiasValidation(
                         track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
                   }
                 }
+              } else if (binVar == "track_phi") {
+                if ((variable == "phi1" && track->track_eta < -0.9) ||
+                    (variable == "phi2" && TMath::Abs(track->track_eta) < 0.9) ||
+                    (variable == "phi3" && track->track_eta > 0.9) || variable == "phi")
+                  if (track->track_phi >= lowcut && track->track_phi < highcut) {
+                    usedtracks++;
+                    selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]++;
+                    xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                        track->track_phi);
+                    if (track->track_charge < 0) {
+                      histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                          (track->track_hac3) / track->track_p);
+                      Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                          track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                    }
+                    if (track->track_charge > 0) {
+                      histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                          (track->track_hac3) / track->track_p);
+                      Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                          track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                    }
+                  }
+              }
             }
           }
         }
       }
+      cout << "number of used tracks in this sample: " << usedtracks << endl;
     }
-    cout << "number of used tracks in this sample: " << usedtracks << endl;
-  }
-  // calculate misalignment per bin
-  Double_t misalignment;
-  Double_t misaliUncert;
-  vector<TString> misalignmentfit;
-  vector<TF1 *> f2;
+    // calculate misalignment per bin
+    Double_t misalignment;
+    Double_t misaliUncert;
+    vector<TString> misalignmentfit;
+    vector<TF1 *> f2;
 
-  for (UInt_t isample = 0; isample < file.size(); isample++) {
-    for (Int_t i = 0; i < numberOfBins; i++) {
-      if (verbose)
-        cout << binningstrvec[i] << " < " + binVar + " < " << binningstrvec[i + 1] << endl;
-      for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
-        vector<Double_t> curvNeg;
-        vector<Double_t> curvPos;
-        if (verbose) {
-          TString controlName = "controlEOP/control_eop_sample";
-          controlName += isample;
-          controlName += "_bin";
-          controlName += i;
-          controlName += "_energy";
-          controlName += iStep;
-          controlName += ".eps";
-          ccontrol->cd();
-          Double_t posMax =
-              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
-          Double_t negMax =
-              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
-          if (posMax > negMax)
-            histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->SetMaximum(1.1 *
-                                                                                                            posMax);
-          histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone();
-          histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone("same");
-          curvNeg = eop::extractgausparams(
-              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "");
-          curvPos = eop::extractgausparams(
-              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "same");
-          ccontrol->Print(controlName);
-        } else {
-          curvNeg = eop::extractgausparams(
-              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
-          curvPos = eop::extractgausparams(
-              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
-        }
+    for (UInt_t isample = 0; isample < file.size(); isample++) {
+      for (Int_t i = 0; i < numberOfBins; i++) {
+        if (verbose)
+          cout << binningstrvec[i] << " < " + binVar + " < " << binningstrvec[i + 1] << endl;
+        for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
+          vector<Double_t> curvNeg;
+          vector<Double_t> curvPos;
+          if (verbose) {
+            TString controlName = "controlEOP/control_eop_sample";
+            controlName += isample;
+            controlName += "_bin";
+            controlName += i;
+            controlName += "_energy";
+            controlName += iStep;
+            controlName += ".eps";
+            ccontrol->cd();
+            Double_t posMax =
+                histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
+            Double_t negMax =
+                histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
+            if (posMax > negMax)
+              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->SetMaximum(1.1 *
+                                                                                                              posMax);
+            histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone();
+            histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone("same");
+            curvNeg = eop::extractgausparams(
+                histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "");
+            curvPos = eop::extractgausparams(
+                histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "same");
+            ccontrol->Print(controlName);
+          } else {
+            curvNeg = eop::extractgausparams(
+                histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
+            curvPos = eop::extractgausparams(
+                histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
+          }
 
-        misalignment = 0.;
-        misaliUncert = 1000.;
+          misalignment = 0.;
+          misaliUncert = 1000.;
 
-        if (selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)] != 0) {
-          Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetYaxis()->SetRangeUser(
-              curvNeg[2], curvNeg[3]);
-          Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetYaxis()->SetRangeUser(
-              curvPos[2], curvPos[3]);
+          if (selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)] != 0) {
+            Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]
+                ->GetYaxis()
+                ->SetRangeUser(curvNeg[2], curvNeg[3]);
+            Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]
+                ->GetYaxis()
+                ->SetRangeUser(curvPos[2], curvPos[3]);
 
-          Double_t meanEnergyNeg =
-              Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
-          Double_t meanEnergyPos =
-              Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
-          Double_t meanEnergy = (meanEnergyNeg + meanEnergyPos) /
-                                2.;  // use mean of positive and negative tracks to reduce energy dependence
+            Double_t meanEnergyNeg =
+                Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+            Double_t meanEnergyPos =
+                Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+            Double_t meanEnergy = (meanEnergyNeg + meanEnergyPos) /
+                                  2.;  // use mean of positive and negative tracks to reduce energy dependence
+            if (verbose)
+              std::cout << "difference in energy between positive and negative tracks: "
+                        << meanEnergyNeg - meanEnergyPos << std::endl;
+
+            if (binVar == "track_eta") {
+              misalignment = 1000000. * 0.5 *
+                             (-TMath::ASin((0.57 * radius / meanEnergy) * curvNeg[0]) +
+                              TMath::ASin((0.57 * radius / meanEnergy) * curvPos[0]));
+              misaliUncert =
+                  1000000. * 0.5 *
+                  (TMath::Sqrt(((0.57 * 0.57 * radius * radius * curvNeg[1] * curvNeg[1]) /
+                                (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvNeg[0] * curvNeg[0])) +
+                               ((0.57 * 0.57 * radius * radius * curvPos[1] * curvPos[1]) /
+                                (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvPos[0] * curvPos[0]))));
+            }
+            if (binVar == "track_phi") {
+              misalignment = 1000. * (curvPos[0] - curvNeg[0]) / (curvPos[0] + curvNeg[0]);
+              misaliUncert = 1000. * 2 / ((curvPos[0] + curvNeg[0]) * (curvPos[0] + curvNeg[0])) *
+                             TMath::Sqrt((curvPos[0] * curvPos[0] * curvPos[1] * curvPos[1]) +
+                                         (curvNeg[0] * curvNeg[0] * curvNeg[1] * curvNeg[1]));
+            }
+          }
           if (verbose)
-            std::cout << "difference in energy between positive and negative tracks: " << meanEnergyNeg - meanEnergyPos
-                      << std::endl;
-
-          if (binVar == "track_eta") {
-            misalignment = 1000000. * 0.5 *
-                           (-TMath::ASin((0.57 * radius / meanEnergy) * curvNeg[0]) +
-                            TMath::ASin((0.57 * radius / meanEnergy) * curvPos[0]));
-            misaliUncert =
-                1000000. * 0.5 *
-                (TMath::Sqrt(((0.57 * 0.57 * radius * radius * curvNeg[1] * curvNeg[1]) /
-                              (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvNeg[0] * curvNeg[0])) +
-                             ((0.57 * 0.57 * radius * radius * curvPos[1] * curvPos[1]) /
-                              (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvPos[0] * curvPos[0]))));
-          }
-          if (binVar == "track_phi") {
-            misalignment = 1000. * (curvPos[0] - curvNeg[0]) / (curvPos[0] + curvNeg[0]);
-            misaliUncert = 1000. * 2 / ((curvPos[0] + curvNeg[0]) * (curvPos[0] + curvNeg[0])) *
-                           TMath::Sqrt((curvPos[0] * curvPos[0] * curvPos[1] * curvPos[1]) +
-                                       (curvNeg[0] * curvNeg[0] * curvNeg[1] * curvNeg[1]));
-          }
+            cout << "misalignment: " << misalignment << "+-" << misaliUncert << endl << endl;
+          // fill intermediate histograms
+          fithisto[i + isample * numberOfBins]->SetBinContent(iStep + 1, misalignment);
+          fithisto[i + isample * numberOfBins]->SetBinError(iStep + 1, misaliUncert);
+          Double_t xBinCentre =
+              xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+          Double_t xBinCenUnc =
+              xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMeanError();
+          combinedxAxisBin[i + isample * numberOfBins]->SetBinContent(iStep + 1, xBinCentre);
+          combinedxAxisBin[i + isample * numberOfBins]->SetBinError(iStep + 1, xBinCenUnc);
         }
-        if (verbose)
-          cout << "misalignment: " << misalignment << "+-" << misaliUncert << endl << endl;
-        // fill intermediate histograms
-        fithisto[i + isample * numberOfBins]->SetBinContent(iStep + 1, misalignment);
-        fithisto[i + isample * numberOfBins]->SetBinError(iStep + 1, misaliUncert);
-        Double_t xBinCentre = xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
-        Double_t xBinCenUnc =
-            xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMeanError();
-        combinedxAxisBin[i + isample * numberOfBins]->SetBinContent(iStep + 1, xBinCentre);
-        combinedxAxisBin[i + isample * numberOfBins]->SetBinError(iStep + 1, xBinCenUnc);
-      }
 
-      Double_t overallmisalignment;
-      Double_t overallmisaliUncert;
-      Double_t overallxBin;
-      Double_t overallxBinUncert;
-      // calculate mean of different energy bins
-      if (NumberOFSteps > 1) {
-        TF1 *fit = new TF1("fit", "pol0", startStep, NumberOFSteps);
-        TF1 *fit2 = new TF1("fit2", "pol0", startStep, NumberOFSteps);
-        if (verbose)
-          fithisto[i + isample * numberOfBins]->Fit("fit", "0");
-        else
-          fithisto[i + isample * numberOfBins]->Fit("fit", "Q0");
-        combinedxAxisBin[i + isample * numberOfBins]->Fit("fit2", "Q0");
-        overallmisalignment = fit->GetParameter(0);
-        overallmisaliUncert = fit->GetParError(0);
-        overallxBin = fit2->GetParameter(0);
-        overallxBinUncert = fit2->GetParError(0);
-        fit->Delete();
+        Double_t overallmisalignment;
+        Double_t overallmisaliUncert;
+        Double_t overallxBin{0.f};
+        Double_t overallxBinUncert{0.f};
+        // calculate mean of different energy bins
+        if (NumberOFSteps > 1 && (fithisto[i + isample * numberOfBins]->Integral() > 0)) {
+          TF1 *fit = new TF1("fit", "pol0", startStep, NumberOFSteps);
+          TF1 *fit2 = new TF1("fit2", "pol0", startStep, NumberOFSteps);
+          if (verbose)
+            fithisto[i + isample * numberOfBins]->Fit("fit", "0");
+          else
+            fithisto[i + isample * numberOfBins]->Fit("fit", "Q0");
+          combinedxAxisBin[i + isample * numberOfBins]->Fit("fit2", "Q0");
+          overallmisalignment = fit->GetParameter(0);
+          overallmisaliUncert = fit->GetParError(0);
+          overallxBin = fit2->GetParameter(0);
+          overallxBinUncert = fit2->GetParError(0);
+          fit->Delete();
+        } else {
+          overallmisalignment = misalignment;
+          overallmisaliUncert = misaliUncert;
+        }
+        // fill final histograms
+        overallhisto[isample]->SetBinContent(i + 1, overallmisalignment);
+        overallhisto[isample]->SetBinError(i + 1, overallmisaliUncert);
+        overallGraph[isample]->SetPoint(i, overallxBin, overallmisalignment);
+        overallGraph[isample]->SetPointError(i, overallxBinUncert, overallmisaliUncert);
+      }
+    }
+
+    // create legend
+    TLegend *leg = new TLegend(0.13, 0.74, 0.98, 0.94);
+    leg->SetFillColor(10);
+    leg->SetTextFont(42);
+    leg->SetTextSize(0.038);
+    if (variable == "phi1")
+      leg->SetHeader("low #eta tracks (#eta < -0.9)");
+    if (variable == "phi2")
+      leg->SetHeader("central tracks (|#eta| < 0.9)");
+    if (variable == "phi3")
+      leg->SetHeader("high #eta tracks (#eta > 0.9)");
+
+    for (UInt_t isample = 0; isample < file.size(); isample++) {
+      // configure final histogram
+      if (binVar == "track_eta") {
+        overallhisto[isample]->GetXaxis()->SetTitle("z [cm]");
+        overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [#murad]");
+      }
+      if (binVar == "track_phi") {
+        overallhisto[isample]->GetXaxis()->SetTitle("#phi");
+        overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [a.u.]");
+      }
+      overallhisto[isample]->GetYaxis()->SetTitleOffset(1.05);
+      overallhisto[isample]->GetYaxis()->SetTitleSize(0.065);
+      overallhisto[isample]->GetYaxis()->SetLabelSize(0.065);
+      overallhisto[isample]->GetXaxis()->SetTitleOffset(0.8);
+      overallhisto[isample]->GetXaxis()->SetTitleSize(0.065);
+      overallhisto[isample]->GetXaxis()->SetLabelSize(0.065);
+      overallhisto[isample]->SetLineWidth(2);
+      overallhisto[isample]->SetLineColor(isample + 1);
+      overallhisto[isample]->SetMarkerColor(isample + 1);
+      overallGraph[isample]->SetLineWidth(2);
+      overallGraph[isample]->SetLineColor(isample + 1);
+      overallGraph[isample]->SetMarkerColor(isample + 1);
+      if (isample == 2) {
+        overallhisto[isample]->SetLineColor(kGreen + 3);
+        overallhisto[isample]->SetMarkerColor(kGreen + 3);
+        overallGraph[isample]->SetLineColor(kGreen + 3);
+        overallGraph[isample]->SetMarkerColor(kGreen + 3);
+      }
+      overallGraph[isample]->SetMarkerStyle(isample + 20);
+      overallGraph[isample]->SetMarkerSize(2);
+
+      // fit to final histogram
+      Char_t funchar[10];
+      sprintf(funchar, "func%i", isample + 1);
+      TString func = funchar;
+      if (binVar == "track_eta")
+        f2.push_back(new TF1(func, "[0]+[1]*x/100.", -500, 500));  //Divide by 100. cm->m
+      if (binVar == "track_phi")
+        f2.push_back(new TF1(func, "[0]+[1]*TMath::Cos(x+[2])", -500, 500));
+
+      f2[isample]->SetLineColor(isample + 1);
+      if (isample == 2)
+        f2[isample]->SetLineColor(kGreen + 3);
+      f2[isample]->SetLineStyle(isample + 1);
+      f2[isample]->SetLineWidth(2);
+
+      if (verbose) {
+        if (overallGraph[isample]->Integral() != 0.f) {
+          overallGraph[isample]->Fit(func, "mR0+");
+
+          cout << "Covariance Matrix:" << endl;
+          TVirtualFitter *fitter = TVirtualFitter::GetFitter();
+          TMatrixD matrix(2, 2, fitter->GetCovarianceMatrix());
+          Double_t oneOne = fitter->GetCovarianceMatrixElement(0, 0);
+          Double_t oneTwo = fitter->GetCovarianceMatrixElement(0, 1);
+          Double_t twoOne = fitter->GetCovarianceMatrixElement(1, 0);
+          Double_t twoTwo = fitter->GetCovarianceMatrixElement(1, 1);
+
+          cout << "( " << oneOne << ", " << twoOne << ")" << endl;
+          cout << "( " << oneTwo << ", " << twoTwo << ")" << endl;
+        }
       } else {
-        overallmisalignment = misalignment;
-        overallmisaliUncert = misaliUncert;
+        if (overallGraph[isample]->Integral() != 0) {
+          overallGraph[isample]->Fit(func, "QmR0+");
+        }
       }
-      // fill final histograms
-      overallhisto[isample]->SetBinContent(i + 1, overallmisalignment);
-      overallhisto[isample]->SetBinError(i + 1, overallmisaliUncert);
-      overallGraph[isample]->SetPoint(i, overallxBin, overallmisalignment);
-      overallGraph[isample]->SetPointError(i, overallxBinUncert, overallmisaliUncert);
-    }
-  }
 
-  // create legend
-  TLegend *leg = new TLegend(0.13, 0.74, 0.98, 0.94);
-  leg->SetFillColor(10);
-  leg->SetTextFont(42);
-  leg->SetTextSize(0.038);
-  if (variable == "phi1")
-    leg->SetHeader("low #eta tracks (#eta < -0.9)");
-  if (variable == "phi2")
-    leg->SetHeader("central tracks (|#eta| < 0.9)");
-  if (variable == "phi3")
-    leg->SetHeader("high #eta tracks (#eta > 0.9)");
-
-  for (UInt_t isample = 0; isample < file.size(); isample++) {
-    // configure final histogram
-    if (binVar == "track_eta") {
-      overallhisto[isample]->GetXaxis()->SetTitle("z [cm]");
-      overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [#murad]");
-    }
-    if (binVar == "track_phi") {
-      overallhisto[isample]->GetXaxis()->SetTitle("#phi");
-      overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [a.u.]");
-    }
-    overallhisto[isample]->GetYaxis()->SetTitleOffset(1.05);
-    overallhisto[isample]->GetYaxis()->SetTitleSize(0.065);
-    overallhisto[isample]->GetYaxis()->SetLabelSize(0.065);
-    overallhisto[isample]->GetXaxis()->SetTitleOffset(0.8);
-    overallhisto[isample]->GetXaxis()->SetTitleSize(0.065);
-    overallhisto[isample]->GetXaxis()->SetLabelSize(0.065);
-    overallhisto[isample]->SetLineWidth(2);
-    overallhisto[isample]->SetLineColor(isample + 1);
-    overallhisto[isample]->SetMarkerColor(isample + 1);
-    overallGraph[isample]->SetLineWidth(2);
-    overallGraph[isample]->SetLineColor(isample + 1);
-    overallGraph[isample]->SetMarkerColor(isample + 1);
-    if (isample == 2) {
-      overallhisto[isample]->SetLineColor(kGreen + 3);
-      overallhisto[isample]->SetMarkerColor(kGreen + 3);
-      overallGraph[isample]->SetLineColor(kGreen + 3);
-      overallGraph[isample]->SetMarkerColor(kGreen + 3);
-    }
-    overallGraph[isample]->SetMarkerStyle(isample + 20);
-    overallGraph[isample]->SetMarkerSize(2);
-
-    // fit to final histogram
-    Char_t funchar[10];
-    sprintf(funchar, "func%i", isample + 1);
-    TString func = funchar;
-    if (binVar == "track_eta")
-      f2.push_back(new TF1(func, "[0]+[1]*x/100.", -500, 500));  //Divide by 100. cm->m
-    if (binVar == "track_phi")
-      f2.push_back(new TF1(func, "[0]+[1]*TMath::Cos(x+[2])", -500, 500));
-
-    f2[isample]->SetLineColor(isample + 1);
-    if (isample == 2)
-      f2[isample]->SetLineColor(kGreen + 3);
-    f2[isample]->SetLineStyle(isample + 1);
-    f2[isample]->SetLineWidth(2);
-
-    if (verbose) {
-      overallGraph[isample]->Fit(func, "mR0+");
-
-      cout << "Covariance Matrix:" << endl;
-      TVirtualFitter *fitter = TVirtualFitter::GetFitter();
-      TMatrixD matrix(2, 2, fitter->GetCovarianceMatrix());
-      Double_t oneOne = fitter->GetCovarianceMatrixElement(0, 0);
-      Double_t oneTwo = fitter->GetCovarianceMatrixElement(0, 1);
-      Double_t twoOne = fitter->GetCovarianceMatrixElement(1, 0);
-      Double_t twoTwo = fitter->GetCovarianceMatrixElement(1, 1);
-
-      cout << "( " << oneOne << ", " << twoOne << ")" << endl;
-      cout << "( " << oneTwo << ", " << twoTwo << ")" << endl;
-    } else
-      overallGraph[isample]->Fit(func, "QmR0+");
-
-    // print fit parameter
-    if (binVar == "track_eta")
-      cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
-           << ", slope: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1) << endl;
-    if (binVar == "track_phi")
-      cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
-           << ", amplitude: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1)
-           << ", shift: " << f2[isample]->GetParameter(2) << "+-" << f2[isample]->GetParError(2) << endl;
-    cout << "fit probability: " << f2[isample]->GetProb() << endl;
-    if (verbose)
-      cout << "chi^2/Ndof: " << f2[isample]->GetChisquare() / f2[isample]->GetNDF() << endl;
-    // write fit function to legend
-    Char_t misalignmentfitchar[20];
-    sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(0));
-    misalignmentfit.push_back("(");
-    misalignmentfit[isample] += misalignmentfitchar;
-    misalignmentfit[isample] += "#pm";
-    sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(0));
-    misalignmentfit[isample] += misalignmentfitchar;
-    if (variable == "eta") {
-      misalignmentfit[isample] += ")#murad #upoint r[m] + (";
-      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
+      // print fit parameter
+      if (binVar == "track_eta")
+        cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
+             << ", slope: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1) << endl;
+      if (binVar == "track_phi")
+        cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
+             << ", amplitude: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1)
+             << ", shift: " << f2[isample]->GetParameter(2) << "+-" << f2[isample]->GetParError(2) << endl;
+      cout << "fit probability: " << f2[isample]->GetProb() << endl;
+      if (verbose)
+        cout << "chi^2/Ndof: " << f2[isample]->GetChisquare() / f2[isample]->GetNDF() << endl;
+      // write fit function to legend
+      Char_t misalignmentfitchar[20];
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(0));
+      misalignmentfit.push_back("(");
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(0));
       misalignmentfit[isample] += misalignmentfitchar;
-      misalignmentfit[isample] += ")#murad #upoint z[m]";
-    } else if (variable.Contains("phi")) {
-      misalignmentfit[isample] += ") + (";
-      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
-      misalignmentfit[isample] += misalignmentfitchar;
-      misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
-      misalignmentfit[isample] += misalignmentfitchar;
-      misalignmentfit[isample] += ") #upoint cos(#phi";
-      if (f2[isample]->GetParameter(2) > 0.)
-        misalignmentfit[isample] += "+";
-      sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParameter(2));
-      misalignmentfit[isample] += misalignmentfitchar;
-      misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParError(2));
-      misalignmentfit[isample] += misalignmentfitchar;
-      misalignmentfit[isample] += ")";
-    }
+      if (variable == "eta") {
+        misalignmentfit[isample] += ")#murad #upoint r[m] + (";
+        sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += "#pm";
+        sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += ")#murad #upoint z[m]";
+      } else if (variable.Contains("phi")) {
+        misalignmentfit[isample] += ") + (";
+        sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += "#pm";
+        sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += ") #upoint cos(#phi";
+        if (f2[isample]->GetParameter(2) > 0.)
+          misalignmentfit[isample] += "+";
+        sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParameter(2));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += "#pm";
+        sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParError(2));
+        misalignmentfit[isample] += misalignmentfitchar;
+        misalignmentfit[isample] += ")";
+      }
 
-    // set pad margins
-    c->cd();
-    gPad->SetTopMargin(0.06);
-    gPad->SetBottomMargin(0.12);
-    gPad->SetLeftMargin(0.13);
-    gPad->SetRightMargin(0.02);
+      // set pad margins
+      c->cd();
+      gPad->SetTopMargin(0.06);
+      gPad->SetBottomMargin(0.12);
+      gPad->SetLeftMargin(0.13);
+      gPad->SetRightMargin(0.02);
 
-    // determine resonable y-axis range
-    Double_t overallmax = 0.;
-    Double_t overallmin = 0.;
-    if (isample == 0) {
-      for (UInt_t i = 0; i < file.size(); i++) {
-        overallmax = max(
-            overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) +
-                0.55 * (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
-                        overallhisto[i]->GetMinimum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),
-            overallmax);
-        overallmin = min(
-            overallhisto[i]->GetMinimum() - fabs(overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())) -
-                0.1 * (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
+      // determine resonable y-axis range
+      Double_t overallmax = 0.;
+      Double_t overallmin = 0.;
+      if (isample == 0) {
+        for (UInt_t i = 0; i < file.size(); i++) {
+          overallmax = max(
+              overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) +
+                  0.55 *
+                      (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
                        overallhisto[i]->GetMinimum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),
-            overallmin);
+              overallmax);
+          overallmin = min(
+              overallhisto[i]->GetMinimum() - fabs(overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())) -
+                  0.1 *
+                      (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
+                       overallhisto[i]->GetMinimum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),
+              overallmin);
+        }
+        overallhisto[isample]->SetMaximum(overallmax);
+        overallhisto[isample]->SetMinimum(overallmin);
+        if (givenMax)
+          overallhisto[isample]->SetMaximum(givenMax);
+        if (givenMin)
+          overallhisto[isample]->SetMinimum(givenMin);
+        overallhisto[isample]->DrawClone("axis");
       }
-      overallhisto[isample]->SetMaximum(overallmax);
-      overallhisto[isample]->SetMinimum(overallmin);
-      if (givenMax)
-        overallhisto[isample]->SetMaximum(givenMax);
-      if (givenMin)
-        overallhisto[isample]->SetMinimum(givenMin);
-      overallhisto[isample]->DrawClone("axis");
+      // set histogram errors to a small value as only errors of the graph should be shown
+      for (int i = 0; i < overallhisto[isample]->GetNbinsX(); i++) {
+        overallhisto[isample]->SetBinError(i + 1, 0.00001);
+      }
+      // draw final histogram
+      overallhisto[isample]->DrawClone("pe1 same");
+      f2[isample]->DrawClone("same");
+      overallGraph[isample]->DrawClone("|| same");
+      overallGraph[isample]->DrawClone("pz same");
+      overallGraph[isample]->SetLineStyle(isample + 1);
+      leg->AddEntry(overallGraph[isample], label[isample] + " (" + misalignmentfit[isample] + ")", "Lp");
     }
-    // set histogram errors to a small value as only errors of the graph should be shown
-    for (int i = 0; i < overallhisto[isample]->GetNbinsX(); i++) {
-      overallhisto[isample]->SetBinError(i + 1, 0.00001);
+    leg->Draw();
+
+    TPaveLabel *CMSlabel = new TPaveLabel(0.13, 0.94, 0.5, 1., "CMS preliminary 2012", "br NDC");
+    CMSlabel->SetFillStyle(0);
+    CMSlabel->SetBorderSize(0);
+    CMSlabel->SetTextSize(0.95);
+    CMSlabel->SetTextAlign(12);
+    CMSlabel->SetTextFont(42);
+    CMSlabel->Draw("same");
+
+    // print plots
+    if (variable == "eta") {
+      c->Print("twist_validation.eps");
+      if (verbose)
+        c->Print("twist_validation.root");
+    } else if (variable == "phi") {
+      c->Print("sagitta_validation_all.eps");
+      if (verbose)
+        c->Print("sagitta_validation_all.root");
+    } else if (variable == "phi1") {
+      c->Print("sagitta_validation_lowEta.eps");
+      if (verbose)
+        c->Print("sagitta_validation_lowEta.root");
+    } else if (variable == "phi2") {
+      c->Print("sagitta_validation_centralEta.eps");
+      if (verbose)
+        c->Print("sagitta_validation_centralEta.root");
+    } else if (variable == "phi3") {
+      c->Print("sagitta_validation_highEta.eps");
+      if (verbose)
+        c->Print("sagitta_validation_highEta.root");
     }
-    // draw final histogram
-    overallhisto[isample]->DrawClone("pe1 same");
-    f2[isample]->DrawClone("same");
-    overallGraph[isample]->DrawClone("|| same");
-    overallGraph[isample]->DrawClone("pz same");
-    overallGraph[isample]->SetLineStyle(isample + 1);
-    leg->AddEntry(overallGraph[isample], label[isample] + " (" + misalignmentfit[isample] + ")", "Lp");
-  }
-  leg->Draw();
 
-  TPaveLabel *CMSlabel = new TPaveLabel(0.13, 0.94, 0.5, 1., "CMS preliminary 2012", "br NDC");
-  CMSlabel->SetFillStyle(0);
-  CMSlabel->SetBorderSize(0);
-  CMSlabel->SetTextSize(0.95);
-  CMSlabel->SetTextAlign(12);
-  CMSlabel->SetTextFont(42);
-  CMSlabel->Draw("same");
-
-  // print plots
-  if (variable == "eta") {
-    c->Print("twist_validation.eps");
-    if (verbose)
-      c->Print("twist_validation.root");
-  } else if (variable == "phi") {
-    c->Print("sagitta_validation_all.eps");
-    if (verbose)
-      c->Print("sagitta_validation_all.root");
-  } else if (variable == "phi1") {
-    c->Print("sagitta_validation_lowEta.eps");
-    if (verbose)
-      c->Print("sagitta_validation_lowEta.root");
-  } else if (variable == "phi2") {
-    c->Print("sagitta_validation_centralEta.eps");
-    if (verbose)
-      c->Print("sagitta_validation_centralEta.root");
-  } else if (variable == "phi3") {
-    c->Print("sagitta_validation_highEta.eps");
-    if (verbose)
-      c->Print("sagitta_validation_highEta.root");
+    time_t end = time(0);
+    cout << "Done in " << int(difftime(end, start)) / 60 << " min and " << int(difftime(end, start)) % 60 << " sec."
+         << endl;
   }
 
-  time_t end = time(0);
-  cout << "Done in " << int(difftime(end, start)) / 60 << " min and " << int(difftime(end, start)) % 60 << " sec."
-       << endl;
-}
+}  // namespace eop

--- a/Alignment/OfflineValidation/macros/momentumBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumBiasValidation.C
@@ -25,10 +25,62 @@
 
 using namespace std;
 
-vector<Double_t> extractgausparams(TH1F *histo, TString option1 = "0", TString option2 = "");
+namespace eop {
 
-void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/hh/current/cms/user/henderle/", TString alignmentWithLabel = "EOP_TBDkbMinBias_2011.root=Summer 2011\\EOP_TBD_2011.root=no bows\\EOP_TBDfrom0T_2011.root=from 0T, no bows\\EOP_plain_2011.root=no mass constraint", bool verbose = false, Double_t givenMin = 0., Double_t givenMax = 0.)
-{
+  vector<Double_t> extractgausparams(TH1F *histo, TString option1 = "0", TString option2 = "");
+  vector<Double_t> extractgausparams(TH1F *histo, TString option1, TString option2) {
+    TF1 *f1 = new TF1("f1", "gaus");
+    f1->SetRange(0., 2.);
+    histo->Fit("f1", "QR0L");
+
+    double mean = f1->GetParameter(1);
+    double deviation = f1->GetParameter(2);
+
+    double lowLim;
+    double upLim;
+    double newmean;
+
+    double degrade = 0.05;
+    unsigned int iteration = 0;
+
+    while (iteration == 0 || (f1->GetProb() < 0.001 && iteration < 10)) {
+      lowLim = mean - (2.0 * deviation * (1 - degrade * iteration));
+      upLim = mean + (2.0 * deviation * (1 - degrade * iteration));
+
+      f1->SetRange(lowLim, upLim);
+      histo->Fit("f1", "QRL0");
+
+      newmean = mean;
+      if (f1->GetParameter(1) < 2 && f1->GetParameter(1) > 0)
+        newmean = f1->GetParameter(1);
+      lowLim = newmean - (1.5 * deviation);  //*(1-degrade*iteration));
+      upLim = newmean + (1.5 * deviation);   //*(1-degrade*iteration));
+      f1->SetRange(lowLim, upLim);
+      f1->SetLineWidth(1);
+      histo->Fit("f1", "QRL+i" + option1, option2);
+      if (f1->GetParameter(1) < 2 && f1->GetParameter(1) > 0)
+        mean = f1->GetParameter(1);
+      deviation = f1->GetParameter(2);
+      iteration++;
+    }
+    vector<Double_t> params;
+    params.push_back(f1->GetParameter(1));
+    params.push_back(f1->GetParError(1));
+    params.push_back(lowLim);
+    params.push_back(upLim);
+    return params;
+  }
+}  // namespace eop
+
+void momentumBiasValidation(
+    TString variable = "eta",
+    TString path = "/scratch/hh/current/cms/user/henderle/",
+    TString alignmentWithLabel =
+        "EOP_TBDkbMinBias_2011.root=Summer 2011\\EOP_TBD_2011.root=no bows\\EOP_TBDfrom0T_2011.root=from 0T, no "
+        "bows\\EOP_plain_2011.root=no mass constraint",
+    bool verbose = false,
+    Double_t givenMin = 0.,
+    Double_t givenMax = 0.) {
   time_t start = time(0);
 
   // give radius at which the misalignment is calculated (arbitrary)
@@ -37,150 +89,160 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
   // configure style
   gROOT->cd();
   gROOT->SetStyle("Plain");
-  if(verbose){
-    std::cout<<"\n all formerly produced control plots in ./controlEOP/ deleted.\n"<<std::endl;
+  if (verbose) {
+    std::cout << "\n all formerly produced control plots in ./controlEOP/ deleted.\n" << std::endl;
     gROOT->ProcessLine(".!if [ -d controlEOP ]; then rm controlEOP/control_eop*.eps; else mkdir controlEOP; fi");
   }
   gStyle->SetPadBorderMode(0);
   gStyle->SetOptStat(0);
-  gStyle->SetTitleFont(42,"XYZ");
-  gStyle->SetLabelFont(42,"XYZ");
+  gStyle->SetTitleFont(42, "XYZ");
+  gStyle->SetLabelFont(42, "XYZ");
   gStyle->SetEndErrorSize(5);
-  gStyle->SetLineStyleString(2,"80 20");
-  gStyle->SetLineStyleString(3,"40 18");
-  gStyle->SetLineStyleString(4,"20 16");
+  gStyle->SetLineStyleString(2, "80 20");
+  gStyle->SetLineStyleString(3, "40 18");
+  gStyle->SetLineStyleString(4, "20 16");
 
   // create canvas
-  TCanvas *c = new TCanvas("c","Canvas",0,0,1150,880);
-  TCanvas* ccontrol = new TCanvas("ccontrol","controlCanvas",0,0,600,300);
+  TCanvas *c = new TCanvas("c", "Canvas", 0, 0, 1150, 880);
+  TCanvas *ccontrol = new TCanvas("ccontrol", "controlCanvas", 0, 0, 600, 300);
 
   // create angular binning
   TString binVar;
-  if(variable=="eta")binVar = "track_eta";
-  else if(variable=="phi" || variable=="phi1" || variable=="phi2" || variable=="phi3")binVar = "track_phi";
-  else{
+  if (variable == "eta")
+    binVar = "track_eta";
+  else if (variable == "phi" || variable == "phi1" || variable == "phi2" || variable == "phi3")
+    binVar = "track_phi";
+  else {
     std::cout << "variable can be eta or phi" << std::endl;
     std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" << std::endl;
   }
-  
+
   Int_t numberOfBins = 0;
-  Double_t startbin = 0.; Double_t lastbin = 0.;
-  if(binVar == "track_eta"){
+  Double_t startbin = 0.;
+  Double_t lastbin = 0.;
+  if (binVar == "track_eta") {
     // tracks beyond abs(eta)=1.65 do not have radii > 99cm (cut value).
-    startbin = -1.65; lastbin = 1.65; numberOfBins = 18;// ~ outermost TEC
+    startbin = -1.65;
+    lastbin = 1.65;
+    numberOfBins = 18;  // ~ outermost TEC
     //startbin = -.917; lastbin = .917; numberOfBins = 10;// ~ outermost TOB
     //startbin = -1.28; lastbin = 1.28; numberOfBins = 14;// ~ innermost TOB
   }
-  if(binVar == "track_phi"){
-    startbin = -TMath::Pi(); lastbin = TMath::Pi();
+  if (binVar == "track_phi") {
+    startbin = -TMath::Pi();
+    lastbin = TMath::Pi();
     numberOfBins = 18;
   }
-  Double_t binsize = (lastbin-startbin)/numberOfBins;
+  Double_t binsize = (lastbin - startbin) / numberOfBins;
   vector<Double_t> binningstrvec;
   vector<Double_t> zBinning_;
-  for(Int_t i = 0; i <= numberOfBins; i++){
-    binningstrvec.push_back(startbin+i*binsize);
-    zBinning_.push_back(radius*100./TMath::Tan(2*TMath::ATan(TMath::Exp(-(startbin+i*binsize)))));
+  for (Int_t i = 0; i <= numberOfBins; i++) {
+    binningstrvec.push_back(startbin + i * binsize);
+    zBinning_.push_back(radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(startbin + i * binsize)))));
   }
 
   // create energy binning
   Int_t startStep = 0;
-  const Int_t NumberOFSteps = 2;Double_t steparray[NumberOFSteps+1] = {50,58,80};//data 2 steps
+  const Int_t NumberOFSteps = 2;
+  Double_t steparray[NumberOFSteps + 1] = {50, 58, 80};  //data 2 steps
   //const Int_t NumberOFSteps = 6;Double_t steparray[NumberOFSteps+1] = {50,55,60,65,70,75,80};//mc 6 steps
 
   vector<Double_t> steps;
   vector<TString> stepstrg;
-  Char_t tmpstep[5];
-  for(Int_t ii=0; ii<=NumberOFSteps; ii++){
+  Char_t tmpstep[10];
+  for (Int_t ii = 0; ii <= NumberOFSteps; ii++) {
     steps.push_back(steparray[ii]);
-    sprintf(tmpstep,"%1.1fGeV",steparray[ii]);
+    sprintf(tmpstep, "%1.1fGeV", steparray[ii]);
     stepstrg.push_back(tmpstep);
   }
 
   // read files
-  vector<TFile*> file;
+  vector<TFile *> file;
   vector<TString> label;
 
   TObjArray *fileLabelPairs = alignmentWithLabel.Tokenize("\\");
   for (Int_t i = 0; i < fileLabelPairs->GetEntries(); ++i) {
     TObjArray *singleFileLabelPair = TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
 
-    if(singleFileLabelPair->GetEntries() == 2) {
-      file.push_back( new TFile(path+(TString(singleFileLabelPair->At(0)->GetName()))) );
-      label.push_back( singleFileLabelPair->At(1)->GetName() );
-    }
-    else {
+    if (singleFileLabelPair->GetEntries() == 2) {
+      file.push_back(new TFile(path + (TString(singleFileLabelPair->At(0)->GetName()))));
+      label.push_back(singleFileLabelPair->At(1)->GetName());
+    } else {
       std::cout << "Please give file name and legend entry in the following form:\n"
-		<< " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
+                << " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
     }
   }
-  cout<<"number of files: "<<file.size()<<endl;
+  cout << "number of files: " << file.size() << endl;
 
   // create trees
-  vector<TTree*> tree;
-  EopVariables* track = new EopVariables();
+  vector<TTree *> tree;
+  EopVariables *track = new EopVariables();
 
-  for(unsigned int i = 0; i < file.size(); i++){
-    tree.push_back((TTree*)file[i]->Get("energyOverMomentumTree/EopTree"));
+  for (unsigned int i = 0; i < file.size(); i++) {
+    tree.push_back((TTree *)file[i]->Get("energyOverMomentumTree/EopTree"));
     tree[i]->SetMakeClass(1);
-    tree[i]->SetBranchAddress("EopVariables",&track);
-    tree[i]->SetBranchAddress("track_outerRadius",&(track->track_outerRadius));
-    tree[i]->SetBranchAddress("track_chi2",&track->track_chi2);
-    tree[i]->SetBranchAddress("track_normalizedChi2",&track->track_normalizedChi2);
-    tree[i]->SetBranchAddress("track_p",&track->track_p);
-    tree[i]->SetBranchAddress("track_pt",&track->track_pt);
-    tree[i]->SetBranchAddress("track_ptError",&track->track_ptError);
-    tree[i]->SetBranchAddress("track_theta",&track->track_theta);
-    tree[i]->SetBranchAddress("track_eta",&track->track_eta);
-    tree[i]->SetBranchAddress("track_phi",&track->track_phi);
-    tree[i]->SetBranchAddress("track_emc1",&track->track_emc1);
-    tree[i]->SetBranchAddress("track_emc3",&track->track_emc3);
-    tree[i]->SetBranchAddress("track_emc5",&track->track_emc5);
-    tree[i]->SetBranchAddress("track_hac1",&track->track_hac1);
-    tree[i]->SetBranchAddress("track_hac3",&track->track_hac3);
-    tree[i]->SetBranchAddress("track_hac5",&track->track_hac5);
-    tree[i]->SetBranchAddress("track_maxPNearby",&track->track_maxPNearby);
-    tree[i]->SetBranchAddress("track_EnergyIn",&track->track_EnergyIn);
-    tree[i]->SetBranchAddress("track_EnergyOut",&track->track_EnergyOut);
-    tree[i]->SetBranchAddress("distofmax",&track->distofmax);
-    tree[i]->SetBranchAddress("track_charge",&track->track_charge);
-    tree[i]->SetBranchAddress("track_nHits",&track->track_nHits);
-    tree[i]->SetBranchAddress("track_nLostHits",&track->track_nLostHits);
-    tree[i]->SetBranchAddress("track_innerOk",&track->track_innerOk);
+    tree[i]->SetBranchAddress("EopVariables", &track);
+    tree[i]->SetBranchAddress("track_outerRadius", &(track->track_outerRadius));
+    tree[i]->SetBranchAddress("track_chi2", &track->track_chi2);
+    tree[i]->SetBranchAddress("track_normalizedChi2", &track->track_normalizedChi2);
+    tree[i]->SetBranchAddress("track_p", &track->track_p);
+    tree[i]->SetBranchAddress("track_pt", &track->track_pt);
+    tree[i]->SetBranchAddress("track_ptError", &track->track_ptError);
+    tree[i]->SetBranchAddress("track_theta", &track->track_theta);
+    tree[i]->SetBranchAddress("track_eta", &track->track_eta);
+    tree[i]->SetBranchAddress("track_phi", &track->track_phi);
+    tree[i]->SetBranchAddress("track_emc1", &track->track_emc1);
+    tree[i]->SetBranchAddress("track_emc3", &track->track_emc3);
+    tree[i]->SetBranchAddress("track_emc5", &track->track_emc5);
+    tree[i]->SetBranchAddress("track_hac1", &track->track_hac1);
+    tree[i]->SetBranchAddress("track_hac3", &track->track_hac3);
+    tree[i]->SetBranchAddress("track_hac5", &track->track_hac5);
+    tree[i]->SetBranchAddress("track_maxPNearby", &track->track_maxPNearby);
+    tree[i]->SetBranchAddress("track_EnergyIn", &track->track_EnergyIn);
+    tree[i]->SetBranchAddress("track_EnergyOut", &track->track_EnergyOut);
+    tree[i]->SetBranchAddress("distofmax", &track->distofmax);
+    tree[i]->SetBranchAddress("track_charge", &track->track_charge);
+    tree[i]->SetBranchAddress("track_nHits", &track->track_nHits);
+    tree[i]->SetBranchAddress("track_nLostHits", &track->track_nLostHits);
+    tree[i]->SetBranchAddress("track_innerOk", &track->track_innerOk);
   }
 
   // create histogram vectors
 
   // basic histograms
-  vector<TH1F*> histonegative;
-  vector<TH1F*> histopositive;
-  vector<TH2F*> Energynegative;
-  vector<TH2F*> Energypositive;
-  vector<TH1F*> xAxisBin;
+  vector<TH1F *> histonegative;
+  vector<TH1F *> histopositive;
+  vector<TH2F *> Energynegative;
+  vector<TH2F *> Energypositive;
+  vector<TH1F *> xAxisBin;
   vector<Int_t> selectedTracks;
   // intermediate histograms
-  vector<TH1F*> fithisto;
-  vector<TH1F*> combinedxAxisBin;
+  vector<TH1F *> fithisto;
+  vector<TH1F *> combinedxAxisBin;
   // final histograms
-  vector<TGraphErrors*> overallGraph;
-  vector<TH1F*> overallhisto;
+  vector<TGraphErrors *> overallGraph;
+  vector<TH1F *> overallhisto;
 
   // book histograms
   // basic histograms
-  for(UInt_t i = 0; i<NumberOFSteps*numberOfBins*file.size(); i++){
+  for (UInt_t i = 0; i < NumberOFSteps * numberOfBins * file.size(); i++) {
     Char_t histochar[20];
-    sprintf(histochar,"%i",i+1);
+    sprintf(histochar, "%i", i + 1);
     TString histostrg = histochar;
-    TString lowEnergyBorder = stepstrg[i%NumberOFSteps];
-    TString highEnergyBorder = stepstrg[i%NumberOFSteps+1];
-    if(binVar == "track_eta")
-      histonegative.push_back(new TH1F("histonegative"+histostrg,lowEnergyBorder+" #leq E < "+highEnergyBorder,50,0,2));
-    else 
-      histonegative.push_back(new TH1F("histonegative"+histostrg,lowEnergyBorder+" #leq E_{T} < "+highEnergyBorder,50,0,2));
-    histopositive.push_back(new TH1F("histopositive"+histostrg,"histopositive"+histostrg,50,0,2));
-    Energynegative.push_back(new TH2F("Energynegative"+histostrg,"Energynegative"+histostrg,5000,0,500,50,0,2));
-    Energypositive.push_back(new TH2F("Energypositive"+histostrg,"Energypositive"+histostrg,5000,0,500,50,0,2));
-    xAxisBin.push_back(new TH1F("xAxisBin"+histostrg,"xAxisBin"+histostrg,1000,-500,500));
+    TString lowEnergyBorder = stepstrg[i % NumberOFSteps];
+    TString highEnergyBorder = stepstrg[i % NumberOFSteps + 1];
+    if (binVar == "track_eta")
+      histonegative.push_back(
+          new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E < " + highEnergyBorder, 50, 0, 2));
+    else
+      histonegative.push_back(
+          new TH1F("histonegative" + histostrg, lowEnergyBorder + " #leq E_{T} < " + highEnergyBorder, 50, 0, 2));
+    histopositive.push_back(new TH1F("histopositive" + histostrg, "histopositive" + histostrg, 50, 0, 2));
+    Energynegative.push_back(
+        new TH2F("Energynegative" + histostrg, "Energynegative" + histostrg, 5000, 0, 500, 50, 0, 2));
+    Energypositive.push_back(
+        new TH2F("Energypositive" + histostrg, "Energypositive" + histostrg, 5000, 0, 500, 50, 0, 2));
+    xAxisBin.push_back(new TH1F("xAxisBin" + histostrg, "xAxisBin" + histostrg, 1000, -500, 500));
     selectedTracks.push_back(0);
     Energynegative[i]->Sumw2();
     Energypositive[i]->Sumw2();
@@ -191,22 +253,24 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
     histopositive[i]->SetLineColor(kRed);
   }
   // intermediate histograms
-  for(UInt_t i = 0; i<numberOfBins*file.size(); i++){
+  for (UInt_t i = 0; i < numberOfBins * file.size(); i++) {
     Char_t histochar[20];
-    sprintf(histochar,"%i",i+1);
+    sprintf(histochar, "%i", i + 1);
     TString histostrg = histochar;
-    fithisto.push_back(new TH1F("fithisto"+histostrg,"fithisto"+histostrg,NumberOFSteps,0,NumberOFSteps));
-    combinedxAxisBin.push_back(new TH1F("combinedxAxisBin"+histostrg,"combinedxAxisBin"+histostrg,NumberOFSteps,0,NumberOFSteps));
+    fithisto.push_back(new TH1F("fithisto" + histostrg, "fithisto" + histostrg, NumberOFSteps, 0, NumberOFSteps));
+    combinedxAxisBin.push_back(
+        new TH1F("combinedxAxisBin" + histostrg, "combinedxAxisBin" + histostrg, NumberOFSteps, 0, NumberOFSteps));
   }
   // final histograms
-  for(UInt_t i = 0; i < file.size(); i++){
-    TString cnt; cnt += i;
-    if(binVar == "track_eta"){
-      overallhisto.push_back(new TH1F("overallhisto"+cnt,"overallhisto"+cnt,numberOfBins,&zBinning_.front()));
+  for (UInt_t i = 0; i < file.size(); i++) {
+    TString cnt;
+    cnt += i;
+    if (binVar == "track_eta") {
+      overallhisto.push_back(new TH1F("overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, &zBinning_.front()));
       overallGraph.push_back(new TGraphErrors(overallhisto.back()));
-    }
-    else{
-      overallhisto.push_back(new TH1F("overallhisto"+cnt,"overallhisto"+cnt,numberOfBins,startbin,startbin+numberOfBins*binsize));
+    } else {
+      overallhisto.push_back(new TH1F(
+          "overallhisto" + cnt, "overallhisto" + cnt, numberOfBins, startbin, startbin + numberOfBins * binsize));
       overallGraph.push_back(new TGraphErrors(overallhisto.back()));
     }
   }
@@ -214,169 +278,211 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
   // fill basic histograms
   Long64_t nevent;
   Int_t usedtracks;
-  for(UInt_t isample = 0; isample < file.size(); isample++){
+  for (UInt_t isample = 0; isample < file.size(); isample++) {
     usedtracks = 0;
     nevent = (Long64_t)tree[isample]->GetEntries();
-    cout << nevent << " tracks in sample "<< isample+1 <<endl;
-    for(Long64_t ientry = 0; ientry < nevent; ++ientry){
+    cout << nevent << " tracks in sample " << isample + 1 << endl;
+    for (Long64_t ientry = 0; ientry < nevent; ++ientry) {
       tree[isample]->GetEntry(ientry);
-      for(Int_t i = 0; i<numberOfBins; i++){
-	for(Int_t iStep = startStep; iStep<NumberOFSteps; iStep++){
-	  Double_t lowerEcut = steps[iStep];
-	  Double_t upperEcut = steps[iStep+1];
-	  Double_t lowcut = binningstrvec[i];
-	  Double_t highcut = binningstrvec[i+1];
-	  // track selection
-	  if(track->track_nHits>=13 && track->track_nLostHits==0 && track->track_outerRadius>99. && track->track_normalizedChi2<5. && 
-	     track->track_EnergyIn<1. && track->track_EnergyOut<8. && track->track_hac3>lowerEcut && track->track_hac3<upperEcut){
-	    if(binVar == "track_eta"){
-	      if(track->track_eta>=lowcut && track->track_eta<highcut){
-		usedtracks++;
-		selectedTracks[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]++;
-		xAxisBin[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(radius*100./TMath::Tan(2*TMath::ATan(TMath::Exp(-(track->track_eta)))));
-		if(track->track_charge<0){
-		  histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill((track->track_hac3)/track->track_p);
-		  Energynegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(track->track_hac3*TMath::Sin(track->track_theta),(track->track_hac3)/track->track_p);
-		}
-		if(track->track_charge>0){
-		  histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill((track->track_hac3)/track->track_p);
-		  Energypositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(track->track_hac3*TMath::Sin(track->track_theta),(track->track_hac3)/track->track_p);
-		}
-	      }
-	    }
-	    else if(binVar == "track_phi"){
-	      if((variable=="phi1" && track->track_eta<-0.9) || (variable=="phi2" && TMath::Abs(track->track_eta)<0.9) || (variable=="phi3" && track->track_eta>0.9) || variable=="phi")
-		if(track->track_phi>=lowcut && track->track_phi<highcut){
-		  usedtracks++;
-		  selectedTracks[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]++;
-		  xAxisBin[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(track->track_phi);
-		  if(track->track_charge<0){
-		    histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill((track->track_hac3)/track->track_p);
-		    Energynegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(track->track_hac3*TMath::Sin(track->track_theta),(track->track_hac3)/track->track_p);
-		  }
-		  if(track->track_charge>0){
-		    histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill((track->track_hac3)/track->track_p);
-		    Energypositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->Fill(track->track_hac3*TMath::Sin(track->track_theta),(track->track_hac3)/track->track_p);
-		  }
-		}
-	    }
-	  }
-	}
+      for (Int_t i = 0; i < numberOfBins; i++) {
+        for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
+          Double_t lowerEcut = steps[iStep];
+          Double_t upperEcut = steps[iStep + 1];
+          Double_t lowcut = binningstrvec[i];
+          Double_t highcut = binningstrvec[i + 1];
+          // track selection
+          if (track->track_nHits >= 13 && track->track_nLostHits == 0 && track->track_outerRadius > 99. &&
+              track->track_normalizedChi2 < 5. && track->track_EnergyIn < 1. && track->track_EnergyOut < 8. &&
+              track->track_hac3 > lowerEcut && track->track_hac3 < upperEcut) {
+            if (binVar == "track_eta") {
+              if (track->track_eta >= lowcut && track->track_eta < highcut) {
+                usedtracks++;
+                selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]++;
+                xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                    radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(track->track_eta)))));
+                if (track->track_charge < 0) {
+                  histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                      (track->track_hac3) / track->track_p);
+                  Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                      track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                }
+                if (track->track_charge > 0) {
+                  histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                      (track->track_hac3) / track->track_p);
+                  Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                      track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                }
+              }
+            } else if (binVar == "track_phi") {
+              if ((variable == "phi1" && track->track_eta < -0.9) ||
+                  (variable == "phi2" && TMath::Abs(track->track_eta) < 0.9) ||
+                  (variable == "phi3" && track->track_eta > 0.9) || variable == "phi")
+                if (track->track_phi >= lowcut && track->track_phi < highcut) {
+                  usedtracks++;
+                  selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]++;
+                  xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                      track->track_phi);
+                  if (track->track_charge < 0) {
+                    histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                        (track->track_hac3) / track->track_p);
+                    Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                        track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                  }
+                  if (track->track_charge > 0) {
+                    histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                        (track->track_hac3) / track->track_p);
+                    Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->Fill(
+                        track->track_hac3 * TMath::Sin(track->track_theta), (track->track_hac3) / track->track_p);
+                  }
+                }
+            }
+          }
+        }
       }
     }
-    cout<<"number of used tracks in this sample: "<<usedtracks<<endl;
-  }  
+    cout << "number of used tracks in this sample: " << usedtracks << endl;
+  }
   // calculate misalignment per bin
   Double_t misalignment;
   Double_t misaliUncert;
   vector<TString> misalignmentfit;
-  vector<TF1*> f2;
+  vector<TF1 *> f2;
 
-  for(UInt_t isample = 0; isample < file.size(); isample++){
-  for(Int_t i = 0; i<numberOfBins; i++){
-    if(verbose)cout<<binningstrvec[i] << " < "+binVar+" < " << binningstrvec[i+1]<<endl;
-    for(Int_t iStep = startStep; iStep<NumberOFSteps; iStep++){
-      vector<Double_t> curvNeg;
-      vector<Double_t> curvPos;
-      if(verbose){
-	TString controlName = "controlEOP/control_eop_sample"; controlName += isample;
-	controlName += "_bin"; controlName += i;
-	controlName += "_energy"; controlName += iStep;
-	controlName += ".eps";
-	ccontrol->cd();
-	Double_t posMax = histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMaximum();
-	Double_t negMax = histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMaximum();
-	  if(posMax>negMax)histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->SetMaximum(1.1*posMax);
-	histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->DrawClone();
-	histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->DrawClone("same");
-	curvNeg = extractgausparams(histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)],"","");
-	curvPos = extractgausparams(histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)],"","same");
-	ccontrol->Print(controlName);
+  for (UInt_t isample = 0; isample < file.size(); isample++) {
+    for (Int_t i = 0; i < numberOfBins; i++) {
+      if (verbose)
+        cout << binningstrvec[i] << " < " + binVar + " < " << binningstrvec[i + 1] << endl;
+      for (Int_t iStep = startStep; iStep < NumberOFSteps; iStep++) {
+        vector<Double_t> curvNeg;
+        vector<Double_t> curvPos;
+        if (verbose) {
+          TString controlName = "controlEOP/control_eop_sample";
+          controlName += isample;
+          controlName += "_bin";
+          controlName += i;
+          controlName += "_energy";
+          controlName += iStep;
+          controlName += ".eps";
+          ccontrol->cd();
+          Double_t posMax =
+              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
+          Double_t negMax =
+              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMaximum();
+          if (posMax > negMax)
+            histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->SetMaximum(1.1 *
+                                                                                                            posMax);
+          histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone();
+          histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->DrawClone("same");
+          curvNeg = eop::extractgausparams(
+              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "");
+          curvPos = eop::extractgausparams(
+              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)], "", "same");
+          ccontrol->Print(controlName);
+        } else {
+          curvNeg = eop::extractgausparams(
+              histonegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
+          curvPos = eop::extractgausparams(
+              histopositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]);
+        }
+
+        misalignment = 0.;
+        misaliUncert = 1000.;
+
+        if (selectedTracks[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)] != 0) {
+          Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetYaxis()->SetRangeUser(
+              curvNeg[2], curvNeg[3]);
+          Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetYaxis()->SetRangeUser(
+              curvPos[2], curvPos[3]);
+
+          Double_t meanEnergyNeg =
+              Energynegative[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+          Double_t meanEnergyPos =
+              Energypositive[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+          Double_t meanEnergy = (meanEnergyNeg + meanEnergyPos) /
+                                2.;  // use mean of positive and negative tracks to reduce energy dependence
+          if (verbose)
+            std::cout << "difference in energy between positive and negative tracks: " << meanEnergyNeg - meanEnergyPos
+                      << std::endl;
+
+          if (binVar == "track_eta") {
+            misalignment = 1000000. * 0.5 *
+                           (-TMath::ASin((0.57 * radius / meanEnergy) * curvNeg[0]) +
+                            TMath::ASin((0.57 * radius / meanEnergy) * curvPos[0]));
+            misaliUncert =
+                1000000. * 0.5 *
+                (TMath::Sqrt(((0.57 * 0.57 * radius * radius * curvNeg[1] * curvNeg[1]) /
+                              (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvNeg[0] * curvNeg[0])) +
+                             ((0.57 * 0.57 * radius * radius * curvPos[1] * curvPos[1]) /
+                              (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvPos[0] * curvPos[0]))));
+          }
+          if (binVar == "track_phi") {
+            misalignment = 1000. * (curvPos[0] - curvNeg[0]) / (curvPos[0] + curvNeg[0]);
+            misaliUncert = 1000. * 2 / ((curvPos[0] + curvNeg[0]) * (curvPos[0] + curvNeg[0])) *
+                           TMath::Sqrt((curvPos[0] * curvPos[0] * curvPos[1] * curvPos[1]) +
+                                       (curvNeg[0] * curvNeg[0] * curvNeg[1] * curvNeg[1]));
+          }
+        }
+        if (verbose)
+          cout << "misalignment: " << misalignment << "+-" << misaliUncert << endl << endl;
+        // fill intermediate histograms
+        fithisto[i + isample * numberOfBins]->SetBinContent(iStep + 1, misalignment);
+        fithisto[i + isample * numberOfBins]->SetBinError(iStep + 1, misaliUncert);
+        Double_t xBinCentre = xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMean();
+        Double_t xBinCenUnc =
+            xAxisBin[i * NumberOFSteps + iStep + isample * (NumberOFSteps * numberOfBins)]->GetMeanError();
+        combinedxAxisBin[i + isample * numberOfBins]->SetBinContent(iStep + 1, xBinCentre);
+        combinedxAxisBin[i + isample * numberOfBins]->SetBinError(iStep + 1, xBinCenUnc);
       }
-      else{
-	curvNeg = extractgausparams(histonegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]);
-	curvPos = extractgausparams(histopositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]);
+
+      Double_t overallmisalignment;
+      Double_t overallmisaliUncert;
+      Double_t overallxBin;
+      Double_t overallxBinUncert;
+      // calculate mean of different energy bins
+      if (NumberOFSteps > 1) {
+        TF1 *fit = new TF1("fit", "pol0", startStep, NumberOFSteps);
+        TF1 *fit2 = new TF1("fit2", "pol0", startStep, NumberOFSteps);
+        if (verbose)
+          fithisto[i + isample * numberOfBins]->Fit("fit", "0");
+        else
+          fithisto[i + isample * numberOfBins]->Fit("fit", "Q0");
+        combinedxAxisBin[i + isample * numberOfBins]->Fit("fit2", "Q0");
+        overallmisalignment = fit->GetParameter(0);
+        overallmisaliUncert = fit->GetParError(0);
+        overallxBin = fit2->GetParameter(0);
+        overallxBinUncert = fit2->GetParError(0);
+        fit->Delete();
+      } else {
+        overallmisalignment = misalignment;
+        overallmisaliUncert = misaliUncert;
       }
-	
-      misalignment = 0.;
-      misaliUncert = 1000.;
-
-      if(selectedTracks[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]!=0){
-
-	Energynegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetYaxis()->SetRangeUser(curvNeg[2],curvNeg[3]);
-	Energypositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetYaxis()->SetRangeUser(curvPos[2],curvPos[3]);
-	
-	Double_t meanEnergyNeg = Energynegative[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMean();
-	Double_t meanEnergyPos = Energypositive[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMean();
-	Double_t meanEnergy = (meanEnergyNeg+meanEnergyPos)/2.;// use mean of positive and negative tracks to reduce energy dependence
-	if(verbose)std::cout<<"difference in energy between positive and negative tracks: "<<meanEnergyNeg-meanEnergyPos<<std::endl;
-
-	if(binVar == "track_eta"){
-	  misalignment = 1000000.*0.5*(-TMath::ASin((0.57*radius/meanEnergy)*curvNeg[0])+TMath::ASin((0.57*radius/meanEnergy)*curvPos[0]));
-	  misaliUncert = 1000000.*0.5*(TMath::Sqrt(((0.57*0.57*radius*radius*curvNeg[1]*curvNeg[1])/(meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvNeg[0]*curvNeg[0]))+
-						   ((0.57*0.57*radius*radius*curvPos[1]*curvPos[1])/(meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvPos[0]*curvPos[0]))));
-	}
-	if(binVar == "track_phi"){
-	  misalignment = 1000.*(curvPos[0]-curvNeg[0])/(curvPos[0]+curvNeg[0]);
-	  misaliUncert = 1000.*2/((curvPos[0]+curvNeg[0])*(curvPos[0]+curvNeg[0]))*TMath::Sqrt((curvPos[0]*curvPos[0]*curvPos[1]*curvPos[1])+
-											       (curvNeg[0]*curvNeg[0]*curvNeg[1]*curvNeg[1]));
-	}
-      }
-      if(verbose)cout<<"misalignment: "<<misalignment<<"+-"<<misaliUncert<<endl<<endl;
-      // fill intermediate histograms
-      fithisto[i+isample*numberOfBins]->SetBinContent(iStep+1,misalignment);
-      fithisto[i+isample*numberOfBins]->SetBinError(iStep+1,misaliUncert);
-      Double_t xBinCentre = xAxisBin[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMean();
-      Double_t xBinCenUnc = xAxisBin[i*NumberOFSteps+iStep+isample*(NumberOFSteps*numberOfBins)]->GetMeanError();
-      combinedxAxisBin[i+isample*numberOfBins]->SetBinContent(iStep+1,xBinCentre);
-      combinedxAxisBin[i+isample*numberOfBins]->SetBinError(iStep+1,xBinCenUnc);
+      // fill final histograms
+      overallhisto[isample]->SetBinContent(i + 1, overallmisalignment);
+      overallhisto[isample]->SetBinError(i + 1, overallmisaliUncert);
+      overallGraph[isample]->SetPoint(i, overallxBin, overallmisalignment);
+      overallGraph[isample]->SetPointError(i, overallxBinUncert, overallmisaliUncert);
     }
-
-    Double_t overallmisalignment;
-    Double_t overallmisaliUncert;
-    Double_t overallxBin;
-    Double_t overallxBinUncert;
-    // calculate mean of different energy bins
-    if(NumberOFSteps>1){
-      TF1* fit = new TF1("fit","pol0",startStep,NumberOFSteps);
-      TF1* fit2 = new TF1("fit2","pol0",startStep,NumberOFSteps);
-      if(verbose)fithisto[i+isample*numberOfBins]->Fit("fit","0");
-      else fithisto[i+isample*numberOfBins]->Fit("fit","Q0");
-      combinedxAxisBin[i+isample*numberOfBins]->Fit("fit2","Q0");
-      overallmisalignment = fit->GetParameter(0);
-      overallmisaliUncert = fit->GetParError(0);
-      overallxBin = fit2->GetParameter(0);
-      overallxBinUncert = fit2->GetParError(0);
-      fit->Delete();
-    }
-    else{
-      overallmisalignment = misalignment;
-      overallmisaliUncert = misaliUncert;
-    }
-    // fill final histograms
-    overallhisto[isample]->SetBinContent(i+1,overallmisalignment);
-    overallhisto[isample]->SetBinError(i+1,overallmisaliUncert);
-    overallGraph[isample]->SetPoint(i,overallxBin,overallmisalignment);
-    overallGraph[isample]->SetPointError(i,overallxBinUncert,overallmisaliUncert);
-  }
   }
 
   // create legend
-  TLegend *leg = new TLegend(0.13,0.74,0.98, 0.94);
+  TLegend *leg = new TLegend(0.13, 0.74, 0.98, 0.94);
   leg->SetFillColor(10);
   leg->SetTextFont(42);
   leg->SetTextSize(0.038);
-  if(variable=="phi1")leg->SetHeader("low #eta tracks (#eta < -0.9)");
-  if(variable=="phi2")leg->SetHeader("central tracks (|#eta| < 0.9)");
-  if(variable=="phi3")leg->SetHeader("high #eta tracks (#eta > 0.9)");
+  if (variable == "phi1")
+    leg->SetHeader("low #eta tracks (#eta < -0.9)");
+  if (variable == "phi2")
+    leg->SetHeader("central tracks (|#eta| < 0.9)");
+  if (variable == "phi3")
+    leg->SetHeader("high #eta tracks (#eta > 0.9)");
 
-  for(UInt_t isample = 0; isample < file.size(); isample++){
+  for (UInt_t isample = 0; isample < file.size(); isample++) {
     // configure final histogram
-    if(binVar == "track_eta"){
+    if (binVar == "track_eta") {
       overallhisto[isample]->GetXaxis()->SetTitle("z [cm]");
       overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [#murad]");
     }
-    if(binVar == "track_phi"){
+    if (binVar == "track_phi") {
       overallhisto[isample]->GetXaxis()->SetTitle("#phi");
       overallhisto[isample]->GetYaxis()->SetTitle("#Delta#phi [a.u.]");
     }
@@ -387,85 +493,92 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
     overallhisto[isample]->GetXaxis()->SetTitleSize(0.065);
     overallhisto[isample]->GetXaxis()->SetLabelSize(0.065);
     overallhisto[isample]->SetLineWidth(2);
-    overallhisto[isample]->SetLineColor(isample+1);
-    overallhisto[isample]->SetMarkerColor(isample+1);
+    overallhisto[isample]->SetLineColor(isample + 1);
+    overallhisto[isample]->SetMarkerColor(isample + 1);
     overallGraph[isample]->SetLineWidth(2);
-    overallGraph[isample]->SetLineColor(isample+1);
-    overallGraph[isample]->SetMarkerColor(isample+1);
-    if(isample==2){
-      overallhisto[isample]->SetLineColor(kGreen+3);
-      overallhisto[isample]->SetMarkerColor(kGreen+3);
-      overallGraph[isample]->SetLineColor(kGreen+3);
-      overallGraph[isample]->SetMarkerColor(kGreen+3);
+    overallGraph[isample]->SetLineColor(isample + 1);
+    overallGraph[isample]->SetMarkerColor(isample + 1);
+    if (isample == 2) {
+      overallhisto[isample]->SetLineColor(kGreen + 3);
+      overallhisto[isample]->SetMarkerColor(kGreen + 3);
+      overallGraph[isample]->SetLineColor(kGreen + 3);
+      overallGraph[isample]->SetMarkerColor(kGreen + 3);
     }
-    overallGraph[isample]->SetMarkerStyle(isample+20);
+    overallGraph[isample]->SetMarkerStyle(isample + 20);
     overallGraph[isample]->SetMarkerSize(2);
 
     // fit to final histogram
     Char_t funchar[10];
-    sprintf(funchar,"func%i",isample+1);
+    sprintf(funchar, "func%i", isample + 1);
     TString func = funchar;
-    if(binVar == "track_eta")f2.push_back(new TF1(func,"[0]+[1]*x/100.",-500,500));//Divide by 100. cm->m
-    if(binVar == "track_phi")f2.push_back(new TF1(func,"[0]+[1]*TMath::Cos(x+[2])",-500,500));
-    
-    f2[isample]->SetLineColor(isample+1);
-    if(isample==2)f2[isample]->SetLineColor(kGreen+3);
-    f2[isample]->SetLineStyle(isample+1);
+    if (binVar == "track_eta")
+      f2.push_back(new TF1(func, "[0]+[1]*x/100.", -500, 500));  //Divide by 100. cm->m
+    if (binVar == "track_phi")
+      f2.push_back(new TF1(func, "[0]+[1]*TMath::Cos(x+[2])", -500, 500));
+
+    f2[isample]->SetLineColor(isample + 1);
+    if (isample == 2)
+      f2[isample]->SetLineColor(kGreen + 3);
+    f2[isample]->SetLineStyle(isample + 1);
     f2[isample]->SetLineWidth(2);
-    
-    if(verbose){
-      overallGraph[isample]->Fit(func,"mR0+");
-      
-      cout<<"Covariance Matrix:"<<endl;
+
+    if (verbose) {
+      overallGraph[isample]->Fit(func, "mR0+");
+
+      cout << "Covariance Matrix:" << endl;
       TVirtualFitter *fitter = TVirtualFitter::GetFitter();
-      TMatrixD matrix(2,2,fitter->GetCovarianceMatrix());
-      Double_t oneOne = fitter->GetCovarianceMatrixElement(0,0);
-      Double_t oneTwo = fitter->GetCovarianceMatrixElement(0,1);
-      Double_t twoOne = fitter->GetCovarianceMatrixElement(1,0);
-      Double_t twoTwo = fitter->GetCovarianceMatrixElement(1,1);
-      
-      cout<<"( "<<oneOne<<", "<<twoOne<<")"<<endl;
-      cout<<"( "<<oneTwo<<", "<<twoTwo<<")"<<endl;
-    }
-    else overallGraph[isample]->Fit(func,"QmR0+");
-    
+      TMatrixD matrix(2, 2, fitter->GetCovarianceMatrix());
+      Double_t oneOne = fitter->GetCovarianceMatrixElement(0, 0);
+      Double_t oneTwo = fitter->GetCovarianceMatrixElement(0, 1);
+      Double_t twoOne = fitter->GetCovarianceMatrixElement(1, 0);
+      Double_t twoTwo = fitter->GetCovarianceMatrixElement(1, 1);
+
+      cout << "( " << oneOne << ", " << twoOne << ")" << endl;
+      cout << "( " << oneTwo << ", " << twoTwo << ")" << endl;
+    } else
+      overallGraph[isample]->Fit(func, "QmR0+");
+
     // print fit parameter
-    if(binVar == "track_eta")
-      cout<<"const: "<<f2[isample]->GetParameter(0)<<"+-"<<f2[isample]->GetParError(0)<<", slope: "<<f2[isample]->GetParameter(1)<<"+-"<<f2[isample]->GetParError(1)<<endl;
-    if(binVar == "track_phi")
-      cout<<"const: "<<f2[isample]->GetParameter(0)<<"+-"<<f2[isample]->GetParError(0)<<", amplitude: "<<f2[isample]->GetParameter(1)<<"+-"<<f2[isample]->GetParError(1)<<", shift: "<<f2[isample]->GetParameter(2)<<"+-"<<f2[isample]->GetParError(2)<<endl;
-    cout<<"fit probability: "<<f2[isample]->GetProb()<<endl;
-    if(verbose)cout<<"chi^2/Ndof: "<<f2[isample]->GetChisquare()/f2[isample]->GetNDF()<<endl;
+    if (binVar == "track_eta")
+      cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
+           << ", slope: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1) << endl;
+    if (binVar == "track_phi")
+      cout << "const: " << f2[isample]->GetParameter(0) << "+-" << f2[isample]->GetParError(0)
+           << ", amplitude: " << f2[isample]->GetParameter(1) << "+-" << f2[isample]->GetParError(1)
+           << ", shift: " << f2[isample]->GetParameter(2) << "+-" << f2[isample]->GetParError(2) << endl;
+    cout << "fit probability: " << f2[isample]->GetProb() << endl;
+    if (verbose)
+      cout << "chi^2/Ndof: " << f2[isample]->GetChisquare() / f2[isample]->GetNDF() << endl;
     // write fit function to legend
     Char_t misalignmentfitchar[20];
-    sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParameter(0));
+    sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(0));
     misalignmentfit.push_back("(");
     misalignmentfit[isample] += misalignmentfitchar;
     misalignmentfit[isample] += "#pm";
-    sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParError(0));
+    sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(0));
     misalignmentfit[isample] += misalignmentfitchar;
-    if(variable=="eta"){
+    if (variable == "eta") {
       misalignmentfit[isample] += ")#murad #upoint r[m] + (";
-      sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParameter(1));
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParError(1));
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += ")#murad #upoint z[m]";
-    }
-    else if(variable.Contains("phi")){
+    } else if (variable.Contains("phi")) {
       misalignmentfit[isample] += ") + (";
-      sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParameter(1));
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParameter(1));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar,"%1.f",f2[isample]->GetParError(1));
+      sprintf(misalignmentfitchar, "%1.f", f2[isample]->GetParError(1));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += ") #upoint cos(#phi";
-      if(f2[isample]->GetParameter(2)>0.)misalignmentfit[isample] += "+";
-      sprintf(misalignmentfitchar,"%1.1f",f2[isample]->GetParameter(2));
+      if (f2[isample]->GetParameter(2) > 0.)
+        misalignmentfit[isample] += "+";
+      sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParameter(2));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += "#pm";
-      sprintf(misalignmentfitchar,"%1.1f",f2[isample]->GetParError(2));
+      sprintf(misalignmentfitchar, "%1.1f", f2[isample]->GetParError(2));
       misalignmentfit[isample] += misalignmentfitchar;
       misalignmentfit[isample] += ")";
     }
@@ -476,32 +589,42 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
     gPad->SetBottomMargin(0.12);
     gPad->SetLeftMargin(0.13);
     gPad->SetRightMargin(0.02);
-    
+
     // determine resonable y-axis range
-    Double_t overallmax=0.;
-    Double_t overallmin=0.;
-    if(isample==0){
-      for(UInt_t i = 0; i < file.size(); i++){
-	overallmax=max(overallhisto[i]->GetMaximum()+overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin())+0.55*(overallhisto[i]->GetMaximum()+overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin())-overallhisto[i]->GetMinimum()+overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),overallmax);
-	overallmin=min(overallhisto[i]->GetMinimum()-fabs(overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin()))-0.1*(overallhisto[i]->GetMaximum()+overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin())-overallhisto[i]->GetMinimum()+overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),overallmin);
-      } 
+    Double_t overallmax = 0.;
+    Double_t overallmin = 0.;
+    if (isample == 0) {
+      for (UInt_t i = 0; i < file.size(); i++) {
+        overallmax = max(
+            overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) +
+                0.55 * (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
+                        overallhisto[i]->GetMinimum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),
+            overallmax);
+        overallmin = min(
+            overallhisto[i]->GetMinimum() - fabs(overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())) -
+                0.1 * (overallhisto[i]->GetMaximum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMaximumBin()) -
+                       overallhisto[i]->GetMinimum() + overallhisto[i]->GetBinError(overallhisto[i]->GetMinimumBin())),
+            overallmin);
+      }
       overallhisto[isample]->SetMaximum(overallmax);
       overallhisto[isample]->SetMinimum(overallmin);
-      if(givenMax)overallhisto[isample]->SetMaximum(givenMax);
-      if(givenMin)overallhisto[isample]->SetMinimum(givenMin);
+      if (givenMax)
+        overallhisto[isample]->SetMaximum(givenMax);
+      if (givenMin)
+        overallhisto[isample]->SetMinimum(givenMin);
       overallhisto[isample]->DrawClone("axis");
     }
     // set histogram errors to a small value as only errors of the graph should be shown
-    for(int i=0; i<overallhisto[isample]->GetNbinsX(); i++){
-      overallhisto[isample]->SetBinError(i+1,0.00001);
+    for (int i = 0; i < overallhisto[isample]->GetNbinsX(); i++) {
+      overallhisto[isample]->SetBinError(i + 1, 0.00001);
     }
     // draw final histogram
     overallhisto[isample]->DrawClone("pe1 same");
     f2[isample]->DrawClone("same");
     overallGraph[isample]->DrawClone("|| same");
     overallGraph[isample]->DrawClone("pz same");
-    overallGraph[isample]->SetLineStyle(isample+1);
-    leg->AddEntry(overallGraph[isample],label[isample]+" ("+misalignmentfit[isample]+")","Lp");   
+    overallGraph[isample]->SetLineStyle(isample + 1);
+    leg->AddEntry(overallGraph[isample], label[isample] + " (" + misalignmentfit[isample] + ")", "Lp");
   }
   leg->Draw();
 
@@ -514,70 +637,29 @@ void momentumBiasValidation(TString variable = "eta", TString path = "/scratch/h
   CMSlabel->Draw("same");
 
   // print plots
-  if(variable == "eta"){
+  if (variable == "eta") {
     c->Print("twist_validation.eps");
-    if(verbose)c->Print("twist_validation.root");
-  }
-  else if(variable == "phi"){
+    if (verbose)
+      c->Print("twist_validation.root");
+  } else if (variable == "phi") {
     c->Print("sagitta_validation_all.eps");
-    if(verbose)c->Print("sagitta_validation_all.root");
-  }
-  else if(variable == "phi1"){
+    if (verbose)
+      c->Print("sagitta_validation_all.root");
+  } else if (variable == "phi1") {
     c->Print("sagitta_validation_lowEta.eps");
-    if(verbose)c->Print("sagitta_validation_lowEta.root");
-  }
-  else if(variable == "phi2"){
+    if (verbose)
+      c->Print("sagitta_validation_lowEta.root");
+  } else if (variable == "phi2") {
     c->Print("sagitta_validation_centralEta.eps");
-    if(verbose)c->Print("sagitta_validation_centralEta.root");
-  }
-  else if(variable == "phi3"){
+    if (verbose)
+      c->Print("sagitta_validation_centralEta.root");
+  } else if (variable == "phi3") {
     c->Print("sagitta_validation_highEta.eps");
-    if(verbose)c->Print("sagitta_validation_highEta.root");
+    if (verbose)
+      c->Print("sagitta_validation_highEta.root");
   }
 
   time_t end = time(0);
-  cout << "Done in " << int(difftime(end,start))/60 << " min and " << int(difftime(end,start))%60 << " sec." << endl;
-}
-
-vector<Double_t> extractgausparams(TH1F *histo, TString option1, TString option2)
-{
-   TF1 *f1 = new TF1("f1","gaus");
-   f1->SetRange(0.,2.);
-   histo->Fit("f1","QR0L");
-
-  double mean =  f1->GetParameter(1);
-  double deviation = f1->GetParameter(2); 
-
-  double lowLim; 
-  double upLim;  
-  double newmean;
-
-  double degrade = 0.05;
-  unsigned int iteration = 0;
-
-  while( iteration == 0 || (f1->GetProb() < 0.001 && iteration < 10) )
-    {
-      lowLim = mean - (2.0*deviation*(1-degrade*iteration));
-      upLim  = mean + (2.0*deviation*(1-degrade*iteration));
-
-      f1->SetRange(lowLim,upLim);
-      histo->Fit("f1","QRL0");
-
-      newmean = mean;
-      if(f1->GetParameter(1)<2 && f1->GetParameter(1)>0)newmean =  f1->GetParameter(1);
-      lowLim = newmean - (1.5*deviation);//*(1-degrade*iteration));
-      upLim  = newmean + (1.5*deviation);//*(1-degrade*iteration));
-      f1->SetRange(lowLim,upLim);
-      f1->SetLineWidth(1);
-      histo->Fit("f1","QRL+i"+option1,option2);
-      if(f1->GetParameter(1)<2 && f1->GetParameter(1)>0)mean =  f1->GetParameter(1);
-      deviation = f1->GetParameter(2);
-      iteration++;
-    }
-  vector<Double_t> params;
-  params.push_back(f1->GetParameter(1));
-  params.push_back(f1->GetParError(1));
-  params.push_back(lowLim);
-  params.push_back(upLim);
-  return params;
+  cout << "Done in " << int(difftime(end, start)) / 60 << " min and " << int(difftime(end, start)) % 60 << " sec."
+       << endl;
 }

--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -108,19 +108,19 @@ std::vector<Double_t> extractgausparams(TH1F* histo, TString option1, TString op
 
 // -----------------------------------------------------------------------------
 //
-//    Main function : momentumBiasValidation
+//    Main function : momentumElectronBiasValidation
 //
 // -----------------------------------------------------------------------------
-void momentumBiasValidation(TString variable,
-                            TString path,
-                            TString alignmentWithLabel,
-                            TString outputType,
-                            Double_t radius = 1.,
-                            Bool_t verbose = false,
-                            Double_t givenMin = 0.,
-                            Double_t givenMax = 0.) {
+void momentumElectronBiasValidation(TString variable,
+                                    TString path,
+                                    TString alignmentWithLabel,
+                                    TString outputType,
+                                    Double_t radius = 1.,
+                                    Bool_t verbose = false,
+                                    Double_t givenMin = 0.,
+                                    Double_t givenMax = 0.) {
   // Displaying first message
-  std::cout << "!!! Welcome to momentumBiasValidation !!!" << std::endl;
+  std::cout << "!!! Welcome to momentumElectronBiasValidation !!!" << std::endl;
   std::cout << std::endl;
   time_t start = time(0);
 
@@ -140,9 +140,10 @@ void momentumBiasValidation(TString variable,
   std::cout << "Initializing the TTree ..." << std::endl;
   std::vector<TTree*> trees(files.size(), 0);
   EopElecVariables* track = new EopElecVariables();
-  if (!initializeTree(files, trees, track))
+  if (!initializeTree(files, trees, track)) {
     delete track;
-  return;
+    return;
+  }
 
   // Configuring ROOT style
   std::cout << "Configuring the ROOT style ..." << std::endl;
@@ -157,7 +158,7 @@ void momentumBiasValidation(TString variable,
   // Loop over files
 
   // To save the table cut
-  TFile* histo1;
+  TFile* histo1 = nullptr;
   std::string fileName;
 
   for (unsigned int ifile = 0; ifile < histos.size(); ifile++) {
@@ -663,7 +664,7 @@ void initializeHistograms(ModeType mode, HistoType& histo) {
   unsigned int index = 0;
   for (unsigned int i = 0; i < (histo.eRange.size() - 1); i++) {
     // Labels for histo title
-    Char_t tmpstep[5];
+    Char_t tmpstep[10];
     sprintf(tmpstep, "%1.1fGeV", histo.eRange[i]);
     TString lowEnergyBorder = tmpstep;
     sprintf(tmpstep, "%1.1fGeV", histo.eRange[i + 1]);
@@ -677,7 +678,7 @@ void initializeHistograms(ModeType mode, HistoType& histo) {
 
     for (unsigned int j = 0; j < (histo.etaRange.size() - 1); j++) {
       // Labels for histo name
-      Char_t tmpstep[5];
+      Char_t tmpstep[10];
       sprintf(tmpstep, "%1.1fGeV", histo.eRange[i]);
       TString lowEnergyBorder = tmpstep;
       sprintf(tmpstep, "%1.1fGeV", histo.eRange[i + 1]);
@@ -1501,22 +1502,4 @@ Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, Eo
     trees[i]->SetBranchAddress("EvtNumber", &track->EvtNumber);
   }
   return true;
-}
-
-// -----------------------------------------------------------------------------
-//
-//    Main (only for stand alone compiled program)
-//
-// -----------------------------------------------------------------------------
-int main() {
-  //momentumBiasValidation("eta","./","EopTree.root=Fit : ","root",1.,true);
-  momentumBiasValidation("eta",
-                         "/opt/sbg/data/data1/cms/cgoetzma/Thesis/Eop_withElectrons/Outputs/GsfTracks/",
-                         "QCD120to170.root=Chris1\\QCD15to30.root=Chris2\\QCD170to300.root=Chris3\\QCD300to470.root="
-                         "Chris4\\QCD30to50.root=Chris5\\QCD470to600.root=Chris6\\QCD50to80.root=Chris7\\QCD600to800."
-                         "root=Chris8\\QCD800to1000.root=Chris9\\QCD80to120.root=Chris10\\DyToEE.root=Chris11",
-                         "root",
-                         1.,
-                         true);
-  return 0;
 }

--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -149,8 +149,8 @@ void momentumElectronBiasValidation(TString variable,
   std::cout << "Configuring the ROOT style ..." << std::endl;
   configureROOTstyle(verbose);
 
-  TCanvas* c = new TCanvas("c", "Canvas", 0, 0, 1150, 800);
-  TCanvas* ccontrol = new TCanvas("ccontrol", "controlCanvas", 0, 0, 600, 300);
+  TCanvas* c = new TCanvas("cElectron", "Canvas", 0, 0, 1150, 800);
+  TCanvas* ccontrol = new TCanvas("ccontrolElectron", "controlCanvas", 0, 0, 600, 300);
 
   // Creating histos
   std::vector<HistoType> histos(files.size());
@@ -417,6 +417,11 @@ void fillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo) {
     // calculate mean of different energy bins
     TF1* fit = new TF1("fit", "pol0", 0, histo.eRange.size() - 1);
     TF1* fit2 = new TF1("fit2", "pol0", 0, histo.eRange.size() - 1);
+
+    if (histo.fit[i]->GetEntries() < 10) {
+      return;
+    }
+
     histo.fit[i]->Fit("fit", fitOption + "0");
     histo.combinedxAxisBin[i]->Fit("fit2", "Q0");
     overallmisalignment = fit->GetParameter(0);
@@ -543,9 +548,11 @@ void layoutFinalPlot(ModeType mode,
     }
 
     // Fit function
-    histos[i].f2->SetLineColor(i + 1);
-    histos[i].f2->SetLineStyle(i + 1);
-    histos[i].f2->SetLineWidth(2);
+    if (histos[i].f2) {
+      histos[i].f2->SetLineColor(i + 1);
+      histos[i].f2->SetLineStyle(i + 1);
+      histos[i].f2->SetLineWidth(2);
+    }
 
     // Other settings
     histos[i].overallhisto->GetYaxis()->SetTitleOffset(1.05);
@@ -610,7 +617,9 @@ void layoutFinalPlot(ModeType mode,
 
     // draw final histogram
     histos[i].overallhisto->DrawClone("pe1 same");
-    histos[i].f2->DrawClone("same");
+    if (histos[i].f2) {
+      histos[i].f2->DrawClone("same");
+    }
     histos[i].overallGraph->DrawClone("|| same");
     histos[i].overallGraph->DrawClone("pz same");
     histos[i].overallGraph->SetLineStyle(i + 1);
@@ -1223,6 +1232,10 @@ void readTree(ModeType mode, TString variable, HistoType& histo, EopElecVariable
 //
 // -----------------------------------------------------------------------------
 std::vector<Double_t> extractgausparams(TH1F* histo, TString option1, TString option2) {
+  if (histo->GetEntries() < 10) {
+    return {0., 0., 0., 0.};
+  }
+
   // Fitting the histogram with a gaussian function
   TF1* f1 = new TF1("f1", "gaus");
   f1->SetRange(0., 2.);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -22,6 +22,9 @@ filesDefaultData_JetHTRun2022A = cms.untracked.vstring(
     '/store/data/Run2022A/JetHT/ALCARECO/TkAlMinBias-PromptReco-v1/000/352/900/00000/96120499-f83f-4b90-a828-58d4c2d26350.root'
 )
 
+filesDefaultData_JetHTRun2018DHcalIsoTrk = cms.untracked.vstring(
+    '/store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/075A1F1E-20B4-134D-9794-AD764DA6730D.root')
+
 filesDefaultMC_NoPU = cms.untracked.vstring(
     '/store/mc/RunIIWinter19PFCalibDR/Single_Pion_gun_E_2to200_13TeV_pythia8/GEN-SIM-RECO/2018ConditionsNoPU_105X_upgrade2018_realistic_v4-v1/270000/2BCBEBAB-BA94-B74F-9BFA-04F849A32558.root'
 )

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -50,13 +50,16 @@
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_unitSubmitPVsplit.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
-  <bin file="testAlignmentOfflineValidation.cpp" name="EoPPion">
-    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_unitEoPPion.sh"/>
+  <bin file="testAlignmentOfflineValidation.cpp" name="EoP">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_unitEoP.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
-  <bin file="testAlignmentOfflineValidation.cpp" name="EoPElectron">
-    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_unitEoPElectron.sh"/>
-    <use name="FWCore/Utilities"/>
+  <bin file="testEoPPlotting.cpp" name="testEoPPlotting">
+    <flags PRE_TEST="EoP"/>
+    <use name="rootmath"/>
+    <use name="roothistmatrix"/>
+    <use name="rootgraphics"/>
+    <use name="Alignment/OfflineValidation"/>
   </bin>
   <bin file="testAlignmentOfflineValidation.cpp" name="Miscellanea">
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_unitMiscellanea.sh"/>

--- a/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
@@ -40,7 +40,7 @@ process = cms.Process("EnergyOverMomentumTree",Run3)
 
 # initialize MessageLogger and output report
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 process.MessageLogger.TrackRefitter=dict()
 process.MessageLogger.EopElecTreeWriter=dict()
     

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_JetHTRun2022A
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_JetHTRun2018DHcalIsoTrk
 
 options = VarParsing.VarParsing("analysis")
 
 options.register ('GlobalTag',
-                  'auto:run3_data',
+                  'auto:run2_data',
                   VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Global Tag to be used")
@@ -24,13 +24,13 @@ process = cms.Process("EnergyOverMomentumTree")
 ####################################################################
 process.load("FWCore.MessageService.MessageLogger_cfi")
 #process.MessageLogger.cerr.threshold = 'ERROR'
-process.MessageLogger.cerr.FwkReport.reportEvery = 10
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 process.MessageLogger.TrackRefitter=dict()
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
 
 # define input files
-process.source = cms.Source("PoolSource", fileNames = filesDefaultData_JetHTRun2022A)
+process.source = cms.Source("PoolSource", fileNames = filesDefaultData_JetHTRun2018DHcalIsoTrk)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.maxEvents)
@@ -97,7 +97,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 # configure alignment track selector
 ####################################################################
 process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
-process.AlignmentTrackSelector.src = cms.InputTag('ALCARECOTkAlMinBias') # 'TkAlIsoProd' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
+process.AlignmentTrackSelector.src = cms.InputTag('TkAlIsoProdFilter') # 'TkAlIsoProd' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
 process.AlignmentTrackSelector.ptMin = 1.
 process.AlignmentTrackSelector.etaMin = -5.
 process.AlignmentTrackSelector.etaMax = 5.
@@ -110,8 +110,8 @@ process.AlignmentTrackSelector.chi2nMax = 100.
 # configure track refitter
 ####################################################################
 process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
-process.MeasurementTrackerEvent.pixelClusterProducer = "ALCARECOTkAlMinBias"
-process.MeasurementTrackerEvent.stripClusterProducer = "ALCARECOTkAlMinBias"
+process.MeasurementTrackerEvent.pixelClusterProducer = "TkAlIsoProdFilter"
+process.MeasurementTrackerEvent.stripClusterProducer = "TkAlIsoProdFilter"
 #process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag([''])
 #process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag([''])
 

--- a/Alignment/OfflineValidation/test/testEoPPlotting.cpp
+++ b/Alignment/OfflineValidation/test/testEoPPlotting.cpp
@@ -1,9 +1,13 @@
 #include <iostream>
 #include <sstream>
+#include <TSystem.h>
 #include "Alignment/OfflineValidation/macros/momentumBiasValidation.C"
 #include "Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C"
 
 int main(int argc, char** argv) {
-  momentumBiasValidation("eta", "./", "test_EopTree.root=TestPion", true);
-  momentumElectronBiasValidation("eta", "./", "test_EopTreeElectron.root=TestEle", "gif", true);
+  //std::cout << "\n==== Executing pion analysis plotting \n" << std::endl;
+  //eop::momentumBiasValidation("eta", "./", "test_EopTree.root=TestPion");
+
+  std::cout << "\n==== Executing electron analysis plotting \n" << std::endl;
+  momentumElectronBiasValidation("eta", "./", "test_EopTreeElectron.root=TestEle", "png", true);
 }

--- a/Alignment/OfflineValidation/test/testEoPPlotting.cpp
+++ b/Alignment/OfflineValidation/test/testEoPPlotting.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <sstream>
+#include "Alignment/OfflineValidation/macros/momentumBiasValidation.C"
+#include "Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C"
+
+int main(int argc, char** argv) {
+  momentumBiasValidation("eta", "./", "test_EopTree.root=TestPion", true);
+  momentumElectronBiasValidation("eta", "./", "test_EopTreeElectron.root=TestEle", "gif", true);
+}

--- a/Alignment/OfflineValidation/test/test_unitEoP.sh
+++ b/Alignment/OfflineValidation/test/test_unitEoP.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING eopTreeWriter (Pion Analysis) ..."
+cmsRun ${LOCAL_TEST_DIR}/eopTreeWriter_cfg.py unitTest=True maxEvents=100 || die "Failure running eopTreeWriter" $?
+
+echo "TESTING eopElecTreeWriter (Electron Analysis) ..."
+cmsRun ${LOCAL_TEST_DIR}/eopElecTreeWriter_cfg.py maxEvents=100 || die "Failure running eopElecTreeWriter" $?

--- a/Alignment/OfflineValidation/test/test_unitEoP.sh
+++ b/Alignment/OfflineValidation/test/test_unitEoP.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING eopTreeWriter (Pion Analysis) ..."
+echo -e "\n\nTESTING eopTreeWriter (Pion Analysis) ..."
 cmsRun ${LOCAL_TEST_DIR}/eopTreeWriter_cfg.py unitTest=True maxEvents=100 || die "Failure running eopTreeWriter" $?
 
-echo "TESTING eopElecTreeWriter (Electron Analysis) ..."
+echo -e "\n\nTESTING eopElecTreeWriter (Electron Analysis) ..."
 cmsRun ${LOCAL_TEST_DIR}/eopElecTreeWriter_cfg.py maxEvents=100 || die "Failure running eopElecTreeWriter" $?

--- a/Alignment/OfflineValidation/test/test_unitEoPElectron.sh
+++ b/Alignment/OfflineValidation/test/test_unitEoPElectron.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-function die { echo $1: status $2 ; exit $2; }
-
-echo "TESTING eopElecTreeWriter (Electron Analysis) ..."
-cmsRun ${LOCAL_TEST_DIR}/eopElecTreeWriter_cfg.py maxEvents=10 || die "Failure running eopElecTreeWriter" $?

--- a/Alignment/OfflineValidation/test/test_unitEoPPion.sh
+++ b/Alignment/OfflineValidation/test/test_unitEoPPion.sh
@@ -1,5 +1,0 @@
-#! /bin/bash
-function die { echo $1: status $2 ; exit $2; }
-
-echo "TESTING eopTreeWriter (Pion Analysis) ..."
-cmsRun ${LOCAL_TEST_DIR}/eopTreeWriter_cfg.py unitTest=True maxEvents=10 || die "Failure running eopTreeWriter" $?


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/pull/40080#discussion_r1034821298.
   * refurbished `momentumElectronBiasValidation.C` macro;
   * applied code-format to `momentumBiasValidation.C` macro, and modified it in order to compile it together with the electron one;
   * added dedicated EoP validation plotting unit tests;

#### PR validation:

Relies on the unit tests created here, run successfully

```
scram b runtests_testEoPPlotting
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A