### PR TITLE
Remove obsolete tf session const_cast's in RecoTracker

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackTfClassifier.cc
@@ -106,7 +106,7 @@ namespace {
         std::vector<tensorflow::Tensor> outputs;
 
         //evaluate the input
-        tensorflow::run(const_cast<tensorflow::Session*>(session_), inputs, {"Identity"}, &outputs);
+        tensorflow::run(session_, inputs, {"Identity"}, &outputs);
 
         for (auto nt = 0; nt < bsize_; nt++) {
           int itrack = nt + bsize_ * nb;

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -715,7 +715,7 @@ std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection co
 
     //eval and rescale
     std::vector<tensorflow::Tensor> outputs;
-    tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
+    tensorflow::run(session, inputs, {"Identity"}, &outputs);
 
     for (auto nt = 0; nt < bsize_; nt++) {
       int itrack = nt + bsize_ * nb;


### PR DESCRIPTION
#### PR description

This PR removes the `const_cast`'s of tensorflow sessions for model evaluation in `RecoTracker/FinalTrackSelectors` and `RecoTracker/MkFit`, which are obsolete with #40161 recently integrated. The resulting, planned changes are documented in #40248.


#### PR validation

The changes to both plugins in `RecoTracker` are only minor, and tests of the general, new functionality  were already part of the PR mentioned above.

@clacaputo @yongbinfeng @valsdav