### PR TITLE
Fix TestIOPoolInputNoParentDictionary to use original dev area env

### DIFF
--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -7,15 +7,13 @@ rm -rf $SCRAM_TEST_NAME
 mkdir $SCRAM_TEST_NAME
 cd $SCRAM_TEST_NAME
 
-# Create a new CMSSW dev area
-OLD_CMSSW_BASE=${CMSSW_BASE}
-LD_LIBRARY_PATH_TO_OLD=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep "^${CMSSW_BASE}/" | tr '\n' ':')
+# Create a new CMSSW dev area and build modified DataFormats/TestObjects in it
+NEW_CMSSW_BASE=$(/bin/pwd -P)/$CMSSW_VERSION
 scram -a $SCRAM_ARCH project $CMSSW_VERSION
 pushd $CMSSW_VERSION/src
-eval `scram run -sh`
 
 # Copy DataFormats/TestObjects code to be able to edit it to make ROOT header parsing to fail
-for DIR in ${OLD_CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do
+for DIR in ${CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do
     if [ -d ${DIR}/src/DataFormats/TestObjects ]; then
         mkdir DataFormats
         cp -Lr ${DIR}/src/DataFormats/TestObjects DataFormats/
@@ -29,23 +27,23 @@ fi
 
 # Enable TransientIntParentT dictionaries
 cat DataFormats/TestObjects/test/BuildFile_extra.xml >> DataFormats/TestObjects/test/BuildFile.xml
-scram build -j $(nproc)
+#Set env and build in sub-shel
+(eval $(scram run -sh) ; scram build -j $(nproc))
 
 popd
 
-# Add OLD_CMSSW_BASE in between CMSSW_BASE and CMSSW_RELEASE_BASE for
-# LD_LIBRARY_PATH and ROOT_INCLUDE_PATH
-export LD_LIBRARY_PATH=$(echo -n ${LD_LIBRARY_PATH} | sed -e "s|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:${LD_LIBRARY_PATH_TO_OLD}:|")
-export ROOT_INCLUDE_PATH=$(echo -n ${ROOT_INCLUDE_PATH} | sed -e "s|${CMSSW_BASE}/src:|${CMSSW_BASE}/src:${OLD_CMSSW_BASE}/src:|")
+# Prepend NEW_CMSSW_BASE's lib/src paths in to LD_LIBRARY_PATH and ROOT_INCLUDE_PATH
+export LD_LIBRARY_PATH=${NEW_CMSSW_BASE}/lib/${SCRAM_ARCH}:${LD_LIBRARY_PATH}
+export ROOT_INCLUDE_PATH=${NEW_CMSSW_BASE}/src:${ROOT_INCLUDE_PATH}
 
 echo "Produce a file with TransientIntParentT<1> product"
 cmsRun ${LOCALTOP}/src/IOPool/Input/test/PoolNoParentDictionaryTestStep1_cfg.py || die 'Failed cmsRun PoolNoParentDictionaryTestStep1_cfg.py' $?
 
 
 # Then make attempt to load TransientIntParentT<1> to fail
-echo "PREVENT_HEADER_PARSING" >> ${CMSSW_BASE}/src/DataFormats/TestObjects/interface/ToyProducts.h
-rm ${CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr_rdict.pcm ${CMSSW_BASE}/lib/${SCRAM_ARCH}/libDataFormatsTestObjectsParent1.so
-sed -i -e 's/libDataFormatsTestObjectsParent1.so/libDataFormatsTestObjectsParent2.so/' ${CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr.rootmap
+echo "PREVENT_HEADER_PARSING" >> ${NEW_CMSSW_BASE}/src/DataFormats/TestObjects/interface/ToyProducts.h
+rm ${NEW_CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr_rdict.pcm ${NEW_CMSSW_BASE}/lib/${SCRAM_ARCH}/libDataFormatsTestObjectsParent1.so
+sed -i -e 's/libDataFormatsTestObjectsParent1.so/libDataFormatsTestObjectsParent2.so/' ${NEW_CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr.rootmap
 
 echo "Read the file without TransientIntParentT<1> dictionary"
 cmsRun ${LOCALTOP}/src/IOPool/Input/test/PoolNoParentDictionaryTestStep2_cfg.py || die 'Failed cmsRun PoolNoParentDictionaryTestStep2_cfg.py' $?


### PR DESCRIPTION
This PR addresses the issue mentioned in https://github.com/cms-sw/cmssw/pull/40384 . This change allows to use the env from the original cmssw dev area and only prepend the `lib/src` paths in to `LD_LIBRARY_PATH` and `ROOT_INCLUDE_PATH`.

FYI @makortel 