### PR TITLE
Utilities/StaticAnalyzer: Add null_ptr guard to ConstCast and ConstCastAway Checkers.

### DIFF
--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -24,16 +24,16 @@ namespace clangcms {
     if (!(clang::CStyleCastExpr::classof(CE) || clang::CXXConstCastExpr::classof(CE)))
       return;
     auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
-    while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
+    while (P && !(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
            C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P)) {
       P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
     }
-    if (isa<AttributedStmt>(P)) {
+    if (P && isa<AttributedStmt>(P)) {
       const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(P);
       if (AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())))
         return;
     }
-    if (isa<DeclStmt>(P)) {
+    if (P && isa<DeclStmt>(P)) {
       const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
       if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
                  hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -21,16 +21,16 @@ namespace clangcms {
 
   void ConstCastChecker::checkPreStmt(const clang::CXXConstCastExpr *CE, clang::ento::CheckerContext &C) const {
     auto P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(CE);
-    while (!(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
+    while (P && !(isa<AttributedStmt>(P) || isa<DeclStmt>(P)) &&
            C.getCurrentAnalysisDeclContext()->getParentMap().hasParent(P)) {
       P = C.getCurrentAnalysisDeclContext()->getParentMap().getParent(P);
     }
-    if (isa<AttributedStmt>(P)) {
+    if (P && isa<AttributedStmt>(P)) {
       const AttributedStmt *AS = dyn_cast_or_null<AttributedStmt>(P);
       if (AS && (hasSpecificAttr<CMSSaAllowAttr>(AS->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(AS->getAttrs())))
         return;
     }
-    if (isa<DeclStmt>(P)) {
+    if (P && isa<DeclStmt>(P)) {
       const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
       if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
                  hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))


### PR DESCRIPTION
Fixes crashes in static-analyzer.

Tested locally.

potentially fixes #40292