### PR TITLE
[ANALYSIS] [LLVM14] Apply code checks

### DIFF
--- a/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
+++ b/CommonTools/RecoUtils/src/PF_PU_AssoMapAlgos.cc
@@ -293,7 +293,7 @@ VertexRef PF_PU_AssoMapAlgos::FindClosestZ(const reco::TrackRef trkref,
 
   //loop over all vertices with a good quality in the vertex collection
   for (unsigned int index_vtx = 0; index_vtx < vtxcollV.size(); ++index_vtx) {
-    VertexRef vertexref = vtxcollV.at(index_vtx);
+    const VertexRef& vertexref = vtxcollV.at(index_vtx);
 
     double nTracks = sqrt(vertexref->tracksSize());
 
@@ -323,7 +323,7 @@ VertexRef PF_PU_AssoMapAlgos::FindClosest3D(TransientTrack transtrk,
 
   //loop over all vertices with a good quality in the vertex collection
   for (unsigned int index_vtx = 0; index_vtx < vtxcollV.size(); ++index_vtx) {
-    VertexRef vertexref = vtxcollV.at(index_vtx);
+    const VertexRef& vertexref = vtxcollV.at(index_vtx);
 
     double nTracks = sqrt(vertexref->tracksSize());
 

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
@@ -324,7 +324,7 @@ void APVShotsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
         const std::vector<const FedChannelConnection*>& conns = _detCabling->getConnections(det);
 
-        if (!(conns.size()))
+        if (conns.empty())
           continue;
         uint16_t lFedId = 0;
         for (uint32_t ch = 0; ch < conns.size(); ch++) {

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsFilter.cc
@@ -175,7 +175,7 @@ bool APVShotsFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventS
 
       const std::vector<const FedChannelConnection*>& conns = _detCabling->getConnections(det);
 
-      if (!(conns.size()))
+      if (conns.empty())
         continue;
       uint16_t lFedId = 0;
       for (uint32_t ch = 0; ch < conns.size(); ch++) {

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -375,7 +375,7 @@ std::vector<int> GenHFHadronMatcher::findHadronJets(const reco::GenParticleColle
   for (reco::GenParticleCollection::const_iterator i_particle = genParticles->begin();
        i_particle != genParticles->end();
        ++i_particle) {
-    const reco::GenParticle& lepton = *i_particle;
+    const reco::GenParticle &lepton = *i_particle;
     const int pdg_abs = lepton.pdgId();
     // Skipping if not a lepton: e/mu
     if (pdg_abs != 11 && pdg_abs != 13)

--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -375,7 +375,7 @@ std::vector<int> GenHFHadronMatcher::findHadronJets(const reco::GenParticleColle
   for (reco::GenParticleCollection::const_iterator i_particle = genParticles->begin();
        i_particle != genParticles->end();
        ++i_particle) {
-    const reco::GenParticle lepton = *i_particle;
+    const reco::GenParticle& lepton = *i_particle;
     const int pdg_abs = lepton.pdgId();
     // Skipping if not a lepton: e/mu
     if (pdg_abs != 11 && pdg_abs != 13)

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -314,7 +314,7 @@ void JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iS
     std::vector<edm::Ptr<reco::Candidate>> constituents = it->getJetConstituents();
     std::vector<edm::Ptr<reco::Candidate>>::const_iterator m;
     for (m = constituents.begin(); m != constituents.end(); ++m) {
-      reco::CandidatePtr constit = *m;
+      const reco::CandidatePtr& constit = *m;
       if (!constit.isNonnull() || !constit.isAvailable()) {
         edm::LogError("MissingJetConstituent") << "Jet constituent required for jet reclustering is missing. "
                                                   "Reclustered jets are not guaranteed to reproduce the original jets!";

--- a/PhysicsTools/PatExamples/src/AnalysisTasksAnalyzerBTag.cc
+++ b/PhysicsTools/PatExamples/src/AnalysisTasksAnalyzerBTag.cc
@@ -74,7 +74,7 @@ void AnalysisTasksAnalyzerBTag::analyze(const edm::EventBase& event) {
 
   // loop Jet collection and fill histograms
   for (std::vector<Jet>::const_iterator Jet_it = Jets->begin(); Jet_it != Jets->end(); ++Jet_it) {
-    pat::Jet Jet(*Jet_it);
+    const pat::Jet& Jet(*Jet_it);
 
     //Categorize the Jets
     if (abs(Jet.partonFlavour()) == 5) {

--- a/TopQuarkAnalysis/TopKinFitter/interface/TtSemiLepKinFitter.h
+++ b/TopQuarkAnalysis/TopKinFitter/interface/TtSemiLepKinFitter.h
@@ -160,10 +160,10 @@ int TtSemiLepKinFitter::fit(const std::vector<pat::Jet>& jets,
     throw edm::Exception(edm::errors::Configuration, "Cannot run the TtSemiLepKinFitter with less than 4 jets");
 
   // get jets in right order
-  const pat::Jet hadP = jets[TtSemiLepEvtPartons::LightQ];
-  const pat::Jet hadQ = jets[TtSemiLepEvtPartons::LightQBar];
-  const pat::Jet hadB = jets[TtSemiLepEvtPartons::HadB];
-  const pat::Jet lepB = jets[TtSemiLepEvtPartons::LepB];
+  const pat::Jet& hadP = jets[TtSemiLepEvtPartons::LightQ];
+  const pat::Jet& hadQ = jets[TtSemiLepEvtPartons::LightQBar];
+  const pat::Jet& hadB = jets[TtSemiLepEvtPartons::HadB];
+  const pat::Jet& lepB = jets[TtSemiLepEvtPartons::LepB];
 
   // initialize particles
   const TLorentzVector p4HadP(hadP.px(), hadP.py(), hadP.pz(), hadP.energy());


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) and [readability-container-size-empty](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html) checks suggested these modifications.