### PR TITLE
[DQM-L1] [LLVM14] Apply code checks

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -115,7 +115,7 @@ namespace dqmoffline {
           continue;
         }
         const std::vector<std::string> &modules(hltConfig.moduleLabels(trigger));
-        const std::string& module(modules[moduleIndex]);
+        const std::string &module(modules[moduleIndex]);
         edm::InputTag filterInputTag = edm::InputTag(module, "", triggerProcess);
         results.push_back(filterInputTag);
       }

--- a/DQMOffline/L1Trigger/src/L1TCommon.cc
+++ b/DQMOffline/L1Trigger/src/L1TCommon.cc
@@ -115,7 +115,7 @@ namespace dqmoffline {
           continue;
         }
         const std::vector<std::string> &modules(hltConfig.moduleLabels(trigger));
-        std::string module(modules[moduleIndex]);
+        const std::string& module(modules[moduleIndex]);
         edm::InputTag filterInputTag = edm::InputTag(module, "", triggerProcess);
         results.push_back(filterInputTag);
       }


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) check suggested these modifications.