### PR TITLE
Utilities/StaticAnalysers: Fix segfault in FiniteMathChecker. Fix garbage values in CMS code rules checkers category.

### DIFF
--- a/Utilities/StaticAnalyzers/BuildFile.xml
+++ b/Utilities/StaticAnalyzers/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="llvm"/>
 <use name="dablooms"/>
+<use name="FWCore/Utilities" source_only="1"/>
 <flags NO_LIB_CHECKING="yes"/>
 <flags CXXFLAGS="-w"/>
 <architecture name="osx">

--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -32,15 +32,27 @@ namespace clangcms {
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
 
+    //	llvm::errs()<<E->getStmtClassName()<<";\t";
+    //	E->dumpPretty(ctx.getASTContext());
+    //	llvm::errs()<<"\n";
+    //	E->dump();
+    //	llvm::errs()<<"\n";
+
     for (clang::Stmt::const_child_iterator I = E->child_begin(), F = E->child_end(); I != F; ++I) {
       const Expr *child = llvm::dyn_cast_or_null<Expr>(*I);
       if (!child)
         continue;
       if (llvm::isa<DeclRefExpr>(child->IgnoreImpCasts())) {
+        //			(*I)->dump();
+        //			llvm::errs()<<"\n";
         const NamedDecl *ND = llvm::cast<DeclRefExpr>(child->IgnoreImpCasts())->getFoundDecl();
         if (llvm::isa<ParmVarDecl>(ND)) {
+          //				ND->dump();
+          //				llvm::errs()<<"\n";
           const ParmVarDecl *PVD = llvm::cast<ParmVarDecl>(ND);
           QualType QT = PVD->getOriginalType();
+          //				QT.dump();
+          //				llvm::errs()<<"\n";
           if (QT->isIncompleteType() || QT->isDependentType())
             continue;
           clang::QualType PQT = QT.getCanonicalType();
@@ -54,8 +66,25 @@ namespace clangcms {
             continue;
           std::string qname = QT.getAsString();
           std::string pname = PQT.getAsString();
+          std::string bpname = "class boost::";
+          std::string cbpname = "const class boost::";
+          std::string sfname = "class std::function<";
+          std::string ehname = "class edm::Handle<";
+          std::string cehname = "const class edm::Handle<";
+          std::string xname = "class xoap::";
+          std::string ername = "class edm::Ptr<";
+          std::string epname = "class edm::Ref<";
+          std::string cername = "const class edm::Ptr<";
+          std::string cepname = "const class edm::Ref<";
+          std::string erviname = "class edm::RefVectorIterator<";
           const CXXMethodDecl *MD =
               llvm::dyn_cast_or_null<CXXMethodDecl>(ctx.getCurrentAnalysisDeclContext()->getDecl());
+          //                              if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
+          //                                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
+          //                                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
+          //                                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
+          //                                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
+          //                                      || pname.substr(0,erviname.length()) == erviname ) continue;
           os << "Function parameter copied by value with size '" << size_param << "' bits > max size '" << max_bits
              << "' bits parameter type '" << pname << "' function '";
 
@@ -71,8 +100,7 @@ namespace clangcms {
           const clang::ento::PathDiagnosticLocation DLoc =
               clang::ento::PathDiagnosticLocation::createBegin(PVD, ctx.getSourceManager());
 
-          std::unique_ptr<BugType> BT = std::make_unique<clang::ento::BugType>(
-              this, "Function parameter copied by value with size > max", "ArgSize");
+          BugType *BT = new BugType(this, "Function parameter copied by value with size > max", "ArgSize");
           std::unique_ptr<BasicBugReport> report =
               std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
           report->addRange(PVD->getSourceRange());
@@ -87,6 +115,7 @@ namespace clangcms {
     CmsException m_exception;
     PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
 
+    //       	return;
     if (!m_exception.reportGeneral(DLoc, BR))
       return;
 
@@ -107,15 +136,36 @@ namespace clangcms {
         continue;
       std::string qname = QT.getAsString();
       std::string pname = PQT.getAsString();
+      std::string bpname = "class boost::";
+      std::string cbpname = "const class boost::";
+      std::string sfname = "class std::function<";
+      std::string ehname = "class edm::Handle<";
+      std::string cehname = "const class edm::Handle<";
+      std::string xname = "class xoap::";
+      std::string ername = "class edm::Ptr<";
+      std::string epname = "class edm::Ref<";
+      std::string cername = "const class edm::Ptr<";
+      std::string cepname = "const class edm::Ref<";
+      std::string erviname = "class edm::RefVectorIterator<";
+
+      //		if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
+      //                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
+      //                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
+      //                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
+      //                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
+      //                      || pname.substr(0,erviname.length()) == erviname ) continue;
       std::string fname = MD->getNameAsString();
       os << "Function parameter passed by value with size of parameter '" << size_param << "' bits > max size '"
-         << max_bits << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
+         << max_bits
+         //	  		<<"'\n";
+         //	  	llvm::errs()<< "Function parameter passed by value with size of parameter '"<<size_param
+         //			<<"' bits > max size '"<<max_bits
+         << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
          << MD->getParent()->getNameAsString() << "'\n";
       std::string oname = "operator";
       //             if ( fname.substr(0,oname.length()) == oname ) continue;
 
-      std::unique_ptr<BugType> BT =
-          std::make_unique<clang::ento::BugType>(this, "Function parameter with size > max", "ArgSize");
+      BugType *BT = new BugType(this, "Function parameter with size > max", "ArgSize");
       std::unique_ptr<BasicBugReport> report = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       BR.emitReport(std::move(report));
     }

--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -32,27 +32,15 @@ namespace clangcms {
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
 
-    //	llvm::errs()<<E->getStmtClassName()<<";\t";
-    //	E->dumpPretty(ctx.getASTContext());
-    //	llvm::errs()<<"\n";
-    //	E->dump();
-    //	llvm::errs()<<"\n";
-
     for (clang::Stmt::const_child_iterator I = E->child_begin(), F = E->child_end(); I != F; ++I) {
       const Expr *child = llvm::dyn_cast_or_null<Expr>(*I);
       if (!child)
         continue;
       if (llvm::isa<DeclRefExpr>(child->IgnoreImpCasts())) {
-        //			(*I)->dump();
-        //			llvm::errs()<<"\n";
         const NamedDecl *ND = llvm::cast<DeclRefExpr>(child->IgnoreImpCasts())->getFoundDecl();
         if (llvm::isa<ParmVarDecl>(ND)) {
-          //				ND->dump();
-          //				llvm::errs()<<"\n";
           const ParmVarDecl *PVD = llvm::cast<ParmVarDecl>(ND);
           QualType QT = PVD->getOriginalType();
-          //				QT.dump();
-          //				llvm::errs()<<"\n";
           if (QT->isIncompleteType() || QT->isDependentType())
             continue;
           clang::QualType PQT = QT.getCanonicalType();
@@ -66,25 +54,8 @@ namespace clangcms {
             continue;
           std::string qname = QT.getAsString();
           std::string pname = PQT.getAsString();
-          std::string bpname = "class boost::";
-          std::string cbpname = "const class boost::";
-          std::string sfname = "class std::function<";
-          std::string ehname = "class edm::Handle<";
-          std::string cehname = "const class edm::Handle<";
-          std::string xname = "class xoap::";
-          std::string ername = "class edm::Ptr<";
-          std::string epname = "class edm::Ref<";
-          std::string cername = "const class edm::Ptr<";
-          std::string cepname = "const class edm::Ref<";
-          std::string erviname = "class edm::RefVectorIterator<";
           const CXXMethodDecl *MD =
               llvm::dyn_cast_or_null<CXXMethodDecl>(ctx.getCurrentAnalysisDeclContext()->getDecl());
-          //                              if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
-          //                                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
-          //                                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
-          //                                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
-          //                                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
-          //                                      || pname.substr(0,erviname.length()) == erviname ) continue;
           os << "Function parameter copied by value with size '" << size_param << "' bits > max size '" << max_bits
              << "' bits parameter type '" << pname << "' function '";
 
@@ -95,7 +66,6 @@ namespace clangcms {
           os << "'\n";
 
           std::string oname = "operator";
-          //                              if ( fname.substr(0,oname.length()) == oname ) continue;
 
           const clang::ento::PathDiagnosticLocation DLoc =
               clang::ento::PathDiagnosticLocation::createBegin(PVD, ctx.getSourceManager());
@@ -115,7 +85,6 @@ namespace clangcms {
     CmsException m_exception;
     PathDiagnosticLocation DLoc = PathDiagnosticLocation::createBegin(MD, SM);
 
-    //       	return;
     if (!m_exception.reportGeneral(DLoc, BR))
       return;
 
@@ -136,34 +105,12 @@ namespace clangcms {
         continue;
       std::string qname = QT.getAsString();
       std::string pname = PQT.getAsString();
-      std::string bpname = "class boost::";
-      std::string cbpname = "const class boost::";
-      std::string sfname = "class std::function<";
-      std::string ehname = "class edm::Handle<";
-      std::string cehname = "const class edm::Handle<";
-      std::string xname = "class xoap::";
-      std::string ername = "class edm::Ptr<";
-      std::string epname = "class edm::Ref<";
-      std::string cername = "const class edm::Ptr<";
-      std::string cepname = "const class edm::Ref<";
-      std::string erviname = "class edm::RefVectorIterator<";
-
-      //		if ( pname.substr(0,bpname.length()) == bpname || pname.substr(0,cbpname.length()) == cbpname
-      //                      || pname.substr(0,ehname.length()) == ehname || pname.substr(0,cehname.length()) == cehname
-      //                      || pname.substr(0,epname.length()) == epname || pname.substr(0,cepname.length()) == cepname
-      //                      || pname.substr(0,ername.length()) == ername || pname.substr(0,cername.length()) == cername
-      //                      || pname.substr(0,sfname.length()) == sfname || pname.substr(0,xname.length()) == xname
-      //                      || pname.substr(0,erviname.length()) == erviname ) continue;
       std::string fname = MD->getNameAsString();
       os << "Function parameter passed by value with size of parameter '" << size_param << "' bits > max size '"
          << max_bits
-         //	  		<<"'\n";
-         //	  	llvm::errs()<< "Function parameter passed by value with size of parameter '"<<size_param
-         //			<<"' bits > max size '"<<max_bits
          << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
          << MD->getParent()->getNameAsString() << "'\n";
       std::string oname = "operator";
-      //             if ( fname.substr(0,oname.length()) == oname ) continue;
 
       BugType *BT = new BugType(this, "Function parameter with size > max", "ArgSize");
       std::unique_ptr<BasicBugReport> report = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);

--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -107,8 +107,7 @@ namespace clangcms {
       std::string pname = PQT.getAsString();
       std::string fname = MD->getNameAsString();
       os << "Function parameter passed by value with size of parameter '" << size_param << "' bits > max size '"
-         << max_bits
-         << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
+         << max_bits << "' bits parameter type '" << pname << "' function '" << fname << "' class '"
          << MD->getParent()->getNameAsString() << "'\n";
       std::string oname = "operator";
 

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -30,7 +30,6 @@
 #include <llvm/ADT/SmallString.h>
 
 #include "ClassChecker.h"
-
 #include <iostream>
 #include <fstream>
 #include <iterator>
@@ -313,8 +312,7 @@ namespace clangcms {
     support::fixAnonNS(mname, sfile);
     std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str() + ".";
     writeLog(tolog);
-    std::unique_ptr<BugType> BT =
-        std::make_unique<BugType>(Checker, "const_cast used in const function ", "Data Class Const Correctness");
+    BugType *BT = new BugType(Checker, "const_cast used in const function ", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(tolog), CELoc);
     BR.emitReport(std::move(R));
     return;
@@ -359,7 +357,7 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+        BugType *BT = new BugType(
             Checker, "ClassChecker : non-const static local variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
@@ -380,8 +378,7 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
-            Checker, "Non-const static member variable accessed", "Data Class Const Correctness");
+        BugType *BT = new BugType(Checker, "Non-const static member variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
@@ -401,8 +398,7 @@ namespace clangcms {
         support::fixAnonNS(mname, sfile);
         std::string tolog = "data class '" + pname + "' const function '" + mname + "' Warning: " + os.str();
         writeLog(tolog);
-        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
-            Checker, "Non-const global static variable accessed", "Data Class Const Correctness");
+        BugType *BT = new BugType(Checker, "Non-const global static variable accessed", "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
         return;
@@ -541,7 +537,7 @@ namespace clangcms {
     if (support::isSafeClassName(support::getQualifiedName(*MD)))
       return;
     writeLog(tolog);
-    std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+    BugType *BT = new BugType(
         Checker, "Non-const member function could modify member data object", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
@@ -566,8 +562,8 @@ namespace clangcms {
         clang::ento::PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
 
     writeLog(tolog);
-    std::unique_ptr<BugType> BT = std::make_unique<BugType>(
-        Checker, "Const cast away from member data in const function", "Data Class Const Correctness");
+    BugType *BT =
+        new BugType(Checker, "Const cast away from member data in const function", "Data Class Const Correctness");
     std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
     BR.emitReport(std::move(R));
   }
@@ -633,10 +629,9 @@ namespace clangcms {
     clang::QualType RTy = Ctx.getCanonicalType(RQT);
     if ((RTy->isPointerType() || RTy->isReferenceType())) {
       if (!support::isConst(RTy)) {
-        std::unique_ptr<BugType> BT = std::make_unique<BugType>(
-            BugType(Checker,
-                    "Const function returns pointer or reference to non-const member data object",
-                    "Data Class Const Correctness"));
+        BugType *BT = new BugType(Checker,
+                                  "Const function returns pointer or reference to non-const member data object",
+                                  "Data Class Const Correctness");
         std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
         BR.emitReport(std::move(R));
       }
@@ -645,10 +640,10 @@ namespace clangcms {
     std::string rtname = RTy.getAsString();
     if ((RTy->isReferenceType() || RTy->isRecordType()) && support::isConst(RTy) &&
         rtname.substr(0, svname.length()) == svname) {
-      std::unique_ptr<BugType> BT = std::make_unique<BugType>(
-          Checker,
-          "Const function returns member data object of type const std::vector<*> or const std::vector<*>&",
-          "Data Class Const Correctness");
+      BugType *BT =
+          new BugType(Checker,
+                      "Const function returns member data object of type const std::vector<*> or const std::vector<*>&",
+                      "Data Class Const Correctness");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       BR.emitReport(std::move(R));
     }

--- a/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ESRecordGetChecker.cpp
@@ -9,7 +9,6 @@ namespace clangcms {
     const CheckerBase *Checker;
     clang::ento::BugReporter &BR;
     clang::AnalysisDeclContext *AC;
-    const clang::ento::BugType *BT;
 
   public:
     ESRWalker(const CheckerBase *checker, clang::ento::BugReporter &br, clang::AnalysisDeclContext *ac)
@@ -62,8 +61,7 @@ namespace clangcms {
             "the token see "
             "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      std::unique_ptr<BugType> BT =
-          std::make_unique<BugType>(Checker, "EventSetupRecord::get function called", "Deprecated API");
+      BugType *BT = new BugType(Checker, "EventSetupRecord::get function called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -70,7 +70,6 @@ namespace clangcms {
                                            "fastmath plugin");
     std::unique_ptr<clang::ento::BasicBugReport> report =
         std::make_unique<clang::ento::BasicBugReport>(*BT, BT->getCheckerName(), CELoc);
-    //report->addRange(Callee->getSourceRange());
     BR.emitReport(std::move(report));
   }
 

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.h
@@ -5,7 +5,6 @@
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include "clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h"
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
-#include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "CmsException.h"
 
 namespace clangcms {

--- a/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/PsetExistsFCallChecker.cpp
@@ -99,7 +99,7 @@ namespace clangcms {
       if (pname.find(pdname) != std::string::npos)
         return;
       os << "function " << mname << " is called in function " << pname;
-      std::unique_ptr<BugType> BT = std::make_unique<BugType>(
+      BugType *BT = new BugType(
           Checker, "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() called", "CMS code rules");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -50,8 +50,7 @@ namespace clangcms {
         if (oname.substr(0, eoname.length()) != eoname) {
           os << "TFileService function " << mname << " is called in function " << pname;
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          std::unique_ptr<BugType> BT =
-              std::make_unique<BugType>(Checker, "TFileService function called ", "ThreadSafety");
+          BugType *BT = new BugType(Checker, "TFileService function called ", "ThreadSafety");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
           R->setDeclWithIssue(AC->getDecl());
           R->addRange(CE->getSourceRange());
@@ -64,8 +63,7 @@ namespace clangcms {
     } else if (support::isKnownThrUnsafeFunc(mname)) {
       os << "Known thread unsafe function " << mname << " is called in function " << pname;
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      std::unique_ptr<BugType> BT =
-          std::make_unique<BugType>(Checker, "known thread unsafe function called", "ThreadSafety");
+      BugType *BT = new BugType(Checker, "known thread unsafe function called", "ThreadSafety");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, os.str(), CELoc);
       R->setDeclWithIssue(AC->getDecl());
       R->addRange(CE->getSourceRange());

--- a/Utilities/StaticAnalyzers/src/TrunCastChecker.h
+++ b/Utilities/StaticAnalyzers/src/TrunCastChecker.h
@@ -5,13 +5,11 @@
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/StaticAnalyzer/Core/BugReporter/BugType.h>
 #include "CmsException.h"
-#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace clangcms {
 
   class TrunCastChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::CXXRecordDecl> > {
   public:
-    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
     void checkASTDecl(const clang::CXXRecordDecl *D,
                       clang::ento::AnalysisManager &Mgr,
                       clang::ento::BugReporter &BR) const;

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -38,25 +38,12 @@ namespace clangcms {
     if (!MD)
       return;
     std::string mname = MD->getQualifiedNameAsString();
-    //	llvm::errs()<<"Parent Decl: '"<<dname<<"'\n";
-    //	llvm::errs()<<"Method Decl: '"<<mname<<"'\n";
-    //	llvm::errs()<<"call expression '";
-    //	CE->printPretty(llvm::errs(),0,Policy);
-    //	llvm::errs()<<"'\n";
-    //	if (!MD) return;
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
     if (mname == "edm::Event::getByLabel" || mname == "edm::Event::getManyByType") {
-      //			if (const CXXRecordDecl * RD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)->getParent() ) {
-      //				llvm::errs()<<"class "<<RD->getQualifiedNameAsString()<<"\n";
-      //				llvm::errs()<<"\n";
-      //				}
       os << "function '";
       llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os, Policy, true);
       os << "' ";
-      //			os<<"call expression '";
-      //			CE->printPretty(os,0,Policy);
-      //			os<<"' ";
       if (mname == "edm::Event::getByLabel") {
         os << "calls edm::Event::getByLabel with arguments '";
         QualType QT;
@@ -125,12 +112,6 @@ namespace clangcms {
           os << "calls '";
           MD->getNameForDiagnostic(os, Policy, true);
           os << "' with argument of type '" << qtname << "'\n";
-          //				llvm::errs()<<"\n";
-          //				llvm::errs()<<"call expression passed edm::Event ";
-          //				CE->printPretty(llvm::errs(),0,Policy);
-          //				llvm::errs()<<" argument name ";
-          //				(*I)->printPretty(llvm::errs(),0,Policy);
-          //				llvm::errs()<<" "<<qtname<<"\n";
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
           BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "Deprecated API");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -38,12 +38,25 @@ namespace clangcms {
     if (!MD)
       return;
     std::string mname = MD->getQualifiedNameAsString();
+    //	llvm::errs()<<"Parent Decl: '"<<dname<<"'\n";
+    //	llvm::errs()<<"Method Decl: '"<<mname<<"'\n";
+    //	llvm::errs()<<"call expression '";
+    //	CE->printPretty(llvm::errs(),0,Policy);
+    //	llvm::errs()<<"'\n";
+    //	if (!MD) return;
     llvm::SmallString<100> buf;
     llvm::raw_svector_ostream os(buf);
     if (mname == "edm::Event::getByLabel" || mname == "edm::Event::getManyByType") {
+      //			if (const CXXRecordDecl * RD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)->getParent() ) {
+      //				llvm::errs()<<"class "<<RD->getQualifiedNameAsString()<<"\n";
+      //				llvm::errs()<<"\n";
+      //				}
       os << "function '";
       llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os, Policy, true);
       os << "' ";
+      //			os<<"call expression '";
+      //			CE->printPretty(os,0,Policy);
+      //			os<<"' ";
       if (mname == "edm::Event::getByLabel") {
         os << "calls edm::Event::getByLabel with arguments '";
         QualType QT;
@@ -94,9 +107,9 @@ namespace clangcms {
         }
       }
 
+      //			llvm::errs()<<os.str()<<"\n";
       PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-      std::unique_ptr<BugType> BT =
-          std::make_unique<BugType>(Checker, "edm::getByLabel or edm::getManyByType called", "Deprecated API");
+      BugType *BT = new BugType(Checker, "edm::getByLabel or edm::getManyByType called", "Deprecated API");
       std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
       R->addRange(CE->getSourceRange());
       BR.emitReport(std::move(R));
@@ -112,9 +125,14 @@ namespace clangcms {
           os << "calls '";
           MD->getNameForDiagnostic(os, Policy, true);
           os << "' with argument of type '" << qtname << "'\n";
+          //				llvm::errs()<<"\n";
+          //				llvm::errs()<<"call expression passed edm::Event ";
+          //				CE->printPretty(llvm::errs(),0,Policy);
+          //				llvm::errs()<<" argument name ";
+          //				(*I)->printPretty(llvm::errs(),0,Policy);
+          //				llvm::errs()<<" "<<qtname<<"\n";
           PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(), AC);
-          std::unique_ptr<BugType> BT =
-              std::make_unique<BugType>(Checker, "function call with argument of type edm::Event", "Deprecated API");
+          BugType *BT = new BugType(Checker, "function call with argument of type edm::Event", "Deprecated API");
           std::unique_ptr<BasicBugReport> R = std::make_unique<BasicBugReport>(*BT, llvm::StringRef(os.str()), CELoc);
           R->addRange(CE->getSourceRange());
           BR.emitReport(std::move(R));


### PR DESCRIPTION
Fix garbage values in CMS code rules checkers categories introduced by the incorrect use of std::unique_ptr with function temporaries.

Fix segfault in FiniteMathChecker caused by used os clang::ento::CheckerBase::getCheckerName().

Testing locally.