### PR TITLE
Fix `PostDQMOffline*` sequences in cmsDriver.py

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1976,7 +1976,8 @@ class ConfigBuilder(object):
         # any 'DQM' job should use DQMStore in non-legacy mode (but not HARVESTING)
         self.loadAndRemember("DQMServices/Core/DQMStoreNonLegacy_cff")
         _,_dqmSeq,_ = self.loadDefaultOrSpecifiedCFF(stepSpec,self.DQMOFFLINEDefaultCFF)
-        sequenceList=postSequenceList=_dqmSeq.split('+')
+        sequenceList=_dqmSeq.split('+')
+        postSequenceList=_dqmSeq.split('+')
         from DQMOffline.Configuration.autoDQM import autoDQM
         self.expandMapping(sequenceList,autoDQM,index=0)
         self.expandMapping(postSequenceList,autoDQM,index=1)


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

When adding a DQM sequence to the command line options (e.g. `DQM:@miniAODDQM`), cmsDriver.py is supposed to add the relative `PostDQMOffline` sequence as selected in autoDQM.py. 
However, due to [this commit](https://github.com/cms-sw/cmssw/commit/fa26238b3adb5eec7c8576add915200d4169a281#diff-cdb26c43130acb8faa9c94529dd55a55671d2621695d7c5a2a47aa20a62e62dfL1979-R1979) in CMSSW_12_6_0_pre3, this does not happen anymore. 

After the commit `sequenceList` and `postSequenceList` are the same object at the same address and filling `sequenceList` inhibits the fill of `postSequenceList` (since `expandMapping` sees no "@" in the array). Since the sequences are the same, no dqmofflineOnPAT_step is produced in the output.

This PR splits the assigment into two lines, which makes `sequenceList` and `postSequenceList` distinct again.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Created a simple config file passing `DQM:@miniAODDQM` to cmsDriver.py, requested `PostDQMOffline*` sequences are back in the `process.schedule` as they were in CMSSW_12_6_0_pre2

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->


<!-- Please delete the text above after you verified all points of the checklist  -->
