### PR TITLE
Fix for TTRHBuilders with PixelCPEFast

### DIFF
--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -7,7 +7,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4MixedTriplets_cfi impor
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
-from RecoLocalTracker.SiPixelRecHits.PixelCPEFastESProducer_cfi import *
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import pixelCPEFastESProducer as PixelCPEFastESProducer
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *


### PR DESCRIPTION
#### PR description:

Running the just merged #38761 on top of the latest IB (`CMSSW_12_6_X_2022-11-30-1100`) I noticed that the combination of https://github.com/cms-sw/cmssw/pull/40003 and https://github.com/cms-sw/cmssw/pull/38761 makes `RECO` steps fail with:

```bash
  File "/data/user/adiflori/fix/src/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py", line 10, in <module>
    from RecoLocalTracker.SiPixelRecHits.PixelCPEFastESProducer_cfi import *
ModuleNotFoundError: No module named 'RecoLocalTracker.SiPixelRecHits.PixelCPEFastESProducer_cfi'
```

This was not spotted as a conflict because `TTRHBuilders_cff.py` was not modified by #38761 and did not show up in the tests because #40003 was included in the IBs just after the last [tests](https://github.com/cms-sw/cmssw/pull/38761#issuecomment-1312503337) were launched for #38761.

This tiny PR fix the discrepancy.

#### PR validation:

`runTheMatrix.py -w upgrade -l 11634.* -t 8` run