### PR TITLE
[SIMULATION] [LLVM 14] bitwise-instead-of-logical warnings fixed

### DIFF
--- a/DataFormats/GeometrySurface/interface/GloballyPositioned.h
+++ b/DataFormats/GeometrySurface/interface/GloballyPositioned.h
@@ -154,7 +154,7 @@ private:
  */
 
   void setCache() {
-    if ((thePos.x() == 0.) & (thePos.y() == 0.)) {
+    if ((thePos.x() == 0.) && (thePos.y() == 0.)) {
       thePhi = theEta = 0.;  // avoid FPE
     } else {
       thePhi = thePos.barePhi();

--- a/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
+++ b/DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h
@@ -27,15 +27,15 @@ public:
   using Bounds::inside;
 
   bool inside(const Local2DPoint& p) const override {
-    return (std::abs(p.x()) < halfWidth) & (std::abs(p.y()) < halfLength);
+    return (std::abs(p.x()) < halfWidth) && (std::abs(p.y()) < halfLength);
   }
 
   bool inside(const Local3DPoint& p) const override {
-    return (std::abs(p.x()) < halfWidth) & (std::abs(p.y()) < halfLength) & (std::abs(p.z()) < halfThickness);
+    return (std::abs(p.x()) < halfWidth) && (std::abs(p.y()) < halfLength) && (std::abs(p.z()) < halfThickness);
   }
 
   bool inside(const Local2DPoint& p, float tollerance) const override {
-    return (std::abs(p.x()) < (halfWidth + tollerance)) & (std::abs(p.y()) < (halfLength + tollerance));
+    return (std::abs(p.x()) < (halfWidth + tollerance)) && (std::abs(p.y()) < (halfLength + tollerance));
   }
 
   bool inside(const Local3DPoint& p, const LocalError& err, float scale = 1.f) const override;

--- a/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
+++ b/DataFormats/GeometrySurface/interface/SimpleDiskBounds.h
@@ -18,8 +18,8 @@ public:
   float thickness() const override { return theZmax - theZmin; }
 
   bool inside(const Local3DPoint& p) const override {
-    return ((p.z() > theZmin) & (p.z() < theZmax)) &&
-           ((p.perp2() > theRmin * theRmin) & (p.perp2() < theRmax * theRmax));
+    return ((p.z() > theZmin) && (p.z() < theZmax)) &&
+           ((p.perp2() > theRmin * theRmin) && (p.perp2() < theRmax * theRmax));
   }
 
   using Bounds::inside;

--- a/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
+++ b/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
@@ -7,13 +7,13 @@ bool DiskSectorBounds::inside(const Local3DPoint& p) const {
   // and rotated  x/y axis
   Local3DPoint tmp(p.y() + theOffset, -p.x(), p.z());
 
-  return ((tmp.z() >= theZmin) & (tmp.z() <= theZmax) & (tmp.perp2() >= theRmin * theRmin) &
+  return ((tmp.z() >= theZmin) && (tmp.z() <= theZmax) && (tmp.perp2() >= theRmin * theRmin) &&
           (tmp.perp2() <= theRmax * theRmax)) &&
          (std::abs(tmp.barePhi()) <= thePhiExtH);
 }
 
 bool DiskSectorBounds::inside(const Local3DPoint& p, const LocalError& err, float scale) const {
-  if ((p.z() < theZmin) | (p.z() > theZmax))
+  if ((p.z() < theZmin) || (p.z() > theZmax))
     return false;
 
   Local2DPoint tmp(p.x(), p.y() + theOffset);

--- a/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
+++ b/DataFormats/GeometrySurface/src/TrapezoidalPlaneBounds.cc
@@ -16,11 +16,11 @@ TrapezoidalPlaneBounds::TrapezoidalPlaneBounds(float be, float te, float a, floa
 int TrapezoidalPlaneBounds::yAxisOrientation() const { return (hbotedge > htopedge) ? -1 : 1; }
 
 bool TrapezoidalPlaneBounds::inside(const Local2DPoint& p) const {
-  return (std::abs(p.y()) < hapothem) & (std::abs(p.x()) < tan_a * std::abs(p.y() + offset));
+  return (std::abs(p.y()) < hapothem) && (std::abs(p.x()) < tan_a * std::abs(p.y() + offset));
 }
 
 bool TrapezoidalPlaneBounds::inside(const Local3DPoint& p) const {
-  return ((std::abs(p.y()) < hapothem) & (std::abs(p.z()) < hthickness)) &&
+  return ((std::abs(p.y()) < hapothem) && (std::abs(p.z()) < hthickness)) &&
          std::abs(p.x()) < tan_a * std::abs(p.y() + offset);
 }
 


### PR DESCRIPTION
LLVM 14 based CLANG IBs show a lot of build warnings about use of bitwise operator instead of logical. This PR fixes some of these warnings