### PR TITLE
Add basic `SiStripApproximateCluster` Monitoring

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -664,9 +664,10 @@ if (process.runType.getRunType() == process.runType.hi_run):
         process.TrackingClient
     )
 
+    # append the approximate clusters monitoring for the HI run case
     from DQM.SiStripMonitorApproximateCluster.SiStripMonitorApproximateCluster_cfi import SiStripMonitorApproximateCluster
-    process.siStriApproximateClusterMonitor = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True))
-    process.p.insert(-1, process.siStriApproximateClusterMonitor)
+    process.siStripApproximateClusterComparator = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True))
+    process.p.insert(process.p.index(process.TrackingClient)+1,process.siStripApproximateClusterComparator)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -4,16 +4,16 @@ import FWCore.ParameterSet.Config as cms
 import sys
 if 'runkey=hi_run' in sys.argv:
   from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_cff import Run3_pp_on_PbPb_approxSiStripClusters
-  process = cms.Process("BeamMonitor", Run3_pp_on_PbPb_approxSiStripClusters)
+  process = cms.Process("SiStripMonitor", Run3_pp_on_PbPb_approxSiStripClusters)
 else:
   from Configuration.Eras.Era_Run3_cff import Run3
-  process = cms.Process("BeamMonitor", Run3)
+  process = cms.Process("SiStripMonitor", Run3)
 
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siStripDigis',
                                          'siStripClusters',
                                          'siStripZeroSuppression',
-                                        'SiStripClusterizer'),
+                                         'SiStripClusterizer'),
     cout = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')),
     destinations = cms.untracked.vstring('cout')
 )
@@ -553,8 +553,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
             'HLT_HIPhysics*'
             ]
 
-
-
     process.SiStripMonitorDigi.UseDCSFiltering = False
     process.SiStripMonitorClusterReal.UseDCSFiltering = False
 
@@ -666,6 +664,9 @@ if (process.runType.getRunType() == process.runType.hi_run):
         process.TrackingClient
     )
 
+    from DQM.SiStripMonitorApproximateCluster.SiStripMonitorApproximateCluster_cfi import SiStripMonitorApproximateCluster
+    process.siStriApproximateClusterMonitor = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True))
+    process.p.insert(-1, process.siStriApproximateClusterMonitor)
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ParameterSet"/>
+<use name="DQMServices/Core"/>
+<flags EDM_PLUGIN="1"/>

--- a/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
@@ -1,7 +1,9 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
-<use name="FWCore/ParameterSet"/>
 <use name="DQMServices/Core"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/SiStripCluster"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/BuildFile.xml
@@ -2,4 +2,6 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DQMServices/Core"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <flags EDM_PLUGIN="1"/>

--- a/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
@@ -5,10 +5,8 @@
 //
 /**\class SiStripMonitorApproximateCluster SiStripMonitorApproximateCluster.cc DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
 
- Description: [one line class summary]
+ Description: Monitor SiStripApproximateClusters and on-demand compare properties with original SiStripClusters
 
- Implementation:
-     [Notes on implementation]
 */
 //
 // Original Author:  Marco Musich
@@ -22,10 +20,9 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DataFormats/Common/interface/DetSet.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,9 +30,47 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
 //
 // class declaration
 //
