### PR TITLE
[12_4_X] Backport of adding "hcal2" DQM to "rerecoCommon" in autoDQM.py

### DIFF
--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -178,9 +178,9 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                              'PostDQMOffline',
                              '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma'],
 
-            'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
+            'rerecoCommon': ['@common+@muon+@L1TMon+@hcal+@hcal2+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps',
                              'PostDQMOffline',
-                             '@common+@muon+@L1TMon+@hcal+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
+                             '@common+@muon+@L1TMon+@hcal+@hcal2+@jetmet+@ecal+@egamma+@L1TMuon+@L1TEgamma+@ctpps'],
 
             'rerecoSingleMuon': ['@common+@muon+@hcal+@jetmet+@ecal+@egamma+@lumi+@L1TMuon+@L1TEgamma+@ctpps',
                                  'PostDQMOffline',


### PR DESCRIPTION
12_4_X  backport of https://github.com/cms-sw/cmssw/pull/40172
In view of 2022 rereco with 12_4_X, as reminded by @rvenditti 
