### PR TITLE
Hide framework classes from ROOT in SiStripTools

### DIFF
--- a/DPGAnalysis/SiStripTools/interface/Multiplicities.h
+++ b/DPGAnalysis/SiStripTools/interface/Multiplicities.h
@@ -1,169 +1,37 @@
 #ifndef DPGAnalysis_SiStripTools_Multiplicities_H
 #define DPGAnalysis_SiStripTools_Multiplicities_H
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+namespace sistriptools::values {
+  class Multiplicity {
+  public:
+    explicit Multiplicity(int iMult) : m_mult{iMult} {}
+    int mult() const { return m_mult; }
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/Common/interface/DetSet.h"
+  private:
+    int m_mult;
+  };
 
-#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/TrackerCommon/interface/ClusterSummary.h"
+  template <class T1, class T2>
+  class MultiplicityPair {
+  public:
+    MultiplicityPair(T1 const& i1, T2 const& i2) : m_multiplicity1(i1), m_multiplicity2(i2) {}
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+    int mult1() const;
+    int mult2() const;
 
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+  private:
+    T1 m_multiplicity1;
+    T2 m_multiplicity2;
+  };
 
-namespace edm {
-  class EventSetup;
-};
-
-#include <string>
-
-class ClusterSummarySingleMultiplicity {
-public:
-  ClusterSummarySingleMultiplicity();
-  ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
-  ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-
-  void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  int mult() const;
-
-private:
-  ClusterSummary::CMSTracker m_subdetenum;
-  ClusterSummary::VariablePlacement m_varenum;
-  int m_mult;
-  edm::EDGetTokenT<ClusterSummary> m_collection;
-};
-
-template <class T>
-class SingleMultiplicity {
-public:
-  SingleMultiplicity();
-  SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
-  SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-
-  void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  int mult() const;
-  //  int mult;
-
-private:
-  int m_modthr;
-  bool m_useQuality;
-  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> m_qualityToken;
-  int m_mult;
-  edm::EDGetTokenT<T> m_collection;
-};
-
-template <class T>
-SingleMultiplicity<T>::SingleMultiplicity() : m_modthr(-1), m_useQuality(false), m_mult(0), m_collection() {}
-
-template <class T>
-SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
-    : m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
-      m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality", false)),
-      m_qualityToken(m_useQuality
-                         ? decltype(m_qualityToken){iC.esConsumes<SiStripQuality, SiStripQualityRcd>(
-                               edm::ESInputTag{"", iConfig.getUntrackedParameter<std::string>("qualityLabel", "")})}
-                         : decltype(m_qualityToken){}),
-      m_mult(0),
-      m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))) {}
-template <class T>
-SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-    : m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
-      m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality", false)),
-      m_qualityToken(m_useQuality
-                         ? decltype(m_qualityToken){iC.esConsumes<SiStripQuality, SiStripQualityRcd>(
-                               edm::ESInputTag(iConfig.getUntrackedParameter<std::string>("qualityLabel", "")))}
-                         : decltype(m_qualityToken){}),
-      m_mult(0),
-      m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))) {}
-
-template <class T>
-void SingleMultiplicity<T>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  m_mult = 0;
-
-  const SiStripQuality* quality = nullptr;
-  if (m_useQuality) {
-    quality = &iSetup.getData(m_qualityToken);
+  template <class T1, class T2>
+  int MultiplicityPair<T1, T2>::mult1() const {
+    return m_multiplicity1.mult();
   }
 
-  edm::Handle<T> digis;
-  iEvent.getByToken(m_collection, digis);
-
-  for (typename T::const_iterator it = digis->begin(); it != digis->end(); it++) {
-    if (!m_useQuality || !quality->IsModuleBad(it->detId())) {
-      if (m_modthr < 0 || int(it->size()) < m_modthr) {
-        m_mult += it->size();
-        //      mult += it->size();
-      }
-    }
+  template <class T1, class T2>
+  int MultiplicityPair<T1, T2>::mult2() const {
+    return m_multiplicity2.mult();
   }
-}
-
-template <class T>
-int SingleMultiplicity<T>::mult() const {
-  return m_mult;
-}
-
-template <class T1, class T2>
-class MultiplicityPair {
-public:
-  MultiplicityPair();
-  MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
-  MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
-
-  void getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  int mult1() const;
-  int mult2() const;
-
-private:
-  T1 m_multiplicity1;
-  T2 m_multiplicity2;
-};
-
-template <class T1, class T2>
-MultiplicityPair<T1, T2>::MultiplicityPair() : m_multiplicity1(), m_multiplicity2() {}
-
-template <class T1, class T2>
-MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
-    : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
-      m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"), iC) {}
-template <class T1, class T2>
-MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
-    : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
-      m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"), iC) {}
-
-template <class T1, class T2>
-void MultiplicityPair<T1, T2>::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  m_multiplicity1.getEvent(iEvent, iSetup);
-  m_multiplicity2.getEvent(iEvent, iSetup);
-}
-
-template <class T1, class T2>
-int MultiplicityPair<T1, T2>::mult1() const {
-  return m_multiplicity1.mult();
-}
-
-template <class T1, class T2>
-int MultiplicityPair<T1, T2>::mult2() const {
-  return m_multiplicity2.mult();
-}
-
-typedef SingleMultiplicity<edm::DetSetVector<SiStripDigi> > SingleSiStripDigiMultiplicity;
-typedef SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > SingleSiStripClusterMultiplicity;
-typedef SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > SingleSiPixelClusterMultiplicity;
-typedef MultiplicityPair<SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> >,
-                         SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > >
-    SiPixelClusterSiStripClusterMultiplicityPair;
-typedef MultiplicityPair<ClusterSummarySingleMultiplicity, ClusterSummarySingleMultiplicity>
-    ClusterSummaryMultiplicityPair;
-
+}  // namespace sistriptools::values
 #endif  // DPGAnalysis_SiStripTools_Multiplicities_H

