### PR TITLE
[SIMULATION] [LLVM14] Apply code checks

### DIFF
--- a/SimGeneral/MixingModule/plugins/TestMix.cc
+++ b/SimGeneral/MixingModule/plugins/TestMix.cc
@@ -187,7 +187,7 @@ void TestMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
                 << cfi3.bunch() << " trigger " << cfi3.getTrigger()
                 << ", from EncodedEventId: " << cfi3->eventId().bunchCrossing() << " " << cfi3->eventId().event()
                 << std::endl;
-      SimVertex myvtx = (*cfi3);
+      const SimVertex& myvtx = (*cfi3);
       std::cout << "Same with op*: " << count3 << " has parent index  " << myvtx.parentIndex() << " bunchcr "
                 << cfi3.bunch() << " trigger " << cfi3.getTrigger()
                 << ", from EncodedEventId: " << myvtx.eventId().bunchCrossing() << " " << myvtx.eventId().event()

--- a/SimMuon/Neutron/src/AsciiNeutronWriter.cc
+++ b/SimMuon/Neutron/src/AsciiNeutronWriter.cc
@@ -18,7 +18,7 @@ void AsciiNeutronWriter::writeCluster(int chamberType, const edm::PSimHitContain
   os.open(s.str().c_str(), ofstream::app);
   os << hits.size() << endl;
   for (size_t i = 0; i < hits.size(); ++i) {
-    PSimHit h = hits[i];
+    const PSimHit& h = hits[i];
     os << h.entryPoint().x() << " " << h.entryPoint().y() << " " << h.entryPoint().z() << " " << h.exitPoint().x()
        << " " << h.exitPoint().y() << " " << h.exitPoint().z() << " " << h.pabs() << " "
        << " " << h.timeOfFlight() << " " << h.energyLoss() << " " << h.particleType() << " " << h.detUnitId() << " "


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) check suggested these modifications.