### PR TITLE
add DT and CSC rechits to AOD content

### DIFF
--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -8,7 +8,9 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_dt4DSegments_*_*', 
         'keep *_dt4DCosmicSegments_*_*',
         'keep *_cscSegments_*_*',
-        'keep *_rpcRecHits_*_*')
+        'keep *_rpcRecHits_*_*',
+        'keep *_dt1DRecHits_*_*',
+        'keep *_csc2DRecHits_*_*')
 )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM


### PR DESCRIPTION
#### PR description:

This PR adds CSC/DT rechits to the AOD datatier, which are the essential inputs for multiple searches of LLP decaying in the muon system and evaluating related trigger performances

The DT/CSC rechits has been added to the AOD in the b-parking dataset from this PR: https://github.com/cms-sw/cmssw/pull/34066

The overall data size increase are ~1.7%
- ZEE + 2018 PU from UL RunIISummer20ULPrePremix aod 100 events: dt1DRecHits add 0.13%, csc2DRecHits add 1.0%; the total increase is about 1.2%
 - 136.898 input (Run2018B ParkingBPH5 run 317661 LS 393) aod 100 events: dt1DRecHits add 0.88%, csc2DRecHits add 0.79%; the total increase is about 1.7%

#### PR validation:

To be presented at https://indico.cern.ch/event/1228914/#6-adding-csc-and-dt-rechits-to