--- a/DPGAnalysis/SiStripTools/plugins/ByMultiplicityEventFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/ByMultiplicityEventFilter.cc
@@ -37,7 +37,7 @@
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
-#include "DPGAnalysis/SiStripTools/interface/Multiplicities.h"
+#include "MultiplicityAlgorithms.h"
 
 //
 // class declaration
@@ -55,7 +55,7 @@ private:
   // ----------member data ---------------------------
 
   T m_multiplicities;
-  StringCutObjectSelector<T> m_selector;
+  StringCutObjectSelector<typename T::value_t> m_selector;
   bool m_taggedMode, m_forcedValue;
 };
 
@@ -97,9 +97,9 @@ template <class T>
 bool ByMultiplicityEventFilter<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  m_multiplicities.getEvent(iEvent, iSetup);
+  auto mult = m_multiplicities.getEvent(iEvent, iSetup);
 
-  bool value = m_selector(m_multiplicities);
+  bool value = m_selector(mult);
   iEvent.put(std::make_unique<bool>(value));
 
   if (m_taggedMode)
@@ -114,6 +114,7 @@ typedef ByMultiplicityEventFilter<SingleMultiplicity<edmNew::DetSetVector<SiStri
 typedef ByMultiplicityEventFilter<SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > > BySiPixelClusterMultiplicityEventFilter;
 typedef ByMultiplicityEventFilter<MultiplicityPair<edmNew::DetSetVector<SiPixelCluster>,edmNew::DetSetVector<SiStripCluster> > > BySiPixelClusterVsSiStripClusterMultiplicityEventFilter;
 */
+using namespace sistriptools::algorithm;
 typedef ByMultiplicityEventFilter<SingleSiStripDigiMultiplicity> BySiStripDigiMultiplicityEventFilter;
 typedef ByMultiplicityEventFilter<SingleSiStripClusterMultiplicity> BySiStripClusterMultiplicityEventFilter;
 typedef ByMultiplicityEventFilter<SingleSiPixelClusterMultiplicity> BySiPixelClusterMultiplicityEventFilter;

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.cc
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.cc
@@ -1,41 +1,38 @@
-#include "DPGAnalysis/SiStripTools/interface/Multiplicities.h"
+#include "MultiplicityAlgorithms.h"
 
-ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity()
-    : m_subdetenum(ClusterSummary::STRIP), m_varenum(ClusterSummary::NCLUSTERS), m_mult(0), m_collection() {}
+using namespace sistriptools::algorithm;
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,
                                                                    edm::ConsumesCollector&& iC)
     : m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),
       m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-      m_mult(0),
       m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))) {}
 
 ClusterSummarySingleMultiplicity::ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig,
                                                                    edm::ConsumesCollector& iC)
     : m_subdetenum((ClusterSummary::CMSTracker)iConfig.getParameter<int>("subDetEnum")),
       m_varenum((ClusterSummary::VariablePlacement)iConfig.getParameter<int>("varEnum")),
-      m_mult(0),
       m_collection(iC.consumes<ClusterSummary>(iConfig.getParameter<edm::InputTag>("clusterSummaryCollection"))) {}
 
