### PR TITLE
[L1] [LLVM14] Apply code checks

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/JetCalibrationMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/JetCalibrationMethods.cc
@@ -17,7 +17,7 @@ namespace l1t {
     for (std::vector<l1t::Jet>::const_iterator uncalibjet = uncalibjets->begin(); uncalibjet != uncalibjets->end();
          ++uncalibjet) {
       if (jetCalibrationType == "None") {
-        l1t::Jet corrjets = *uncalibjet;
+        const l1t::Jet& corrjets = *uncalibjet;
         jets->push_back(corrjets);
         continue;
       }

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -75,7 +75,7 @@ namespace l1t {
       for (std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();
            notCorrectedRegion != regions.end();
            notCorrectedRegion++) {
-        const CaloRegion& newSubRegion = *notCorrectedRegion;
+        const CaloRegion &newSubRegion = *notCorrectedRegion;
         subRegions->push_back(newSubRegion);
       }
     }

--- a/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
+++ b/L1Trigger/L1TCalorimeter/src/PUSubtractionMethods.cc
@@ -75,7 +75,7 @@ namespace l1t {
       for (std::vector<CaloRegion>::const_iterator notCorrectedRegion = regions.begin();
            notCorrectedRegion != regions.end();
            notCorrectedRegion++) {
-        CaloRegion newSubRegion = *notCorrectedRegion;
+        const CaloRegion& newSubRegion = *notCorrectedRegion;
         subRegions->push_back(newSubRegion);
       }
     }

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1103,7 +1103,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
   unsigned int chargeCorrelation = 1;
   const std::vector<esCut>& cuts = condMu.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut cut = cuts.at(jj);
+    const esCut& cut = cuts.at(jj);
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
         chargeCorrelation = 2;
@@ -1126,7 +1126,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
   // Loop over objects and extract the cuts on the objects
   const std::vector<esObject>& objects = condMu.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject object = objects.at(jj);
+    const esObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -1152,7 +1152,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
 
     const std::vector<esCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut cut = cuts.at(kk);
+      const esCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::UnconstrainedPt:
@@ -1384,7 +1384,7 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
 
   const std::vector<esCut>& cuts = corrMu->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut cut = cuts.at(kk);
+    const esCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::UnconstrainedPt:  // Added for displaced muons
@@ -1749,7 +1749,7 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
   // Loop over objects and extract the cuts on the objects
   const std::vector<esObject>& objects = condCalo.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject object = objects.at(jj);
+    const esObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -1772,7 +1772,7 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
 
     const std::vector<esCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut cut = cuts.at(kk);
+      const esCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::Threshold:
@@ -2007,7 +2007,7 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
 
   const std::vector<esCut>& cuts = corrCalo->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut cut = cuts.at(kk);
+    const esCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::Threshold:
@@ -2279,7 +2279,7 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
   // Loop over objects and extract the cuts on the objects
   const std::vector<esObject>& objects = condEnergySum.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject object = objects.at(jj);
+    const esObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -2293,7 +2293,7 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
 
     const std::vector<esCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut cut = cuts.at(kk);
+      const esCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::Threshold:
@@ -2469,7 +2469,7 @@ bool l1t::TriggerMenuParser::parseEnergySumCorr(const tmeventsetup::esObject* co
 
   const std::vector<esCut>& cuts = corrESum->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut cut = cuts.at(kk);
+    const esCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::Threshold:
@@ -2598,7 +2598,7 @@ bool l1t::TriggerMenuParser::parseExternal(tmeventsetup::esCondition condExt, un
   // Get object for External conditions
   const std::vector<esObject>& objects = condExt.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject object = objects.at(jj);
+    const esObject& object = objects.at(jj);
     if (object.getType() == esObjectType::EXT) {
       relativeBx = object.getBxOffset();
       channelID = object.getExternalChannelId();
@@ -2697,7 +2697,7 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
   int cutType = 0;
   const std::vector<esCut>& cuts = corrCond.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut cut = cuts.at(jj);
+    const esCut& cut = cuts.at(jj);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
@@ -2788,7 +2788,7 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
 
   // loop over legs
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject object = objects.at(jj);
+    const esObject& object = objects.at(jj);
     LogDebug("TriggerMenuParser") << "      obj name = " << object.getName() << "\n";
     LogDebug("TriggerMenuParser") << "      obj type = " << object.getType() << "\n";
     LogDebug("TriggerMenuParser") << "      obj op = " << object.getComparisonOperator() << "\n";
@@ -2996,7 +2996,7 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
   int cutType = 0;
   const std::vector<esCut>& cuts = corrCond.getCuts();
   for (size_t lll = 0; lll < cuts.size(); lll++) {  // START esCut lll
-    const esCut cut = cuts.at(lll);
+    const esCut& cut = cuts.at(lll);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
@@ -3043,7 +3043,7 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
 
   // Loop over legs
   for (size_t lll = 0; lll < objects.size(); lll++) {
-    const esObject object = objects.at(lll);
+    const esObject& object = objects.at(lll);
     LogDebug("TriggerMenuParser") << "      obj name = " << object.getName() << "\n";
     LogDebug("TriggerMenuParser") << "      obj type = " << object.getType() << "\n";
     LogDebug("TriggerMenuParser") << "      obj bx = " << object.getBxOffset() << "\n";
@@ -3159,7 +3159,7 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
   int cutType = 0;
   const std::vector<esCut>& cuts = corrCond.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut cut = cuts.at(jj);
+    const esCut& cut = cuts.at(jj);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanRegionModule.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanRegionModule.cc
@@ -277,7 +277,7 @@ L1MuKBMTrackCollection L1TMuonBarrelKalmanRegionModule::sort4(const L1MuKBMTrack
       s2_3 = in[2];
     }
 
-    L1MuKBMTrack s2_2 = in[1];
+    const L1MuKBMTrack& s2_2 = in[1];
     //Step 2;
     L1MuKBMTrack s3_1 = s2_1;
     L1MuKBMTrack s3_2;

--- a/L1Trigger/TrackFindingTMTT/src/DupFitTrkKiller.cc
+++ b/L1Trigger/TrackFindingTMTT/src/DupFitTrkKiller.cc
@@ -167,7 +167,7 @@ namespace tmtt {
         pair<unsigned int, unsigned int> htCell = trk->cellLocationFit();
         // If this HT cell was not already memorized, rescue this track, since it is probably not a duplicate,
         // but just a track whose fitted helix parameters are a bit wierd for some reason.
-        if (std::count(htCellUsed.begin(), htCellUsed.end(), htCell) == 0) {
+        if (htCellUsed.count(htCell) == 0) {
           tracksFiltered.push_back(trk);  // Rescue track.
           // Optionally store cell location to avoid rescuing other tracks at the same location, which may be duplicates of this track.
           bool outsideCheck = (goOutsideArray || trk->pt() > settings_->houghMinPt());
@@ -222,7 +222,7 @@ namespace tmtt {
       pair<unsigned int, unsigned int> htCell = trk.cellLocationFit();
       // If this HT cell was not already memorized, rescue this track, since it is probably not a duplicate,
       // but just a track whose fitted helix parameters are a bit wierd for some reason.
-      if (std::count(htCellUsed.begin(), htCellUsed.end(), htCell) == 0) {
+      if (htCellUsed.count(htCell) == 0) {
         tracksFiltered.push_back(&trk);  // Rescue track.
         // Store cell location to avoid rescuing other tracks at the same location, which may be duplicates of this track.
         htCellUsed.insert(htCell);

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
@@ -80,7 +80,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSet
   // Get input
   const auto &tp = iEvent.get(tpToken_);
   for (unsigned int i = 0; i < tp.size(); i++) {
-    EcalTriggerPrimitiveDigi d = tp[i];
+    const EcalTriggerPrimitiveDigi& d = tp[i];
     int subdet = d.id().subDet() - 1;
     if (subdet == 0) {
       ecal_et_[subdet]->Fill(d.compressedEt());
@@ -168,7 +168,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSet
 
   EcalTPGScale ecalScale(tokens_, iSetup);
   for (unsigned int i = 0; i < tp.size(); i++) {
-    EcalTriggerPrimitiveDigi d = tp[i];
+    const EcalTriggerPrimitiveDigi& d = tp[i];
     const EcalTrigTowerDetId TPtowid = d.id();
     std::map<EcalTrigTowerDetId, float>::iterator it = mapTow_Et.find(TPtowid);
     float Et = ecalScale.getTPGInGeV(d.compressedEt(), TPtowid);

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
@@ -80,7 +80,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSet
   // Get input
   const auto &tp = iEvent.get(tpToken_);
   for (unsigned int i = 0; i < tp.size(); i++) {
-    const EcalTriggerPrimitiveDigi& d = tp[i];
+    const EcalTriggerPrimitiveDigi &d = tp[i];
     int subdet = d.id().subDet() - 1;
     if (subdet == 0) {
       ecal_et_[subdet]->Fill(d.compressedEt());
@@ -168,7 +168,7 @@ void EcalTrigPrimAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSet
 
   EcalTPGScale ecalScale(tokens_, iSetup);
   for (unsigned int i = 0; i < tp.size(); i++) {
-    const EcalTriggerPrimitiveDigi& d = tp[i];
+    const EcalTriggerPrimitiveDigi &d = tp[i];
     const EcalTrigTowerDetId TPtowid = d.id();
     std::map<EcalTrigTowerDetId, float>::iterator it = mapTow_Et.find(TPtowid);
     float Et = ecalScale.getTPGInGeV(d.compressedEt(), TPtowid);


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).
[performance-unnecessary-copy-initialization](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-unnecessary-copy-initialization.html) and [readability-container-size-empty](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html) checks suggested these modifications.