### PR TITLE
[RECONSTRUCTION] [LLVM14] Apply code checks

### DIFF
--- a/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
+++ b/JetMETCorrections/Modules/plugins/JetResolutionDemo.cc
@@ -105,7 +105,7 @@ void JetResolutionDemo::analyze(const edm::Event& iEvent, const edm::EventSetup&
     const std::vector<JME::Binning>& bins = resolution.getResolutionObject()->getDefinition().getBins();
 
     // Check that the first bin is eta
-    if ((bins.size()) && (bins[0] == JME::Binning::JetEta)) {
+    if ((!bins.empty()) && (bins[0] == JME::Binning::JetEta)) {
       const std::vector<JME::JetResolutionObject::Record> records = resolution.getResolutionObject()->getRecords();
       // Get all records from the object. Each record correspond to a different binning and different parameters
 

--- a/MagneticField/ParametrizedEngine/src/poly2d_base.cc
+++ b/MagneticField/ParametrizedEngine/src/poly2d_base.cc
@@ -169,7 +169,7 @@ double poly2d_base::Eval() {
 
 //_______________________________________________________________________________
 void poly2d_base::Collect() {
-  if (!(data.size()))
+  if (data.empty())
     return;
 
   unsigned j1, j2, rpow, zpow, noff = 0, jend = data.size();

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -59,7 +59,7 @@ public:
     unsigned int md_len = 0;
     std::string tracked(conf.trackedPart().dump());
 
-    EVP_DigestInit_ex(mdctx, md, NULL);
+    EVP_DigestInit_ex(mdctx, md, nullptr);
     EVP_DigestUpdate(mdctx, tracked.c_str(), tracked.size());
     EVP_DigestFinal_ex(mdctx, id_md5_, &md_len);
     EVP_MD_CTX_free(mdctx);

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -388,7 +388,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> > constituents = it->getJetConstituents();
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
-          const reco::CandidatePtr& constit = *m;
+          const reco::CandidatePtr &constit = *m;
           if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;
@@ -414,7 +414,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> > constituents = it->jet()->getJetConstituents();
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
-          const reco::CandidatePtr& constit = *m;
+          const reco::CandidatePtr &constit = *m;
           if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -388,7 +388,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> > constituents = it->getJetConstituents();
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
-          reco::CandidatePtr constit = *m;
+          const reco::CandidatePtr& constit = *m;
           if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;
@@ -414,7 +414,7 @@ void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, con
         std::vector<edm::Ptr<reco::Candidate> > constituents = it->jet()->getJetConstituents();
         std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
         for (m = constituents.begin(); m != constituents.end(); ++m) {
-          reco::CandidatePtr constit = *m;
+          const reco::CandidatePtr& constit = *m;
           if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) {
             edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
             continue;

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -105,7 +105,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
   bool meet_single_thresh = false;
   //Loop over barrel superclusters, and apply threshold
   for (int loop = 0; loop < int(BarrelSuperClusters.size()); loop++) {
-    SuperCluster clus1 = BarrelSuperClusters[loop];
+    const SuperCluster& clus1 = BarrelSuperClusters[loop];
     float eta1 = clus1.eta();
     float energy1 = clus1.energy();
     float theta1 = 2 * atan(exp(-1. * eta1));
@@ -119,7 +119,7 @@ void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
 
   //Loop over endcap superclusters, and apply threshold
   for (int loop = 0; loop < int(EndcapSuperClusters.size()); loop++) {
-    SuperCluster clus1 = EndcapSuperClusters[loop];
+    const SuperCluster& clus1 = EndcapSuperClusters[loop];
     float eta1 = clus1.eta();
     float energy1 = clus1.energy();
     float theta1 = 2 * atan(exp(-1. * eta1));

--- a/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
@@ -152,7 +152,7 @@ void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     return;
   }
 
-  reco::BasicClusterCollection clusterCollection = *bccHandle;
+  const reco::BasicClusterCollection& clusterCollection = *bccHandle;
 
   LogTrace("EcalClusters") << "Got the BasicClusterCollection" << std::endl;
 

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -106,7 +106,7 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
 
   std::vector<DetId> scUncleanSeedDetId;  // counting the unclean
   for (int isc = 0; isc < uncleanSize; ++isc) {
-    const reco::SuperCluster unsc = uncleanSC[isc];
+    const reco::SuperCluster& unsc = uncleanSC[isc];
     scUncleanSeedDetId.push_back(unsc.seed()->seed());
     reco::CaloCluster_iterator bciter = unsc.clustersBegin();
     for (; bciter != unsc.clustersEnd(); ++bciter) {
@@ -144,7 +144,6 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
     edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
     return;
   }
-  reco::BasicClusterCollection basicClustersProd = *bccHandle;
 
   LogTrace("EcalCleaning") << "Got the BasicClusters from the event again";
   int bcSize = bccHandle->size();
@@ -166,7 +165,7 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
         }
       }
     }
-    const reco::SuperCluster unsc = uncleanSC[isc];
+    const reco::SuperCluster& unsc = uncleanSC[isc];
     reco::SuperCluster newSC(unsc.energy(), unsc.position(), seed, clusterPtrVector);
     newSC.setFlags(reco::CaloCluster::uncleanOnly);
     superClusters.push_back(newSC);
@@ -207,14 +206,14 @@ void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const ed
   // print out the clean collection SC
   LogTrace("EcalCleaning") << "Clean Collection SC ";
   for (int i = 0; i < cleanSize; ++i) {
-    const reco::SuperCluster csc = cleanSC[i];
+    const reco::SuperCluster& csc = cleanSC[i];
     LogTrace("EcalCleaning") << " >>> clean    #" << i << "; Energy: " << csc.energy() << " eta: " << csc.eta()
                              << " sc seed detid: " << csc.seed()->seed().rawId();
   }
   // the unclean SC
   LogTrace("EcalCleaning") << "Unclean Collection SC ";
   for (int i = 0; i < uncleanSize; ++i) {
-    const reco::SuperCluster usc = uncleanSC[i];
+    const reco::SuperCluster& usc = uncleanSC[i];
     LogTrace("EcalCleaning") << " >>> unclean  #" << i << "; Energy: " << usc.energy() << " eta: " << usc.eta()
                              << " sc seed detid: " << usc.seed()->seed().rawId();
   }

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -281,7 +281,6 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup
     edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
     return;
   }
-  reco::BasicClusterCollection basicClustersProd = *bccHandle;
 
   LogTrace("UnifiedSC") << "Got the BasicClusters from the event again";
   //
@@ -294,8 +293,7 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup
     edm::LogWarning("MissingInput") << "could not handle the new BasicClusters (Unclean Only)!";
     return;
   }
-  reco::BasicClusterCollection basicClustersUncleanOnlyProd = *bccHandleUncleanOnly;
-  LogTrace("UnifiedSC") << "Got the BasicClusters from the event again  (Unclean Only)";
+   LogTrace("UnifiedSC") << "Got the BasicClusters from the event again  (Unclean Only)";
   //
 
   // now we can build the SC collection

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -293,7 +293,7 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup
     edm::LogWarning("MissingInput") << "could not handle the new BasicClusters (Unclean Only)!";
     return;
   }
-   LogTrace("UnifiedSC") << "Got the BasicClusters from the event again  (Unclean Only)";
+  LogTrace("UnifiedSC") << "Got the BasicClusters from the event again  (Unclean Only)";
   //
 
   // now we can build the SC collection

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
@@ -116,7 +116,7 @@ void ParticleBasedIsoProducer::produce(edm::Event& theEvent, const edm::EventSet
     std::vector<reco::PFCandidateRef> pfCandIsoPairPho;
     for (unsigned int lCand = 0; lCand < nObj; lCand++) {
       pfEGCandRef = reco::PFCandidateRef(pfEGCandidateHandle, lCand);
-      reco::PhotonRef myPho = (pfEGCandToPhotonMap)[pfEGCandRef];
+      const reco::PhotonRef& myPho = (pfEGCandToPhotonMap)[pfEGCandRef];
 
       if (myPho.isNonnull()) {
         //std::cout << "ParticleBasedIsoProducer photons PF SC " << pfEGCandRef->superClusterRef()->energy() << " Photon SC " << myPho->superCluster()->energy() << std::endl;
@@ -149,7 +149,7 @@ void ParticleBasedIsoProducer::produce(edm::Event& theEvent, const edm::EventSet
     std::vector<reco::PFCandidateRef> pfCandIsoPairEle;
     for (unsigned int lCand = 0; lCand < nObj; lCand++) {
       pfEGCandRef = reco::PFCandidateRef(pfEGCandidateHandle, lCand);
-      reco::GsfElectronRef myEle = (pfEGCandToElectronMap)[pfEGCandRef];
+      const reco::GsfElectronRef& myEle = (pfEGCandToElectronMap)[pfEGCandRef];
 
       if (myEle.isNonnull()) {
         //	std::cout << "ParticleBasedIsoProducer Electorns PF SC " << pfEGCandRef->superClusterRef()->energy() << " Electron SC " << myEle->superCluster()->energy() << std::endl;

--- a/RecoEgamma/EgammaMCTools/src/ElectronMCTruthFinder.cc
+++ b/RecoEgamma/EgammaMCTools/src/ElectronMCTruthFinder.cc
@@ -135,7 +135,7 @@ std::vector<ElectronMCTruth> ElectronMCTruthFinder::find(const std::vector<SimTr
       //std::cout << " (*iEleTk)->trackId() " << (*iEleTk).trackId() << " (*iEleTk)->vertIndex() "<< (*iEleTk).vertIndex()  << " (*iSimTk).vertIndex() "  <<  (*iSimTk).vertIndex() << " (*iSimTk).type() " <<   (*iSimTk).type() << " (*iSimTk).trackId() " << (*iSimTk).trackId() << std::endl;
 
       int vertexId1 = (*iSimTk).vertIndex();
-      SimVertex vertex1 = theSimVertices[vertexId1];
+      const SimVertex& vertex1 = theSimVertices[vertexId1];
       int vertexId2 = trLast.vertIndex();
       //SimVertex vertex2 = theSimVertices[vertexId2];
 

--- a/RecoEgamma/EgammaMCTools/src/PhotonMCTruthFinder.cc
+++ b/RecoEgamma/EgammaMCTools/src/PhotonMCTruthFinder.cc
@@ -152,7 +152,7 @@ std::vector<PhotonMCTruth> PhotonMCTruthFinder::find(const std::vector<SimTrack>
         //std::cout << " Looping on gamma looking for conversions " << (*iPhoTk).momentum() << " photon track ID " << (*iPhoTk).trackId() << std::endl;
 
         // check who is his mother
-        SimVertex vertex = theSimVertices[photonVertexIndex];
+        const SimVertex& vertex = theSimVertices[photonVertexIndex];
         phoMotherId = -1;
         if (vertex.parentIndex() != -1) {
           unsigned motherGeantId = vertex.parentIndex();
@@ -177,7 +177,7 @@ std::vector<PhotonMCTruth> PhotonMCTruthFinder::find(const std::vector<SimTrack>
             continue;
 
           int vertexId = (*iEleTk).vertIndex();
-          SimVertex vertex = theSimVertices[vertexId];
+          const SimVertex& vertex = theSimVertices[vertexId];
           int motherId = -1;
 
           //std::cout << " Secondary from photons particle type " << (*iEleTk).type() << " trackId " <<  (*iEleTk).trackId() << " vertex ID " << vertexId << std::endl;
@@ -226,7 +226,7 @@ std::vector<PhotonMCTruth> PhotonMCTruthFinder::find(const std::vector<SimTrack>
                 //std::cout << " (*iEleTk)->trackId() " << (*iEleTk).trackId() << " (*iEleTk)->vertIndex() "<< (*iEleTk).vertIndex()  << " (*iSimTk).vertIndex() "  <<  (*iSimTk).vertIndex() << " (*iSimTk).type() " <<   (*iSimTk).type() << " (*iSimTk).trackId() " << (*iSimTk).trackId() << std::endl;
 
                 int vertexId1 = (*iSimTk).vertIndex();
-                SimVertex vertex1 = theSimVertices[vertexId1];
+                const SimVertex& vertex1 = theSimVertices[vertexId1];
                 int vertexId2 = trLast.vertIndex();
                 //SimVertex vertex2 = theSimVertices[vertexId2];
 
@@ -299,7 +299,7 @@ std::vector<PhotonMCTruth> PhotonMCTruthFinder::find(const std::vector<SimTrack>
 
         if (phoMotherId >= 0) {
           phoMotherVtxIndex = theSimTracks[phoMotherId].vertIndex();
-          SimVertex motherVtx = theSimVertices[phoMotherVtxIndex];
+          const SimVertex& motherVtx = theSimVertices[phoMotherVtxIndex];
           motherVtxPosition = math::XYZTLorentzVectorD(
               motherVtx.position().x(), motherVtx.position().y(), motherVtx.position().z(), motherVtx.position().e());
 
@@ -322,7 +322,7 @@ std::vector<PhotonMCTruth> PhotonMCTruthFinder::find(const std::vector<SimTrack>
 
           //int convVtxId =  trkFromConversion[0].vertIndex();
           int convVtxId = electronsFromConversions[0].vertexInd();
-          SimVertex convVtx = theSimVertices[convVtxId];
+          const SimVertex& convVtx = theSimVertices[convVtxId];
           // CLHEP::HepLorentzVector vtxPosition = convVtx.position();
           math::XYZTLorentzVectorD vtxPosition(
               convVtx.position().x(), convVtx.position().y(), convVtx.position().z(), convVtx.position().e());

--- a/RecoEgamma/EgammaMCTools/src/PizeroMCTruthFinder.cc
+++ b/RecoEgamma/EgammaMCTools/src/PizeroMCTruthFinder.cc
@@ -81,7 +81,7 @@ std::vector<PizeroMCTruth> PizeroMCTruthFinder::find(const std::vector<SimTrack>
       continue;
 
     int vertexId = (*iSimTk).vertIndex();
-    SimVertex vertex = theSimVertices[vertexId];
+    const SimVertex& vertex = theSimVertices[vertexId];
 
     std::cout << " Particle type " << (*iSimTk).type() << " Sim Track ID " << (*iSimTk).trackId() << " momentum "
               << (*iSimTk).momentum() << " vertex position " << vertex.position() << std::endl;
@@ -131,7 +131,7 @@ std::vector<PizeroMCTruth> PizeroMCTruthFinder::find(const std::vector<SimTrack>
     std::cout << " mcPhotons.size " << mcPhotons.size() << std::endl;
     for (std::vector<PhotonMCTruth>::iterator iPho = mcPhotons.begin(); iPho != mcPhotons.end(); ++iPho) {
       int phoVtxIndex = (*iPho).vertexInd();
-      SimVertex phoVtx = theSimVertices[phoVtxIndex];
+      const SimVertex& phoVtx = theSimVertices[phoVtxIndex];
       unsigned int phoParentInd = phoVtx.parentIndex();
       std::cout << " photon parent vertex index " << phoParentInd << std::endl;
 

--- a/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
+++ b/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
@@ -620,7 +620,7 @@ void HIMultiTrackSelector::selectVertices(unsigned int tsNum,
   for (VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end(); it != ed; ++it) {
     LogDebug("SelectVertex") << " select vertex with z position " << it->z() << " " << it->chi2() << " " << it->ndof()
                              << " " << TMath::Prob(it->chi2(), static_cast<int32_t>(it->ndof()));
-    Vertex vtx = *it;
+    const Vertex& vtx = *it;
     bool pass = vertexCut_[tsNum](vtx);
     if (pass) {
       points.push_back(it->position());

--- a/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
+++ b/RecoHI/HiTracking/plugins/HIMultiTrackSelector.cc
@@ -620,7 +620,7 @@ void HIMultiTrackSelector::selectVertices(unsigned int tsNum,
   for (VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end(); it != ed; ++it) {
     LogDebug("SelectVertex") << " select vertex with z position " << it->z() << " " << it->chi2() << " " << it->ndof()
                              << " " << TMath::Prob(it->chi2(), static_cast<int32_t>(it->ndof()));
-    const Vertex& vtx = *it;
+    const Vertex &vtx = *it;
     bool pass = vertexCut_[tsNum](vtx);
     if (pass) {
       points.push_back(it->position());

--- a/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
+++ b/RecoJets/JetAlgorithms/src/HEPTopTaggerV2.cc
@@ -472,7 +472,7 @@ namespace external {
                                         const ClusterSequence& cseq,
                                         const double small_radius) {
     for (unsigned i = 0; i < big_fatjets.size(); i++) {
-      PseudoJet this_jet = big_fatjets[i];
+      const PseudoJet& this_jet = big_fatjets[i];
       PseudoJet parent1(0, 0, 0, 0), parent2(0, 0, 0, 0);
       bool test = cseq.has_parents(this_jet, parent1, parent2);
       double dR = 100;

--- a/RecoJets/JetAnalyzers/src/myFastSimVal.cc
+++ b/RecoJets/JetAnalyzers/src/myFastSimVal.cc
@@ -2673,7 +2673,7 @@ void myFastSimVal::analyze(const Event& evt, const EventSetup& es) {
 
   // --- Loop over towers and make a lists of used and unused towers
   for (CaloTowerCollection::const_iterator tower = caloTowers->begin(); tower != caloTowers->end(); tower++) {
-    CaloTower t = *tower;
+    const CaloTower& t = *tower;
     Double_t et = tower->et();
 
     if (et > 0) {
@@ -2757,7 +2757,7 @@ void myFastSimVal::analyze(const Event& evt, const EventSetup& es) {
 
   // --- Loop over towers and make a lists of used and unused towers
   for (CaloTowerCollection::const_iterator tower = caloTowers->begin(); tower != caloTowers->end(); tower++) {
-    CaloTower t = *tower;
+    const CaloTower& t = *tower;
     Double_t et = tower->et();
 
     if (et > 0) {
@@ -2842,7 +2842,7 @@ void myFastSimVal::analyze(const Event& evt, const EventSetup& es) {
 
   // --- Loop over towers and make a lists of used and unused towers
   for (CaloTowerCollection::const_iterator tower = caloTowers->begin(); tower != caloTowers->end(); tower++) {
-    CaloTower t = *tower;
+    const CaloTower& t = *tower;
     Double_t et = tower->et();
 
     if (et > 0) {

--- a/RecoJets/JetProducers/plugins/QjetsAdder.cc
+++ b/RecoJets/JetProducers/plugins/QjetsAdder.cc
@@ -19,7 +19,7 @@ void QjetsAdder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   QjetsVolatility.reserve(jets->size());
 
   for (typename edm::View<reco::Jet>::const_iterator jetIt = jets->begin(); jetIt != jets->end(); ++jetIt) {
-    reco::Jet newCand(*jetIt);
+    const reco::Jet& newCand(*jetIt);
 
     if (newCand.pt() < cutoff_) {
       QjetsVolatility.push_back(-1);

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -491,7 +491,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
         double dZ0 = 9999.;
         double dZ_tmp = 9999.;
         for (unsigned vtx_i = 0; vtx_i < allvtx.size(); vtx_i++) {
-          auto iv = allvtx[vtx_i];
+          const auto& iv = allvtx[vtx_i];
 
           if (iv.isFake())
             continue;

--- a/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegment4DT0Corrector.cc
@@ -67,7 +67,7 @@ void DTSegment4DT0Corrector::produce(Event& event, const EventSetup& setup) {
 
     // Loop over the rechits of this ChamberId
     for (DTRecSegment4DCollection::const_iterator segment4D = range.first; segment4D != range.second; ++segment4D) {
-      DTRecSegment4D tmpseg = *segment4D;
+      const DTRecSegment4D& tmpseg = *segment4D;
 
       DTRecSegment4D* newSeg = tmpseg.clone();
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -567,7 +567,7 @@ void DTSegmentUpdator::rejectBadHits(DTChamberRecSegment2D* phiSeg) const {
     float normResidual = mean_residual > 0 ? std::abs(residuals[i]) / mean_residual : 0;
     ++i;
     if (normResidual < 1.5) {
-      DTRecHit1D newHit1D = (*hit);
+      const DTRecHit1D& newHit1D = (*hit);
       updatedRecHits.push_back(newHit1D);
       if (debug)
         cout << " accepted " << i << "th hit"

--- a/RecoLuminosity/LumiProducer/src/NormDML.cc
+++ b/RecoLuminosity/LumiProducer/src/NormDML.cc
@@ -153,7 +153,7 @@ void lumi::NormDML::parseAfterglows(const std::string& afterglowStr, std::map<un
   unsigned int threshold;
   for (tokenizer::iterator tok_iter = tokens.begin(); tok_iter != tokens.end(); ++tok_iter) {
     if (counter % 2 == 0) {
-      std::string valStr = *(tok_iter);
+      const std::string& valStr = *(tok_iter);
       float val = 0.;
       std::stringstream strStream(valStr);
       strStream >> val;

--- a/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
+++ b/RecoMET/METAlgorithms/src/MuonMETAlgo.cc
@@ -46,7 +46,7 @@ void MuonMETAlgo::MuonMETAlgo_run(const edm::View<reco::Muon>& inputMuons,
                                   const edm::ValueMap<reco::MuonMETCorrectionData>& vm_muCorrData,
                                   const edm::View<T>& v_uncorMET,
                                   std::vector<T>* v_corMET) {
-  T uncorMETObj = v_uncorMET.front();
+  const T& uncorMETObj = v_uncorMET.front();
 
   double corMETX = uncorMETObj.px();
   double corMETY = uncorMETObj.py();

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -1375,7 +1375,7 @@ void HcalNoiseInfoProducer::filltracks(edm::Event& iEvent,
 
   summary.trackenergy_ = 0.0;
   for (reco::TrackCollection::const_iterator iTrack = handle->begin(); iTrack != handle->end(); ++iTrack) {
-    reco::Track trk = *iTrack;
+    const reco::Track& trk = *iTrack;
     if (trk.pt() < minTrackPt_ || fabs(trk.eta()) > maxTrackEta_)
       continue;
 

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
@@ -143,7 +143,7 @@ vector<Trajectory> CosmicMuonSmoother::fit(const TrajectorySeed& seed,
   if (hits.front()->isValid()) {
     // FIXME  FIXME  CLONE !!!
     //  TrackingRecHit::RecHitPointer preciseHit = hits.front()->clone(predTsos);
-    auto preciseHit = hits.front();
+    const auto& preciseHit = hits.front();
 
     LogTrace(category_) << "first hit is at det " << hits.front()->det()->surface().position();
 
@@ -204,7 +204,7 @@ vector<Trajectory> CosmicMuonSmoother::fit(const TrajectorySeed& seed,
       // FIXME  FIXME  CLONE !!!
       // update  (FIXME!)
       // TransientTrackingRecHit::RecHitPointer preciseHit = (**ihit).clone(predTsos);
-      auto preciseHit = *ihit;
+      const auto& preciseHit = *ihit;
 
       if (!preciseHit->isValid()) {
         currTsos = predTsos;

--- a/RecoMuon/MuonSeedGenerator/src/MuonSeedOrcaPatternRecognition.cc
+++ b/RecoMuon/MuonSeedGenerator/src/MuonSeedOrcaPatternRecognition.cc
@@ -526,7 +526,7 @@ void MuonSeedOrcaPatternRecognition::complete(MuonRecHitContainer& seedSegments,
   ConstMuonRecHitPointer first = seedSegments[0];  // first rechit of seed
   GlobalPoint ptg2 = first->globalPosition();      // its global pos +v
   for (unsigned nr = 0; nr < recHits.size(); ++nr) {
-    MuonRecHitPointer recHit(recHits[nr]);
+    const MuonRecHitPointer& recHit(recHits[nr]);
     GlobalPoint ptg1(recHit->globalPosition());
     float deta = fabs(ptg1.eta() - ptg2.eta());
     // Geom::Phi should keep it in the range [-pi, pi]

--- a/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporter.cc
@@ -97,7 +97,7 @@ void GeneralTracksImporter::importToBlock(const edm::Event& e, BlockElementImpor
     std::sort(vetoed.begin(), vetoed.end());
   }
   const auto muonH = e.getHandle(muons_);
-  const auto muons = *muonH;
+  const auto& muons = *muonH;
   elems.reserve(elems.size() + tracks->size());
   std::vector<bool> mask(tracks->size(), true);
   reco::MuonRef muonref;

--- a/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauCommonUtilities.h
@@ -44,7 +44,7 @@ namespace reco {
                                                  bool sort = true) {
       std::vector<CandidatePtr> output;
       for (Iterator iter = begin; iter != end; ++iter) {
-        reco::CandidatePtr ptr(*iter);
+        const reco::CandidatePtr& ptr(*iter);
         if (std::abs(ptr->pdgId()) == pdgId)
           output.push_back(ptr);
       }

--- a/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/TruncatedAverageDeDxEstimator.h
@@ -18,7 +18,7 @@ public:
     for (size_t i = 0; i + nTrunc < Hits.size(); i++) {
       sumdedx += Hits[i].charge();
     }
-    double avrdedx = (Hits.size()) ? sumdedx / (Hits.size() - nTrunc) : 0.0;
+    double avrdedx = (!Hits.empty()) ? sumdedx / (Hits.size() - nTrunc) : 0.0;
     return std::make_pair(avrdedx, -1);
   }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -515,7 +515,7 @@ void MultiTrackSelector::selectVertices(unsigned int tsNum,
   for (VertexCollection::const_iterator it = vtxs.begin(), ed = vtxs.end(); it != ed; ++it) {
     LogDebug("SelectVertex") << " select vertex with z position " << it->z() << " " << it->chi2() << " " << it->ndof()
                              << " " << TMath::Prob(it->chi2(), static_cast<int32_t>(it->ndof()));
-    Vertex vtx = *it;
+    const Vertex& vtx = *it;
     bool pass = vertexCut_[tsNum](vtx);
     if (pass) {
       points.push_back(it->position());

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.cc
@@ -106,7 +106,7 @@ void NuclearTrackCorrector::produce(edm::Event& iEvent, const edm::EventSetup& i
   swap_map(temp_m_TrajectoryCollection, m_TrackToTrajMap);
 
   for (unsigned int i = 0; i < m_NuclearInteractionCollection.size(); i++) {
-    reco::NuclearInteraction ni = m_NuclearInteractionCollection[i];
+    const reco::NuclearInteraction& ni = m_NuclearInteractionCollection[i];
     if (ni.likelihood() < 0.4)
       continue;
 

--- a/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
@@ -167,7 +167,7 @@ bool CtfSpecialSeedGenerator::buildSeeds(const edm::EventSetup& iSetup,
   //SeedFromGenericPairOrTriplet seedBuilder(conf_, magfield.product(), tracker.product(), theBuilder.product());
   edm::LogInfo("CtfSpecialSeedGenerator") << "osh.size() " << osh.size();
   for (unsigned int i = 0; i < osh.size(); i++) {
-    SeedingHitSet shs = osh[i];
+    const SeedingHitSet& shs = osh[i];
     if (preliminaryCheck(shs, iSetup)) {
       std::vector<TrajectorySeed*> seeds = theSeedBuilder->seed(shs, dir, navdir, iSetup);
       for (std::vector<TrajectorySeed*>::const_iterator iSeed = seeds.begin(); iSeed != seeds.end(); iSeed++) {

--- a/TrackingTools/GsfTools/interface/MultiGaussianStateCombiner.icc
+++ b/TrackingTools/GsfTools/interface/MultiGaussianStateCombiner.icc
@@ -16,7 +16,7 @@ typename MultiGaussianStateCombiner<N>::SingleStatePtr MultiGaussianStateCombine
     return SingleStatePtr();
   }
 
-  const SingleStatePtr firstState(theComponents.front());
+  const SingleStatePtr& firstState(theComponents.front());
   if (theComponents.size() == 1) {
     return firstState;
   }

--- a/TrackingTools/GsfTools/src/MultiGaussianStateCombiner1D.cc
+++ b/TrackingTools/GsfTools/src/MultiGaussianStateCombiner1D.cc
@@ -17,7 +17,7 @@ SingleGaussianState1D MultiGaussianStateCombiner1D::combine(const VSC& theCompon
     return SingleGaussianState1D();
   }
 
-  const SingleGaussianState1D firstState(theComponents.front());
+  const SingleGaussianState1D& firstState(theComponents.front());
   if (theComponents.size() == 1)
     return firstState;
 

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
@@ -30,7 +30,7 @@ void MultiTrajectoryStateAssembler::addState(const TrajectoryStateOnSurface tsos
   // Add components (i.e. state to be added can be single or multi state)
   //
   GetComponents comps(tsos);
-  MultiTSOS components(comps());
+  const MultiTSOS& components(comps());
   addStateVector(components);
 }
 

--- a/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
+++ b/TrackingTools/GsfTools/src/MultiTrajectoryStateAssembler.cc
@@ -30,7 +30,7 @@ void MultiTrajectoryStateAssembler::addState(const TrajectoryStateOnSurface tsos
   // Add components (i.e. state to be added can be single or multi state)
   //
   GetComponents comps(tsos);
-  const MultiTSOS& components(comps());
+  const MultiTSOS &components(comps());
   addStateVector(components);
 }
 

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -119,7 +119,7 @@ void TempTrajectory::join(TempTrajectory& segment) {
 PropagationDirection TempTrajectory::direction() const { return PropagationDirection(theDirection); }
 
 void TempTrajectory::check() const {
-  if (theData.size() == 0)
+  if (theData.empty())
     throw cms::Exception("TrackingTools/PatternTools",
                          "Trajectory::check() - information requested from empty Trajectory");
 }


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
Mostly these changes are suggested by improved [performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) check.