### PR TITLE
[GEM] enable GEM packer/unpacker for phase 2 scenario

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -49,7 +49,8 @@ run2_GEM_2017.toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-(run3_GEM & ~phase2_GEM).toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
+run3_GEM.toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
+phase2_GEM.toReplaceWith(DigiToRawTask, _gem_DigiToRawTask)
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([rpcpacker]))

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -111,7 +111,8 @@ run2_GEM_2017.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-(run3_GEM & ~phase2_GEM).toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
+run3_GEM.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
+phase2_GEM.toReplaceWith(RawToDigiTask, _gem_RawToDigiTask)
 
 from EventFilter.HGCalRawToDigi.HGCalRawToDigi_cfi import *
 _hgcal_RawToDigiTask = RawToDigiTask.copy()

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -15,4 +15,4 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run3_GEM.toModify(gemRecHits, ge21Off=True)
-phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis", ge21Off=False)
+phase2_GEM.toModify(gemRecHits, ge21Off=False)


### PR DESCRIPTION
#### PR description:

* This PR is covering the issue (https://github.com/cms-sw/cmssw/issues/39984)
* For the phase 2 scenario, we were skipping the GEM packing/unpacking step and using `simMuonGEMDigis` instead `muonGEMdigis`, because the modules are completed yet.
* Now we have completed modules. So we made an update to make it be able to run GEM packing/unpacking steps for phase-2 scenario.

#### PR validation:
* The PR has tested with the `runTheMatrix.py -l 20834.911`, which is mentioned in the issue.
* We are expecting some differences from the plots that is using DAQ status, which is the missing information from previous version.

@jshlee @watson-ij @quark2 