### PR TITLE
[124X] Update Run3 offline and online data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,17 +33,17 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-12 13:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v9',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v8',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v6 but with snapshot at 2022-10-04 14:22:26 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v6',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-11-01 12:00:00 (UTC)
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v9',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v9',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v10 but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v8',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-12-15 07:25:06 (UTC)
     'run3_data'                    : '124X_dataRun3_v14',
-    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
+    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2022-12-19 18:12:44 (UTC)
     'run3_data_relval'             : '124X_dataRun3_relval_v12',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -42,9 +42,9 @@ autoCond = {
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v5 but with snapshot at 2022-10-04 14:19:51 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v5',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-11-01 12:00:00 (UTC)
-    'run3_data'                    : '124X_dataRun3_v11',
+    'run3_data'                    : '124X_dataRun3_v14',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v11',
+    'run3_data_relval'             : '124X_dataRun3_relval_v12',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

Backport of #40318 and #40367

This PR updates the offline and online data GTs.

Offline GTs updated are (`auto:run3_data`) and the offline relval GT (`auto:run3_data_relval`) with:

- latest conditions to be used for the 2022E Re-Reco ([CMSTalk post](https://cms-talk.web.cern.ch/t/offline-call-for-offline-conditions-for-the-2022e-re-reco/17856/2))
- updated HCAL QIED conditions requested in ([CMSTalk post](https://cms-talk.web.cern.ch/t/gt-offline-request-of-updating-replacing-hcal-offline-conditions/18539))
- Removal of some MVASelector tags for tracking following ([CMSTalk post](https://cms-talk.web.cern.ch/t/proposal-of-removal-of-bdt-based-gbrwrapperrcd-tags-for-tracking-selection-from-run-3-globaltags/16757))

For the online data GTs:

- The HLT and Express frozen GTs have only been updated for the snapshot time.
- The HLT relval GT has been updated to remove the tag `HcalElectronicsMap_full_v2.0_hlt`, as requested in [this cmsTalk post](https://cms-talk.web.cern.ch/t/hlt-express-prompt-offline-request-of-redundant-unused-hcal-tags-removal/16312).
- The Prompt GT has been updated to include the tag `HeavyIonRPRcd_75x_v0_prompt` that was added for the Hi test run data-taking, in 124X_dataRun3_Prompt_v10.


**GT differences:**

**Run 3 data (offline)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v14/124X_dataRun3_v11

**Run 3 data RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_relval_v6/124X_dataRun3_relval_v12

**Diff between new offline and new offline_relval GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v14/124X_dataRun3_relval_v12

**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v8/124X_dataRun3_HLT_frozen_v9

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_relval_v8/124X_dataRun3_HLT_relval_v9

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v8/124X_dataRun3_Express_frozen_v9

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v7/124X_dataRun3_Prompt_frozen_v8

**diff between HLT and HLT_relval GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v9/124X_dataRun3_HLT_relval_v9

#### PR validation:

`runTheMatrix.py -l 139.001 --ibeos -j16`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40318 and #40367
