### PR TITLE
Avoid short-circuiting ESWatchers in SiStripCorrelateBadStripAndNoise

### DIFF
--- a/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.cc
+++ b/DQM/SiStripMonitorSummary/plugins/SiStripCorrelateBadStripAndNoise.cc
@@ -16,7 +16,9 @@ SiStripCorrelateBadStripAndNoise::SiStripCorrelateBadStripAndNoise(const edm::Pa
 }
 
 void SiStripCorrelateBadStripAndNoise::beginRun(const edm::Run &run, const edm::EventSetup &es) {
-  if (noiseWatcher_.check(es) || qualityWatcher_.check(es)) {
+  auto newNoise = noiseWatcher_.check(es);
+  auto newQuality = qualityWatcher_.check(es);
+  if (newNoise || newQuality) {
     edm::LogInfo("") << "[SiStripCorrelateBadStripAndNoise::beginRun]" << std::endl;
 
     quality_ = &es.getData(qualityToken_);


### PR DESCRIPTION
#### PR description:

Be sure to call check for all ESWatchers for each event.

#### PR validation:

Code compiles.