### PR TITLE
Improve module type resolver system so that it would be usable for Alpaka modules

### DIFF
--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -36,7 +36,7 @@
 
 // forward declarations
 namespace edm {
-  class ModuleTypeResolverBase;
+  class ModuleTypeResolverMaker;
 
   namespace eventsetup {
     class EventSetupProvider;
@@ -55,15 +55,15 @@ namespace edm {
       std::shared_ptr<base_type> addTo(EventSetupsController& esController,
                                        EventSetupProvider& iProvider,
                                        edm::ParameterSet& iConfiguration,
-                                       ModuleTypeResolverBase const* resolver,
+                                       ModuleTypeResolverMaker const* resolverMaker,
                                        bool replaceExisting = false) const {
         std::string modtype = iConfiguration.template getParameter<std::string>("@module_type");
         //cerr << "Factory: module_type = " << modtype << endl;
         typename MakerMap::iterator it = makers_.find(modtype);
 
         if (it == makers_.end()) {
-          std::shared_ptr<Maker> wm(
-              detail::resolveMaker<edmplugin::PluginFactory<ComponentMakerBase<T>*()>>(modtype, resolver));
+          std::shared_ptr<Maker> wm(detail::resolveMaker<edmplugin::PluginFactory<ComponentMakerBase<T>*()>>(
+              modtype, resolverMaker, iConfiguration));
 
           //cerr << "Factory: created the worker" << endl;
 

--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -49,7 +49,7 @@ namespace edm {
       //~ComponentFactory();
 
       typedef ComponentMakerBase<T> Maker;
-      typedef std::map<std::string, std::shared_ptr<Maker>> MakerMap;
+      typedef std::map<std::string, std::shared_ptr<Maker const>> MakerMap;
       typedef typename T::base_type base_type;
       // ---------- const member functions ---------------------
       std::shared_ptr<base_type> addTo(EventSetupsController& esController,
@@ -60,7 +60,7 @@ namespace edm {
         std::string modtype = iConfiguration.template getParameter<std::string>("@module_type");
         //cerr << "Factory: module_type = " << modtype << endl;
         typename MakerMap::iterator it = makers_.find(modtype);
-        Maker* maker = nullptr;
+        Maker const* maker = nullptr;
 
         if (it == makers_.end()) {
           maker = detail::resolveMaker<edmplugin::PluginFactory<ComponentMakerBase<T>*()>>(

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -59,6 +59,7 @@ namespace edm {
   class LuminosityBlockProcessingStatus;
   class RunProcessingStatus;
   class IOVSyncValue;
+  class ModuleTypeResolverMaker;
 
   namespace eventsetup {
     class EventSetupProvider;
@@ -311,6 +312,7 @@ namespace edm {
     ServiceToken serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
     InputSource::ItemType lastSourceTransition_ = InputSource::IsInvalid;
+    edm::propagate_const<std::unique_ptr<ModuleTypeResolverMaker const>> moduleTypeResolverMaker_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::SerialTaskQueue queueWhichWaitsForIOVsToFinish_;

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -32,7 +32,7 @@ namespace edm {
   class EventSetupImpl;
   class EventSetupRecordIntervalFinder;
   class IOVSyncValue;
-  class ModuleTypeResolverBase;
+  class ModuleTypeResolverMaker;
   class ParameterSet;
 
   namespace eventsetup {
@@ -90,7 +90,7 @@ namespace edm {
       void forceCacheClear();
 
       void checkESProducerSharing(
-          ModuleTypeResolverBase const* resolver,
+          ModuleTypeResolverMaker const* resolverMaker,
           EventSetupProvider& precedingESProvider,
           std::set<ParameterSetIDHolder>& sharingCheckDone,
           std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers,

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -34,7 +34,7 @@ namespace edm {
   class EventSetupRecordIntervalFinder;
   class ParameterSet;
   class IOVSyncValue;
-  class ModuleTypeResolverBase;
+  class ModuleTypeResolverMaker;
   class ServiceToken;
   class WaitingTaskHolder;
   class WaitingTaskList;
@@ -82,7 +82,7 @@ namespace edm {
     class EventSetupsController {
     public:
       EventSetupsController();
-      explicit EventSetupsController(ModuleTypeResolverBase const* resolver);
+      explicit EventSetupsController(ModuleTypeResolverMaker const* resolverMaker);
 
       EventSetupsController(EventSetupsController const&) = delete;
       EventSetupsController const& operator=(EventSetupsController const&) = delete;
@@ -201,7 +201,7 @@ namespace edm {
       std::multimap<ParameterSetID, ESProducerInfo> esproducers_;
       std::multimap<ParameterSetID, ESSourceInfo> essources_;
 
-      ModuleTypeResolverBase const* typeResolver_ = nullptr;
+      ModuleTypeResolverMaker const* typeResolverMaker_ = nullptr;
 
       bool hasNonconcurrentFinder_ = false;
       bool mustFinishConfiguration_ = true;

--- a/FWCore/Framework/interface/ModuleRegistry.h
+++ b/FWCore/Framework/interface/ModuleRegistry.h
@@ -41,7 +41,7 @@ namespace edm {
   class ModuleRegistry {
   public:
     ModuleRegistry() = default;
-    explicit ModuleRegistry(std::unique_ptr<ModuleTypeResolverMaker>);
+    explicit ModuleRegistry(ModuleTypeResolverMaker const* resolverMaker) : typeResolverMaker_(resolverMaker) {}
     std::shared_ptr<maker::ModuleHolder> getModule(MakeModuleParams const& p,
                                                    std::string const& moduleLabel,
                                                    signalslot::Signal<void(ModuleDescription const&)>& iPre,
@@ -65,7 +65,7 @@ namespace edm {
 
   private:
     std::map<std::string, edm::propagate_const<std::shared_ptr<maker::ModuleHolder>>> labelToModule_;
-    std::unique_ptr<ModuleTypeResolverMaker> typeResolverMaker_;
+    ModuleTypeResolverMaker const* typeResolverMaker_;
   };
 }  // namespace edm
 

--- a/FWCore/Framework/interface/ModuleRegistry.h
+++ b/FWCore/Framework/interface/ModuleRegistry.h
@@ -26,7 +26,7 @@
 // user include files
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
-#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
 
 // forward declarations
 namespace edm {
@@ -41,7 +41,7 @@ namespace edm {
   class ModuleRegistry {
   public:
     ModuleRegistry() = default;
-    explicit ModuleRegistry(std::unique_ptr<ModuleTypeResolverBase>);
+    explicit ModuleRegistry(std::unique_ptr<ModuleTypeResolverMaker>);
     std::shared_ptr<maker::ModuleHolder> getModule(MakeModuleParams const& p,
                                                    std::string const& moduleLabel,
                                                    signalslot::Signal<void(ModuleDescription const&)>& iPre,
@@ -65,7 +65,7 @@ namespace edm {
 
   private:
     std::map<std::string, edm::propagate_const<std::shared_ptr<maker::ModuleHolder>>> labelToModule_;
-    std::unique_ptr<ModuleTypeResolverBase> typeResolver_;
+    std::unique_ptr<ModuleTypeResolverMaker> typeResolverMaker_;
   };
 }  // namespace edm
 

--- a/FWCore/Framework/interface/ModuleTypeResolverBase.h
+++ b/FWCore/Framework/interface/ModuleTypeResolverBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <memory>
 #include <string>
 
 // user include files
@@ -35,7 +36,7 @@ namespace edm {
        to kInitialIndex. The int returned from the function is the new index to use on next call or is a value of kLastIndex which
        means no further calls should be made. The returned string is the next concrete type to be used when making a call.
        On subsequent call, the argument basename can be the same string as returned from the previous call to the function.
-        **/
+    **/
     virtual std::pair<std::string, int> resolveType(std::string basename, int index) const = 0;
   };
 }  // namespace edm

--- a/FWCore/Framework/interface/ModuleTypeResolverMaker.h
+++ b/FWCore/Framework/interface/ModuleTypeResolverMaker.h
@@ -1,0 +1,44 @@
+#ifndef FWCore_Framework_ModuleTypeResolverMaker_h
+#define FWCore_Framework_ModuleTypeResolverMaker_h
+
+#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+
+namespace edm {
+  class ParameterSet;
+
+  /**
+   * This class hierarchy implements an abstract factory pattern for
+   * the creation of module type resolver objects (derived from
+   * ModuleTypeResolverBase). This pattern allows the use of
+   * information in the module PSet in the module type resolver in a
+   * way that the PSet is parsed only once per module instance.
+   *
+   * Per-module setting is useful e.g. in the Alpaka use case to be
+   * able to set the Alpaka backend separately for each module. This
+   * ability is useful to have e.g. automatically-selected modules and
+   * modules set to explicitly use a host backend in the same job for
+   * physics comparisons, or for testing.
+   *
+   * A derived class of this abstract base class is meant to be owned
+   * by the EventProcessor (or equivalent). The concrete object can be
+   * created with a plugin factory (in case of EventProcessor the
+   * plugin name comes from the configuration). The class provides a
+   * factory function to create a concrete ModuleTypeResolverBase
+   * object based on the module PSet.
+   */
+  class ModuleTypeResolverMaker {
+  public:
+    virtual ~ModuleTypeResolverMaker() = default;
+
+    /**
+     * This function creates an implementation of the ModuleTypeResolverBase class based on the module PSet.
+     *
+     * The return value reflects that the implementation
+     * ModuleTypeResolverMaker may cache the ModuleTypeResolverBase objects if it
+     * wants to.
+     */
+    virtual std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const& modulePSet) const = 0;
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h
+++ b/FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h
@@ -1,0 +1,15 @@
+#ifndef FWCore_Framework_itnerface_ModuleTypeResolverFactory_h
+#define FWCore_Framework_itnerface_ModuleTypeResolverFactory_h
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+  class ModuleTypeResolverMaker;
+
+  using ModuleTypeResolverMakerFactory = edmplugin::PluginFactory<ModuleTypeResolverMaker const*()>;
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -113,6 +113,7 @@ namespace edm {
   class GlobalSchedule;
   struct TriggerTimingReport;
   class ModuleRegistry;
+  class ModuleTypeResolverMaker;
   class ThinnedAssociationsHelper;
   class SubProcessParentageHelper;
   class TriggerResultInserter;
@@ -135,7 +136,8 @@ namespace edm {
              std::shared_ptr<ActivityRegistry> areg,
              std::shared_ptr<ProcessConfiguration const> processConfiguration,
              PreallocationConfiguration const& config,
-             ProcessContext const* processContext);
+             ProcessContext const* processContext,
+             ModuleTypeResolverMaker const* resolverMaker);
     void finishSetup(ParameterSet& proc_pset,
                      service::TriggerNamesService const& tns,
                      ProductRegistry& preg,

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -26,6 +26,7 @@ namespace edm {
   class StreamID;
   class PreallocationConfiguration;
   class SubProcessParentageHelper;
+  class ModuleTypeResolverMaker;
   namespace service {
     class TriggerNamesService;
   }
@@ -55,6 +56,7 @@ namespace edm {
                                            bool hasSubprocesses,
                                            PreallocationConfiguration const& iAllocConfig,
                                            ProcessContext const*,
+                                           ModuleTypeResolverMaker const*,
                                            ProcessBlockHelperBase& processBlockHelper);
 
     class MadeModules {
@@ -70,7 +72,8 @@ namespace edm {
     MadeModules initModules(ParameterSet& parameterSet,
                             service::TriggerNamesService const& tns,
                             PreallocationConfiguration const& iAllocConfig,
-                            ProcessContext const*);
+                            ProcessContext const*,
+                            ModuleTypeResolverMaker const* typeResolverMaker);
     std::unique_ptr<Schedule> finishSchedule(MadeModules,
                                              ParameterSet& parameterSet,
                                              service::TriggerNamesService const& tns,

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -36,6 +36,7 @@ namespace edm {
   class LuminosityBlockPrincipal;
   class LumiTransitionInfo;
   class MergeableRunProductMetadata;
+  class ModuleTypeResolverMaker;
   class ParameterSet;
   class Principal;
   class ProcessBlockTransitionInfo;
@@ -63,7 +64,8 @@ namespace edm {
                ServiceToken const& token,
                serviceregistry::ServiceLegacy iLegacy,
                PreallocationConfiguration const& preallocConfig,
-               ProcessContext const* parentProcessContext);
+               ProcessContext const* parentProcessContext,
+               ModuleTypeResolverMaker const* typeResolverMaker);
 
     ~SubProcess() override;
 

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -29,6 +29,7 @@ namespace edm {
   class StreamID;
   class StreamContext;
   class ModuleRegistry;
+  class ModuleTypeResolverMaker;
   class PreallocationConfiguration;
   namespace eventsetup {
     class ESRecordsToProxyIndices;
@@ -37,7 +38,9 @@ namespace edm {
   public:
     typedef std::vector<Worker*> AllWorkers;
 
-    WorkerManager(std::shared_ptr<ActivityRegistry> actReg, ExceptionToActionTable const& actions);
+    WorkerManager(std::shared_ptr<ActivityRegistry> actReg,
+                  ExceptionToActionTable const& actions,
+                  ModuleTypeResolverMaker const* typeResolverMaker);
     WorkerManager(WorkerManager&&) = default;
 
     WorkerManager(std::shared_ptr<ModuleRegistry> modReg,

--- a/FWCore/Framework/interface/WorkerRegistry.h
+++ b/FWCore/Framework/interface/WorkerRegistry.h
@@ -22,6 +22,7 @@ namespace edm {
   class ActivityRegistry;
   struct WorkerParams;
   class ModuleRegistry;
+  class ModuleTypeResolverMaker;
   class ParameterSet;
   namespace maker {
     class ModuleHolder;
@@ -37,7 +38,7 @@ namespace edm {
 
   class WorkerRegistry {
   public:
-    explicit WorkerRegistry(std::shared_ptr<ActivityRegistry> areg);
+    explicit WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, ModuleTypeResolverMaker const* resolverMaker);
     WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, std::shared_ptr<ModuleRegistry> iModReg);
     ~WorkerRegistry();
 

--- a/FWCore/Framework/interface/makeModuleTypeResolverMaker.h
+++ b/FWCore/Framework/interface/makeModuleTypeResolverMaker.h
@@ -1,0 +1,14 @@
+#ifndef FWCore_Framework_makeModuleTypeResolverMaker_h
+#define FWCore_Framework_makeModuleTypeResolverMaker_h
+
+#include <memory>
+
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
+
+namespace edm {
+  class ParameterSet;
+
+  std::unique_ptr<edm::ModuleTypeResolverMaker const> makeModuleTypeResolverMaker(edm::ParameterSet const& pset);
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/interface/resolveMaker.h
+++ b/FWCore/Framework/interface/resolveMaker.h
@@ -20,7 +20,7 @@ namespace edm::detail {
   auto resolveMaker(std::string const& moduleType,
                     ModuleTypeResolverMaker const* resolverMaker,
                     edm::ParameterSet const& modulePSet,
-                    TCache& makerCache) -> typename TCache::mapped_type::element_type* {
+                    TCache& makerCache) -> typename TCache::mapped_type::element_type const* {
     if (resolverMaker) {
       auto resolver = resolverMaker->makeResolver(modulePSet);
       auto index = resolver->kInitialIndex;

--- a/FWCore/Framework/interface/resolveMaker.h
+++ b/FWCore/Framework/interface/resolveMaker.h
@@ -2,6 +2,7 @@
 #define FWCore_Framework_interface_resolveMaker_h
 
 #include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <memory>
@@ -13,8 +14,11 @@ namespace edm::detail {
                                                 ModuleTypeResolverBase const* resolver);
 
   template <typename TFactory>
-  auto resolveMaker(std::string const& moduleType, ModuleTypeResolverBase const* resolver) {
-    if (resolver) {
+  auto resolveMaker(std::string const& moduleType,
+                    ModuleTypeResolverMaker const* resolverMaker,
+                    edm::ParameterSet const& modulePSet) {
+    if (resolverMaker) {
+      auto resolver = resolverMaker->makeResolver(modulePSet);
       auto index = resolver->kInitialIndex;
       auto newType = moduleType;
       do {
@@ -30,7 +34,7 @@ namespace edm::detail {
         //failed to find a plugin
         return TFactory::get()->create(moduleType);
       } catch (cms::Exception& iExcept) {
-        detail::annotateResolverMakerExceptionAndRethrow(iExcept, moduleType, resolver);
+        detail::annotateResolverMakerExceptionAndRethrow(iExcept, moduleType, resolver.get());
       }
     }
     return TFactory::get()->create(moduleType);

--- a/FWCore/Framework/interface/resolveMaker.h
+++ b/FWCore/Framework/interface/resolveMaker.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
 #include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
+#include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <memory>
@@ -13,10 +14,13 @@ namespace edm::detail {
                                                 std::string const& modtype,
                                                 ModuleTypeResolverBase const* resolver);
 
-  template <typename TFactory>
+  // Returns a non-owning pointer to the maker. Can be nullptr if
+  // failed to insert the maker to the cache
+  template <typename TFactory, typename TCache>
   auto resolveMaker(std::string const& moduleType,
                     ModuleTypeResolverMaker const* resolverMaker,
-                    edm::ParameterSet const& modulePSet) {
+                    edm::ParameterSet const& modulePSet,
+                    TCache& makerCache) -> typename TCache::mapped_type::element_type* {
     if (resolverMaker) {
       auto resolver = resolverMaker->makeResolver(modulePSet);
       auto index = resolver->kInitialIndex;
@@ -25,19 +29,38 @@ namespace edm::detail {
         auto [ttype, tindex] = resolver->resolveType(std::move(newType), index);
         newType = std::move(ttype);
         index = tindex;
+        // try the maker cache first
+        auto found = makerCache.find(newType);
+        if (found != makerCache.end()) {
+          return found->second.get();
+        }
+
+        // if not in cache, then try to create
         auto m = TFactory::get()->tryToCreate(newType);
         if (m) {
-          return m;
+          //FDEBUG(1) << "Factory:  created worker of type " << newType << std::endl;
+          auto [it, succeeded] = makerCache.emplace(newType, std::move(m));
+          if (not succeeded) {
+            return nullptr;
+          }
+          return it->second.get();
         }
+        // not found, try next one
       } while (index != resolver->kLastIndex);
       try {
         //failed to find a plugin
-        return TFactory::get()->create(moduleType);
+        auto m = TFactory::get()->create(moduleType);
+        return nullptr;  // dummy return, the create() call throws an exception
       } catch (cms::Exception& iExcept) {
         detail::annotateResolverMakerExceptionAndRethrow(iExcept, moduleType, resolver.get());
       }
     }
-    return TFactory::get()->create(moduleType);
+    auto [it, succeeded] = makerCache.emplace(moduleType, TFactory::get()->create(moduleType));
+    //FDEBUG(1) << "Factory:  created worker of type " << moduleType << std::endl;
+    if (not succeeded) {
+      return nullptr;
+    }
+    return it->second.get();
   }
 }  // namespace edm::detail
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -40,6 +40,7 @@
 #include "FWCore/Framework/interface/ensureAvailableAccelerators.h"
 #include "FWCore/Framework/interface/globalTransitionAsync.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
 #include "FWCore/Framework/src/SendSourceTerminationSignalIfException.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -108,6 +109,14 @@ namespace {
   private:
     edm::SerialTaskQueue& queue_;
   };
+
+  std::unique_ptr<edm::ModuleTypeResolverMaker const> makeModuleTypeResolverMaker(edm::ParameterSet const& pset) {
+    auto const& name = pset.getUntrackedParameter<std::string>("@module_type_resolver");
+    if (name.empty()) {
+      return nullptr;
+    }
+    return edm::ModuleTypeResolverMakerFactory::get()->create(name);
+  }
 }  // namespace
 
 namespace edm {
@@ -220,7 +229,8 @@ namespace edm {
         branchIDListHelper_(),
         serviceToken_(),
         input_(),
-        espController_(new eventsetup::EventSetupsController),
+        moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*parameterSet)),
+        espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
         act_table_(),
         processConfiguration_(),
@@ -256,7 +266,8 @@ namespace edm {
         branchIDListHelper_(),
         serviceToken_(),
         input_(),
-        espController_(new eventsetup::EventSetupsController),
+        moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*parameterSet)),
+        espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
         act_table_(),
         processConfiguration_(),
@@ -292,7 +303,8 @@ namespace edm {
         branchIDListHelper_(),
         serviceToken_(),
         input_(),
-        espController_(new eventsetup::EventSetupsController),
+        moduleTypeResolverMaker_(makeModuleTypeResolverMaker(*processDesc->getProcessPSet())),
+        espController_(std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get())),
         esp_(),
         act_table_(),
         processConfiguration_(),

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -501,7 +501,8 @@ namespace edm {
           // initialize the Schedule
           ServiceRegistry::Operate operate(serviceToken_);
           auto const& tns = ServiceRegistry::instance().get<service::TriggerNamesService>();
-          madeModules = items.initModules(*parameterSet, tns, preallocations_, &processContext_);
+          madeModules =
+              items.initModules(*parameterSet, tns, preallocations_, &processContext_, moduleTypeResolverMaker_.get());
         });
 
         group.run([&, this, tempReg]() {
@@ -595,7 +596,8 @@ namespace edm {
                                    token,
                                    serviceregistry::kConfigurationOverrides,
                                    preallocations_,
-                                   &processContext_);
+                                   &processContext_,
+                                   moduleTypeResolverMaker_);
       }
     } catch (...) {
       //in case of an exception, make sure Services are available

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/MergeableRunProductMetadata.h"
 #include "FWCore/Framework/interface/ModuleChanger.h"
+#include "FWCore/Framework/interface/makeModuleTypeResolverMaker.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
@@ -40,7 +41,6 @@
 #include "FWCore/Framework/interface/ensureAvailableAccelerators.h"
 #include "FWCore/Framework/interface/globalTransitionAsync.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
-#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
 #include "FWCore/Framework/src/SendSourceTerminationSignalIfException.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -109,14 +109,6 @@ namespace {
   private:
     edm::SerialTaskQueue& queue_;
   };
-
-  std::unique_ptr<edm::ModuleTypeResolverMaker const> makeModuleTypeResolverMaker(edm::ParameterSet const& pset) {
-    auto const& name = pset.getUntrackedParameter<std::string>("@module_type_resolver");
-    if (name.empty()) {
-      return nullptr;
-    }
-    return edm::ModuleTypeResolverMakerFactory::get()->create(name);
-  }
 }  // namespace
 
 namespace edm {

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -394,7 +394,7 @@ namespace edm {
     }
 
     void EventSetupProvider::checkESProducerSharing(
-        ModuleTypeResolverBase const* resolver,
+        ModuleTypeResolverMaker const* resolverMaker,
         EventSetupProvider& precedingESProvider,
         std::set<ParameterSetIDHolder>& sharingCheckDone,
         std::map<EventSetupRecordKey, std::vector<ComponentDescription const*>>& referencedESProducers,
@@ -531,7 +531,7 @@ namespace edm {
         } else {
           if (esController.isLastMatch(psetID, subProcessIndex_, precedingESProvider.subProcessIndex_)) {
             ParameterSet& pset = esController.getESProducerPSet(psetID, subProcessIndex_);
-            ModuleFactory::get()->addTo(esController, *this, pset, resolver, true);
+            ModuleFactory::get()->addTo(esController, *this, pset, resolverMaker, true);
           }
         }
       }

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -90,7 +90,7 @@ namespace edm {
     }
 
     // ---------------------------------------------------------------
-    void fillEventSetupProvider(ModuleTypeResolverBase const* resolver,
+    void fillEventSetupProvider(ModuleTypeResolverMaker const* resolverMaker,
                                 EventSetupsController& esController,
                                 EventSetupProvider& cp,
                                 ParameterSet& params) {
@@ -100,7 +100,7 @@ namespace edm {
            itName != itNameEnd;
            ++itName) {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
-        ModuleFactory::get()->addTo(esController, cp, *providerPSet, resolver);
+        ModuleFactory::get()->addTo(esController, cp, *providerPSet, resolverMaker);
       }
 
       std::vector<std::string> sources = params.getParameter<std::vector<std::string> >("@all_essources");
@@ -108,7 +108,7 @@ namespace edm {
       for (std::vector<std::string>::iterator itName = sources.begin(), itNameEnd = sources.end(); itName != itNameEnd;
            ++itName) {
         ParameterSet* providerPSet = params.getPSetForUpdate(*itName);
-        SourceFactory::get()->addTo(esController, cp, *providerPSet, resolver);
+        SourceFactory::get()->addTo(esController, cp, *providerPSet, resolverMaker);
       }
     }
   }  // namespace eventsetup

--- a/FWCore/Framework/src/EventSetupProviderMaker.h
+++ b/FWCore/Framework/src/EventSetupProviderMaker.h
@@ -7,7 +7,7 @@
 // forward declarations
 namespace edm {
   class ActivityRegistry;
-  class ModuleTypeResolverBase;
+  class ModuleTypeResolverMaker;
   class ParameterSet;
   namespace eventsetup {
     class EventSetupProvider;
@@ -17,7 +17,7 @@ namespace edm {
                                                                unsigned subProcessIndex,
                                                                ActivityRegistry*);
 
-    void fillEventSetupProvider(ModuleTypeResolverBase const* resolver,
+    void fillEventSetupProvider(ModuleTypeResolverMaker const* resolverMaker,
                                 EventSetupsController& esController,
                                 EventSetupProvider& cp,
                                 ParameterSet& params);

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -39,7 +39,8 @@ namespace edm {
   namespace eventsetup {
 
     EventSetupsController::EventSetupsController() {}
-    EventSetupsController::EventSetupsController(ModuleTypeResolverBase const* resolver) : typeResolver_(resolver) {}
+    EventSetupsController::EventSetupsController(ModuleTypeResolverMaker const* resolverMaker)
+        : typeResolverMaker_(resolverMaker) {}
 
     void EventSetupsController::endIOVsAsync(edm::WaitingTaskHolder iEndTask) {
       for (auto& eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
@@ -61,7 +62,7 @@ namespace edm {
       // Construct the ESProducers and ESSources
       // shared_ptrs to them are temporarily stored in this
       // EventSetupsController and in the EventSetupProvider
-      fillEventSetupProvider(typeResolver_, *this, *returnValue, iPSet);
+      fillEventSetupProvider(typeResolverMaker_, *this, *returnValue, iPSet);
 
       numberOfConcurrentIOVs_.readConfigurationParameters(eventSetupPset, maxConcurrentIOVs, dumpOptions);
 
@@ -430,7 +431,7 @@ namespace edm {
         for (auto precedingESProvider = providers_.begin(); precedingESProvider != esProvider; ++precedingESProvider) {
           (*esProvider)
               ->checkESProducerSharing(
-                  typeResolver_, **precedingESProvider, sharingCheckDone, referencedESProducers, *this);
+                  typeResolverMaker_, **precedingESProvider, sharingCheckDone, referencedESProducers, *this);
         }
 
         (*esProvider)->resetRecordToProxyPointers();

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/src/Factory.h"
 #include "FWCore/Framework/interface/maker/MakerPluginFactory.h"
-#include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
 #include "FWCore/Framework/interface/resolveMaker.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -20,13 +20,13 @@ namespace edm {
 
   Factory const* Factory::get() { return &singleInstance_; }
 
-  Maker* Factory::findMaker(const MakeModuleParams& p, ModuleTypeResolverBase const* resolver) const {
+  Maker* Factory::findMaker(const MakeModuleParams& p, ModuleTypeResolverMaker const* resolverMaker) const {
     std::string modtype = p.pset_->getParameter<std::string>("@module_type");
     FDEBUG(1) << "Factory: module_type = " << modtype << std::endl;
     MakerMap::iterator it = makers_.find(modtype);
 
     if (it == makers_.end()) {
-      std::unique_ptr<Maker> wm = detail::resolveMaker<MakerPluginFactory>(modtype, resolver);
+      std::unique_ptr<Maker> wm = detail::resolveMaker<MakerPluginFactory>(modtype, resolverMaker, *p.pset_);
       FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
 
       std::pair<MakerMap::iterator, bool> ret = makers_.insert({modtype, std::move(wm)});
@@ -38,10 +38,10 @@ namespace edm {
 
   std::shared_ptr<maker::ModuleHolder> Factory::makeModule(
       const MakeModuleParams& p,
-      const ModuleTypeResolverBase* resolver,
+      const ModuleTypeResolverMaker* resolverMaker,
       signalslot::Signal<void(const ModuleDescription&)>& pre,
       signalslot::Signal<void(const ModuleDescription&)>& post) const {
-    auto maker = findMaker(p, resolver);
+    auto maker = findMaker(p, resolverMaker);
     auto mod(maker->makeModule(p, pre, post));
     return mod;
   }

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -20,7 +20,7 @@ namespace edm {
 
   Factory const* Factory::get() { return &singleInstance_; }
 
-  Maker* Factory::findMaker(const MakeModuleParams& p, ModuleTypeResolverMaker const* resolverMaker) const {
+  Maker const* Factory::findMaker(const MakeModuleParams& p, ModuleTypeResolverMaker const* resolverMaker) const {
     std::string modtype = p.pset_->getParameter<std::string>("@module_type");
     FDEBUG(1) << "Factory: module_type = " << modtype << std::endl;
     MakerMap::iterator it = makers_.find(modtype);

--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -24,16 +24,10 @@ namespace edm {
     std::string modtype = p.pset_->getParameter<std::string>("@module_type");
     FDEBUG(1) << "Factory: module_type = " << modtype << std::endl;
     MakerMap::iterator it = makers_.find(modtype);
-
-    if (it == makers_.end()) {
-      std::unique_ptr<Maker> wm = detail::resolveMaker<MakerPluginFactory>(modtype, resolverMaker, *p.pset_);
-      FDEBUG(1) << "Factory:  created worker of type " << modtype << std::endl;
-
-      std::pair<MakerMap::iterator, bool> ret = makers_.insert({modtype, std::move(wm)});
-
-      it = ret.first;
+    if (it != makers_.end()) {
+      return it->second.get();
     }
-    return it->second;
+    return detail::resolveMaker<MakerPluginFactory>(modtype, resolverMaker, *p.pset_, makers_);
   }
 
   std::shared_ptr<maker::ModuleHolder> Factory::makeModule(

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -13,7 +13,7 @@
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 namespace edm {
-  class ModuleTypeResolverBase;
+  class ModuleTypeResolverMaker;
 
   class Factory {
   public:
@@ -25,7 +25,7 @@ namespace edm {
 
     //This function is not const-thread safe
     std::shared_ptr<maker::ModuleHolder> makeModule(const MakeModuleParams&,
-                                                    const ModuleTypeResolverBase*,
+                                                    const ModuleTypeResolverMaker*,
                                                     signalslot::Signal<void(const ModuleDescription&)>& pre,
                                                     signalslot::Signal<void(const ModuleDescription&)>& post) const;
 
@@ -33,7 +33,7 @@ namespace edm {
 
   private:
     Factory();
-    Maker* findMaker(const MakeModuleParams& p, const ModuleTypeResolverBase*) const;
+    Maker* findMaker(const MakeModuleParams& p, const ModuleTypeResolverMaker*) const;
     static Factory const singleInstance_;
     //It is not safe to create modules across threads
     CMS_SA_ALLOW mutable MakerMap makers_;

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -17,7 +17,7 @@ namespace edm {
 
   class Factory {
   public:
-    typedef std::map<std::string, edm::propagate_const<std::unique_ptr<Maker>>> MakerMap;
+    typedef std::map<std::string, std::unique_ptr<Maker const>> MakerMap;
 
     ~Factory();
 
@@ -33,7 +33,7 @@ namespace edm {
 
   private:
     Factory();
-    Maker* findMaker(const MakeModuleParams& p, const ModuleTypeResolverMaker*) const;
+    Maker const* findMaker(const MakeModuleParams& p, const ModuleTypeResolverMaker*) const;
     static Factory const singleInstance_;
     //It is not safe to create modules across threads
     CMS_SA_ALLOW mutable MakerMap makers_;

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -24,7 +24,7 @@ namespace edm {
       signalslot::Signal<void(ModuleDescription const&)>& iPost) {
     auto modItr = labelToModule_.find(moduleLabel);
     if (modItr == labelToModule_.end()) {
-      auto modPtr = Factory::get()->makeModule(p, typeResolverMaker_.get(), iPre, iPost);
+      auto modPtr = Factory::get()->makeModule(p, typeResolverMaker_, iPre, iPost);
 
       // Transfer ownership of worker to the registry
       labelToModule_[moduleLabel] = modPtr;

--- a/FWCore/Framework/src/ModuleRegistry.cc
+++ b/FWCore/Framework/src/ModuleRegistry.cc
@@ -24,7 +24,7 @@ namespace edm {
       signalslot::Signal<void(ModuleDescription const&)>& iPost) {
     auto modItr = labelToModule_.find(moduleLabel);
     if (modItr == labelToModule_.end()) {
-      auto modPtr = Factory::get()->makeModule(p, typeResolver_.get(), iPre, iPost);
+      auto modPtr = Factory::get()->makeModule(p, typeResolverMaker_.get(), iPre, iPost);
 
       // Transfer ownership of worker to the registry
       labelToModule_[moduleLabel] = modPtr;

--- a/FWCore/Framework/src/ModuleTypeResolverFactoryMaker.cc
+++ b/FWCore/Framework/src/ModuleTypeResolverFactoryMaker.cc
@@ -1,0 +1,3 @@
+#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
+
+EDM_REGISTER_PLUGINFACTORY(edm::ModuleTypeResolverMakerFactory, "CMS EDM Framework Module Type Resolver Maker");

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -490,12 +490,13 @@ namespace edm {
                      std::shared_ptr<ActivityRegistry> areg,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
                      PreallocationConfiguration const& prealloc,
-                     ProcessContext const* processContext)
+                     ProcessContext const* processContext,
+                     ModuleTypeResolverMaker const* resolverMaker)
       :  //Only create a resultsInserter if there is a trigger path
         resultsInserter_{tns.getTrigPaths().empty()
                              ? std::shared_ptr<TriggerResultInserter>{}
                              : makeInserter(proc_pset, prealloc, preg, actions, areg, processConfiguration)},
-        moduleRegistry_(new ModuleRegistry()),
+        moduleRegistry_(std::make_shared<ModuleRegistry>(resolverMaker)),
         all_output_communicators_(),
         preallocConfig_(prealloc),
         pathNames_(&tns.getTrigPaths()),

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -147,10 +147,18 @@ namespace edm {
                                                         bool hasSubprocesses,
                                                         PreallocationConfiguration const& config,
                                                         ProcessContext const* processContext,
+                                                        ModuleTypeResolverMaker const* typeResolverMaker,
                                                         ProcessBlockHelperBase& processBlockHelper) {
     auto& tns = ServiceRegistry::instance().get<service::TriggerNamesService>();
-    auto ret = std::make_unique<Schedule>(
-        parameterSet, tns, *preg_, *act_table_, actReg_, processConfiguration(), config, processContext);
+    auto ret = std::make_unique<Schedule>(parameterSet,
+                                          tns,
+                                          *preg_,
+                                          *act_table_,
+                                          actReg_,
+                                          processConfiguration(),
+                                          config,
+                                          processContext,
+                                          typeResolverMaker);
     ret->finishSetup(parameterSet,
                      tns,
                      *preg_,
@@ -169,9 +177,17 @@ namespace edm {
   ScheduleItems::MadeModules ScheduleItems::initModules(ParameterSet& parameterSet,
                                                         service::TriggerNamesService const& tns,
                                                         PreallocationConfiguration const& config,
-                                                        ProcessContext const* processContext) {
-    return MadeModules(std::make_unique<Schedule>(
-        parameterSet, tns, *preg_, *act_table_, actReg_, processConfiguration(), config, processContext));
+                                                        ProcessContext const* processContext,
+                                                        ModuleTypeResolverMaker const* typeResolverMaker) {
+    return MadeModules(std::make_unique<Schedule>(parameterSet,
+                                                  tns,
+                                                  *preg_,
+                                                  *act_table_,
+                                                  actReg_,
+                                                  processConfiguration(),
+                                                  config,
+                                                  processContext,
+                                                  typeResolverMaker));
   }
 
   std::unique_ptr<Schedule> ScheduleItems::finishSchedule(MadeModules madeModules,

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -60,7 +60,8 @@ namespace edm {
                          ServiceToken const& token,
                          serviceregistry::ServiceLegacy iLegacy,
                          PreallocationConfiguration const& preallocConfig,
-                         ProcessContext const* parentProcessContext)
+                         ProcessContext const* parentProcessContext,
+                         ModuleTypeResolverMaker const* typeResolverMaker)
       : EDConsumerBase(),
         serviceToken_(),
         parentPreg_(parentProductRegistry),
@@ -161,8 +162,12 @@ namespace edm {
         parentThinnedAssociationsHelper, keepAssociation, droppedBranchIDToKeptBranchID_);
 
     // intialize the Schedule
-    schedule_ = items.initSchedule(
-        *processParameterSet_, hasSubProcesses, preallocConfig, &processContext_, *processBlockHelper_);
+    schedule_ = items.initSchedule(*processParameterSet_,
+                                   hasSubProcesses,
+                                   preallocConfig,
+                                   &processContext_,
+                                   typeResolverMaker,
+                                   *processBlockHelper_);
 
     // set the items
     act_table_ = std::move(items.act_table_);
@@ -225,7 +230,8 @@ namespace edm {
                                  newToken,
                                  iLegacy,
                                  preallocConfig,
-                                 &processContext_);
+                                 &processContext_,
+                                 typeResolverMaker);
     }
   }
 

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -14,8 +14,10 @@ static const std::string kProducerType("EDProducer");
 namespace edm {
   // -----------------------------
 
-  WorkerManager::WorkerManager(std::shared_ptr<ActivityRegistry> areg, ExceptionToActionTable const& actions)
-      : workerReg_(areg),
+  WorkerManager::WorkerManager(std::shared_ptr<ActivityRegistry> areg,
+                               ExceptionToActionTable const& actions,
+                               ModuleTypeResolverMaker const* typeResolverMaker)
+      : workerReg_(areg, typeResolverMaker),
         actionTable_(&actions),
         allWorkers_(),
         unscheduled_(*areg),

--- a/FWCore/Framework/src/WorkerRegistry.cc
+++ b/FWCore/Framework/src/WorkerRegistry.cc
@@ -15,8 +15,8 @@
 
 namespace edm {
 
-  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg)
-      : modRegistry_(new ModuleRegistry), m_workerMap(), actReg_(areg) {}
+  WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, ModuleTypeResolverMaker const* resolverMaker)
+      : modRegistry_(std::make_shared<ModuleRegistry>(resolverMaker)), m_workerMap(), actReg_(areg) {}
 
   WorkerRegistry::WorkerRegistry(std::shared_ptr<ActivityRegistry> areg, std::shared_ptr<ModuleRegistry> modReg)
       : modRegistry_(modReg), m_workerMap(), actReg_(areg) {}

--- a/FWCore/Framework/src/makeModuleTypeResolverMaker.cc
+++ b/FWCore/Framework/src/makeModuleTypeResolverMaker.cc
@@ -1,0 +1,15 @@
+#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
+#include "FWCore/Framework/interface/makeModuleTypeResolverMaker.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <string>
+
+namespace edm {
+  std::unique_ptr<edm::ModuleTypeResolverMaker const> makeModuleTypeResolverMaker(edm::ParameterSet const& pset) {
+    auto const& name = pset.getUntrackedParameter<std::string>("@module_type_resolver");
+    if (name.empty()) {
+      return nullptr;
+    }
+    return edm::ModuleTypeResolverMakerFactory::get()->create(name);
+  }
+}  // namespace edm

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -189,6 +189,13 @@
   <use name="FWCore/ParameterSet"/>
 </library>
 
+<library file="stubs/TestTypeResolverPlugins.cc" name="FWCoreFrameworkTestTypeResolver">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+</library>
+
 <bin name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc,global_producer_t.cppunit.cc,global_filter_t.cppunit.cc,one_outputmodule_t.cppunit.cc,global_outputmodule_t.cppunit.cc,stream_producer_t.cppunit.cc,stream_filter_t.cppunit.cc,limited_producer_t.cppunit.cc,limited_filter_t.cppunit.cc,limited_outputmodule_t.cppunit.cc,checkForModuleDependencyCorrectness_t.cppunit.cc">
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>

--- a/FWCore/Framework/test/TestTypeResolvers.h
+++ b/FWCore/Framework/test/TestTypeResolvers.h
@@ -3,9 +3,13 @@
 
 #include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
 #include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 namespace edm::test {
@@ -48,6 +52,56 @@ namespace edm::test {
     std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const&) const final {
       return std::make_shared<ComplexTestTypeResolver>();
     }
+  };
+
+  class ConfigurableTestTypeResolver : public edm::ModuleTypeResolverBase {
+  public:
+    ConfigurableTestTypeResolver(std::string variant) : variant_(std::move(variant)) {}
+    std::pair<std::string, int> resolveType(std::string basename, int index) const final {
+      constexpr auto kGeneric = "generic::";
+      constexpr auto kOther = "edm::test::other::";
+      constexpr auto kCPU = "edm::test::cpu::";
+      if (index != kInitialIndex and index != kLastIndex) {
+        basename.replace(basename.find(kOther), strlen(kOther), kCPU);
+        return {basename, kLastIndex};
+      }
+      if (index == kInitialIndex and basename.find(kGeneric) != std::string::npos) {
+        if (not variant_.empty()) {
+          if (variant_ == "other") {
+            basename.replace(basename.find(kGeneric), strlen(kGeneric), kOther);
+          } else if (variant_ == "cpu") {
+            basename.replace(basename.find(kGeneric), strlen(kGeneric), kCPU);
+          }
+          return {basename, kLastIndex};
+        }
+        basename.replace(basename.find(kGeneric), strlen(kGeneric), kOther);
+        return {basename, kInitialIndex + 1};
+      }
+      return {basename, kLastIndex};
+    }
+
+  private:
+    std::string const variant_;
+  };
+  class ConfigurableTestTypeResolverMaker : public edm::ModuleTypeResolverMaker {
+  public:
+    ConfigurableTestTypeResolverMaker() = default;
+    std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const& pset) const final {
+      auto variant = pset.getUntrackedParameter<std::string>("variant");
+      if (not variant.empty() and variant != "other" and variant != "cpu") {
+        throw edm::Exception(edm::errors::Configuration) << "variant can be empty, 'other', or 'cpu'. Got " << variant;
+      }
+      auto found = cache_.find(variant);
+      if (found == cache_.end()) {
+        bool inserted;
+        std::tie(found, inserted) = cache_.emplace(variant, std::make_shared<ConfigurableTestTypeResolver>(variant));
+      }
+      return found->second;
+    }
+
+  private:
+    // no protection needed because this object is used only in single-thread context
+    CMS_SA_ALLOW mutable std::unordered_map<std::string, std::shared_ptr<ConfigurableTestTypeResolver>> cache_;
   };
 }  // namespace edm::test
 

--- a/FWCore/Framework/test/TestTypeResolvers.h
+++ b/FWCore/Framework/test/TestTypeResolvers.h
@@ -2,7 +2,9 @@
 #define FWCore_Framework_test_TestTypeResolvers_h
 
 #include "FWCore/Framework/interface/ModuleTypeResolverBase.h"
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -12,6 +14,13 @@ namespace edm::test {
     SimpleTestTypeResolver() = default;
     std::pair<std::string, int> resolveType(std::string basename, int index) const final {
       return {basename, kLastIndex};
+    }
+  };
+  class SimpleTestTypeResolverMaker : public edm::ModuleTypeResolverMaker {
+  public:
+    SimpleTestTypeResolverMaker() = default;
+    std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const&) const final {
+      return std::make_shared<SimpleTestTypeResolver>();
     }
   };
 
@@ -31,6 +40,13 @@ namespace edm::test {
         return {basename, kInitialIndex + 1};
       }
       return {basename, kLastIndex};
+    }
+  };
+  class ComplexTestTypeResolverMaker : public edm::ModuleTypeResolverMaker {
+  public:
+    ComplexTestTypeResolverMaker() = default;
+    std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const&) const final {
+      return std::make_shared<ComplexTestTypeResolver>();
     }
   };
 }  // namespace edm::test

--- a/FWCore/Framework/test/TestTypeResolvers.h
+++ b/FWCore/Framework/test/TestTypeResolvers.h
@@ -7,6 +7,7 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
+#include <cstring>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -87,9 +88,12 @@ namespace edm::test {
   public:
     ConfigurableTestTypeResolverMaker() = default;
     std::shared_ptr<ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const& pset) const final {
-      auto variant = pset.getUntrackedParameter<std::string>("variant");
-      if (not variant.empty() and variant != "other" and variant != "cpu") {
-        throw edm::Exception(edm::errors::Configuration) << "variant can be empty, 'other', or 'cpu'. Got " << variant;
+      std::string variant;
+      if (pset.existsAs<std::string>("variant", false)) {
+        variant = pset.getUntrackedParameter<std::string>("variant");
+        if (variant != "other" and variant != "cpu") {
+          throw edm::Exception(edm::errors::Configuration) << "Variant must be 'other' or 'cpu'. Got " << variant;
+        }
       }
       auto found = cache_.find(variant);
       if (found == cache_.end()) {

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -143,13 +143,13 @@ void testEventsetupplugin::finderTest()
   doInit();
   EventSetupsController esController;
   EventSetupProvider provider(&activityRegistry);
-  edm::ModuleTypeResolverBase const* resolver = nullptr;
+  edm::ModuleTypeResolverMaker const* resolverMaker = nullptr;
 
   edm::ParameterSet dummyFinderPSet;
   dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
   dummyFinderPSet.addParameter("@module_label", std::string(""));
   dummyFinderPSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, resolver);
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, resolverMaker);
 
   ComponentDescription descFinder("LoadableDummyFinder", "", ComponentDescription::unknownID(), true);
   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
@@ -160,7 +160,7 @@ void testEventsetupplugin::finderTest()
   dummyProviderPSet.addParameter("@module_type", std::string("LoadableDummyProvider"));
   dummyProviderPSet.addParameter("@module_label", std::string(""));
   dummyProviderPSet.registerIt();
-  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, resolver);
+  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, resolverMaker);
 
   ComponentDescription desc("LoadableDummyProvider", "", ComponentDescription::unknownID(), false);
   descriptions = provider.proxyProviderDescriptions();
@@ -171,7 +171,7 @@ void testEventsetupplugin::finderTest()
   dummySourcePSet.addParameter("@module_type", std::string("LoadableDummyESSource"));
   dummySourcePSet.addParameter("@module_label", std::string(""));
   dummySourcePSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, resolver);
+  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, resolverMaker);
 
   ComponentDescription descSource("LoadableDummyESSource", "", ComponentDescription::unknownID(), true);
   descriptions = provider.proxyProviderDescriptions();
@@ -182,15 +182,15 @@ void testEventsetupplugin::finderTest()
 void testEventsetupplugin::simpleResolverTest() {
   doInit();
 
-  edm::test::SimpleTestTypeResolver resolver;
-  EventSetupsController esController(&resolver);
+  edm::test::SimpleTestTypeResolverMaker resolverMaker;
+  EventSetupsController esController(&resolverMaker);
   EventSetupProvider provider(&activityRegistry);
 
   edm::ParameterSet dummyFinderPSet;
   dummyFinderPSet.addParameter("@module_type", std::string("LoadableDummyFinder"));
   dummyFinderPSet.addParameter("@module_label", std::string(""));
   dummyFinderPSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolver);
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolverMaker);
 
   ComponentDescription descFinder("LoadableDummyFinder", "", ComponentDescription::unknownID(), true);
   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
@@ -201,7 +201,7 @@ void testEventsetupplugin::simpleResolverTest() {
   dummyProviderPSet.addParameter("@module_type", std::string("LoadableDummyProvider"));
   dummyProviderPSet.addParameter("@module_label", std::string(""));
   dummyProviderPSet.registerIt();
-  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+  ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolverMaker);
 
   ComponentDescription desc("LoadableDummyProvider", "", ComponentDescription::unknownID(), false);
   descriptions = provider.proxyProviderDescriptions();
@@ -212,7 +212,7 @@ void testEventsetupplugin::simpleResolverTest() {
   dummySourcePSet.addParameter("@module_type", std::string("LoadableDummyESSource"));
   dummySourcePSet.addParameter("@module_label", std::string(""));
   dummySourcePSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+  SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolverMaker);
 
   ComponentDescription descSource("LoadableDummyESSource", "", ComponentDescription::unknownID(), true);
   descriptions = provider.proxyProviderDescriptions();
@@ -223,15 +223,15 @@ void testEventsetupplugin::simpleResolverTest() {
 void testEventsetupplugin::complexResolverTest() {
   doInit();
 
-  edm::test::ComplexTestTypeResolver resolver;
-  EventSetupsController esController(&resolver);
+  edm::test::ComplexTestTypeResolverMaker resolverMaker;
+  EventSetupsController esController(&resolverMaker);
   EventSetupProvider provider(&activityRegistry);
 
   edm::ParameterSet dummyFinderPSet;
   dummyFinderPSet.addParameter("@module_type", std::string("generic::LoadableDummyFinderA"));
   dummyFinderPSet.addParameter("@module_label", std::string(""));
   dummyFinderPSet.registerIt();
-  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolver);
+  SourceFactory::get()->addTo(esController, provider, dummyFinderPSet, &resolverMaker);
 
   ComponentDescription descFinder("generic::LoadableDummyFinderA", "", ComponentDescription::unknownID(), true);
   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
@@ -246,7 +246,7 @@ void testEventsetupplugin::complexResolverTest() {
     dummyProviderPSet.addParameter("@module_type", std::string("generic::LoadableDummyProviderA"));
     dummyProviderPSet.addParameter("@module_label", std::string(""));
     dummyProviderPSet.registerIt();
-    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolverMaker);
 
     ComponentDescription desc("generic::LoadableDummyProviderA", "", ComponentDescription::unknownID(), false);
     descriptions = provider.proxyProviderDescriptions();
@@ -264,7 +264,7 @@ void testEventsetupplugin::complexResolverTest() {
     dummyProviderPSet.addParameter("@module_type", std::string("generic::LoadableDummyProviderB"));
     dummyProviderPSet.addParameter("@module_label", std::string(""));
     dummyProviderPSet.registerIt();
-    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolver);
+    ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet, &resolverMaker);
 
     ComponentDescription desc("generic::LoadableDummyProviderB", "", ComponentDescription::unknownID(), false);
     descriptions = provider.proxyProviderDescriptions();
@@ -282,7 +282,7 @@ void testEventsetupplugin::complexResolverTest() {
     dummySourcePSet.addParameter("@module_type", std::string("generic::LoadableDummyESSourceA"));
     dummySourcePSet.addParameter("@module_label", std::string(""));
     dummySourcePSet.registerIt();
-    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolverMaker);
 
     ComponentDescription descSource("generic::LoadableDummyESSourceA", "", ComponentDescription::unknownID(), true);
     descriptions = provider.proxyProviderDescriptions();
@@ -300,7 +300,7 @@ void testEventsetupplugin::complexResolverTest() {
     dummySourcePSet.addParameter("@module_type", std::string("generic::LoadableDummyESSourceB"));
     dummySourcePSet.addParameter("@module_label", std::string(""));
     dummySourcePSet.registerIt();
-    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolver);
+    SourceFactory::get()->addTo(esController, provider, dummySourcePSet, &resolverMaker);
 
     ComponentDescription descSource("generic::LoadableDummyESSourceB", "", ComponentDescription::unknownID(), true);
     descriptions = provider.proxyProviderDescriptions();

--- a/FWCore/Framework/test/stubs/TestTypeResolverPlugins.cc
+++ b/FWCore/Framework/test/stubs/TestTypeResolverPlugins.cc
@@ -1,0 +1,6 @@
+#include "FWCore/Framework/test/TestTypeResolvers.h"
+
+#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
+DEFINE_EDM_PLUGIN(edm::ModuleTypeResolverMakerFactory,
+                  edm::test::ConfigurableTestTypeResolverMaker,
+                  "edm::test::ConfigurableTestTypeResolverMaker");

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -962,6 +962,50 @@ namespace edmtest {
   };
 }  // namespace edmtest
 
+namespace edm::test {
+  namespace other {
+    class IntProducer : public edm::global::EDProducer<> {
+    public:
+      explicit IntProducer(edm::ParameterSet const& p)
+          : token_{produces()}, value_(p.getParameter<int>("valueOther")) {}
+      void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const final { e.emplace(token_, value_); }
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<int>("valueOther");
+        desc.add<int>("valueCpu");
+        desc.addUntracked<std::string>("variant", "");
+
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+    private:
+      edm::EDPutTokenT<edmtest::IntProduct> token_;
+      int value_;
+    };
+  }  // namespace other
+  namespace cpu {
+    class IntProducer : public edm::global::EDProducer<> {
+    public:
+      explicit IntProducer(edm::ParameterSet const& p) : token_{produces()}, value_(p.getParameter<int>("valueCpu")) {}
+      void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const final { e.emplace(token_, value_); }
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<int>("valueOther");
+        desc.add<int>("valueCpu");
+        desc.addUntracked<std::string>("variant", "");
+
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+    private:
+      edm::EDPutTokenT<edmtest::IntProduct> token_;
+      int value_;
+    };
+  }  // namespace cpu
+}  // namespace edm::test
+
 using edmtest::AddAllIntsProducer;
 using edmtest::AddIntsProducer;
 using edmtest::BusyWaitIntLimitedProducer;
@@ -1007,3 +1051,5 @@ DEFINE_FWK_MODULE(IntProducerBeginProcessBlock);
 DEFINE_FWK_MODULE(IntProducerEndProcessBlock);
 DEFINE_FWK_MODULE(TransientIntProducerEndProcessBlock);
 DEFINE_FWK_MODULE(edmtest::MustRunIntProducer);
+DEFINE_FWK_MODULE(edm::test::other::IntProducer);
+DEFINE_FWK_MODULE(edm::test::cpu::IntProducer);

--- a/FWCore/Framework/test/test_catch2_Factory.cc
+++ b/FWCore/Framework/test/test_catch2_Factory.cc
@@ -109,7 +109,6 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_type", "generic::DoesNotExistModule");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
     SECTION("default behavior") {
-      pset.addUntrackedParameter<std::string>("variant", "");
       edm::test::ConfigurableTestTypeResolverMaker resolver;
       using Catch::Matchers::Contains;
       CHECK_THROWS_WITH(
@@ -196,7 +195,6 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_label", "gen");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
     SECTION("default behavior") {
-      pset.addUntrackedParameter<std::string>("variant", "");
       edm::test::ConfigurableTestTypeResolverMaker resolver;
       REQUIRE(edm::test::cpu::FactoryTestAProd::count_ == 0);
       REQUIRE(edm::test::other::FactoryTestAProd::count_ == 0);

--- a/FWCore/Framework/test/test_catch2_Factory.cc
+++ b/FWCore/Framework/test/test_catch2_Factory.cc
@@ -85,7 +85,7 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     ParameterSet pset;
     pset.addParameter<std::string>("@module_type", "DoesNotExistModule");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
-    edm::test::SimpleTestTypeResolver resolver;
+    edm::test::SimpleTestTypeResolverMaker resolver;
     using Catch::Matchers::Contains;
     CHECK_THROWS_WITH(
         factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
@@ -96,7 +96,7 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     ParameterSet pset;
     pset.addParameter<std::string>("@module_type", "generic::DoesNotExistModule");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
-    edm::test::ComplexTestTypeResolver resolver;
+    edm::test::ComplexTestTypeResolverMaker resolver;
     using Catch::Matchers::Contains;
     CHECK_THROWS_WITH(
         factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post),
@@ -122,7 +122,7 @@ TEST_CASE("test edm::Factory", "[Factory]") {
     pset.addParameter<std::string>("@module_type", "edm::test::FactoryTestBProd");
     pset.addParameter<std::string>("@module_label", "b");
     pset.addParameter<std::string>("@module_edm_type", "EDProducer");
-    edm::test::SimpleTestTypeResolver resolver;
+    edm::test::SimpleTestTypeResolverMaker resolver;
     REQUIRE(edm::test::FactoryTestBProd::count_ == 0);
     REQUIRE(factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post));
     REQUIRE(edm::test::FactoryTestBProd::count_ == 1);
@@ -135,7 +135,7 @@ TEST_CASE("test edm::Factory", "[Factory]") {
       pset.addParameter<std::string>("@module_type", "generic::FactoryTestAProd");
       pset.addParameter<std::string>("@module_label", "gen");
       pset.addParameter<std::string>("@module_edm_type", "EDProducer");
-      edm::test::ComplexTestTypeResolver resolver;
+      edm::test::ComplexTestTypeResolverMaker resolver;
       REQUIRE(edm::test::cpu::FactoryTestAProd::count_ == 0);
       REQUIRE(edm::test::other::FactoryTestAProd::count_ == 0);
       REQUIRE(factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post));
@@ -149,7 +149,7 @@ TEST_CASE("test edm::Factory", "[Factory]") {
       pset.addParameter<std::string>("@module_type", "generic::FactoryTestCProd");
       pset.addParameter<std::string>("@module_label", "cgen");
       pset.addParameter<std::string>("@module_edm_type", "EDProducer");
-      edm::test::ComplexTestTypeResolver resolver;
+      edm::test::ComplexTestTypeResolverMaker resolver;
       REQUIRE(edm::test::cpu::FactoryTestCProd::count_ == 0);
       REQUIRE(factory->makeModule(MakeModuleParams(&pset, prodReg, &preallocConfig, procConfig), &resolver, pre, post));
       REQUIRE(edm::test::cpu::FactoryTestCProd::count_ == 1);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -149,6 +149,8 @@
 
   <test name="TestIntegrationProcessAccelerator" command="run_TestProcessAccelerator.sh"/>
 
+  <test name="TestFWCoreIntegrationModuleTypeResolver" command="run_TestModuleTypeResolver.sh"/>
+
   <test name="CatchStdExceptiontest" command="CatchStdExceptiontest.sh"/>
 
   <test name="CatchCmsExceptiontest" command="CatchCmsExceptiontest.sh"/>

--- a/FWCore/Integration/test/ESTestProducers.cc
+++ b/FWCore/Integration/test/ESTestProducers.cc
@@ -344,6 +344,39 @@ namespace edmtest {
   }
 }  // namespace edmtest
 
+namespace edm::test {
+  namespace other {
+    class ESTestProducerA : public edm::ESProducer {
+    public:
+      ESTestProducerA(edm::ParameterSet const& pset) : value_(pset.getParameter<int>("valueOther")) {
+        setWhatProduced(this);
+      }
+      std::optional<edmtest::ESTestDataA> produce(ESTestRecordA const& rec) {
+        ++value_;
+        return edmtest::ESTestDataA(value_);
+      }
+
+    private:
+      int value_;
+    };
+  }  // namespace other
+  namespace cpu {
+    class ESTestProducerA : public edm::ESProducer {
+    public:
+      ESTestProducerA(edm::ParameterSet const& pset) : value_(pset.getParameter<int>("valueCpu")) {
+        setWhatProduced(this);
+      }
+      std::optional<edmtest::ESTestDataA> produce(ESTestRecordA const& rec) {
+        ++value_;
+        return edmtest::ESTestDataA(value_);
+      }
+
+    private:
+      int value_;
+    };
+  }  // namespace cpu
+}  // namespace edm::test
+
 using namespace edmtest;
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerA);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerB);
@@ -359,3 +392,5 @@ DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerJ);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerK);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestProducerAZ);
 DEFINE_FWK_EVENTSETUP_MODULE(ESTestDataProxyProviderJ);
+DEFINE_FWK_EVENTSETUP_MODULE(edm::test::other::ESTestProducerA);
+DEFINE_FWK_EVENTSETUP_MODULE(edm::test::cpu::ESTestProducerA);

--- a/FWCore/Integration/test/ProcessAccelerator_t.cpp
+++ b/FWCore/Integration/test/ProcessAccelerator_t.cpp
@@ -14,10 +14,10 @@
 static constexpr auto s_tag = "[ProcessAccelerator]";
 
 namespace {
-  std::string makeConfig(bool test2Enabled,
-                         std::string_view test1,
-                         std::string_view test2,
-                         std::string_view accelerator) {
+  std::string makeSwitchConfig(bool test2Enabled,
+                               std::string_view test1,
+                               std::string_view test2,
+                               std::string_view accelerator) {
     const std::string appendTest2 = test2Enabled ? "self._enabled.append('test2')" : "";
     return fmt::format(
         R"_(from FWCore.TestProcessor.TestProcess import *
@@ -58,18 +58,74 @@ process.moduleToTest(process.s)
         test1,
         test2);
   }
+
+  std::string makeResolverConfig(bool test2Enabled, std::string_view accelerator, std::string_view variant) {
+    const std::string appendTest2 = test2Enabled ? "self._enabled.append('test2')" : "";
+    const std::string explicitVariant =
+        variant.empty() ? std::string(variant) : fmt::format(", variant=cms.untracked.string('{}')", variant);
+    return fmt::format(
+        R"_(from FWCore.TestProcessor.TestProcess import *
+import FWCore.ParameterSet.Config as cms
+
+class ModuleTypeResolverTest:
+    def __init__(self, accelerators):
+        self._variants = []
+        if "test2" in accelerators:
+            self._variants.append("test2")
+        if "test1" in accelerators:
+            self._variants.append("test1")
+        if len(self._variants) == 0:
+            raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "No 'test1' or 'test2' accelerator available")
+
+    def plugin(self):
+        return "TestTypeResolverMaker"
+
+    def setModuleVariant(self, module):
+        if "generic::" in module.type_():
+            if hasattr(module, "variant"):
+                if module.variant.value() not in self._variants:
+                    raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Module {{}} has the Test variant set explicitly to {{}}, but its accelerator is not available for the job".format(module.label_(), module.variant.value()))
+            else:
+                module.variant = cms.untracked.string(self._variants[0])
+
+class ProcessAcceleratorTest(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorTest,self).__init__()
+        self._labels = ["test1", "test2"]
+        self._enabled = ["test1"]
+        {}
+    def labels(self):
+        return self._labels
+    def enabledLabels(self):
+        return self._enabled
+    def moduleTypeResolver(self, accelerators):
+        return ModuleTypeResolverTest(accelerators)
+
+process = TestProcess()
+process.options.accelerators = ["{}"]
+process.ProcessAcceleratorTest = ProcessAcceleratorTest()
+process.m = cms.EDProducer("generic::IntProducer",
+    valueCpu = cms.int32(1), valueOther = cms.int32(2)
+    {}
+)
+process.moduleToTest(process.m)
+)_",
+        appendTest2,
+        accelerator,
+        explicitVariant);
+  }
 }  // namespace
 
-TEST_CASE("Configuration", s_tag) {
+TEST_CASE("Configuration with SwitchProducer", s_tag) {
   const std::string test1{"cms.EDProducer('IntProducer', ivalue = cms.int32(1))"};
   const std::string test2{"cms.EDProducer('ManyIntProducer', ivalue = cms.int32(2), values = cms.VPSet())"};
 
-  const std::string baseConfig_auto = makeConfig(true, test1, test2, "*");
-  const std::string baseConfig_test1 = makeConfig(true, test1, test2, "test1");
-  const std::string baseConfig_test2 = makeConfig(true, test1, test2, "test2");
-  const std::string baseConfigTest2Disabled_auto = makeConfig(false, test1, test2, "*");
-  const std::string baseConfigTest2Disabled_test1 = makeConfig(false, test1, test2, "test1");
-  const std::string baseConfigTest2Disabled_test2 = makeConfig(false, test1, test2, "test2");
+  const std::string baseConfig_auto = makeSwitchConfig(true, test1, test2, "*");
+  const std::string baseConfig_test1 = makeSwitchConfig(true, test1, test2, "test1");
+  const std::string baseConfig_test2 = makeSwitchConfig(true, test1, test2, "test2");
+  const std::string baseConfigTest2Disabled_auto = makeSwitchConfig(false, test1, test2, "*");
+  const std::string baseConfigTest2Disabled_test1 = makeSwitchConfig(false, test1, test2, "test1");
+  const std::string baseConfigTest2Disabled_test2 = makeSwitchConfig(false, test1, test2, "test2");
 
   SECTION("Configuration hash is not changed") {
     auto pset_auto = edm::readConfig(baseConfig_auto);
@@ -154,5 +210,32 @@ TEST_CASE("Configuration", s_tag) {
     REQUIRE_THROWS_WITH(
         edm::test::TestProcessor(configTest2Disabled_test2),
         Catch::Contains("The system has no compute accelerators that match the patterns") && Catch::Contains("test1"));
+  }
+}
+
+TEST_CASE("Configuration with ModuleTypeResolver", s_tag) {
+  SECTION("Configuration hash is not changed") {
+    auto pset_auto = edm::readConfig(makeResolverConfig(true, "*", ""));
+    auto pset_test1 = edm::readConfig(makeResolverConfig(true, "test1", ""));
+    auto pset_test2 = edm::readConfig(makeResolverConfig(true, "test2", ""));
+    auto pset_test1explicit = edm::readConfig(makeResolverConfig(true, "*", "test1"));
+    auto pset_test2explicit = edm::readConfig(makeResolverConfig(true, "*", "test2"));
+    auto psetTest2Disabled_auto = edm::readConfig(makeResolverConfig(false, "*", ""));
+    auto psetTest2Disabled_test1 = edm::readConfig(makeResolverConfig(false, "test1", ""));
+    REQUIRE_THROWS_WITH(edm::readConfig(makeResolverConfig(false, "test2", "")),
+                        Catch::Contains("UnavailableAccelerator"));
+    pset_auto->registerIt();
+    pset_test1->registerIt();
+    pset_test2->registerIt();
+    pset_test1explicit->registerIt();
+    pset_test2explicit->registerIt();
+    psetTest2Disabled_auto->registerIt();
+    psetTest2Disabled_test1->registerIt();
+    REQUIRE(pset_auto->id() == pset_test1->id());
+    REQUIRE(pset_auto->id() == pset_test2->id());
+    REQUIRE(pset_auto->id() == pset_test1explicit->id());
+    REQUIRE(pset_auto->id() == pset_test2explicit->id());
+    REQUIRE(pset_auto->id() == psetTest2Disabled_auto->id());
+    REQUIRE(pset_auto->id() == psetTest2Disabled_test1->id());
   }
 }

--- a/FWCore/Integration/test/run_TestModuleTypeResolver.sh
+++ b/FWCore/Integration/test/run_TestModuleTypeResolver.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+TESTDIR=${LOCALTOP}/src/FWCore/Integration/test
+TEST=testModuleTypeResolver_cfg.py
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+function runSuccess {
+    echo "cmsRun ${TESTDIR}/${TEST} $1"
+    cmsRun ${TESTDIR}/${TEST} $1 || die "cmsRun ${TEST} $1" $?
+    echo
+}
+function runFailure {
+    echo "cmsRun ${TESTDIR}/${TEST} $1 (job itself is expected to fail)"
+    cmsRun -j testModuleTypeResolver_jobreport.xml ${TESTDIR}/${TEST} $1 && die "cmsRun ${TEST} $1 did not fail" 1
+    EXIT_CODE=$(edmFjrDump --exitCode testModuleTypeResolver_jobreport.xml)
+    if [ "x${EXIT_CODE}" != "x8035" ]; then
+        echo "ModuleTypeResolver test for unavailable accelerator reported exit code ${EXIT_CODE} which is different from the expected 8035"
+        exit 1
+    fi
+    echo
+}
+
+runSuccess ""
+runSuccess "-- --enableOther --expectOther"
+runSuccess "-- --enableOther --accelerators=cpu"
+runSuccess "-- --enableOther --setInResolver=cpu"
+runSuccess "-- --enableOther --setInResolver=other --expectOther"
+runSuccess "-- --enableOther --setInResolver=cpu --setInModule=other --expectOther"
+runSuccess "-- --enableOther --setInResolver=other --setInModule=cpu"
+runSuccess "-- --enableOther --setInModule=cpu"
+
+runFailure "-- --setInResolver=other --expectOther"
+runFailure "-- --setInModule=other --expectOther"
+runFailure "-- --setInResolver=other --setInModule=cpu"

--- a/FWCore/Integration/test/testModuleTypeResolver_cfg.py
+++ b/FWCore/Integration/test/testModuleTypeResolver_cfg.py
@@ -1,0 +1,110 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ProcessAccelerator.')
+
+parser.add_argument("--enableOther", action="store_true", help="Enable other accelerator")
+parser.add_argument("--setInResolver", type=str, default="", help="Set the default variant in module type resolver")
+parser.add_argument("--setInModule", type=str, default="", help="Set the default variant in module itself")
+parser.add_argument("--accelerators", type=str, help="Comma-separated string for accelerators to enable")
+parser.add_argument("--expectOther", action="store_true", help="Set this if the 'other' variant is expected to get run")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+class ModuleTypeResolverTest:
+    def __init__(self, accelerators):
+        self._variants = []
+        if "other" in accelerators:
+            self._variants.append("other")
+        if "cpu" in accelerators:
+            self._variants.append("cpu")
+        if args.setInResolver != "":
+            if args.setInResolver not in self._variants:
+                raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Trying to set variant globally in ModuleTypeResolverTest to {}, but a corresponding accelerator is not available".format(args.setInResolver))
+            self._variants.remove(args.setInResolver)
+            self._variants.insert(0, args.setInResolver)
+        if len(self._variants) == 0:
+            raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "No 'cpu' or 'other' accelerator available")
+
+    def plugin(self):
+        return "edm::test::ConfigurableTestTypeResolverMaker"
+
+    def setModuleVariant(self, module):
+        if module.type_().startswith("generic::"):
+            if hasattr(module, "variant"):
+                if module.variant.value() not in self._variants:
+                    raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Module {} has the Test variant set explicitly to {}, but its accelerator is not available for the job".format(module.label_(), module.variant.value()))
+            else:
+                module.variant = cms.untracked.string(self._variants[0])
+
+class ProcessAcceleratorTest(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorTest,self).__init__()
+        self._labels = ["other"]
+        self._enabled = []
+        if args.enableOther:
+            self._enabled.append("other")
+    def labels(self):
+        return self._labels
+    def enabledLabels(self):
+        return self._enabled
+    def moduleTypeResolver(self, accelerators):
+        return ModuleTypeResolverTest(accelerators)
+
+process = cms.Process("PROD1")
+
+process.add_(ProcessAcceleratorTest())
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(1)
+)
+process.maxEvents.input = 3
+if args.accelerators is not None:
+    process.options.accelerators = args.accelerators.split(",")
+
+# EventSetup
+process.emptyESSourceA = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordA"),
+    firstValid = cms.vuint32(1,2,3),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.esTestProducerA = cms.ESProducer("generic::ESTestProducerA", valueCpu = cms.int32(10), valueOther = cms.int32(20))
+
+process.esTestAnalyzerA = cms.EDAnalyzer("ESTestAnalyzerA",
+    runsToGetDataFor = cms.vint32(1,2,3),
+    expectedValues=cms.untracked.vint32(11,12,13)
+)
+
+# Event
+process.intProducer = cms.EDProducer("generic::IntProducer", valueCpu = cms.int32(1), valueOther = cms.int32(2))
+
+process.intConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("intProducer"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+
+if args.setInModule != "":
+    process.esTestProducerA.variant = cms.untracked.string(args.setInModule)
+    process.intProducer.variant = cms.untracked.string(args.setInModule)
+
+if args.expectOther:
+    process.esTestAnalyzerA.expectedValues = [21, 22, 23]
+    process.intConsumer.valueMustMatch = 2
+
+process.t = cms.Task(
+    process.intProducer
+)
+process.p = cms.Path(
+    process.intConsumer + process.esTestAnalyzerA,
+    process.t
+)

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1545,7 +1545,31 @@ class Process(object):
             selectedAccelerators = sorted(list(resolved))
         parameterSet.addVString(False, "@selected_accelerators", selectedAccelerators)
 
-        # Customize
+        # Get and apply module type resolver
+        moduleTypeResolver = None
+        moduleTypeResolverPlugin = ""
+        for acc in self.__dict__['_Process__accelerators'].values():
+            resolver = acc.moduleTypeResolver(selectedAccelerators)
+            if resolver is not None:
+                if moduleTypeResolver is not None:
+                    raise RuntimeError("Module type resolver was already set to {} when {} tried to set it to {}. A job can have at most one ProcessAccelerator that sets module type resolver.".format(
+                        moduleTypeResolver.__class__.__name__,
+                        acc.__class__.__name__,
+                        resolver.__class__.__name__))
+                moduleTypeResolver = resolver
+        if moduleTypeResolver is not None:
+            # Plugin name and its configuration
+            moduleTypeResolverPlugin = moduleTypeResolver.plugin()
+
+            # Customize modules
+            for modlist in [self.producers_, self.filters_, self.analyzers_,
+                            self.es_producers_, self.es_sources_]:
+                for module in modlist().values():
+                    moduleTypeResolver.setModuleVariant(module)
+
+        parameterSet.addString(False, "@module_type_resolver", moduleTypeResolverPlugin)
+
+        # Customize process
         wrapped = ProcessForProcessAccelerator(self)
         for acc in self.__dict__['_Process__accelerators'].values():
             acc.apply(wrapped, selectedAccelerators)
@@ -1988,6 +2012,21 @@ class ProcessAccelerator(_ConfigureComponent,_Unlabelable):
         """Override to return a list of strings for the accelerator labels
         that are enabled in the system the job is being run on."""
         return []
+    def moduleTypeResolver(self, accelerators):
+        """Override to return an object that implements "module type resolver"
+        in python. The object should have the following methods
+        - __init__(self, accelerators)
+          * accelerators = list of selected accelerators
+        - plugin(self):
+          * should return a string for the type resolver plugin name
+        - setModuleVariant(self, module):
+          * Called for each ED and ES module. Should act only if
+            module.type_() contains the magic identifier
+
+        At most one of the ProcessAccelerators in a job can return a
+non-None object
+        """
+        return None
     def apply(self, process, accelerators):
         """Override if need to customize the Process at worker node. The
         selected available accelerator labels are given in the
@@ -2137,11 +2176,40 @@ if __name__=="__main__":
                 ), **kargs)
     specialImportRegistry.registerSpecialImportForType(SwitchProducerTest2, "from test import SwitchProducerTest2")
 
+    class TestModuleTypeResolver:
+        def __init__(self, accelerators):
+            # first element is used as the default is nothing is set
+            self._valid_backends = []
+            if "test1" in accelerators:
+                self._valid_backends.append("test1_backend")
+            if "test2" in accelerators:
+                self._valid_backends.append("test2_backend")
+            if len(self._valid_backends) == 0:
+                raise EDMException(edm.errors.UnavailableAccelerator, "Machine has no accelerators that Test supports (has {})".format(", ".join(accelerators)))
+
+        def plugin(self):
+            return "TestModuleTypeResolver"
+
+        def setModuleVariant(self, module):
+            if "@test" in module.type_():
+                defaultBackend = self._valid_backends[0]
+                if hasattr(module, "test"):
+                    if hasattr(module.test, "backend"):
+                        if module.test.backend.value() not in self._valid_backends:
+                            raise EDMException(edm.errors.UnavailableAccelerator, "Module {} has the Test backend set explicitly, but its accelerator is not available for the job".format(module.label_()))
+                    else:
+                        module.test.backend = untracked.string(defaultBackend)
+                else:
+                    module.test = untracked.PSet(
+                        backend = untracked.string(defaultBackend)
+                    )
+
     class ProcessAcceleratorTest(ProcessAccelerator):
-        def __init__(self, enabled=["test1", "test2", "anothertest3"]):
-            super(ProcessAcceleratorTest,self).__init__()
+        def __init__(self, enabled=["test1", "test2", "anothertest3"], moduleTypeResolverMaker=None):
+            super().__init__()
             self._labels = ["test1", "test2", "anothertest3"]
             self.setEnabled(enabled)
+            self._moduleTypeResolverMaker = moduleTypeResolverMaker
         def setEnabled(self, enabled):
             invalid = set(enabled).difference(set(self._labels))
             if len(invalid) > 0:
@@ -2155,15 +2223,20 @@ if __name__=="__main__":
             return self._labels
         def enabledLabels(self):
             return self._enabled
+        def moduleTypeResolver(self, accelerators):
+            if not self._moduleTypeResolverMaker:
+                return super().moduleTypeResolver(accelerators)
+            return self._moduleTypeResolverMaker(accelerators)
         def apply(self, process, accelerators):
             process.AcceleratorTestService = Service("AcceleratorTestService")
     specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorTest, "from test import ProcessAcceleratorTest")
 
     class ProcessAcceleratorTest2(ProcessAccelerator):
-        def __init__(self, enabled=["anothertest3", "anothertest4"]):
-            super(ProcessAcceleratorTest2,self).__init__()
+        def __init__(self, enabled=["anothertest3", "anothertest4"], moduleTypeResolverMaker=None):
+            super().__init__()
             self._labels = ["anothertest3", "anothertest4"]
             self.setEnabled(enabled)
+            self._moduleTypeResolverMaker = moduleTypeResolverMaker
         def setEnabled(self, enabled):
             invalid = set(enabled).difference(set(self._labels))
             if len(invalid) > 0:
@@ -2177,6 +2250,10 @@ if __name__=="__main__":
             return self._labels
         def enabledLabels(self):
             return self._enabled
+        def moduleTypeResolver(self, accelerators):
+            if not self._moduleTypeResolverMaker:
+                return super().moduleTypeResolver(accelerators)
+            return self._moduleTypeResolverMaker(accelerators)
         def apply(self, process, accelerators):
             pass
     specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorTest2, "from test import ProcessAcceleratorTest2")
@@ -4523,6 +4600,8 @@ process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
             self.assertTrue(["cpu"], p.values["@available_accelerators"][1])
             self.assertFalse(p.values["@selected_accelerators"][0])
             self.assertTrue(["cpu"], p.values["@selected_accelerators"][1])
+            self.assertFalse(p.values["@module_type_resolver"][0])
+            self.assertEqual("", p.values["@module_type_resolver"][1])
 
             proc = Process("TEST")
             self.assertRaises(TypeError, setattr, proc, "processAcceleratorTest", ProcessAcceleratorTest())
@@ -4590,6 +4669,8 @@ process.ProcessAcceleratorTest = ProcessAcceleratorTest(
             self.assertEqual("AcceleratorTestService", p.values["services"][1][0].values["@service_type"][1])
             self.assertFalse(p.values["@available_accelerators"][0])
             self.assertTrue(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+            self.assertFalse(p.values["@module_type_resolver"][0])
+            self.assertEqual("", p.values["@module_type_resolver"][1])
 
             proc = Process("TEST")
             proc.ProcessAcceleratorTest = ProcessAcceleratorTest(enabled=["test1"])
@@ -4722,6 +4803,62 @@ process.ProcessAcceleratorTest = ProcessAcceleratorTest(
                                                              aa = int32(11),
                                                              bb = PSet(cc = int32(12))))
             proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            self.assertRaises(RuntimeError, proc.fillProcessDesc, p)
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(
+                moduleTypeResolverMaker=lambda accelerators: TestModuleTypeResolver(accelerators))
+            proc.ProcessAcceleratorTest2 = ProcessAcceleratorTest2()
+            proc.normalProducer = EDProducer("FooProducer")
+            proc.testProducer = EDProducer("BarProducer@test")
+            proc.test2Producer = EDProducer("BarProducer@test", test=untracked.PSet(backend=untracked.string("test2_backend")))
+            proc.testAnalyzer = EDAnalyzer("Analyzer@test")
+            proc.testFilter = EDAnalyzer("Filter@test")
+            proc.testESProducer = ESProducer("ESProducer@test")
+            proc.testESSource = ESSource("ESSource@test")
+            proc.p = Path(proc.normalProducer+proc.testProducer+proc.test2Producer+proc.testAnalyzer+proc.testFilter)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual("TestModuleTypeResolver", p.values["@module_type_resolver"][1])
+            self.assertEqual("FooProducer", p.values["normalProducer"][1].values["@module_type"][1])
+            self.assertEqual(len(list(filter(lambda x: not "@" in x, p.values["normalProducer"][1].values.keys()))), 0)
+            self.assertEqual("BarProducer@test", p.values["testProducer"][1].values["@module_type"][1])
+            self.assertEqual(False, p.values["testProducer"][1].values["test"][0])
+            self.assertEqual(False, p.values["testProducer"][1].values["test"][1].values["backend"][0])
+            self.assertEqual("test1_backend", p.values["testProducer"][1].values["test"][1].values["backend"][1])
+            self.assertEqual("BarProducer@test", p.values["test2Producer"][1].values["@module_type"][1])
+            self.assertEqual("test2_backend", p.values["test2Producer"][1].values["test"][1].values["backend"][1])
+            self.assertEqual("Analyzer@test", p.values["testAnalyzer"][1].values["@module_type"][1])
+            self.assertEqual("test1_backend", p.values["testAnalyzer"][1].values["test"][1].values["backend"][1])
+            self.assertEqual("Filter@test", p.values["testFilter"][1].values["@module_type"][1])
+            self.assertEqual("test1_backend", p.values["testFilter"][1].values["test"][1].values["backend"][1])
+            self.assertEqual("ESProducer@test", p.values["ESProducer@test@testESProducer"][1].values["@module_type"][1])
+            self.assertEqual("test1_backend", p.values["ESProducer@test@testESProducer"][1].values["test"][1].values["backend"][1])
+            self.assertEqual("ESSource@test", p.values["ESSource@test@testESSource"][1].values["@module_type"][1])
+            self.assertEqual("test1_backend", p.values["ESSource@test@testESSource"][1].values["test"][1].values["backend"][1])
+
+            # No required accelerators available
+            proc = Process("Test")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(
+                moduleTypeResolverMaker=lambda accelerators: TestModuleTypeResolver(accelerators))
+            proc.options.accelerators = []
+            self.assertRaises(EDMException, proc.fillProcessDesc, p)
+
+            proc = Process("Test")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(
+                moduleTypeResolverMaker=lambda accelerators: TestModuleTypeResolver(accelerators))
+            proc.options.accelerators = ["test1"]
+            proc.test2Producer = EDProducer("BarProducer@test", test=untracked.PSet(backend=untracked.string("test2_backend")))
+            proc.p = Path(proc.test2Producer)
+            self.assertRaises(EDMException, proc.fillProcessDesc, p)
+
+            # Two ProcessAccelerators return type resolver
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(
+                moduleTypeResolverMaker=lambda accelerators: TestModuleTypeResolver(accelerators))
+            proc.ProcessAcceleratorTest2 = ProcessAcceleratorTest2(
+                moduleTypeResolverMaker=lambda accelerators: TestModuleTypeResolver(accelerators))
             p = TestMakePSet()
             self.assertRaises(RuntimeError, proc.fillProcessDesc, p)
 

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -31,6 +31,7 @@ class edm(object):
     class errors(object):
         #Allowed errors to used within Python
         Configuration = "{Configuration}"
+        UnavailableAccelerator = "{UnavailableAccelerator}"
 
 class EDMException(Exception):
     def __init__(self, error, message):

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -29,7 +29,7 @@ if sys.getrecursionlimit()<5000:
 
 class edm(object):
     class errors(object):
-        #Allowed errors to used within Python
+        #Allowed errors to be used within Python
         Configuration = "{Configuration}"
         UnavailableAccelerator = "{UnavailableAccelerator}"
 

--- a/FWCore/PythonParameterSet/src/PyBind11Wrapper.cc
+++ b/FWCore/PythonParameterSet/src/PyBind11Wrapper.cc
@@ -17,6 +17,12 @@ namespace edm {
               newLine = errorNameEnd + 1;
             }
             throw edm::Exception(edm::errors::Configuration) << error.substr(newLine + 1, std::string::npos);
+          } else if ("UnavailableAccelerator" == errorName) {
+            auto newLine = error.find('\n', errorNameEnd + 1);
+            if (newLine == std::string::npos) {
+              newLine = errorNameEnd + 1;
+            }
+            throw edm::Exception(edm::errors::UnavailableAccelerator) << error.substr(newLine + 1, std::string::npos);
           }
         }
       }

--- a/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makeprocess_t.cppunit.cc
@@ -515,22 +515,43 @@ void testmakeprocess::taskTestWithSchedule() {
 }
 
 void testmakeprocess::edmException() {
-  char const* const kTest =
-      "import FWCore.ParameterSet.Config as cms\n"
-      "raise cms.EDMException(cms.edm.errors.Configuration,'test message')\n";
+  {
+    char const* const kTest =
+        "import FWCore.ParameterSet.Config as cms\n"
+        "raise cms.EDMException(cms.edm.errors.Configuration,'test message')\n";
 
-  bool exceptionHappened = false;
-  try {
-    (void)pSet(kTest);
-  } catch (edm::Exception const& e) {
-    exceptionHappened = true;
-    CPPUNIT_ASSERT(e.categoryCode() == edm::errors::Configuration);
-  } catch (std::exception const& e) {
-    std::cout << "wrong error " << e.what() << std::endl;
-    exceptionHappened = true;
-    CPPUNIT_ASSERT(false);
+    bool exceptionHappened = false;
+    try {
+      (void)pSet(kTest);
+    } catch (edm::Exception const& e) {
+      exceptionHappened = true;
+      CPPUNIT_ASSERT(e.categoryCode() == edm::errors::Configuration);
+    } catch (std::exception const& e) {
+      std::cout << "wrong error " << e.what() << std::endl;
+      exceptionHappened = true;
+      CPPUNIT_ASSERT(false);
+    }
+    CPPUNIT_ASSERT(exceptionHappened);
   }
-  CPPUNIT_ASSERT(exceptionHappened);
+
+  {
+    char const* const kTest =
+        "import FWCore.ParameterSet.Config as cms\n"
+        "raise cms.EDMException(cms.edm.errors.UnavailableAccelerator,'test message')\n";
+
+    bool exceptionHappened = false;
+    try {
+      (void)pSet(kTest);
+    } catch (edm::Exception const& e) {
+      exceptionHappened = true;
+      CPPUNIT_ASSERT(e.categoryCode() == edm::errors::UnavailableAccelerator);
+    } catch (std::exception const& e) {
+      std::cout << "wrong error " << e.what() << std::endl;
+      exceptionHappened = true;
+      CPPUNIT_ASSERT(false);
+    }
+    CPPUNIT_ASSERT(exceptionHappened);
+  }
 }
 
 /*

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -62,6 +62,7 @@ namespace edm {
   class ThinnedAssociationsHelper;
   class ExceptionToActionTable;
   class HistoryAppender;
+  class ModuleTypeResolverMaker;
 
   namespace eventsetup {
     class EventSetupProvider;
@@ -335,6 +336,7 @@ This simulates a problem happening early in the job which causes processing not 
       std::shared_ptr<ProcessBlockHelper> processBlockHelper_;
       std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
       ServiceToken serviceToken_;
+      std::unique_ptr<ModuleTypeResolverMaker const> moduleTypeResolverMaker_;
       std::unique_ptr<eventsetup::EventSetupsController> espController_;
       std::shared_ptr<eventsetup::EventSetupProvider> esp_;
       std::shared_ptr<EventSetupTestHelper> esHelper_;

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -33,6 +33,7 @@
 #include "FWCore/Framework/interface/ProductPutterBase.h"
 #include "FWCore/Framework/interface/DelayedReader.h"
 #include "FWCore/Framework/interface/ensureAvailableAccelerators.h"
+#include "FWCore/Framework/interface/makeModuleTypeResolverMaker.h"
 
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
@@ -84,7 +85,6 @@ namespace edm {
     TestProcessor::TestProcessor(Config const& iConfig, ServiceToken iToken)
         : globalControl_(oneapi::tbb::global_control::max_allowed_parallelism, 1),
           arena_(1),
-          espController_(std::make_unique<eventsetup::EventSetupsController>()),
           historyAppender_(std::make_unique<HistoryAppender>()),
           moduleRegistry_(std::make_shared<ModuleRegistry>()) {
       //Setup various singletons
@@ -93,6 +93,8 @@ namespace edm {
       ProcessDescImpl desc(iConfig.pythonConfiguration());
 
       auto psetPtr = desc.parameterSet();
+      moduleTypeResolverMaker_ = makeModuleTypeResolverMaker(*psetPtr);
+      espController_ = std::make_unique<eventsetup::EventSetupsController>(moduleTypeResolverMaker_.get());
 
       validateTopLevelParameterSets(psetPtr.get());
 
@@ -168,10 +170,8 @@ namespace edm {
 
       processBlockHelper_ = std::make_shared<ProcessBlockHelper>();
 
-      // should we add the module type resolver support for TestProcessor?
-      ModuleTypeResolverMaker const* typeResolverMaker = nullptr;
       schedule_ = items.initSchedule(
-          *psetPtr, false, preallocations_, &processContext_, typeResolverMaker, *processBlockHelper_);
+          *psetPtr, false, preallocations_, &processContext_, moduleTypeResolverMaker_.get(), *processBlockHelper_);
       // set the data members
       act_table_ = std::move(items.act_table_);
       actReg_ = items.actReg_;

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -168,7 +168,10 @@ namespace edm {
 
       processBlockHelper_ = std::make_shared<ProcessBlockHelper>();
 
-      schedule_ = items.initSchedule(*psetPtr, false, preallocations_, &processContext_, *processBlockHelper_);
+      // should we add the module type resolver support for TestProcessor?
+      ModuleTypeResolverMaker const* typeResolverMaker = nullptr;
+      schedule_ = items.initSchedule(
+          *psetPtr, false, preallocations_, &processContext_, typeResolverMaker, *processBlockHelper_);
       // set the data members
       act_table_ = std::move(items.act_table_);
       actReg_ = items.actReg_;

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -52,7 +52,8 @@ namespace edm {
                                                  ProductRegistry& preg,
                                                  std::shared_ptr<ProcessConfiguration> processConfiguration)
       : exceptionToActionTable_(new ExceptionToActionTable),
-        workerManager_(std::make_shared<ActivityRegistry>(), *exceptionToActionTable_) {
+        // no type resolver for modules in SecondaryEventProvider for now
+        workerManager_(std::make_shared<ActivityRegistry>(), *exceptionToActionTable_, nullptr) {
     std::vector<std::string> shouldBeUsedLabels;
     std::set<std::string> unscheduledLabels;
     const PreallocationConfiguration preallocConfig;


### PR DESCRIPTION
#### PR description:

This PR contains changes to the generic module type resolver system (https://github.com/cms-sw/cmssw/pull/37731, https://github.com/cms-sw/cmssw/pull/39391) in the framework so that it would be usable for a specific implementation for Alpaka modules (that comes in a subsequent PR). I explored a few approaches on the implementation, and settled in one that makes most of its work in the python configuration (as opposed to C++ code).

The changes include in the python configuration side
* Allow `UnavailableAccelerator` `edm::Exception` to be thrown in python (extending #40315) 
* Add `ModuleTypeResolver` functionality to `ProcessAccelerator`:
  * `ProcessAccelerator` can return (via `moduleTypeResolver()` member function) a "type resolver" object (based on the accelerators available in the machine) that is used to 
      * specify a `ModuleTypeResolver` plugin for C++ code with an accompanied PSet
      * customize each module PSet; must limit to a PSet specifying the variant ("backend") of the module with untracked parameters

and in the C++ side
* Use abstract factory pattern for module type resolver in order to use information from the module PSet in the type resolver, in a way that the PSet is parsed only once per module instance
* Module makers are now cached by their resolved module type in order to allow the type resolver return different type name per module instance
* `ModuleTypeResolverMaker` is constructed in `EventProcessor`, and percolated to relevant ED and ES module factories

#### PR validation:

Framework unit tests pass (except for `TestIOPoolInputNoParentDictionary` that needs an improvement done in a separate PR).