### PR TITLE
Updated Geant4 user actions

### DIFF
--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -15,6 +15,7 @@
 class NewTrackAction;
 class TrackingAction;
 class CMSSteppingVerbose;
+class G4VProcess;
 
 class StackingAction : public G4UserStackingAction {
 public:
@@ -46,7 +47,8 @@ private:
   bool savePDandCinTracker, savePDandCinCalo;
   bool savePDandCinMuon, saveFirstSecondary;
   bool savePDandCinAll;
-  bool killInCalo, killInCaloEfH;
+  bool killInCalo{false};
+  bool killInCaloEfH{false};
   bool killHeavy, trackNeutrino, killDeltaRay;
   bool killExtra;
   bool killGamma;
@@ -71,16 +73,17 @@ private:
   G4VSolid* worldSolid;
   const TrackingAction* trackAction;
   const CMSSteppingVerbose* steppingVerbose;
+  const G4VProcess* m_Compton{nullptr};
   NewTrackAction* newTA;
   TrackInformationExtractor extractor;
 
   // Russian roulette regions
-  const G4Region* regionEcal;
-  const G4Region* regionHcal;
-  const G4Region* regionMuonIron;
-  const G4Region* regionPreShower;
-  const G4Region* regionCastor;
-  const G4Region* regionWorld;
+  const G4Region* regionEcal{nullptr};
+  const G4Region* regionHcal{nullptr};
+  const G4Region* regionMuonIron{nullptr};
+  const G4Region* regionPreShower{nullptr};
+  const G4Region* regionCastor{nullptr};
+  const G4Region* regionWorld{nullptr};
 
   // Russian roulette energy limits
   double gRusRoEnerLim;
@@ -100,8 +103,8 @@ private:
   double gRusRoWorld;
   double nRusRoWorld;
   // flags
-  bool gRRactive;
-  bool nRRactive;
+  bool gRRactive{false};
+  bool nRRactive{false};
 };
 
 #endif

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -15,6 +15,7 @@
 #include "G4VSolid.hh"
 #include "G4TransportationManager.hh"
 #include "G4GammaGeneralProcess.hh"
