### PR TITLE
add filter for intermediate resonance particles

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
@@ -45,7 +45,7 @@ private:
   // ----------member data ---------------------------
 
   edm::EDGetTokenT<LHEEventProduct> src_;
-  std::vector<int> pdgIdVec_;
+  const std::vector<int> pdgIdVec_;
   std::set<int> pdgIds_;  // Set of PDG Ids to include
   double ptMin_;          // number of particles required to pass filter
   double ptMax_;          // number of particles required to pass filter

--- a/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
@@ -37,7 +37,7 @@
 class LHEIntermediateParticlePtFilter : public edm::global::EDFilter<> {
 public:
   explicit LHEIntermediateParticlePtFilter(const edm::ParameterSet&);
-  ~LHEIntermediateParticlePtFilter() override;
+  ~LHEIntermediateParticlePtFilter() override = default;
 
   bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 

--- a/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
@@ -1,0 +1,105 @@
+// -*- C++ -*-
+//
+// Package:    LHEIntermediateParticlePtFilter
+// Class:      LHEIntermediateParticlePtFilter
+//
+/* 
+
+ Description: Filter to select events with pT in a given range.
+ (Based on LHEGenericFilter)
+
+     
+*/
+//
+
+// system include files
+#include <memory>
+#include <iostream>
+#include <set>
+
+// user include files
+#include "Math/Vector4D.h"
+#include "Math/Vector4Dfwd.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+
+//
+// class declaration
+//
+
+class LHEIntermediateParticlePtFilter : public edm::global::EDFilter<> {
+public:
+  explicit LHEIntermediateParticlePtFilter(const edm::ParameterSet&);
+  ~LHEIntermediateParticlePtFilter() override;
+
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<LHEEventProduct> src_;
+  std::vector<int> pdgIdVec_;
+  std::set<int> pdgIds_;  // Set of PDG Ids to include
+  double ptMin_;          // number of particles required to pass filter
+  double ptMax_;          // number of particles required to pass filter
+};
+
+using namespace edm;
+using namespace std;
+
+LHEIntermediateParticlePtFilter::LHEIntermediateParticlePtFilter(const edm::ParameterSet& iConfig)
+    : pdgIdVec_(iConfig.getParameter<std::vector<int>>("selectedPdgIds")),
+      ptMin_(iConfig.getParameter<double>("ptMin")),
+      ptMax_(iConfig.getParameter<double>("ptMax")) {
+  //here do whatever other initialization is needed
+  src_ = consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("src"));
+  pdgIds_ = std::set<int>(pdgIdVec_.begin(), pdgIdVec_.end());
+}
+
+LHEIntermediateParticlePtFilter::~LHEIntermediateParticlePtFilter() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+// ------------ method called to skim the data  ------------
+bool LHEIntermediateParticlePtFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<LHEEventProduct> EvtHandle;
+  iEvent.getByToken(src_, EvtHandle);
+
+  std::vector<lhef::HEPEUP::FiveVector> lheParticles = EvtHandle->hepeup().PUP;
+  std::vector<ROOT::Math::PxPyPzEVector> cands;
+
+  for (unsigned int i = 0; i < lheParticles.size(); ++i) {
+    if (EvtHandle->hepeup().ISTUP[i] != 2) {  // look at intermediate resonances
+      continue;
+    }
+    int pdgId = EvtHandle->hepeup().IDUP[i];
+    if (pdgIds_.count(pdgId)) {
+      cands.push_back(
+          ROOT::Math::PxPyPzEVector(lheParticles[i][0], lheParticles[i][1], lheParticles[i][2], lheParticles[i][3]));
+    }
+  }
+  double vpt_ = -1;
+  if (!cands.empty()) {
+    ROOT::Math::PxPyPzEVector tot = cands.at(0);
+    for (unsigned icand = 1; icand < cands.size(); ++icand) {
+      tot += cands.at(icand);
+    }
+    vpt_ = tot.pt();
+  }
+  if ((ptMax_ < 0. || vpt_ <= ptMax_) && vpt_ > ptMin_) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(LHEIntermediateParticlePtFilter);

--- a/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEIntermediateParticlePtFilter.cc
@@ -14,7 +14,6 @@
 
 // system include files
 #include <memory>
-#include <iostream>
 #include <set>
 
 // user include files
@@ -47,8 +46,8 @@ private:
   edm::EDGetTokenT<LHEEventProduct> src_;
   const std::vector<int> pdgIdVec_;
   std::set<int> pdgIds_;  // Set of PDG Ids to include
-  double ptMin_;          // number of particles required to pass filter
-  double ptMax_;          // number of particles required to pass filter
+  const double ptMin_;    // number of particles required to pass filter
+  const double ptMax_;    // number of particles required to pass filter
 };
 
 using namespace edm;
@@ -61,11 +60,6 @@ LHEIntermediateParticlePtFilter::LHEIntermediateParticlePtFilter(const edm::Para
   //here do whatever other initialization is needed
   src_ = consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("src"));
   pdgIds_ = std::set<int>(pdgIdVec_.begin(), pdgIdVec_.end());
-}
-
-LHEIntermediateParticlePtFilter::~LHEIntermediateParticlePtFilter() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 // ------------ method called to skim the data  ------------
@@ -94,11 +88,8 @@ bool LHEIntermediateParticlePtFilter::filter(edm::StreamID, edm::Event& iEvent, 
     }
     vpt_ = tot.pt();
   }
-  if ((ptMax_ < 0. || vpt_ <= ptMax_) && vpt_ > ptMin_) {
-    return true;
-  } else {
-    return false;
-  }
+
+  return (ptMax_ < 0. || vpt_ <= ptMax_) && (vpt_ > ptMin_);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
Add this GenFilter. There is a similar LHEPtFilter, but it only filters outgoing particles. This filter does the filtering on intermediate particles. For example, for a boosted Higgs, we would like to filter on the pT of the Higgs (not the final state partons). The current LHEPtFilter does not do that. This doesn't affect any other PRs or external code. 

(An attempt to extend the current LHEPtFilter was made instead of adding this filter, but difficulties were encountered with the plugin and I hope to get this addition added soon so we can ask for a small production of the sample.)

I would like to backport this also to 10_6_X to that it can be used for a Run 2 UL thesis.


