### PR TITLE
[backport to 12_4_X] modify nanoDQMIO configuration

### DIFF
--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -1,72 +1,177 @@
 import FWCore.ParameterSet.Config as cms
 
-#Example version list of MEs to save with singel Luminosity Granularity
-#in the nanoDQMIO reduced version of DQMIO data Tier
-#It needs process.DQMStore.saveByLumi = cms.untracked.bool(True)
-#to make effect in the MEs saved by DQMStore
-#DQMIO with per Lumisection data, are a special kind of DQM files 
-#containing almost the full set of DQM Monitor Elements (MEs) saved 
-#with single lumisection time granularity. 
-#Saying "almost" we refer to the fact that only Monitor Elements 
-#produced in DQM Step1 are saved, 
-#while those produced in the Harvesting step are not, 
-#even if they could be obtained with some ad-hoc harvesting on Step1 data
-#Hence, DQM Step2 (HARVESTING DQM) should not follow when saveByLumi is True
-#since most DQM Harvesting modules expect perRun output
-#https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO
+# Configuration file for nanoDQMIO
+# Use this file to specify which monitoring elements (MEs) will be stored in the nanoDQMIO format.
+# For more information, see https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO.
+
+# Use the full ME path, as displayed for example in the DQM GUI.
+
+# The current selection of MEs is for the reprocessing of 2022 data.
 
 nanoDQMIO_perLSoutput = cms.PSet(
-      MEsToSave = cms.untracked.vstring(*( #Using tuple to avoid python limit of 255 arguments
-                                           #as suggested in:
-                #https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePoolInputSources#Example_3_More_than_255_input_fi
-
-                #Examples:
-                #'Muons/MuonRecoAnalyzer/',               #Folder and its subfolders
-                #'Muons/MuonIdDQM/GlobalMuons/hDT1Pullx'  #particular ME
-            
-              #Version 0.1 for nanoDQMIO in CMSSW_12_1_0 ReReco of Pilot Test Runs taken in Autumn 2021
- #DT
- 'DT/02-Segments/03-MeanT0/T0MeanAllWheels',
-            
- #ECAL            
- 'EcalBarrel/EBOccupancyTask/EBOT digi occupancy',
- 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE -',
- 'EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE +',
-
- #Muon POG
- 'Muons/MuonRecoAnalyzer/',               
- 'Muons/MuonIdDQM/GlobalMuons/',
-            
- #Tracker/Tracking
- #PixelPhase1
- 'PixelPhase1/Phase1_MechanicalView/',
- 'PixelPhase1/Tracks/',
-
- #SiStrip
- 'SiStrip/MechanicalView/',
-
- #Tracking histograms:
- 'Tracking/PrimaryVertices/highPurityTracks/pt_0to1/offline/',
- 'Tracking/TrackParameters/generalTracks/LSanalysis/',
- 'Tracking/TrackParameters/highPurityTracks/pt_1/LSanalysis/',
- 'Tracking/TrackParameters/highPurityTracks/pt_0to1/LSanalysis/',
- 'Tracking/TrackParameters/highPurityTracks/dzPV0p1/LSanalysis/',
- 'Tracking/TrackParameters/generalTracks/GeneralProperties/',
- 'Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/',
- 'Tracking/TrackParameters/highPurityTracks/pt_0to1/GeneralProperties/',
- 'Tracking/TrackParameters/highPurityTracks/dzPV0p1/GeneralProperties/',
- 'Tracking/TrackParameters/generalTracks/HitProperties/',
- 'Tracking/TrackParameters/highPurityTracks/pt_1/HitProperties/',
- 'Tracking/TrackParameters/highPurityTracks/pt_0to1/HitProperties/',
- 'Tracking/TrackParameters/highPurityTracks/dzPV0p1/HitProperties/',
- 'Tracking/TrackParameters/generalTracks/HitProperties/Pixel/',
- 'Tracking/TrackParameters/highPurityTracks/pt_1/HitProperties/Pixel/',
- 'Tracking/TrackParameters/highPurityTracks/pt_0to1/HitProperties/Pixel/',
- 'Tracking/TrackParameters/highPurityTracks/dzPV0p1/HitProperties/Pixel/',
- 'Tracking/TrackParameters/generalTracks/HitProperties/Strip/',
- 'Tracking/TrackParameters/highPurityTracks/pt_1/HitProperties/Strip/',
- 'Tracking/TrackParameters/highPurityTracks/pt_0to1/HitProperties/Strip/',
- 'Tracking/TrackParameters/highPurityTracks/dzPV0p1/HitProperties/Strip/'
-              )
-      )
+  MEsToSave = cms.untracked.vstring(*(
+    "Hcal/DigiTask/Occupancy/depth/depth1",
+    "Hcal/DigiTask/Occupancy/depth/depth2",
+    "Hcal/DigiTask/Occupancy/depth/depth3",
+    "Hcal/DigiTask/Occupancy/depth/depth4",
+    "Hcal/DigiTask/Occupancy/depth/depth5",
+    "Hcal/DigiTask/Occupancy/depth/depth6",
+    "Hcal/DigiTask/Occupancy/depth/depth7",
+    "Hcal/DigiTask/Occupancy/depth/depthHO",
+    "Hcal/DigiTask/OccupancyCut/depth/depth1",
+    "Hcal/DigiTask/OccupancyCut/depth/depth2",
+    "Hcal/DigiTask/OccupancyCut/depth/depth3",
+    "Hcal/DigiTask/OccupancyCut/depth/depth4",
+    "Hcal/DigiTask/OccupancyCut/depth/depth5",
+    "Hcal/DigiTask/OccupancyCut/depth/depth6",
+    "Hcal/DigiTask/OccupancyCut/depth/depth7",
+    "Hcal/DigiTask/OccupancyCut/depth/depthHO",
+    "EcalBarrel/EBOccupancyTask/EBOT digi occupancy",
+    "EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE -",
+    "EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE +",
+    "Ecal/EventInfo/processedEvents",
+    "PixelPhase1/Tracks/charge_PXBarrel",
+    "PixelPhase1/Tracks/charge_PXForward",
+    "PixelPhase1/Tracks/PXBarrel/charge_PXLayer_1",
+    "PixelPhase1/Tracks/PXBarrel/charge_PXLayer_2",
+    "PixelPhase1/Tracks/PXBarrel/charge_PXLayer_3",
+    "PixelPhase1/Tracks/PXBarrel/charge_PXLayer_4",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_+1",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_+2",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_+3",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_-1",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_-2",
+    "PixelPhase1/Tracks/PXForward/charge_PXDisk_-3",
+    "PixelPhase1/Tracks/PXBarrel/size_PXLayer_1",
+    "PixelPhase1/Tracks/PXBarrel/size_PXLayer_2",
+    "PixelPhase1/Tracks/PXBarrel/size_PXLayer_3",
+    "PixelPhase1/Tracks/PXBarrel/size_PXLayer_4",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_+1",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_+2",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_+3",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_-1",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_-2",
+    "PixelPhase1/Tracks/PXForward/size_PXDisk_-3",
+    "HLT/Vertexing/hltPixelVertices/hltPixelVertices/goodvtxNbr",
+    "PixelPhase1/Tracks/num_clusters_ontrack_PXBarrel",
+    "PixelPhase1/Tracks/num_clusters_ontrack_PXForward",
+    "PixelPhase1/Tracks/clusterposition_zphi_ontrack",
+    "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_1",
+    "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_2",
+    "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_3",
+    "PixelPhase1/Tracks/PXBarrel/clusterposition_zphi_ontrack_PXLayer_4",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+1",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+2",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_+3",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-1",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-2",
+    "PixelPhase1/Tracks/PXForward/clusterposition_xy_ontrack_PXDisk_-3",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_1/NormalizedHitResiduals_TEC__wheel__1",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_2/NormalizedHitResiduals_TEC__wheel__2",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_3/NormalizedHitResiduals_TEC__wheel__3",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_4/NormalizedHitResiduals_TEC__wheel__4",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_5/NormalizedHitResiduals_TEC__wheel__5",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_6/NormalizedHitResiduals_TEC__wheel__6",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_7/NormalizedHitResiduals_TEC__wheel__7",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_8/NormalizedHitResiduals_TEC__wheel__8",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_9/NormalizedHitResiduals_TEC__wheel__9",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_1/NormalizedHitResiduals_TEC__wheel__1",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_2/NormalizedHitResiduals_TEC__wheel__2",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_3/NormalizedHitResiduals_TEC__wheel__3",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_4/NormalizedHitResiduals_TEC__wheel__4",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_5/NormalizedHitResiduals_TEC__wheel__5",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_6/NormalizedHitResiduals_TEC__wheel__6",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_7/NormalizedHitResiduals_TEC__wheel__7",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_8/NormalizedHitResiduals_TEC__wheel__8",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_9/NormalizedHitResiduals_TEC__wheel__9",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_1/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__1",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_2/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__2",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_3/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__3",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_4/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__4",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_5/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__5",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_6/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__6",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_7/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__7",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_8/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__8",
+    "SiStrip/MechanicalView/TEC/PLUS/wheel_9/Summary_ClusterStoNCorr__OnTrack__TEC__PLUS__wheel__9",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_1/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__1",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_2/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__2",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_3/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__3",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_4/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__4",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_5/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__5",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_6/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__6",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_7/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__7",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_8/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__8",
+    "SiStrip/MechanicalView/TEC/MINUS/wheel_9/Summary_ClusterStoNCorr__OnTrack__TEC__MINUS__wheel__9",
+    "SiStrip/MechanicalView/TIB/layer_1/NormalizedHitResiduals_TIB__Layer__1",
+    "SiStrip/MechanicalView/TIB/layer_2/NormalizedHitResiduals_TIB__Layer__2",
+    "SiStrip/MechanicalView/TIB/layer_3/NormalizedHitResiduals_TIB__Layer__3",
+    "SiStrip/MechanicalView/TIB/layer_4/NormalizedHitResiduals_TIB__Layer__4",
+    "SiStrip/MechanicalView/TIB/layer_1/Summary_ClusterStoNCorr__OnTrack__TIB__layer__1",
+    "SiStrip/MechanicalView/TIB/layer_2/Summary_ClusterStoNCorr__OnTrack__TIB__layer__2",
+    "SiStrip/MechanicalView/TIB/layer_3/Summary_ClusterStoNCorr__OnTrack__TIB__layer__3",
+    "SiStrip/MechanicalView/TIB/layer_4/Summary_ClusterStoNCorr__OnTrack__TIB__layer__4",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_1/NormalizedHitResiduals_TID__wheel__1",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_2/NormalizedHitResiduals_TID__wheel__2",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_3/NormalizedHitResiduals_TID__wheel__3",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_1/NormalizedHitResiduals_TID__wheel__1",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_2/NormalizedHitResiduals_TID__wheel__2",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_3/NormalizedHitResiduals_TID__wheel__3",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_1/Summary_ClusterStoNCorr__OnTrack__TID__PLUS__wheel__1",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_2/Summary_ClusterStoNCorr__OnTrack__TID__PLUS__wheel__2",
+    "SiStrip/MechanicalView/TID/PLUS/wheel_3/Summary_ClusterStoNCorr__OnTrack__TID__PLUS__wheel__3",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_1/Summary_ClusterStoNCorr__OnTrack__TID__MINUS__wheel__1",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_2/Summary_ClusterStoNCorr__OnTrack__TID__MINUS__wheel__2",
+    "SiStrip/MechanicalView/TID/MINUS/wheel_3/Summary_ClusterStoNCorr__OnTrack__TID__MINUS__wheel__3",
+    "SiStrip/MechanicalView/TOB/layer_1/NormalizedHitResiduals_TOB__Layer__1",
+    "SiStrip/MechanicalView/TOB/layer_2/NormalizedHitResiduals_TOB__Layer__2",
+    "SiStrip/MechanicalView/TOB/layer_3/NormalizedHitResiduals_TOB__Layer__3",
+    "SiStrip/MechanicalView/TOB/layer_4/NormalizedHitResiduals_TOB__Layer__4",
+    "SiStrip/MechanicalView/TOB/layer_5/NormalizedHitResiduals_TOB__Layer__5",
+    "SiStrip/MechanicalView/TOB/layer_6/NormalizedHitResiduals_TOB__Layer__6",
+    "SiStrip/MechanicalView/TOB/layer_1/Summary_ClusterStoNCorr__OnTrack__TOB__layer__1",
+    "SiStrip/MechanicalView/TOB/layer_2/Summary_ClusterStoNCorr__OnTrack__TOB__layer__2",
+    "SiStrip/MechanicalView/TOB/layer_3/Summary_ClusterStoNCorr__OnTrack__TOB__layer__3",
+    "SiStrip/MechanicalView/TOB/layer_4/Summary_ClusterStoNCorr__OnTrack__TOB__layer__4",
+    "SiStrip/MechanicalView/TOB/layer_5/Summary_ClusterStoNCorr__OnTrack__TOB__layer__5",
+    "SiStrip/MechanicalView/TOB/layer_6/Summary_ClusterStoNCorr__OnTrack__TOB__layer__6",
+    "SiStrip/MechanicalView/MainDiagonal Position",
+    "SiStrip/MechanicalView/NumberOfClustersInPixel",
+    "SiStrip/MechanicalView/NumberOfClustersInStrip",
+    "Tracking/TrackParameters/GeneralProperties/Chi2oNDF_lumiFlag_GenTk",
+    "Tracking/TrackParameters/GeneralProperties/NumberOfRecHitsPerTrack_lumiFlag_GenTk",
+    "Tracking/TrackParameters/GeneralProperties/NumberOfTracks_lumiFlag_GenTk",
+    "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDxyToPV_GenTk",
+    "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDzToPV_GenTk",
+    "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIP3DToPV_GenTk",
+    "Tracking/TrackParameters/generalTracks/HitProperties/NumberOfMissingOuterRecHitsPerTrack_GenTk",
+    "Tracking/TrackParameters/generalTracks/HitProperties/NumberMORecHitsPerTrackVsPt_GenTk",
+    "OfflinePV/offlinePrimaryVertices/tagVtxProb",
+    "OfflinePV/offlinePrimaryVertice/tagType",
+    "OfflinePV/Resolution/PV/pull_x",
+    "OfflinePV/Resolution/PV/pull_y",
+    "OfflinePV/Resolution/PV/pull_z",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_highPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_highPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_mediumPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_mediumPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_lowPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/CHFrac_lowPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_highPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_highPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_mediumPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_mediumPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_lowPt_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/ChMultiplicity_lowPt_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Constituents",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Eta",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Eta_uncor",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/JetEnergyCorr",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/NJets",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Phi",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Phi_Barrel",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Phi_EndCap",
+    "JetMET/Jet/Cleanedak4PFJetsCHS/Pt",
+    "JetMET/MET/pfMETT1/Cleaned/METSig",
+    "JetMET/vertices",     
+  ) )
 )

