### PR TITLE
Initialize variables for SiStripMonitorDigi::SubDetMEs

### DIFF
--- a/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
+++ b/DQM/SiStripMonitorDigi/interface/SiStripMonitorDigi.h
@@ -70,18 +70,18 @@ public:
   };
 
   struct SubDetMEs {
-    int totNDigis;
-    MonitorElement* SubDetTotDigiProf;
-    MonitorElement* SubDetDigiApvProf;
-    MonitorElement* SubDetDigiApvTH2;
+    int totNDigis = 0;
+    MonitorElement* SubDetTotDigiProf = nullptr;
+    MonitorElement* SubDetDigiApvProf = nullptr;
+    MonitorElement* SubDetDigiApvTH2 = nullptr;
 
     //int totApvShots;
     std::vector<APVShot> SubDetApvShots;
-    MonitorElement* SubDetNApvShotsTH1;
-    MonitorElement* SubDetChargeMedianApvShotsTH1;
-    MonitorElement* SubDetNStripsApvShotsTH1;
-    MonitorElement* SubDetNApvShotsProf;
-    MonitorElement* SubDetNApvShotsNApvTH1;
+    MonitorElement* SubDetNApvShotsTH1 = nullptr;
+    MonitorElement* SubDetChargeMedianApvShotsTH1 = nullptr;
+    MonitorElement* SubDetNStripsApvShotsTH1 = nullptr;
+    MonitorElement* SubDetNApvShotsProf = nullptr;
+    MonitorElement* SubDetNApvShotsNApvTH1 = nullptr;
   };
 
   struct DigiFailureMEs {

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -1164,16 +1164,6 @@ void SiStripMonitorDigi::createLayerMEs(DQMStore::IBooker& ibooker, std::string 
 //
 void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker& ibooker, std::string label) {
   SubDetMEs subdetMEs;
-  subdetMEs.totNDigis = 0;
-  subdetMEs.SubDetTotDigiProf = nullptr;
-  subdetMEs.SubDetDigiApvProf = nullptr;
-  subdetMEs.SubDetDigiApvTH2 = nullptr;
-
-  subdetMEs.SubDetApvShots.clear();
-  subdetMEs.SubDetNApvShotsTH1 = nullptr;
-  subdetMEs.SubDetChargeMedianApvShotsTH1 = nullptr;
-  subdetMEs.SubDetNStripsApvShotsTH1 = nullptr;
-  subdetMEs.SubDetNApvShotsProf = nullptr;
 
   std::string HistoName;
 


### PR DESCRIPTION
#### PR description:

This avoids an uninitialization warning in debug builds.

#### PR validation:

Building under CMSSW_13_0_DBG_X_2022-12-08-2300 no longer issues the warning.