### PR TITLE
B2G HLT DQM update

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -8,10 +8,8 @@ from DQMOffline.Trigger.B2GTnPMonitor_cfi import B2GegmGsfElectronIDsForDQM,B2Ge
 from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 
 ### B2G triggers:
-# HLT_AK8PFHT*_TrimMass50
-# HLT_AK8PFJet*_TrimMass30
 # HLT_AK8PFJet*_MassSD30
-# HLT_AK8DiPFJet250_250_MassSD30
+# HLT_AK8DiPFJet*_*_MassSD*
 # HLT_Mu37_Ele27_CaloIdL_MW
 # HLT_Mu27_Ele37_CaloIdL_MW
 # HLT_Mu37_TkMu27
@@ -50,102 +48,51 @@ AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone(
     )
 )
 
-# AK8PFHT800_TrimMass50 monitoring
 
-AK8PFHT800_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection      = "pt > 200 && eta < 2.4",
-    jetSelection_HT = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
+# AK8PFJet420_MassSD30 monitoring
+
+AK8PFJet420_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
+    ptcut = 200,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"])
 )
 
-AK8PFHT800_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
+AK8PFJet420_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
     jets = "ak8PFJetsPuppi",
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"])
 )
 
-AK8PFHT800_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
+AK8PFJet420_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"]),
     histoPSet = dict(
         htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
         htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
     )
 )
 
-# AK8PFJet400_TrimMass30 monitoring
+# AK8DiPFJet270_270_MassSD30 monitoring
 
-AK8PFJet400_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+AK8DiPFJet270_270_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
     ptcut = 200,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"])
 )
 
-AK8PFJet400_TrimMass30_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+AK8DiPFJet270_270_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
     jets = "ak8PFJetsPuppi",
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"])
 )
 
-AK8PFJet400_TrimMass30_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+AK8DiPFJet270_270_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"]),
-    histoPSet = dict(
-        htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
-        htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
-    )
-)
-
-# AK8PFJet400_MassSD30 monitoring
-
-AK8PFJet400_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
-    ptcut = 200,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"])
-)
-
-AK8PFJet400_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"])
-)
-
-AK8PFJet400_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"]),
-    histoPSet = dict(
-        htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
-        htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
-    )
-)
-
-# AK8DiPFJet250_250_MassSD30 monitoring
-
-AK8DiPFJet250_250_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
-    ptcut = 200,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"])
-)
-
-AK8DiPFJet250_250_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"])
-)
-
-AK8DiPFJet250_250_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"]),
     histoPSet = dict(
         htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
         htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
@@ -179,17 +126,11 @@ b2gMonitorHLT = cms.Sequence(
 
     AK8PFJet500_Mjjmonitoring +
 
-    AK8PFHT800_TrimMass50_HTmonitoring +
-    AK8PFHT800_TrimMass50_Mjjmonitoring +
+    AK8PFJet420_MassSD30_PromptMonitoring +
+    AK8PFJet420_MassSD30_Mjjmonitoring +
 
-    AK8PFJet400_TrimMass30_PromptMonitoring +
-    AK8PFJet400_TrimMass30_Mjjmonitoring +
-
-    AK8PFJet400_MassSD30_PromptMonitoring +
-    AK8PFJet400_MassSD30_Mjjmonitoring +
-
-    AK8DiPFJet250_250_MassSD30_PromptMonitoring +
-    AK8DiPFJet250_250_MassSD30_Mjjmonitoring +
+    AK8DiPFJet270_270_MassSD30_PromptMonitoring +
+    AK8DiPFJet270_270_MassSD30_Mjjmonitoring +
 
     B2GegHLTDQMOfflineTnPSource
 
@@ -206,10 +147,8 @@ b2gMonitorHLT = cms.Sequence(
 b2gHLTDQMSourceWithRECO = cms.Sequence(
     PFHT1050_Softdropmonitoring +
     AK8PFJet500_Softdropmonitoring +
-    AK8PFHT800_TrimMass50_Softdropmonitoring +
-    AK8PFJet400_TrimMass30_Softdropmonitoring +
-    AK8PFJet400_MassSD30_Softdropmonitoring +
-    AK8DiPFJet250_250_MassSD30_Softdropmonitoring
+    AK8PFJet420_MassSD30_Softdropmonitoring +
+    AK8DiPFJet270_270_MassSD30_Softdropmonitoring
 )
 
 b2gHLTDQMSourceExtra = cms.Sequence(


### PR DESCRIPTION
#### PR description:

Changes to the B2G HLT DQM module, following the removal of the TrimMass paths in [this JIRA ticket](https://its.cern.ch/jira/browse/CMSHLT-2590), and the recent threshold changes in [another JIRA ticket](https://its.cern.ch/jira/browse/CMSHLT-2519).

The only expected change affects the B2G HLT DQM plots, where two sets of plots will be removed, and some others changed due to using a different threshold version of trigger.

#### PR validation:

I ran the recommended test commands to validate this PR. No other validation was performed, as this is a minor change only affecting DQM.
