### PR TITLE
Avoid short-circuiting ESWatchers in FastSimProducer

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -203,7 +203,10 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   //  Initialize the calorimeter geometry
   if (simulateCalorimetry) {
-    if (watchCaloGeometry_.check(iSetup) || watchCaloTopology_.check(iSetup)) {
+    //evaluate here since || short circuits and we want to be sure bother are updated
+    auto newGeom = watchCaloGeometry_.check(iSetup);
+    auto newTopo = watchCaloTopology_.check(iSetup);
+    if (newGeom || newTopo) {
       auto const& pG = iSetup.getData(caloGeometryESToken_);
       myCalorimetry->getCalorimeter()->setupGeometry(pG);
 


### PR DESCRIPTION
#### PR description:

Be sure to call check for all ESWatchers for each event. This problem was uncovered by running the fast sim in gdb and doing break points on HFShowerLibrary::~HFShowerLibrary which showed unexpected deletions going on.

#### PR validation:

Code compiles.