### PR TITLE
Allow caching of HFShowerLibrary

### DIFF
--- a/SimDataFormats/CaloHit/interface/HFShowerPhoton.h
+++ b/SimDataFormats/CaloHit/interface/HFShowerPhoton.h
@@ -17,8 +17,11 @@ public:
 
   HFShowerPhoton(float x = 0, float y = 0, float z = 0, float lambda = 0, float t = 0);
   HFShowerPhoton(const Point& p, float time, float lambda);
-  HFShowerPhoton(const HFShowerPhoton&);
-  virtual ~HFShowerPhoton();
+  HFShowerPhoton(const HFShowerPhoton&) = default;
+  HFShowerPhoton(HFShowerPhoton&&) = default;
+
+  HFShowerPhoton& operator=(const HFShowerPhoton&) = default;
+  HFShowerPhoton& operator=(HFShowerPhoton&&) = default;
 
   const Point& position() const { return position_; }
   float x() const { return position_.X(); }

--- a/SimDataFormats/CaloHit/src/HFShowerPhoton.cc
+++ b/SimDataFormats/CaloHit/src/HFShowerPhoton.cc
@@ -7,17 +7,9 @@
 #include <iomanip>
 
 HFShowerPhoton::HFShowerPhoton(float x, float y, float z, float lambda, float t)
-    : position_(Point(x, y, z)), lambda_(lambda), time_(t) {}
+    : position_(x, y, z), lambda_(lambda), time_(t) {}
 
 HFShowerPhoton::HFShowerPhoton(const Point& p, float t, float lambda) : position_(p), lambda_(lambda), time_(t) {}
-
-HFShowerPhoton::HFShowerPhoton(const HFShowerPhoton& right) {
-  position_ = right.position_;
-  lambda_ = right.lambda_;
-  time_ = right.time_;
-}
-
-HFShowerPhoton::~HFShowerPhoton() {}
 
 std::ostream& operator<<(std::ostream& os, const HFShowerPhoton& it) {
   os << "X " << std::setw(6) << it.x() << " Y " << std::setw(6) << it.y() << " Z " << std::setw(6) << it.z() << " t "

--- a/SimG4CMS/Calo/interface/HFFibre.h
+++ b/SimG4CMS/Calo/interface/HFFibre.h
@@ -14,28 +14,39 @@
 
 #include <vector>
 #include <string>
+#include <array>
 
 class HFFibre {
 public:
   //Constructor and Destructor
-  HFFibre(const std::string& name,
-          const HcalDDDSimConstants* hcons,
-          const HcalSimulationParameters* hps,
-          edm::ParameterSet const& p);
-  ~HFFibre() = default;
+  HFFibre(const HcalDDDSimConstants* hcons, const HcalSimulationParameters* hps, edm::ParameterSet const& p);
 
-  double attLength(double lambda);
-  double tShift(const G4ThreeVector& point, int depth, int fromEndAbs = 0);
-  double zShift(const G4ThreeVector& point, int depth, int fromEndAbs = 0);
+  double attLength(double lambda) const;
+  double tShift(const G4ThreeVector& point, int depth, int fromEndAbs = 0) const;
+  double zShift(const G4ThreeVector& point, int depth, int fromEndAbs = 0) const;
+
+  struct Params {
+    Params() = default;
+    Params(double iFractionOfSpeedOfLightInFibre,
+           const HcalDDDSimConstants* hcons,
+           const HcalSimulationParameters* hps);
+    double fractionOfSpeedOfLightInFibre_;
+    std::vector<double> gParHF_;
+    std::vector<double> rTableHF_;
+    std::vector<double> shortFibreLength_;
+    std::vector<double> longFibreLength_;
+    std::vector<double> attenuationLength_;
+    std::array<double, 2> lambdaLimits_;
+  };
+
+  HFFibre(Params iP);
 
 private:
-  const HcalDDDSimConstants* hcalConstant_;
-  const HcalSimulationParameters* hcalsimpar_;
-  double cFibre;
-  std::vector<double> gpar, radius;
-  std::vector<double> shortFL, longFL;
-  std::vector<double> attL;
-  int nBinR, nBinAtt;
-  double lambLim[2];
+  double cFibre_;
+  std::vector<double> gpar_, radius_;
+  std::vector<double> shortFL_, longFL_;
+  std::vector<double> attL_;
+  int nBinR_, nBinAtt_;
+  std::array<double, 2> lambLim_;
 };
 #endif

--- a/SimG4CMS/Calo/interface/HFShower.h
+++ b/SimG4CMS/Calo/interface/HFShower.h
@@ -26,7 +26,6 @@ public:
            const HcalSimulationParameters *hps,
            edm::ParameterSet const &p,
            int chk = 0);
-  virtual ~HFShower();
 
 public:
   struct Hit {
@@ -43,10 +42,8 @@ public:
   std::vector<Hit> getHits(const G4Step *aStep, bool forLibraryProducer, double zoffset);
 
 private:
-  const HcalDDDSimConstants *hcalConstant_;
-
-  std::unique_ptr<HFCherenkov> cherenkov_;
-  std::unique_ptr<HFFibre> fibre_;
+  HFCherenkov cherenkov_;
+  HFFibre fibre_;
 
   int chkFibre_;
   bool applyFidCut_;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -52,7 +52,28 @@ public:
                             double time,
                             bool onlyLong = false);
 
+  struct Params {
+    double probMax_;
+    double backProb_;
+    double dphi_;
+    bool equalizeTimeShift_;
+    bool verbose_;
+    bool applyFidCut_;
+  };
+  struct FileParams {
+    std::string fileName_;
+    std::string emBranchName_;
+    std::string hadBranchName_;
+    std::string branchEvInfo_;
+    int fileVersion_;
+  };
+  HFShowerLibrary(Params const &, FileParams const &, HFFibre::Params);
+
 private:
+  HFShowerLibrary(const HcalDDDSimConstants *hcons,
+                  const HcalSimulationParameters *hps,
+                  edm::ParameterSet const &hfShower,
+                  edm::ParameterSet const &hfShowerLibrary);
   bool rInside(double r) const;
   HFShowerPhotonCollection getRecord(int, int) const;
   void loadEventInfo(TBranch *);

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -60,8 +60,7 @@ private:
   HFShowerPhotonCollection extrapolate(int, double);
   void storePhoton(HFShowerPhoton const &iPhoton, HFShowerPhotonCollection &iPhotons) const;
 
-  const HcalDDDSimConstants *hcalConstant_;
-  std::unique_ptr<HFFibre> fibre_;
+  HFFibre fibre_;
   std::unique_ptr<TFile> hf_;
   TBranch *emBranch_, *hadBranch_;
 

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -53,12 +53,12 @@ public:
                             bool onlyLong = false);
 
 private:
-  bool rInside(double r);
+  bool rInside(double r) const;
   HFShowerPhotonCollection getRecord(int, int) const;
   void loadEventInfo(TBranch *);
-  void interpolate(int, double);
-  void extrapolate(int, double);
-  void storePhoton(HFShowerPhoton const &iPhoton);
+  HFShowerPhotonCollection interpolate(int, double);
+  HFShowerPhotonCollection extrapolate(int, double);
+  void storePhoton(HFShowerPhoton const &iPhoton, HFShowerPhotonCollection &iPhotons) const;
 
   const HcalDDDSimConstants *hcalConstant_;
   std::unique_ptr<HFFibre> fibre_;
@@ -75,7 +75,5 @@ private:
   double probMax_, backProb_;
   double dphi_, rMin_, rMax_;
   std::vector<double> gpar_;
-
-  HFShowerPhotonCollection pe_;
 };
 #endif

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -63,23 +63,23 @@ protected:
 private:
   const HcalDDDSimConstants *hcalConstant_;
   std::unique_ptr<HFFibre> fibre_;
-  TFile *hf;
-  TBranch *emBranch, *hadBranch;
+  TFile *hf_;
+  TBranch *emBranch_, *hadBranch_;
 
-  bool verbose, applyFidCut, newForm, v3version;
-  int nMomBin, totEvents, evtPerBin;
-  float libVers, listVersion;
-  std::vector<double> pmom;
+  bool verbose_, applyFidCut_, newForm_, v3version_;
+  int nMomBin_, totEvents_, evtPerBin_;
+  float libVers_, listVersion_;
+  std::vector<double> pmom_;
 
   int fileVersion_;
   bool equalizeTimeShift_;
-  double probMax, backProb;
-  double dphi, rMin, rMax;
-  std::vector<double> gpar;
+  double probMax_, backProb_;
+  double dphi_, rMin_, rMax_;
+  std::vector<double> gpar_;
 
