### PR TITLE
[12_6_X] Add missing dependence on DataFormats/MuonReco

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
+++ b/RecoLocalMuon/GEMCSCSegment/test/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/MuonReco"/>
 <use name="DataFormats/GEMRecHit"/>
 <use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="Geometry/GEMGeometry"/>


### PR DESCRIPTION
#### PR description:

Backport of #40166 (with the same branch) to 12_6_X (in case we'd have a need to run UBSAN there).

#### PR validation:

None beyond #40166