### PR TITLE
addition of WFs with post-EE conditions [12_5_X]

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -26,6 +26,8 @@ upgradeKeys[2017] = [
     '2024PU',
     '2021FS',
     '2021FSPU',
+    '2021postEE',
+    '2021postEEPU',
 ]
 
 upgradeKeys[2026] = [
@@ -2046,6 +2048,14 @@ upgradeProperties[2017] = {
         'Era' : 'Run3_FastSim',
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
         'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
+    },
+    '2021postEE' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2022_realistic_postEE',
+        'HLTmenu': '@relval2022',
+        'Era' : 'Run3',
+        'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
+        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
 }
 


### PR DESCRIPTION
#### PR description:

This PR is to add WFs (IDs 13600.0 to 13948.0) with GT: phase1_2022_realistic_postEE for the release validation for the post-EE scenario. 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40151 