### PR TITLE
Handle PYTHON3PATH as well in TestIOPoolInputNoParentDictionary

### DIFF
--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -10,6 +10,7 @@ cd $SCRAM_TEST_NAME
 # Create a new CMSSW dev area
 OLD_CMSSW_BASE=${CMSSW_BASE}
 LD_LIBRARY_PATH_TO_OLD=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep "^${CMSSW_BASE}/" | tr '\n' ':')
+PYTHON3PATH_TO_OLD=$(echo $PYTHON3PATH | tr ':' '\n' | grep "^${CMSSW_BASE}/" | tr '\n' ':')
 scram -a $SCRAM_ARCH project $CMSSW_VERSION
 pushd $CMSSW_VERSION/src
 eval `scram run -sh`
@@ -34,8 +35,9 @@ scram build -j $(nproc)
 popd
 
 # Add OLD_CMSSW_BASE in between CMSSW_BASE and CMSSW_RELEASE_BASE for
-# LD_LIBRARY_PATH and ROOT_INCLUDE_PATH
+# LD_LIBRARY_PATH, PYTHON3PATH, and ROOT_INCLUDE_PATH
 export LD_LIBRARY_PATH=$(echo -n ${LD_LIBRARY_PATH} | sed -e "s|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:${LD_LIBRARY_PATH_TO_OLD}:|")
+export PYTHON3PATH=$(echo -n ${PYTHON3PATH} | sed -e "s|${CMSSW_BASE}/lib/${SCRAM_ARCH}:|${CMSSW_BASE}/lib/${SCRAM_ARCH}::${PYTHON3PATH_TO_OLD}:|")
 export ROOT_INCLUDE_PATH=$(echo -n ${ROOT_INCLUDE_PATH} | sed -e "s|${CMSSW_BASE}/src:|${CMSSW_BASE}/src:${OLD_CMSSW_BASE}/src:|")
 
 echo "Produce a file with TransientIntParentT<1> product"


### PR DESCRIPTION
#### PR description:

Testing #40383 locally revealed another shortcoming in the `TestIOPoolInputNoParentDictionary`: adding new parameters to the process description makes the test fail, because the python configuration code is taken from the developer area created by the test, and does not include the changes done in the developer area where the test is initiated. This PR extends the treatment of `LD_LIBRARY_PATH` and `ROOT_INCLUDE_PATH` to `PYTHON3PATH`, which appears to fix the issue.

I opened a separate PR because the issue and content is independent of the content of #40383.

#### PR validation:

The test passes with #40383.