### PR TITLE
Low pt electron seeding: optimisation for phase2

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
@@ -160,6 +160,10 @@ private:  // member data
   const double minPtThreshold_;
   const double maxPtThreshold_;
 
+  //Phase2
+  const bool isPhase2_;
+  const double barrelOnlyAbsEta_;
+
   // pow( sinh(1.65), 2. )
   static constexpr double boundary_ = 2.50746495928 * 2.50746495928;
   // pow( ele_mass, 2. )
@@ -189,7 +193,9 @@ LowPtGsfElectronSeedProducer::LowPtGsfElectronSeedProducer(const edm::ParameterS
       passThrough_(conf.getParameter<bool>("PassThrough")),
       usePfTracks_(conf.getParameter<bool>("UsePfTracks")),
       minPtThreshold_(conf.getParameter<double>("MinPtThreshold")),
-      maxPtThreshold_(conf.getParameter<double>("MaxPtThreshold")) {
+      maxPtThreshold_(conf.getParameter<double>("MaxPtThreshold")),
+      isPhase2_(conf.getParameter<bool>("isPhase2")),  
+      barrelOnlyAbsEta_(conf.getParameter<double>("barrelOnlyAbsEta")) {
   if (usePfTracks_) {
     pfTracks_ = consumes(conf.getParameter<edm::InputTag>("pfTracks"));
     hcalClusters_ = consumes(conf.getParameter<edm::InputTag>("hcalClusters"));
@@ -332,6 +338,10 @@ void LowPtGsfElectronSeedProducer::loop(const edm::Handle<std::vector<T> >& hand
   for (unsigned int itrk = 0; itrk < handle.product()->size(); itrk++) {
     edm::Ref<std::vector<T> > templatedRef(handle, itrk);  // TrackRef or PFRecTrackRef
     reco::TrackRef trackRef = getBaseRef(handle, itrk);
+
+    if (isPhase2_ && std::abs(trackRef->eta())>barrelOnlyAbsEta_) {
+      continue;
+    }
 
     if (!(trackRef->quality(reco::TrackBase::qualityByName("highPurity")))) {
       continue;
@@ -665,6 +675,8 @@ void LowPtGsfElectronSeedProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<bool>("UsePfTracks", true);
   desc.add<double>("MinPtThreshold", 1.0);
   desc.add<double>("MaxPtThreshold", 15.);
+  desc.add<bool>("isPhase2", false);
+  desc.add<double>("barrelOnlyAbsEta", 1.6);
   descriptions.add("lowPtGsfElectronSeeds", desc);
 }
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
@@ -194,7 +194,7 @@ LowPtGsfElectronSeedProducer::LowPtGsfElectronSeedProducer(const edm::ParameterS
       usePfTracks_(conf.getParameter<bool>("UsePfTracks")),
       minPtThreshold_(conf.getParameter<double>("MinPtThreshold")),
       maxPtThreshold_(conf.getParameter<double>("MaxPtThreshold")),
-      isPhase2_(conf.getParameter<bool>("isPhase2")),  
+      isPhase2_(conf.getParameter<bool>("isPhase2")),
       barrelOnlyAbsEta_(conf.getParameter<double>("barrelOnlyAbsEta")) {
   if (usePfTracks_) {
     pfTracks_ = consumes(conf.getParameter<edm::InputTag>("pfTracks"));
@@ -339,7 +339,7 @@ void LowPtGsfElectronSeedProducer::loop(const edm::Handle<std::vector<T> >& hand
     edm::Ref<std::vector<T> > templatedRef(handle, itrk);  // TrackRef or PFRecTrackRef
     reco::TrackRef trackRef = getBaseRef(handle, itrk);
 
-    if (isPhase2_ && std::abs(trackRef->eta())>barrelOnlyAbsEta_) {
+    if (isPhase2_ && std::abs(trackRef->eta()) > barrelOnlyAbsEta_) {
       continue;
     }
 

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -30,6 +30,8 @@ lowPtGsfElectronSeeds = cms.EDProducer(
     UsePfTracks = cms.bool(True),
     MinPtThreshold = cms.double(1.0),
     MaxPtThreshold = cms.double(15.),
+    isPhase2 = cms.bool(False),
+    barrelOnlyAbsEta = cms.double(1.6),
     )
 
 # Modifiers for FastSim
@@ -52,3 +54,6 @@ bParking.toModify(lowPtGsfElectronSeeds,
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(lowPtGsfElectronSeeds,MinPtThreshold = 5.0)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(lowPtGsfElectronSeeds,isPhase2 = True)


### PR DESCRIPTION
#### PR description:
Currently low pt electrons (`vector<pat::Electron>  "slimmedLowPtElectrons"`) in phase2 are reco'ed only in barrel. While trying to make tracker-driven seeds of low pt electrons, we loop over endcap tracks also, which is necessary for Phase1 but can be omitted in Phase2, because the code is setup for ECAL/HCAL only. 

This is just to speed up the Phase2 reco, and is an attempt to follow up on this issue: https://github.com/cms-sw/cmssw/issues/40231

There should be no physics change. But, in barrel/endcap transition region, some differences may show up for edge cases where the electron was in endcap tracker initially, but after a brem it bent towards barrel and the energy deposit is recorded in ECAL barrel. 

#### PR validation:
Workflow `21034.21` runs fine.