### PR TITLE
[JMENanoAOD] Backport of #40232 (Setup DQM and increase precision of PileUp ID & QGL input variables) to 12_6_X

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineMC_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineMC_cff.py
@@ -33,3 +33,5 @@ for tracks in selectedTracks :
 from PhysicsTools.NanoAOD.nanoDQM_cff import nanoDQMMC
 DQMOfflineNanoAOD.replace(nanoDQM, nanoDQMMC)
 #PostDQMOfflineNanoAOD.replace(nanoDQM, nanoDQMMC)
+from PhysicsTools.NanoAOD.nanojmeDQM_cff import nanojmeDQMMC
+DQMOfflineNanoJME.replace(nanojmeDQM, nanojmeDQMMC)

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -275,3 +275,5 @@ DQMOfflineNanoAOD = cms.Sequence(nanoDQM)
 #PostDQMOfflineNanoAOD = cms.Sequence(nanoDQM)
 from PhysicsTools.NanoAOD.nanogenDQM_cff import nanogenDQM
 DQMOfflineNanoGen = cms.Sequence(nanogenDQM)
+from PhysicsTools.NanoAOD.nanojmeDQM_cff import nanojmeDQM
+DQMOfflineNanoJME = cms.Sequence(nanojmeDQM)

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -206,6 +206,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                            'PostDQMOffline',
                            'DQMHarvestNanoAOD'],
 