+
+namespace siStripRawPrime {
+  struct monitorApproxCluster {
+  public:
+    monitorApproxCluster()
+        : h_barycenter_{nullptr}, h_width_{nullptr}, h_avgCharge_{nullptr}, h_isSaturated_{nullptr}, isBooked_{false} {}
+
+    void fill(const SiStripApproximateCluster& cluster) {
+      h_barycenter_->Fill(cluster.barycenter());
+      h_width_->Fill(cluster.width());
+      h_avgCharge_->Fill(cluster.avgCharge());
+      h_isSaturated_->Fill(cluster.isSaturated() ? 1 : -1);
+    }
+
+    void book(dqm::implementation::DQMStore::IBooker& ibook, const std::string& folder) {
+      ibook.setCurrentFolder(folder);
+      h_barycenter_ =
+          ibook.book1D("clusterBarycenter", "cluster barycenter;cluster barycenter;#clusters", 7680., 0., 7680.);
+      h_width_ = ibook.book1D("clusterWidth", "cluster width;cluster width;#clusters", 128, -0.5, 127.5);
+      h_avgCharge_ =
+          ibook.book1D("clusterAvgCharge", "average strip charge;average strip charge;#clusters", 256, -0.5, 255.5);
+      h_isSaturated_ = ibook.book1D("clusterSaturation", "cluster saturation;is saturated?;#clusters", 3, -1.5, 1.5);
+      h_isSaturated_->getTH1F()->GetXaxis()->SetBinLabel(1, "Not saturated");
+      h_isSaturated_->getTH1F()->GetXaxis()->SetBinLabel(3, "Saturated");
+      isBooked_ = true;
+    }
+
+    bool isBooked() { return isBooked_; }
+
+  private:
+    dqm::reco::MonitorElement* h_barycenter_;
+    dqm::reco::MonitorElement* h_width_;
+    dqm::reco::MonitorElement* h_avgCharge_;
+    dqm::reco::MonitorElement* h_isSaturated_;
+    bool isBooked_;
+  };
+}  // namespace siStripRawPrime
 
 class SiStripMonitorApproximateCluster : public DQMEDAnalyzer {
 public:
@@ -52,11 +87,11 @@ private:
   // ------------ member data ------------
   std::string folder_;
   bool compareClusters_;
-  MonitorElement* h_nclusters_{nullptr};
-  MonitorElement* h_barycenter_{nullptr};
-  MonitorElement* h_width_{nullptr};
-  MonitorElement* h_avgCharge_{nullptr};
-  MonitorElement* h_isSaturated_{nullptr};
+  MonitorElement* h_nclusters_;
+
+  siStripRawPrime::monitorApproxCluster allClusters{};
+  siStripRawPrime::monitorApproxCluster matchedClusters{};
+  siStripRawPrime::monitorApproxCluster unMatchedClusters{};
 
   // for comparisons
   MonitorElement* h_isMatched_{nullptr};
@@ -138,19 +173,18 @@ void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const e
     // starts here comaparison with regular clusters
     if (compareClusters_) {
       edmNew::DetSetVector<SiStripCluster>::const_iterator isearch =
-          stripClusterCollection_->find(detid);  // search  clusters of detid
+          stripClusterCollection_->find(detid);  // search clusters of same detid
       strip_clusters_detset = (*isearch);
     }
 
-    bool isMatched{false};
     for (const auto& cluster : detClusters) {
       nApproxClusters++;
-      h_barycenter_->Fill(cluster.barycenter());
-      h_width_->Fill(cluster.width());
-      h_avgCharge_->Fill(cluster.avgCharge());
-      h_isSaturated_->Fill(cluster.isSaturated() ? 1 : -1);
+
+      // fill the full cluster collection
+      allClusters.fill(cluster);
 
       if (compareClusters_ && !strip_clusters_detset.empty()) {
+        // build the converted cluster for the matching
         uint16_t nStrips{0};
         auto det = std::find_if(tkDets.begin(), tkDets.end(), [detid](auto& elem) -> bool {
           return (elem->geographicalId().rawId() == detid);
@@ -159,30 +193,42 @@ void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const e
         nStrips = p.nstrips() - 1;
 
         const auto convertedCluster = SiStripCluster(cluster, nStrips);
+
         float distance{9999.};
         const SiStripCluster* closestCluster{nullptr};
         for (const auto& stripCluster : strip_clusters_detset) {
+          // by construction the approximated cluster width has same
+          // size as the original cluster
+          if (cluster.width() != stripCluster.size()) {
+            continue;
+          }
+
           float deltaBarycenter = convertedCluster.barycenter() - stripCluster.barycenter();
-          if (deltaBarycenter < distance) {
+          if (std::abs(deltaBarycenter) < distance) {
             closestCluster = &stripCluster;
-            distance = deltaBarycenter;
+            distance = std::abs(deltaBarycenter);
           }
         }
 
         // Matching criteria:
         // - if exists a closest cluster in the DetId
         // - the size coincides with the original one
-        if (closestCluster && (cluster.width() == closestCluster->size())) {
-          isMatched = true;
-          h_deltaBarycenter_->Fill(distance);
+        if (closestCluster) {
+          h_deltaBarycenter_->Fill(closestCluster->barycenter() - convertedCluster.barycenter());
           h_deltaSize_->Fill(closestCluster->size() - convertedCluster.size());
           h_deltaCharge_->Fill(closestCluster->charge() - convertedCluster.charge());
           h_deltaFirstStrip_->Fill(closestCluster->firstStrip() - convertedCluster.firstStrip());
           h_deltaEndStrip_->Fill(closestCluster->endStrip() - convertedCluster.endStrip());
         }
 
-        h_isMatched_->Fill(isMatched ? 1 : -1);
-
+        // perfect match (also barycenter coindices)
+        if (std::abs(distance) <= 1.f) {
+          matchedClusters.fill(cluster);
+          h_isMatched_->Fill(1);
+        } else {
+          unMatchedClusters.fill(cluster);
+          h_isMatched_->Fill(-1);
+        }
       }  // if we're doing the comparison cluster by cluster
 
     }  // loop on clusters in a detset
@@ -195,27 +241,24 @@ void SiStripMonitorApproximateCluster::bookHistograms(DQMStore::IBooker& ibook,
                                                       edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
   h_nclusters_ = ibook.book1D("numberOfClusters", "total N. of clusters;N. of clusters;#clusters", 500., 0., 500000.);
-  h_barycenter_ =
-      ibook.book1D("clusterBarycenter", "cluster barycenter;cluster barycenter;#clusters", 7680., 0., 7680.);
-  h_width_ = ibook.book1D("clusterWidth", "cluster width;cluster width;#clusters", 128, -0.5, 127.5);
-  h_avgCharge_ =
-      ibook.book1D("clusterAvgCharge", "average strip charge;average strip charge;#clusters", 256, -0.5, 255.5);
-  h_isSaturated_ = ibook.book1D("clusterSaturation", "cluster saturation;is saturated?;#clusters", 3, -1.5, 1.5);
-  h_isSaturated_->getTH1F()->GetXaxis()->SetBinLabel(1, "Not saturated");
-  h_isSaturated_->getTH1F()->GetXaxis()->SetBinLabel(3, "Saturated");
+  allClusters.book(ibook, folder_);
 
   //  for comparisons
   if (compareClusters_) {
+    // book monitoring for matche and unmatched clusters separately
+    matchedClusters.book(ibook, fmt::format("{}/MatchedClusters", folder_));
+    unMatchedClusters.book(ibook, fmt::format("{}/UnmatchedClusters", folder_));
+
     ibook.setCurrentFolder(fmt::format("{}/ClusterComparisons", folder_));
     h_deltaBarycenter_ =
-        ibook.book1D("deltaBarycenter", "#Delta barycenter;#Delta barycenter;cluster pairs", 201, -100.5, 100.5);
+        ibook.book1D("deltaBarycenter", "#Delta barycenter;#Delta barycenter;cluster pairs", 501, -1000.5, 1000.5);
     h_deltaSize_ = ibook.book1D("deltaSize", "#Delta size;#Delta size;cluster pairs", 201, -100.5, 100.5);
-    h_deltaCharge_ = ibook.book1D("deltaCharge", "#Delta charge;#Delta charge;cluster pairs", 500, -1000.5, 1000.5);
+    h_deltaCharge_ = ibook.book1D("deltaCharge", "#Delta charge;#Delta charge;cluster pairs", 501, -1000.5, 1000.5);
 
     h_deltaFirstStrip_ =
-        ibook.book1D("deltaFirstStrip", "#Delta FirstStrip; #Delta firstStrip;cluster pairs", 201, -100.5, 100.5);
+        ibook.book1D("deltaFirstStrip", "#Delta FirstStrip; #Delta firstStrip;cluster pairs", 501, -1000.5, 1000.5);
     h_deltaEndStrip_ =
-        ibook.book1D("deltaEndStrip", "#Delta EndStrip; #Delta endStrip; cluster pairs", 201, -100.5, 100.5);
+        ibook.book1D("deltaEndStrip", "#Delta EndStrip; #Delta endStrip; cluster pairs", 501, -1000.5, 1000.5);
 
     h_isMatched_ = ibook.book1D("isClusterMatched", "cluster matching;is matched?;#clusters", 3, -1.5, 1.5);
     h_isMatched_->getTH1F()->GetXaxis()->SetBinLabel(1, "Not matched");

--- a/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
@@ -1,0 +1,134 @@
+// -*- C++ -*-
+//
+// Package:    DQM/SiStripMonitorApproximateCluster
+// Class:      SiStripMonitorApproximateCluster
+//
+/**\class SiStripMonitorApproximateCluster SiStripMonitorApproximateCluster.cc DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Thu, 08 Dec 2022 20:51:10 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+//
+// class declaration
+//
+
+class SiStripMonitorApproximateCluster : public DQMEDAnalyzer {
+public:
+  explicit SiStripMonitorApproximateCluster(const edm::ParameterSet&);
+  ~SiStripMonitorApproximateCluster() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ------------ member data ------------
+  std::string folder_;
+  MonitorElement* h_nclusters;
+  MonitorElement* h_barycenter;
+  MonitorElement* h_width;
+  MonitorElement* h_avgCharge;
+  MonitorElement* h_isSaturated;
+
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripApproximateCluster> > clusterProducerStripToken_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+SiStripMonitorApproximateCluster::SiStripMonitorApproximateCluster(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      // Poducer name of input StripClusterCollection
+      clusterProducerStripToken_(consumes<edmNew::DetSetVector<SiStripApproximateCluster> >(
+          iConfig.getParameter<edm::InputTag>("ClusterProducerStrip"))) {
+  // now do what ever initialization is needed
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  // get collection of DetSetVector of clusters from Event
+  edm::Handle<edmNew::DetSetVector<SiStripApproximateCluster> > cluster_detsetvector;
+  iEvent.getByToken(clusterProducerStripToken_, cluster_detsetvector);
+
+  if (!cluster_detsetvector.isValid()) {
+    edm::LogError("SiStripMonitorApproximateCluster")
+        << "SiStripApproximate cluster collection is not valid!" << std::endl;
+    return;
+  }
+
+  int nStripClusters{0};
+  const edmNew::DetSetVector<SiStripApproximateCluster>* clusterCollection = cluster_detsetvector.product();
+
+  for (const auto& detClusters : *clusterCollection) {
+    for (const auto& cluster : detClusters) {
+      nStripClusters++;
+      h_barycenter->Fill(cluster.barycenter());
+      h_width->Fill(cluster.width());
+      h_avgCharge->Fill(cluster.avgCharge());
+      h_isSaturated->Fill(cluster.isSaturated() ? 1 : -1);
+    }
+  }
+  h_nclusters->Fill(nStripClusters);
+}
+
+void SiStripMonitorApproximateCluster::bookHistograms(DQMStore::IBooker& ibook,
+                                                      edm::Run const& run,
+                                                      edm::EventSetup const& iSetup) {
+  ibook.setCurrentFolder(folder_);
+  h_nclusters = ibook.book1D("numberOfClusters", "total N. of clusters;N. of clusters;#clusters", 500., 0., 500000.);
+  h_barycenter = ibook.book1D("clusterBarycenter", "cluster barycenter;cluster barycenter;#clusters", 7680., 0., 7680.);
+  h_width = ibook.book1D("clusterWidth", "cluster width;cluster width;#clusters", 128, -0.5, 127.5);
+  h_avgCharge =
+      ibook.book1D("clusterAvgCharge", "average strip charge;average strip charge;#clusters", 256, -0.5, 255.5);
+  h_isSaturated = ibook.book1D("clusterSaturation", "cluster saturation;cluster saturation;is saturated", 3, -1.5, 1.5);
+  h_isSaturated->getTH1F()->GetXaxis()->SetBinLabel(1, "Not saturated");
+  h_isSaturated->getTH1F()->GetXaxis()->SetBinLabel(3, "Saturated");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SiStripMonitorApproximateCluster::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("ClusterProducerStrip", edm::InputTag("hltSiStripClusters2ApproxClusters"));
+  desc.add<std::string>("folder", "SiStripApproximateClusters");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(SiStripMonitorApproximateCluster);

--- a/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
+++ b/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
@@ -3,5 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # SiStripMonitorCluster
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SiStripMonitorApproximateCluster = DQMEDAnalyzer("SiStripMonitorApproximateCluster",
-                                                 ClusterProducerStrip = cms.InputTag('hltSiStripClusters2ApproxClusters'),
+                                                 compareClusters = cms.bool(False),
+                                                 ApproxClustersProducer = cms.InputTag('hltSiStripClusters2ApproxClusters'),
+                                                 ClustersProducer = cms.InputTag('siStripClusters'),
                                                  folder = cms.string('SiStripApproximateClusters'))

--- a/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
+++ b/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
@@ -2,8 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 # SiStripMonitorCluster
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-SiStripMonitorApproximateCluster = DQMEDAnalyzer("SiStripMonitorApproximateCluster",
-                                                 compareClusters = cms.bool(False),
-                                                 ApproxClustersProducer = cms.InputTag('hltSiStripClusters2ApproxClusters'),
-                                                 ClustersProducer = cms.InputTag('siStripClusters'),
-                                                 folder = cms.string('SiStripApproximateClusters'))
+from DQM.SiStripMonitorApproximateCluster.siStripMonitorApproximateCluster_cfi import siStripMonitorApproximateCluster
+SiStripMonitorApproximateCluster =  siStripMonitorApproximateCluster.clone()

--- a/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
+++ b/DQM/SiStripMonitorApproximateCluster/python/SiStripMonitorApproximateCluster_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+# SiStripMonitorCluster
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+SiStripMonitorApproximateCluster = DQMEDAnalyzer("SiStripMonitorApproximateCluster",
+                                                 ClusterProducerStrip = cms.InputTag('hltSiStripClusters2ApproxClusters'),
+                                                 folder = cms.string('SiStripApproximateClusters'))

--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py
@@ -189,18 +189,32 @@ from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 #    *SiStripMonitorTrackMB*MonitorTrackResiduals
 #    *dqmInfoSiStrip)
 
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+
 SiStripDQMTier0 = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackCommon*SiStripMonitorTrackIB*refittedForPixelDQM*MonitorTrackResiduals
     *dqmInfoSiStrip)
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+
+from DQM.SiStripMonitorApproximateCluster.SiStripMonitorApproximateCluster_cfi import SiStripMonitorApproximateCluster
+SiStripDQMTier0_approx = SiStripDQMTier0.copy()
+SiStripDQMTier0_approx += cms.Sequence(SiStripMonitorApproximateCluster)
+approxSiStripClusters.toReplaceWith(SiStripDQMTier0, SiStripDQMTier0_approx)
 
 SiStripDQMTier0Common = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX        
     *SiStripMonitorTrackCommon*SiStripMonitorTrackIB
     *dqmInfoSiStrip)
 
+SiStripDQMTier0Common_approx = SiStripDQMTier0Common.copy()
+SiStripDQMTier0Common_approx += cms.Sequence(SiStripMonitorApproximateCluster)
+approxSiStripClusters.toReplaceWith(SiStripDQMTier0Common, SiStripDQMTier0Common_approx)
+
 SiStripDQMTier0MinBias = cms.Sequence(
     APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorClusterBPTX
     *SiStripMonitorTrackMB*SiStripMonitorTrackIB*refittedForPixelDQM*MonitorTrackResiduals
     *dqmInfoSiStrip)
+
+SiStripDQMTier0MinBias_approx = SiStripDQMTier0MinBias.copy()
+SiStripDQMTier0MinBias_approx += cms.Sequence(SiStripMonitorApproximateCluster)
+approxSiStripClusters.toReplaceWith(SiStripDQMTier0MinBias, SiStripDQMTier0MinBias_approx)


### PR DESCRIPTION
#### PR description:

Title says it all. Provide a new package in order to be able to monitor both online and offline the `SiStripApproximateCluster` collection and created the necessary modifications to be able to run it in the offline DQM by usage of the `approxSiStripClusters` process modifier and in the SiStrip Online DQM client.

#### PR validation:

Run successfully `runTheMatrix.py -l 140.58 -t 4 -j 8 --ibeos` and obtained plots, both with the `compareClusters` parameter set to `True` or `False`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport is needed
