### PR TITLE
[UBSAN] Add missing dependence to Calibration/HcalCalibAlgos/test/BuildFile.xml

### DIFF
--- a/Calibration/HcalCalibAlgos/test/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/test/BuildFile.xml
@@ -20,6 +20,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/Records"/>
+<use name="JetMETCorrections/JetCorrector"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="Calibration/IsolatedParticles"/>


### PR DESCRIPTION
#### PR description:

Adding the dependence explicitly was missed in https://github.com/cms-sw/cmssw/pull/40139. This should fix the UBSAN build failure.


#### PR validation:

None