+            'nanojmeDQM': ['DQMOfflineNanoJME',
+                             'PostDQMOffline',
+                             'DQMHarvestNanoAOD'],
+
             'pfDQM': ['DQMOfflinePF+DQMOfflinePFExtended',
                       'PostDQMOffline',
                       'DQMHarvestPF'],

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -105,7 +105,7 @@ config_recojets = list(filter(lambda k: k['enabled'], config_recojets))
 nanoInfo_recojets = {
   "ak4calo" : {
     "name": "JetCalo",
-    "doc" : "AK4 Calo jets with JECs applied",
+    "doc" : "AK4 Calo jets (slimmedCaloJets)",
   },
   "ak4pf" : {
     "name"  : "JetPF",
@@ -183,6 +183,7 @@ PARTICLENETAK4VARS = cms.PSet(
   particleNetAK4_CvsL = Var("?(pt>=15)?bDiscriminator('pfParticleNetAK4DiscriminatorsJetTags:CvsL'):-1",float,doc="ParticleNetAK4 tagger c vs udsg discriminator",precision=10),
   particleNetAK4_CvsB = Var("?(pt>=15)?bDiscriminator('pfParticleNetAK4DiscriminatorsJetTags:CvsB'):-1",float,doc="ParticleNetAK4 tagger c vs b discriminator",precision=10),
   particleNetAK4_QvsG = Var("?(pt>=15)?bDiscriminator('pfParticleNetAK4DiscriminatorsJetTags:QvsG'):-1",float,doc="ParticleNetAK4 tagger uds vs g discriminator",precision=10),
+  particleNetAK4_G = Var("?(pt>=15)?bDiscriminator('pfParticleNetAK4DiscriminatorsJetTags:probg'):-1",float,doc="ParticleNetAK4 tagger g raw score",precision=10),
   particleNetAK4_puIdDisc = Var("?(pt>=15)?1-bDiscriminator('pfParticleNetAK4JetTags:probpu'):-1",float,doc="ParticleNetAK4 tagger pileup jet discriminator",precision=10),
 )
 
@@ -205,7 +206,7 @@ def AddJetID(proc, jetName="", jetSrc="", jetTableName="", jetTaskName=""):
   Setup modules to calculate PF jet ID
   """
 
-  isPUPPIJet = True if "Puppi" in jetName else False
+  isPUPPIJet = True if "PUPPI" in jetName.upper() else False
 
   looseJetId = "looseJetId{}".format(jetName)
   setattr(proc, looseJetId, proc.looseJetId.clone(
@@ -392,6 +393,7 @@ def AddParticleNetAK4Scores(proc, jetTableName=""):
   getattr(proc, jetTableName).variables.particleNetAK4_CvsL = PARTICLENETAK4VARS.particleNetAK4_CvsL
   getattr(proc, jetTableName).variables.particleNetAK4_CvsB = PARTICLENETAK4VARS.particleNetAK4_CvsB
   getattr(proc, jetTableName).variables.particleNetAK4_QvsG = PARTICLENETAK4VARS.particleNetAK4_QvsG
+  getattr(proc, jetTableName).variables.particleNetAK4_G = PARTICLENETAK4VARS.particleNetAK4_G
   getattr(proc, jetTableName).variables.particleNetAK4_puIdDisc = PARTICLENETAK4VARS.particleNetAK4_puIdDisc
 
   return proc
@@ -485,6 +487,9 @@ def SavePatJets(proc, jetName, payload, patJetFinalColl, jetTablePrefix, jetTabl
   jetTableDocDefault = jetTableDoc + " with JECs applied. Jets with pt >= {ptcut:.0f} GeV are stored.".format(ptcut=ptcut)
   if runOnMC:
     jetTableDocDefault += "For jets with pt < {ptcut:.0f} GeV, only those matched to gen jets are stored.".format(ptcut=ptcut)
+
+  if doCalo:
+    jetTableDocDefault = jetTableDoc
 
   jetTableName = "jet{}Table".format(jetName)
   setattr(proc,jetTableName, simpleCandidateFlatTableProducer.clone(
@@ -698,6 +703,7 @@ def ReclusterAK4PuppiJets(proc, recoJA, runOnMC):
   proc.jetPuppiTable.variables.particleNetAK4_CvsL     = PARTICLENETAK4VARS.particleNetAK4_CvsL
   proc.jetPuppiTable.variables.particleNetAK4_CvsB     = PARTICLENETAK4VARS.particleNetAK4_CvsB
   proc.jetPuppiTable.variables.particleNetAK4_QvsG     = PARTICLENETAK4VARS.particleNetAK4_QvsG
+  proc.jetPuppiTable.variables.particleNetAK4_G        = PARTICLENETAK4VARS.particleNetAK4_G
   proc.jetPuppiTable.variables.particleNetAK4_puIdDisc = PARTICLENETAK4VARS.particleNetAK4_puIdDisc
 
   #
@@ -872,6 +878,7 @@ def ReclusterAK4CHSJets(proc, recoJA, runOnMC):
   proc.jetTable.variables.particleNetAK4_CvsL       = PARTICLENETAK4VARS.particleNetAK4_CvsL
   proc.jetTable.variables.particleNetAK4_CvsB       = PARTICLENETAK4VARS.particleNetAK4_CvsB
   proc.jetTable.variables.particleNetAK4_QvsG       = PARTICLENETAK4VARS.particleNetAK4_QvsG
+  proc.jetTable.variables.particleNetAK4_G          = PARTICLENETAK4VARS.particleNetAK4_G
   proc.jetTable.variables.particleNetAK4_puIdDisc   = PARTICLENETAK4VARS.particleNetAK4_puIdDisc
 
   #Adding hf shower shape producer to the jet sequence. By default this producer is not automatically rerun at the NANOAOD step

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -144,23 +144,23 @@ PFJETVARS = cms.PSet(P4Vars,
   nConstPhotons   = Var("photonMultiplicity()",int,doc="number of photons in the jet"),
 )
 PUIDVARS = cms.PSet(
-  puId_dR2Mean    = Var("?(pt>=10)?userFloat('puId_dR2Mean'):-1",float,doc="pT^2-weighted average square distance of jet constituents from the jet axis (PileUp ID BDT input variable)", precision=6),
-  puId_majW       = Var("?(pt>=10)?userFloat('puId_majW'):-1",float,doc="major axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision=6),
-  puId_minW       = Var("?(pt>=10)?userFloat('puId_minW'):-1",float,doc="minor axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision=6),
-  puId_frac01     = Var("?(pt>=10)?userFloat('puId_frac01'):-1",float,doc="fraction of constituents' pT contained within dR <0.1 (PileUp ID BDT input variable)", precision=6),
-  puId_frac02     = Var("?(pt>=10)?userFloat('puId_frac02'):-1",float,doc="fraction of constituents' pT contained within 0.1< dR <0.2 (PileUp ID BDT input variable)", precision=6),
-  puId_frac03     = Var("?(pt>=10)?userFloat('puId_frac03'):-1",float,doc="fraction of constituents' pT contained within 0.2< dR <0.3 (PileUp ID BDT input variable)", precision=6),
-  puId_frac04     = Var("?(pt>=10)?userFloat('puId_frac04'):-1",float,doc="fraction of constituents' pT contained within 0.3< dR <0.4 (PileUp ID BDT input variable)", precision=6),
-  puId_ptD        = Var("?(pt>=10)?userFloat('puId_ptD'):-1",float,doc="pT-weighted average pT of constituents (PileUp ID BDT input variable)", precision=6),
-  puId_beta       = Var("?(pt>=10)?userFloat('puId_beta'):-1",float,doc="fraction of pT of charged constituents associated to PV (PileUp ID BDT input variable)", precision=6),
-  puId_pull       = Var("?(pt>=10)?userFloat('puId_pull'):-1",float,doc="magnitude of pull vector (PileUp ID BDT input variable)", precision=6),
-  puId_jetR       = Var("?(pt>=10)?userFloat('puId_jetR'):-1",float,doc="fraction of jet pT carried by the leading constituent (PileUp ID BDT input variable)", precision=6),
-  puId_jetRchg    = Var("?(pt>=10)?userFloat('puId_jetRchg'):-1",float,doc="fraction of jet pT carried by the leading charged constituent (PileUp ID BDT input variable)", precision=6),
+  puId_dR2Mean    = Var("?(pt>=10)?userFloat('puId_dR2Mean'):-1",float,doc="pT^2-weighted average square distance of jet constituents from the jet axis (PileUp ID BDT input variable)", precision=14),
+  puId_majW       = Var("?(pt>=10)?userFloat('puId_majW'):-1",float,doc="major axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision=14),
+  puId_minW       = Var("?(pt>=10)?userFloat('puId_minW'):-1",float,doc="minor axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision=14),
+  puId_frac01     = Var("?(pt>=10)?userFloat('puId_frac01'):-1",float,doc="fraction of constituents' pT contained within dR <0.1 (PileUp ID BDT input variable)", precision=14),
+  puId_frac02     = Var("?(pt>=10)?userFloat('puId_frac02'):-1",float,doc="fraction of constituents' pT contained within 0.1< dR <0.2 (PileUp ID BDT input variable)", precision=14),
+  puId_frac03     = Var("?(pt>=10)?userFloat('puId_frac03'):-1",float,doc="fraction of constituents' pT contained within 0.2< dR <0.3 (PileUp ID BDT input variable)", precision=14),
+  puId_frac04     = Var("?(pt>=10)?userFloat('puId_frac04'):-1",float,doc="fraction of constituents' pT contained within 0.3< dR <0.4 (PileUp ID BDT input variable)", precision=14),
+  puId_ptD        = Var("?(pt>=10)?userFloat('puId_ptD'):-1",float,doc="pT-weighted average pT of constituents (PileUp ID BDT input variable)", precision=14),
+  puId_beta       = Var("?(pt>=10)?userFloat('puId_beta'):-1",float,doc="fraction of pT of charged constituents associated to PV (PileUp ID BDT input variable)", precision=14),
+  puId_pull       = Var("?(pt>=10)?userFloat('puId_pull'):-1",float,doc="magnitude of pull vector (PileUp ID BDT input variable)", precision=14),
+  puId_jetR       = Var("?(pt>=10)?userFloat('puId_jetR'):-1",float,doc="fraction of jet pT carried by the leading constituent (PileUp ID BDT input variable)", precision=14),
+  puId_jetRchg    = Var("?(pt>=10)?userFloat('puId_jetRchg'):-1",float,doc="fraction of jet pT carried by the leading charged constituent (PileUp ID BDT input variable)", precision=14),
   puId_nCharged   = Var("?(pt>=10)?userInt('puId_nCharged'):-1",int,doc="number of charged constituents (PileUp ID BDT input variable)"),
 )
 QGLVARS = cms.PSet(
-  qgl_axis2       =  Var("?(pt>=10)?userFloat('qgl_axis2'):-1",float,doc="ellipse minor jet axis (Quark vs Gluon likelihood input variable)", precision=10),
-  qgl_ptD         =  Var("?(pt>=10)?userFloat('qgl_ptD'):-1",float,doc="pT-weighted average pT of constituents (Quark vs Gluon likelihood input variable)", precision=10),
+  qgl_axis2       =  Var("?(pt>=10)?userFloat('qgl_axis2'):-1",float,doc="ellipse minor jet axis (Quark vs Gluon likelihood input variable)", precision=14),
+  qgl_ptD         =  Var("?(pt>=10)?userFloat('qgl_ptD'):-1",float,doc="pT-weighted average pT of constituents (Quark vs Gluon likelihood input variable)", precision=14),
   qgl_mult        =  Var("?(pt>=10)?userInt('qgl_mult'):-1", int,doc="PF candidates multiplicity (Quark vs Gluon likelihood input variable)"),
 )
 BTAGVARS = cms.PSet(
@@ -233,7 +233,7 @@ def AddJetID(proc, jetName="", jetSrc="", jetTableName="", jetTaskName=""):
       ),
     )
   )
-  
+
   run2_jme_2016.toModify(
     getattr(proc, tightJetId).filterParams, version = "RUN2UL16{}".format("PUPPI" if isPUPPIJet else "CHS")
   ).toModify(

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -233,6 +233,12 @@ def AddJetID(proc, jetName="", jetSrc="", jetTableName="", jetTaskName=""):
       ),
     )
   )
+  
+  run2_jme_2016.toModify(
+    getattr(proc, tightJetId).filterParams, version = "RUN2UL16{}".format("PUPPI" if isPUPPIJet else "CHS")
+  ).toModify(
+    getattr(proc, tightJetIdLepVeto).filterParams, version = "RUN2UL16{}".format("PUPPI" if isPUPPIJet else "CHS")
+  )
 
   #
   # Save variables as userInts in each jet
@@ -577,6 +583,15 @@ def ReclusterAK4PuppiJets(proc, recoJA, runOnMC):
 
   jetName = recoJetInfo.jetUpper
   patJetFinalColl = recoJetInfo.patJetFinalCollection
+
+  #
+  # Set the jetID for UL 16 era
+  #
+  run2_jme_2016.toModify(
+    proc.tightJetPuppiId.filterParams, version = "RUN2UL16PUPPI"
+  ).toModify(
+    proc.tightJetIdLepVeto.filterParams, version = "RUN2UL16PUPPI"
+  )
 
   #
   # Change the input jet source for jetCorrFactorsNano

--- a/PhysicsTools/NanoAOD/python/nanojmeDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanojmeDQM_cff.py
@@ -1,0 +1,197 @@
+import FWCore.ParameterSet.Config as cms
+import copy
+
+from PhysicsTools.NanoAOD.nanoDQM_cfi import nanoDQM
+from PhysicsTools.NanoAOD.nanoDQM_tools_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+
+nanojmeDQM = nanoDQM.clone()
+
+#============================================
+#
+# Add more variables for AK4 Puppi jets
+#
+#============================================
+nanojmeDQM.vplots.Jet.plots.extend([
+    Plot1D('nConstChHads', 'nConstChHads', 20, 14.5, 34.5, 'number of charged hadrons in the jet'),
+    Plot1D('nConstElecs', 'nConstElecs', 3, -0.5, 2.5, 'number of electrons in the jet'),
+    Plot1D('nConstHFEMs', 'nConstHFEMs', 1, -0.5, 0.5, 'number of HF EMs in the jet'),
+    Plot1D('nConstHFHads', 'nConstHFHads', 1, -0.5, 0.5, 'number of HF Hadrons in the jet'),
+    Plot1D('nConstMuons', 'nConstMuons', 2, -0.5, 1.5, 'number of muons in the jet'),
+    Plot1D('nConstNeuHads', 'nConstNeuHads', 8, 1.5, 9.5, 'number of neutral hadrons in the jet'),
+    Plot1D('nConstPhotons', 'nConstPhotons', 16, 5.5, 21.5, 'number of photons in the jet'),
+    Plot1D('puId_dR2Mean','puId_dR2Mean', 120, -1, 0.2, "pT^2-weighted average square distance of jet constituents from the jet axis (PileUp ID BDT input variable)"),
+    Plot1D('puId_majW','puId_majW', 70, -1, 0.4, "major axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)"),
+    Plot1D('puId_minW','puId_minW', 70, -1, 0.4, "minor axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)"),
+    Plot1D('puId_frac01','puId_frac01', 22, -1, 1, "fraction of constituents' pT contained within dR <0.1 (PileUp ID BDT input variable)"),
+    Plot1D('puId_frac02','puId_frac02', 22, -1, 1, "fraction of constituents' pT contained within 0.1< dR <0.2 (PileUp ID BDT input variable)"),
+    Plot1D('puId_frac03','puId_frac03', 22, -1, 1, "fraction of constituents' pT contained within 0.2< dR <0.3 (PileUp ID BDT input variable)"),
+    Plot1D('puId_frac04','puId_frac04', 22, -1, 1, "fraction of constituents' pT contained within 0.3< dR <0.4 (PileUp ID BDT input variable)"),
+    Plot1D('puId_ptD','puId_ptD', 20, -1, 1, "pT-weighted average pT of constituents (PileUp ID BDT input variable)"),
+    Plot1D('puId_beta','puId_beta', 50, -1, 1, "fraction of pT of charged constituents associated to PV (PileUp ID BDT input variable)"),
+    Plot1D('puId_pull','puId_pull', 208, -1, 0.04, "magnitude of pull vector (PileUp ID BDT input variable)"),
+    Plot1D('puId_jetR','puId_jetR', 50, -1, 1, "fraction of jet pT carried by the leading constituent (PileUp ID BDT input variable)"),
+    Plot1D('puId_jetRchg','puId_jetRchg', 50, -1, 1,  "fraction of jet pT carried by the leading charged constituent (PileUp ID BDT input variable)"),
+    Plot1D('puId_nCharged','puId_nCharged', 40, -0.5, 39.5, "number of charged constituents (PileUp ID BDT input variable)"),
+    Plot1D('qgl_axis2','qgl_axis2', 60, -1, 0.5, "ellipse minor jet axis (Quark vs Gluon likelihood input variable)"),
+    Plot1D('qgl_ptD','qgl_ptD', 40, -1, 1, "pT-weighted average pT of constituents (Quark vs Gluon likelihood input variable)"),
+    Plot1D('qgl_mult','qgl_mult', 61, -1.5, 59.5, "PF candidates multiplicity (Quark vs Gluon likelihood input variable)"),
+    Plot1D('btagDeepFlavG','btagDeepFlavG',20, -1, 1, "DeepFlavour gluon tag raw score"),
+    Plot1D('btagDeepFlavUDS','btagDeepFlavUDS',20, -1, 1, "DeepFlavour uds tag raw score"),
+    Plot1D('btagDeepFlavQG','btagDeepFlavQG',20, -1, 1, "DeepJet g vs uds discriminator"),
+    Plot1D('particleNetAK4_B','particleNetAK4_B',20, -1, 1, "ParticleNetAK4 tagger b vs all (udsg, c) discriminator"),
+    Plot1D('particleNetAK4_CvsL','particleNetAK4_CvsL',20, -1, 1, "ParticleNetAK4 tagger c vs udsg discriminator"),
+    Plot1D('particleNetAK4_CvsB','particleNetAK4_CvsB',20, -1, 1, "ParticleNetAK4 tagger c vs b discriminator"),
+    Plot1D('particleNetAK4_QvsG','particleNetAK4_QvsG',20, -1, 1, "ParticleNetAK4 tagger uds vs g discriminator"),
+    Plot1D('particleNetAK4_G','particleNetAK4_G',20, -1, 1, "ParticleNetAK4 tagger g raw score"),
+    Plot1D('particleNetAK4_puIdDisc','particleNetAK4_puIdDisc',20, -1, 1, "ParticleNetAK4 tagger pileup jet discriminator"),
+    Plot1D('hfEmEF', 'hfEmEF', 20, 0, 1, 'electromagnetic energy fraction in HF'),
+    Plot1D('hfHEF', 'hfHEF', 20, 0, 1, 'hadronic energy fraction in HF'),
+])
+
+#============================================
+#
+# Setup for AK4 CHS jets
+#
+#============================================
+_ak4chsplots = cms.VPSet(
+    Count1D('_size', 20, -0.5, 19.5, 'AK4 PF CHS jets with JECs applied.')
+)
+for plot in nanojmeDQM.vplots.Jet.plots:
+    if plot.name.value()=="_size": continue
+    _ak4chsplots.append(plot)
+    _ak4chsplots.extend([
+        Plot1D('chFPV1EF', 'chFPV1EF', 20, 0, 2, 'charged fromPV==1 Energy Fraction (component of the total charged Energy Fraction).'),
+        Plot1D('chFPV2EF', 'chFPV2EF', 20, 0, 2, 'charged fromPV==2 Energy Fraction (component of the total charged Energy Fraction).'),
+        Plot1D('chFPV3EF', 'chFPV3EF', 20, 0, 2, 'charged fromPV==3 Energy Fraction (component of the total charged Energy Fraction).'),
+    ])
+
+nanojmeDQM.vplots.JetCHS = cms.PSet(
+    sels = nanojmeDQM.vplots.Jet.sels,
+    plots = _ak4chsplots
+)
+
+#============================================
+#
+# Add more variables for AK8 Puppi jets
+#
+#============================================
+nanojmeDQM.vplots.FatJet.plots.extend([
+    Plot1D('nConstChHads', 'nConstChHads', 20, 14.5, 34.5, 'number of charged hadrons in the jet'),
+    Plot1D('nConstElecs', 'nConstElecs', 3, -0.5, 2.5, 'number of electrons in the jet'),
+    Plot1D('nConstHFEMs', 'nConstHFEMs', 1, -0.5, 0.5, 'number of HF EMs in the jet'),
+    Plot1D('nConstHFHads', 'nConstHFHads', 1, -0.5, 0.5, 'number of HF Hadrons in the jet'),
+    Plot1D('nConstMuons', 'nConstMuons', 2, -0.5, 1.5, 'number of muons in the jet'),
+    Plot1D('nConstNeuHads', 'nConstNeuHads', 8, 1.5, 9.5, 'number of neutral hadrons in the jet'),
+    Plot1D('nConstPhotons', 'nConstPhotons', 16, 5.5, 21.5, 'number of photons in the jet'),
+    Plot1D('neEmEF', 'neEmEF', 20, 0.3, 0.4, 'neutral Electromagnetic Energy Fraction'),
+    Plot1D('neHEF', 'neHEF', 20, 0.01, 0.2, 'neutral Hadron Energy Fraction'),
+])
+
+#============================================
+#
+# Setup for AK8 Puppi jets for JEC studies
+#
+#============================================
+nanojmeDQM.vplots.FatJetForJEC = cms.PSet(
+    sels = cms.PSet(
+        CentralPt30 = cms.string('abs(eta) < 2.4 && pt > 30'),
+        ForwardPt30 = cms.string('abs(eta) > 2.4 && pt > 30')
+    ),
+    plots = cms.VPSet(
+        Count1D('_size', 20, -0.5, 19.5, 'AK8 PF Puppi jets with JECs applied. Reclustered for JEC studies so only minimal info stored.'),
+        Plot1D('area', 'area', 20, 0.2, 0.8, 'jet catchment area, for JECs'),
+        Plot1D('eta', 'eta', 20, -6, 6, 'eta'),
+        Plot1D('jetId', 'jetId', 8, -0.5, 7.5, 'Jet ID flags bit1 is loose (always false in 2017 since it does not exist), bit2 is tight, bit3 is tightLepVeto'),
+        Plot1D('mass', 'mass', 20, 0, 200, 'mass'),
+        Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+        Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
+        Plot1D('rawFactor', 'rawFactor', 20, -0.5, 0.5, '1 - Factor to get back to raw pT'),
+        Plot1D('nConstChHads', 'nConstChHads', 20, 14.5, 34.5, 'number of charged hadrons in the jet'),
+        Plot1D('nConstElecs', 'nConstElecs', 3, -0.5, 2.5, 'number of electrons in the jet'),
+        Plot1D('nConstHFEMs', 'nConstHFEMs', 1, -0.5, 0.5, 'number of HF EMs in the jet'),
+        Plot1D('nConstHFHads', 'nConstHFHads', 1, -0.5, 0.5, 'number of HF Hadrons in the jet'),
+        Plot1D('nConstMuons', 'nConstMuons', 2, -0.5, 1.5, 'number of muons in the jet'),
+        Plot1D('nConstNeuHads', 'nConstNeuHads', 8, 1.5, 9.5, 'number of neutral hadrons in the jet'),
+        Plot1D('nConstPhotons', 'nConstPhotons', 16, 5.5, 21.5, 'number of photons in the jet'),
+        Plot1D('nConstituents', 'nConstituents', 20, 0, 80, 'Number of particles in the jet'),
+        Plot1D('nElectrons', 'nElectrons', 5, -0.5, 4.5, 'number of electrons in the jet'),
+        Plot1D('nMuons', 'nMuons', 4, -0.5, 3.5, 'number of muons in the jet'),
+        Plot1D('hadronFlavour', 'hadronFlavour', 6, -0.5, 5.5, 'flavour from hadron ghost clustering'),
+        Plot1D('partonFlavour', 'partonFlavour', 40, -9.5, 30.5, 'flavour from parton matching'),
+        Plot1D('chEmEF', 'chEmEF', 20, 0, 1, 'charged Electromagnetic Energy Fraction'),
+        Plot1D('chHEF', 'chHEF', 20, 0, 2, 'charged Hadron Energy Fraction'),
+        Plot1D('neEmEF', 'neEmEF', 20, 0.3, 0.4, 'neutral Electromagnetic Energy Fraction'),
+        Plot1D('neHEF', 'neHEF', 20, 0.01, 0.2, 'neutral Hadron Energy Fraction'),
+        Plot1D('hfEmEF', 'hfEmEF', 20, 0, 1, 'electromagnetic energy fraction in HF'),
+        Plot1D('hfHEF', 'hfHEF', 20, 0, 1, 'hadronic energy fraction in HF'),
+        Plot1D('muEF', 'muEF', 20, -1, 1, 'muon Energy Fraction'),
+        NoPlot('genJetIdx'),
+    ),
+)
+
+#============================================
+#
+# Setup for AK8 CHS jets
+#
+#============================================
+_ak8chsplots = cms.VPSet(
+    Count1D('_size', 20, -0.5, 19.5, 'AK8 CHS jets with JECs applied.')
+)
+for plot in nanojmeDQM.vplots.FatJetForJEC.plots:
+    if plot.name.value()=="_size": continue
+    _ak8chsplots.append(plot)
+
+nanojmeDQM.vplots.FatJetCHS = cms.PSet(
+    sels = nanojmeDQM.vplots.FatJetForJEC.sels,
+    plots = _ak8chsplots,
+)
+
+#============================================
+#
+# Setup for AK4 Calo jets
+#
+#============================================
+nanojmeDQM.vplots.JetCalo = cms.PSet(
+    sels = cms.PSet(
+        CentralPt30 = cms.string('abs(eta) < 2.4 && pt > 30'),
+        ForwardPt30 = cms.string('abs(eta) > 2.4 && pt > 30')
+    ),
+    plots = cms.VPSet(
+        Count1D('_size', 20, -0.5, 19.5, 'AK4 Calo jets (slimmedCaloJets)'),
+        Plot1D('area', 'area', 20, 0.2, 0.8, 'jet catchment area'),
+        Plot1D('eta', 'eta', 20, -6, 6, 'eta'),
+        Plot1D('mass', 'mass', 20, 0, 200, 'mass'),
+        Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+        Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
+        Plot1D('rawFactor', 'rawFactor', 20, -0.5, 0.5, '1 - Factor to get back to raw pT'),
+        Plot1D('emf', 'emf', 20, 0, 1, 'electromagnetic energy fraction'),
+        Plot1D('hadronFlavour', 'hadronFlavour', 6, -0.5, 5.5, 'flavour from hadron ghost clustering'),
+        Plot1D('partonFlavour', 'partonFlavour', 40, -9.5, 30.5, 'flavour from parton matching'),
+        NoPlot('genJetIdx'),
+    ),
+)
+
+
+##MC
+nanojmeDQMMC = nanojmeDQM.clone()
+#nanojmeDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")
+nanojmeDQMMC.vplots.LowPtElectron.sels.Prompt = cms.string("genPartFlav == 1")
+nanojmeDQMMC.vplots.Muon.sels.Prompt = cms.string("genPartFlav == 1")
+nanojmeDQMMC.vplots.Photon.sels.Prompt = cms.string("genPartFlav == 1")
+nanojmeDQMMC.vplots.Tau.sels.Prompt = cms.string("genPartFlav == 5")
+nanojmeDQMMC.vplots.Jet.sels.Prompt = cms.string("genJetIdx != 1")
+nanojmeDQMMC.vplots.Jet.sels.PromptB = cms.string("genJetIdx != 1 && hadronFlavour == 5")
+nanojmeDQMMC.vplots.JetCHS.sels.Prompt = cms.string("genJetIdx != 1")
+nanojmeDQMMC.vplots.JetCHS.sels.PromptB = cms.string("genJetIdx != 1 && hadronFlavour == 5")
+
+from DQMServices.Core.DQMQualityTester import DQMQualityTester
+nanoDQMQTester = DQMQualityTester(
+    qtList = cms.untracked.FileInPath('PhysicsTools/NanoAOD/test/dqmQualityTests.xml'),
+    prescaleFactor = cms.untracked.int32(1),                               
+    testInEventloop = cms.untracked.bool(False),
+    qtestOnEndLumi = cms.untracked.bool(False),
+    verboseQT =  cms.untracked.bool(True)
+)
+
+nanojmeHarvest = cms.Sequence( nanoDQMQTester )


### PR DESCRIPTION
Backport from #40232 

**Orignal PR description:**

This PR updates the JMENano workflow to make the following changes:

- Setup the DQM for JMENano. The DQM step name is nanojmeDQM.
- Increase the precision for the PileUp ID and Quark-Gluon Likelihood input variables.
- Add AK4 jet ParticleNet gluon raw score.
- Bugfix related to JetID configurations in JMENano.

**Backport PR validation:**

- passes the JMENano workflows: `runTheMatrix.py -i all --ibeos -l 10224.15,11024.15,25202.15,11634.15`