### PR TITLE
[RECONSTRUCTION] [LLVM 14] bitwise-instead-of-logical warnings fixed

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/trackerHitRTTI.h
+++ b/DataFormats/TrackerRecHit2D/interface/trackerHitRTTI.h
@@ -27,16 +27,16 @@ namespace trackerHitRTTI {
   inline bool isProjMono(TrackingRecHit const& hit) { return rtti(hit) == projMono || rtti(hit) == fastProjMono; }
   inline bool isProjStereo(TrackingRecHit const& hit) { return rtti(hit) == projStereo || rtti(hit) == fastProjStereo; }
   inline bool isProjected(TrackingRecHit const& hit) {
-    return ((rtti(hit) == projMono) | (rtti(hit) == projStereo)) ||
-           (rtti(hit) == fastProjMono) | (rtti(hit) == fastProjStereo);
+    return ((rtti(hit) == projMono) || (rtti(hit) == projStereo)) ||
+           (rtti(hit) == fastProjMono) || (rtti(hit) == fastProjStereo);
   }
   inline bool isMatched(TrackingRecHit const& hit) { return rtti(hit) == match || rtti(hit) == fastMatch; }
   inline bool isMulti(TrackingRecHit const& hit) { return rtti(hit) == multi; }
-  inline bool isSingleType(TrackingRecHit const& hit) { return (rtti(hit) > 0) & (rtti(hit) < 4); }
-  inline bool isFromDet(TrackingRecHit const& hit) { return (((rtti(hit) > 0) & (rtti(hit) < 6)) | (rtti(hit) == 12)); }
-  inline bool isFast(TrackingRecHit const& hit) { return (rtti(hit) > 5) & (rtti(hit) <= 9); }
+  inline bool isSingleType(TrackingRecHit const& hit) { return (rtti(hit) > 0) && (rtti(hit) < 4); }
+  inline bool isFromDet(TrackingRecHit const& hit) { return (((rtti(hit) > 0) && (rtti(hit) < 6)) || (rtti(hit) == 12)); }
+  inline bool isFast(TrackingRecHit const& hit) { return (rtti(hit) > 5) && (rtti(hit) <= 9); }
   inline bool isFromDetOrFast(TrackingRecHit const& hit) {
-    return (((rtti(hit) > 0) & (rtti(hit) < 10)) | (rtti(hit) == 12));
+    return (((rtti(hit) > 0) && (rtti(hit) < 10)) || (rtti(hit) == 12));
   }
   inline bool isTiming(TrackingRecHit const& hit) { return rtti(hit) == mipTiming; }
   inline bool isVector(TrackingRecHit const& hit) { return rtti(hit) == vector; }

--- a/DataFormats/TrackerRecHit2D/interface/trackerHitRTTI.h
+++ b/DataFormats/TrackerRecHit2D/interface/trackerHitRTTI.h
@@ -27,13 +27,15 @@ namespace trackerHitRTTI {
   inline bool isProjMono(TrackingRecHit const& hit) { return rtti(hit) == projMono || rtti(hit) == fastProjMono; }
   inline bool isProjStereo(TrackingRecHit const& hit) { return rtti(hit) == projStereo || rtti(hit) == fastProjStereo; }
   inline bool isProjected(TrackingRecHit const& hit) {
-    return ((rtti(hit) == projMono) || (rtti(hit) == projStereo)) ||
-           (rtti(hit) == fastProjMono) || (rtti(hit) == fastProjStereo);
+    return ((rtti(hit) == projMono) || (rtti(hit) == projStereo)) || (rtti(hit) == fastProjMono) ||
+           (rtti(hit) == fastProjStereo);
   }
   inline bool isMatched(TrackingRecHit const& hit) { return rtti(hit) == match || rtti(hit) == fastMatch; }
   inline bool isMulti(TrackingRecHit const& hit) { return rtti(hit) == multi; }
   inline bool isSingleType(TrackingRecHit const& hit) { return (rtti(hit) > 0) && (rtti(hit) < 4); }
-  inline bool isFromDet(TrackingRecHit const& hit) { return (((rtti(hit) > 0) && (rtti(hit) < 6)) || (rtti(hit) == 12)); }
+  inline bool isFromDet(TrackingRecHit const& hit) {
+    return (((rtti(hit) > 0) && (rtti(hit) < 6)) || (rtti(hit) == 12));
+  }
   inline bool isFast(TrackingRecHit const& hit) { return (rtti(hit) > 5) && (rtti(hit) <= 9); }
   inline bool isFromDetOrFast(TrackingRecHit const& hit) {
     return (((rtti(hit) > 0) && (rtti(hit) < 10)) || (rtti(hit) == 12));

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -96,7 +96,7 @@ namespace reco {
     float trackWeight(const TREF &r) const {
       int i = 0;
       for (auto const &t : tracks_) {
-        if ((r.id() == t.id()) & (t.key() == r.key()))
+        if ((r.id() == t.id()) && (t.key() == r.key()))
           return weights_[i] / 255.f;
         ++i;
       }


### PR DESCRIPTION
LLVM 14 based CLANG IBs show a lot of build warnings about use of bitwise operator instead of logical. This PR fixes some of these warnings