### PR TITLE
HCAL: Modifications to the LUT validation script

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
+++ b/CaloOnlineTools/HcalOnlineDb/test/genLUT.sh
@@ -181,6 +181,7 @@ then
     mkdir -p $CondDir/$Tag/Debug
     hcalLUT merge storePrepend="$flist" outputFile=$CondDir/$Tag/${Tag}.xml
     sed -i 's:UTF-8:ISO-8859-1:g' $CondDir/$Tag/${Tag}.xml
+    sed -i 's:"no" :'\''no'\'':g' $CondDir/$Tag/${Tag}.xml
     sed -i '/^$/d' $CondDir/$Tag/${Tag}.xml
     mv *$Tag*.{xml,dat} $CondDir/$Tag/Debug
 


### PR DESCRIPTION
#### PR description:

Modifications to the HCAL LUTs validation script that explicitly check and report whether the fine grain bits in the HCAL LUTs are changing. This is to assure that we know if the fine grain bits are changing when creating a new LUT

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

This PR is not a backport. This PR updates the "service" scripts for LUTs generation and validation

<!-- Please delete the text above after you verified all points of the checklist  -->
