### PR TITLE
Move TF session in L1Trigger/L1NNTauProducer to global cache

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -7,7 +7,10 @@
 
 class TauNNId {
 public:
-  TauNNId(const std::string &iInput, const tensorflow::Session *session, const std::string &iWeightFile, int iNParticles);
+  TauNNId(const std::string &iInput,
+          const tensorflow::Session *session,
+          const std::string &iWeightFile,
+          int iNParticles);
   ~TauNNId();
 
   void setNNVectorVar();

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -5,14 +5,9 @@
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
 
-struct TauNNTFCache {
-  TauNNTFCache() : graphDef(nullptr) {}
-  std::atomic<tensorflow::GraphDef *> graphDef;
-};
-
 class TauNNId {
 public:
-  TauNNId(const std::string &iInput, const TauNNTFCache *cache, const std::string &iWeightFile, int iNParticles);
+  TauNNId(const std::string &iInput, const tensorflow::Session *session, const std::string &iWeightFile, int iNParticles);
   ~TauNNId();
 
   void setNNVectorVar();
@@ -20,7 +15,7 @@ public:
   float compute(const l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts);
 
 private:
-  tensorflow::Session *session_;
+  const tensorflow::Session *session_;
   std::vector<float> NNvectorVar_;
   std::string fInput_;
   int fNParticles_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -11,7 +11,7 @@ public:
           const tensorflow::Session *session,
           const std::string &iWeightFile,
           int iNParticles);
-  ~TauNNId();
+  ~TauNNId(){};
 
   void setNNVectorVar();
   float EvaluateNN();

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -48,8 +48,10 @@ L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg, const tensorflow:
       fNParticles_(cfg.getParameter<int>("nparticles")),
       fL1PFToken_(consumes<vector<l1t::PFCandidate>>(cfg.getParameter<edm::InputTag>("L1PFObjects"))) {
   std::string lNNFile = cfg.getParameter<std::string>("NNFileName");  //,"L1Trigger/Phase2L1Taus/data/tau_3layer.pb");
-  fTauNNId_ = std::make_unique<TauNNId>(
-      lNNFile.find("v0") == std::string::npos ? "input_1:0" : "dense_1_input:0", cache->getSession(), lNNFile, fNParticles_);
+  fTauNNId_ = std::make_unique<TauNNId>(lNNFile.find("v0") == std::string::npos ? "input_1:0" : "dense_1_input:0",
+                                        cache->getSession(),
+                                        lNNFile,
+                                        fNParticles_);
   produces<l1t::PFTauCollection>("L1PFTausNN");
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -14,14 +14,14 @@
 
 using namespace l1t;
 
-class L1NNTauProducer : public edm::stream::EDProducer<edm::GlobalCache<TauNNTFCache>> {
+class L1NNTauProducer : public edm::stream::EDProducer<edm::GlobalCache<tensorflow::SessionCache>> {
 public:
-  explicit L1NNTauProducer(const edm::ParameterSet&, const TauNNTFCache*);
+  explicit L1NNTauProducer(const edm::ParameterSet&, const tensorflow::SessionCache*);
   ~L1NNTauProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static std::unique_ptr<TauNNTFCache> initializeGlobalCache(const edm::ParameterSet&);
-  static void globalEndJob(const TauNNTFCache*);
+  static std::unique_ptr<tensorflow::SessionCache> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(const tensorflow::SessionCache*){};
 
 private:
   std::unique_ptr<TauNNId> fTauNNId_;
@@ -40,7 +40,7 @@ private:
 
 static constexpr float track_trigger_eta_max = 2.5;
 
-L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg, const TauNNTFCache* cache)
+L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg, const tensorflow::SessionCache* cache)
     : fSeedPt_(cfg.getParameter<double>("seedpt")),
       fConeSize_(cfg.getParameter<double>("conesize")),
       fTauSize_(cfg.getParameter<double>("tausize")),
@@ -49,22 +49,16 @@ L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg, const TauNNTFCach
       fL1PFToken_(consumes<vector<l1t::PFCandidate>>(cfg.getParameter<edm::InputTag>("L1PFObjects"))) {
   std::string lNNFile = cfg.getParameter<std::string>("NNFileName");  //,"L1Trigger/Phase2L1Taus/data/tau_3layer.pb");
   fTauNNId_ = std::make_unique<TauNNId>(
-      lNNFile.find("v0") == std::string::npos ? "input_1:0" : "dense_1_input:0", cache, lNNFile, fNParticles_);
+      lNNFile.find("v0") == std::string::npos ? "input_1:0" : "dense_1_input:0", cache->getSession(), lNNFile, fNParticles_);
   produces<l1t::PFTauCollection>("L1PFTausNN");
 }
-std::unique_ptr<TauNNTFCache> L1NNTauProducer::initializeGlobalCache(const edm::ParameterSet& cfg) {
+
+std::unique_ptr<tensorflow::SessionCache> L1NNTauProducer::initializeGlobalCache(const edm::ParameterSet& cfg) {
   tensorflow::setLogging("3");
-  std::string lNNFile = cfg.getParameter<std::string>("NNFileName");
-  edm::FileInPath fp(lNNFile);
-  TauNNTFCache* cache = new TauNNTFCache();
-  cache->graphDef = tensorflow::loadGraphDef(fp.fullPath());
-  return std::unique_ptr<TauNNTFCache>(cache);
+  std::string graphPath = edm::FileInPath(cfg.getParameter<std::string>("NNFileName")).fullPath();
+  return std::make_unique<tensorflow::SessionCache>(graphPath);
 }
-void L1NNTauProducer::globalEndJob(const TauNNTFCache* cache) {
-  if (cache->graphDef != nullptr) {
-    delete cache->graphDef;
-  }
-}
+
 void L1NNTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
   iEvent.getByToken(fL1PFToken_, l1PFCandidates);

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -5,10 +5,9 @@
 
 static constexpr unsigned int n_particles_max = 10;
 
-TauNNId::TauNNId(const std::string &iInput, const TauNNTFCache *cache, const std::string &iWeightFile, int iNParticles) {
+TauNNId::TauNNId(const std::string &iInput, const tensorflow::Session * session, const std::string &iWeightFile, int iNParticles) : session_(session) {
   NNvectorVar_.clear();
   edm::FileInPath fp(iWeightFile);
-  session_ = tensorflow::createSession(cache->graphDef);
   fNParticles_ = iNParticles;
 
   fPt_ = std::make_unique<float[]>(fNParticles_);
@@ -19,6 +18,7 @@ TauNNId::TauNNId(const std::string &iInput, const TauNNTFCache *cache, const std
 }
 
 TauNNId::~TauNNId() { tensorflow::closeSession(session_); }
+
 void TauNNId::setNNVectorVar() {
   NNvectorVar_.clear();
   for (int i0 = 0; i0 < fNParticles_; i0++) {

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -5,7 +5,11 @@
 
 static constexpr unsigned int n_particles_max = 10;
 
-TauNNId::TauNNId(const std::string &iInput, const tensorflow::Session * session, const std::string &iWeightFile, int iNParticles) : session_(session) {
+TauNNId::TauNNId(const std::string &iInput,
+                 const tensorflow::Session *session,
+                 const std::string &iWeightFile,
+                 int iNParticles)
+    : session_(session) {
   NNvectorVar_.clear();
   edm::FileInPath fp(iWeightFile);
   fNParticles_ = iNParticles;

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -21,8 +21,6 @@ TauNNId::TauNNId(const std::string &iInput,
   fInput_ = iInput;
 }
 
-TauNNId::~TauNNId() { tensorflow::closeSession(session_); }
-
 void TauNNId::setNNVectorVar() {
   NNvectorVar_.clear();
   for (int i0 = 0; i0 < fNParticles_; i0++) {


### PR DESCRIPTION
#### PR description

This PR adapts the `L1NNTauProducer` and `TauNNId` helper object in `L1Trigger` to use a single, const tensorflow session stored in the global cache. For this, it's using the central `SessionCache` struct introduced in #40284.

This is part of the planned changes documented in #40248, intended to treat all tf sessions as constant for model evaluation purposes and therefore preventing copies across stream module instances for saving memory.


#### PR validation

There was no new functionality added to the `L1NNTauProducer`, so existing test cases should fully cover the changes.

@clacaputo @yongbinfeng @valsdav