--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -29,6 +29,8 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "EcalBarrel/EBOccupancyTask/EBOT digi occupancy",
     "EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE -",
     "EcalEndcap/EEOccupancyTask/EEOT digi occupancy EE +",
+    "EcalBarrel/EBOccupancyTask/EBOT DCC entries",
+    "EcalEndcap/EEOccupancyTask/EEOT DCC entries",
     "Ecal/EventInfo/processedEvents",
     "PixelPhase1/Tracks/charge_PXBarrel",
     "PixelPhase1/Tracks/charge_PXForward",

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -640,22 +640,29 @@ namespace dqm::implementation {
     auto const& meset = store_->globalMEs_[edm::LuminosityBlockID(runNumber, lumi)];
     auto it = meset.lower_bound(path);
 
-    // decide if the ME should be save din DQMIO based on the list provided
-    bool saveIt = true;
-
-    // rfind can be used as a prefix match.
+    // decide if the ME should be saved in DQMIO and/or nanoDQMIO
+    // if doSaveByLumi_ is false: store all monitoring elements (needed for harvesting step!)
+    // if doSaveByLumi_ is true: store only selected monitoring elements (i.e. "nanoDQMIO")
     while (it != meset.end() && (*it)->getFullname().rfind(path_str, 0) == 0) {
+      bool saveIt = true;  // default value if doSaveByLumi_ is false
+
       if (store_->doSaveByLumi_ && not store_->MEsToSave_.empty()) {
+        std::string name = (*it)->getFullname();
+        saveIt = false;  // default value if doSaveByLumi_ is true
         for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
              ipath != store_->MEsToSave_.end();
              ++ipath) {
-          std::string name = (*it)->getFullname();
-          if (name.find(*ipath) != std::string::npos) {
+          std::string nameToSave = *ipath;
+          // option 1 (used in the past): inclusive selection
+          // (store all MEs that contain any of the requested patterns)
+          // if (name.find(nameToSave) != std::string::npos) {
+          // option 2 (current criterion): exact selection
+          // (store only MEs that exactly match a requested pattern)
+          if (name == nameToSave) {
             saveIt = true;
-            //std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
+            // std::cout<<name<<" compared to"<<ipath->data()<<std::endl;
             break;
           }
-          saveIt = false;
         }
       }
 


### PR DESCRIPTION
#### PR description:

This PR prepares the production of the nanoDQMIO dataset for 2022 data.
The modifications are twofold:

- The configuration file listing the monitoring elements (MEs) to be stored is modified in accordance with the requests from subsystems.
- The selection of the MEs is changed so that only those MEs that exactly match a pattern in the configuration file are stored. Previously, each ME that contained a pattern in the configuration file was stored, leading to the storing of some unneeded MEs with overlapping names.

More information on the context of this PR can be found in this [google doc](https://docs.google.com/document/d/1VvDBvkMlKeJWKg9km30Kg3f1Lv3KB2HXE9Ne4HBbKLo/edit?usp=sharing) (note: under development, subject to change).

#### PR validation:

The modified selection and configuration was used to produce nanoDQMIO files locally. No issues were observed and the content of the nanoDQMIO file in terms of ME content is as expected. The usual runTheMatrix.py -l limited -i all --ibeos tests were run for the original PR to master.

#### Backport

This is a backport of [PR40266](https://github.com/cms-sw/cmssw/pull/40266).
It is needed since we would use the updated nanoDQMIO configuration for the reprocessing of 2022 data.
