### PR TITLE
[12.5.X] Adjust collections of Tracker clusters to be saved for Phase-2 ALCARECO

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlBeamHalo_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlBeamHalo_Output_cff.py
@@ -6,13 +6,36 @@ OutALCARECOTkAlBeamHalo_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlBeamHalo')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlBeamHalo_*_*', 
+        'keep recoTracks_ALCARECOTkAlBeamHalo_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlBeamHalo_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlBeamHalo_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlBeamHalo_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlBeamHalo_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*')
 )
 
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
+_run3_common_removedCommands = OutALCARECOTkAlBeamHalo_noDrop.outputCommands.copy()
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlBeamHalo_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlBeamHalo_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlBeamHalo_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlBeamHalo_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlBeamHalo_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 OutALCARECOTkAlBeamHalo = copy.deepcopy(OutALCARECOTkAlBeamHalo_noDrop)
 OutALCARECOTkAlBeamHalo.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_Output_cff.py
@@ -6,13 +6,33 @@ OutALCARECOTkAlDiMuonAndVertex_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlDiMuonAndVertex')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlDiMuon_*_*', 
-        'keep *_ALCARECOTkAlDiMuonVertexTracks_*_*',
+        'keep recoTracks_ALCARECOTkAlDiMuon_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlDiMuon_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlDiMuon_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlDiMuon_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlDiMuon_*_*',
+        'keep recoTracks_ALCARECOTkAlDiMuonVertexTracks_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlDiMuonVertexTracks_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlDiMuonVertexTracks_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlDiMuonVertexTracks_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlDiMuonVertexTracks_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*',
         'keep *_offlinePrimaryVertices_*_*')
 )
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlDiMuonAndVertex_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlDiMuon_*_*')
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlDiMuonVertexTracks_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlDiMuon_*_*',
+                                'keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlDiMuonVertexTracks_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlDiMuonAndVertex_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 OutALCARECOTkAlDiMuonAndVertex = OutALCARECOTkAlDiMuonAndVertex_noDrop.clone()
 OutALCARECOTkAlDiMuonAndVertex.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlJetHT_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlJetHT')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlJetHT_*_*', 
+        'keep recoTracks_ALCARECOTkAlJetHT_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlJetHT_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlJetHT_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlJetHT_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJetHT_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -25,6 +29,16 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlJetHT_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlJetHT_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJetHT_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlJetHT_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlJetHT_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 
 OutALCARECOTkAlJetHT = OutALCARECOTkAlJetHT_noDrop.clone()
 OutALCARECOTkAlJetHT.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlJpsiMuMuHI')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlJpsiMuMuHI_*_*', 
+        'keep recoTracks_ALCARECOTkAlJpsiMuMuHI_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlJpsiMuMuHI_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlJpsiMuMuHI_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMuHI_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMuHI_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlJpsiMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlJpsiMuMuHI_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMuHI_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlJpsiMuMuHI_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlJpsiMuMuHI_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlJpsiMuMuHI = OutALCARECOTkAlJpsiMuMuHI_noDrop.clone()
 OutALCARECOTkAlJpsiMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlJpsiMuMu_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlJpsiMuMu')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlJpsiMuMu_*_*', 
+        'keep recoTracks_ALCARECOTkAlJpsiMuMu_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlJpsiMuMu_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlJpsiMuMu_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMu_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMu_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlJpsiMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlJpsiMuMu_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlJpsiMuMu_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlJpsiMuMu_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlJpsiMuMu = OutALCARECOTkAlJpsiMuMu_noDrop.clone()
 OutALCARECOTkAlJpsiMuMu.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlMinBiasHI_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMinBiasHI')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlMinBiasHI_*_*', 
+        'keep recoTracks_ALCARECOTkAlMinBiasHI_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlMinBiasHI_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlMinBiasHI_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlMinBiasHI_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMinBiasHI_*_*', 
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -24,6 +28,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlMinBiasHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlMinBiasHI_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMinBiasHI_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlMinBiasHI_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlMinBiasHI_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlMinBiasHI = copy.deepcopy(OutALCARECOTkAlMinBiasHI_noDrop)
 OutALCARECOTkAlMinBiasHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlMinBias_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMinBias')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlMinBias_*_*', 
