### PR TITLE
[DQM] [LLVM14] Apply code checks

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/src/ESFEDIntegrityTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESFEDIntegrityTask.cc
@@ -94,7 +94,7 @@ void ESFEDIntegrityTask::analyze(const Event& e, const EventSetup& c) {
 
       if (e.getByToken(dccCollections_, dccs)) {
         for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-          ESDCCHeaderBlock esdcc = (*dccItr);
+          const ESDCCHeaderBlock& esdcc = (*dccItr);
 
           esDCC_L1A_FreqMap[esdcc.getLV1()]++;
           esDCC_BX_FreqMap[esdcc.getBX()]++;
@@ -127,7 +127,7 @@ void ESFEDIntegrityTask::analyze(const Event& e, const EventSetup& c) {
   vector<int> fiberStatus;
   if (e.getByToken(dccCollections_, dccs)) {
     for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-      ESDCCHeaderBlock dcc = (*dccItr);
+      const ESDCCHeaderBlock& dcc = (*dccItr);
 
       if (dcc.getDCCErrors() > 0) {
         if (meESFedsFatal_)

--- a/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
@@ -216,7 +216,7 @@ void ESIntegrityTask::analyze(const Event& e, const EventSetup& c) {
   vector<int> fiberStatus;
   if (e.getByToken(dccCollections_, dccs)) {
     for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-      ESDCCHeaderBlock dcc = (*dccItr);
+      const ESDCCHeaderBlock& dcc = (*dccItr);
 
       meFED_->Fill(dcc.fedId());
 

--- a/DQM/EcalPreshowerMonitorModule/src/ESRawDataTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESRawDataTask.cc
@@ -108,7 +108,7 @@ void ESRawDataTask::analyze(const Event& e, const EventSetup& c) {
 
       if (e.getByToken(dccCollections_, dccs)) {
         for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-          ESDCCHeaderBlock esdcc = (*dccItr);
+          const ESDCCHeaderBlock& esdcc = (*dccItr);
 
           esDCC_L1A_FreqMap[esdcc.getLV1()]++;
           esDCC_BX_FreqMap[esdcc.getBX()]++;
@@ -141,7 +141,7 @@ void ESRawDataTask::analyze(const Event& e, const EventSetup& c) {
   vector<int> fiberStatus;
   if (e.getByToken(dccCollections_, dccs)) {
     for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-      ESDCCHeaderBlock dcc = (*dccItr);
+      const ESDCCHeaderBlock& dcc = (*dccItr);
 
       //if (dcc.getRunNumber() != runNum_) {
       //meRunNumberErrors_->Fill(dcc.fedId());

--- a/DQM/EcalPreshowerMonitorModule/src/ESTrendTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESTrendTask.cc
@@ -129,7 +129,7 @@ void ESTrendTask::analyze(const Event& e, const EventSetup& c) {
   Handle<ESRawDataCollection> dccs;
   if (e.getByToken(dccCollections_, dccs)) {
     for (ESRawDataCollection::const_iterator dccItr = dccs->begin(); dccItr != dccs->end(); ++dccItr) {
-      ESDCCHeaderBlock dcc = (*dccItr);
+      const ESDCCHeaderBlock& dcc = (*dccItr);
 
       if (dcc.getDCCErrors() == 101)
         slinkCRCErr++;

--- a/DQM/L1TMonitorClient/src/L1TOccupancyClientHistogramService.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClientHistogramService.cc
@@ -69,7 +69,7 @@ void L1TOccupancyClientHistogramService::setMaskedBins(string iHistName, const v
   }
 
   for (unsigned int i = 0; i < iMaskedAreas.size(); i++) {
-    ParameterSet iMA = iMaskedAreas[i];
+    const ParameterSet& iMA = iMaskedAreas[i];
     int iTypeUnits = iMA.getParameter<int>("kind");
 
     //get boundaries from python

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -590,7 +590,7 @@ namespace SingleTopTChannelLepton_miniAOD {
       // check jetID for calo jets
       //unsigned int idx = jet - jets->begin();
 
-      pat::Jet sel = *jet;
+      const pat::Jet& sel = *jet;
 
       if (jetSelect == nullptr)
         jetSelect = std::make_unique<StringCutObjectSelector<pat::Jet>>(jetSelect_);
@@ -600,7 +600,7 @@ namespace SingleTopTChannelLepton_miniAOD {
       //      if (!jetSelect(sel)) continue;
 
       // prepare jet to fill monitor histograms
-      pat::Jet monitorJet = *jet;
+      const pat::Jet& monitorJet = *jet;
 
       ++mult;
 

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -568,14 +568,14 @@ namespace TopSingleLepton_miniAOD {
       // check jetID for calo jets
       //unsigned int idx = jet - jets->begin();
 
-      pat::Jet sel = *jet;
+      const pat::Jet& sel = *jet;
 
       if (!(*jetSelect)(sel))
         continue;
       //      if (!jetSelect(sel)) continue;
 
       // prepare jet to fill monitor histograms
-      pat::Jet monitorJet = *jet;
+      const pat::Jet& monitorJet = *jet;
 
       ++mult;
 

--- a/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
+++ b/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
@@ -187,7 +187,7 @@ void RPCMonitorDigi::analyze(const edm::Event& event, const edm::EventSetup& set
   if (rpcHits.isValid()) {
     //    RPC rec hits NOT associated to a muon
     for (auto rpcRecHitIter = rpcHits->begin(); rpcRecHitIter != rpcHits->end(); rpcRecHitIter++) {
-      RPCRecHit rpcRecHit = (*rpcRecHitIter);
+      const RPCRecHit& rpcRecHit = (*rpcRecHitIter);
       int detId = (int)rpcRecHit.rpcId();
       if (rechitNoise.find(detId) == rechitNoise.end() || rechitNoise[detId].empty()) {
         std::vector<RPCRecHit> myVect(1, rpcRecHit);
@@ -313,7 +313,7 @@ void RPCMonitorDigi::performSourceOperation(std::map<RPCDetId, std::vector<RPCRe
     std::string tmpName;
     for (std::vector<RPCRecHit>::const_iterator recHitIter = recHits.begin(); recHitIter != recHits.end();
          recHitIter++) {
-      RPCRecHit recHit = (*recHitIter);
+      const RPCRecHit& recHit = (*recHitIter);
 
       int bx = recHit.BunchX();
       bxSet.insert(bx);

--- a/DQM/SiStripMonitorClient/src/SiStripHistoPlotter.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripHistoPlotter.cc
@@ -308,7 +308,7 @@ void SiStripHistoPlotter::makeCondDBPlots(DQMStore* dqm_store, const PlotParamet
   std::vector<MonitorElement*> all_mes = dqm_store->getContents(par.Path);
 
   for (std::vector<std::string>::const_iterator ih = htypes.begin(); ih != htypes.end(); ih++) {
-    std::string type = (*ih);
+    const std::string& type = (*ih);
     if (type.empty())
       continue;
     std::string tag = par.Path + "/";

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
@@ -292,7 +292,7 @@ void SiStripSpyDisplayModule::analyze(const edm::Event& iEvent, const edm::Event
     const std::vector<const FedChannelConnection*>& conns = detCabling_->getConnections(*d);
     //cout << "________________________________________________" << endl;
     //cout << "FED channels found in detId " << *d << " is " << conns.size() << endl;
-    if (!(conns.size())) {
+    if (conns.empty()) {
       // TODO: Properly DEBUG/warning this...
       //cout << "Skipping detID " << uint32_t(*d) << endl;
       continue;

--- a/DQM/TrackingMonitorClient/src/TrackingUtility.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingUtility.cc
@@ -198,7 +198,7 @@ bool TrackingUtility::goToDir(DQMStore::IBooker& ibooker, DQMStore::IGetter& ige
   }
   std::vector<std::string> subDirVec = igetter.getSubdirs();
   for (std::vector<std::string>::const_iterator ic = subDirVec.begin(); ic != subDirVec.end(); ic++) {
-    std::string fname = (*ic);
+    const std::string& fname = (*ic);
     if ((fname.find("Reference") != std::string::npos) || (fname.find("AlCaReco") != std::string::npos) ||
         (fname.find("HLT") != std::string::npos))
       continue;

--- a/DQMOffline/RecoB/plugins/MiniAODTaggerAnalyzer.cc
+++ b/DQMOffline/RecoB/plugins/MiniAODTaggerAnalyzer.cc
@@ -104,7 +104,7 @@ void MiniAODTaggerAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 
       // only add to histograms when discriminator values are valid
       if (numerator >= 0 && denominator > 0) {
-        reco::Jet recoJet = *jet;
+        const reco::Jet& recoJet = *jet;
         if (jetTagPlotter_->etaPtBin().inBin(recoJet, jec)) {
           jetTagPlotter_->analyzeTag(recoJet, jec, numerator / denominator, jet->partonFlavour());
         }

--- a/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
+++ b/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
@@ -124,7 +124,7 @@ void HLTMuonOfflineAnalyzer::dqmBeginRun(const edm::Run &iRun, const edm::EventS
   set<string>::iterator iPath;
   vector<string>::const_iterator ilabel;
   for (iPath = hltPaths.begin(); iPath != hltPaths.end(); iPath++) {
-    string path = *iPath;
+    const string& path = *iPath;
     vector<string> labels = moduleLabels(path);
     bool isLastLabel = false;
     for (ilabel = labels.begin(); ilabel != labels.end(); ilabel++) {

--- a/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
+++ b/DQMOffline/Trigger/plugins/HLTMuonOfflineAnalyzer.cc
@@ -124,7 +124,7 @@ void HLTMuonOfflineAnalyzer::dqmBeginRun(const edm::Run &iRun, const edm::EventS
   set<string>::iterator iPath;
   vector<string>::const_iterator ilabel;
   for (iPath = hltPaths.begin(); iPath != hltPaths.end(); iPath++) {
-    const string& path = *iPath;
+    const string &path = *iPath;
     vector<string> labels = moduleLabels(path);
     bool isLastLabel = false;
     for (ilabel = labels.begin(); ilabel != labels.end(); ilabel++) {

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -307,7 +307,7 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun, const edm::EventSetup
   _plotters.clear();
   for (std::set<std::string>::iterator iPath = _hltPaths.begin(); iPath != _hltPaths.end(); ++iPath) {
     // Avoiding the dependence of the version number for the trigger paths
-    std::string path = *iPath;
+    const std::string& path = *iPath;
     std::string shortpath = path;
     if (path.rfind("_v") < path.length()) {
       shortpath = path.substr(0, path.rfind("_v"));

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -307,7 +307,7 @@ void HLTExoticaSubAnalysis::beginRun(const edm::Run &iRun, const edm::EventSetup
   _plotters.clear();
   for (std::set<std::string>::iterator iPath = _hltPaths.begin(); iPath != _hltPaths.end(); ++iPath) {
     // Avoiding the dependence of the version number for the trigger paths
-    const std::string& path = *iPath;
+    const std::string &path = *iPath;
     std::string shortpath = path;
     if (path.rfind("_v") < path.length()) {
       shortpath = path.substr(0, path.rfind("_v"));

--- a/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc
@@ -219,7 +219,7 @@ void HLTHiggsSubAnalysis::beginRun(const edm::Run& iRun, const edm::EventSetup& 
   for (std::set<std::string>::iterator iPath = _hltPaths.begin(); iPath != _hltPaths.end(); ++iPath) {
     // Avoiding the dependence of the version number for
     // the trigger paths
-    std::string path = *iPath;
+    const std::string& path = *iPath;
     std::string shortpath = path;
     if (path.rfind("_v") < path.length()) {
       shortpath = path.substr(0, path.rfind("_v"));

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -154,7 +154,7 @@ void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &
   analyzers_.clear();
   set<string>::iterator iPath;
   for (iPath = hltPaths.begin(); iPath != hltPaths.end(); iPath++) {
-    const string& path = *iPath;
+    const string &path = *iPath;
     string shortpath = path;
     if (path.rfind("_v") < path.length())
       shortpath = path.substr(0, path.rfind("_v"));

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -154,7 +154,7 @@ void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &
   analyzers_.clear();
   set<string>::iterator iPath;
   for (iPath = hltPaths.begin(); iPath != hltPaths.end(); iPath++) {
-    string path = *iPath;
+    const string& path = *iPath;
     string shortpath = path;
     if (path.rfind("_v") < path.length())
       shortpath = path.substr(0, path.rfind("_v"));

--- a/Validation/CSCRecHits/src/CSCRecHitMatcher.cc
+++ b/Validation/CSCRecHits/src/CSCRecHitMatcher.cc
@@ -101,7 +101,7 @@ void CSCRecHitMatcher::matchCSCRecHit2DsToSimTrack(const CSCRecHit2DCollection& 
       // does the strip number match?
       bool stripMatch(false);
       for (size_t iS = 0; iS < d->nStrips(); ++iS) {
-        if (std::find(hit_strips.begin(), hit_strips.end(), d->channels(iS)) != hit_strips.end())
+        if (hit_strips.find(d->channels(iS)) != hit_strips.end())
           stripMatch = true;
       }
 

--- a/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalBHValidation.cc
@@ -154,7 +154,7 @@ void HGCalBHValidation::analyze(const edm::Event& e, const edm::EventSetup&) {
     edm::LogVerbatim("HGCalValidation") << "HGCalBHValidation: HGCalDigi "
                                         << "buffer " << hecoll->size();
     for (HGCalDigiCollection::const_iterator it = hecoll->begin(); it != hecoll->end(); ++it) {
-      HGCalDataFrame df(*it);
+      const HGCalDataFrame& df(*it);
       double energy = df[iSample_].data();
       if (DetId(df.id()).det() == DetId::HGCalHSc) {
         HGCScintillatorDetId cell(df.id());

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -490,7 +490,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     }
 
     const reco::TrackRef mtdTrackref = reco::TrackRef(iEvent.getHandle(RecTrackToken_), trackAssoc[trackref]);
-    const reco::Track track = *mtdTrackref;
+    const reco::Track& track = *mtdTrackref;
 
     bool isBTL = false;
     bool twoETLdiscs = false;

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -2410,7 +2410,7 @@ void ElectronMcFakeValidator::analyze(const edm::Event &iEvent, const edm::Event
 
   // get the beamspot from the Event:
   auto recoBeamSpotHandle = iEvent.getHandle(beamSpotTag_);
-  const BeamSpot& bs = *recoBeamSpotHandle;
+  const BeamSpot &bs = *recoBeamSpotHandle;
 
   auto isoFromDepsTk03Handle = iEvent.getHandle(isoFromDepsTk03Tag_);
   auto isoFromDepsTk04Handle = iEvent.getHandle(isoFromDepsTk04Tag_);

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -2410,7 +2410,7 @@ void ElectronMcFakeValidator::analyze(const edm::Event &iEvent, const edm::Event
 
   // get the beamspot from the Event:
   auto recoBeamSpotHandle = iEvent.getHandle(beamSpotTag_);
-  const BeamSpot bs = *recoBeamSpotHandle;
+  const BeamSpot& bs = *recoBeamSpotHandle;
 
   auto isoFromDepsTk03Handle = iEvent.getHandle(isoFromDepsTk03Tag_);
   auto isoFromDepsTk04Handle = iEvent.getHandle(isoFromDepsTk04Tag_);

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -4325,7 +4325,7 @@ void PhotonValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
             p_nHitsVsR_[type]->Fill(mcConvR_, float(tracks[i]->numberOfValidHits() - 0.0001));
             h_tkChi2_[type]->Fill(tracks[i]->normalizedChi2());
 
-            RefToBase<reco::Track> tfrb = tracks[i];
+            const RefToBase<reco::Track>& tfrb = tracks[i];
             RefToBaseVector<reco::Track> tc;
             tc.push_back(tfrb);
             // reco::RecoToSimCollection q = trackAssociator->associateRecoToSim(tc,theConvTP_);
@@ -4666,7 +4666,7 @@ void PhotonValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
               }
               ///////////  Quantities per track
               for (unsigned int i = 0; i < tracks.size(); i++) {
-                RefToBase<reco::Track> tfrb(tracks[i]);
+                const RefToBase<reco::Track>& tfrb(tracks[i]);
                 itAss = myAss.find(tfrb.get());
                 if (itAss == myAss.end())
                   continue;
@@ -4787,7 +4787,7 @@ void PhotonValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
                 h_convSLVtxRvsZ_[2]->Fill(tracks[0]->innerPosition().z(), sqrt(tracks[0]->innerPosition().Perp2()));
               }
 
-              RefToBase<reco::Track> tfrb = tracks[i];
+              const RefToBase<reco::Track>& tfrb = tracks[i];
               RefToBaseVector<reco::Track> tc;
               tc.push_back(tfrb);
               reco::SimToRecoCollection q = trackAssociator->associateSimToReco(tc, theConvTP_);

--- a/Validation/RecoEgamma/plugins/TkConvValidator.cc
+++ b/Validation/RecoEgamma/plugins/TkConvValidator.cc
@@ -1454,7 +1454,7 @@ void TkConvValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
     //////////////////Measure reco efficiencies
     // cout << " size of conversions " << convHandle->size() << endl;
     for (reco::ConversionCollection::const_iterator conv = convHandle->begin(); conv != convHandle->end(); ++conv) {
-      const reco::Conversion aConv = (*conv);
+      const reco::Conversion& aConv = (*conv);
       if (arbitratedMerged_ && !aConv.quality(reco::Conversion::arbitratedMerged))
         continue;
       if (generalTracksOnly_ && !aConv.quality(reco::Conversion::generalTracksOnly))
@@ -1586,7 +1586,7 @@ void TkConvValidator::analyze(const edm::Event& e, const edm::EventSetup& esup) 
   // ########################### RECO to SIM ############################## //
 
   for (reco::ConversionCollection::const_iterator conv = convHandle->begin(); conv != convHandle->end(); ++conv) {
-    const reco::Conversion aConv = (*conv);
+    const reco::Conversion& aConv = (*conv);
     if (arbitratedMerged_ && !aConv.quality(reco::Conversion::arbitratedMerged))
       continue;
     if (generalTracksOnly_ && !aConv.quality(reco::Conversion::generalTracksOnly))


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) and [readability-container-size-empty](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html) checks suggested these modifications.