-void ClusterSummarySingleMultiplicity::getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  m_mult = 0;
+ClusterSummarySingleMultiplicity::value_t ClusterSummarySingleMultiplicity::getEvent(
+    const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  int mult = 0;
 
   edm::Handle<ClusterSummary> clustsumm;
   iEvent.getByToken(m_collection, clustsumm);
 
   switch (m_varenum) {
     case ClusterSummary::NCLUSTERS:
-      m_mult = int(clustsumm->getNClus(m_subdetenum));
+      mult = int(clustsumm->getNClus(m_subdetenum));
       break;
     case ClusterSummary::CLUSTERSIZE:
-      m_mult = int(clustsumm->getClusSize(m_subdetenum));
+      mult = int(clustsumm->getClusSize(m_subdetenum));
       break;
     case ClusterSummary::CLUSTERCHARGE:
-      m_mult = int(clustsumm->getClusCharge(m_subdetenum));
+      mult = int(clustsumm->getClusCharge(m_subdetenum));
       break;
     default:
-      m_mult = -1;
+      mult = -1;
   }
+  return value_t(mult);
 }
-
-int ClusterSummarySingleMultiplicity::mult() const { return m_mult; }

--- a/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.h
+++ b/DPGAnalysis/SiStripTools/plugins/MultiplicityAlgorithms.h
@@ -1,0 +1,151 @@
+#ifndef DPGAnalysis_SiStripTools_MultiplicityAlgorithms_H
+#define DPGAnalysis_SiStripTools_MultiplicityAlgorithms_H
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/DetSet.h"
+
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/TrackerCommon/interface/ClusterSummary.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+
+#include "DPGAnalysis/SiStripTools/interface/Multiplicities.h"
+
+namespace edm {
+  class EventSetup;
+};
+
+#include <string>
+
+namespace sistriptools::algorithm {
+  class ClusterSummarySingleMultiplicity {
+  public:
+    using value_t = values::Multiplicity;
+    ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
+    ClusterSummarySingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
+
+    value_t getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) const;
+
+  private:
+    ClusterSummary::CMSTracker m_subdetenum;
+    ClusterSummary::VariablePlacement m_varenum;
+    edm::EDGetTokenT<ClusterSummary> m_collection;
+  };
+
+  template <class T>
+  class SingleMultiplicity {
+  public:
+    using value_t = values::Multiplicity;
+    SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
+    SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
+
+    value_t getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) const;
+
+  private:
+    int m_modthr;
+    bool m_useQuality;
+    edm::ESGetToken<SiStripQuality, SiStripQualityRcd> m_qualityToken;
+    edm::EDGetTokenT<T> m_collection;
+  };
+
+  template <class T>
+  SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+      : m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
+        m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality", false)),
+        m_qualityToken(m_useQuality
+                           ? decltype(m_qualityToken){iC.esConsumes<SiStripQuality, SiStripQualityRcd>(
+                                 edm::ESInputTag{"", iConfig.getUntrackedParameter<std::string>("qualityLabel", "")})}
+                           : decltype(m_qualityToken){}),
+        m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))) {}
+  template <class T>
+  SingleMultiplicity<T>::SingleMultiplicity(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : m_modthr(iConfig.getUntrackedParameter<int>("moduleThreshold")),
+        m_useQuality(iConfig.getUntrackedParameter<bool>("useQuality", false)),
+        m_qualityToken(m_useQuality
+                           ? decltype(m_qualityToken){iC.esConsumes<SiStripQuality, SiStripQualityRcd>(
+                                 edm::ESInputTag(iConfig.getUntrackedParameter<std::string>("qualityLabel", "")))}
+                           : decltype(m_qualityToken){}),
+        m_collection(iC.consumes<T>(iConfig.getParameter<edm::InputTag>("collectionName"))) {}
+
+  template <class T>
+  typename SingleMultiplicity<T>::value_t SingleMultiplicity<T>::getEvent(const edm::Event& iEvent,
+                                                                          const edm::EventSetup& iSetup) const {
+    int mult = 0;
+
+    const SiStripQuality* quality = nullptr;
+    if (m_useQuality) {
+      quality = &iSetup.getData(m_qualityToken);
+    }
+
+    edm::Handle<T> digis;
+    iEvent.getByToken(m_collection, digis);
+
+    for (typename T::const_iterator it = digis->begin(); it != digis->end(); it++) {
+      if (!m_useQuality || !quality->IsModuleBad(it->detId())) {
+        if (m_modthr < 0 || int(it->size()) < m_modthr) {
+          mult += it->size();
+          //      mult += it->size();
+        }
+      }
+    }
+    return value_t(mult);
+  }
+
+  template <class T1, class T2>
+  class MultiplicityPair {
+  public:
+    using value_t = values::MultiplicityPair<typename T1::value_t, typename T2::value_t>;
+    MultiplicityPair();
+    MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
+    MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC);
+
+    value_t getEvent(const edm::Event& iEvent, const edm::EventSetup& iSetup) const;
+
+  private:
+    T1 m_multiplicity1;
+    T2 m_multiplicity2;
+  };
+
+  template <class T1, class T2>
+  MultiplicityPair<T1, T2>::MultiplicityPair() : m_multiplicity1(), m_multiplicity2() {}
+
+  template <class T1, class T2>
+  MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+      : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
+        m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"), iC) {}
+  template <class T1, class T2>
+  MultiplicityPair<T1, T2>::MultiplicityPair(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : m_multiplicity1(iConfig.getParameter<edm::ParameterSet>("firstMultiplicityConfig"), iC),
+        m_multiplicity2(iConfig.getParameter<edm::ParameterSet>("secondMultiplicityConfig"), iC) {}
+
+  template <class T1, class T2>
+  typename MultiplicityPair<T1, T2>::value_t MultiplicityPair<T1, T2>::getEvent(const edm::Event& iEvent,
+                                                                                const edm::EventSetup& iSetup) const {
+    auto m1 = m_multiplicity1.getEvent(iEvent, iSetup);
+    auto m2 = m_multiplicity2.getEvent(iEvent, iSetup);
+    return value_t(m1, m2);
+  }
+
+  typedef SingleMultiplicity<edm::DetSetVector<SiStripDigi> > SingleSiStripDigiMultiplicity;
+  typedef SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > SingleSiStripClusterMultiplicity;
+  typedef SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> > SingleSiPixelClusterMultiplicity;
+  typedef MultiplicityPair<SingleMultiplicity<edmNew::DetSetVector<SiPixelCluster> >,
+                           SingleMultiplicity<edmNew::DetSetVector<SiStripCluster> > >
+      SiPixelClusterSiStripClusterMultiplicityPair;
+  typedef MultiplicityPair<ClusterSummarySingleMultiplicity, ClusterSummarySingleMultiplicity>
+      ClusterSummaryMultiplicityPair;
+}  // namespace sistriptools::algorithm
+
+#endif  // DPGAnalysis_SiStripTools_Multiplicities_H

