### PR TITLE
Enable Phase-2 HLT wf which runs together with DIGI+L1

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -16,7 +16,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 numWFIB = []
 numWFIB.extend([20034.0]) #2026D86
 numWFIB.extend([20834.0,20834.911,20834.103]) #2026D88 DDD XML, DD4hep XML, aging
-numWFIB.extend([20834.75]) #2026D88 with HLT75e33
+numWFIB.extend([20834.75,20834.76]) #2026D88 with HLT75e33 after RECO, HLTe33 with the same step with Digi+L1
 numWFIB.extend([21061.97]) #2026D88 premixing stage1 (NuGun+PU)
 numWFIB.extend([20834.5,20834.9,20834.501,20834.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([21034.99,21034.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,6 +99,7 @@ if __name__ == '__main__':
                      12434.0, #2023 ttbar
                      20834.0, #2026D88 ttbar (2022 new baseline)
                      20834.75, #2026D88 ttbar with HLT75e33
+                     20834.76, #2026D88 ttbar with HLT75e33 in the same step as DIGI+L1
                      #20834.911, #2026D88 ttbar DD4hep XML
                      21034.999, #2026D88 ttbar premixing stage1+stage2, PU50
                      20896.0, #CE_E_Front_120um D88


### PR DESCRIPTION
#### PR description:
As title says, this PR enable the workflow which Phase-2 HLT runs together with DIGI+L1 as expect. This will help for code clean up, and move forward the goal of running them together as usual Run-2/Run-3 workflow.

#### PR validation:
Run with `20834.76`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.
