### PR TITLE
[DB] [LLVM14] Apply code checks

### DIFF
--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -237,7 +237,7 @@ namespace DBoxMetadataHelper {
         output.push_back(toAppend);
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < pathsPrep.size(); ++iPath) {
-          std::string thisString = pathsPrep[iPath];
+          const std::string& thisString = pathsPrep[iPath];
           // skip userText since we want to see actual contents, not metadata
           if (thisString.find("userText") == std::string::npos) {
             // if the line to be added has less than colWidth chars, and is not a new tag ("inputTag"), append to current
@@ -260,7 +260,7 @@ namespace DBoxMetadataHelper {
         output.push_back(toAppend);
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < pathsProd.size(); ++iPath) {
-          std::string thisString = pathsProd[iPath];
+          const std::string& thisString = pathsProd[iPath];
 
           if (thisString.find("userText") == std::string::npos) {
             // if the line to be added has less than colWidth chars append to current
@@ -614,7 +614,7 @@ namespace DBoxMetadataHelper {
       output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
       toAppend.clear();
       for (unsigned int iPath = 0; iPath < thePaths.size(); ++iPath) {
-        std::string thisString = thePaths[iPath];
+        const std::string& thisString = thePaths[iPath];
         // skip userText since we want to compare actual contents, not metadata
         if (thisString.find("userText") == std::string::npos) {
           // if the line to be added has less than colWidth chars, and is not a new tag ("inputTag"), append to current

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -45,7 +45,7 @@ namespace {
 
     // constants for ROC level simulation for Phase1
     enum shiftEnumerator { FPixRocIdShift = 3, BPixRocIdShift = 6 };
-    static const int rocIdMaskBits = 0x1F;
+    const int rocIdMaskBits = 0x1F;
 
     struct packedBadRocFraction {
       std::vector<int> badRocNumber;

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
@@ -144,7 +144,7 @@ std::vector<FactorizedJetCorrectorCalculator::VarTypes> FactorizedJetCorrectorCa
     const std::vector<std::string>& fNames) const {
   std::vector<VarTypes> result;
   for (unsigned i = 0; i < fNames.size(); i++) {
-    std::string ss = fNames[i];
+    const std::string& ss = fNames[i];
     if (ss == "JetPt")
       result.push_back(kJetPt);
     else if (ss == "JetEta")

--- a/CondTools/SiStrip/plugins/SiStripBadChannelPatcher.cc
+++ b/CondTools/SiStrip/plugins/SiStripBadChannelPatcher.cc
@@ -77,7 +77,7 @@ void SiStripBadChannelPatcher::fillDescriptions(edm::ConfigurationDescriptions& 
 unsigned int SiStripBadChannelPatcher::fedFromDetId(const uint32_t& detid) {
   // For the cabled det_id retrieve the FEDid
   const std::vector<const FedChannelConnection*>& conns = detCabling_->getConnections(detid);
-  if (!(conns.size())) {
+  if (conns.empty()) {
     edm::LogWarning("SiStripBadChannelPatcher")
         << " DetId " << detid << " appears to be uncabled, returning NOT_A_FEDID !";
     return sistrip::NOT_A_FEDID;


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) and [readability-container-size-empty](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html) checks suggested these modifications.