+        'keep recoTracks_ALCARECOTkAlMinBias_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlMinBias_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlMinBias_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlMinBias_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMinBias_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -25,6 +29,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlMinBias_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlMinBias_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMinBias_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlMinBias_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlMinBias_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlMinBias = OutALCARECOTkAlMinBias_noDrop.clone()
 OutALCARECOTkAlMinBias.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolatedHI')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlMuonIsolatedHI_*_*', 
+        'keep recoTracks_ALCARECOTkAlMuonIsolatedHI_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlMuonIsolatedHI_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlMuonIsolatedHI_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedHI_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedHI_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlMuonIsolatedHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlMuonIsolatedHI_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedHI_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlMuonIsolatedHI_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlMuonIsolatedHI_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlMuonIsolatedHI = OutALCARECOTkAlMuonIsolatedHI_noDrop.clone()
 OutALCARECOTkAlMuonIsolatedHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedPA_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlMuonIsolatedPA_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolatedPA')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlMuonIsolatedPA_*_*', 
+        'keep recoTracks_ALCARECOTkAlMuonIsolatedPA_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlMuonIsolatedPA_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlMuonIsolatedPA_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedPA_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedPA_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -15,5 +19,23 @@ OutALCARECOTkAlMuonIsolatedPA_noDrop = cms.PSet(
 )
 
 import copy
+_run3_common_removedCommands = OutALCARECOTkAlMuonIsolatedPA_noDrop.outputCommands.copy()
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlMuonIsolatedPA_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlMuonIsolatedPA_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolatedPA_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlMuonIsolatedPA_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlMuonIsolatedPA_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 OutALCARECOTkAlMuonIsolatedPA = copy.deepcopy(OutALCARECOTkAlMuonIsolatedPA_noDrop)
 OutALCARECOTkAlMuonIsolatedPA.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlMuonIsolated_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolated')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlMuonIsolated_*_*', 
+        'keep recoTracks_ALCARECOTkAlMuonIsolated_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlMuonIsolated_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlMuonIsolated_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolated_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolated_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlMuonIsolated_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlMuonIsolated_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlMuonIsolated_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlMuonIsolated_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlMuonIsolated_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlMuonIsolated = OutALCARECOTkAlMuonIsolated_noDrop.clone()
 OutALCARECOTkAlMuonIsolated.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuHI')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlUpsilonMuMuHI_*_*', 
+        'keep recoTracks_ALCARECOTkAlUpsilonMuMuHI_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlUpsilonMuMuHI_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlUpsilonMuMuHI_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuHI_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuHI_*_*',        
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlUpsilonMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlUpsilonMuMuHI_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuHI_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlUpsilonMuMuHI_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlUpsilonMuMuHI_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlUpsilonMuMuHI = OutALCARECOTkAlUpsilonMuMuHI_noDrop.clone()
 OutALCARECOTkAlUpsilonMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuPA_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlUpsilonMuMuPA_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMuPA')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlUpsilonMuMuPA_*_*', 