-  int npe;
-  HFShowerPhotonCollection pe;
-  std::unique_ptr<HFShowerPhotonCollection> photo;
-  HFShowerPhotonCollection photon;
+  int npe_;
+  HFShowerPhotonCollection pe_;
+  std::unique_ptr<HFShowerPhotonCollection> photo_;
+  HFShowerPhotonCollection photon_;
 };
 #endif

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -77,7 +77,6 @@ private:
   double dphi_, rMin_, rMax_;
   std::vector<double> gpar_;
 
-  int npe_;
   HFShowerPhotonCollection pe_;
   std::unique_ptr<HFShowerPhotonCollection> photo_;
 };

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -80,6 +80,5 @@ private:
   int npe_;
   HFShowerPhotonCollection pe_;
   std::unique_ptr<HFShowerPhotonCollection> photo_;
-  HFShowerPhotonCollection photon_;
 };
 #endif

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -63,7 +63,7 @@ protected:
 private:
   const HcalDDDSimConstants *hcalConstant_;
   std::unique_ptr<HFFibre> fibre_;
-  TFile *hf_;
+  std::unique_ptr<TFile> hf_;
   TBranch *emBranch_, *hadBranch_;
 
   bool verbose_, applyFidCut_, newForm_, v3version_;

--- a/SimG4CMS/Calo/interface/HFShowerLibrary.h
+++ b/SimG4CMS/Calo/interface/HFShowerLibrary.h
@@ -52,15 +52,14 @@ public:
                             double time,
                             bool onlyLong = false);
 
-protected:
+private:
   bool rInside(double r);
-  void getRecord(int, int);
+  HFShowerPhotonCollection getRecord(int, int) const;
   void loadEventInfo(TBranch *);
   void interpolate(int, double);
   void extrapolate(int, double);
-  void storePhoton(int j);
+  void storePhoton(HFShowerPhoton const &iPhoton);
 
-private:
   const HcalDDDSimConstants *hcalConstant_;
   std::unique_ptr<HFFibre> fibre_;
   std::unique_ptr<TFile> hf_;
@@ -78,6 +77,5 @@ private:
   std::vector<double> gpar_;
 
   HFShowerPhotonCollection pe_;
-  std::unique_ptr<HFShowerPhotonCollection> photo_;
 };
 #endif

--- a/SimG4CMS/Calo/interface/HFShowerParam.h
+++ b/SimG4CMS/Calo/interface/HFShowerParam.h
@@ -28,7 +28,6 @@ public:
                 const HcalDDDSimConstants* hcons,
                 const HcalSimulationParameters* hps,
                 edm::ParameterSet const& p);
