### PR TITLE
[RECONSTRUCTION-UPGRADE] [LLVM14] Apply code checks

### DIFF
--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -84,7 +84,7 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   evt.getByToken(srcTrackTimeError_, trackTimeErrH);
   evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
   const auto muonH = evt.getHandle(muons_);
-  const auto muons = *muonH;
+  const auto& muons = *muonH;
 
   auto candidates = std::make_unique<reco::PFCandidateCollection>();
 


### PR DESCRIPTION
Applying code checks changes suggested by LLVM 14 ( which we want to integrate in cmssw once fully testing in CLANG IBs).