### PR TITLE
Phase2-hgx333 Bug fix for invalid DetID declaration for SimHits n V16/V17 geometry versions of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalTypes.h
+++ b/Geometry/HGCalCommonData/interface/HGCalTypes.h
@@ -84,7 +84,7 @@ public:
   static constexpr std::array<int, 3> edgeWaferLDThree = {{1, -2, -15}};
   static constexpr std::array<int, 3> edgeWaferHDTop = {{1, 0, 9}};
   static constexpr std::array<int, 3> edgeWaferHDBottom = {{-1, 0, -10}};
-  static constexpr std::array<int, 3> edgeWaferHDLeft = {{-1, 2, 4}};
+  static constexpr std::array<int, 3> edgeWaferHDLeft = {{-1, 2, 5}};
   static constexpr std::array<int, 3> edgeWaferHDRight = {{1, -2, -18}};
   static constexpr std::array<int, 3> edgeWaferHDFive = {{-1, 2, 18}};
 

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -532,7 +532,8 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
 #endif
   if (itr == hgpar_->typesInLayers_.end()) {
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferIndex";
+    edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV
+                                  << " in wadferIndex";
 #endif
     return false;
   }
@@ -545,7 +546,8 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
 #endif
     if (ktr == hgpar_->waferInfoMap_.end()) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferInfoMap";
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV
+                                    << " in wadferInfoMap";
 #endif
       return false;
     }
@@ -556,7 +558,8 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
 #endif
     if (!(jtr->second)) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferIn";
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV
+                                    << " in wadferIn";
 #endif
       return false;
     }
@@ -568,17 +571,19 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
       if (hgpar_->waferMaskMode_ > 0) {
         if (ktr->second.first == HGCalTypes::WaferOut) {
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " due to WaferOut";
+          edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV
+                                        << " due to WaferOut";
 #endif
           return false;
-	}
+        }
       } else {
         if (ktr->second.first < HGCalTypes::WaferCornerMin) {
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " due to WaferCornerMin";
+          edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV
+                                        << " due to WaferCornerMin";
 #endif
           return false;
-	}
+        }
       }
     }
   }
@@ -605,13 +610,15 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
   if (mode_ != HGCalGeometryMode::Hexagon8Cassette) {
     if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N)) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 1 condition " << cellU << ":" << cellV << ":" << N;
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 1 condition " << cellU << ":" << cellV
+                                    << ":" << N;
 #endif
       return false;
     }
     if (((cellV - cellU) >= N) || ((cellU - cellV) > N)) {
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 2 condition " << cellU << ":" << cellV << ":" << N;
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 2 condition " << cellU << ":" << cellV
+                                    << ":" << N;
 #endif
       return false;
     }
@@ -1919,7 +1926,8 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, int cellU,
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Input " << lay << ":" << ll << ":" << waferU << ":" << waferV << ":" << cellU
                                   << ":" << cellV << " Position " << x << ":" << y << ":" << rr << " Compare Limits "
-                                  << hgpar_->rMinLayHex_[ll] << ":" << hgpar_->rMaxLayHex_[ll] << " Flag " << result << " from Radius Limits";
+                                  << hgpar_->rMinLayHex_[ll] << ":" << hgpar_->rMaxLayHex_[ll] << " Flag " << result
+                                  << " from Radius Limits";
 #endif
     if (result && waferHexagon8File()) {
       int N = (type == 0) ? hgpar_->nCellsFine_ : hgpar_->nCellsCoarse_;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -530,8 +530,12 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
   edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants::isValidHex8:WaferType " << layer << ":" << modU << ":" << modV
                                 << ":" << indx << " Test " << (itr != hgpar_->typesInLayers_.end());
 #endif
-  if (itr == hgpar_->typesInLayers_.end())
+  if (itr == hgpar_->typesInLayers_.end()) {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferIndex";
+#endif
     return false;
+  }
 
   if (fullAndPart_) {
     auto ktr = hgpar_->waferInfoMap_.find(indx);
@@ -539,26 +543,42 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, bool fullAndP
     edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants::isValidHex8:WaferInfoMap " << layer << ":" << modU << ":"
                                   << modV << ":" << indx << " Test " << (ktr != hgpar_->waferInfoMap_.end());
 #endif
-    if (ktr == hgpar_->waferInfoMap_.end())
+    if (ktr == hgpar_->waferInfoMap_.end()) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferInfoMap";
+#endif
       return false;
+    }
   } else {
     auto jtr = waferIn_.find(indx);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants::isValidHex8:WaferIn " << jtr->first << ":" << jtr->second;
 #endif
-    if (!(jtr->second))
+    if (!(jtr->second)) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " in wadferIn";
+#endif
       return false;
+    }
   }
 
   if (fullAndPart || fullAndPart_) {
     auto ktr = hgpar_->waferTypes_.find(indx);
     if (ktr != hgpar_->waferTypes_.end()) {
       if (hgpar_->waferMaskMode_ > 0) {
-        if (ktr->second.first == HGCalTypes::WaferOut)
+        if (ktr->second.first == HGCalTypes::WaferOut) {
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " due to WaferOut";
+#endif
           return false;
+	}
       } else {
-        if (ktr->second.first < HGCalTypes::WaferCornerMin)
+        if (ktr->second.first < HGCalTypes::WaferCornerMin) {
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot find " << layer << ":" << modU << ":" << modV << " due to WaferCornerMin";
+#endif
           return false;
+	}
       }
     }
   }
