### PR TITLE
Check for null histogram in PlotAlignmentValidation

### DIFF
--- a/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
+++ b/Alignment/OfflineValidation/src/PlotAlignmentValidation.cc
@@ -2127,13 +2127,17 @@ void PlotAlignmentValidation::plotDMRHistogram(PlotAlignmentValidation::DMRPlotI
       if (isBadModule)
         continue;
       fUsedModules << *_moduleId << "\n";
-      h->Fill(*varToPlot);
+      if (h) {
+        h->Fill(*varToPlot);
+      }
     }
 
     //Finalize
     fUsedModules.close();
     fBadModules->Close();
-    h->SetName(histoname.Data());
+    if (h) {
+      h->SetName(histoname.Data());
+    }
   }
 
   //Store histogram


### PR DESCRIPTION
#### PR description:

This fixes a compiler error when compiling with debug on.

#### PR validation:

Compiling under CMSSW_13_0_DBG_X_2022-12-08-2300 no longer issues an error.