### PR TITLE
Migrate HI_DiJetSkim_cff.py to use reco::JetCorrector

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/HI_DiJetSkim_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/HI_DiJetSkim_cff.py
@@ -15,10 +15,10 @@ primaryVertexFilterForJets = cms.EDFilter("VertexSelector",
     )
 
 # jet energy correction (L2+L3)
-from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
-icPu5CaloJetsL2L3 = cms.EDProducer('CaloJetCorrectionProducer',
+from JetMETCorrections.Configuration.JetCorrectorsAllAlgos_cff import ic5CaloL2RelativeCorrector, ic5CaloL3AbsoluteCorrector, ic5CaloL2L3Corrector, ic5CaloL2L3CorrectorTask
+icPu5CaloJetsL2L3 = cms.EDProducer('CorrectedCaloJetProducer',
     src = cms.InputTag('iterativeConePu5CaloJets'),
-    correctors = cms.vstring('ic5CaloL2L3')
+    correctors = cms.VInputTag('ic5CaloL2L3Corrector')
     )
 
 # leading jet E_T filter
@@ -65,5 +65,6 @@ diJetSkimSequence = cms.Sequence(hltJetHI
                                  * goodLeadingJet
                                  * goodSecondJet
                                  * backToBackDijets
-                                 * dijetFilter
+                                 * dijetFilter,
+                                 ic5CaloL2L3CorrectorTask
                                  )


### PR DESCRIPTION
#### PR description:

Migrate HI_DiJetSkim_cff.py to use reco::JetCorrector. This cff was still using the old JetCorrector class which was deprecated in 2014. This was causing a unit test failure in  Configuration/DataProcessing after we deleted the central cff files for the old deprecated JetCorrectors. This migrated cff does not appear to be used in RelVals or in any other test run by the IBs.

I did a straightforward migration using the new JetCorrector with the corresponding name.

#### PR validation:

Unit test now passes in my local area.