@@ -582,11 +602,20 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
                                 << " Tests " << (cellU >= 0) << ":" << (cellU < 2 * N) << ":" << (cellV >= 0) << ":"
                                 << (cellV < 2 * N) << ":" << ((cellV - cellU) < N) << ":" << ((cellU - cellV) <= N);
 #endif
-  if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N))
-    return false;
-  if (((cellV - cellU) >= N) || ((cellU - cellV) > N))
-    return false;
-
+  if (mode_ != HGCalGeometryMode::Hexagon8Cassette) {
+    if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N)) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 1 condition " << cellU << ":" << cellV << ":" << N;
+#endif
+      return false;
+    }
+    if (((cellV - cellU) >= N) || ((cellU - cellV) > N)) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 2 condition " << cellU << ":" << cellV << ":" << N;
+#endif
+      return false;
+    }
+  }
   return isValidCell8(layer, modU, modV, cellU, cellV, type);
 }
 
@@ -1851,7 +1880,7 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, int cellU,
     result = HGCalWaferMask::goodCell(cellU, cellV, partn.first);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Input " << lay << ":" << waferU << ":" << waferV << ":" << cellU << ":" << cellV
-                                  << " Result " << result;
+                                  << " Result " << result << " from goodCell";
 #endif
   } else {
     float x(0), y(0);
@@ -1885,11 +1914,12 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, int cellU,
 #endif
     double rr = sqrt(x * x + y * y);
     int ll = lay - hgpar_->firstLayer_;
-    result = ((rr >= hgpar_->rMinLayHex_[ll]) && (rr <= hgpar_->rMaxLayHex_[ll]));
+    double tol = waferHexagon8File() ? 0.5 : 0.0;
+    result = (((rr + tol) >= hgpar_->rMinLayHex_[ll]) && (rr <= hgpar_->rMaxLayHex_[ll]));
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Input " << lay << ":" << ll << ":" << waferU << ":" << waferV << ":" << cellU
                                   << ":" << cellV << " Position " << x << ":" << y << ":" << rr << " Compare Limits "
-                                  << hgpar_->rMinLayHex_[ll] << ":" << hgpar_->rMaxLayHex_[ll] << " Flag " << result;
+                                  << hgpar_->rMinLayHex_[ll] << ":" << hgpar_->rMaxLayHex_[ll] << " Flag " << result << " from Radius Limits";
 #endif
     if (result && waferHexagon8File()) {
       int N = (type == 0) ? hgpar_->nCellsFine_ : hgpar_->nCellsCoarse_;
@@ -1897,7 +1927,7 @@ bool HGCalDDDConstants::isValidCell8(int lay, int waferU, int waferV, int cellU,
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "Input " << lay << ":" << waferU << ":" << waferV << ":" << cellU << ":" << cellV
                                     << " N " << N << " part " << partn.first << ":" << partn.second << " Result "
-                                    << result;
+                                    << result << " from goodCell";
 #endif
     }
   }

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -312,7 +312,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           int u2 = ((u + 1) / 2);
           good = ((v - u2) >= (3 * n4 - 1));
           break;
-        } 
+        }
         case (HGCalTypes::WaferCorner3): {
           good = ((u + v) >= (5 * n2 - 1));
           break;

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -120,30 +120,30 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
       switch (rotn) {
         case (HGCalTypes::WaferCorner0): {
           int u2 = u / 2;
-          good = ((v - u2) < n);
+          good = ((v - u2) <= n);
           break;
         }
         case (HGCalTypes::WaferCorner1): {
-          good = ((v + u) < (3 * n - 1));
+          good = ((v + u) < (3 * n));
           break;
         }
         case (HGCalTypes::WaferCorner2): {
           int v2 = (v + 1) / 2;
-          good = ((u - v2) < n);
+          good = ((u - v2) <= n);
           break;
         }
         case (HGCalTypes::WaferCorner3): {
-          int u2 = (u + 1) / 2;
+          int u2 = (u - 1) / 2;
           good = (u2 <= v);
           break;
         }
         case (HGCalTypes::WaferCorner4): {
-          good = ((v + u) >= n);
+          good = ((v + u) >= n - 1);
           break;
         }
         default: {
           int v2 = v / 2;
-          good = (u > v2);
+          good = (u >= v2);
           break;
         }
       }
@@ -168,7 +168,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner4): {
-          good = (u >= n2);
+          good = (u >= n2 - 1);
           break;
         }
         default: {
@@ -185,7 +185,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner1): {
-          good = (u < (5 * n4));
+          good = (u <= (5 * n4));
           break;
         }
         case (HGCalTypes::WaferCorner2): {
@@ -193,7 +193,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner3): {
-          good = (v >= (3 * n4));
+          good = (v >= (3 * n4 - 1));
           break;
         }
         case (HGCalTypes::WaferCorner4): {
@@ -201,7 +201,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         default: {
-          good = ((v - u) < n4);
+          good = ((v - u) <= n4);
           break;
         }
       }
