### PR TITLE
[LTO] Fix uninitialized variable warning from PixelTrackFitting

### DIFF
--- a/CommonTools/Utils/interface/DynArray.h
+++ b/CommonTools/Utils/interface/DynArray.h
@@ -88,8 +88,8 @@ namespace dynarray {
 #define unInitDynArray(T, n, x)                                                \
   alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \
   DynArray<T> x(x##_storage)
-#define declareDynArray(T, n, x)                                               \
-  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \
+#define declareDynArray(T, n, x)                                                 \
+  alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]{}; \
   DynArray<T> x(x##_storage, n)
 #define initDynArray(T, n, x, i)                                               \
   alignas(alignof(T)) unsigned char x##_storage[sizeof(T) * dynarray::num(n)]; \


### PR DESCRIPTION
This fixes the last remaining LTO IBs warnings.

[a]
```
  RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h:100:14: warning: 'r_storage.26_571' may be used uninitialized [-Wmaybe-uninitialized]
   100 |     linearFit(r.data(), z.data(), n, errZ2.data(), cotTheta_, intercept_, covss_, covii_, covsi_);
      |              ^
RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc: In member function 'run':
CommonTools/Statistics/interface/LinearFit.h:29:6: note: by argument 1 of type 'const float *' to 'linearFit' declared here
   29 | void linearFit(T const* __restrict__ x,
      |      ^
In member function 'calculate',
    inlined from '__ct ' at RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h:45:14,
    inlined from 'run' at RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc:159:43:
  RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h:100:14: warning: 'z_storage.27_192' may be used uninitialized [-Wmaybe-uninitialized]
   100 |     linearFit(r.data(), z.data(), n, errZ2.data(), cotTheta_, intercept_, covss_, covii_, covsi_);
```