### PR TITLE
HCAL:  configurable option to use actual Run3 HF ShowerLibrary for Run2 MC

### DIFF
--- a/Configuration/ProcessModifiers/python/applyHFLibraryFix_cff.py
+++ b/Configuration/ProcessModifiers/python/applyHFLibraryFix_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+#--- For using Run3 HFSHowerLibrary for Run2 simulation
+#--- instead of the default one with a problem (deficit of entries)
+ 
+applyHFLibraryFix = cms.Modifier()
+

--- a/Geometry/HcalSimData/python/HFParameters_cff.py
+++ b/Geometry/HcalSimData/python/HFParameters_cff.py
@@ -23,14 +23,21 @@ HFShowerBlock = cms.PSet(
 )
 
 ##
-## Change the HFShowerLibrary file from Run 2
+## Change the HFShowerLibrary file for Run2
 ##
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
-run2_common.toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
+#
+#--- Default: to keep using the library with a problem
+(~applyHFLibraryFix & run2_common).toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
+#
+#--- Alternative: to use Run3 library with applyHFLibraryFix modifier
+(applyHFLibraryFix & run2_common).toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_run3_v6.root', FileVersion = 2 )
+(applyHFLibraryFix & run2_common).toModify( HFShowerBlock, EqualizeTimeShift = True )
+#
 run2_common.toModify( HFShowerBlock, ProbMax = 0.5 )
 
 ##
-## Change for the new HFShowerLibrary file to be used for Run 3
+## Change for the latest HFShowerLibrary file for Run 3
 ##
 from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
 run3_HFSL.toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_run3_v6.root', FileVersion = 2 )

--- a/Geometry/HcalSimData/python/HFParameters_cff.py
+++ b/Geometry/HcalSimData/python/HFParameters_cff.py
@@ -26,6 +26,7 @@ HFShowerBlock = cms.PSet(
 ## Change the HFShowerLibrary file for Run2
 ##
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.ProcessModifiers.applyHFLibraryFix_cff import applyHFLibraryFix
 #
 #--- Default: to keep using the library with a problem
 (~applyHFLibraryFix & run2_common).toModify( HFLibraryFileBlock, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -116,6 +116,7 @@ hcalSimParameters.hoHamamatsu = hcalSimParameters.ho.clone()
 
 # Customises the HCAL digitiser for post LS1 running
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
+from Configuration.ProcessModifiers.applyHFLibraryFix_cff import applyHFLibraryFix
 
 run2_common.toModify( hcalSimParameters, 
     ho = dict( siPMCode = 1 ),

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -114,16 +114,25 @@ hcalSimParameters.hoZecotek = hcalSimParameters.ho.clone()
 
 hcalSimParameters.hoHamamatsu = hcalSimParameters.ho.clone()
 
-# Customises the HCal digitiser for post LS1 running
+# Customises the HCAL digitiser for post LS1 running
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
-run2_common.toModify( hcalSimParameters, 
-    ho = dict(
-        siPMCode = cms.int32(1)
-    ),
-    hf1 = dict( samplingFactor = cms.double(0.335) ),
-    hf2 = dict( samplingFactor = cms.double(0.335) )
-)
 
+run2_common.toModify( hcalSimParameters, 
+    ho = dict( siPMCode = 1 ),
+#--- Default for Run2 HFShowerLibrary file
+    hf1 = dict( samplingFactor = 0.335 ),
+    hf2 = dict( samplingFactor = 0.335 )
+)
+#--- Alternative: usage of Run3 HFShowerLibrary file for Run2
+(applyHFLibraryFix & run2_common).toModify( hcalSimParameters, 
+    hf1 = dict( samplingFactor = 0.37,
+                timePhase = 9.0
+              ),
+    hf2 = dict( samplingFactor = 0.37,
+                timePhase = 8.0
+              )
+)
+   
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 run2_HE_2017.toModify( hcalSimParameters,
     he = dict(


### PR DESCRIPTION
#### PR description:

Follow up on the issue https://github.com/cms-sw/cmssw/issues/40218 
After discussion in Simulation meeting on Friday, Dec.16 
https://indico.cern.ch/event/1230771/    
  ->   https://indico.cern.ch/event/1230771/contributions/5185071/attachments/2568386/4428907/Run2_HFShowerLibrary_SIM_Dec12_2022.pdf

The decision has been taken:  to have a configurable option to use actual Run3 HFSHowerLibrary file for Run2 simulation.

@Dr15Jones and @makortel  suggested to use modifier for enabling the option:

(1 ) with cmsDriver this option can be enabled with
     `--procModifiers applyHFLibraryFix`

(2)  In the job config may look (specifically for Run2_2018 era in the example below) like this:
```
from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
from Configuration.ProcessModifiers.applyHFLibraryFix_cff import applyHFLibraryFix
process = cms.Process('SIM',Run2_2018,applyHFLibraryFix)
``` 

#### PR validation:

(1) without option activation (default) : runTheMatrix.py -l limited  
(2) with activation : using wf 10824.0_TTbar_13+2018

#### If this PR is a backport 

No