### PR TITLE
add unit test for `TriggerEvent*` analyzers

### DIFF
--- a/HLTrigger/HLTcore/interface/HLTEventAnalyzerAOD.h
+++ b/HLTrigger/HLTcore/interface/HLTEventAnalyzerAOD.h
@@ -1,5 +1,5 @@
-#ifndef HLTcore_HLTEventAnalyzerAOD_h
-#define HLTcore_HLTEventAnalyzerAOD_h
+#ifndef HLTrigger_HLTcore_HLTEventAnalyzerAOD_h
+#define HLTrigger_HLTcore_HLTEventAnalyzerAOD_h
 
 /** \class HLTEventAnalyzerAOD
  *
@@ -13,10 +13,12 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
 namespace edm {
   class ConfigurationDescriptions;
 }
@@ -27,15 +29,20 @@ namespace edm {
 class HLTEventAnalyzerAOD : public edm::stream::EDAnalyzer<> {
 public:
   explicit HLTEventAnalyzerAOD(const edm::ParameterSet &);
-  ~HLTEventAnalyzerAOD() override;
+  ~HLTEventAnalyzerAOD() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  void endRun(edm::Run const &, edm::EventSetup const &) override;
   void beginRun(edm::Run const &, edm::EventSetup const &) override;
+  void endRun(edm::Run const &, edm::EventSetup const &) override {}
+
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   virtual void analyzeTrigger(const edm::Event &, const edm::EventSetup &, const std::string &triggerName);
 
 private:
+  using LOG = edm::LogVerbatim;
+
+  static constexpr const char *logMsgType_ = "HLTEventAnalyzerAOD";
+
   /// module config parameters
   const std::string processName_;
   const std::string triggerName_;
@@ -44,9 +51,11 @@ private:
   const edm::InputTag triggerEventTag_;
   const edm::EDGetTokenT<trigger::TriggerEvent> triggerEventToken_;
 
-  /// additional class data memebers
+  /// additional class data members
+  bool const verbose_;
   edm::Handle<edm::TriggerResults> triggerResultsHandle_;
   edm::Handle<trigger::TriggerEvent> triggerEventHandle_;
   HLTPrescaleProvider hltPrescaleProvider_;
 };
-#endif
+
+#endif  // HLTrigger_HLTcore_HLTEventAnalyzerAOD_h

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerAOD.cc
@@ -9,7 +9,6 @@
 
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/Common/interface/TriggerResultsByName.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "HLTrigger/HLTcore/interface/HLTEventAnalyzerAOD.h"
@@ -17,7 +16,7 @@
 #include <cassert>
 
 //
-// constructors and destructor
+// constructor
 //
 HLTEventAnalyzerAOD::HLTEventAnalyzerAOD(const edm::ParameterSet& ps)
     : processName_(ps.getParameter<std::string>("processName")),
@@ -26,18 +25,14 @@ HLTEventAnalyzerAOD::HLTEventAnalyzerAOD(const edm::ParameterSet& ps)
       triggerResultsToken_(consumes<edm::TriggerResults>(triggerResultsTag_)),
       triggerEventTag_(ps.getParameter<edm::InputTag>("triggerEvent")),
       triggerEventToken_(consumes<trigger::TriggerEvent>(triggerEventTag_)),
+      verbose_(ps.getParameter<bool>("verbose")),
       hltPrescaleProvider_(ps, consumesCollector(), *this) {
-  using namespace std;
-  using namespace edm;
-
-  LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD configuration: " << endl
-                                     << "   ProcessName = " << processName_ << endl
-                                     << "   TriggerName = " << triggerName_ << endl
-                                     << "   TriggerResultsTag = " << triggerResultsTag_.encode() << endl
-                                     << "   TriggerEventTag = " << triggerEventTag_.encode() << endl;
+  LOG(logMsgType_) << logMsgType_ << " configuration:\n"
+                   << "   ProcessName = " << processName_ << "\n"
+                   << "   TriggerName = " << triggerName_ << "\n"
+                   << "   TriggerResultsTag = " << triggerResultsTag_.encode() << "\n"
+                   << "   TriggerEventTag = " << triggerEventTag_.encode();
 }
-
-HLTEventAnalyzerAOD::~HLTEventAnalyzerAOD() = default;
 
 //
 // member functions
@@ -45,19 +40,16 @@ HLTEventAnalyzerAOD::~HLTEventAnalyzerAOD() = default;
 void HLTEventAnalyzerAOD::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("processName", "HLT");
-  desc.add<std::string>("triggerName", "@");
+  desc.add<std::string>("triggerName", "@")
+      ->setComment("name of trigger Path to consider (use \"@\" to consider all Paths)");
   desc.add<edm::InputTag>("triggerResults", edm::InputTag("TriggerResults", "", "HLT"));
   desc.add<edm::InputTag>("triggerEvent", edm::InputTag("hltTriggerSummaryAOD", "", "HLT"));
   desc.add<unsigned int>("stageL1Trigger", 1);
+  desc.add<bool>("verbose", true)->setComment("enable verbose mode");
   descriptions.add("hltEventAnalyzerAODDefault", desc);
 }
 
-void HLTEventAnalyzerAOD::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
-
 void HLTEventAnalyzerAOD::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
-  using namespace std;
-  using namespace edm;
-
   bool changed(true);
   if (hltPrescaleProvider_.init(iRun, iSetup, processName_, changed)) {
     HLTConfigProvider const& hltConfig = hltPrescaleProvider_.hltConfigProvider();
@@ -68,45 +60,38 @@ void HLTEventAnalyzerAOD::beginRun(edm::Run const& iRun, edm::EventSetup const& 
         const unsigned int n(hltConfig.size());
         const unsigned int triggerIndex(hltConfig.triggerIndex(triggerName_));
         if (triggerIndex >= n) {
-          LogVerbatim("HLTEventAnalyzerAOD")
-              << "HLTEventAnalyzerAOD::analyze:"
-              << " TriggerName " << triggerName_ << " not available in (new) config!" << endl;
-          LogVerbatim("HLTEventAnalyzerAOD") << "Available TriggerNames are: " << endl;
+          LOG(logMsgType_) << logMsgType_ << "::beginRun: TriggerName " << triggerName_
+                           << " not available in (new) config!";
+          LOG(logMsgType_) << "Available TriggerNames are:";
           hltConfig.dump("Triggers");
         }
       }
-      hltConfig.dump("ProcessName");
-      hltConfig.dump("GlobalTag");
-      hltConfig.dump("TableName");
-      hltConfig.dump("Streams");
-      hltConfig.dump("Datasets");
-      hltConfig.dump("PrescaleTable");
-      hltConfig.dump("ProcessPSet");
+      // in verbose mode, print process info to stdout
+      if (verbose_) {
+        hltConfig.dump("ProcessName");
+        hltConfig.dump("GlobalTag");
+        hltConfig.dump("TableName");
+        hltConfig.dump("Streams");
+        hltConfig.dump("Datasets");
+        hltConfig.dump("PrescaleTable");
+        hltConfig.dump("ProcessPSet");
+      }
     }
   } else {
-    LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD::analyze:"
-                                       << " config extraction failure with process name " << processName_ << endl;
+    LOG(logMsgType_) << logMsgType_ << "::beginRun: config extraction failure with process name " << processName_;
   }
 }
 
-// ------------ method called to produce the data  ------------
 void HLTEventAnalyzerAOD::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace std;
-  using namespace edm;
-
-  LogVerbatim("HLTEventAnalyzerAOD") << endl;
-
   // get event products
   iEvent.getByToken(triggerResultsToken_, triggerResultsHandle_);
   if (!triggerResultsHandle_.isValid()) {
-    LogVerbatim("HLTEventAnalyzerAOD")
-        << "HLTEventAnalyzerAOD::analyze: Error in getting TriggerResults product from Event!" << endl;
+    LOG(logMsgType_) << logMsgType_ << "::analyze: Error in getting TriggerResults product from Event!";
     return;
   }
   iEvent.getByToken(triggerEventToken_, triggerEventHandle_);
   if (!triggerEventHandle_.isValid()) {
-    LogVerbatim("HLTEventAnalyzerAOD")
-        << "HLTEventAnalyzerAOD::analyze: Error in getting TriggerEvent product from Event!" << endl;
+    LOG(logMsgType_) << logMsgType_ << "::analyze: Error in getting TriggerEvent product from Event!";
     return;
   }
 
@@ -131,13 +116,6 @@ void HLTEventAnalyzerAOD::analyze(const edm::Event& iEvent, const edm::EventSetu
 void HLTEventAnalyzerAOD::analyzeTrigger(const edm::Event& iEvent,
                                          const edm::EventSetup& iSetup,
                                          const std::string& triggerName) {
-  using namespace std;
-  using namespace edm;
-  using namespace reco;
-  using namespace trigger;
-
-  LogVerbatim("HLTEventAnalyzerAOD") << endl;
-
   HLTConfigProvider const& hltConfig = hltPrescaleProvider_.hltConfigProvider();
 
   const unsigned int n(hltConfig.size());
@@ -146,62 +124,75 @@ void HLTEventAnalyzerAOD::analyzeTrigger(const edm::Event& iEvent,
 
   // abort on invalid trigger name
   if (triggerIndex >= n) {
-    LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD::analyzeTrigger: path " << triggerName << " - not found!"
-                                       << endl;
+    LOG(logMsgType_) << logMsgType_ << "::analyzeTrigger: path " << triggerName << " - not found!";
     return;
   }
 
   auto const prescales = hltPrescaleProvider_.prescaleValues<double>(iEvent, iSetup, triggerName);
-  LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD::analyzeTrigger: path " << triggerName << " ["
-                                     << triggerIndex << "] "
-                                     << "prescales L1T,HLT: " << prescales.first << "," << prescales.second << endl;
+
+  LOG(logMsgType_) << logMsgType_ << "::analyzeTrigger: path " << triggerName << " [" << triggerIndex
+                   << "] prescales L1T,HLT: " << prescales.first << "," << prescales.second;
+
   auto const prescalesInDetail = hltPrescaleProvider_.prescaleValuesInDetail<double>(iEvent, iSetup, triggerName);
-  std::ostringstream message;
-  for (unsigned int i = 0; i < prescalesInDetail.first.size(); ++i) {
-    message << " " << i << ":" << prescalesInDetail.first[i].first << "/" << prescalesInDetail.first[i].second;
+  {
+    LOG logtmp(logMsgType_);
+    logtmp << logMsgType_ << "::analyzeTrigger: path " << triggerName << " [" << triggerIndex
+           << "]\n prescales L1T: " << prescalesInDetail.first.size();
+    for (size_t idx = 0; idx < prescalesInDetail.first.size(); ++idx) {
+      logtmp << " " << idx << ":" << prescalesInDetail.first[idx].first << "/" << prescalesInDetail.first[idx].second;
+    }
+    logtmp << "\n prescale HLT: " << prescalesInDetail.second;
   }
-  LogVerbatim("HLTEventAnalyzerAOD") << "HLTEventAnalyzerAOD::analyzeTrigger: path " << triggerName << " ["
-                                     << triggerIndex << "] " << endl
-                                     << "prescales L1T: " << prescalesInDetail.first.size() << message.str() << endl
-                                     << " prescale HLT: " << prescalesInDetail.second << endl;
+
+  // results from TriggerResults product
+  LOG(logMsgType_) << " Trigger path status:"
+                   << " WasRun=" << triggerResultsHandle_->wasrun(triggerIndex)
+                   << " Accept=" << triggerResultsHandle_->accept(triggerIndex)
+                   << " Error=" << triggerResultsHandle_->error(triggerIndex);
 
   // modules on this trigger path
   const unsigned int m(hltConfig.size(triggerIndex));
-  const vector<string>& moduleLabels(hltConfig.moduleLabels(triggerIndex));
+  const std::vector<std::string>& moduleLabels(hltConfig.moduleLabels(triggerIndex));
+  assert(m == moduleLabels.size());
 
-  // Results from TriggerResults product
-  LogVerbatim("HLTEventAnalyzerAOD") << " Trigger path status:"
-                                     << " WasRun=" << triggerResultsHandle_->wasrun(triggerIndex)
-                                     << " Accept=" << triggerResultsHandle_->accept(triggerIndex)
-                                     << " Error =" << triggerResultsHandle_->error(triggerIndex) << endl;
+  // skip empty Paths
+  if (m == 0) {
+    LOG(logMsgType_) << logMsgType_ << "::analyzeTrigger: path " << triggerName << " [" << triggerIndex
+                     << "] is empty!";
+    return;
+  }
+
+  // index of last module executed in this Path
   const unsigned int moduleIndex(triggerResultsHandle_->index(triggerIndex));
-  LogVerbatim("HLTEventAnalyzerAOD") << " Last active module - label/type: " << moduleLabels[moduleIndex] << "/"
-                                     << hltConfig.moduleType(moduleLabels[moduleIndex]) << " [" << moduleIndex
-                                     << " out of 0-" << (m - 1) << " on this path]" << endl;
   assert(moduleIndex < m);
 
-  // Results from TriggerEvent product - Attention: must look only for
-  // modules actually run in this path for this event!
+  LOG(logMsgType_) << " Last active module - label/type: " << moduleLabels[moduleIndex] << "/"
+                   << hltConfig.moduleType(moduleLabels[moduleIndex]) << " [" << moduleIndex << " out of 0-" << (m - 1)
+                   << " on this path]";
+
+  // results from TriggerEvent product
+  // Attention: must look only for modules actually run in this path for this event!
   for (unsigned int j = 0; j <= moduleIndex; ++j) {
-    const string& moduleLabel(moduleLabels[j]);
-    const string moduleType(hltConfig.moduleType(moduleLabel));
+    const std::string& moduleLabel(moduleLabels[j]);
+    const std::string moduleType(hltConfig.moduleType(moduleLabel));
+
     // check whether the module is packed up in TriggerEvent product
-    const unsigned int filterIndex(triggerEventHandle_->filterIndex(InputTag(moduleLabel, "", processName_)));
+    const unsigned int filterIndex(triggerEventHandle_->filterIndex(edm::InputTag(moduleLabel, "", processName_)));
     if (filterIndex < triggerEventHandle_->sizeFilters()) {
-      LogVerbatim("HLTEventAnalyzerAOD") << " 'L3' filter in slot " << j << " - label/type " << moduleLabel << "/"
-                                         << moduleType << endl;
-      const Vids& VIDS(triggerEventHandle_->filterIds(filterIndex));
-      const Keys& KEYS(triggerEventHandle_->filterKeys(filterIndex));
-      const size_type nI(VIDS.size());
-      const size_type nK(KEYS.size());
+      LOG(logMsgType_) << " 'L3' filter in slot " << j << " - label/type " << moduleLabel << "/" << moduleType;
+
+      const trigger::Vids& VIDS(triggerEventHandle_->filterIds(filterIndex));
+      const trigger::Keys& KEYS(triggerEventHandle_->filterKeys(filterIndex));
+      const trigger::size_type nI(VIDS.size());
+      const trigger::size_type nK(KEYS.size());
       assert(nI == nK);
-      const size_type n(max(nI, nK));
-      LogVerbatim("HLTEventAnalyzerAOD") << "   " << n << " accepted 'L3' objects found: " << endl;
-      const TriggerObjectCollection& TOC(triggerEventHandle_->getObjects());
-      for (size_type i = 0; i != n; ++i) {
-        const TriggerObject& TO(TOC[KEYS[i]]);
-        LogVerbatim("HLTEventAnalyzerAOD") << "   " << i << " " << VIDS[i] << "/" << KEYS[i] << ": " << TO.id() << " "
-                                           << TO.pt() << " " << TO.eta() << " " << TO.phi() << " " << TO.mass() << endl;
+
+      LOG(logMsgType_) << "   " << nI << " accepted 'L3' objects found: ";
+      const trigger::TriggerObjectCollection& TOC(triggerEventHandle_->getObjects());
+      for (trigger::size_type idx = 0; idx < nI; ++idx) {
+        const trigger::TriggerObject& TO(TOC[KEYS[idx]]);
+        LOG(logMsgType_) << "   " << idx << " " << VIDS[idx] << "/" << KEYS[idx] << ": " << TO.id() << " " << TO.pt()
+                         << " " << TO.eta() << " " << TO.phi() << " " << TO.mass();
       }
     }
   }

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -12,3 +12,6 @@
 
 <!-- test the HLTPrescaleExample plugin -->
 <test name="test_HLTPrescaleExample" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py"/>
+
+<!-- test EDAnalyzers using TriggerEvent and TriggerEventWithRefs -->
+<test name="test_TriggerEventAnalyzers" command="testTriggerEventAnalyzers.sh"/>

--- a/HLTrigger/HLTcore/test/testTriggerEventAnalyzers.sh
+++ b/HLTrigger/HLTcore/test/testTriggerEventAnalyzers.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Pass in name and status
+function die {
+  echo $1: status $2
+  echo === Log file ===
+  cat ${3:-/dev/null}
+  echo === End log file ===
+  exit $2
+}
+
+# run test job
+TESTDIR="${LOCALTOP}"/src/HLTrigger/HLTcore/test
+
+cmsRun "${TESTDIR}"/testTriggerEventAnalyzers_cfg.py &> log_testTriggerEventAnalyzers \
+  || die "Failure running testTriggerEventAnalyzers_cfg.py" $? log_testTriggerEventAnalyzers

--- a/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
+++ b/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+## VarParsing
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing('analysis')
+options.register('logLevel', 'WARNING', options.multiplicity.singleton, options.varType.string, 'value of MessageLogger.cerr.threshold')
+options.register('globalTag', '125X_mcRun3_2022_realistic_v3', options.multiplicity.singleton, options.varType.string, 'name of GlobalTag')
+options.setDefault('inputFiles', [
+  '/store/relval/CMSSW_12_6_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun3_2022_realistic_v3-v1/2580000/2d96539c-b321-401f-b7b2-51884a5d421f.root',
+])
+options.setDefault('maxEvents', 10)
+options.parseArguments()
+
+process = cms.Process('TEST')
+
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 0
+process.options.wantSummary = False
+process.maxEvents.input = options.maxEvents
+
+## Source
+process.source = cms.Source('PoolSource',
+  fileNames = cms.untracked.vstring(options.inputFiles)
+)
+print('process.source.fileNames =', process.source.fileNames.value())
+
+## GlobalTag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+print('process.GlobalTag.globaltag =', process.GlobalTag.globaltag.value())
+
+## EventData modules
+from HLTrigger.HLTcore.hltEventAnalyzerAOD_cfi import hltEventAnalyzerAOD as _hltEventAnalyzerAOD
+process.triggerEventAnalyzer = _hltEventAnalyzerAOD.clone(
+  processName = 'HLT',
+  triggerName = '@',
+  triggerResults = 'TriggerResults::HLT',
+  triggerEvent = 'hltTriggerSummaryAOD::HLT',
+  stageL1Trigger = 2,
+  verbose = False,
+)
+
+from HLTrigger.HLTcore.hltEventAnalyzerRAW_cfi import hltEventAnalyzerRAW as _hltEventAnalyzerRAW
+process.triggerEventWithRefsAnalyzer = _hltEventAnalyzerRAW.clone(
+  processName = 'HLT',
+  triggerName = '@',
+  triggerResults = 'TriggerResults::HLT',
+  triggerEventWithRefs = 'hltTriggerSummaryRAW::HLT',
+  verbose = False,
+  permissive = True,
+)
+
+from HLTrigger.HLTcore.triggerSummaryAnalyzerAOD_cfi import triggerSummaryAnalyzerAOD as _triggerSummaryAnalyzerAOD
+process.triggerEventSummaryAnalyzer = _triggerSummaryAnalyzerAOD.clone(
+  inputTag = 'hltTriggerSummaryAOD'
+)
+
+from HLTrigger.HLTcore.triggerSummaryAnalyzerRAW_cfi import triggerSummaryAnalyzerRAW as _triggerSummaryAnalyzerRAW
+process.triggerEventWithRefsSummaryAnalyzer = _triggerSummaryAnalyzerRAW.clone(
+  inputTag = 'hltTriggerSummaryRAW'
+)
+
+## MessageLogger
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 1 # only report every Nth event start
+process.MessageLogger.cerr.FwkReport.limit = -1      # max number of reported messages (all if -1)
+process.MessageLogger.cerr.enableStatistics = False  # enable "MessageLogger Summary" message
+process.MessageLogger.cerr.threshold = options.logLevel
+setattr(process.MessageLogger.cerr, options.logLevel,
+  cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(1), # every event!
+    limit = cms.untracked.int32(-1)       # no limit! (default is limit=0, i.e. no messages reported)
+  )
+)
+process.MessageLogger.HLTEventAnalyzerAOD = dict()
+process.MessageLogger.HLTEventAnalyzerRAW = dict()
+process.MessageLogger.TriggerSummaryAnalyzerAOD = dict()
+process.MessageLogger.TriggerSummaryAnalyzerRAW = dict()
+
+## Path
+process.triggerEventAnalysisPath = cms.Path(
+    process.triggerEventAnalyzer
+  + process.triggerEventSummaryAnalyzer
+  + process.triggerEventWithRefsAnalyzer
+  + process.triggerEventWithRefsSummaryAnalyzer
+)


### PR DESCRIPTION
#### PR description:

This PR adds a unit test involving the following four `EDAnalyzers` of the `HLTrigger/HLTcore` package: `HLTEventAnalyzerAOD`, `HLTEventAnalyzerRAW`, `TriggerSummaryAnalyzerAOD`, and `TriggerSummaryAnalyzerRAW`.

The main purpose of this unit test is to detect when non-backward-compatible changes are introduced in the `TriggerEvent` and `TriggerEventWithRefs` data formats. This tries to partially address the issue discussed in #39287.

If/when non-backward-compatible changes to these data-formats will be needed, one will have to either disable this new unit test, and/or update its EDM input file.

Small updates are made to `HLTEventAnalyzer*` to fix an edge case (empty Paths), and reduce duplication of source code. In the case of `HLTEventAnalyzerRAW`, a flag named `permissive` is added to allow bypassing exceptions due to Refs of `triggerEventWithRefs` pointing to unavailable collections.

Default behaviour is unchanged, although printouts of `HLTEventAnalyzerAOD` and `HLTEventAnalyzerRAW` are slightly changed.

Merely technical. No changes expected in the outputs of PR tests.

#### PR validation:

The new unit test passes. Also checked that the new unit test reports the non-backward-compatible change discussed in #39287 (when using the EDM inputs in the description of that issue).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A