-  virtual ~HFShowerParam();
 
 public:
   struct Hit {
@@ -41,9 +40,8 @@ public:
   std::vector<Hit> getHits(const G4Step* aStep, double weight, bool& isKilled);
 
 private:
-  const HcalDDDSimConstants* hcalConstants_;
   std::unique_ptr<HFShowerLibrary> showerLibrary_;
-  std::unique_ptr<HFFibre> fibre_;
+  HFFibre fibre_;
   std::unique_ptr<HFGflash> gflash_;
   bool fillHisto_;
   double pePerGeV_, edMin_, ref_index_, aperture_, attLMeanInv_;

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -23,7 +23,7 @@ HFShower::HFShower(const std::string &name,
                    const HcalSimulationParameters *hps,
                    edm::ParameterSet const &p,
                    int chk)
-    : hcalConstant_(hcons), chkFibre_(chk) {
+    : cherenkov_(p.getParameter<edm::ParameterSet>("HFShower")), fibre_(hcons, hps, p), chkFibre_(chk) {
   edm::ParameterSet m_HF = p.getParameter<edm::ParameterSet>("HFShower");
   applyFidCut_ = m_HF.getParameter<bool>("ApplyFiducialCut");
   edm::ParameterSet m_HF2 = m_HF.getParameter<edm::ParameterSet>("HFShowerBlock");
@@ -33,14 +33,9 @@ HFShower::HFShower(const std::string &name,
   edm::LogVerbatim("HFShower") << "HFShower:: Maximum probability cut off " << probMax_ << " Check flag " << chkFibre_
                                << " EqualizeTimeShift " << equalizeTimeShift_;
 
-  cherenkov_ = std::make_unique<HFCherenkov>(m_HF);
-  fibre_ = std::make_unique<HFFibre>(name, hcalConstant_, hps, p);
-
   //Special Geometry parameters
-  gpar_ = hcalConstant_->getGparHF();
+  gpar_ = hcons->getGparHF();
 }
-
-HFShower::~HFShower() {}
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight) {
   std::vector<HFShower::Hit> hits;
@@ -115,7 +110,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
   double time =
-      (equalizeTimeShift_) ? (fibre_->tShift(localPos, depth, -1)) : (fibre_->tShift(localPos, depth, chkFibre_));
+      (equalizeTimeShift_) ? (fibre_.tShift(localPos, depth, -1)) : (fibre_.tShift(localPos, depth, chkFibre_));
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "
@@ -128,15 +123,15 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
   std::vector<double> momz;
   if (!applyFidCut_) {  // _____ Tmp close of the cherenkov function
     if (ok)
-      npe = cherenkov_->computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
-    wavelength = cherenkov_->getWL();
-    momz = cherenkov_->getMom();
+      npe = cherenkov_.computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
+    wavelength = cherenkov_.getWL();
+    momz = cherenkov_.getMom();
   }  // ^^^^^ End of Tmp close of the cherenkov function
   if (ok && npe > 0) {
     for (int i = 0; i < npe; ++i) {
       double p = 1.;
       if (!applyFidCut_)
-        p = fibre_->attLength(wavelength[i]);
+        p = fibre_.attLength(wavelength[i]);
       double r1 = G4UniformRand();
       double r2 = G4UniformRand();
 #ifdef EDM_ML_DEBUG
@@ -222,7 +217,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
 
 #ifdef EDM_ML_DEBUG
-  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? 0 : fibre_.tShift(localPos, depth, chkFibre_);
   edm::LogVerbatim("HFShower") << "HFShower::getHits: in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "
                                << zFibre << " Trans " << translation << " Time " << tSlice << " " << time
                                << "\n                  Direction " << momentumDir << " Local " << localMom;
@@ -232,9 +227,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   std::vector<double> wavelength;
   std::vector<double> momz;
   if (ok)
-    npe = cherenkov_->computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
-  wavelength = cherenkov_->getWL();
-  momz = cherenkov_->getMom();
+    npe = cherenkov_.computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
+  wavelength = cherenkov_.getWL();
+  momz = cherenkov_.getMom();
   if (ok && npe > 0) {
     for (int i = 0; i < npe; ++i) {
       hit.depth = depth;
@@ -326,7 +321,7 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   double zCoor = localPos.z();
   double zFibre = (0.5 * gpar_[1] - zCoor - translation.z());
   double tSlice = (aStep->GetPostStepPoint()->GetGlobalTime());
-  double time = (equalizeTimeShift_) ? 0 : fibre_->tShift(localPos, depth, chkFibre_);
+  double time = (equalizeTimeShift_) ? 0 : fibre_.tShift(localPos, depth, chkFibre_);
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShower::getHits(SL): in " << name << " Z " << zCoor << "(" << globalPos.z() << ") "
@@ -336,9 +331,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
   // npe should be 0
   int npe = 0;
   if (ok)
-    npe = cherenkov_->computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
-  std::vector<double> wavelength = cherenkov_->getWL();
-  std::vector<double> momz = cherenkov_->getMom();
+    npe = cherenkov_.computeNPE(aStep, particleDef, pBeta, u, v, w, stepl, zFibre, dose, npeDose);
+  std::vector<double> wavelength = cherenkov_.getWL();
+  std::vector<double> momz = cherenkov_.getMom();
 
   for (int i = 0; i < npe; ++i) {
     hit.depth = depth;

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -24,7 +24,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
                                  const HcalDDDSimConstants* hcons,
                                  const HcalSimulationParameters* hps,
                                  edm::ParameterSet const& p)
-    : hcalConstant_(hcons), hf_(nullptr), emBranch_(nullptr), hadBranch_(nullptr), npe_(0) {
+    : hcalConstant_(hcons), hf_(), emBranch_(nullptr), hadBranch_(nullptr), npe_(0) {
   edm::ParameterSet m_HF =
       (p.getParameter<edm::ParameterSet>("HFShower")).getParameter<edm::ParameterSet>("HFShowerBlock");
   probMax_ = m_HF.getParameter<double>("ProbMax");
@@ -48,7 +48,7 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
   if (pTreeName.find('.') == 0)
     pTreeName.erase(0, 2);
   const char* nTree = pTreeName.c_str();
-  hf_ = TFile::Open(nTree);
+  hf_ = std::unique_ptr<TFile>(TFile::Open(nTree));
 
   if (!hf_->IsOpen()) {
     edm::LogError("HFShower") << "HFShowerLibrary: opening " << nTree << " failed";

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -24,52 +24,52 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
                                  const HcalDDDSimConstants* hcons,
                                  const HcalSimulationParameters* hps,
                                  edm::ParameterSet const& p)
-    : hcalConstant_(hcons), hf(nullptr), emBranch(nullptr), hadBranch(nullptr), npe(0) {
+    : hcalConstant_(hcons), hf_(nullptr), emBranch_(nullptr), hadBranch_(nullptr), npe_(0) {
   edm::ParameterSet m_HF =
       (p.getParameter<edm::ParameterSet>("HFShower")).getParameter<edm::ParameterSet>("HFShowerBlock");
-  probMax = m_HF.getParameter<double>("ProbMax");
+  probMax_ = m_HF.getParameter<double>("ProbMax");
   equalizeTimeShift_ = m_HF.getParameter<bool>("EqualizeTimeShift");
 
   edm::ParameterSet m_HS =
       (p.getParameter<edm::ParameterSet>("HFShowerLibrary")).getParameter<edm::ParameterSet>("HFLibraryFileBlock");
   edm::FileInPath fp = m_HS.getParameter<edm::FileInPath>("FileName");
   std::string pTreeName = fp.fullPath();
-  backProb = m_HS.getParameter<double>("BackProbability");
+  backProb_ = m_HS.getParameter<double>("BackProbability");
   std::string emName = m_HS.getParameter<std::string>("TreeEMID");
   std::string hadName = m_HS.getParameter<std::string>("TreeHadID");
   std::string branchEvInfo = m_HS.getUntrackedParameter<std::string>(
       "BranchEvt", "HFShowerLibraryEventInfos_hfshowerlib_HFShowerLibraryEventInfo");
   std::string branchPre = m_HS.getUntrackedParameter<std::string>("BranchPre", "HFShowerPhotons_hfshowerlib_");
   std::string branchPost = m_HS.getUntrackedParameter<std::string>("BranchPost", "_R.obj");
-  verbose = m_HS.getUntrackedParameter<bool>("Verbosity", false);
-  applyFidCut = m_HS.getParameter<bool>("ApplyFiducialCut");
+  verbose_ = m_HS.getUntrackedParameter<bool>("Verbosity", false);
+  applyFidCut_ = m_HS.getParameter<bool>("ApplyFiducialCut");
   fileVersion_ = m_HS.getParameter<int>("FileVersion");
 
   if (pTreeName.find('.') == 0)
     pTreeName.erase(0, 2);
   const char* nTree = pTreeName.c_str();
-  hf = TFile::Open(nTree);
+  hf_ = TFile::Open(nTree);
 
-  if (!hf->IsOpen()) {
+  if (!hf_->IsOpen()) {
     edm::LogError("HFShower") << "HFShowerLibrary: opening " << nTree << " failed";
     throw cms::Exception("Unknown", "HFShowerLibrary") << "Opening of " << pTreeName << " fails\n";
   } else {
     edm::LogVerbatim("HFShower") << "HFShowerLibrary: opening " << nTree << " successfully";
   }
 
-  newForm = (branchEvInfo.empty());
+  newForm_ = (branchEvInfo.empty());
   TTree* event(nullptr);
-  if (newForm)
-    event = (TTree*)hf->Get("HFSimHits");
+  if (newForm_)
+    event = (TTree*)hf_->Get("HFSimHits");
   else
-    event = (TTree*)hf->Get("Events");
+    event = (TTree*)hf_->Get("Events");
   if (event) {
     TBranch* evtInfo(nullptr);
-    if (!newForm) {
+    if (!newForm_) {
       std::string info = branchEvInfo + branchPost;
       evtInfo = event->GetBranch(info.c_str());
     }
-    if (evtInfo || newForm) {
+    if (evtInfo || newForm_) {
       loadEventInfo(evtInfo);
     } else {
       edm::LogError("HFShower") << "HFShowerLibrary: HFShowerLibrayEventInfo"
@@ -83,60 +83,60 @@ HFShowerLibrary::HFShowerLibrary(const std::string& name,
   }
 
   std::stringstream ss;
-  ss << "HFShowerLibrary: Library " << libVers << " ListVersion " << listVersion << " File version " << fileVersion_
-     << " Events Total " << totEvents << " and " << evtPerBin << " per bin\n";
-  ss << "HFShowerLibrary: Energies (GeV) with " << nMomBin << " bins\n";
-  for (int i = 0; i < nMomBin; ++i) {
+  ss << "HFShowerLibrary: Library " << libVers_ << " ListVersion " << listVersion_ << " File version " << fileVersion_
+     << " Events Total " << totEvents_ << " and " << evtPerBin_ << " per bin\n";
+  ss << "HFShowerLibrary: Energies (GeV) with " << nMomBin_ << " bins\n";
+  for (int i = 0; i < nMomBin_; ++i) {
     if (i / 10 * 10 == i && i > 0) {
       ss << "\n";
     }
-    ss << "  " << pmom[i] / CLHEP::GeV;
+    ss << "  " << pmom_[i] / CLHEP::GeV;
   }
   edm::LogVerbatim("HFShower") << ss.str();
 
   std::string nameBr = branchPre + emName + branchPost;
-  emBranch = event->GetBranch(nameBr.c_str());
-  if (verbose)
-    emBranch->Print();
+  emBranch_ = event->GetBranch(nameBr.c_str());
+  if (verbose_)
+    emBranch_->Print();
   nameBr = branchPre + hadName + branchPost;
-  hadBranch = event->GetBranch(nameBr.c_str());
-  if (verbose)
-    hadBranch->Print();
+  hadBranch_ = event->GetBranch(nameBr.c_str());
+  if (verbose_)
+    hadBranch_->Print();
 
-  v3version = false;
-  if (emBranch->GetClassName() == std::string("vector<float>")) {
-    v3version = true;
+  v3version_ = false;
+  if (emBranch_->GetClassName() == std::string("vector<float>")) {
+    v3version_ = true;
   }
 
-  edm::LogVerbatim("HFShower") << " HFShowerLibrary:Branch " << emName << " has " << emBranch->GetEntries()
-                               << " entries and Branch " << hadName << " has " << hadBranch->GetEntries()
+  edm::LogVerbatim("HFShower") << " HFShowerLibrary:Branch " << emName << " has " << emBranch_->GetEntries()
+                               << " entries and Branch " << hadName << " has " << hadBranch_->GetEntries()
                                << " entries\n HFShowerLibrary::No packing information - Assume x, y, z are not in "
                                   "packed form\n Maximum probability cut off "
-                               << probMax << "  Back propagation of light probability " << backProb
+                               << probMax_ << "  Back propagation of light probability " << backProb_
                                << " Flag for equalizing Time Shift for different eta " << equalizeTimeShift_;
 
   fibre_ = std::make_unique<HFFibre>(name, hcalConstant_, hps, p);
-  photo = std::make_unique<HFShowerPhotonCollection>();
+  photo_ = std::make_unique<HFShowerPhotonCollection>();
 
   //Radius (minimum and maximum)
   std::vector<double> rTable = hcalConstant_->getRTableHF();
-  rMin = rTable[0];
-  rMax = rTable[rTable.size() - 1];
+  rMin_ = rTable[0];
+  rMax_ = rTable[rTable.size() - 1];
 
   //Delta phi
   std::vector<double> phibin = hcalConstant_->getPhiTableHF();
-  dphi = phibin[0];
+  dphi_ = phibin[0];
 
-  edm::LogVerbatim("HFShower") << "HFShowerLibrary: rMIN " << rMin / CLHEP::cm << " cm and rMax " << rMax / CLHEP::cm
-                               << " (Half) Phi Width of wedge " << dphi / CLHEP::deg;
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary: rMIN " << rMin_ / CLHEP::cm << " cm and rMax " << rMax_ / CLHEP::cm
+                               << " (Half) Phi Width of wedge " << dphi_ / CLHEP::deg;
 
   //Special Geometry parameters
-  gpar = hcalConstant_->getGparHF();
+  gpar_ = hcalConstant_->getGparHF();
 }
 
 HFShowerLibrary::~HFShowerLibrary() {
-  if (hf)
-    hf->Close();
+  if (hf_)
+    hf_->Close();
 }
 
 std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step* aStep,
@@ -161,7 +161,7 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::getHits(const G4Step* aStep,
 #ifdef EDM_ML_DEBUG
   G4String partType = track->GetDefinition()->GetParticleName();
   const G4ThreeVector localPos = preStepPoint->GetTouchable()->GetHistory()->GetTopTransform().TransformPoint(hitPoint);
-  double zoff = localPos.z() + 0.5 * gpar[1];
+  double zoff = localPos.z() + 0.5 * gpar_[1];
 
   edm::LogVerbatim("HFShower") << "HFShowerLibrary::getHits " << partType << " of energy "
                                << track->GetKineticEnergy() / CLHEP::GeV << " GeV weight= " << weight
@@ -215,13 +215,13 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
   double stheta = sin(momDir.theta());
 
   if (isEM) {
-    if (pin < pmom[nMomBin - 1]) {
+    if (pin < pmom_[nMomBin_ - 1]) {
       interpolate(0, pin);
     } else {
       extrapolate(0, pin);
     }
   } else {
-    if (pin < pmom[nMomBin - 1]) {
+    if (pin < pmom_[nMomBin_ - 1]) {
       interpolate(1, pin);
     } else {
       extrapolate(1, pin);
@@ -230,16 +230,16 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
 
   int nHit = 0;
   HFShowerLibrary::Hit oneHit;
-  for (int i = 0; i < npe; ++i) {
-    double zv = std::abs(pe[i].z());  // abs local z
+  for (int i = 0; i < npe_; ++i) {
+    double zv = std::abs(pe_[i].z());  // abs local z
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe[i] << " zv " << zv;
+    edm::LogVerbatim("HFShower") << "HFShowerLibrary: Hit " << i << " " << pe_[i] << " zv " << zv;
 #endif
-    if (zv <= gpar[1] && pe[i].lambda() > 0 && (pe[i].z() >= 0 || (zv > gpar[0] && (!onlyLong)))) {
+    if (zv <= gpar_[1] && pe_[i].lambda() > 0 && (pe_[i].z() >= 0 || (zv > gpar_[0] && (!onlyLong)))) {
       int depth = 1;
       if (onlyLong) {
       } else if (!backward) {  // fully valid only for "front" particles
-        if (pe[i].z() < 0)
+        if (pe_[i].z() < 0)
           depth = 2;                 // with "front"-simulated shower lib.
       } else {                       // for "backward" particles - almost equal
         double r = G4UniformRand();  // share between L and S fibers
@@ -249,27 +249,27 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
 
       // Updated coordinate transformation from local
       //  back to global using two Euler angles: phi and theta
-      double pex = pe[i].x();
-      double pey = pe[i].y();
+      double pex = pe_[i].x();
+      double pey = pe_[i].y();
 
       double xx = pex * ctheta * cphi - pey * sphi + zv * stheta * cphi;
       double yy = pex * ctheta * sphi + pey * cphi + zv * stheta * sphi;
       double zz = -pex * stheta + zv * ctheta;
 
       G4ThreeVector pos = hitPoint + G4ThreeVector(xx, yy, zz);
-      zv = std::abs(pos.z()) - gpar[4] - 0.5 * gpar[1];
+      zv = std::abs(pos.z()) - gpar_[4] - 0.5 * gpar_[1];
       G4ThreeVector lpos = G4ThreeVector(pos.x(), pos.y(), zv);
 
       zv = fibre_->zShift(lpos, depth, 0);  // distance to PMT !
 
       double r = pos.perp();
-      double p = fibre_->attLength(pe[i].lambda());
+      double p = fibre_->attLength(pe_[i].lambda());
       double fi = pos.phi();
       if (fi < 0)
         fi += CLHEP::twopi;
-      int isect = int(fi / dphi) + 1;
+      int isect = int(fi / dphi_) + 1;
       isect = (isect + 1) / 2;
-      double dfi = ((isect * 2 - 1) * dphi - fi);
+      double dfi = ((isect * 2 - 1) * dphi_ - fi);
       if (dfi < 0)
         dfi = -dfi;
       double dfir = r * sin(dfi);
@@ -282,30 +282,31 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
       double r1 = G4UniformRand();
       double r2 = G4UniformRand();
       double r3 = backward ? G4UniformRand() : -9999.;
-      if (!applyFidCut)
-        dfir += gpar[5];
+      if (!applyFidCut_)
+        dfir += gpar_[5];
 
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HFShower") << "HFShowerLibrary: rLimits " << rInside(r) << " attenuation " << r1 << ":"
-                                   << exp(-p * zv) << " r2 " << r2 << " r3 " << r3 << " rDfi " << gpar[5] << " zz "
-                                   << zz << " zLim " << gpar[4] << ":" << gpar[4] + gpar[1] << "\n"
+                                   << exp(-p * zv) << " r2 " << r2 << " r3 " << r3 << " rDfi " << gpar_[5] << " zz "
+                                   << zz << " zLim " << gpar_[4] << ":" << gpar_[4] + gpar_[1] << "\n"
                                    << "  rInside(r) :" << rInside(r) << "  r1 <= exp(-p*zv) :" << (r1 <= exp(-p * zv))
-                                   << "  r2 <= probMax :" << (r2 <= probMax * weight)
-                                   << "  r3 <= backProb :" << (r3 <= backProb)
-                                   << "  dfir > gpar[5] :" << (dfir > gpar[5]) << "  zz >= gpar[4] :" << (zz >= gpar[4])
-                                   << "  zz <= gpar[4]+gpar[1] :" << (zz <= gpar[4] + gpar[1]);
+                                   << "  r2 <= probMax :" << (r2 <= probMax_ * weight)
+                                   << "  r3 <= backProb :" << (r3 <= backProb_)
+                                   << "  dfir > gpar[5] :" << (dfir > gpar_[5])
+                                   << "  zz >= gpar[4] :" << (zz >= gpar_[4])
+                                   << "  zz <= gpar[4]+gpar[1] :" << (zz <= gpar_[4] + gpar_[1]);
 #endif
-      if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax * weight && dfir > gpar[5] && zz >= gpar[4] &&
-          zz <= gpar[4] + gpar[1] && r3 <= backProb && (depth != 2 || zz >= gpar[4] + gpar[0])) {
+      if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax_ * weight && dfir > gpar_[5] && zz >= gpar_[4] &&
+          zz <= gpar_[4] + gpar_[1] && r3 <= backProb_ && (depth != 2 || zz >= gpar_[4] + gpar_[0])) {
         double tdiff = (equalizeTimeShift_) ? (fibre_->tShift(lpos, depth, -1)) : (fibre_->tShift(lpos, depth, 1));
         oneHit.position = pos;
         oneHit.depth = depth;
-        oneHit.time = (tSlice + (pe[i].t()) + tdiff);
+        oneHit.time = (tSlice + (pe_[i].t()) + tdiff);
         hit.push_back(oneHit);
 
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HFShower") << "HFShowerLibrary: Final Hit " << nHit << " position " << (hit[nHit].position)
-                                     << " Depth " << (hit[nHit].depth) << " Time " << tSlice << ":" << pe[i].t() << ":"
+                                     << " Depth " << (hit[nHit].depth) << " Time " << tSlice << ":" << pe_[i].t() << ":"
                                      << tdiff << ":" << (hit[nHit].time);
 #endif
         ++nHit;
@@ -314,18 +315,18 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
       else
         edm::LogVerbatim("HFShower") << "HFShowerLibrary: REJECTED !!!";
 #endif
-      if (onlyLong && zz >= gpar[4] + gpar[0] && zz <= gpar[4] + gpar[1]) {
+      if (onlyLong && zz >= gpar_[4] + gpar_[0] && zz <= gpar_[4] + gpar_[1]) {
         r1 = G4UniformRand();
         r2 = G4UniformRand();
-        if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax && dfir > gpar[5]) {
+        if (rInside(r) && r1 <= exp(-p * zv) && r2 <= probMax_ && dfir > gpar_[5]) {
           double tdiff = (equalizeTimeShift_) ? (fibre_->tShift(lpos, 2, -1)) : (fibre_->tShift(lpos, 2, 1));
           oneHit.position = pos;
           oneHit.depth = 2;
-          oneHit.time = (tSlice + (pe[i].t()) + tdiff);
+          oneHit.time = (tSlice + (pe_[i].t()) + tdiff);
           hit.push_back(oneHit);
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HFShower") << "HFShowerLibrary: Final Hit " << nHit << " position " << (hit[nHit].position)
-                                       << " Depth " << (hit[nHit].depth) << " Time " << tSlice << ":" << pe[i].t()
+                                       << " Depth " << (hit[nHit].depth) << " Time " << tSlice << ":" << pe_[i].t()
                                        << ":" << tdiff << ":" << (hit[nHit].time);
 #endif
           ++nHit;
@@ -335,73 +336,73 @@ std::vector<HFShowerLibrary::Hit> HFShowerLibrary::fillHits(const G4ThreeVector&
   }
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HFShower") << "HFShowerLibrary: Total Hits " << nHit << " out of " << npe << " PE";
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary: Total Hits " << nHit << " out of " << npe_ << " PE";
 #endif
-  if (nHit > npe && !onlyLong) {
-    edm::LogWarning("HFShower") << "HFShowerLibrary: Hit buffer " << npe << " smaller than " << nHit << " Hits";
+  if (nHit > npe_ && !onlyLong) {
+    edm::LogWarning("HFShower") << "HFShowerLibrary: Hit buffer " << npe_ << " smaller than " << nHit << " Hits";
   }
   return hit;
 }
 
-bool HFShowerLibrary::rInside(double r) { return (r >= rMin && r <= rMax); }
+bool HFShowerLibrary::rInside(double r) { return (r >= rMin_ && r <= rMax_); }
 
 void HFShowerLibrary::getRecord(int type, int record) {
   int nrc = record - 1;
-  photon.clear();
-  photo->clear();
+  photon_.clear();
+  photo_->clear();
   if (type > 0) {
-    if (newForm) {
-      if (!v3version) {
-        hadBranch->SetAddress(&photo);
-        int position = (fileVersion_ >= 2) ? nrc : (nrc + totEvents);
-        hadBranch->GetEntry(position);
+    if (newForm_) {
+      if (!v3version_) {
+        hadBranch_->SetAddress(&photo_);
+        int position = (fileVersion_ >= 2) ? nrc : (nrc + totEvents_);
+        hadBranch_->GetEntry(position);
       } else {
         std::vector<float> t;
         std::vector<float>* tp = &t;
-        hadBranch->SetAddress(&tp);
-        hadBranch->GetEntry(nrc + totEvents);
+        hadBranch_->SetAddress(&tp);
+        hadBranch_->GetEntry(nrc + totEvents_);
         unsigned int tSize = t.size() / 5;
-        photo->reserve(tSize);
+        photo_->reserve(tSize);
         for (unsigned int i = 0; i < tSize; i++) {
-          photo->push_back(
+          photo_->push_back(
               HFShowerPhoton(t[i], t[1 * tSize + i], t[2 * tSize + i], t[3 * tSize + i], t[4 * tSize + i]));
         }
       }
     } else {
-      hadBranch->SetAddress(&photon);
-      hadBranch->GetEntry(nrc);
+      hadBranch_->SetAddress(&photon_);
+      hadBranch_->GetEntry(nrc);
     }
   } else {
-    if (newForm) {
-      if (!v3version) {
-        emBranch->SetAddress(&photo);
-        emBranch->GetEntry(nrc);
+    if (newForm_) {
+      if (!v3version_) {
+        emBranch_->SetAddress(&photo_);
+        emBranch_->GetEntry(nrc);
       } else {
         std::vector<float> t;
         std::vector<float>* tp = &t;
-        emBranch->SetAddress(&tp);
-        emBranch->GetEntry(nrc);
+        emBranch_->SetAddress(&tp);
+        emBranch_->GetEntry(nrc);
         unsigned int tSize = t.size() / 5;
-        photo->reserve(tSize);
+        photo_->reserve(tSize);
         for (unsigned int i = 0; i < tSize; i++) {
-          photo->push_back(
+          photo_->push_back(
               HFShowerPhoton(t[i], t[1 * tSize + i], t[2 * tSize + i], t[3 * tSize + i], t[4 * tSize + i]));
         }
       }
     } else {
-      emBranch->SetAddress(&photon);
-      emBranch->GetEntry(nrc);
+      emBranch_->SetAddress(&photon_);
+      emBranch_->GetEntry(nrc);
     }
   }
 #ifdef EDM_ML_DEBUG
-  int nPhoton = (newForm) ? photo->size() : photon.size();
+  int nPhoton = (newForm_) ? photo_->size() : photon_.size();
   edm::LogVerbatim("HFShower") << "HFShowerLibrary::getRecord: Record " << record << " of type " << type << " with "
                                << nPhoton << " photons";
   for (int j = 0; j < nPhoton; j++)
-    if (newForm)
-      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photo->at(j);
+    if (newForm_)
+      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photo_->at(j);
     else
-      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photon[j];
+      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photon_[j];
 #endif
 }
 
@@ -413,59 +414,60 @@ void HFShowerLibrary::loadEventInfo(TBranch* branch) {
     edm::LogVerbatim("HFShower") << "HFShowerLibrary::loadEventInfo loads EventInfo Collection of size "
                                  << eventInfoCollection.size() << " records";
 
-    totEvents = eventInfoCollection[0].totalEvents();
-    nMomBin = eventInfoCollection[0].numberOfBins();
-    evtPerBin = eventInfoCollection[0].eventsPerBin();
-    libVers = eventInfoCollection[0].showerLibraryVersion();
-    listVersion = eventInfoCollection[0].physListVersion();
-    pmom = eventInfoCollection[0].energyBins();
+    totEvents_ = eventInfoCollection[0].totalEvents();
+    nMomBin_ = eventInfoCollection[0].numberOfBins();
+    evtPerBin_ = eventInfoCollection[0].eventsPerBin();
+    libVers_ = eventInfoCollection[0].showerLibraryVersion();
+    listVersion_ = eventInfoCollection[0].physListVersion();
+    pmom_ = eventInfoCollection[0].energyBins();
   } else {
     edm::LogVerbatim("HFShower") << "HFShowerLibrary::loadEventInfo loads EventInfo from hardwired"
                                  << " numbers";
 
-    nMomBin = 16;
-    evtPerBin = (fileVersion_ == 0) ? 5000 : 10000;
-    totEvents = nMomBin * evtPerBin;
-    libVers = (fileVersion_ == 0) ? 1.1 : 1.2;
-    listVersion = 3.6;
-    pmom = {2, 3, 5, 7, 10, 15, 20, 30, 50, 75, 100, 150, 250, 350, 500, 1000};
+    nMomBin_ = 16;
+    evtPerBin_ = (fileVersion_ == 0) ? 5000 : 10000;
+    totEvents_ = nMomBin_ * evtPerBin_;
+    libVers_ = (fileVersion_ == 0) ? 1.1 : 1.2;
+    listVersion_ = 3.6;
+    pmom_ = {2, 3, 5, 7, 10, 15, 20, 30, 50, 75, 100, 150, 250, 350, 500, 1000};
   }
-  for (int i = 0; i < nMomBin; i++)
-    pmom[i] *= CLHEP::GeV;
+  for (int i = 0; i < nMomBin_; i++)
+    pmom_[i] *= CLHEP::GeV;
 }
 
 void HFShowerLibrary::interpolate(int type, double pin) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShowerLibrary:: Interpolate for Energy " << pin / CLHEP::GeV << " GeV with "
-                               << nMomBin << " momentum bins and " << evtPerBin << " entries/bin -- total "
-                               << totEvents;
+                               << nMomBin_ << " momentum bins and " << evtPerBin_ << " entries/bin -- total "
+                               << totEvents_;
 #endif
   int irc[2] = {0, 0};
   double w = 0.;
   double r = G4UniformRand();
 
-  if (pin < pmom[0]) {
-    w = pin / pmom[0];
-    irc[1] = int(evtPerBin * r) + 1;
+  if (pin < pmom_[0]) {
+    w = pin / pmom_[0];
+    irc[1] = int(evtPerBin_ * r) + 1;
     irc[0] = 0;
   } else {
-    for (int j = 0; j < nMomBin - 1; j++) {
-      if (pin >= pmom[j] && pin < pmom[j + 1]) {
-        w = (pin - pmom[j]) / (pmom[j + 1] - pmom[j]);
-        if (j == nMomBin - 2) {
-          irc[1] = int(evtPerBin * 0.5 * r);
+    for (int j = 0; j < nMomBin_ - 1; j++) {
+      if (pin >= pmom_[j] && pin < pmom_[j + 1]) {
+        w = (pin - pmom_[j]) / (pmom_[j + 1] - pmom_[j]);
+        if (j == nMomBin_ - 2) {
+          irc[1] = int(evtPerBin_ * 0.5 * r);
         } else {
-          irc[1] = int(evtPerBin * r);
+          irc[1] = int(evtPerBin_ * r);
         }
-        irc[1] += (j + 1) * evtPerBin + 1;
+        irc[1] += (j + 1) * evtPerBin_ + 1;
         r = G4UniformRand();
-        irc[0] = int(evtPerBin * r) + 1 + j * evtPerBin;
+        irc[0] = int(evtPerBin_ * r) + 1 + j * evtPerBin_;
         if (irc[0] < 0) {
           edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = " << irc[0] << " now set to 0";
           irc[0] = 0;
-        } else if (irc[0] > totEvents) {
-          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = " << irc[0] << " now set to " << totEvents;
-          irc[0] = totEvents;
+        } else if (irc[0] > totEvents_) {
+          edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[0] = " << irc[0] << " now set to "
+                                      << totEvents_;
+          irc[0] = totEvents_;
         }
       }
     }
@@ -473,22 +475,22 @@ void HFShowerLibrary::interpolate(int type, double pin) {
   if (irc[1] < 1) {
     edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " << irc[1] << " now set to 1";
     irc[1] = 1;
-  } else if (irc[1] > totEvents) {
-    edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " << irc[1] << " now set to " << totEvents;
-    irc[1] = totEvents;
+  } else if (irc[1] > totEvents_) {
+    edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[1] = " << irc[1] << " now set to " << totEvents_;
+    irc[1] = totEvents_;
   }
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShowerLibrary:: Select records " << irc[0] << " and " << irc[1] << " with weights "
                                << 1 - w << " and " << w;
 #endif
-  pe.clear();
-  npe = 0;
+  pe_.clear();
+  npe_ = 0;
   int npold = 0;
   for (int ir = 0; ir < 2; ir++) {
     if (irc[ir] > 0) {
       getRecord(type, irc[ir]);
-      int nPhoton = (newForm) ? photo->size() : photon.size();
+      int nPhoton = (newForm_) ? photo_->size() : photon_.size();
       npold += nPhoton;
       for (int j = 0; j < nPhoton; j++) {
         r = G4UniformRand();
@@ -499,40 +501,40 @@ void HFShowerLibrary::interpolate(int type, double pin) {
     }
   }
 
-  if ((npe > npold || (npold == 0 && irc[0] > 0)) && !(npe == 0 && npold == 0))
+  if ((npe_ > npold || (npold == 0 && irc[0] > 0)) && !(npe_ == 0 && npold == 0))
     edm::LogWarning("HFShower") << "HFShowerLibrary: Interpolation Warning =="
                                 << " records " << irc[0] << " and " << irc[1] << " gives a buffer of " << npold
-                                << " photons and fills " << npe << " *****";
+                                << " photons and fills " << npe_ << " *****";
 #ifdef EDM_ML_DEBUG
   else
     edm::LogVerbatim("HFShower") << "HFShowerLibrary: Interpolation == records " << irc[0] << " and " << irc[1]
-                                 << " gives a buffer of " << npold << " photons and fills " << npe << " PE";
+                                 << " gives a buffer of " << npold << " photons and fills " << npe_ << " PE";
   for (int j = 0; j < npe; j++)
-    edm::LogVerbatim("HFShower") << "Photon " << j << " " << pe[j];
+    edm::LogVerbatim("HFShower") << "Photon " << j << " " << pe_[j];
 #endif
 }
 
 void HFShowerLibrary::extrapolate(int type, double pin) {
-  int nrec = int(pin / pmom[nMomBin - 1]);
-  double w = (pin - pmom[nMomBin - 1] * nrec) / pmom[nMomBin - 1];
+  int nrec = int(pin / pmom_[nMomBin_ - 1]);
+  double w = (pin - pmom_[nMomBin_ - 1] * nrec) / pmom_[nMomBin_ - 1];
   nrec++;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShowerLibrary:: Extrapolate for Energy " << pin / CLHEP::GeV << " GeV with "
-                               << nMomBin << " momentum bins and " << evtPerBin << " entries/bin -- "
-                               << "total " << totEvents << " using " << nrec << " records";
+                               << nMomBin_ << " momentum bins and " << evtPerBin_ << " entries/bin -- "
+                               << "total " << totEvents_ << " using " << nrec << " records";
 #endif
   std::vector<int> irc(nrec);
 
   for (int ir = 0; ir < nrec; ir++) {
     double r = G4UniformRand();
-    irc[ir] = int(evtPerBin * 0.5 * r) + (nMomBin - 1) * evtPerBin + 1;
+    irc[ir] = int(evtPerBin_ * 0.5 * r) + (nMomBin_ - 1) * evtPerBin_ + 1;
     if (irc[ir] < 1) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir << "] = " << irc[ir] << " now set to 1";
       irc[ir] = 1;
-    } else if (irc[ir] > totEvents) {
+    } else if (irc[ir] > totEvents_) {
       edm::LogWarning("HFShower") << "HFShowerLibrary:: Illegal irc[" << ir << "] = " << irc[ir] << " now set to "
-                                  << totEvents;
-      irc[ir] = totEvents;
+                                  << totEvents_;
+      irc[ir] = totEvents_;
 #ifdef EDM_ML_DEBUG
     } else {
       edm::LogVerbatim("HFShower") << "HFShowerLibrary::Extrapolation use irc[" << ir << "] = " << irc[ir];
@@ -540,13 +542,13 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
     }
   }
 
-  pe.clear();
-  npe = 0;
+  pe_.clear();
+  npe_ = 0;
   int npold = 0;
   for (int ir = 0; ir < nrec; ir++) {
     if (irc[ir] > 0) {
       getRecord(type, irc[ir]);
-      int nPhoton = (newForm) ? photo->size() : photon.size();
+      int nPhoton = (newForm_) ? photo_->size() : photon_.size();
       npold += nPhoton;
       for (int j = 0; j < nPhoton; j++) {
         double r = G4UniformRand();
@@ -563,27 +565,27 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
   edm::LogVerbatim("HFShower") << "HFShowerLibrary:: uses " << npold << " photons";
 #endif
 
-  if (npe > npold || npold == 0)
+  if (npe_ > npold || npold == 0)
     edm::LogWarning("HFShower") << "HFShowerLibrary: Extrapolation Warning == " << nrec << " records " << irc[0] << ", "
-                                << irc[1] << ", ... gives a buffer of " << npold << " photons and fills " << npe
+                                << irc[1] << ", ... gives a buffer of " << npold << " photons and fills " << npe_
                                 << " *****";
 #ifdef EDM_ML_DEBUG
   else
     edm::LogVerbatim("HFShower") << "HFShowerLibrary: Extrapolation == " << nrec << " records " << irc[0] << ", "
-                                 << irc[1] << ", ... gives a buffer of " << npold << " photons and fills " << npe
+                                 << irc[1] << ", ... gives a buffer of " << npold << " photons and fills " << npe_
                                  << " PE";
   for (int j = 0; j < npe; j++)
-    edm::LogVerbatim("HFShower") << "Photon " << j << " " << pe[j];
+    edm::LogVerbatim("HFShower") << "Photon " << j << " " << pe_[j];
 #endif
 }
 
 void HFShowerLibrary::storePhoton(int j) {
-  if (newForm)
-    pe.push_back(photo->at(j));
+  if (newForm_)
+    pe_.push_back(photo_->at(j));
   else
-    pe.push_back(photon[j]);
-  npe++;
+    pe_.push_back(photon_[j]);
+  npe_++;
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HFShower") << "HFShowerLibrary: storePhoton " << j << " npe " << npe << " " << pe[npe - 1];
+  edm::LogVerbatim("HFShower") << "HFShowerLibrary: storePhoton " << j << " npe " << npe_ << " " << pe_[npe_ - 1];
 #endif
 }

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -348,7 +348,6 @@ bool HFShowerLibrary::rInside(double r) { return (r >= rMin_ && r <= rMax_); }
 
 void HFShowerLibrary::getRecord(int type, int record) {
   int nrc = record - 1;
-  photon_.clear();
   photo_->clear();
   if (type > 0) {
     if (newForm_) {
@@ -369,7 +368,7 @@ void HFShowerLibrary::getRecord(int type, int record) {
         }
       }
     } else {
-      hadBranch_->SetAddress(&photon_);
+      hadBranch_->SetAddress(photo_.get());
       hadBranch_->GetEntry(nrc);
     }
   } else {
@@ -390,19 +389,16 @@ void HFShowerLibrary::getRecord(int type, int record) {
         }
       }
     } else {
-      emBranch_->SetAddress(&photon_);
+      emBranch_->SetAddress(photo_.get());
       emBranch_->GetEntry(nrc);
     }
   }
 #ifdef EDM_ML_DEBUG
-  int nPhoton = (newForm_) ? photo_->size() : photon_.size();
+  int nPhoton = photo_->size();
   edm::LogVerbatim("HFShower") << "HFShowerLibrary::getRecord: Record " << record << " of type " << type << " with "
                                << nPhoton << " photons";
   for (int j = 0; j < nPhoton; j++)
-    if (newForm_)
-      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photo_->at(j);
-    else
-      edm::LogVerbatim("HFShower") << "Photon " << j << " " << photon_[j];
+    edm::LogVerbatim("HFShower") << "Photon " << j << " " << photo_->at(j);
 #endif
 }
 
@@ -490,7 +486,7 @@ void HFShowerLibrary::interpolate(int type, double pin) {
   for (int ir = 0; ir < 2; ir++) {
     if (irc[ir] > 0) {
       getRecord(type, irc[ir]);
-      int nPhoton = (newForm_) ? photo_->size() : photon_.size();
+      int nPhoton = photo_->size();
       npold += nPhoton;
       for (int j = 0; j < nPhoton; j++) {
         r = G4UniformRand();
@@ -548,7 +544,7 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
   for (int ir = 0; ir < nrec; ir++) {
     if (irc[ir] > 0) {
       getRecord(type, irc[ir]);
-      int nPhoton = (newForm_) ? photo_->size() : photon_.size();
+      int nPhoton = photo_->size();
       npold += nPhoton;
       for (int j = 0; j < nPhoton; j++) {
         double r = G4UniformRand();
@@ -580,10 +576,7 @@ void HFShowerLibrary::extrapolate(int type, double pin) {
 }
 
 void HFShowerLibrary::storePhoton(int j) {
-  if (newForm_)
-    pe_.push_back(photo_->at(j));
-  else
-    pe_.push_back(photon_[j]);
+  pe_.push_back(photo_->at(j));
   npe_++;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HFShower") << "HFShowerLibrary: storePhoton " << j << " npe " << npe_ << " " << pe_[npe_ - 1];

--- a/SimG4CMS/Calo/test/BuildFile.xml
+++ b/SimG4CMS/Calo/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="test_catch2_*.cc" name="testSimG4CMSCaloCatch2">
+  <use name="catch2"/>
+  <use name="SimG4CMS/Calo"/>
+</bin>

--- a/SimG4CMS/Calo/test/test_catch2_hffibre.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hffibre.cc
@@ -2,21 +2,65 @@
 #include "SimG4CMS/Calo/interface/HFFibre.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 
+namespace test_hffibre {
+  HFFibre::Params defaultParams() {
+    HFFibre::Params fibreParams;
+    //Taken from values used by IB workflow 250202.181
+    fibreParams.fractionOfSpeedOfLightInFibre_ = 0.5;
+    fibreParams.gParHF_ = {{220, 1650, 300, 0, 11150, 3.75, 11370}};
+    fibreParams.rTableHF_ = {{12.5 * cm,
+                              16.9 * cm,
+                              20.1 * cm,
+                              24 * cm,
+                              28.6 * cm,
+                              34 * cm,
+                              40.6 * cm,
+                              48.3 * cm,
+                              57.6 * cm,
+                              68.6 * cm,
+                              81.81 * cm,
+                              197.5 * cm,
+                              116.2 * cm,
+                              130 * cm}};
+    fibreParams.shortFibreLength_ = {{206 * cm,
+                                      211.881 * cm,
+                                      220.382 * cm,
+                                      235.552 * cm,
+                                      245.62 * cm,
+                                      253.909 * cm,
+                                      255.012 * cm,
+                                      263.007 * cm,
+                                      264.348 * cm,
+                                      268.5 * cm,
+                                      268.5 * cm,
+                                      270 * cm,
+                                      273.5 * cm}};
+    fibreParams.longFibreLength_ = {{227.993 * cm,
+                                     237.122 * cm,
+                                     241.701 * cm,
+                                     256.48 * cm,
+                                     266.754 * cm,
+                                     275.988 * cm,
+                                     276.982 * cm,
+                                     284.989 * cm,
+                                     286.307 * cm,
+                                     290.478 * cm,
+                                     290.5 * cm,
+                                     292 * cm,
+                                     295.5 * cm}};
+    fibreParams.attenuationLength_ = {
+        {0.000809654 / cm, 0.000713002 / cm, 0.000654918 / cm, 0.000602767 / cm, 0.000566295 / cm, 0.000541647 / cm,
+         0.000516175 / cm, 0.000502512 / cm, 0.000504225 / cm, 0.000506212 / cm, 0.000506275 / cm, 0.000487621 / cm,
+         0.000473034 / cm, 0.000454002 / cm, 0.000442383 / cm, 0.000441043 / cm, 0.00044361 / cm,  0.000433124 / cm,
+         0.000440188 / cm, 0.000435257 / cm, 0.000439224 / cm, 0.000431385 / cm, 0.00041707 / cm,  0.000415677 / cm,
+         0.000408389 / cm, 0.000400293 / cm, 0.000400989 / cm, 0.000395417 / cm, 0.00038936 / cm,  0.000383942 / cm}};
+    fibreParams.lambdaLimits_ = {{300, 600}};
+    return fibreParams;
+  }
+}  // namespace test_hffibre
+
 TEST_CASE("test HFFibre", "[HFFibre]") {
-  HFFibre::Params params;
-  params.fractionOfSpeedOfLightInFibre_ = 0.5;
-  params.gParHF_ = {{220, 1650, 300, 0, 11150, 3.75, 11370}};
-  params.rTableHF_ = {{12.5, 16.9, 20.1, 24, 28.6, 34, 40.6, 48.3, 57.6, 68.6, 81.81, 197.5, 116.2, 130}};
-  params.shortFibreLength_ = {
-      {206, 211.881, 220.382, 235.552, 245.62, 253.909, 255.012, 263.007, 264.348, 268.5, 268.5, 270, 273.5}};
-  params.longFibreLength_ = {
-      {227.993, 237.122, 241.701, 256.48, 266.754, 275.988, 276.982, 284.989, 286.307, 290.478, 290.5, 292, 295.5}};
-  params.attenuationLength_ = {{0.000809654, 0.000713002, 0.000654918, 0.000602767, 0.000566295, 0.000541647,
-                                0.000516175, 0.000502512, 0.000504225, 0.000506212, 0.000506275, 0.000487621,
-                                0.000473034, 0.000454002, 0.000442383, 0.000441043, 0.00044361,  0.000433124,
-                                0.000440188, 0.000435257, 0.000439224, 0.000431385, 0.00041707,  0.000415677,
-                                0.000408389, 0.000400293, 0.000400989, 0.000395417, 0.00038936,  0.000383942}};
-  params.lambdaLimits_ = {{300, 600}};
+  HFFibre::Params params = test_hffibre::defaultParams();
 
   HFFibre fibre(params);
   SECTION("Attenuation") {

--- a/SimG4CMS/Calo/test/test_catch2_hffibre.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hffibre.cc
@@ -1,0 +1,39 @@
+#include "catch.hpp"
+#include "SimG4CMS/Calo/interface/HFFibre.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+
+TEST_CASE("test HFFibre", "[HFFibre]") {
+  HFFibre::Params params;
+  params.fractionOfSpeedOfLightInFibre_ = 0.5;
+  params.gParHF_ = {{220, 1650, 300, 0, 11150, 3.75, 11370}};
+  params.rTableHF_ = {{12.5, 16.9, 20.1, 24, 28.6, 34, 40.6, 48.3, 57.6, 68.6, 81.81, 197.5, 116.2, 130}};
+  params.shortFibreLength_ = {
+      {206, 211.881, 220.382, 235.552, 245.62, 253.909, 255.012, 263.007, 264.348, 268.5, 268.5, 270, 273.5}};
+  params.longFibreLength_ = {
+      {227.993, 237.122, 241.701, 256.48, 266.754, 275.988, 276.982, 284.989, 286.307, 290.478, 290.5, 292, 295.5}};
+  params.attenuationLength_ = {{0.000809654, 0.000713002, 0.000654918, 0.000602767, 0.000566295, 0.000541647,
+                                0.000516175, 0.000502512, 0.000504225, 0.000506212, 0.000506275, 0.000487621,
+                                0.000473034, 0.000454002, 0.000442383, 0.000441043, 0.00044361,  0.000433124,
+                                0.000440188, 0.000435257, 0.000439224, 0.000431385, 0.00041707,  0.000415677,
+                                0.000408389, 0.000400293, 0.000400989, 0.000395417, 0.00038936,  0.000383942}};
+  params.lambdaLimits_ = {{300, 600}};
+
+  HFFibre fibre(params);
+  SECTION("Attenuation") {
+    REQUIRE(params.attenuationLength_[0] == fibre.attLength(0));
+    REQUIRE(params.attenuationLength_.back() == fibre.attLength(1000));
+    const auto binSize = (params.lambdaLimits_[1] - params.lambdaLimits_[0]) / params.attenuationLength_.size();
+    for (std::size_t i = 0; i < params.attenuationLength_.size(); ++i) {
+      REQUIRE(fibre.attLength(params.lambdaLimits_[0] + binSize * i) == params.attenuationLength_[i]);
+    }
+  }
+
+  SECTION("zShift") {
+    REQUIRE(fibre.zShift({0, 0, 0}, 0) == *(params.longFibreLength_.end() - 1) - 0.5 * params.gParHF_[1]);
+  }
+
+  SECTION("tShift") {
+    REQUIRE(fibre.zShift({0, 0, 0}, 0) / (params.fractionOfSpeedOfLightInFibre_ * c_light) ==
+            fibre.tShift({0, 0, 0}, 0));
+  }
+}

--- a/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
@@ -1,0 +1,144 @@
+#include "catch.hpp"
+#include "SimG4CMS/Calo/interface/HFShowerLibrary.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "FWCore/PluginManager/interface/PresenceFactory.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "CLHEP/Random/MixMaxRng.h"
+#include "Randomize.hh"
+
+namespace {
+  std::shared_ptr<edm::Presence> setupMessageLogger(bool iDoSetup) {
+    if (not iDoSetup) {
+      return std::shared_ptr<edm::Presence>();
+    }
+    // Initialise the plug-in manager.
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+    try {
+      return std::shared_ptr<edm::Presence>(
+          edm::PresenceFactory::get()->makePresence("SingleThreadMSPresence").release());
+    } catch (cms::Exception &e) {
+      std::cerr << e.explainSelf() << std::endl;
+      throw;
+    }
+  }
+
+  class SetRandomEngine {
+  public:
+    explicit SetRandomEngine(long iSeed) : m_current(iSeed), m_previous(G4Random::getTheEngine()) {
+      G4Random::setTheEngine(&m_current);
+    }
+    ~SetRandomEngine() { G4Random::setTheEngine(m_previous); }
+
+  private:
+    CLHEP::MixMaxRng m_current;
+    decltype(G4Random::getTheEngine()) m_previous;
+  };
+}  // namespace
+namespace test_hffibre {
+  HFFibre::Params defaultParams();
+}
+
+TEST_CASE("test HFShowerLibrary", "[HFShowerLibrary]") {
+  //pass 'true' to turn on MessageLogger output
+  static std::shared_ptr<edm::Presence> gobbleUpTheGoop = setupMessageLogger(false);
+
+  auto fibreParams = test_hffibre::defaultParams();
+
+  //These values come from IB workflow 250202.181
+  HFShowerLibrary::Params params;
+  params.probMax_ = 1.;   // 0.5;
+  params.backProb_ = 1.;  //0.2;
+  params.dphi_ = 10 * deg;
+  params.equalizeTimeShift_ = false;
+  params.verbose_ = false;
+  params.applyFidCut_ = true;
+
+  SECTION("v4 file") {
+    HFShowerLibrary::FileParams fileParams;
+    edm::FileInPath p("SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root");
+    fileParams.fileName_ = p.fullPath();
+    fileParams.emBranchName_ = "emParticles";
+    fileParams.hadBranchName_ = "hadParticles";
+    fileParams.branchEvInfo_ = "";
+    fileParams.fileVersion_ = 0;
+
+    HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
+    SECTION("fillHits") {
+      SetRandomEngine guard(11);
+
+      SECTION("non EM or Hadron") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
+        REQUIRE(hits.empty());
+        REQUIRE(not ok);
+      }
+      SECTION("photon within threshold") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 2.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 2);
+      }
+    }
+  }
+  SECTION("v3 file") {
+    HFShowerLibrary::FileParams fileParams;
+    edm::FileInPath p("SimG4CMS/Calo/data/HFShowerLibrary_oldpmt_noatt_eta4_16en_v3.root");
+    fileParams.fileName_ = p.fullPath();
+    fileParams.emBranchName_ = "emParticles";
+    fileParams.hadBranchName_ = "hadParticles";
+    fileParams.branchEvInfo_ = "";
+    fileParams.fileVersion_ = 0;
+
+    HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
+    SECTION("fillHits") {
+      SetRandomEngine guard(11);
+
+      SECTION("non EM or Hadron") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
+        REQUIRE(hits.empty());
+        REQUIRE(not ok);
+      }
+      SECTION("photon within threshold") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 5.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 1);
+      }
+    }
+  }
+  SECTION("v6 file") {
+    HFShowerLibrary::FileParams fileParams;
+    edm::FileInPath p("SimG4CMS/Calo/data/HFShowerLibrary_run3_v6.root");
+    fileParams.fileName_ = p.fullPath();
+    fileParams.emBranchName_ = "emParticles";
+    fileParams.hadBranchName_ = "hadParticles";
+    fileParams.branchEvInfo_ = "";
+    fileParams.fileVersion_ = 2;
+
+    params.equalizeTimeShift_ = true;
+
+    HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
+    SECTION("fillHits") {
+      SetRandomEngine guard(11);
+
+      SECTION("non EM or Hadron") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
+        REQUIRE(hits.empty());
+        REQUIRE(not ok);
+      }
+      SECTION("photon within threshold") {
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 2.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 5);
+      }
+    }
+  }
+}

--- a/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
+++ b/SimG4CMS/Calo/test/test_catch2_hfshowerlibrary.cc
@@ -66,18 +66,26 @@ TEST_CASE("test HFShowerLibrary", "[HFShowerLibrary]") {
 
     HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
     SECTION("fillHits") {
-      SetRandomEngine guard(11);
-
       SECTION("non EM or Hadron") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
         REQUIRE(hits.empty());
         REQUIRE(not ok);
       }
       SECTION("photon within threshold") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits(
             {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 2.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 2);
+      }
+      SECTION("pion within threshold") {
+        SetRandomEngine guard(11);
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 211, 2.2 * GeV, ok, 1., 0.);
         REQUIRE(ok);
         REQUIRE(hits.size() == 2);
       }
@@ -94,18 +102,26 @@ TEST_CASE("test HFShowerLibrary", "[HFShowerLibrary]") {
 
     HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
     SECTION("fillHits") {
-      SetRandomEngine guard(11);
-
       SECTION("non EM or Hadron") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
         REQUIRE(hits.empty());
         REQUIRE(not ok);
       }
       SECTION("photon within threshold") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits(
             {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 5.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 1);
+      }
+      SECTION("pion within threshold") {
+        SetRandomEngine guard(11);
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 211, 5.2 * GeV, ok, 1., 0.);
         REQUIRE(ok);
         REQUIRE(hits.size() == 1);
       }
@@ -124,20 +140,28 @@ TEST_CASE("test HFShowerLibrary", "[HFShowerLibrary]") {
 
     HFShowerLibrary showerLibrary(params, fileParams, std::move(fibreParams));
     SECTION("fillHits") {
-      SetRandomEngine guard(11);
-
       SECTION("non EM or Hadron") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits({0, 0, 0}, {0, 0, 0}, 0, 0., ok, 1., 0.);
         REQUIRE(hits.empty());
         REQUIRE(not ok);
       }
       SECTION("photon within threshold") {
+        SetRandomEngine guard(11);
         bool ok = false;
         auto hits = showerLibrary.fillHits(
             {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 22, 2.2 * GeV, ok, 1., 0.);
         REQUIRE(ok);
         REQUIRE(hits.size() == 5);
+      }
+      SECTION("pion within threshold") {
+        SetRandomEngine guard(11);
+        bool ok = false;
+        auto hits = showerLibrary.fillHits(
+            {-470.637, -618.696, 11150}, {0.000467326, -0.00804975, 0.999967}, 211, 5.2 * GeV, ok, 1., 0.);
+        REQUIRE(ok);
+        REQUIRE(hits.size() == 2);
       }
     }
   }

--- a/SimG4CMS/Calo/test/test_catch2_main.cc
+++ b/SimG4CMS/Calo/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
#### PR description:

- Modernized code related to HFShowerLibrary
- decreased memory size of HFShowerPhoton by remove unnecessary virtualization
- Added ability to cache entire contents of HFShowerLibrary file and share it safely across instances of modules. (Ability is off by default).

#### PR validation:

- Added a unit test for HFShowerLibrary to show with and without caching give same results. Test also shows that all three existing data files can be read without errors.
- Ran demonstrator which produces pileup files by running the GEN+SIM step for the minimum bias within the mixing module. This generated around 80,000 min bias per job (800 minibias/event with 100 events) using 8 threads without issues.

Comparing timing with and without caching showed a 1-2% speed improvement when using caching.