### PR TITLE
Utilities/StaticAnalyzers: Check for CMS_THREAD_SAFETY or CMS_SA_ALLOW attributes on statments using const_cast and skip warnings.

### DIFF
--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -23,22 +23,22 @@ namespace clangcms {
   void ConstCastAwayChecker::checkPreStmt(const clang::ExplicitCastExpr *CE, clang::ento::CheckerContext &C) const {
     if (!(clang::CStyleCastExpr::classof(CE) || clang::CXXConstCastExpr::classof(CE)))
       return;
-      auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
-      while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P))
-             && C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P))
-      {
-             P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
-      }
-      if (isa<AttributedStmt>(P)) {
-        const AttributedStmt * AS = dyn_cast_or_null<AttributedStmt>(P);
-        if ( AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())) )
-          return;
-      }
-      if (isa<DeclStmt>(P)) {
-        const DeclStmt * DS = dyn_cast_or_null<DeclStmt>(P);
-        if ( DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())) )
-          return;
-      }
+    auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
+    while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
+           C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P)) {
+      P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
+    }
+    if (isa<AttributedStmt>(P)) {
+      const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(P);
+      if (AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())))
+        return;
+    }
+    if (isa<DeclStmt>(P)) {
+      const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
+      if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
+                 hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
+        return;
+    }
 
     const Expr *SE = CE->getSubExpr();
     const CXXRecordDecl *CRD = nullptr;

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include <clang/AST/ExprCXX.h>
 #include <clang/AST/Attr.h>
+#include <clang/AST/ParentMap.h>
 
 #include <memory>
 
@@ -22,6 +23,23 @@ namespace clangcms {
   void ConstCastAwayChecker::checkPreStmt(const clang::ExplicitCastExpr *CE, clang::ento::CheckerContext &C) const {
     if (!(clang::CStyleCastExpr::classof(CE) || clang::CXXConstCastExpr::classof(CE)))
       return;
+      auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
+      while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P))
+             && C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P))
+      {
+             P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
+      }
+      if (isa<AttributedStmt>(P)) {
+        const AttributedStmt * AS = dyn_cast_or_null<AttributedStmt>(P);
+        if ( AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())) )
+          return;
+      }
+      if (isa<DeclStmt>(P)) {
+        const DeclStmt * DS = dyn_cast_or_null<DeclStmt>(P);
+        if ( DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())) )
+          return;
+      }
+
     const Expr *SE = CE->getSubExpr();
     const CXXRecordDecl *CRD = nullptr;
     std::string cname;

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -20,22 +20,22 @@ using namespace llvm;
 namespace clangcms {
 
   void ConstCastChecker::checkPreStmt(const clang::CXXConstCastExpr *CE, clang::ento::CheckerContext &C) const {
-      auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
-      while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P))
-             && C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P))
-      {
-             P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
-      }
-      if (isa<AttributedStmt>(P)) {
-        const AttributedStmt * AS = dyn_cast_or_null<AttributedStmt>(P);
-        if ( AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs() ) ) )
-          return;
-      }
-      if (isa<DeclStmt>(P)) {
-        const DeclStmt * DS = dyn_cast_or_null<DeclStmt>(P);
-        if ( DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
-          return;
-      }
+    auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
+    while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
+           C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P)) {
+      P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
+    }
+    if (isa<AttributedStmt>(P)) {
+      const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(P);
+      if (AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())))
+        return;
+    }
+    if (isa<DeclStmt>(P)) {
+      const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
+      if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
+                 hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
+        return;
+    }
 
     const Expr *SE = CE->getSubExprAsWritten();
     const CXXRecordDecl *CRD = nullptr;

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -6,6 +6,7 @@
 
 #include <clang/AST/Attr.h>
 #include <clang/AST/ExprCXX.h>
+#include <clang/AST/ParentMap.h>
 
 #include <memory>
 
@@ -19,6 +20,23 @@ using namespace llvm;
 namespace clangcms {
 
   void ConstCastChecker::checkPreStmt(const clang::CXXConstCastExpr *CE, clang::ento::CheckerContext &C) const {
+      auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
+      while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P))
+             && C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P))
+      {
+             P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
+      }
+      if (isa<AttributedStmt>(P)) {
+        const AttributedStmt * AS = dyn_cast_or_null<AttributedStmt>(P);
+        if ( AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs() ) ) )
+          return;
+      }
+      if (isa<DeclStmt>(P)) {
+        const DeclStmt * DS = dyn_cast_or_null<DeclStmt>(P);
+        if ( DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
+          return;
+      }
+
     const Expr *SE = CE->getSubExprAsWritten();
     const CXXRecordDecl *CRD = nullptr;
     std::string cname;


### PR DESCRIPTION
This adds a veto on ConstCastChecker and ConstCastAwayChecker using the CMS_THREAD_SAFETY or CMS_SA_ALLOW attributes at the beginning of statements using const_cast or casting const away.

For example 

```
--- a/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
+++ b/FWCore/Framework/src/EventSetupRecordIntervalFinder.cc
@@ -12,6 +12,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include <cassert>
 #include <mutex>
 
@@ -67,7 +68,7 @@ namespace edm {
   std::set<EventSetupRecordKey> EventSetupRecordIntervalFinder::findingForRecords() const {
     if (intervals_.empty()) {
       //we are delaying our reading
-      const_cast<EventSetupRecordIntervalFinder*>(this)->delaySettingRecords();
+      CMS_SA_ALLOW const_cast<EventSetupRecordIntervalFinder*>(this)->delaySettingRecords();
     }

```
removes the warning about the use of const_cast.

Tested locally.