### PR TITLE
Typo: Fix the correct object to Clone

### DIFF
--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -371,7 +371,7 @@ namespace fwlite {
       if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
-        hist = (TProfile *)hist->Clone(hname);
+        hist = (TProfile *)htemplate->Clone(hname);
       } else if (drawopt.Contains("SAME", TString::kIgnoreCase)) {
         hist = getSameProf(hname);
       }
@@ -463,7 +463,7 @@ namespace fwlite {
       if (htemplate != nullptr) {
         if ((strcmp(hname, "htemp") == 0) && (strcmp(hname, htemplate->GetName()) != 0))
           htempDelete();
-        hist = (TH2 *)hist->Clone(hname);
+        hist = (TH2 *)htemplate->Clone(hname);
       } else if (drawopt.Contains("SAME", TString::kIgnoreCase)) {
         hist = getSameH2(hname);
       }


### PR DESCRIPTION
While building cmssw with Profile-Guided Optimization flags, cmssw build failed with error [a].  This PR fixes the issue by using the correct object to clone ( just like  https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/FWLite/interface/Scanner.h#L257 )
```
PhysicsTools/FWLite/interface/Scanner.h:466:34: error: 'this' pointer is null [-Werror=nonnull]
  466 |         hist = (TH2 *)hist->Clone(hname);
      |                       ~~~~~~~~~~~^~~~~~~
PhysicsTools/FWLite/interface/Scanner.h:374:39: error: 'this' pointer is null [-Werror=nonnull]
  374 |         hist = (TProfile *)hist->Clone(hname);
      |                            ~~~~~~~~~~~^~~~~~~
``` 