### PR TITLE
Fix -1 precision in SimpleFlatTableProducer

### DIFF
--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -53,14 +53,15 @@ public:
   void fill(std::vector<const ObjType *> &selobjs, nanoaod::FlatTable &out) const override {
     std::vector<ValType> vals(selobjs.size());
     for (unsigned int i = 0, n = vals.size(); i < n; ++i) {
+      ValType val = func_(*selobjs[i]);
       if constexpr (std::is_same<ValType, float>()) {
         if (this->precision_ == -2) {
-          vals[i] = MiniFloatConverter::reduceMantissaToNbitsRounding(func_(*selobjs[i]), precisionFunc_(*selobjs[i]));
-        } else {
-          vals[i] = func_(*selobjs[i]);
-        }
+          auto prec = precisionFunc_(*selobjs[i]);
+          vals[i] = prec > 0 ? MiniFloatConverter::reduceMantissaToNbitsRounding(val, prec) : val;
+        } else
+          vals[i] = val;
       } else {
-        vals[i] = func_(*selobjs[i]);
+        vals[i] = val;
       }
     }
     out.template addColumn<ValType>(this->name_, vals, this->doc_, this->precision_);


### PR DESCRIPTION
Reopening a new PR after I messed up the previous one and included a lot of erroneous commits from other development.

When using a string function for the precision in SimpleFlatTableProducer, -1 does not actually result in full precision. This is because reduceMantissaToNbitsRounding doesn't actually accept -1 as an argument, in other places where this is used, the call to reduceMantissaToNbinsRounding is bypassed: https://github.com/kdlong/cmssw/blob/ece4581e13b78bc0f0fb87c93296bcbe90c79500/DataFormats/NanoAOD/interface/FlatTable.h#L28

I'm not aware of this showing up in the normal nano production, but we use it in the Wmass customisation here [1], and have only realised that the pt precision, which should be -1 => full precision, is actually set incorrectly to quite low precision (not 100% sure how it is treated).

[1] https://github.com/kdlong/cmssw/blob/ece4581e13b78bc0f0fb87c93296bcbe90c79500/PhysicsTools/NanoAOD/python/nano_cff.py#L206