### PR TITLE
[LTO] Add default initialization to fix LTO build warnings

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericBase.h
@@ -13,23 +13,23 @@ public:
     // individual pixel signals. It should be applied to all pixels in the
     // cluster [signal_i = fminf(signal_i, pixmax)] before the column and row
     // sums are made. Morris
-    int pixmx;
+    int pixmx{};
 
     // These are errors predicted by PIXELAV
-    float sigmay;  // CPE Generic y-error for multi-pixel cluster
-    float sigmax;  // CPE Generic x-error for multi-pixel cluster
-    float sy1;     // CPE Generic y-error for single single-pixel
-    float sy2;     // CPE Generic y-error for single double-pixel cluster
-    float sx1;     // CPE Generic x-error for single single-pixel cluster
-    float sx2;     // CPE Generic x-error for single double-pixel cluster
+    float sigmay{};  // CPE Generic y-error for multi-pixel cluster
+    float sigmax{};  // CPE Generic x-error for multi-pixel cluster
+    float sy1{};     // CPE Generic y-error for single single-pixel
+    float sy2{};     // CPE Generic y-error for single double-pixel cluster
+    float sx1{};     // CPE Generic x-error for single single-pixel cluster
+    float sx2{};     // CPE Generic x-error for single double-pixel cluster
 
     // These are irradiation bias corrections
-    float deltay;  // CPE Generic y-bias for multi-pixel cluster
-    float deltax;  // CPE Generic x-bias for multi-pixel cluster
-    float dy1;     // CPE Generic y-bias for single single-pixel cluster
-    float dy2;     // CPE Generic y-bias for single double-pixel cluster
-    float dx1;     // CPE Generic x-bias for single single-pixel cluster
-    float dx2;     // CPE Generic x-bias for single double-pixel cluster
+    float deltay{};  // CPE Generic y-bias for multi-pixel cluster
+    float deltax{};  // CPE Generic x-bias for multi-pixel cluster
+    float dy1{};     // CPE Generic y-bias for single single-pixel cluster
+    float dy2{};     // CPE Generic y-bias for single double-pixel cluster
+    float dx1{};     // CPE Generic x-bias for single single-pixel cluster
+    float dx2{};     // CPE Generic x-bias for single double-pixel cluster
   };
 
   PixelCPEGenericBase(edm::ParameterSet const& conf,


### PR DESCRIPTION
Add the default initialization for `ClusterParamGeneric` data members to avoid the build warnings we are getting in the LTO IBs
```
  RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc:223:21: warning: 'cp.sx2' may be used uninitialized [-Wmaybe-uninitialized]
   223 |     g.sx2 = toMicron(cp.sx2);
      |                     ^
RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc:185:25: note: 'cp' declared here
  185 |     ClusterParamGeneric cp;
      |                         ^
  RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc:224:34: warning: 'cp.sy1' may be used uninitialized [-Wmaybe-uninitialized]
   224 |     g.sy1 = std::max(21, toMicron(cp.sy1));  // for some angles sy1 is very small
      |                                  ^
RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc:185:25: note: 'cp' declared here
  185 |     ClusterParamGeneric cp;
      |                         ^

```