### PR TITLE
Move TF session in DeepMETProducer to global cache

### DIFF
--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -278,4 +278,19 @@ namespace tensorflow {
     run(session, {}, outputNames, outputs, threadPoolName);
   }
 
+  void SessionCache::closeSession() {
+    // delete the session if set
+    Session* s = session.load();
+    if (s != nullptr) {
+      tensorflow::closeSession(s);
+      session.store(nullptr);
+    }
+
+    // delete the graph if set
+    if (graph.load() != nullptr) {
+      delete graph.load();
+      graph.store(nullptr);
+    }
+  }
+
 }  // namespace tensorflow

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -22,6 +22,12 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
+<bin name="testTFSessionCache" file="testRunner.cpp,testSessionCache.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
 <bin name="testTFThreadPools" file="testRunner.cpp,testThreadPools.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>

--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -30,7 +30,7 @@ void testBase::setUp() {
 
   // create the graph
   std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
-  std::string cmd = "python3 " + testPath + "/" + pyScript() + " " + dataPath_;
+  std::string cmd = "python3 -W ignore " + testPath + "/" + pyScript() + " " + dataPath_;
   std::array<char, 128> buffer;
   std::string result;
   std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);

--- a/PhysicsTools/TensorFlow/test/testSessionCache.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCache.cc
@@ -1,0 +1,46 @@
+/*
+ * Tests for interacting with the SessionCache.
+ *
+ * Author: Marcel Rieger
+ */
+
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
+#include "testBase.h"
+
+class testSessionCache : public testBase {
+  CPPUNIT_TEST_SUITE(testSessionCache);
+  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  std::string pyScript() const override;
+  void checkAll() override;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCache);
+
+std::string testSessionCache::pyScript() const { return "createconstantgraph.py"; }
+
+void testSessionCache::checkAll() {
+  std::string pbFile = dataPath_ + "/constantgraph.pb";
+
+  tensorflow::setLogging();
+
+  // load the graph and the session
+  tensorflow::SessionCache cache(pbFile);
+  CPPUNIT_ASSERT(cache.graph.load() != nullptr);
+  CPPUNIT_ASSERT(cache.session.load() != nullptr);
+
+  // get a const session pointer
+  const tensorflow::Session* session = cache.getSession();
+  CPPUNIT_ASSERT(session != nullptr);
+
+  // cleanup
+  cache.closeSession();
+  CPPUNIT_ASSERT(cache.graph.load() == nullptr);
+  CPPUNIT_ASSERT(cache.session.load() == nullptr);
+}


### PR DESCRIPTION
#### PR description

This PR

- adds a new `SessionCache` to the `PhysicsTools/TensorFlow` interface that is intended to simplify the storage of the tf session in the global cache for plugins (at least for the most common use case of plugins loading a single model), and
- adapts the `DeepMETProducer` in `RecoMET/METPUSubtraction` to use this cache object, effectively moving its session object to the global cache.

This is part of the planned changes documented in #40248, intended to treat all tf sessions as constant for model evaluation purposes and therefore preventing copies across stream module instances for saving memory.


#### PR validation

I added a new test case that covers the `SessionCache` object. There was no new functionality added to the `DeepMETProducer` per se, so existing test cases should still fully apply.

@clacaputo @yongbinfeng @valsdav