### PR TITLE
Allow throwing of edm::Exceptions from python

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -240,6 +240,8 @@ int main(int argc, char* argv[]) {
       try {
         std::unique_ptr<edm::ParameterSet> parameterSet = edm::readConfig(fileName, argc, argv);
         processDesc.reset(new edm::ProcessDesc(std::move(parameterSet)));
+      } catch (edm::Exception const&) {
+        throw;
       } catch (cms::Exception& iException) {
         edm::Exception e(edm::errors::ConfigFileReadError, "", iException);
         throw e;

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -27,6 +27,16 @@ from .ExceptionHandling import *
 if sys.getrecursionlimit()<5000:
     sys.setrecursionlimit(5000)
 
+class edm(object):
+    class errors(object):
+        #Allowed errors to used within Python
+        Configuration = "{Configuration}"
+
+class EDMException(Exception):
+    def __init__(self, error, message):
+        super().__init__(error+"\n"+message)
+
+
 def checkImportPermission(minLevel = 2, allowedPatterns = []):
     """
     Raise an exception if called by special config files. This checks

--- a/FWCore/PythonParameterSet/src/PyBind11Wrapper.cc
+++ b/FWCore/PythonParameterSet/src/PyBind11Wrapper.cc
@@ -1,9 +1,26 @@
 #include "FWCore/PythonParameterSet/interface/PyBind11Wrapper.h"
 #include "FWCore/Utilities/interface/Exception.h"
-//#include <iostream>
+#include "FWCore/Utilities/interface/EDMException.h"
 namespace edm {
 
   void pythonToCppException(const std::string& iType, const std::string& error) {
+    auto colon = error.find(':');
+    if (colon != std::string::npos) {
+      if (error.substr(0, colon) == "EDMException") {
+        auto errorNameStart = error.find('{');
+        auto errorNameEnd = error.find('}');
+        if (errorNameStart != std::string::npos and errorNameEnd != std::string::npos) {
+          auto errorName = error.substr(errorNameStart + 1, errorNameEnd - errorNameStart - 1);
+          if ("Configuration" == errorName) {
+            auto newLine = error.find('\n', errorNameEnd + 1);
+            if (newLine == std::string::npos) {
+              newLine = errorNameEnd + 1;
+            }
+            throw edm::Exception(edm::errors::Configuration) << error.substr(newLine + 1, std::string::npos);
+          }
+        }
+      }
+    }
     throw cms::Exception(iType) << " unknown python problem occurred.\n" << error << std::endl;
   }
 }  // namespace edm

--- a/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
@@ -8,6 +8,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PythonParameterSet/interface/PyBind11ProcessDesc.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -31,6 +32,7 @@ class testmakeprocess : public CppUnit::TestFixture {
   CPPUNIT_TEST(taskTest);
   CPPUNIT_TEST(taskTestWithEmptySchedule);
   CPPUNIT_TEST(taskTestWithSchedule);
+  CPPUNIT_TEST(edmException);
   //CPPUNIT_TEST(windowsLineEndingTest);
   //CPPUNIT_TEST_EXCEPTION(emptyPsetTest,edm::Exception);
   CPPUNIT_TEST_SUITE_END();
@@ -46,6 +48,7 @@ public:
   void taskTest();
   void taskTestWithEmptySchedule();
   void taskTestWithSchedule();
+  void edmException();
   //void windowsLineEndingTest();
 private:
   typedef std::shared_ptr<edm::ParameterSet> ParameterSetPtr;
@@ -509,6 +512,25 @@ void testmakeprocess::taskTestWithSchedule() {
     result = false;
   }
   CPPUNIT_ASSERT(result);
+}
+
+void testmakeprocess::edmException() {
+  char const* const kTest =
+      "import FWCore.ParameterSet.Config as cms\n"
+      "raise cms.EDMException(cms.edm.errors.Configuration,'test message')\n";
+
+  bool exceptionHappened = false;
+  try {
+    (void)pSet(kTest);
+  } catch (edm::Exception const& e) {
+    exceptionHappened = true;
+    CPPUNIT_ASSERT(e.categoryCode() == edm::errors::Configuration);
+  } catch (std::exception const& e) {
+    std::cout << "wrong error " << e.what() << std::endl;
+    exceptionHappened = true;
+    CPPUNIT_ASSERT(false);
+  }
+  CPPUNIT_ASSERT(exceptionHappened);
 }
 
 /*


### PR DESCRIPTION
#### PR description:

Only a selected set of edm::errors codes are allowed.

#### PR validation:

Code compiles and a simple script shows it works.