--- a/DPGAnalysis/SiStripTools/src/classes.h
+++ b/DPGAnalysis/SiStripTools/src/classes.h
@@ -8,27 +8,4 @@
 
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace DPGAnalysis_SiStripTools {
-  struct dictionary {
-    TinyEventCollection dummycoll;
-    SingleSiStripDigiMultiplicity dummy1;
-    SingleSiPixelClusterMultiplicity dummy2;
-    SingleSiStripClusterMultiplicity dummy3;
-    SiPixelClusterSiStripClusterMultiplicityPair dummy4;
-    ClusterSummarySingleMultiplicity dummy5;
-    ClusterSummaryMultiplicityPair dummy6;
-
-    edm::Wrapper<TinyEventCollection> dummywrappedcoll;
-    edm::Wrapper<EventWithHistory> dummywrappedEWH;
-    edm::Wrapper<APVCyclePhaseCollection> dummywrappedAPVC;
-
-    /*
-    edm::Wrapper<SingleSiStripDigiMultiplicity> dummywrapped1;
-    edm::Wrapper<SingleSiStripClusterMultiplicity> dummywrapped2;
-    edm::Wrapper<SingleSiPixelClusterMultiplicity> dummywrapped3;
-    edm::Wrapper<SiPixelClusterSiStripClusterMultiplicityPair> dummywrapped4;
-    */
-  };
-}  // namespace DPGAnalysis_SiStripTools
-
 #endif  // DPGAnalysis_SiStripTools_classes_H

--- a/DPGAnalysis/SiStripTools/src/classes_def.xml
+++ b/DPGAnalysis/SiStripTools/src/classes_def.xml
@@ -4,12 +4,8 @@
   <class name="std::vector<TinyEvent>" persistent="false"/>
   <class name="EventWithHistory" persistent="false"/>
   <class name="APVCyclePhaseCollection" persistent="false"/>
-  <class name="SingleSiStripDigiMultiplicity" persistent="false"/>
-  <class name="SingleSiStripClusterMultiplicity" persistent="false"/>
-  <class name="SingleSiPixelClusterMultiplicity" persistent="false"/>
-  <class name="SiPixelClusterSiStripClusterMultiplicityPair" persistent="false"/>
-  <class name="ClusterSummarySingleMultiplicity" persistent="false"/>
-  <class name="ClusterSummaryMultiplicityPair" persistent="false"/>
+  <class name="sistriptools::values::Multiplicity" persistent="false"/>
+  <class name="sistriptools::values::MultiplicityPair<sistriptools::values::Multiplicity, sistriptools::values::Multiplicity>" persistent="false"/>
 
   <class name="edm::Wrapper<std::vector<TinyEvent> >" persistent="false"/>
   <class name="edm::Wrapper<EventWithHistory>" persistent="false"/>


### PR DESCRIPTION
#### PR description:

- separate classes that do the calculation from those that hold the results
- Use ROOT dictionaries only for results to avoid causing additional auto parsing.

#### PR validation:

Code compiles.