### PR TITLE
Update SiPixel bad components in Run 3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -80,9 +80,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '125X_mcRun4_realistic_v5'
 }


### PR DESCRIPTION
#### PR description:

This PR updates the SiPixel bad component tags in the Run 3 realistic MC GTs, requested in https://cms-talk.web.cern.ch/t/mc-gt-updating-sipixel-bad-components-for-2023-2024/17736.
The tags updated are:

- `SiPixelQuality_phase1_2023_v4_mc`
For 2023 realistic GT
- `SiPixelQuality_forDigitizer_phase1_2023_v4_mc`  with label `forDigitizer`
For 2023 realistic GT
- `SiPixelQuality_phase1_2024_v4_mc`
For 2024 realistic GT
- `SiPixelQuality_forDigitizer_phase1_2024_v4_mc` with label `forDigitizer`
For 2024 realistic GT

The new GTs and their diff wrt to the last GTs in autoCond are here:
**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v1/125X_mcRun3_2023_realistic_v5
**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v1/125X_mcRun3_2024_realistic_v5

#### PR validation:
```
test parameters:
  - workflows = 12434.0,12834.0
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and No backport needed.
