### PR TITLE
update `SiStripMonitorApproximateCluster` ME ranges

### DIFF
--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -666,7 +666,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
     # append the approximate clusters monitoring for the HI run case
     from DQM.SiStripMonitorApproximateCluster.SiStripMonitorApproximateCluster_cfi import SiStripMonitorApproximateCluster
-    process.siStripApproximateClusterComparator = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True))
+    process.siStripApproximateClusterComparator = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True),
+                                                                                         ClustersProducer = cms.InputTag("hltSiStripClusterizerForRawPrime"))
     process.p.insert(process.p.index(process.TrackingClient)+1,process.siStripApproximateClusterComparator)
 
 ### process customizations included here

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -621,9 +621,9 @@ if (process.runType.getRunType() == process.runType.hi_run):
     # Select events based on the pixel cluster multiplicity
     import  HLTrigger.special.hltPixelActivityFilter_cfi
     process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
-        inputTag  = cms.InputTag('siPixelClusters'),
-        minClusters = cms.uint32(1),
-        maxClusters = cms.uint32(50000)
+        inputTag  = 'siPixelClusters',
+        minClusters = 1,
+        maxClusters = 50000
         )
 
     # BaselineValidator Module
@@ -666,8 +666,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
     # append the approximate clusters monitoring for the HI run case
     from DQM.SiStripMonitorApproximateCluster.SiStripMonitorApproximateCluster_cfi import SiStripMonitorApproximateCluster
-    process.siStripApproximateClusterComparator = SiStripMonitorApproximateCluster.clone(compareClusters = cms.bool(True),
-                                                                                         ClustersProducer = cms.InputTag("hltSiStripClusterizerForRawPrime"))
+    process.siStripApproximateClusterComparator = SiStripMonitorApproximateCluster.clone(compareClusters = True,
+                                                                                         ClustersProducer = "hltSiStripClusterizerForRawPrime")
     process.p.insert(process.p.index(process.TrackingClient)+1,process.siStripApproximateClusterComparator)
 
 ### process customizations included here

--- a/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
@@ -199,6 +199,7 @@ void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const e
         for (const auto& stripCluster : strip_clusters_detset) {
           // by construction the approximated cluster width has same
           // size as the original cluster
+
           if (cluster.width() != stripCluster.size()) {
             continue;
           }
@@ -214,18 +215,17 @@ void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const e
         // - if exists a closest cluster in the DetId
         // - the size coincides with the original one
         if (closestCluster) {
+          // comparisong plots
           h_deltaBarycenter_->Fill(closestCluster->barycenter() - convertedCluster.barycenter());
           h_deltaSize_->Fill(closestCluster->size() - convertedCluster.size());
           h_deltaCharge_->Fill(closestCluster->charge() - convertedCluster.charge());
           h_deltaFirstStrip_->Fill(closestCluster->firstStrip() - convertedCluster.firstStrip());
           h_deltaEndStrip_->Fill(closestCluster->endStrip() - convertedCluster.endStrip());
-        }
-
-        // perfect match (also barycenter coindices)
-        if (std::abs(distance) <= 1.f) {
+          // monitoring plots
           matchedClusters.fill(cluster);
           h_isMatched_->Fill(1);
         } else {
+          // monitoring plots
           unMatchedClusters.fill(cluster);
           h_isMatched_->Fill(-1);
         }
@@ -251,14 +251,14 @@ void SiStripMonitorApproximateCluster::bookHistograms(DQMStore::IBooker& ibook,
 
     ibook.setCurrentFolder(fmt::format("{}/ClusterComparisons", folder_));
     h_deltaBarycenter_ =
-        ibook.book1D("deltaBarycenter", "#Delta barycenter;#Delta barycenter;cluster pairs", 501, -1000.5, 1000.5);
+        ibook.book1D("deltaBarycenter", "#Delta barycenter;#Delta barycenter;cluster pairs", 101, -50.5, 50.5);
     h_deltaSize_ = ibook.book1D("deltaSize", "#Delta size;#Delta size;cluster pairs", 201, -100.5, 100.5);
-    h_deltaCharge_ = ibook.book1D("deltaCharge", "#Delta charge;#Delta charge;cluster pairs", 501, -1000.5, 1000.5);
+    h_deltaCharge_ = ibook.book1D("deltaCharge", "#Delta charge;#Delta charge;cluster pairs", 401, -200.5, 200.5);
 
     h_deltaFirstStrip_ =
-        ibook.book1D("deltaFirstStrip", "#Delta FirstStrip; #Delta firstStrip;cluster pairs", 501, -1000.5, 1000.5);
+        ibook.book1D("deltaFirstStrip", "#Delta FirstStrip; #Delta firstStrip;cluster pairs", 101, -50.5, 50.5);
     h_deltaEndStrip_ =
-        ibook.book1D("deltaEndStrip", "#Delta EndStrip; #Delta endStrip; cluster pairs", 501, -1000.5, 1000.5);
+        ibook.book1D("deltaEndStrip", "#Delta EndStrip; #Delta endStrip; cluster pairs", 101, -50.5, 50.5);
 
     h_isMatched_ = ibook.book1D("isClusterMatched", "cluster matching;is matched?;#clusters", 3, -1.5, 1.5);
     h_isMatched_->getTH1F()->GetXaxis()->SetBinLabel(1, "Not matched");
@@ -269,10 +269,13 @@ void SiStripMonitorApproximateCluster::bookHistograms(DQMStore::IBooker& ibook,
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void SiStripMonitorApproximateCluster::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("compareClusters", false);
-  desc.add<edm::InputTag>("ApproxClustersProducer", edm::InputTag("hltSiStripClusters2ApproxClusters"));
-  desc.add<edm::InputTag>("ClustersProducer", edm::InputTag("siStripClusters"));
-  desc.add<std::string>("folder", "SiStripApproximateClusters");
+  desc.setComment("Monitor SiStripApproximateCluster collection and compare with regular SiStrip clusters");
+  desc.add<bool>("compareClusters", false)->setComment("if true, will compare with regualr Strip clusters");
+  desc.add<edm::InputTag>("ApproxClustersProducer", edm::InputTag("hltSiStripClusters2ApproxClusters"))
+      ->setComment("approxmate clusters collection");
+  desc.add<edm::InputTag>("ClustersProducer", edm::InputTag("hltSiStripClusterizerForRawPrime"))
+      ->setComment("regular clusters collection");
+  desc.add<std::string>("folder", "SiStripApproximateClusters")->setComment("Top Level Folder");
   descriptions.addWithDefaultLabel(desc);
 }
 


### PR DESCRIPTION
#### PR description:

The goal of this PR is mostly to calibrate the ranges of the MEs introduced in PR https://github.com/cms-sw/cmssw/pull/40295 after analyzing the 2022 HI Test run data.

#### PR validation:

Run this branch using the following modifications on top: https://gist.github.com/mmusich/bccffd6294eacd75a7d74c61e11a7e34

and then running 
```
 cmsRun DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py runkey=hi_run
```

The resulting DQM file is available at: https://cernbox.cern.ch/s/trAIVAsxgYauCrm

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A