### PR TITLE
[125X] Update online data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,14 +33,14 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-11-09 21:24:02 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v8',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v9',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v3',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-11-09 21:24:02 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v8',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v8 but with snapshot at 2022-11-09 21:24:02 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v7',
+    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v4',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v9',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v10 but with snapshot at 2022-12-19 18:00:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v8',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-12-15 07:25:06 (UTC)
     'run3_data'                    : '124X_dataRun3_v14',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2022-12-15 07:28:44 (UTC)


### PR DESCRIPTION
#### PR description:

Backport of #40367 

This PR is to update the online data GTs.

- The HLT and Express frozen GTs have only been updated for the snapshot time.
- The HLT relval GT has been updated to remove the tag `HcalElectronicsMap_full_v2.0_hlt`, as requested in [this cmsTalk post](https://cms-talk.web.cern.ch/t/hlt-express-prompt-offline-request-of-redundant-unused-hcal-tags-removal/16312).
- The Prompt GT has been updated to include the tag `HeavyIonRPRcd_75x_v0_prompt` that was added for the Hi test run data-taking, in `124X_dataRun3_Prompt_v10`.

The GT differences are shown below:

**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v8/124X_dataRun3_HLT_frozen_v9

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_HLT_relval_v3/125X_dataRun3_HLT_relval_v4

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v8/124X_dataRun3_Express_frozen_v9

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v7/124X_dataRun3_Prompt_frozen_v8

**diff between HLT and HLT_relval GTs**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v9/125X_dataRun3_HLT_relval_v4


#### PR validation:

`runTheMatrix.py -l 139.001,1001.3,1002.3 --ibeos -j16`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40367 