### PR TITLE
Remove last use of tbb::task::suspend

### DIFF
--- a/FWCore/Concurrency/interface/include_first_syncWait.h
+++ b/FWCore/Concurrency/interface/include_first_syncWait.h
@@ -8,32 +8,19 @@
 //  Created by Chris Jones on 2/24/21.
 //
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "oneapi/tbb/task_group.h"
-#include "oneapi/tbb/task.h"
 #include <exception>
 
 namespace edm {
   template <typename F>
   [[nodiscard]] std::exception_ptr syncWait(F&& iFunc) {
     std::exception_ptr exceptPtr{};
-    //oneapi::tbb::task::suspend can only be run from within a task running in this arena. For 1 thread,
-    // it is often (always?) the case where not such task is being run here. Therefore we need
-    // to use a temp task_group to start up such a task.
     oneapi::tbb::task_group group;
-    group.run([&]() {
-      oneapi::tbb::task::suspend([&](oneapi::tbb::task::suspend_point tag) {
-        auto waitTask = make_waiting_task([tag, &exceptPtr](std::exception_ptr const* iExcept) {
-          if (iExcept) {
-            exceptPtr = *iExcept;
-          }
-          oneapi::tbb::task::resume(tag);
-        });
-        iFunc(WaitingTaskHolder(group, waitTask));
-      });  //suspend
-    });    //group.run
+    FinalWaitingTask last{group};
+    group.run([&]() { iFunc(WaitingTaskHolder(group, &last)); });  //group.run
 
-    group.wait();
-    return exceptPtr;
+    return last.waitNoThrow();
   }
 }  // namespace edm
 #endif /* FWCore_Concurrency_syncWait_h */


### PR DESCRIPTION
#### PR description:

Switching to use the deferred task implementation avoids the problems where suspend could resume a function on a different thread.

#### PR validation:

Code compiles and FWCore/Concurrency unit tests pass.