### PR TITLE
[ALCA] [LLVM14] Apply code checks

### DIFF
--- a/Alignment/CocoaModel/src/EntryMgr.cc
+++ b/Alignment/CocoaModel/src/EntryMgr.cc
@@ -114,8 +114,8 @@ EntryData* EntryMgr::findEntryByLongName(const ALIstring& optoName, const ALIstr
 //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 EntryData* EntryMgr::findEntry(const std::vector<ALIstring>& wl) {
   EntryData* data = nullptr;
-  ALIstring optoName = wl[2];
-  ALIstring entryName = wl[3];
+  const ALIstring& optoName = wl[2];
+  const ALIstring& entryName = wl[3];
   data = findEntryByLongName(optoName, entryName);
 
   return data;

--- a/Alignment/CocoaModel/src/Model.cc
+++ b/Alignment/CocoaModel/src/Model.cc
@@ -358,7 +358,7 @@ void Model::readSystemDescription() {
             std::cerr << "!!!SYSTEM_TREE_DESCRIPTION section: object " << *((*vvscite).begin())
                       << " is not hanging from object 'system' " << std::endl;
             for (vvscite = OptODictionary().begin(); vvscite != OptODictionary().end(); ++vvscite) {
-              std::vector<ALIstring> ptemp = *vvscite;
+              const std::vector<ALIstring>& ptemp = *vvscite;
               ALIUtils::dumpVS(ptemp, "OBJECT ", std::cerr);
             }
             exit(9);

--- a/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
@@ -27,7 +27,7 @@ TkModuleGroupSelector::TkModuleGroupSelector(AlignableTracker *aliTracker,
   std::vector<std::string> parameterNames = cfg.getParameterNames();
   for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
        ++iParam) {
-    const std::string& name = (*iParam);
+    const std::string &name = (*iParam);
     if (name != "RunRange" && name != "ReferenceRun" && name != "Granularity") {
       throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::TkModuleGroupSelector:"
                                         << " Unknown parameter name '" << name << "' in PSet. Maybe a typo?";
@@ -107,7 +107,7 @@ void TkModuleGroupSelector::verifyParameterNames(const edm::ParameterSet &pset, 
   std::vector<std::string> parameterNames = pset.getParameterNames();
   for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
        ++iParam) {
-    const std::string& name = (*iParam);
+    const std::string &name = (*iParam);
     if (name != "levels" && name != "RunRange" && name != "split" && name != "ReferenceRun") {
       throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::verifyParameterNames:"
                                         << " Unknown parameter name '" << name << "' in PSet number " << psetnr

--- a/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/TkModuleGroupSelector.cc
@@ -27,7 +27,7 @@ TkModuleGroupSelector::TkModuleGroupSelector(AlignableTracker *aliTracker,
   std::vector<std::string> parameterNames = cfg.getParameterNames();
   for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
        ++iParam) {
-    const std::string name = (*iParam);
+    const std::string& name = (*iParam);
     if (name != "RunRange" && name != "ReferenceRun" && name != "Granularity") {
       throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::TkModuleGroupSelector:"
                                         << " Unknown parameter name '" << name << "' in PSet. Maybe a typo?";
@@ -107,7 +107,7 @@ void TkModuleGroupSelector::verifyParameterNames(const edm::ParameterSet &pset, 
   std::vector<std::string> parameterNames = pset.getParameterNames();
   for (std::vector<std::string>::const_iterator iParam = parameterNames.begin(); iParam != parameterNames.end();
        ++iParam) {
-    const std::string name = (*iParam);
+    const std::string& name = (*iParam);
     if (name != "levels" && name != "RunRange" && name != "split" && name != "ReferenceRun") {
       throw cms::Exception("BadConfig") << "@SUB=TkModuleGroupSelector::verifyParameterNames:"
                                         << " Unknown parameter name '" << name << "' in PSet number " << psetnr

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
@@ -1762,7 +1762,7 @@ void AlignmentMonitorMuonResiduals::event(const edm::Event &iEvent,
     std::vector<TrajectoryMeasurement> measurements = traj->measurements();
 
     for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end(); ++im) {
-      const TrajectoryMeasurement meas = *im;
+      const TrajectoryMeasurement& meas = *im;
       const TransientTrackingRecHit *hit = &(*meas.recHit());
       const DetId id = hit->geographicalId();
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonResiduals.cc
@@ -1762,7 +1762,7 @@ void AlignmentMonitorMuonResiduals::event(const edm::Event &iEvent,
     std::vector<TrajectoryMeasurement> measurements = traj->measurements();
 
     for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end(); ++im) {
-      const TrajectoryMeasurement& meas = *im;
+      const TrajectoryMeasurement &meas = *im;
       const TransientTrackingRecHit *hit = &(*meas.recHit());
       const DetId id = hit->geographicalId();
 

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorTemplate.cc
@@ -102,7 +102,7 @@ void AlignmentMonitorTemplate::event(const edm::Event& iEvent,
 
     std::vector<TrajectoryMeasurement> measurements = traj->measurements();
     for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end(); ++im) {
-      const TrajectoryMeasurement meas = *im;
+      const TrajectoryMeasurement& meas = *im;
       const TransientTrackingRecHit* hit = &(*meas.recHit());
       const DetId id = hit->geographicalId();
 

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
@@ -169,7 +169,7 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(const std::vecto
   int ipos = 1;
   AlgebraicMatrix selderiv(nparam, 2);
   for (std::vector<AlgebraicMatrix>::const_iterator imat = vecderiv.begin(); imat != vecderiv.end(); ++imat) {
-    AlgebraicMatrix thisselderiv = (*imat);
+    const AlgebraicMatrix& thisselderiv = (*imat);
     int npar = thisselderiv.num_row();
     selderiv.sub(ipos, 1, thisselderiv);
     ipos += npar;

--- a/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/CompositeAlignmentParameters.cc
@@ -169,7 +169,7 @@ AlgebraicMatrix CompositeAlignmentParameters::derivativesLegacy(const std::vecto
   int ipos = 1;
   AlgebraicMatrix selderiv(nparam, 2);
   for (std::vector<AlgebraicMatrix>::const_iterator imat = vecderiv.begin(); imat != vecderiv.end(); ++imat) {
-    const AlgebraicMatrix& thisselderiv = (*imat);
+    const AlgebraicMatrix &thisselderiv = (*imat);
     int npar = thisselderiv.num_row();
     selderiv.sub(ipos, 1, thisselderiv);
     ipos += npar;

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonHIPTrajectorySelector.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentMuonHIPTrajectorySelector.cc
@@ -145,7 +145,7 @@ void AlignmentMuonHIPTrajectorySelector::produce(edm::Event& iEvent, const edm::
       double tracker_dof = 0.;
       for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end();
            ++im) {
-        const TrajectoryMeasurement meas = *im;
+        const TrajectoryMeasurement& meas = *im;
         auto hit = &(*meas.recHit());
         const DetId id = hit->geographicalId();
 
@@ -193,7 +193,7 @@ void AlignmentMuonHIPTrajectorySelector::produce(edm::Event& iEvent, const edm::
 
         for (std::vector<TrajectoryMeasurement>::const_iterator im = measurements.begin(); im != measurements.end();
              ++im) {
-          const TrajectoryMeasurement meas = *im;
+          const TrajectoryMeasurement& meas = *im;
           auto hit = &(*meas.recHit());
           const DetId id = hit->geographicalId();
 

--- a/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
+++ b/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
@@ -426,7 +426,7 @@ void TkLasBeamFitter::getLasBeams(TkFittedLasBeam &beam, vector<TrajectoryStateO
   for (TkLasBeam::const_iterator iHit = beam.begin(); iHit < beam.end(); ++iHit) {
     // iHit is a SiStripLaserRecHit2D
 
-    const SiStripLaserRecHit2D& hit(*iHit);
+    const SiStripLaserRecHit2D &hit(*iHit);
 
     this->getLasHits(beam, hit, gd, globHit, hitsAtTecPlus);
     sumZ += globHit.back().z();

--- a/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
+++ b/Alignment/LaserAlignment/plugins/TkLasBeamFitter.cc
@@ -426,7 +426,7 @@ void TkLasBeamFitter::getLasBeams(TkFittedLasBeam &beam, vector<TrajectoryStateO
   for (TkLasBeam::const_iterator iHit = beam.begin(); iHit < beam.end(); ++iHit) {
     // iHit is a SiStripLaserRecHit2D
 
-    const SiStripLaserRecHit2D hit(*iHit);
+    const SiStripLaserRecHit2D& hit(*iHit);
 
     this->getLasHits(beam, hit, gd, globHit, hitsAtTecPlus);
     sumZ += globHit.back().z();

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -490,7 +490,7 @@ void MillePedeAlignmentAlgorithm::run(const edm::EventSetup &setup, const EventI
   const auto tracksPerTraj = theTrajectoryFactory->tracksPerTrajectory();
   for (auto iRefTraj = trajectories.cbegin(), iRefTrajE = trajectories.cend(); iRefTraj != iRefTrajE;
        ++iRefTraj, ++refTrajCount) {
-    const RefTrajColl::value_type& refTrajPtr = *iRefTraj;
+    const RefTrajColl::value_type &refTrajPtr = *iRefTraj;
     if (theMonitor)
       theMonitor->fillRefTrajectory(refTrajPtr);
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -490,7 +490,7 @@ void MillePedeAlignmentAlgorithm::run(const edm::EventSetup &setup, const EventI
   const auto tracksPerTraj = theTrajectoryFactory->tracksPerTrajectory();
   for (auto iRefTraj = trajectories.cbegin(), iRefTrajE = trajectories.cend(); iRefTraj != iRefTrajE;
        ++iRefTraj, ++refTrajCount) {
-    RefTrajColl::value_type refTrajPtr = *iRefTraj;
+    const RefTrajColl::value_type& refTrajPtr = *iRefTraj;
     if (theMonitor)
       theMonitor->fillRefTrajectory(refTrajPtr);
 

--- a/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/MuonResidualsFromTrack.cc
@@ -102,7 +102,7 @@ MuonResidualsFromTrack::MuonResidualsFromTrack(edm::ESHandle<TransientTrackingRe
     if (m_debug)
       std::cout << "    TrajectoryMeasurement #" << nTrajMeasurement << std::endl;
 
-    TrajectoryMeasurement trajMeasurement = *iTrajMeasurement;
+    const TrajectoryMeasurement& trajMeasurement = *iTrajMeasurement;
 
     TrajectoryStateOnSurface tsos =
         m_tsoscomb(trajMeasurement.forwardPredictedState(), trajMeasurement.backwardPredictedState());

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -371,7 +371,7 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     edm::LogError("EopElecTreeWriter") << "Error: no primary vertex found!";
     return;
   }
-  reco::Vertex vert = vertex.front();
+  const reco::Vertex& vert = vertex.front();
   h_nEventsWithVertex->Fill(0.5);
 
   // getting calorimeter geometry

--- a/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
@@ -175,7 +175,7 @@ void JetHTAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   int counter = 0;
   for (reco::VertexCollection::const_iterator pvIt = pvtx.begin(); pvIt != pvtx.end(); pvIt++) {
-    reco::Vertex iPV = *pvIt;
+    const reco::Vertex& iPV = *pvIt;
     counter++;
 
     if (iPV.isFake())

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -423,7 +423,7 @@ void SplitVertexResolution::analyze(const edm::Event& iEvent, const edm::EventSe
   int goodcounter = 0;
 
   for (auto pvIt = pvtx.cbegin(); pvIt != pvtx.cend(); ++pvIt) {
-    reco::Vertex iPV = *pvIt;
+    const reco::Vertex& iPV = *pvIt;
     counter++;
     if (iPV.isFake())
       continue;

--- a/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
@@ -1309,7 +1309,7 @@ std::set<unsigned int> PixelCalibConfiguration::getTKFECCrates(
     const std::set<std::string> portCards = portcardmap->portcards(*imodule);
     for (std::set<std::string>::const_iterator portCards_itr = portCards.begin(); portCards_itr != portCards.end();
          ++portCards_itr) {
-      const std::string portcardname = *portCards_itr;
+      const std::string& portcardname = *portCards_itr;
       std::map<std::string, PixelPortCardConfig*>::const_iterator portcardconfig_itr =
           mapNamePortCard.find(portcardname);
       assert(portcardconfig_itr != mapNamePortCard.end());

--- a/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/Calibration/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -580,10 +580,10 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event& iEvent, c
                 //cycle on subdets
                 for (uint32_t idet = 0; idet < SiStripRegionCabling::ALLSUBDETS; idet++) {  //cicle between 1 and 4
                   //get vector of layers whin subdet of region
-                  const SiStripRegionCabling::WedgeCabling regSubdetLayers = regSubdets[idet];  // at most 10 layers
+                  const SiStripRegionCabling::WedgeCabling& regSubdetLayers = regSubdets[idet];  // at most 10 layers
                   for (uint32_t ilayer = 0; ilayer < SiStripRegionCabling::ALLLAYERS; ilayer++) {
                     //get map of vectors of feds withing the layer of subdet of region
-                    const SiStripRegionCabling::ElementCabling fedVectorMap =
+                    const SiStripRegionCabling::ElementCabling& fedVectorMap =
                         regSubdetLayers[ilayer];  // vector of the fed
                     SiStripRegionCabling::ElementCabling::const_iterator itFedMap = fedVectorMap.begin();
                     for (; itFedMap != fedVectorMap.end(); itFedMap++) {

--- a/Calibration/HcalIsolatedTrackReco/plugins/SiStripRegFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/SiStripRegFEDSelector.cc
@@ -91,10 +91,10 @@ void SiStripRegFEDSelector::produce(edm::StreamID, edm::Event& iEvent, const edm
       //cycle on subdets
       for (uint32_t idet = 0; idet < SiStripRegionCabling::ALLSUBDETS; idet++) {
         //get vector of layers within subdet of region
-        const SiStripRegionCabling::WedgeCabling regSubdetLayers = regSubdets[idet];
+        const SiStripRegionCabling::WedgeCabling& regSubdetLayers = regSubdets[idet];
         for (uint32_t ilayer = 0; ilayer < SiStripRegionCabling::ALLLAYERS; ilayer++) {
           //get map of vectors of feds withing the layer of subdet of region
-          const SiStripRegionCabling::ElementCabling fedVectorMap = regSubdetLayers[ilayer];
+          const SiStripRegionCabling::ElementCabling& fedVectorMap = regSubdetLayers[ilayer];
           SiStripRegionCabling::ElementCabling::const_iterator it = fedVectorMap.begin();
           for (; it != fedVectorMap.end(); it++) {
             for (uint32_t op = 0; op < (it->second).size(); op++) {

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
@@ -771,7 +771,7 @@ void IsolatedTracksNxN::analyze(const edm::Event &iEvent, const edm::EventSetup 
       if (!((*recVtxs)[ind].isFake())) {
         reco::Vertex::trackRef_iterator vtxTrack = (*recVtxs)[ind].tracks_begin();
         for (vtxTrack = (*recVtxs)[ind].tracks_begin(); vtxTrack != (*recVtxs)[ind].tracks_end(); vtxTrack++) {
-          const edm::RefToBase<reco::Track>& pvtxTrack = (*vtxTrack);
+          const edm::RefToBase<reco::Track> &pvtxTrack = (*vtxTrack);
           if (pTrack == pvtxTrack.get()) {
             pVtxTkId = ind;
             break;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
@@ -771,7 +771,7 @@ void IsolatedTracksNxN::analyze(const edm::Event &iEvent, const edm::EventSetup 
       if (!((*recVtxs)[ind].isFake())) {
         reco::Vertex::trackRef_iterator vtxTrack = (*recVtxs)[ind].tracks_begin();
         for (vtxTrack = (*recVtxs)[ind].tracks_begin(); vtxTrack != (*recVtxs)[ind].tracks_end(); vtxTrack++) {
-          const edm::RefToBase<reco::Track> pvtxTrack = (*vtxTrack);
+          const edm::RefToBase<reco::Track>& pvtxTrack = (*vtxTrack);
           if (pTrack == pvtxTrack.get()) {
             pVtxTkId = ind;
             break;


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) check suggested these modifications.