+#include "G4LossTableManager.hh"
 
 StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterSet& p, const CMSSteppingVerbose* sv)
     : trackAction(trka), steppingVerbose(sv) {
@@ -38,16 +39,6 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   savePDandCinCalo = p.getUntrackedParameter<bool>("SavePrimaryDecayProductsAndConversionsInCalo", false);
   savePDandCinMuon = p.getUntrackedParameter<bool>("SavePrimaryDecayProductsAndConversionsInMuon", false);
   saveFirstSecondary = p.getUntrackedParameter<bool>("SaveFirstLevelSecondary", false);
-  killInCalo = false;
-  killInCaloEfH = false;
-
-  // Russian Roulette
-  regionEcal = nullptr;
-  regionHcal = nullptr;
-  regionMuonIron = nullptr;
-  regionPreShower = nullptr;
-  regionCastor = nullptr;
-  regionWorld = nullptr;
 
   gRusRoEnerLim = p.getParameter<double>("RusRoGammaEnergyLimit") * CLHEP::MeV;
   nRusRoEnerLim = p.getParameter<double>("RusRoNeutronEnergyLimit") * CLHEP::MeV;
@@ -66,8 +57,6 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   nRusRoCastor = p.getParameter<double>("RusRoCastorNeutron");
   nRusRoWorld = p.getParameter<double>("RusRoWorldNeutron");
 
-  gRRactive = false;
-  nRRactive = false;
   if (gRusRoEnerLim > 0.0 && (gRusRoEcal < 1.0 || gRusRoHcal < 1.0 || gRusRoMuonIron < 1.0 || gRusRoPreShower < 1.0 ||
                               gRusRoCastor < 1.0 || gRusRoWorld < 1.0)) {
     gRRactive = true;
@@ -177,6 +166,14 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
   auto track = const_cast<G4Track*>(aTrack);
   const G4VProcess* creatorProc = aTrack->GetCreatorProcess();
 
+  if (creatorProc == nullptr && aTrack->GetParentID() != 0) {
+    edm::LogWarning("StackingAction::ClassifyNewTrack")
+      << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy();
+  }
+  if (aTrack->GetKineticEnergy() < 0.0) {
+    edm::LogWarning("StackingAction::ClassifyNewTrack")
+      << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy() << " creator " << creatorProc->GetProcessName();  
+  }
   // primary
   if (creatorProc == nullptr || aTrack->GetParentID() == 0) {
     if (!trackNeutrino && (abspdg == 12 || abspdg == 14 || abspdg == 16 || abspdg == 18)) {
@@ -214,14 +211,32 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
       // potentially good for tracking
       const double ke = aTrack->GetKineticEnergy();
       G4int subType = (nullptr != creatorProc) ? creatorProc->GetProcessSubType() : 0;
+      // VI: this part of code is needed for Geant4 10.7 only
       if (subType == 16) {
         auto ptr = dynamic_cast<const G4GammaGeneralProcess*>(creatorProc);
         if (nullptr != ptr) {
           creatorProc = ptr->GetSelectedProcess();
-          subType = (nullptr != creatorProc) ? creatorProc->GetProcessSubType() : 0;
+          if (nullptr == creatorProc) {
+            if(nullptr == m_Compton) {
+	      auto vp = G4LossTableManager::Instance()->GetEmProcessVector();
+              for(auto & p : vp) {
+		if(fComptonScattering == p->GetProcessSubType()) {
+		  m_Compton = p;
+		  break;
+		}
+	      }
+	    }
+	    creatorProc = m_Compton;
+	  }
+	  subType = creatorProc->GetProcessSubType();
           track->SetCreatorProcess(creatorProc);
         }
+	if(creatorProc == nullptr) {
+	  edm::LogWarning("StackingAction::ClassifyNewTrack")
+	    << " SubType=16 and no creatorProc; TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << ke << " SubType=" << subType;
+	}
       }
+      // VI - end
       LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
                                        << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()
                                        << " Ekin(MeV)=" << ke / CLHEP::MeV << " subType=" << subType << " ";

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -168,11 +168,14 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
 
   if (creatorProc == nullptr && aTrack->GetParentID() != 0) {
     edm::LogWarning("StackingAction::ClassifyNewTrack")
-      << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy();
+        << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " "
+        << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy();
   }
   if (aTrack->GetKineticEnergy() < 0.0) {
     edm::LogWarning("StackingAction::ClassifyNewTrack")
-      << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy() << " creator " << creatorProc->GetProcessName();  
+        << " TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " "
+        << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << aTrack->GetKineticEnergy() << " creator "
+        << creatorProc->GetProcessName();
   }
   // primary
   if (creatorProc == nullptr || aTrack->GetParentID() == 0) {
@@ -217,24 +220,26 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
         if (nullptr != ptr) {
           creatorProc = ptr->GetSelectedProcess();
           if (nullptr == creatorProc) {
-            if(nullptr == m_Compton) {
-	      auto vp = G4LossTableManager::Instance()->GetEmProcessVector();
-              for(auto & p : vp) {
-		if(fComptonScattering == p->GetProcessSubType()) {
-		  m_Compton = p;
-		  break;
-		}
-	      }
-	    }
-	    creatorProc = m_Compton;
-	  }
-	  subType = creatorProc->GetProcessSubType();
+            if (nullptr == m_Compton) {
+              auto vp = G4LossTableManager::Instance()->GetEmProcessVector();
+              for (auto& p : vp) {
+                if (fComptonScattering == p->GetProcessSubType()) {
+                  m_Compton = p;
+                  break;
+                }
+              }
+            }
+            creatorProc = m_Compton;
+          }
+          subType = creatorProc->GetProcessSubType();
           track->SetCreatorProcess(creatorProc);
         }
-	if(creatorProc == nullptr) {
-	  edm::LogWarning("StackingAction::ClassifyNewTrack")
-	    << " SubType=16 and no creatorProc; TrackID=" << aTrack->GetTrackID() << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << ke << " SubType=" << subType;
-	}
+        if (creatorProc == nullptr) {
+          edm::LogWarning("StackingAction::ClassifyNewTrack")
+              << " SubType=16 and no creatorProc; TrackID=" << aTrack->GetTrackID()
+              << " ParentID=" << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()
+              << " Ekin(MeV)=" << ke << " SubType=" << subType;
+        }
       }
       // VI - end
       LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -99,10 +99,12 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
   TrackStatus tstat = (theTrack->GetTrackStatus() == fAlive) ? sAlive : sKilledByProcess;
 
   if (theTrack->GetKineticEnergy() < 0.0) {
-    if (nWarnings < 5) {
+    if (nWarnings < 2) {
       ++nWarnings;
       edm::LogWarning("SimG4CoreApplication")
-          << "Track #" << theTrack->GetTrackID() << " " << theTrack->GetDefinition()->GetParticleName()
+          << "SteppingAction::UserSteppingAction: Track #" 
+          << theTrack->GetTrackID() << " " 
+          << theTrack->GetDefinition()->GetParticleName()
           << " Ekin(MeV)= " << theTrack->GetKineticEnergy() / MeV;
     }
     theTrack->SetKineticEnergy(0.0);

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -102,10 +102,8 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     if (nWarnings < 2) {
       ++nWarnings;
       edm::LogWarning("SimG4CoreApplication")
-          << "SteppingAction::UserSteppingAction: Track #" 
-          << theTrack->GetTrackID() << " " 
-          << theTrack->GetDefinition()->GetParticleName()
-          << " Ekin(MeV)= " << theTrack->GetKineticEnergy() / MeV;
+          << "SteppingAction::UserSteppingAction: Track #" << theTrack->GetTrackID() << " "
+          << theTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)= " << theTrack->GetKineticEnergy() / MeV;
     }
     theTrack->SetKineticEnergy(0.0);
   }


### PR DESCRIPTION
#### PR description:
Geant4 StackingAction is updated to fix rare issues happens in the case of active G4GammaGeneralProcess. This happens due to loss of numerical precision in selection of a concrete gamma process in PostStepDoIt action. This should fully resolve #40090

In SteppingAction the limit on number of warnings is reduced from 5 to 2. There is no sense for repeated warnings. 

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: May be backported to 12_6

