### PR TITLE
Update VertexWord.h sumPt to 12b format, 10b int.

### DIFF
--- a/DataFormats/L1Trigger/interface/VertexWord.h
+++ b/DataFormats/L1Trigger/interface/VertexWord.h
@@ -8,6 +8,8 @@
 //
 // author:      Alexx Perloff
 // created:     March 17, 2021
+// modified by:    Nick Manganelli
+// modified:    November 18, 2022
 //
 ///////
 
@@ -30,11 +32,11 @@ namespace l1t {
       kZ0Size = 15,           // Width of z-position
       kZ0MagSize = 6,         // Width of z-position magnitude (signed)
       kNTrackInPVSize = 8,    // Width of the multiplicity in the PV (unsigned)
-      kSumPtSize = 10,        // Width of pT
-      kSumPtMagSize = 8,      // Width of pT magnitude (unsigned)
+      kSumPtSize = 12,        // Width of pT
+      kSumPtMagSize = 10,     // Width of pT magnitude (unsigned)
       kQualitySize = 3,       // Width of the quality field
       kNTrackOutPVSize = 10,  // Width of the multiplicity outside the PV (unsigned)
-      kUnassignedSize = 17,   // Width of the unassigned bits
+      kUnassignedSize = 15,   // Width of the unassigned bits
 
       kVertexWordSize = kValidSize + kZ0Size + kNTrackInPVSize + kSumPtSize + kQualitySize + kNTrackOutPVSize +
                         kUnassignedSize,  // Width of the vertex word in bits


### PR DESCRIPTION
(cherry picked from commit 449e51f6eda8467ef60bf65639a2ab3b30acc6ce)

#### PR description:
The Vertex Word constants are updated to increase the SumPt integer (magnitude) from 8b to 10b (total of 12b)

Local PR: https://github.com/cms-l1t-offline/cmssw/pull/1057

#### PR validation:
The outputs of this PR match corresponding changes in the firmware outputs.

The standard code-checks/formatting are performed on the updated code





