### PR TITLE
ECAL Phase 2 - Skip new ALCA step for Phase 2 ECAL development WFs

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1645,11 +1645,13 @@ class UpgradeWorkflow_ecalDevel(UpgradeWorkflow):
                 'DigiTrigger',
                 'RecoGlobal',
                 'HARVESTGlobal',
+                'ALCAPhase2',
             ],
             PU = [
                 'DigiTrigger',
                 'RecoGlobal',
                 'HARVESTGlobal',
+                'ALCAPhase2',
             ],
             **kwargs)
         self.__digi = digi
@@ -1671,6 +1673,9 @@ class UpgradeWorkflow_ecalDevel(UpgradeWorkflow):
             mods['-s'] = 'HARVESTING:@ecalOnlyValidation+@ecal'
             mods |= self.__harvest
         stepDict[stepName][k] = merge([mods, stepDict[step][k]])
+        # skip ALCA step
+        if 'ALCA' in step:
+            stepDict[stepName][k] = None
 
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and '2026' in key


### PR DESCRIPTION
#### PR description:

After the ALCA step was introduced for Phase 2 WFs with #39858  the `ecalDevel` workflows with suffix `.61` and `.612` failed during the new step5 since the track collections were not produced in the reco step. Since these WFs are intended for ECAL reconstruction developments, the reconstruction of other subdetector collections is not complete.

This PR skips the ALCA step for the ecalDevel WFs.

#### PR validation:

WF 20034.61 now runs to completion with four steps only.