### PR TITLE
initialise pointers in subclasses of `FastTimerService`

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -1067,7 +1067,7 @@ void FastTimerService::postGlobalEndLumi(edm::GlobalContext const& gc) {
       fmt::sprintf("run %d, lumisection %d", gc.luminosityBlockID().run(), gc.luminosityBlockID().luminosityBlock());
   printTransition(out, lumi_transition_[index], label);
 
-  if (enable_dqm_transitions_) {
+  if (enable_dqm_ and enable_dqm_transitions_) {
     plots_->fill_lumi(lumi_transition_[index], gc.luminosityBlockID().luminosityBlock());
   }
 }
@@ -1098,7 +1098,7 @@ void FastTimerService::postGlobalEndRun(edm::GlobalContext const& gc) {
   }
   printTransition(out, run_transition_[index], label);
 
-  if (enable_dqm_transitions_) {
+  if (enable_dqm_ and enable_dqm_transitions_) {
     plots_->fill_run(run_transition_[index]);
   }
 }

--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -344,14 +344,14 @@ private:
 
   private:
     // resources spent in the module
-    dqm::reco::MonitorElement* time_thread_;       // TH1F
-    dqm::reco::MonitorElement* time_thread_byls_;  // TProfile
-    dqm::reco::MonitorElement* time_real_;         // TH1F
-    dqm::reco::MonitorElement* time_real_byls_;    // TProfile
-    dqm::reco::MonitorElement* allocated_;         // TH1F
-    dqm::reco::MonitorElement* allocated_byls_;    // TProfile
-    dqm::reco::MonitorElement* deallocated_;       // TH1F
-    dqm::reco::MonitorElement* deallocated_byls_;  // TProfile
+    dqm::reco::MonitorElement* time_thread_ = nullptr;       // TH1F
+    dqm::reco::MonitorElement* time_thread_byls_ = nullptr;  // TProfile
+    dqm::reco::MonitorElement* time_real_ = nullptr;         // TH1F
+    dqm::reco::MonitorElement* time_real_byls_ = nullptr;    // TProfile
+    dqm::reco::MonitorElement* allocated_ = nullptr;         // TH1F
+    dqm::reco::MonitorElement* allocated_byls_ = nullptr;    // TProfile
+    dqm::reco::MonitorElement* deallocated_ = nullptr;       // TH1F
+    dqm::reco::MonitorElement* deallocated_byls_ = nullptr;  // TProfile
   };
 
   // plots associated to each path or endpath
@@ -380,12 +380,12 @@ private:
     //   be better suited than a double, but there is no "TH1L" in ROOT.
 
     // how many times each module and their dependencies has run
-    dqm::reco::MonitorElement* module_counter_;  // TH1D
+    dqm::reco::MonitorElement* module_counter_ = nullptr;  // TH1D
     // resources spent in each module and their dependencies
-    dqm::reco::MonitorElement* module_time_thread_total_;  // TH1D
-    dqm::reco::MonitorElement* module_time_real_total_;    // TH1D
-    dqm::reco::MonitorElement* module_allocated_total_;    // TH1D
-    dqm::reco::MonitorElement* module_deallocated_total_;  // TH1D
+    dqm::reco::MonitorElement* module_time_thread_total_ = nullptr;  // TH1D
+    dqm::reco::MonitorElement* module_time_real_total_ = nullptr;    // TH1D
+    dqm::reco::MonitorElement* module_allocated_total_ = nullptr;    // TH1D
+    dqm::reco::MonitorElement* module_deallocated_total_ = nullptr;  // TH1D
   };
 
   class PlotsPerProcess {


### PR DESCRIPTION
#### PR description:

I encountered a seg-fault from `FastTimerService` when using `enableDQMTransitions = True` (this parameter is set to `False` by default).

A reproducer is below [*]. I _think_ it comes down to initialising the pointers used as members of the subclasses of the service (in particular, those of `PlotsPerElement`).

Without initialising them, one can get a crash for example in
https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/HLTrigger/Timer/plugins/FastTimerService.cc#L477
when this is called from
https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/HLTrigger/Timer/plugins/FastTimerService.cc#L766
because `run_` does not book "byLS" histograms
https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/HLTrigger/Timer/plugins/FastTimerService.cc#L719
but an (uninitialised) non-zero pointer can pass
https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/HLTrigger/Timer/plugins/FastTimerService.cc#L476
leading to a seg fault one line below.

Initially, I noticed that, if `enableDQM=False` (or if `enableDQM=True`, but the `DQMStore` service is not available) and `enableDQMTransitions=True`, `plots_.book` is not called, but `plots_.fill_lumi` and `plots_.fill_run` are still attempted, e.g.
https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/HLTrigger/Timer/plugins/FastTimerService.cc#L1071
If the pointers are initialised to zero, there will not be a seg fault in any case, but I tried to improve the logic of the `if` clause preceding `fill_lumi/run` just for clarity (I initially thought this check was the problem, but this alone does not solve the seg-faults, because of the uninitialised pointers).

Merely technical. No changes expected.

[*]
```py
import FWCore.ParameterSet.Config as cms

# Process
process = cms.Process('DQM')

process.options.numberOfThreads = 4
process.options.numberOfStreams = 0
process.options.numberOfConcurrentLuminosityBlocks = 2

process.maxEvents.input = 200

# Source (EDM input)
process.source = cms.Source('PoolSource',
  fileNames = cms.untracked.vstring('/store/data/Run2022B/HLTPhysics/RAW/v1/000/355/456/00000/69b26b27-4bd1-4524-bc18-45f7b9b5e076.root')
)

process.load('DQMServices.Core.DQMStore_cfi')

# FastTimerService (Service)
from HLTrigger.Timer.FastTimerService_cfi import FastTimerService as _FastTimerService
process.FastTimerService = _FastTimerService.clone(
  dqmTimeRange = 2000,
  enableDQM = True,
  enableDQMTransitions = True,
  enableDQMbyLumiSection = True,
  enableDQMbyModule = True,
  enableDQMbyPath = True,
  enableDQMbyProcesses = True
)
```

#### PR validation:

Tests with the reproducer.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A (small bugfix, maybe worth backports)