### PR TITLE
Phase2-hgx334A Try to align cassette shifts of silicon and scintillator parts of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
@@ -497,11 +497,12 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
   }
   if (std::abs(thickTot - thick) >= tol2_) {
     if (thickTot > thick) {
-      edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick << " is smaller than " << thickTot
+      edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick
+                                 << " is smaller than " << thickTot
                                  << ": thickness of all its components in the top part **** ERROR ****";
     } else {
-      edm::LogWarning("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick << " does not match with " << thickTot
-                                   << " of the components in top part";
+      edm::LogWarning("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick
+                                   << " does not match with " << thickTot << " of the components in top part";
     }
   }
 
@@ -539,9 +540,10 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
     int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
     int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k << ":"
-                                  << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien
-                                  << ":" << cassette << ":" << place;
+    edm::LogVerbatim("HGCalGeom")
+        << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k << ":"
+        << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette << ":"
+        << place;
 #endif
     auto cshift = cassette_.getShift(layer + 1, -1, cassette);
     double xpos = xyoff.first + cshift.first + nc * delx;
@@ -550,7 +552,9 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
     double xorig = xyoff.first + nc * delx;
     double yorig = xyoff.second + nr * dy;
     double angle = std::atan2(yorig, xorig);
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette
+                                  << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":"
+                                  << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
 #endif
     std::string wafer;
     int i(999);

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
@@ -485,7 +485,7 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
                                     << " of dimensions " << r1 << ", " << r2 << ", " << hthickl << ", "
                                     << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
-      DDTranslation tran(cshift.first, cshift.second, zpos);
+      DDTranslation tran(-cshift.first, cshift.second, zpos);
       cpv.position(glog1, glog, copy, tran, rot);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Position " << glog1.name() << " number " << copy
@@ -546,7 +546,7 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
         << place;
 #endif
     auto cshift = cassette_.getShift(layer + 1, -1, cassette);
-    double xpos = xyoff.first + cshift.first + nc * delx;
+    double xpos = xyoff.first - cshift.first + nc * delx;
     double ypos = xyoff.second + cshift.second + nr * dy;
 #ifdef EDM_ML_DEBUG
     double xorig = xyoff.first + nc * delx;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedLayer.cc
@@ -469,7 +469,7 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
       double phi2 = dphi * (fimax - fimin + 1);
       auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << " iR "
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << ":" << (layer + 1) << " iR "
                                     << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
                                     << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R " << r1 << ":"
                                     << r2 << " Thick " << (2.0 * hthickl) << " phi " << fimin << ":" << fimax << ":"
@@ -497,10 +497,10 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
   }
   if (std::abs(thickTot - thick) >= tol2_) {
     if (thickTot > thick) {
-      edm::LogError("HGCalGeom") << "Thickness of the partition " << thick << " is smaller than " << thickTot
+      edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick << " is smaller than " << thickTot
                                  << ": thickness of all its components in the top part **** ERROR ****";
     } else {
-      edm::LogWarning("HGCalGeom") << "Thickness of the partition " << thick << " does not match with " << thickTot
+      edm::LogWarning("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << thick << " does not match with " << thickTot
                                    << " of the components in top part";
     }
   }
@@ -539,13 +539,19 @@ void DDHGCalMixRotatedLayer::positionMix(const DDLogicalPart& glog,
     int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
     int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << " index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k << ":"
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k << ":"
                                   << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien
                                   << ":" << cassette << ":" << place;
 #endif
-    auto cshift = cassette_.getShift(layer + 1, 1, cassette);
+    auto cshift = cassette_.getShift(layer + 1, -1, cassette);
     double xpos = xyoff.first + cshift.first + nc * delx;
     double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+    double xorig = xyoff.first + nc * delx;
+    double yorig = xyoff.second + nr * dy;
+    double angle = std::atan2(yorig, xorig);
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+#endif
     std::string wafer;
     int i(999);
     if (part == HGCalTypes::WaferFull) {

--- a/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
@@ -419,9 +419,15 @@ void DDHGCalSiliconRotatedModule::positionSensitive(const DDLogicalPart& glog, i
     int orien = HGCalProperty::waferOrient(waferProperty_[k]);
     int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
     int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
-    auto cshift = cassette_.getShift(layer + 1, 1, cassette);
+    auto cshift = cassette_.getShift(layer + 1, -1, cassette);
     double xpos = xyoff.first + cshift.first + nc * delx;
     double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+    double xorig = xyoff.first + nc * delx;
+    double yorig = xyoff.second + nr * dy;
+    double angle = std::atan2(yorig, xorig);
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+#endif
     std::string wafer;
     int i(999);
     if (part == HGCalTypes::WaferFull) {

--- a/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
@@ -420,7 +420,7 @@ void DDHGCalSiliconRotatedModule::positionSensitive(const DDLogicalPart& glog, i
     int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
     int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
     auto cshift = cassette_.getShift(layer + 1, -1, cassette);
-    double xpos = xyoff.first + cshift.first + nc * delx;
+    double xpos = xyoff.first - cshift.first + nc * delx;
     double ypos = xyoff.second + cshift.second + nr * dy;
 #ifdef EDM_ML_DEBUG
     double xorig = xyoff.first + nc * delx;

--- a/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalSiliconRotatedModule.cc
@@ -426,7 +426,10 @@ void DDHGCalSiliconRotatedModule::positionSensitive(const DDLogicalPart& glog, i
     double xorig = xyoff.first + nc * delx;
     double yorig = xyoff.second + nr * dy;
     double angle = std::atan2(yorig, xorig);
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette "
+                                  << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original "
+                                  << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":"
+                                  << ypos;
 #endif
     std::string wafer;
     int i(999);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
@@ -416,7 +416,7 @@ struct HGCalMixRotatedLayer {
                                       << cms::convert2mm(r2) << ", " << cms::convert2mm(hthickl) << ", "
                                       << convertRadToDeg(phi1) << ", " << convertRadToDeg(phi2);
 #endif
-        dd4hep::Position tran(cshift.first, cshift.second, zpos);
+        dd4hep::Position tran(-cshift.first, cshift.second, zpos);
         glog.placeVolume(glog1, copy, tran);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Position " << glog1.name() << " number " << copy
@@ -482,7 +482,7 @@ struct HGCalMixRotatedLayer {
           << ":" << place;
 #endif
       auto cshift = cassette_.getShift(layer + 1, -1, cassette);
-      double xpos = xyoff.first + cshift.first + nc * delx;
+      double xpos = xyoff.first - cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
 #ifdef EDM_ML_DEBUG
       double xorig = xyoff.first + nc * delx;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
@@ -396,7 +396,7 @@ struct HGCalMixRotatedLayer {
         double phi2 = (forFireworks_ == 1) ? (dphi * (fimax - fimin + 1)) : (dphi * fimax);
         auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy  << ":" << (layer + 1) << " iR "
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << ":" << (layer + 1) << " iR "
                                       << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
                                       << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R "
                                       << cms::convert2mm(r1) << ":" << cms::convert2mm(r2) << " Thick "
@@ -430,7 +430,9 @@ struct HGCalMixRotatedLayer {
     }
     if (std::abs(thickTot - thick) > tol2_) {
       if (thickTot > thick) {
-        edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << cms::convert2mm(thick) << " is smaller than " << cms::convert2mm(thickTot) << ": thickness of all its components in the top part **** ERROR ****";
+        edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << cms::convert2mm(thick)
+                                   << " is smaller than " << cms::convert2mm(thickTot)
+                                   << ": thickness of all its components in the top part **** ERROR ****";
       } else {
         edm::LogWarning("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << cms::convert2mm(thick)
                                      << " does not match with " << cms::convert2mm(thickTot)
@@ -474,9 +476,10 @@ struct HGCalMixRotatedLayer {
       int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
       int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k
-                                    << ":" << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":"
-                                    << orien << ":" << cassette << ":" << place;
+      edm::LogVerbatim("HGCalGeom")
+          << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k << ":"
+          << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette
+          << ":" << place;
 #endif
       auto cshift = cassette_.getShift(layer + 1, -1, cassette);
       double xpos = xyoff.first + cshift.first + nc * delx;
@@ -485,7 +488,9 @@ struct HGCalMixRotatedLayer {
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette
+                                    << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":"
+                                    << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
 #endif
       std::string wafer;
       int i(999);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
@@ -396,7 +396,7 @@ struct HGCalMixRotatedLayer {
         double phi2 = (forFireworks_ == 1) ? (dphi * (fimax - fimin + 1)) : (dphi * fimax);
         auto cshift = cassette_.getShift(layer + 1, 1, cassette);
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy << " iR "
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer: Layer " << copy  << ":" << (layer + 1) << " iR "
                                       << std::get<1>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << ":"
                                       << std::get<2>(HGCalTileIndex::tileUnpack(tileIndex_[ti])) << " R "
                                       << cms::convert2mm(r1) << ":" << cms::convert2mm(r2) << " Thick "
@@ -430,11 +430,9 @@ struct HGCalMixRotatedLayer {
     }
     if (std::abs(thickTot - thick) > tol2_) {
       if (thickTot > thick) {
-        edm::LogError("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(thick) << " is smaller than "
-                                   << cms::convert2mm(thickTot)
-                                   << ": thickness of all its components in the top part **** ERROR ****";
+        edm::LogError("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << cms::convert2mm(thick) << " is smaller than " << cms::convert2mm(thickTot) << ": thickness of all its components in the top part **** ERROR ****";
       } else {
-        edm::LogWarning("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(thick)
+        edm::LogWarning("HGCalGeom") << "DDHGCalMixRotatedLayer: Thickness of the partition " << cms::convert2mm(thick)
                                      << " does not match with " << cms::convert2mm(thickTot)
                                      << " of the components in top part";
       }
@@ -476,13 +474,19 @@ struct HGCalMixRotatedLayer {
       int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
       int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << " index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::index:Property:layertype:type:part:orien:cassette:place:offsets:ind " << k
                                     << ":" << waferProperty_[k] << ":" << layertype << ":" << type << ":" << part << ":"
                                     << orien << ":" << cassette << ":" << place;
 #endif
-      auto cshift = cassette_.getShift(layer + 1, 1, cassette);
+      auto cshift = cassette_.getShift(layer + 1, -1, cassette);
       double xpos = xyoff.first + cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+      double xorig = xyoff.first + nc * delx;
+      double yorig = xyoff.second + nr * dy;
+      double angle = std::atan2(yorig, xorig);
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalMixRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+#endif
       std::string wafer;
       int i(999);
       if (part == HGCalTypes::WaferFull) {

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
@@ -366,7 +366,10 @@ struct HGCalSiliconRotatedModule {
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette "
+                                    << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original "
+                                    << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos
+                                    << ":" << ypos;
 #endif
       std::string wafer;
       int i(999);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
@@ -359,9 +359,15 @@ struct HGCalSiliconRotatedModule {
       int orien = HGCalProperty::waferOrient(waferProperty_[k]);
       int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
       int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
-      auto cshift = cassette_.getShift(layer + 1, 1, cassette);
+      auto cshift = cassette_.getShift(layer + 1, -1, cassette);
       double xpos = xyoff.first + cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+      double xorig = xyoff.first + nc * delx;
+      double yorig = xyoff.second + nr * dy;
+      double angle = std::atan2(yorig, xorig);
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedLayer::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cshift.first << ":" << cshift.second << " Original " << xorig << ":" << yorig << ":" << convertRadToDeg(angle) << " Final " << xpos << ":" << ypos;
+#endif
       std::string wafer;
       int i(999);
       if (part == HGCalTypes::WaferFull) {

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedModule.cc
@@ -360,7 +360,7 @@ struct HGCalSiliconRotatedModule {
       int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
       int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
       auto cshift = cassette_.getShift(layer + 1, -1, cassette);
-      double xpos = xyoff.first + cshift.first + nc * delx;
+      double xpos = xyoff.first - cshift.first + nc * delx;
       double ypos = xyoff.second + cshift.second + nr * dy;
 #ifdef EDM_ML_DEBUG
       double xorig = xyoff.first + nc * delx;


### PR DESCRIPTION
#### PR description:

Try to align cassette shifts of silicon and scintillator parts of HGCal. For non-zero shifts of cassettes, the silicon wafers and scintillator tiles used to move in opposite directions. Also, the direction of the shift did not match the value provided in the xml file. Both these effects are corrected in the construction of G4 geometry for DDD as well as DD4hep implementations.

#### PR validation:

Use the dump geometry option to check this

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special