@@ -214,7 +214,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner1): {
-          good = (u < n);
+          good = (u <= n);
           break;
         }
         case (HGCalTypes::WaferCorner2): {
@@ -222,7 +222,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner3): {
-          good = (v >= n);
+          good = (v >= n - 1);
           break;
         }
         case (HGCalTypes::WaferCorner4): {
@@ -230,7 +230,7 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         default: {
-          good = (u > v);
+          good = (u >= v);
           break;
         }
       }
@@ -301,28 +301,28 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
     case (HGCalTypes::WaferSemi2): {  //WaferSemi2
       switch (rotn) {
         case (HGCalTypes::WaferCorner0): {
-          good = ((u + v) < (4 * n3));
+          good = ((u + v) <= (4 * n3 + 1));
           break;
         }
         case (HGCalTypes::WaferCorner1): {
-          good = ((2 * u - v) < n2);
+          good = ((2 * u - v) <= n2);
           break;
         }
         case (HGCalTypes::WaferCorner2): {
           int u2 = ((u + 1) / 2);
-          good = ((v - u2) >= (3 * n4));
+          good = ((v - u2) >= (3 * n4 - 1));
           break;
-        }
+        } 
         case (HGCalTypes::WaferCorner3): {
-          good = ((u + v) >= (5 * n2));
+          good = ((u + v) >= (5 * n2 - 1));
           break;
         }
         case (HGCalTypes::WaferCorner4): {
-          good = ((2 * u - v) > (3 * n2));
+          good = ((2 * u - v) >= (3 * n2));
           break;
         }
         default: {
-          int u2 = ((n == 8) ? ((u + 1) / 2) : (u / 2));
+          int u2 = (u + 1) / 2;
           good = ((v - u2) < n4);
           break;
         }
@@ -365,19 +365,19 @@ bool HGCalWaferMask::goodCell(int u, int v, int n, int type, int rotn) {
           break;
         }
         case (HGCalTypes::WaferCorner1): {
-          good = (u < (3 * n4));
+          good = (u <= (3 * n4));
           break;
         }
         case (HGCalTypes::WaferCorner2): {
-          good = ((v - u) >= n4);
+          good = ((v - u) >= n4 - 1);
           break;
         }
         case (HGCalTypes::WaferCorner3): {
-          good = (v >= (5 * n4));
+          good = (v >= (5 * n4 - 1));
           break;
         }
         case (HGCalTypes::WaferCorner4): {
-          good = (u >= (5 * n4));
+          good = (u >= (5 * n4 - 1));
           break;
         }
         default: {


### PR DESCRIPTION
#### PR description:

Bug fix for invalid DetID declaration for SimHits n V16/V17 geometry versions of HGCal

#### PR validation:

Use test scripts in #40168 to verify that the new validity checks pass all SimHit ID's of V16 and V17 geometries of HGCal. This is the best possible validation of the correction made to the code. Running the code testHGCalSimSingleMuonPt100_cfg.py from Validation/HGCalValidation/scripts after activating the  printout option yielded 2218 | 542 cells with validity flag 0 for V16 | V17 geometries in the original version and after the correction, both the geometries yielded 0 such cells indicating that all SimHit cells now pass the validity tests 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Need to be back ported to earlier CMSSW versions