### PR TITLE
Replace old cms_test_conditions schema with cms_cond_general_w; use C…

### DIFF
--- a/CondTools/SiStrip/python/o2o_db_manager.py
+++ b/CondTools/SiStrip/python/o2o_db_manager.py
@@ -5,7 +5,7 @@ import logging
 import CondCore.Utilities.credentials as auth
 
 prod_db_service = ['cms_orcon_prod', 'cms_orcon_prod/cms_cond_general_w']
-dev_db_service = ['cms_orcoff_prep', 'cms_orcoff_prep/cms_test_conditions']
+dev_db_service = ['cms_orcoff_prep', 'cms_orcoff_prep/cms_cond_general_w']
 schema_dict = {'cms_orcon_prod':'cms_cond_o2o', 'cms_orcoff_prep':'cms_cond_strip'}
 sqlalchemy_tpl = 'oracle://%s:%s@%s'
 coral_tpl = 'oracle://%s/%s'

--- a/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
+++ b/OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc
@@ -202,6 +202,10 @@ std::string SiStripPayloadHandler<SiStripPayload>::queryConfigMap(std::string co
   edm::LogInfo("SiStripPayloadHandler") << "[SiStripPayloadHandler::" << __func__ << "] "
                                         << "Query " << m_configMapDb << " to see if the payload is already in DB.";
 
+  // if dev/prep, use CMS_COND_STRIP
+  if (m_condDb.find("prep") != std::string::npos) {
+    m_cfgMapSchemaName = "CMS_COND_STRIP";
+  }
   auto cmDbSession = m_connectionPool.createCoralSession(m_configMapDb);
   // query the STRIP_CONFIG_TO_PAYLOAD_MAP table
   cmDbSession->transaction().start(true);


### PR DESCRIPTION
#### PR description:

Currently, the O2O DAQ tests fail when `scram b runtests` is used on lxplus.  This PR fixes the issues with two changes:

  - In `CondTools/SiStrip/python/o2o_db_manager.py`, the account used to access `cms_orcoff_prep`, `cms_test_conditions`, is outdated and should no longer be used.  Instead, it has been replaced with `cms_cond_general_w`.
  - In `OnlineDB/SiStripO2O/plugins/SiStripPayloadHandler.cc`, the default schema name for the mapping table is CMS_COND_O2O.  However, this is only true for the production DB; when accessing the prep DB, the correct schema is CMS_COND_STRIP.  This PR sets the schema to CMS_COND_STRIP if the prep DB is being used.

Because both sections of code changed are relevant only to the DAQ O2Os, the rest of CMSSW should be unaffected.

#### PR validation:

The changes have been tested successfully with the usual `scram b runtests` on lxplus.  Additionally, they were tested with an independent testing setup on lxplus:

  - The O2O test directory on the P5 node, `/nfshome0/trackerpro/o2o/scripts/test`, was copied to lxplus.  All .
  - The O2O `.netrc` and `.cms_cond/db.key` files were also copied to lxplus.
  - All relevant filepaths and environmental vars were updated to account for the new locations of CMSSW and the authentication files.
  - A tunnel to P5 was set up with screen: `screen ssh -N -L 10121:cmsrac51-v:10121 trackerpro@cmsusr`
  - The script `temp_run.sh`, a copy of the usual `prepareGlobal.sh` script, was used to run the test jobs.

For additional validation, the changes must tested on P5 after the PR is accepted.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Because the node at P5 is about to move from CMSSW_12_2_1_patch2 to CMSSW_12_4_3, a backport to 12_4_X will most likely be necessary.