### PR TITLE
Utilities/StaticAnalyzer: Update cms.NonFiniteMath optional.getParamDumper checkers

### DIFF
--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -32,27 +32,15 @@ namespace clangcms {
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
 
-    //	llvm::errs()<<E->getStmtClassName()<<";\t";
-    //	E->dumpPretty(ctx.getASTContext());
-    //	llvm::errs()<<"\n";
-    //	E->dump();
-    //	llvm::errs()<<"\n";
-
     for (clang::Stmt::const_child_iterator I = E->child_begin(), F = E->child_end(); I != F; ++I) {
       const Expr *child = llvm::dyn_cast_or_null<Expr>(*I);
       if (!child)
         continue;
       if (llvm::isa<DeclRefExpr>(child->IgnoreImpCasts())) {
-        //			(*I)->dump();
-        //			llvm::errs()<<"\n";
         const NamedDecl *ND = llvm::cast<DeclRefExpr>(child->IgnoreImpCasts())->getFoundDecl();
         if (llvm::isa<ParmVarDecl>(ND)) {
-          //				ND->dump();
-          //				llvm::errs()<<"\n";
           const ParmVarDecl *PVD = llvm::cast<ParmVarDecl>(ND);
           QualType QT = PVD->getOriginalType();
-          //				QT.dump();
-          //				llvm::errs()<<"\n";
           if (QT->isIncompleteType() || QT->isDependentType())
             continue;
           clang::QualType PQT = QT.getCanonicalType();
@@ -66,25 +54,8 @@ namespace clangcms {
             continue;
           std::string qname = QT.getAsString();
           std::string pname = PQT.getAsString();
-          std::string bpname = "class boost::";
-          std::string cbpname = "const class boost::";
-          std::string sfname = "class std::function<";
-          std::string ehname = "class edm::Handle<";
-          std::string cehname = "const class edm::Handle<";
-          std::string xname = "class xoap::";
-          std::string ername = "class edm::Ptr<";
-          std::string epname = "class edm::Ref<";
-          std::string cername = "const class edm::Ptr<";
-          std::string cepname = "const class edm::Ref<";
-          std::string erviname = "class edm::RefVectorIterator<";
           const CXXMethodDecl *MD =
               llvm::dyn_cast_or_null<CXXMethodDecl>(ctx.getCurrentAnalysisDeclContext()->getDecl());
-          //                              if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
-          //                                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
-          //                                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
-          //                                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
-          //                                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
-          //                                      || pname.substr(0,erviname.length()) == erviname ) continue;
           os << "Function parameter copied by value with size '" << size_param << "' bits > max size '" << max_bits
              << "' bits parameter type '" << pname << "' function '";
 
@@ -100,7 +71,8 @@ namespace clangcms {
           const clang::ento::PathDiagnosticLocation DLoc =
               clang::ento::PathDiagnosticLocation::createBegin(PVD, ctx.getSourceManager());
 
-          BugType *BT = new BugType(this, "Function parameter copied by value with size > max", "ArgSize");
+          std::unique_ptr<BugType> BT = std::make_unique<clang::ento::BugType>(
+              this, "Function parameter copied by value with size > max", "ArgSize");
           std::unique_ptr<BasicBugReport> report =
               std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
           report->addRange(PVD->getSourceRange());
@@ -115,7 +87,6 @@ namespace clangcms {
     CmsException m_exception;
     PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
 
-    //       	return;
     if (!m_exception.reportGeneral(DLoc, BR))
       return;
 
@@ -136,36 +107,15 @@ namespace clangcms {
         continue;
       std::string qname = QT.getAsString();
       std::string pname = PQT.getAsString();
-      std::string bpname = "class boost::";
-      std::string cbpname = "const class boost::";
-      std::string sfname = "class std::function<";
-      std::string ehname = "class edm::Handle<";
-      std::string cehname = "const class edm::Handle<";
-      std::string xname = "class xoap::";
-      std::string ername = "class edm::Ptr<";
-      std::string epname = "class edm::Ref<";
-      std::string cername = "const class edm::Ptr<";
-      std::string cepname = "const class edm::Ref<";
-      std::string erviname = "class edm::RefVectorIterator<";
-
-      //		if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
-      //                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
-      //                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
-      //                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
-      //                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
-      //                      || pname.substr(0,erviname.length()) == erviname ) continue;
       std::string fname = MD->getNameAsString();
       os << "Function parameter passed by value with size of parameter '" << size_param << "' bits > max size '"
-         << max_bits
-         //	  		<<"'\n";
-         //	  	llvm::errs()<< "Function parameter passed by value with size of parameter '"<<size_param
-         //			<<"' bits > max size '"<<max_bits
-         << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
+         << max_bits << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
          << MD->getParent()->getNameAsString() << "'\n";
       std::string oname = "operator";
       //             if ( fname.substr(0,oname.length()) == oname ) continue;
 
-      BugType *BT = new BugType(this, "Function parameter with size > max", "ArgSize");
+      std::unique_ptr<BugType> BT =
+          std::make_unique<clang::ento::BugType>(this, "Function parameter with size > max", "ArgSize");
       std::unique_ptr<BasicBugReport> report = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       BR.emitReport(std::move(report));
     }

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -30,6 +30,7 @@
 #include <llvm/ADT/SmallString.h>
 
 #include "ClassChecker.h"
+
 #include <iostream>
 #include <fstream>
 #include <iterator>
@@ -312,7 +313,8 @@ namespace clangcms {
     support::fixAnonNS(mname, sfile);
     std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str() + ".";
     writeLog(tolog);
-    BugType *BT = new BugType(Checker, "const_cast used in const function ", "Data Class Const Correctness");
+    std::unique_ptr<BugType> BT =
+        std::make_unique<BugType>(Checker, "const_cast used in const function ", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(tolog), CELoc);
     BR.emitReport(std::move(R));
     return;
@@ -357,7 +359,7 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        BugType *BT = new BugType(
+        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
             Checker, "ClassChecker : non-const static local variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
@@ -378,7 +380,8 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        BugType *BT = new BugType(Checker, "Non-const static member variable accessed", "Data Class Const Correctness");
+        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+            Checker, "Non-const static member variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
@@ -398,7 +401,8 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        BugType *BT = new BugType(Checker, "Non-const global static variable accessed", "Data Class Const Correctness");
+        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+            Checker, "Non-const global static variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
@@ -537,7 +541,7 @@ namespace clangcms {
     if (support::isSafeClassName(support::getQualifiedName(*MD)))
       return;
     writeLog(tolog);
-    BugType *BT = new BugType(
+    std::unique_ptr<BugType> BT = std::make_unique<BugType>(
         Checker, "Non-const member function could modify member data object", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
@@ -562,8 +566,8 @@ namespace clangcms {
         clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
 
     writeLog(tolog);
-    BugType *BT =
-        new BugType(Checker, "Const cast away from member data in const function", "Data Class Const Correctness");
+    std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+        Checker, "Const cast away from member data in const function", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
   }
@@ -629,9 +633,10 @@ namespace clangcms {
     clang::QualType RTy = Ctx.getCanonicalType(RQT);
     if ((RTy->isPointerType() || RTy->isReferenceType())) {
       if (!support::isConst(RTy)) {
-        BugType *BT = new BugType(Checker,
-                                  "Const function returns pointer or reference to non-const member data object",
-                                  "Data Class Const Correctness");
+        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+            BugType(Checker,
+                    "Const function returns pointer or reference to non-const member data object",
+                    "Data Class Const Correctness"));
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
       }
@@ -640,10 +645,10 @@ namespace clangcms {
     std::string rtname = RTy.getAsString();
     if ((RTy->isReferenceType() || RTy->isRecordType()) && support::isConst(RTy) &&
         rtname.substr(0, svname.length()) == svname) {
-      BugType *BT =
-          new BugType(Checker,
-                      "Const function returns member data object of type const std::vector<*> or const std::vector<*>&",
-                      "Data Class Const Correctness");
+      std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+          Checker,
+          "Const function returns member data object of type const std::vector<*> or const std::vector<*>&",
+          "Data Class Const Correctness");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       BR.emitReport(std::move(R));
     }

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -9,6 +9,7 @@ namespace clangcms {
     const CheckerBase *Checker;
     clang::ento::BugReporter &BR;
     clang::AnalysisDeclContext *AC;
+    const clang::ento::BugType *BT;
 
   public:
     ESRWalker(const CheckerBase *checker, clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac)
@@ -61,7 +62,8 @@ namespace clangcms {
             "the token see "
             "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "Deprecated API");
+      std::unique_ptr<BugType> BT =
+          std::make_unique<BugType>(Checker, "EventSetupRecord::get function called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -42,7 +42,7 @@ namespace clangcms {
         Visit(child);
       }
   }
- 
+
   void FMWalkAST::VisitCallExpr(clang::CallExpr *CE) {
     const clang::Expr *Callee = CE->getCallee();
     const FunctionDecl *FD = CE->getDirectCallee();
@@ -64,22 +64,19 @@ namespace clangcms {
 
     clang::ento::PathDiagnosticLocation CELoc =
         clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-    BugType *BT = new clang::ento::BugType(
-          Checker,
-          "std::isnan / std::isinf does not work when fast-math is used. Please use "
-          "edm::isNotFinite from 'FWCore/Utilities/interface/isFinite.h'",
-          "fastmath plugin");
+    BugType *BT = new clang::ento::BugType(Checker,
+                                           "std::isnan / std::isinf does not work when fast-math is used. Please use "
+                                           "edm::isNotFinite from 'FWCore/Utilities/interface/isFinite.h'",
+                                           "fastmath plugin");
     std::unique_ptr<clang::ento::BasicBugReport> report =
         std::make_unique<clang::ento::BasicBugReport>(*BT, BT->getCheckerName(), CELoc);
     //report->addRange(Callee->getSourceRange());
     BR.emitReport(std::move(report));
-
   }
 
-
   void FiniteMathChecker::checkASTDecl(const clang::CXXRecordDecl *RD,
-                                    clang::ento::AnalysisManager &mgr,
-                                    clang::ento::BugReporter &BR) const {
+                                       clang::ento::AnalysisManager &mgr,
+                                       clang::ento::BugReporter &BR) const {
     const clang::SourceManager &SM = BR.getSourceManager();
     const char *sfile = SM.getPresumedLoc(RD->getLocation()).getFilename();
     if (!support::isCmsLocalFile(sfile))

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -11,15 +11,47 @@
 
 #include <utility>
 
+using namespace clang;
+using namespace clang::ento;
+using namespace llvm;
+
 namespace clangcms {
 
-  void FiniteMathChecker::checkPreStmt(const clang::CallExpr *CE, clang::ento::CheckerContext &ctx) const {
-    const clang::ento::ProgramStateRef state = ctx.getState();
-    const clang::LocationContext *LC = ctx.getLocationContext();
-    const clang::Expr *Callee = CE->getCallee();
-    const clang::FunctionDecl *FD = state->getSVal(Callee, LC).getAsFunctionDecl();
+  class FMWalkAST : public clang::StmtVisitor<FMWalkAST> {
+    const CheckerBase *Checker;
+    clang::ento::BugReporter &BR;
+    clang::AnalysisDeclContext *AC;
+    const NamedDecl *ND;
 
+  public:
+    FMWalkAST(const CheckerBase *checker,
+              clang::ento::BugReporter &br,
+              clang::AnalysisDeclContext *ac,
+              const NamedDecl *nd)
+        : Checker(checker), BR(br), AC(ac), ND(nd) {}
+
+    // Stmt visitor methods.
+    void VisitChildren(clang::Stmt *S);
+    void VisitStmt(clang::Stmt *S) { VisitChildren(S); }
+    void VisitCallExpr(clang::CallExpr *CE);
+  };
+
+  void FMWalkAST::VisitChildren(clang::Stmt *S) {
+    for (clang::Stmt::child_iterator I = S->child_begin(), E = S->child_end(); I != E; ++I)
+      if (clang::Stmt *child = *I) {
+        Visit(child);
+      }
+  }
+ 
+  void FMWalkAST::VisitCallExpr(clang::CallExpr *CE) {
+    const clang::Expr *Callee = CE->getCallee();
+    const FunctionDecl *FD = CE->getDirectCallee();
     if (!FD)
+      return;
+
+    const char *sfile = BR.getSourceManager().getPresumedLoc(CE->getExprLoc()).getFilename();
+    std::string sname(sfile);
+    if (!support::isInterestingLocation(sname))
       return;
 
     // Get the name of the callee.
@@ -30,21 +62,36 @@ namespace clangcms {
     if (!II->isStr("isnan") && !II->isStr("isinf"))
       return;
 
-    clang::ento::ExplodedNode *N = ctx.generateErrorNode();
-    if (!N)
-      return;
-
-    if (!BT)
-      BT = std::make_unique<clang::ento::BugType>(
-          this,
+    clang::ento::PathDiagnosticLocation CELoc =
+        clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
+    BugType *BT = new clang::ento::BugType(
+          Checker,
           "std::isnan / std::isinf does not work when fast-math is used. Please use "
           "edm::isNotFinite from 'FWCore/Utilities/interface/isFinite.h'",
           "fastmath plugin");
-    std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
-        std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, BT->getCheckerName(), N);
     std::unique_ptr<clang::ento::BasicBugReport> report =
-        std::make_unique<clang::ento::BasicBugReport>(*BT, BT->getCheckerName(), PSBR->getLocation());
-    report->addRange(Callee->getSourceRange());
-    ctx.emitReport(std::move(report));
+        std::make_unique<clang::ento::BasicBugReport>(*BT, BT->getCheckerName(), CELoc);
+    //report->addRange(Callee->getSourceRange());
+    BR.emitReport(std::move(report));
+
+  }
+
+
+  void FiniteMathChecker::checkASTDecl(const clang::CXXRecordDecl *RD,
+                                    clang::ento::AnalysisManager &mgr,
+                                    clang::ento::BugReporter &BR) const {
+    const clang::SourceManager &SM = BR.getSourceManager();
+    const char *sfile = SM.getPresumedLoc(RD->getLocation()).getFilename();
+    if (!support::isCmsLocalFile(sfile))
+      return;
+
+    for (clang::CXXRecordDecl::method_iterator I = RD->method_begin(), E = RD->method_end(); I != E; ++I) {
+      clang::CXXMethodDecl *MD = llvm::cast<clang::CXXMethodDecl>((*I)->getMostRecentDecl());
+      clang::Stmt *Body = MD->getBody();
+      if (Body) {
+        FMWalkAST walker(this, BR, mgr.getAnalysisDeclContext(MD), MD);
+        walker.Visit(Body);
+      }
+    }
   }
 }  // namespace clangcms

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
@@ -3,16 +3,18 @@
 
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 
 namespace clangcms {
-  class FiniteMathChecker : public clang::ento::Checker<clang::ento::check::PreStmt<clang::CallExpr> > {
-    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
+  class FiniteMathChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXRecordDecl> > {
 
   public:
-    void checkPreStmt(const clang::CallExpr *ref, clang::ento::CheckerContext &C) const;
+    void checkASTDecl(const clang::CXXRecordDecl *CRD,
+                      clang::ento::AnalysisManager &mgr,
+                      clang::ento::BugReporter &BR) const;
   };
 }  // namespace clangcms
 

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
@@ -10,7 +10,6 @@
 
 namespace clangcms {
   class FiniteMathChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXRecordDecl> > {
-
   public:
     void checkASTDecl(const clang::CXXRecordDecl *CRD,
                       clang::ento::AnalysisManager &mgr,

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -99,7 +99,7 @@ namespace clangcms {
       if (pname.find(pdname) != std::string::npos)
         return;
       os << "function " << mname << " is called in function " << pname;
-      BugType *BT = new BugType(
+      std::unique_ptr<BugType> BT = std::make_unique<BugType>(
           Checker, "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "CMS code rules");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -50,7 +50,8 @@ namespace clangcms {
         if (oname.substr(0, eoname.length()) != eoname) {
           os << "TFileService function " << mname << " is called in function " << pname;
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          BugType *BT = new BugType(Checker, "TFileService function called ", "ThreadSafety");
+          std::unique_ptr<BugType> BT =
+              std::make_unique<BugType>(Checker, "TFileService function called ", "ThreadSafety");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
           R->setDeclWithIssue(AC->getDecl());
           R->addRange(CE->getSourceRange());
@@ -63,7 +64,8 @@ namespace clangcms {
     } else if (support::isKnownThrUnsafeFunc(mname)) {
       os << "Known thread unsafe function " << mname << " is called in function " << pname;
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      BugType *BT = new BugType(Checker, "known thread unsafe function called", "ThreadSafety");
+      std::unique_ptr<BugType> BT =
+          std::make_unique<BugType>(Checker, "known thread unsafe function called", "ThreadSafety");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getSourceRange());

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -38,25 +38,12 @@ namespace clangcms {
     if (!MD)
       return;
     std::string mname = MD->getQualifiedNameAsString();
-    //	llvm::errs()<<"Parent Decl: '"<<dname<<"'\n";
-    //	llvm::errs()<<"Method Decl: '"<<mname<<"'\n";
-    //	llvm::errs()<<"call expression '";
-    //	CE->printPretty(llvm::errs(),0,Policy);
-    //	llvm::errs()<<"'\n";
-    //	if (!MD) return;
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
     if (mname == "edm::Event::getByLabel" || mname == "edm::Event::getManyByType") {
-      //			if (const CXXRecordDecl * RD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)->getParent() ) {
-      //				llvm::errs()<<"class "<<RD->getQualifiedNameAsString()<<"\n";
-      //				llvm::errs()<<"\n";
-      //				}
       os << "function '";
       llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os, Policy, true);
       os << "' ";
-      //			os<<"call expression '";
-      //			CE->printPretty(os,0,Policy);
-      //			os<<"' ";
       if (mname == "edm::Event::getByLabel") {
         os << "calls edm::Event::getByLabel with arguments '";
         QualType QT;
@@ -107,9 +94,9 @@ namespace clangcms {
         }
       }
 
-      //			llvm::errs()<<os.str()<<"\n";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      BugType *BT = new BugType(Checker, "edm::getByLabel or edm::getManyByType called", "Deprecated API");
+      std::unique_ptr<BugType> BT =
+          std::make_unique<BugType>(Checker, "edm::getByLabel or edm::getManyByType called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));
@@ -125,14 +112,9 @@ namespace clangcms {
           os << "calls '";
           MD->getNameForDiagnostic(os, Policy, true);
           os << "' with argument of type '" << qtname << "'\n";
-          //				llvm::errs()<<"\n";
-          //				llvm::errs()<<"call expression passed edm::Event ";
-          //				CE->printPretty(llvm::errs(),0,Policy);
-          //				llvm::errs()<<" argument name ";
-          //				(*I)->printPretty(llvm::errs(),0,Policy);
-          //				llvm::errs()<<" "<<qtname<<"\n";
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "Deprecated API");
+          std::unique_ptr<BugType> BT =
+              std::make_unique<BugType>(Checker, "function call with argument of type edm::Event", "Deprecated API");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
           R->addRange(CE->getSourceRange());
           BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/getParamDumper.cpp
+++ b/Utilities/StaticAnalyzers/src/getParamDumper.cpp
@@ -118,7 +118,11 @@ namespace clangcms {
     return;
   }
 
-  bool getParamDumper::evalCall(const CallExpr *CE, CheckerContext &C) const {
+  bool getParamDumper::evalCall(const CallEvent &Call, CheckerContext &C) const {
+    const auto *CE = llvm::dyn_cast_or_null<clang::CallExpr>(Call.getOriginExpr());
+    if (!CE)
+      return false;
+
     FnCheck Handler = llvm::StringSwitch<FnCheck>(C.getCalleeName(CE))
                           .Case("getParameter", &getParamDumper::analyzerEval)
                           .Case("getUntrackedParameter", &getParamDumper::analyzerEval)

--- a/Utilities/StaticAnalyzers/src/getParamDumper.h
+++ b/Utilities/StaticAnalyzers/src/getParamDumper.h
@@ -3,6 +3,7 @@
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
+#include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 
 namespace clangcms {
 
@@ -13,7 +14,7 @@ namespace clangcms {
     typedef void (getParamDumper::*FnCheck)(const clang::CallExpr *, clang::ento::CheckerContext &C) const;
 
   public:
-    bool evalCall(const clang::CallExpr *CE, clang::ento::CheckerContext &C) const;
+    bool evalCall(const clang::ento::CallEvent &Call, clang::ento::CheckerContext &C) const;
 
     void checkASTDecl(const clang::CXXRecordDecl *CRD,
                       clang::ento::AnalysisManager &mgr,


### PR DESCRIPTION
The cms.NonFiniteMath checker was not flagging the used of std::isnan and std::isinf in if statements.
For example [`if (std::isnan((m)(i, j)) || std::isinf((m)(i, j))`](https://github.com/gartung/cmssw/blob/313882e5e642400489929bcae78886a3d98ad63d/DataFormats/PatCandidates/src/PackedCandidate.cc#L185) was flagged  but  [`if (std::isnan(entry.second))`](https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/RecoBTag/Combined/plugins/DeepFlavourJetTagsProducer.cc#L261) was not.

This change allows the later to be flagged.

Update the getParamDumper plugin so that is compiles when included in the plugin registry.

Tested locally.