### PR TITLE
Make propagation failure state available in steering code

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -22,7 +22,7 @@ SRCS := $(wildcard ${CMS_DIR}/src/*.cc) $(wildcard ${SACMS}/*.cc)
 ifdef WITH_ROOT
 SRCS += ${SACMS}/tkNtuple/WriteMemoryFile.cc
 DictsDict.cc ${DICTPCM}: ${SACMS}/tkNtuple/DictsLinkDef.h
-	rootcint -v3 -f $@ $<
+	rootcint -v3 -f DictsDict.cc $<
 	mv DictsDict_rdict.pcm ${DICTPCM}
 endif
 SRCB := $(notdir ${SRCS})

--- a/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
+++ b/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
@@ -138,7 +138,7 @@ namespace mkfit {
       const auto label = tkcand.label();
       TrackExtra extra(label);
 
-      // track_print(tkcand, "XXX");
+      // track_print(event, tkcand, "quality_process -> track_print:");
 
       // access temp seed trk and set matching seed hits
       const auto &seed = event->seedTracks_[itrack];

--- a/RecoTracker/MkFitCore/interface/Config.h
+++ b/RecoTracker/MkFitCore/interface/Config.h
@@ -3,18 +3,22 @@
 
 namespace mkfit {
 
-  enum PropagationFlagsEnum { PF_none = 0, PF_use_param_b_field = 0x1, PF_apply_material = 0x2 };
+  enum PropagationFlagsEnum { PF_none = 0, PF_use_param_b_field = 0x1, PF_apply_material = 0x2,
+                              PF_copy_input_state_on_fail = 0x4 };
 
   struct PropagationFlags {
     bool use_param_b_field : 1;
     bool apply_material : 1;
+    bool copy_input_state_on_fail : 1;
     // Could add: bool use_trig_approx       -- now Config::useTrigApprox = true
     // Could add: int  n_prop_to_r_iters : 8 -- now Config::Niter = 5
 
-    PropagationFlags() : use_param_b_field(false), apply_material(false) {}
+    PropagationFlags() : use_param_b_field(false), apply_material(false), copy_input_state_on_fail(false) {}
 
     PropagationFlags(int pfe)
-        : use_param_b_field(pfe & PF_use_param_b_field), apply_material(pfe & PF_apply_material) {}
+        : use_param_b_field(pfe & PF_use_param_b_field),
+        apply_material(pfe & PF_apply_material),
+        copy_input_state_on_fail(pfe & PF_copy_input_state_on_fail) {}
   };
 
   class PropagationConfig {
@@ -82,7 +86,7 @@ namespace mkfit {
 
     // Config for propagation - could/should enter into PropagationFlags?!
     constexpr int Niter = 5;
-    constexpr bool useTrigApprox = true;
+    constexpr bool useTrigApprox = false;
 
     // Config for Bfield. Note: for now the same for CMS-phase1 and CylCowWLids.
     constexpr float Bfield = 3.8112;

--- a/RecoTracker/MkFitCore/interface/TrackerInfo.h
+++ b/RecoTracker/MkFitCore/interface/TrackerInfo.h
@@ -7,7 +7,7 @@
 
 namespace mkfit {
 
-  enum WithinSensitiveRegion_e { WSR_Undef = -1, WSR_Inside = 0, WSR_Edge, WSR_Outside };
+  enum WithinSensitiveRegion_e { WSR_Undef = -1, WSR_Inside = 0, WSR_Edge, WSR_Outside, WSR_Failed };
 
   struct WSR_Result {
     // Could also store XHitSize count equivalent here : 16;

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -9,11 +9,11 @@ namespace mkfit {
 
 #define COMPUTE_CHI2_ARGS                                                                                    \
   const MPlexLS &, const MPlexLV &, const MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLV &, \
-      const int, const PropagationFlags, const bool
+      MPlexQI &, const int, const PropagationFlags, const bool
 
-#define UPDATE_PARAM_ARGS                                                                                         \
-  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, const int, \
-      const PropagationFlags, const bool
+#define UPDATE_PARAM_ARGS                                                                              \
+  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, \
+      MPlexQI &, const int, const PropagationFlags, const bool
 
   class FindingFoos {
   public:

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -477,6 +477,7 @@ namespace mkfit {
                                 const MPlexHV& msPar,
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
+                                MPlexQI& outFailFlag,
                                 const int N_proc,
                                 const PropagationFlags propFlags,
                                 const bool propToHit) {
@@ -489,7 +490,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperation(
           KFO_Update_Params | KFO_Local_Cov, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
@@ -524,6 +525,7 @@ namespace mkfit {
                                      const MPlexHV& msPar,
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
+                                     MPlexQI& outFailFlag,
                                      const int N_proc,
                                      const PropagationFlags propFlags,
                                      const bool propToHit) {
@@ -536,7 +538,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperation(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {
@@ -743,6 +745,7 @@ namespace mkfit {
                                       const MPlexHV& msPar,
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
+                                      MPlexQI& outFailFlag,
                                       const int N_proc,
                                       const PropagationFlags propFlags,
                                       const bool propToHit) {
@@ -755,7 +758,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationEndcap(KFO_Update_Params, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
@@ -788,6 +791,7 @@ namespace mkfit {
                                            const MPlexHV& msPar,
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
+                                           MPlexQI& outFailFlag,
                                            const int N_proc,
                                            const PropagationFlags propFlags,
                                            const bool propToHit) {
@@ -800,7 +804,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationEndcap(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -27,6 +27,7 @@ namespace mkfit {
                                 const MPlexHV& msPar,
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
+                                MPlexQI& outFailFlag,
                                 const int N_proc,
                                 const PropagationFlags propFlags,
                                 const bool propToHit);
@@ -46,6 +47,7 @@ namespace mkfit {
                                      const MPlexHV& msPar,
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
+                                     MPlexQI& outFailFlag,
                                      const int N_proc,
                                      const PropagationFlags propFlags,
                                      const bool propToHit);
@@ -77,6 +79,7 @@ namespace mkfit {
                                       const MPlexHV& msPar,
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
+                                      MPlexQI& outFailFlag,
                                       const int N_proc,
                                       const PropagationFlags propFlags,
                                       const bool propToHit);
@@ -96,6 +99,7 @@ namespace mkfit {
                                            const MPlexHV& msPar,
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
+                                           MPlexQI& outFailFlag,
                                            const int N_proc,
                                            const PropagationFlags propFlags,
                                            const bool propToHit);

--- a/RecoTracker/MkFitCore/src/MkBase.h
+++ b/RecoTracker/MkFitCore/src/MkBase.h
@@ -33,7 +33,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = r;
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
 
     void propagateTracksToHitR(const MPlexHV& par,
@@ -46,7 +46,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(par.constAt(n, 0, 0), par.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf, noMatEffPtr);
     }
 
     //----------------------------------------------------------------------------
@@ -58,7 +58,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = z;
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
 
     void propagateTracksToHitZ(const MPlexHV& par,
@@ -71,7 +71,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = par.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf, noMatEffPtr);
     }
 
     void propagateTracksToPCAZ(const int N_proc, const PropagationFlags pf) {
@@ -85,8 +85,10 @@ namespace mkfit {
                           (1 + slope * slope);  // PCA to origin
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
+
+    void clearFailFlag() { m_FailFlag.setVal(0); }
 
     //----------------------------------------------------------------------------
 
@@ -94,6 +96,7 @@ namespace mkfit {
     MPlexLS m_Err[2];
     MPlexLV m_Par[2];
     MPlexQI m_Chg;
+    MPlexQI m_FailFlag;
   };
 
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -554,6 +554,7 @@ namespace mkfit {
 
             dcall(pre_prop_print(curr_layer, mkfndr.get()));
 
+            mkfndr->clearFailFlag();
             (mkfndr.get()->*fnd_foos.m_propagate_foo)(
                 layer_info.propagate_to(), curr_tridx, prop_config.finding_inter_layer_pflags);
 
@@ -844,6 +845,7 @@ namespace mkfit {
             //propagate to layer
             dcall(pre_prop_print(curr_layer, mkfndr.get()));
 
+            mkfndr->clearFailFlag();
             (mkfndr.get()->*fnd_foos.m_propagate_foo)(
                 layer_info.propagate_to(), end - itrack, prop_config.finding_inter_layer_pflags);
 
@@ -1072,6 +1074,7 @@ namespace mkfit {
 #endif
 
         // propagate to current layer
+        mkfndr->clearFailFlag();
         (mkfndr->*fnd_foos.m_propagate_foo)(
             layer_info.propagate_to(), end - itrack, prop_config.finding_inter_layer_pflags);
 
@@ -1350,7 +1353,7 @@ namespace mkfit {
         // ./mkFit ... | perl -ne 'if (/^BKF_OVERLAP/) { s/^BKF_OVERLAP //og; print; }' > bkf_ovlp.rtt
         printf(
             "BKF_OVERLAP event/I:label/I:prod_type/I:is_findable/I:layer/I:is_stereo/I:is_barrel/I:"
-            "pt/F:eta/F:phi/F:chi2/F:isnan/I:isfin/I:gtzero/I:hit_label/I:"
+            "pt/F:pt_cur/F:eta/F:phi/F:phi_cur/F:r_cur/F:z_cur/F:chi2/F:isnan/I:isfin/I:gtzero/I:hit_label/I:"
             "sx_t/F:sy_t/F:sz_t/F:d_xy/F:d_z/F\n");
         first = false;
       }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -398,6 +398,13 @@ namespace mkfit {
     // Vectorizing this makes it run slower!
     //#pragma omp simd
     for (int itrack = 0; itrack < N_proc; ++itrack) {
+
+      if (m_FailFlag[itrack]) {
+        m_XWsrResult[itrack].m_wsr = WSR_Failed;
+        m_XHitSize[itrack] = -1;
+        continue;
+      }
+
       if (m_XWsrResult[itrack].m_wsr == WSR_Outside) {
         m_XHitSize[itrack] = -1;
         continue;
@@ -732,6 +739,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV tmpPropPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -739,6 +747,7 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      tmpPropPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -817,6 +826,7 @@ namespace mkfit {
     // are already done when computing chi2. Not sure it's worth caching them?)
 
     dprint("update parameters");
+    clearFailFlag();
     (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                    m_Par[iP],
                                    m_Chg,
@@ -824,6 +834,7 @@ namespace mkfit {
                                    m_msPar,
                                    m_Err[iC],
                                    m_Par[iC],
+                                   m_FailFlag,
                                    N_proc,
                                    m_prop_config->finding_intra_layer_pflags,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -946,6 +957,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV propPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -953,6 +965,7 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      propPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -1000,6 +1013,7 @@ namespace mkfit {
 
       if (oneCandPassCut) {
         MPlexQI tmpChg = m_Chg;
+        clearFailFlag();
         (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                        m_Par[iP],
                                        tmpChg,
@@ -1007,6 +1021,7 @@ namespace mkfit {
                                        m_msPar,
                                        m_Err[iC],
                                        m_Par[iC],
+                                       m_FailFlag,
                                        N_proc,
                                        m_prop_config->finding_intra_layer_pflags,
                                        m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -1185,6 +1200,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV propPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -1192,19 +1208,21 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      propPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
 #pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
       for (int itrack = 0; itrack < N_proc; ++itrack) {
-        // make sure the hit was in the compatiblity window for the candidate
-
-        float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
-
-        if (hit_cnt < m_XHitSize[itrack]) {
-          // XXX-NUM-ERR assert(chi2 >= 0);
+        // We can be in failed state from the initial propagation before selectHitIndices
+        // and there hit_count for track is set to -1 and WSR state to Failed, handled below.
+        // Or we might have hit it here in propagate-to-hit.
+        if (!m_FailFlag[itrack] && hit_cnt < m_XHitSize[itrack]) {
+          // make sure the hit was in the compatiblity window for the candidate
+          const float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
           const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
+          // XXX-NUM-ERR assert(chi2 >= 0);
 
           dprint("chi2=" << chi2 << " for trkIdx=" << itrack << " hitIdx=" << m_XHitArr.At(itrack, hit_cnt, 0));
           if (chi2 < max_c2) {
@@ -1306,6 +1324,11 @@ namespace mkfit {
         fake_hit_idx = Hit::kHitMaxClusterIdx;
       }
 
+      // Override for failed propagation, this trumps all other cases.
+      if (m_XWsrResult[itrack].m_wsr == WSR_Failed) {
+        fake_hit_idx = Hit::kHitStopIdx;
+      }
+
       IdxChi2List tmpList;
       tmpList.trkIdx = m_CandIdx(itrack, 0, 0);
       tmpList.hitIdx = fake_hit_idx;
@@ -1331,6 +1354,7 @@ namespace mkfit {
   void MkFinder::updateWithLoadedHit(int N_proc, const FindingFoos &fnd_foos) {
     // See comment in MkBuilder::find_tracks_in_layer() about intra / inter flags used here
     // for propagation to the hit.
+    clearFailFlag();
     (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                    m_Par[iP],
                                    m_Chg,
@@ -1338,9 +1362,18 @@ namespace mkfit {
                                    m_msPar,
                                    m_Err[iC],
                                    m_Par[iC],
+                                   m_FailFlag,
                                    N_proc,
                                    m_prop_config->finding_inter_layer_pflags,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
+
+    for (int i = 0; i < N_proc; ++i) {
+      if (m_FailFlag[i]) {
+        printf("XXXXXXX fail in update, recovering ...\n");
+        m_Err[iC].copySlot(i, m_Err[iP]);
+        m_Par[iC].copySlot(i, m_Par[iP]);
+      }
+    }
   }
 
   //==============================================================================
@@ -1625,13 +1658,15 @@ namespace mkfit {
     float tmp_err[6] = {666, 0, 666, 0, 0, 666};
     float tmp_pos[3];
 
+    auto barrel_pf(m_prop_config->backward_fit_pflags);
+    barrel_pf.copy_input_state_on_fail = true;
+
     for (auto lp_iter = st_par.make_iterator(SteeringParams::IT_BkwFit); lp_iter.is_valid(); ++lp_iter) {
       const int layer = lp_iter.layer();
 
       const LayerOfHits &L = eventofhits[layer];
       const LayerInfo &LI = *L.layer_info();
 
-      // XXXX
 #if defined(DEBUG_BACKWARD_FIT)
       const Hit *last_hit_ptr[NN];
 #endif
@@ -1687,8 +1722,10 @@ namespace mkfit {
 
       // ZZZ Could add missing hits here, only if there are any actual matches.
 
+      clearFailFlag();
+
       if (LI.is_barrel()) {
-        propagateTracksToHitR(m_msPar, N_proc, m_prop_config->backward_fit_pflags, &no_mat_effs);
+        propagateTracksToHitR(m_msPar, N_proc, barrel_pf, &no_mat_effs);
 
         kalmanOperation(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
                         m_Err[iP],
@@ -1713,16 +1750,32 @@ namespace mkfit {
                               N_proc);
       }
 
-      //fixup invpt sign and charge
-      for (int n = 0; n < N_proc; ++n) {
-        if (m_Par[iC].At(n, 3, 0) < 0) {
-          m_Chg.At(n, 0, 0) = -m_Chg.At(n, 0, 0);
-          m_Par[iC].At(n, 3, 0) = -m_Par[iC].At(n, 3, 0);
+      //fixup for failed propagation or invpt sign and charge
+      for (int i = 0; i < N_proc; ++i) {
+        if (m_FailFlag[i] && LI.is_barrel()) {
+          // Barrel pflags are set to include PF_copy_input_state_on_fail.
+          // Endcap errors are immaterial here (relevant for fwd search), with prop error codes
+          // one could do other things.
+          // Are there also fail conditions in KalmanUpdate?
+          printf("YYYYYYYYY prop fail in bk-fit, recovering ...\n");
+          m_Err[iC].copySlot(i, m_Err[iP]);
+          m_Par[iC].copySlot(i, m_Par[iP]);
+        } else if (tmp_chi2[i] > 200 || tmp_chi2[i] < 0) {
+          printf("YYYYYYYYY chi2 fail in bk-fit, recovering ...\n");
+          // Go back to propagated state (at the current hit, the previous one is lost).
+          m_Err[iC].copySlot(i, m_Err[iP]);
+          m_Par[iC].copySlot(i, m_Par[iP]);
+        }
+        if (m_Par[iC].At(i, 3, 0) < 0) {
+          m_Chg.At(i, 0, 0) = -m_Chg.At(i, 0, 0);
+          m_Par[iC].At(i, 3, 0) = -m_Par[iC].At(i, 3, 0);
         }
       }
 
-      for (int i = 0; i < N_proc; ++i) {
 #if defined(DEBUG_BACKWARD_FIT)
+      // clang-format off
+      const char beg_cur_sep = '/'; // set to ' ' root parsable printouts
+      for (int i = 0; i < N_proc; ++i) {
         if (chiDebug && last_hit_ptr[i]) {
           TrackCand &bb = *m_TrkCand[i];
           int ti = iP;
@@ -1732,43 +1785,40 @@ namespace mkfit {
 #if defined(MKFIT_STANDALONE)
           const MCHitInfo &mchi = m_event->simHitsInfo_[last_hit_ptr[i]->mcHitID()];
 
-          printf(
-              "BKF_OVERLAP %d %d %d %d %d %d %d "
-              "%f %f %f %f %d %d %d %d "
-              "%f %f %f %f %f\n",
+          printf("BKF_OVERLAP %d %d %d %d %d %d %d "
+                 "%f%c%f %f %f%c%f %f %f %f %d %d %d %d "
+                 "%f %f %f %f %f\n",
               m_event->evtID(),
 #else
-          printf(
-              "BKF_OVERLAP %d %d %d %d %d %d "
-              "%f %f %f %f %d %d %d "
-              "%f %f %f %f %f\n",
+          printf("BKF_OVERLAP %d %d %d %d %d %d "
+                 "%f%c%f %f %f%c%f %f %f %f %d %d %d "
+                 "%f %f %f %f %f\n",
 #endif
-              bb.label(),
-              (int)bb.prodType(),
-              bb.isFindable(),
-              layer,
-              L.is_stereo(),
-              L.is_barrel(),
-              bb.pT(),
+              bb.label(), (int)bb.prodType(), bb.isFindable(),
+              layer, L.is_stereo(), L.is_barrel(),
+              bb.pT(), beg_cur_sep, 1.0f / m_Par[ti].At(i, 3, 0),
               bb.posEta(),
-              bb.posPhi(),
+              bb.posPhi(), beg_cur_sep, std::atan2(m_Par[ti].At(i, 1, 0), m_Par[ti].At(i, 0, 0)),
+              std::hypot(m_Par[ti].At(i, 0, 0), m_Par[ti].At(i, 1, 0)),
+              m_Par[ti].At(i, 2, 0),
               chi_prnt,
-              std::isnan(chi),
-              std::isfinite(chi),
-              chi > 0,
+              std::isnan(chi), std::isfinite(chi), chi > 0,
 #if defined(MKFIT_STANDALONE)
               mchi.mcTrackID(),
 #endif
-              e2s(m_Err[ti].At(i, 0, 0)),
-              e2s(m_Err[ti].At(i, 1, 1)),
-              e2s(m_Err[ti].At(i, 2, 2)),  // sx_t sy_t sz_t -- track errors
+              // The following three can get negative / prouce nans in e2s.
+              // std::abs the args for FPE hunt.
+              e2s(std::abs(m_Err[ti].At(i, 0, 0))),
+              e2s(std::abs(m_Err[ti].At(i, 1, 1))),
+              e2s(std::abs(m_Err[ti].At(i, 2, 2))),  // sx_t sy_t sz_t -- track errors
               1e4f * std::hypot(m_msPar.At(i, 0, 0) - m_Par[ti].At(i, 0, 0),
                                 m_msPar.At(i, 1, 0) - m_Par[ti].At(i, 1, 0)),  // d_xy
               1e4f * (m_msPar.At(i, 2, 0) - m_Par[ti].At(i, 2, 0))             // d_z
           );
         }
-#endif
       }
+      // clang-format on
+#endif
 
       // update chi2
       m_Chi2.add(tmp_chi2);

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -413,7 +413,7 @@ namespace mkfit {
               << " pT=" << 1. / std::abs(outPar.At(n, 3, 0)) << std::endl);
 
 #ifdef DEBUG
-      if (n < N_proc) {
+      if (debug && n < N_proc) {
         dmutex_guard;
         std::cout << n << " jacobian" << std::endl;
         printf("%5f %5f %5f %5f %5f %5f\n",
@@ -490,6 +490,7 @@ namespace mkfit {
                               const MPlexQF& msRad,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr) {
@@ -503,18 +504,17 @@ namespace mkfit {
     outPar = inPar;
 
     MPlexLL errorProp;
-    MPlexQI failFlag;
 
-    helixAtRFromIterativeCCS(inPar, inChg, msRad, outPar, errorProp, failFlag, N_proc, pflags);
+    helixAtRFromIterativeCCS(inPar, inChg, msRad, outPar, errorProp, outFailFlag, N_proc, pflags);
 
 #ifdef DEBUG
-    {
+    if (debug) {
       for (int kk = 0; kk < N_proc; ++kk) {
         dprintf("outErr before prop %d\n", kk);
         for (int i = 0; i < 6; ++i) {
           for (int j = 0; j < 6; ++j)
             dprintf("%8f ", outErr.At(kk, i, j));
-          printf("\n");
+          dprintf("\n");
         }
         dprintf("\n");
 
@@ -522,7 +522,7 @@ namespace mkfit {
         for (int i = 0; i < 6; ++i) {
           for (int j = 0; j < 6; ++j)
             dprintf("%8f ", errorProp.At(kk, i, j));
-          printf("\n");
+          dprintf("\n");
         }
         dprintf("\n");
       }
@@ -535,7 +535,7 @@ namespace mkfit {
       MPlexQF propSign;
 #pragma omp simd
       for (int n = 0; n < NN; ++n) {
-        if (n >= N_proc || (failFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0)))) {
+        if (n >= N_proc || (outFailFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0)))) {
           hitsRl(n, 0, 0) = 0.f;
           hitsXi(n, 0, 0) = 0.f;
         } else {
@@ -577,15 +577,12 @@ namespace mkfit {
      }
    */
 
-    // FIXUP BOTCHED (low pT) propagations.
-    // For now let's enforce reseting output to input for failed cases. But:
-    // - perhaps this should be optional;
-    // - alternatively, it could also be an extra output parameter;
-    // - if we pass fail outwards, we might *not* need to also reset botched output.
-    for (int i = 0; i < N_proc; ++i) {
-      if (failFlag(i, 0, 0)) {
-        outPar.copySlot(i, inPar);
-        outErr.copySlot(i, inErr);
+    if (pflags.copy_input_state_on_fail) {
+      for (int i = 0; i < N_proc; ++i) {
+        if (outFailFlag(i, 0, 0)) {
+          outPar.copySlot(i, inPar);
+          outErr.copySlot(i, inErr);
+        }
       }
     }
   }
@@ -598,6 +595,7 @@ namespace mkfit {
                               const MPlexQF& msZ,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr) {
@@ -608,16 +606,16 @@ namespace mkfit {
 
     MPlexLL errorProp;
 
-    helixAtZ(inPar, inChg, msZ, outPar, errorProp, N_proc, pflags);
+    helixAtZ(inPar, inChg, msZ, outPar, errorProp, outFailFlag, N_proc, pflags);
 
 #ifdef DEBUG
-    {
+    if (debug) {
       for (int kk = 0; kk < N_proc; ++kk) {
         dprintf("inErr %d\n", kk);
         for (int i = 0; i < 6; ++i) {
           for (int j = 0; j < 6; ++j)
             dprintf("%8f ", inErr.constAt(kk, i, j));
-          printf("\n");
+          dprintf("\n");
         }
         dprintf("\n");
 
@@ -625,7 +623,7 @@ namespace mkfit {
         for (int i = 0; i < 6; ++i) {
           for (int j = 0; j < 6; ++j)
             dprintf("%8f ", errorProp.At(kk, i, j));
-          printf("\n");
+          dprintf("\n");
         }
         dprintf("\n");
       }
@@ -666,6 +664,15 @@ namespace mkfit {
     MultHelixPropEndcap(errorProp, outErr, temp);
     MultHelixPropTranspEndcap(errorProp, temp, outErr);
 
+    if (pflags.copy_input_state_on_fail) {
+      for (int i = 0; i < N_proc; ++i) {
+        if (outFailFlag(i, 0, 0)) {
+          outPar.copySlot(i, inPar);
+          outErr.copySlot(i, inErr);
+        }
+      }
+    }
+
     // This dump is now out of its place as similarity is done with matriplex ops.
     /*
 #ifdef DEBUG
@@ -699,6 +706,7 @@ namespace mkfit {
                 const MPlexQF& msZ,
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
+                MPlexQI& outFailFlag,
                 const int N_proc,
                 const PropagationFlags pflags) {
     errorProp.setVal(0.f);
@@ -924,10 +932,29 @@ namespace mkfit {
               << " pT=" << 1. / std::abs(outPar.At(n, 3, 0)) << std::endl);
     }
 
+    // Check for errors, set fail-flag.
+    for (int n = 0; n < NN; ++n) {
+      // We propagate for alpha: mark fail when prop angle more than pi/2
+      if (std::abs(alpha[n]) > 1.57) {
+        dprintf("helixAtZ: more than quarter turn, alpha = %f\n", alpha[n]);
+        outFailFlag[n] = 1;
+      } else {
+        // Have we reached desired z? We can't know, we copy desired z to actual z.
+        // Are we close to apex? Same condition as in propToR, 12.5 deg, cos(78.5deg) = 0.2
+        float dotp = (outPar.At(n, 0, 0) * std::cos(outPar.At(n, 4, 0)) +
+                      outPar.At(n, 1, 0) * std::sin(outPar.At(n, 4, 0))) /
+                     std::hypot(outPar.At(n, 0, 0), outPar.At(n, 1, 0));
+        if (dotp < 0.2 || dotp < 0) {
+          dprintf("helixAtZ: dot product bad, dotp = %f\n", dotp);
+          outFailFlag[n] = 1;
+        }
+      }
+    }
+
 #ifdef DEBUG
 #pragma omp simd
     for (int n = 0; n < NN; ++n) {
-      if (n < N_proc) {
+      if (debug && n < N_proc) {
         dmutex_guard;
         std::cout << n << ": jacobian" << std::endl;
         printf("%5f %5f %5f %5f %5f %5f\n",

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.h
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.h
@@ -36,6 +36,7 @@ namespace mkfit {
                               const MPlexQF& msRad,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr = nullptr);
@@ -45,6 +46,7 @@ namespace mkfit {
                                        const MPlexQF& msRad,
                                        MPlexLV& outPar,
                                        MPlexLL& errorProp,
+                                       MPlexQI& outFailFlag,
                                        const int N_proc);
 
   void helixAtRFromIterativeCCS(const MPlexLV& inPar,
@@ -62,6 +64,7 @@ namespace mkfit {
                               const MPlexQF& msZ,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr = nullptr);
@@ -71,6 +74,7 @@ namespace mkfit {
                 const MPlexQF& msZ,
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
+                MPlexQI& outFailFlag,
                 const int N_proc,
                 const PropagationFlags pflags);
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -452,8 +452,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
 
   for (int n = nmin; n < nmax; ++n) {
     dprint_np(n,
-              "propagation end, dump parameters"
-                  << std::endl
+              "propagation end, dump parameters\n"
                   << "   pos = " << outPar(n, 0, 0) << " " << outPar(n, 1, 0) << " " << outPar(n, 2, 0) << "\t\t r="
                   << std::sqrt(outPar(n, 0, 0) * outPar(n, 0, 0) + outPar(n, 1, 0) * outPar(n, 1, 0)) << std::endl
                   << "   mom = " << std::cos(outPar(n, 4, 0)) / outPar(n, 3, 0) << " "
@@ -463,7 +462,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
 
 #ifdef DEBUG
   for (int n = nmin; n < nmax; ++n) {
-    if (n < N_proc) {
+    if (debug && n < N_proc) {
       dmutex_guard;
       std::cout << n << ": jacobian" << std::endl;
       printf("%5f %5f %5f %5f %5f %5f\n",

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -250,7 +250,7 @@ namespace mkfit {
       printf("Read %i seedtracks (neg value means actual reading was skipped)\n", ns);
       for (int it = 0; it < ns; it++) {
         const Track &ss = seedTracks_[it];
-        printf("  %3i q=%+i pT=%7.3f eta=% 7.3f nHits=%i label=%4i algo=%2i\n",
+        printf("  %-3i q=%+i pT=%7.3f eta=% 7.3f nHits=%i label=%4i algo=%2i\n",
                it,
                ss.charge(),
                ss.pT(),
@@ -302,7 +302,7 @@ namespace mkfit {
     printf("Read %i simtracks\n", nt);
     for (int it = 0; it < nt; it++) {
       const Track &t = simTracks_[it];
-      printf("  %3i q=%+i pT=%7.3f eta=% 7.3f nHits=%2d  label=%4d\n",
+      printf("  %-3i q=%+i pT=%7.3f eta=% 7.3f nHits=%2d  label=%4d\n",
              it,
              t.charge(),
              t.pT(),
@@ -359,7 +359,7 @@ namespace mkfit {
     printf("Read %i rectracks\n", nert);
     for (int it = 0; it < nert; it++) {
       const Track &t = cmsswTracks_[it];
-      printf("  %i with q=%+i pT=%7.3f eta=% 7.3f nHits=%2d  label=%4d algo=%2d\n",
+      printf("  %-3i with q=%+i pT=%7.3f eta=% 7.3f nHits=%2d  label=%4d algo=%2d\n",
              it,
              t.charge(),
              t.pT(),


### PR DESCRIPTION
### Changes

Added  MPlexQI MkBase::m_FailFlag (parent class of MkFinder). One has to
manually clear it when desired (before propagation).
* Now only 0 and 1 are used ... could have differnt error codes, eg.
  failed to reach, step too large, etc.

The fail-flag mplex is passed into all propagation and propaget+kalman_op
functions (barrel and endcap - there was limited handling with forced restore
for barrel propagation before, state was not visible outside).
* Are there some error states in KalmanOp? We could pass that in as well.

Added WSR_Failed as member of enum WithinSensitiveRegion_e
* Handled in selectHitIndices() and findTracksCloneEngine() -> stop the candidate.

With this we can now stop also endcap tracks when they are about to reach
apex. Until now endcap tracks went on looping. Another check done is how large
the helix angle along the step was attempted (pi/2 forces error).
* Other propToR/Z checks can be added / tried. fail codes, kamlnaOp fail

In backward fit the endcap fails are somewhat accidental -- trying to fix them
does not really help as hits are already chosen. So we only do rollback in barrel.

### Other things to check, maybe

We can probably remove "can-reach-radius" check in MkBuilder::fund_track_unroll_candidates()

Config::useTrigApprox = true now -- should we do false?
* Was causing FPE in helixAtRFromIterativeCCS_impl()
* Make iteration specific?
* Test alpha of all tracks in vector unit?

Retry backward-search with non-swapped first/second layers in the plan?
  b-tagging efficiency / resolution / number of hits
