### PR TITLE
Backport of changes to LHEGenericMassFilter

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -24,6 +24,7 @@ class LHEGenericMassFilter : public edm::global::EDFilter<> {
 public:
   explicit LHEGenericMassFilter(const edm::ParameterSet&);
   ~LHEGenericMassFilter() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
   bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
@@ -35,14 +36,16 @@ private:
   const std::vector<int> particleID_;  // vector of particle IDs to look for
   const double minMass_;
   const double maxMass_;
+  const bool requiredOutgoingStatus_;  // Whether particles required to pass filter must have outgoing status
 };
 
 LHEGenericMassFilter::LHEGenericMassFilter(const edm::ParameterSet& iConfig)
     : src_(consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("src"))),
       numRequired_(iConfig.getParameter<int>("NumRequired")),
-      particleID_(iConfig.getParameter<std::vector<int> >("ParticleID")),
+      particleID_(iConfig.getParameter<std::vector<int>>("ParticleID")),
       minMass_(iConfig.getParameter<double>("MinMass")),
-      maxMass_(iConfig.getParameter<double>("MaxMass")) {}
+      maxMass_(iConfig.getParameter<double>("MaxMass")),
+      requiredOutgoingStatus_(iConfig.getParameter<bool>("RequiredOutgoingStatus")) {}
 
 // ------------ method called to skim the data  ------------
 bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
@@ -57,7 +60,8 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
   double E = 0.;
 
   for (int i = 0; i < EvtHandle->hepeup().NUP; ++i) {
-    if (EvtHandle->hepeup().ISTUP[i] != 1) {  // keep only outgoing particles
+    // if requiredOutgoingStatus_ keep only outgoing particles, otherwise keep them all
+    if (requiredOutgoingStatus_ && EvtHandle->hepeup().ISTUP[i] != 1) {
       continue;
     }
     for (unsigned int j = 0; j < particleID_.size(); ++j) {
@@ -82,6 +86,17 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
     }
   }
   return false;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void LHEGenericMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("NumRequired", 1);
+  desc.add<vector<int>>("ParticleID", std::vector<int>{1});
+  desc.add<double>("MinMass", 0.0);
+  desc.add<double>("MaxMass", 1.0);
+  desc.add<bool>("RequiredOutgoingStatus", true);
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:
This is a backport of PR 39459 (https://github.com/cms-sw/cmssw/pull/39459#event-7613224176). This extends the capabilities for the LHEGenericMassFilter plugin to allow to filter on specific particles and include whether they are final state particles or not.

#### PR validation:

Passed:
scram build code-checks
scram build code-format

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

original PR 39459 (https://github.com/cms-sw/cmssw/pull/39459#event-7613224176). This is meant to be backported to 10.6.30 patch1 for ultra legacy monte carlo production samples of toponium. See the PR for toponium samples here: https://github.com/cms-sw/genproductions/pull/3132#issuecomment-1115223895 . The 10.6.30 patch1 was the release version the monte carlo contact was using.

