### PR TITLE
[GENERATORS] [CLANG] Fixed unused-but-set-variable warnings

### DIFF
--- a/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/ConcurrentHadronizerFilter.h
@@ -262,8 +262,6 @@ namespace edm {
     std::unique_ptr<HepMC::GenEvent> finalEvent;
     std::unique_ptr<GenEventInfoProduct> finalGenEventInfo;
 
-    //sum of weights for events passing hadronization
-    double waccept = 0;
     //number of accepted events
     unsigned int naccept = 0;
 
@@ -327,7 +325,6 @@ namespace edm {
       if (cache->filter_ && !cache->filter_->filter(event.get(), genEventInfo->weight()))
         continue;
 
-      waccept += genEventInfo->weight();
       ++naccept;
 
       //keep the LAST accepted event (which is equivalent to choosing randomly from the accepted events)

--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -188,8 +188,6 @@ namespace edm {
     std::unique_ptr<HepMC::GenEvent> finalEvent;
     std::unique_ptr<GenEventInfoProduct> finalGenEventInfo;
 
-    //sum of weights for events passing hadronization
-    double waccept = 0;
     //number of accepted events
     unsigned int naccept = 0;
 
@@ -253,7 +251,6 @@ namespace edm {
       if (filter_ && !filter_->filter(event.get(), genEventInfo->weight()))
         continue;
 
-      waccept += genEventInfo->weight();
       ++naccept;
 
       //keep the LAST accepted event (which is equivalent to choosing randomly from the accepted events)

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -385,8 +385,6 @@ GenLumiInfoProduct::XSec GenXSecAnalyzer::compute(const GenLumiInfoProduct &iLum
   // sum of cross sections and errors over different processes
   double sigSelSum = 0.0;
   double err2SelSum = 0.0;
-  double sigSum = 0.0;
-  double err2Sum = 0.0;
 
   std::vector<GenLumiInfoProduct::XSec> tempVector_before;
   std::vector<GenLumiInfoProduct::XSec> tempVector_after;
@@ -474,10 +472,6 @@ GenLumiInfoProduct::XSec GenXSecAnalyzer::compute(const GenLumiInfoProduct &iLum
     double deltaFin = sigmaFin * relErr;
 
     tempVector_after.push_back(GenLumiInfoProduct::XSec(sigmaFin, deltaFin));
-
-    // sum of cross sections and errors over different processes
-    sigSum += sigmaFin;
-    err2Sum += deltaFin * deltaFin;
 
   }  // end of loop over different processes
   tempVector_before.push_back(GenLumiInfoProduct::XSec(sigSelSum, sqrt(err2SelSum)));

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -161,10 +161,7 @@ namespace lhef {
   }
 
   LHERunInfo::XSec LHERunInfo::xsec() const {
-    double sigSelSum = 0.0;
-    double sigSum = 0.0;
     double sigBrSum = 0.0;
-    double err2Sum = 0.0;
     double errBr2Sum = 0.0;
     int idwtup = heprup.IDWTUP;
     for (std::vector<Process>::const_iterator proc = processes.begin(); proc != processes.end(); ++proc) {
@@ -234,13 +231,9 @@ namespace lhef {
       double delta2Sum = delta2Veto + sigma2Err / sigma2Sum;
       relErr = (delta2Sum > 0.0 ? std::sqrt(delta2Sum) : 0.0);
 
-      double deltaFin = sigmaFin * relErr;
       double deltaFinBr = sigmaFinBr * relErr;
 
-      sigSelSum += sigmaAvg;
-      sigSum += sigmaFin;
       sigBrSum += sigmaFinBr;
-      err2Sum += deltaFin * deltaFin;
       errBr2Sum += deltaFinBr * deltaFinBr;
     }
 
@@ -254,7 +247,6 @@ namespace lhef {
     double sigSum = 0.0;
     double sigBrSum = 0.0;
     double errSel2Sum = 0.0;
-    double err2Sum = 0.0;
     double errBr2Sum = 0.0;
     double errMatch2Sum = 0.0;
     unsigned long nAccepted = 0;
@@ -340,7 +332,6 @@ namespace lhef {
         relErr = (delta2Sum > 0.0 ? std::sqrt(delta2Sum) : 0.0);
         relAccErr = (delta2Veto > 0.0 ? std::sqrt(delta2Veto) : 0.0);
       }
-      double deltaFin = sigmaFin * relErr;
       double deltaFinBr = sigmaFinBr * relErr;
 
       double ntotal_proc = proc->nTotalPos() + proc->nTotalNeg();
@@ -366,7 +357,6 @@ namespace lhef {
       sigSum += sigmaFin;
       sigBrSum += sigmaFinBr;
       errSel2Sum += sigma2Err;
-      err2Sum += deltaFin * deltaFin;
       errBr2Sum += deltaFinBr * deltaFinBr;
       errMatch2Sum += sigmaFin * relAccErr * sigmaFin * relAccErr;
     }


### PR DESCRIPTION
This PR fixes `unused-but-set-variable` warnings which we get with LLVM14 in CLANG IBS