### PR TITLE
Avoid CPE Fast ES Producers Renaming

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -10,9 +10,8 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 # 2. Pixel Generic CPE
 #
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
-from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import pixelCPEFastESProducer as PixelCPEFastESProducer
-#from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase1_cfi import pixelCPEFastESProducerPhase1 as PixelCPEFastESProducerPhase1
-from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase2_cfi import pixelCPEFastESProducerPhase2 as PixelCPEFastESProducerPhase2
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import *
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase2_cfi import *
 #
 # 3. ESProducer for the Magnetic-field dependent template records
 #

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -7,7 +7,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4MixedTriplets_cfi impor
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
-from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import pixelCPEFastESProducer as PixelCPEFastESProducer
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *


### PR DESCRIPTION
Following https://github.com/cms-sw/cmssw/pull/40206#discussion_r1036618794 this PR fix the issue of `PixelCPEFastESProducer`s renaming. 


#### PR Validation

Tested with `runTheMatrix.py -w upgrade -l 20834.501 -t 8`, `runTheMatrix.py -w upgrade -l 11634.501 -t 8` and with the [gist](https://gist.github.com/mmusich/1bbb30be65b0a28aee6e6d60ea0ca5b5) from #40003 by @mmusich.

@makortel 