### PR TITLE
Utilities/StaticAnalysers: Fix assert in ConstCast and ConstCastAway checkers.

### DIFF
--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -8,6 +8,7 @@
 #include <clang/AST/ExprCXX.h>
 #include <clang/AST/Attr.h>
 #include <clang/AST/ParentMap.h>
+#include <clang/AST/Stmt.h>
 
 #include <memory>
 
@@ -35,9 +36,13 @@ namespace clangcms {
     }
     if (isa<DeclStmt>(P)) {
       const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
-      if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
-                 hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
-        return;
+      if (DS) {
+        for (auto D : DS->decls()) {
+          if (hasSpecificAttr<CMSSaAllowAttr>(D->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(D->getAttrs())) {
+            return;
+          }
+        }
+      }
     }
 
     const Expr *SE = CE->getSubExpr();

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -32,9 +32,13 @@ namespace clangcms {
     }
     if (isa<DeclStmt>(P)) {
       const DeclStmt *DS = dyn_cast_or_null<DeclStmt>(P);
-      if (DS && (hasSpecificAttr<CMSSaAllowAttr>(DS->getSingleDecl()->getAttrs()) ||
-                 hasSpecificAttr<CMSThreadSafeAttr>(DS->getSingleDecl()->getAttrs())))
-        return;
+      if (DS) {
+        for (auto D : DS->decls()) {
+          if (hasSpecificAttr<CMSSaAllowAttr>(D->getAttrs()) || hasSpecificAttr<CMSThreadSafeAttr>(D->getAttrs())) {
+            return;
+          }
+        }
+      }
     }
 
     const Expr *SE = CE->getSubExprAsWritten();


### PR DESCRIPTION
Fix crash in clang static analyser caused by this assertionb
```
include/clang/AST/DeclGroup.h:84: clang::Decl* clang::DeclGroupRef::getSingleDecl(): Assertion `isSingleDecl() && "Isn't a single decl"' failed.
```