### PR TITLE
Delete commented out imports of deprecated JetCorrector cffs

### DIFF
--- a/L1Trigger/L1TNtuples/test/test_JetRecoProducer.py
+++ b/L1Trigger/L1TNtuples/test/test_JetRecoProducer.py
@@ -42,7 +42,6 @@ process.TFileService = cms.Service("TFileService",
 # producer under test
 process.load("L1Trigger.L1TNtuples.l1JetRecoTreeProducer_cfi")
 
-# get corrected jets
 #process.l1RecoTreeProducer.jetTag = cms.untracked.InputTag("ak4PFCHSJetsL2")
 
 process.p = cms.Path(

--- a/L1Trigger/L1TNtuples/test/test_JetRecoProducer.py
+++ b/L1Trigger/L1TNtuples/test/test_JetRecoProducer.py
@@ -43,7 +43,6 @@ process.TFileService = cms.Service("TFileService",
 process.load("L1Trigger.L1TNtuples.l1JetRecoTreeProducer_cfi")
 
 # get corrected jets
-#from JetMETCorrections.Configuration.JetCorrectionProducers_cff import ak4PFCHSJetsL2
 #process.l1RecoTreeProducer.jetTag = cms.untracked.InputTag("ak4PFCHSJetsL2")
 
 process.p = cms.Path(

--- a/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/metCorrections_cff.py
@@ -4,7 +4,6 @@ import FWCore.ParameterSet.Config as cms
 from JetMETCorrections.Type1MET.correctionTermsPfMetType1Type2_cff import *
 from JetMETCorrections.Type1MET.correctionTermsCaloMet_cff import *
 from JetMETCorrections.Type1MET.correctedMet_cff import caloMetT1, caloMetT1T2, pfMetT1, pfMetT1T2
-#from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import *
 
 #from JetMETCorrections.Type1MET.pfMETCorrections_cff import *
 

--- a/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
+++ b/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
@@ -389,7 +389,6 @@ process.PassingHLT = cms.EDProducer("trgMatchedGsfElectronProducer",
 ##   |_____/_/\_\\__\___|_|  |_| |_|\__,_|_|    \_/ \__,_|_|  |___/
 ##   
 ## Here we show how to use a module to compute an external variable
-## ak5PFResidual.useCondDB = False
 
 process.superClusterDRToNearestJet = cms.EDProducer("DeltaRNearestJetComputer",
     probes = cms.InputTag("goodSuperClusters"),

--- a/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
+++ b/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
@@ -389,7 +389,6 @@ process.PassingHLT = cms.EDProducer("trgMatchedGsfElectronProducer",
 ##   |_____/_/\_\\__\___|_|  |_| |_|\__,_|_|    \_/ \__,_|_|  |___/
 ##   
 ## Here we show how to use a module to compute an external variable
-## process.load("JetMETCorrections.Configuration.DefaultJEC_cff")
 ## ak5PFResidual.useCondDB = False
 
 process.superClusterDRToNearestJet = cms.EDProducer("DeltaRNearestJetComputer",

--- a/Validation/RecoJets/python/JetValidation_cff.py
+++ b/Validation/RecoJets/python/JetValidation_cff.py
@@ -18,8 +18,6 @@ newAk4CaloL2L3CorrectorChain = cms.Sequence(
     newAk4CaloL2L3Corrector
 )
 
-#newAk7CaloL2L3 = ak7CaloL2L3.clone()
-
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3CorrectorChain,ak4PFL1FastL2L3Corrector,ak4PFL3AbsoluteCorrector,ak4PFL2RelativeCorrector,ak4PFL1FastjetCorrector
 
 newAk4PFL1FastL2L3Corrector = ak4PFL1FastL2L3Corrector.clone()
@@ -27,8 +25,6 @@ newAk4PFL1FastL2L3CorrectorChain = cms.Sequence(
     #ak4PFL1FastjetCorrector * ak4PFL2RelativeCorrector * ak4PFL3AbsoluteCorrector * 
     newAk4PFL1FastL2L3Corrector
 )
-
-#newAk4JPTL1FastL2L3 = ak4JPTL1FastL2L3.clone()
 
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3CorrectorChain,ak4PFCHSL1FastL2L3Corrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector
 

--- a/Validation/RecoJets/python/JetValidation_cff.py
+++ b/Validation/RecoJets/python/JetValidation_cff.py
@@ -18,7 +18,6 @@ newAk4CaloL2L3CorrectorChain = cms.Sequence(
     newAk4CaloL2L3Corrector
 )
 
-#from JetMETCorrections.Configuration.JetCorrectionServicesAllAlgos_cff import ak7CaloL2L3,ak7CaloL2Relative,ak7CaloL3Absolute
 #newAk7CaloL2L3 = ak7CaloL2L3.clone()
 
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFL1FastL2L3CorrectorChain,ak4PFL1FastL2L3Corrector,ak4PFL3AbsoluteCorrector,ak4PFL2RelativeCorrector,ak4PFL1FastjetCorrector
@@ -29,7 +28,6 @@ newAk4PFL1FastL2L3CorrectorChain = cms.Sequence(
     newAk4PFL1FastL2L3Corrector
 )
 
-#from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4JPTL1FastL2L3,ak4JPTL1Fastjet,ak4JPTL2Relative,ak4JPTL3Absolute
 #newAk4JPTL1FastL2L3 = ak4JPTL1FastL2L3.clone()
 
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFCHSL1FastL2L3CorrectorChain,ak4PFCHSL1FastL2L3Corrector,ak4PFCHSL3AbsoluteCorrector,ak4PFCHSL2RelativeCorrector,ak4PFCHSL1FastjetCorrector


### PR DESCRIPTION
#### PR description:

We just removed central cff files related to deprecated JetCorrector's (#39953). This PR removes lines of Python configuration code where those files were imported and those particular lines were already commented out.

@vlimant suggested we do this centrally in Issue #40304. Easy to do, so I just did it.

#### PR validation:

Only deletes comment lines.
