### PR TITLE
Fix Geant4 physics configuration

### DIFF
--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -80,8 +80,16 @@ ParametrisedEMPhysics::ParametrisedEMPhysics(const std::string& name, const edm:
   bool genn = theParSet.getParameter<bool>("G4NeutronGeneralProcess");
   G4HadronicParameters::Instance()->SetEnableNeutronGeneralProcess(genn);
 
-  if (theParSet.getParameter<bool>("G4TransportWithMSC"))
-    param->SetTransportationWithMsc(G4TransportationWithMscType::fEnabled);
+  bool pe = p.getParameter<bool>("PhotoeffectBelowKShell");
+  param->SetPhotoeffectBelowKShell(pe);
+  G4TransportationWithMscType trtype = G4TransportationWithMscType::fDisabled;
+  int type = p.getParameter<int>("G4TransportWithMSC");
+  if (type == 1) {
+    trtype = G4TransportationWithMscType::fEnabled;
+  } else if (type == 2) {
+    trtype = G4TransportationWithMscType::fMultipleSteps;
+  }
+  param->SetTransportationWithMsc(trtype);
 #endif
 
   bool mudat = theParSet.getParameter<bool>("ReadMuonData");

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -75,18 +75,6 @@ CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver, const edm::ParameterSet& p
   double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
   param->SetLowestElectronEnergy(tcut);
   param->SetLowestMuHadEnergy(tcut);
-#if G4VERSION_NUMBER >= 1110
-  bool pe = p.getParameter<bool>("PhotoeffectBelowKShell");
-  param->SetPhotoeffectBelowKShell(pe);
-  G4TransportationWithMscType trtype = fDisabled;
-  int type = p.getParameter<int>("G4TransportWithMSC");
-  if (trtype == 1) {
-    trtype = fEnabled;
-  } else if (trtype == 2) {
-    trtype = fMultipleSteps;
-  }
-  param->SetTransportationWithMsc(trtype);
-#endif
 }
 
 CMSEmStandardPhysics::~CMSEmStandardPhysics() {}


### PR DESCRIPTION
#### PR description:

The IB with Geant4 11.1 was broken, `G4TransportWithMSC` is now an int. Also move the configuration options for `PhotoeffectBelowKShell` and `G4TransportWithMSC` to `ParametrisedEMPhysics`, where it was before.

#### PR validation:

builds and works for `G4VECGEOM` IB; no backport needed, but urgent for the next `G4VECGEOM` IB.