### PR TITLE
Fix incorrect keyword in JetCorrector dictionary

### DIFF
--- a/JetMETCorrections/JetCorrector/src/classes_def.xml
+++ b/JetMETCorrections/JetCorrector/src/classes_def.xml
@@ -1,4 +1,4 @@
 <lcgdict>
-  <class name="reco::JetCorrector" persistence="false"/>
+  <class name="reco::JetCorrector" persistent="false"/>
   <class name="edm::Wrapper<reco::JetCorrector>" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

The keyword is `persistent` not `persistence`

#### PR validation:

Code compiles.