+        'keep recoTracks_ALCARECOTkAlUpsilonMuMuPA_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlUpsilonMuMuPA_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlUpsilonMuMuPA_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuPA_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuPA_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -14,6 +18,25 @@ OutALCARECOTkAlUpsilonMuMuPA_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
+_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMuPA_noDrop.outputCommands.copy()
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlUpsilonMuMuPA_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlUpsilonMuMuPA_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMuPA_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlUpsilonMuMuPA_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlUpsilonMuMuPA_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 OutALCARECOTkAlUpsilonMuMuPA = copy.deepcopy(OutALCARECOTkAlUpsilonMuMuPA_noDrop)
 OutALCARECOTkAlUpsilonMuMuPA.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlUpsilonMuMu_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMu')
     ),
     outputCommands = cms.untracked.vstring( 
-        'keep *_ALCARECOTkAlUpsilonMuMu_*_*', 
+        'keep recoTracks_ALCARECOTkAlUpsilonMuMu_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlUpsilonMuMu_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlUpsilonMuMu_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMu_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMu_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlUpsilonMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlUpsilonMuMu_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlUpsilonMuMu_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlUpsilonMuMu_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlUpsilonMuMu = OutALCARECOTkAlUpsilonMuMu_noDrop.clone()
 OutALCARECOTkAlUpsilonMuMu.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlWMuNu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlWMuNu_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlWMuNu_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlWMuNu')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlWMuNu_*_*',
+        'keep recoTracks_ALCARECOTkAlWMuNu_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlWMuNu_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlWMuNu_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlWMuNu_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlWMuNu_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -14,6 +18,26 @@ OutALCARECOTkAlWMuNu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
-OutALCARECOTkAlWMuNu = copy.deepcopy(OutALCARECOTkAlWMuNu_noDrop)
+_run3_common_removedCommands = OutALCARECOTkAlWMuNu_noDrop.outputCommands.copy()
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlWMuNu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlWMuNu_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlWMuNu_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlWMuNu_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlWMuNu_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
+OutALCARECOTkAlWMuNu = OutALCARECOTkAlWMuNu_noDrop.clone()
 OutALCARECOTkAlWMuNu.outputCommands.insert(0, "drop *")
+

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuHI')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlZMuMuHI_*_*', 
+        'keep recoTracks_ALCARECOTkAlZMuMuHI_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlZMuMuHI_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlZMuMuHI_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlZMuMuHI_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMuHI_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlZMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlZMuMuHI_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMuHI_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlZMuMuHI_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlZMuMuHI_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlZMuMuHI = OutALCARECOTkAlZMuMuHI_noDrop.clone()
 OutALCARECOTkAlZMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuPA_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlZMuMuPA_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlZMuMuPA')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlZMuMuPA_*_*', 
+        'keep recoTracks_ALCARECOTkAlZMuMuPA_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlZMuMuPA_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlZMuMuPA_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlZMuMuPA_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMuPA_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -14,6 +18,25 @@ OutALCARECOTkAlZMuMuPA_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
 import copy
+_run3_common_removedCommands = OutALCARECOTkAlZMuMuPA_noDrop.outputCommands.copy()
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlZMuMuPA_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlZMuMuPA_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMuPA_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlZMuMuPA_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlZMuMuPA_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
+
 OutALCARECOTkAlZMuMuPA = copy.deepcopy(OutALCARECOTkAlZMuMuPA_noDrop)
 OutALCARECOTkAlZMuMuPA.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -6,7 +6,11 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOTkAlZMuMu')
     ),
     outputCommands = cms.untracked.vstring(
-        'keep *_ALCARECOTkAlZMuMu_*_*', 
+        'keep recoTracks_ALCARECOTkAlZMuMu_*_*',
+        'keep recoTrackExtras_ALCARECOTkAlZMuMu_*_*',
+        'keep TrackingRecHitsOwned_ALCARECOTkAlZMuMu_*_*',
+        'keep SiPixelClusteredmNewDetSetVector_ALCARECOTkAlZMuMu_*_*',
+        'keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMu_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
@@ -23,6 +27,15 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(OutALCARECOTkAlZMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+# in Phase2, remove the SiStrip clusters and keep the OT ones instead
+_phase2_common_removedCommands = OutALCARECOTkAlZMuMu_noDrop.outputCommands.copy()
+_phase2_common_removedCommands.remove('keep SiStripClusteredmNewDetSetVector_ALCARECOTkAlZMuMu_*_*')
+
+_phase2_common_extraCommands = ['keep Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOTkAlZMuMu_*_*']
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(OutALCARECOTkAlZMuMu_noDrop, outputCommands = _phase2_common_removedCommands + _phase2_common_extraCommands )
 
 OutALCARECOTkAlZMuMu = OutALCARECOTkAlZMuMu_noDrop.clone()
 OutALCARECOTkAlZMuMu.outputCommands.insert(0, "drop *")

--- a/CommonTools/RecoAlgos/BuildFile.xml
+++ b/CommonTools/RecoAlgos/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/SiStripCluster"/>
 <use name="DataFormats/SiPixelCluster"/>
+<use name="DataFormats/Phase2TrackerCluster"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Candidate"/>

--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -20,6 +20,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 
 namespace helper {
@@ -39,7 +40,9 @@ namespace helper {
     void processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
                             edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
                             edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
-                            edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters);
+                            edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters,
+                            edmNew::DetSetVector<Phase2TrackerCluster1D> &phase2OTDsvToFill,
+                            edm::RefProd<edmNew::DetSetVector<Phase2TrackerCluster1D> > refPhase2OTClusters);
 
   private:
     /// A struct for clusters associated to hits
@@ -77,7 +80,7 @@ namespace helper {
     typedef ClusterHitRecord<SiStripRecHit2D::ClusterRef> StripClusterHitRecord;
     //FIXME:: this is just temporary solution for phase2,
     //probably is good to add a Phase2ClusterStorer?
-    typedef ClusterHitRecord<Phase2TrackerRecHit1D::CluRef> Phase2OTClusterHitRecord;
+    typedef ClusterHitRecord<Phase2TrackerRecHit1D::ClusterRef> Phase2OTClusterHitRecord;
 
     //------------------------------------------------------------------
     //!  Processes all the clusters of a specific type

--- a/CommonTools/RecoAlgos/interface/ClusterStorer.h
+++ b/CommonTools/RecoAlgos/interface/ClusterStorer.h
@@ -65,7 +65,7 @@ namespace helper {
       /// Set the reference of the hit of this record to 'newRef',
       /// will not modify the ref stored in this object.
       template <typename RecHitType>
-      void rekey(const ClusterRefType &newRef) const;
+      void rekey(const ClusterRefType &newRef);
 
     private:
       ClusterHitRecord() {}  /// private => unusable

--- a/CommonTools/RecoAlgos/interface/MuonSelector.h
+++ b/CommonTools/RecoAlgos/interface/MuonSelector.h
@@ -22,6 +22,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "CommonTools/RecoAlgos/interface/ClusterStorer.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
@@ -74,6 +75,7 @@ namespace helper {
     std::unique_ptr<TrackingRecHitCollection> selStandAloneTracksHits_;
     std::unique_ptr<edmNew::DetSetVector<SiStripCluster>> selStripClusters_;
     std::unique_ptr<edmNew::DetSetVector<SiPixelCluster>> selPixelClusters_;
+    std::unique_ptr<edmNew::DetSetVector<Phase2TrackerCluster1D>> selPhase2OTClusters_;
 
     reco::MuonRefProd rMuons_;
     reco::TrackRefProd rTracks_;
@@ -128,6 +130,9 @@ namespace helper {
     edm::RefProd<edmNew::DetSetVector<SiPixelCluster>> rPixelClusters =
         evt.template getRefBeforePut<edmNew::DetSetVector<SiPixelCluster>>();
 
+    edm::RefProd<edmNew::DetSetVector<Phase2TrackerCluster1D>> rPhase2OTClusters =
+        evt.template getRefBeforePut<edmNew::DetSetVector<Phase2TrackerCluster1D>>();
+
     id_ = 0;
     igbd_ = 0;
     isad_ = 0;
@@ -145,7 +150,12 @@ namespace helper {
       processMuon(mu);
     }
     //--- Clone the clusters and fixup refs
-    clusterStorer_.processAllClusters(*selPixelClusters_, rPixelClusters, *selStripClusters_, rStripClusters);
+    clusterStorer_.processAllClusters(*selPixelClusters_,
+                                      rPixelClusters,
+                                      *selStripClusters_,
+                                      rStripClusters,
+                                      *selPhase2OTClusters_,
+                                      rPhase2OTClusters);
   }
 
   //----------------------------------------------------------------------
@@ -161,6 +171,7 @@ namespace helper {
       //--- New: save clusters too
       produces<edmNew::DetSetVector<SiPixelCluster>>().setBranchAlias(alias + "PixelClusters");
       produces<edmNew::DetSetVector<SiStripCluster>>().setBranchAlias(alias + "StripClusters");
+      produces<edmNew::DetSetVector<Phase2TrackerCluster1D>>().setBranchAlias(alias + "Phase2OTClusters");
       produces<reco::TrackCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonTracks");
       produces<reco::TrackExtraCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonExtras");
       produces<TrackingRecHitCollection>("GlobalMuon").setBranchAlias(alias + "GlobalMuonHits");

--- a/CommonTools/RecoAlgos/interface/TrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/TrackSelector.h
@@ -22,6 +22,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/Phase2TrackerCluster/interface/Phase2TrackerCluster1D.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "CommonTools/RecoAlgos/interface/ClusterStorer.h"
 #include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
@@ -71,6 +72,7 @@ namespace helper {
     std::unique_ptr<TrackingRecHitCollection> selHits_;
     std::unique_ptr<edmNew::DetSetVector<SiStripCluster> > selStripClusters_;
     std::unique_ptr<edmNew::DetSetVector<SiPixelCluster> > selPixelClusters_;
+    std::unique_ptr<edmNew::DetSetVector<Phase2TrackerCluster1D> > selPhase2OTClusters_;
 
     //--- References to products (i.e. to collections):
     reco::TrackRefProd rTracks_;
@@ -107,6 +109,8 @@ namespace helper {
         evt.template getRefBeforePut<edmNew::DetSetVector<SiPixelCluster> >();
     edm::RefProd<edmNew::DetSetVector<SiStripCluster> > rStripClusters =
         evt.template getRefBeforePut<edmNew::DetSetVector<SiStripCluster> >();
+    edm::RefProd<edmNew::DetSetVector<Phase2TrackerCluster1D> > rPhase2OTClusters =
+        evt.template getRefBeforePut<edmNew::DetSetVector<Phase2TrackerCluster1D> >();
 
     //--- Indices into collections handled with RefProd
     idx_ = 0;   //!<  index to track extra coll
@@ -121,7 +125,12 @@ namespace helper {
       processTrack(trk);
     }
     //--- Clone the clusters and fixup refs
-    clusterStorer_.processAllClusters(*selPixelClusters_, rPixelClusters, *selStripClusters_, rStripClusters);
+    clusterStorer_.processAllClusters(*selPixelClusters_,
+                                      rPixelClusters,
+                                      *selStripClusters_,
+                                      rStripClusters,
+                                      *selPhase2OTClusters_,
+                                      rPhase2OTClusters);
   }
 
   //----------------------------------------------------------------------
@@ -135,6 +144,7 @@ namespace helper {
       //--- New: save clusters too
       produces<edmNew::DetSetVector<SiPixelCluster> >().setBranchAlias(alias + "PixelClusters");
       produces<edmNew::DetSetVector<SiStripCluster> >().setBranchAlias(alias + "StripClusters");
+      produces<edmNew::DetSetVector<Phase2TrackerCluster1D> >().setBranchAlias(alias + "Phase2OTClusters");
     }
   };  // (end of class TrackSelectorBase)
 

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -71,13 +71,17 @@ namespace helper {
   void ClusterStorer::clear() {
     pixelClusterRecords_.clear();
     stripClusterRecords_.clear();
+    phase2OTClusterRecords_.clear();
   }
 
   // -------------------------------------------------------------
-  void ClusterStorer::processAllClusters(edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
-                                         edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
-                                         edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
-                                         edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters) {
+  void ClusterStorer::processAllClusters(
+      edmNew::DetSetVector<SiPixelCluster> &pixelDsvToFill,
+      edm::RefProd<edmNew::DetSetVector<SiPixelCluster> > refPixelClusters,
+      edmNew::DetSetVector<SiStripCluster> &stripDsvToFill,
+      edm::RefProd<edmNew::DetSetVector<SiStripCluster> > refStripClusters,
+      edmNew::DetSetVector<Phase2TrackerCluster1D> &phase2OTDsvToFill,
+      edm::RefProd<edmNew::DetSetVector<Phase2TrackerCluster1D> > refPhase2OTClusters) {
     if (!pixelClusterRecords_.empty()) {
       this->processClusters<SiPixelRecHit, SiPixelCluster>(pixelClusterRecords_, pixelDsvToFill, refPixelClusters);
     }
@@ -88,6 +92,10 @@ namespace helper {
       // ClusterHitRecord<typename SiStripRecHit2D::ClusterRef>::rekey<RecHitType>
       // is specialised such that 'RecHitType' is not used...
       this->processClusters<SiStripRecHit2D, SiStripCluster>(stripClusterRecords_, stripDsvToFill, refStripClusters);
+    }
+    if (!phase2OTClusterRecords_.empty()) {
+      this->processClusters<Phase2TrackerRecHit1D, Phase2TrackerCluster1D>(
+          phase2OTClusterRecords_, phase2OTDsvToFill, refPhase2OTClusters);
     }
   }
 

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -105,7 +105,7 @@ namespace helper {
                                       edmNew::DetSetVector<ClusterType> &dsvToFill,
                                       edm::RefProd<edmNew::DetSetVector<ClusterType> > &refprod) {
     std::sort(clusterRecords.begin(), clusterRecords.end());  // this sorts them by detid
-    typedef typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::const_iterator RIT;
+    typedef typename std::vector<ClusterHitRecord<typename HitType::ClusterRef> >::iterator RIT;
     RIT it = clusterRecords.begin(), end = clusterRecords.end();
     size_t clusters = 0;
     while (it != end) {
@@ -143,7 +143,7 @@ namespace helper {
   // generic rekey (in practise for pixel only...)
   template <typename ClusterRefType>  // template for class
   template <typename RecHitType>      // template for member function
-  void ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType &newRef) const {
+  void ClusterStorer::ClusterHitRecord<ClusterRefType>::rekey(const ClusterRefType &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     RecHitType *hit = nullptr;
     if (genericHit.geographicalId().rawId() == detid_) {  // a hit on this det, so it's simple
@@ -159,9 +159,7 @@ namespace helper {
   // RecHitType is not used.
   template <>
   template <typename RecHitType>  // or template<> to specialise also here?
-  void ClusterStorer::ClusterHitRecord<SiStripRecHit2D::ClusterRef>::
-      //  rekey<SiStripRecHit2D>(const SiStripRecHit2D::ClusterRef &newRef) const
-      rekey(const SiStripRecHit2D::ClusterRef &newRef) const {
+  void ClusterStorer::ClusterHitRecord<SiStripRecHit2D::ClusterRef>::rekey(const SiStripRecHit2D::ClusterRef &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 
@@ -187,9 +185,7 @@ namespace helper {
   // RecHitType is not used.
   template <>
   template <typename RecHitType>  // or template<> to specialise also here?
-  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::
-      //  rekey<VectorHit>(const VectorHit::ClusterRef &newRef) const
-      rekey(const VectorHit::ClusterRef &newRef) const {
+  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::rekey(const VectorHit::ClusterRef &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 

--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -182,4 +182,30 @@ namespace helper {
     (*cluRef) = OmniClusterRef(newRef);
   }
 
+  // -------------------------------------------------------------
+  // Specific rekey for class template ClusterRefType = VectorHit::ClusterRef,
+  // RecHitType is not used.
+  template <>
+  template <typename RecHitType>  // or template<> to specialise also here?
+  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::
+      //  rekey<VectorHit>(const VectorHit::ClusterRef &newRef) const
+      rekey(const VectorHit::ClusterRef &newRef) const {
+    TrackingRecHit &genericHit = (*hits_)[index_];
+    const std::type_info &hit_type = typeid(genericHit);
+
+    OmniClusterRef *cluRef = nullptr;
+    if (typeid(VectorHit) == hit_type) {
+      VectorHit &vHit = static_cast<VectorHit &>(genericHit);
+      // FIXME: this essentially uses a hack
+      // https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L291
+      cluRef = (SiStripDetId(detid_).stereo() ? &vHit.upperClusterRef() : &vHit.lowerClusterRef());
+    } else {
+      return;
+    }
+
+    assert(cluRef != nullptr);            // to catch missing RecHit types
+    assert(cluRef->key() == ref_.key());  // otherwise something went wrong
+    (*cluRef) = OmniClusterRef(newRef);
+  }
+
 }  // namespace helper

--- a/CommonTools/RecoAlgos/src/MuonSelector.cc
+++ b/CommonTools/RecoAlgos/src/MuonSelector.cc
@@ -5,8 +5,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-
-#include <DataFormats/SiStripDetId/interface/SiStripDetId.h>
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -26,6 +25,7 @@ namespace helper {
         selStandAloneTracksHits_(new TrackingRecHitCollection),
         selStripClusters_(new edmNew::DetSetVector<SiStripCluster>),
         selPixelClusters_(new edmNew::DetSetVector<SiPixelCluster>),
+        selPhase2OTClusters_(new edmNew::DetSetVector<Phase2TrackerCluster1D>),
         rMuons_(),
         rTracks_(),
         rTrackExtras_(),
@@ -202,6 +202,9 @@ namespace helper {
         const ProjectedSiStripRecHit2D &pHit = static_cast<const ProjectedSiStripRecHit2D &>(hit);
         if (!pHit.originalHit().cluster().isAvailable())
           return false;
+      } else if (hit_type == typeid(Phase2TrackerRecHit1D)) {
+        if (!static_cast<const Phase2TrackerRecHit1D &>(hit).cluster().isAvailable())
+          return false;
       } else {
         // std::cout << "|   It is a " << hit_type.name() << " hit !?" << std::endl;
         // Do nothing. We might end up here for FastSim hits.
@@ -230,6 +233,7 @@ namespace helper {
     if (cloneClusters()) {
       evt.put(std::move(selStripClusters_));
       evt.put(std::move(selPixelClusters_));
+      evt.put(std::move(selPhase2OTClusters_));
     }
     return h;
   }

--- a/CommonTools/RecoAlgos/src/TrackSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackSelector.cc
@@ -10,6 +10,7 @@ namespace helper {
         selHits_(new TrackingRecHitCollection),
         selStripClusters_(new edmNew::DetSetVector<SiStripCluster>),
         selPixelClusters_(new edmNew::DetSetVector<SiPixelCluster>),
+        selPhase2OTClusters_(new edmNew::DetSetVector<Phase2TrackerCluster1D>),
         rTracks_(),
         rTrackExtras_(),
         rHits_(),
@@ -62,6 +63,7 @@ namespace helper {
     evt.put(std::move(selHits_));
     evt.put(std::move(selStripClusters_));
     evt.put(std::move(selPixelClusters_));
+    evt.put(std::move(selPhase2OTClusters_));
     return h;
   }
 

--- a/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
@@ -10,6 +10,7 @@
 class Phase2TrackerRecHit1D final : public TrackerSingleRecHit {
 public:
   typedef OmniClusterRef::Phase2Cluster1DRef CluRef;
+  typedef OmniClusterRef::Phase2Cluster1DRef ClusterRef;
 
   Phase2TrackerRecHit1D() {}
 

--- a/DataFormats/TrackerRecHit2D/interface/VectorHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/VectorHit.h
@@ -92,6 +92,9 @@ public:
   ClusterRef upperCluster() const { return theUpperCluster.cluster_phase2OT(); }
   OmniClusterRef const lowerClusterRef() const { return theLowerCluster; }
   OmniClusterRef const upperClusterRef() const { return theUpperCluster; }
+  // Non const variants needed for cluster re-keying
+  OmniClusterRef& lowerClusterRef() { return theLowerCluster; }
+  OmniClusterRef& upperClusterRef() { return theUpperCluster; }
 
   //FIXME::to update with a proper CPE maybe...
   Global3DPoint lowerGlobalPos() const;


### PR DESCRIPTION
#### PR description:

This is a follow-up of PR https://github.com/cms-sw/cmssw/pull/39858.
After the backport of that PR (https://github.com/cms-sw/cmssw/pull/39898) was integrated, it was possible to test the production of RelVal samples (see e.g. on DAS: [/RelValMinBias_14TeV/CMSSW_12_5_2-TkAlMinBias-125X_mcRun4_realistic_v3_2026D88PU-v1/ALCARECO](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=dataset%3D/RelValMinBias_14TeV/CMSSW_12_5_2-TkAlMinBias-125X_mcRun4_realistic_v3_2026D88PU-v1/ALCARECO)).
When trying to run over it, it became clear that is not possible to refit tracks, due to the missing event products (the Phase-2 Outer Tracker clusters) that are necessary for CPE re-computation, leading to this error:

```
Begin processing the 1st record. Run 1, Event 301, LumiSection 4 on stream 6 at 13-Dec-2022 12:50:01.219 CET
----- Begin Fatal Exception 13-Dec-2022 12:50:57 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 4 event: 306 stream: 2
   [1] Running path 'p2'
   [2] Calling method for module TrackRefitter/'FinalTrackRefitter'
Exception Message:
RefCore: A request to resolve a reference to a product of type 'edmNew::DetSetVector<Phase2TrackerCluster1D>' with ProductID '4:449'
can not be satisfied because the product cannot be found.
Probably the branch containing the product is not stored in the input file.
   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

This PR adds the minimal amount of changes in the `CommonTools/RecoAlgos` package in order to be able to retain the Phase-2 OT clusters after running the `AlignmentTrackSelector` module that relies on it:

https://github.com/cms-sw/cmssw/blob/52c0dacc1af916e537cb419a39ec5845ae5087bf/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc#L13-L17

This is done in commit 3c18fe00873f1260753d964175ed30466970f3ba.
Secondly the `outputCommands` of all the Tracker Alignment ALCARECO producers is modified in order to retain `Phase2TrackerCluster1DedmNewDetSetVector` in the output - in case the production is run for Phase-2 - while removing `SiStripClusteredmNewDetSetVector` (since there is no SiStrip detector in phase-2). I profit of that to re-adjust the commands for event contents to cope with no SCAL in Run3 that were leftover from https://github.com/cms-sw/cmssw/pull/38415 and https://github.com/cms-sw/cmssw/pull/38590. 
This is done in commit 19e04f4afa53b6eac5a96a270b49747ef12fb283.
Additionally this contains commit 06b919bb9d0ba72137aa41a900f5af9f4c2da50d  which fixes a problem with the vector hits workflow spotted in master and commit 651c25a09e7facf2fc30ffb2d1df90e24426c3da which makes the `ClusterStorer::rekey` methods non-`const` as per recommendations in https://github.com/cms-sw/cmssw/pull/40363.

#### PR validation:

Run two typical workflows for Run-3 and Phase-2 with

```
runTheMatrix.py -l 11634.0,20834.0 -t 4 -j 8 --ibeos
```

And tested the event content of `TkAlMinBias` indeed changes as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a combined backport of https://github.com/cms-sw/cmssw/pull/40323 and https://github.com/cms-sw/cmssw/pull/40363 (partially backported). It is backported in this cycle in order to use it for the production of `ALCARECO`s within the context of the L1T production happening in that cycle, see https://its.cern.ch/jira/browse/PDMVRELVALS-178 and [McM](https://cms-pdmv.cern.ch/mcm/edit?db_name=mccms&query=TRK-2022Dec07-00001&page=0)