### PR TITLE
Turn off Tauolapp output redirection

### DIFF
--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -206,6 +206,7 @@ void TauolappInterface::init(const edm::EventSetup& es) {
   }
 
   Tauolapp::Log::LogWarning(false);
+  Tauolapp::Log::IgnoreRedirection(true);
 
   return;
 }


### PR DESCRIPTION
#### PR description:

Tauolapp has an option to redirect its message logging.  Unfortunately, as detailed in #40260, the way it accomplishes this for external packages that use `std::cout` or `std::cerr` is not thread safe.  This PR adds a call to `Tauolapp::Log::IgnoreRedirection(true)` to disable the thread-unsafe buffer manipulations of the standard output streams.

This is a purely technical fix that may at the most lead to some mangled output due to concurrent writes to the (thread safe) unmodified `std::cout`.

Resolves #40260.

#### PR validation:

Compiles, trivial technical fix.