### PR TITLE
Fix `ClusterStorer` for `VectorHit`s

### DIFF
--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -65,7 +65,7 @@ namespace helper {
       /// Set the reference of the hit of this record to 'newRef',
       /// will not modify the ref stored in this object.
       template <typename RecHitType>
-      void rekey(const ClusterRefType &newRef) const;
+      void rekey(const ClusterRefType &newRef);
 
     private:
       ClusterHitRecord() {}  /// private => unusable

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -105,7 +105,7 @@ namespace helper {
                                       edmNew::DetSetVector<ClusterType> &dsvToFill,
                                       edm::RefProd<edmNew::DetSetVector<ClusterType> > &refprod) {
     std::sort(clusterRecords.begin(), clusterRecords.end());  // this sorts them by detid
-    typedef typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::const_iterator RIT;
+    typedef typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::iterator RIT;
     RIT it = clusterRecords.begin(), end = clusterRecords.end();
     size_t clusters = 0;
     while (it != end) {
@@ -143,7 +143,7 @@ namespace helper {
   // generic rekey (in practise for pixel only...)
   template <typename ClusterRefType>  // template for class
   template <typename RecHitType>      // template for member function
-  void ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType &newRef) const {
+  void ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     RecHitType *hit = nullptr;
     if (genericHit.geographicalId().rawId() == detid_) {  // a hit on this det, so it's simple
@@ -159,9 +159,7 @@ namespace helper {
   // RecHitType is not used.
   template <>
   template <typename RecHitType>  // or template<> to specialise also here?
-  void ClusterStorer::ClusterHitRecord<SiStripRecHit2D::ClusterRef>::
-      //  rekey<SiStripRecHit2D>(const SiStripRecHit2D::ClusterRef &newRef) const
-      rekey(const SiStripRecHit2D::ClusterRef &newRef) const {
+  void ClusterStorer::ClusterHitRecord<SiStripRecHit2D::ClusterRef>::rekey(const SiStripRecHit2D::ClusterRef &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 
@@ -187,9 +185,7 @@ namespace helper {
   // RecHitType is not used.
   template <>
   template <typename RecHitType>  // or template<> to specialise also here?
-  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::
-      //  rekey<VectorHit>(const VectorHit::ClusterRef &newRef) const
-      rekey(const VectorHit::ClusterRef &newRef) const {
+  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::rekey(const VectorHit::ClusterRef &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -182,4 +182,30 @@ namespace helper {
     (*cluRef) = OmniClusterRef(newRef);
   }
 
+  // -------------------------------------------------------------
+  // Specific rekey for class template ClusterRefType = VectorHit::ClusterRef,
+  // RecHitType is not used.
+  template <>
+  template <typename RecHitType>  // or template<> to specialise also here?
+  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::
+      //  rekey<VectorHit>(const VectorHit::ClusterRef &newRef) const
+      rekey(const VectorHit::ClusterRef &newRef) const {
+    TrackingRecHit &genericHit = (*hits_)[index_];
+    const std::type_info &hit_type = typeid(genericHit);
+
+    OmniClusterRef *cluRef = nullptr;
+    if (typeid(VectorHit) == hit_type) {
+      VectorHit &vHit = static_cast<VectorHit &>(genericHit);
+      // FIXME: this essentially uses a hack
+      // https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L291
+      cluRef = (SiStripDetId(detid_).stereo() ? &vHit.upperClusterRef() : &vHit.lowerClusterRef());
+    } else {
+      return;
+    }
+
+    assert(cluRef != nullptr);            // to catch missing RecHit types
+    assert(cluRef->key() == ref_.key());  // otherwise something went wrong
+    (*cluRef) = OmniClusterRef(newRef);
+  }
+
 }  // namespace helper

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -452,7 +452,7 @@ class UpgradeWorkflow_vectorHits(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         stepDict[stepName][k] = merge([{'--procModifiers': 'vectorHits'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return fragment=="TTbar_14TeV" and '2026' in key
+        return (fragment=="TTbar_14TeV" or fragment=="SingleMuPt10Extended") and '2026' in key
 upgradeWFs['vectorHits'] = UpgradeWorkflow_vectorHits(
     steps = [
         'RecoGlobal',

--- a/DataFormats/TrackerRecHit2D/interface/VectorHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/VectorHit.h
@@ -92,6 +92,9 @@ public:
   ClusterRef upperCluster() const { return theUpperCluster.cluster_phase2OT(); }
   OmniClusterRef const lowerClusterRef() const { return theLowerCluster; }
   OmniClusterRef const upperClusterRef() const { return theUpperCluster; }
+  // Non const variants needed for cluster re-keying
+  OmniClusterRef& lowerClusterRef() { return theLowerCluster; }
+  OmniClusterRef& upperClusterRef() { return theUpperCluster; }
 
   //FIXME::to update with a proper CPE maybe...
   Global3DPoint lowerGlobalPos() const;


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/40323#issuecomment-1357133153.
If fixes the `vectorHit`s based workflows in step-5 that we hitting an assertion after the merge of #40323. 
I profit of this PR to add some workflows to test the vectorHits with singleMuon gun events (in order to have quicker turnaround in test times).

#### PR validation:

Run successfully:
```
 runTheMatrix.py --what upgrade -l 11634.0,20818.9,20834.0
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be part of backports of https://github.com/cms-sw/cmssw/pull/40323
