### PR TITLE
Update of HLT-specific MC GT for frozen "V1.4" HLT menu to "postEE" scenario [`12_4_X` only]

### DIFF
--- a/Configuration/HLT/python/autoCondHLT.py
+++ b/Configuration/HLT/python/autoCondHLT.py
@@ -38,7 +38,7 @@ hltGTs = {
     'run3_mc_FULL'           : ('124X_mcRun3_2022_realistic_forTSG_menu1p4_v1'   ,l1Menus['FULL']),
     'run3_mc_GRun'           : ('124X_mcRun3_2022_realistic_forTSG_menu1p4_v1'   ,l1Menus['GRun']),
     'run3_mc_2022v12'        : ('phase1_2022_realistic'                          ,l1Menus['2022v12']),
-    'run3_mc_2022v14'        : ('124X_mcRun3_2022_realistic_forTSG_menu1p4_v1'   ,l1Menus['2022v14']),
+    'run3_mc_2022v14'        : ('phase1_2022_realistic_postEE'                   ,l1Menus['2022v14']),
     'run3_mc_HIon'           : ('124X_mcRun3_2022_realistic_HI_forTSG_menu1p4_v1',l1Menus['HIon']),
     'run3_mc_PIon'           : ('124X_mcRun3_2022_realistic_forTSG_menu1p4_v1'   ,l1Menus['PIon']),
     'run3_mc_PRef'           : ('124X_mcRun3_2022_realistic_forTSG_menu1p4_v1'   ,l1Menus['PRef']),


### PR DESCRIPTION
#### PR description:

This PR is specific to the `12_4_X` release cycle.

It updates the HLT-specific MC GT for the frozen "V1.4" pp menu to the `auto:phase1_2022_realistic_postEE` GT introduced in #39019.

This change does not affect any workflow (not in PR tests, nor in IBs). It is done mainly to have in `autoCondHLT` the same GT that will be used with this HLT menu in central MC production (i.e. `Run3Summer22EE` campaign), see [CMSHLT-2524](https://its.cern.ch/jira/browse/CMSHLT-2524).

#### PR validation:

TSG tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A