### PR TITLE
provide a record for `cond::BasicPayload`

### DIFF
--- a/CondCore/BasicCondPlugins/BuildFile.xml
+++ b/CondCore/BasicCondPlugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="CondCore/ESSources"/>
+<use name="CondFormats/Common"/>
+<use name="CondFormats/DataRecord"/>
+<flags EDM_PLUGIN="1"/>

--- a/CondCore/BasicCondPlugins/src/plugin.cc
+++ b/CondCore/BasicCondPlugins/src/plugin.cc
@@ -1,0 +1,14 @@
+/*
+ *  plugin.cc
+ *  CMSSW
+ *
+ *  Created by Marco Musich on 30/11/2022.
+ *
+ */
+
+#include "CondCore/ESSources/interface/registration_macros.h"
+#include "CondFormats/DataRecord/interface/BasicPayloadRcd.h"
+#include "CondFormats/Common/interface/BasicPayload.h"
+#include "CondCore/CondDB/interface/Serialization.h"
+
+REGISTER_PLUGIN(BasicPayloadRcd, cond::BasicPayload);

--- a/CondFormats/Common/src/T_EventSetup_BasicPayload.cc
+++ b/CondFormats/Common/src/T_EventSetup_BasicPayload.cc
@@ -1,0 +1,7 @@
+// system include files
+
+// user include files
+#include "CondFormats/Common/interface/BasicPayload.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(cond::BasicPayload);

--- a/CondFormats/DataRecord/interface/BasicPayloadRcd.h
+++ b/CondFormats/DataRecord/interface/BasicPayloadRcd.h
@@ -1,0 +1,8 @@
+#ifndef DataRecord_BasicPayloadRcd_h
+#define DataRecord_BasicPayloadRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class BasicPayloadRcd : public edm::eventsetup::EventSetupRecordImplementation<BasicPayloadRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/BasicPayloadRcd.cc
+++ b/CondFormats/DataRecord/src/BasicPayloadRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/BasicPayloadRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(BasicPayloadRcd);


### PR DESCRIPTION
#### PR description:

This PR is purely technical, it adds a "navigation school" record to for the payloads of type  `cond::BasicPayload` in order to be able to play with them in the Conditions DB browser, e.g. for queueing / creating `GlobalTag` with them, in order to avoid using instead records used in production.
No regressions expected anywhere.

#### PR validation:

None, `cmssw` compiles. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A (not needed)



