### PR TITLE
[ALCA] [CLANG] Fixed unused-but-set-variable warnings

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer.cc
@@ -919,10 +919,8 @@ void EcalLaserAnalyzer::endJob() {
     // Loop on events
     //================
 
-    Long64_t nbytes = 0, nb = 0;
     for (Long64_t jentry = 0; jentry < ADCtrees[iCry]->GetEntriesFast(); jentry++) {
-      nb = ADCtrees[iCry]->GetEntry(jentry);
-      nbytes += nb;
+      ADCtrees[iCry]->GetEntry(jentry);
 
       // Get back color
 
@@ -1169,10 +1167,8 @@ void EcalLaserAnalyzer::endJob() {
     // Final loop on events
     //=======================
 
-    Long64_t nbytes = 0, nb = 0;
     for (Long64_t jentry = 0; jentry < APDtrees[iCry]->GetEntriesFast(); jentry++) {
-      nb = APDtrees[iCry]->GetEntry(jentry);
-      nbytes += nb;
+      APDtrees[iCry]->GetEntry(jentry);
 
       double pnmean;
       if (pn0 < 10 && pn1 > 10) {

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalLaserAnalyzer2.cc
@@ -865,10 +865,8 @@ void EcalLaserAnalyzer2::endJob() {
     // Loop on events
     //================
 
-    Long64_t nbytes = 0, nb = 0;
     for (Long64_t jentry = 0; jentry < ADCtrees[iCry]->GetEntriesFast(); jentry++) {  // Loop on events
-      nb = ADCtrees[iCry]->GetEntry(jentry);
-      nbytes += nb;
+      ADCtrees[iCry]->GetEntry(jentry);
 
       flagfit = 1;
       apdAmpl = 0.0;
@@ -1119,10 +1117,8 @@ void EcalLaserAnalyzer2::endJob() {
     // Final loop on events
     //=======================
 
-    Long64_t nbytes = 0, nb = 0;
     for (Long64_t jentry = 0; jentry < APDtrees[iCry]->GetEntriesFast(); jentry++) {
-      nb = APDtrees[iCry]->GetEntry(jentry);
-      nbytes += nb;
+      APDtrees[iCry]->GetEntry(jentry);
 
       double pnmean;
       if (pn0 < 10 && pn1 > 10) {

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalMatacqAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalMatacqAnalyzer.cc
@@ -361,15 +361,13 @@ void EcalMatacqAnalyzer::endJob() {
   // loop over the entries of the tree
   TChain* fChain = (TChain*)tree;
   Long64_t nentries = fChain->GetEntriesFast();
-  Long64_t nbytes = 0, nb = 0;
 
   for (Long64_t jentry = 0; jentry < nentries; jentry++) {
     // load the event
     Long64_t ientry = fChain->LoadTree(jentry);
     if (ientry < 0)
       break;
-    nb = fChain->GetEntry(jentry);
-    nbytes += nb;
+    fChain->GetEntry(jentry);
 
     status = 0;
     peak = -1;

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalPerEvtLaserAnalyzer.cc
@@ -654,10 +654,8 @@ void EcalPerEvtLaserAnalyzer::endJob() {
 
   // Define submodule and channel number inside the submodule (as Patrice)
 
-  Long64_t nbytes = 0, nb = 0;
   for (Long64_t jentry = 0; jentry < ADCtrees->GetEntriesFast(); jentry++) {  // Loop on events
-    nb = ADCtrees->GetEntry(jentry);
-    nbytes += nb;
+    ADCtrees->GetEntry(jentry);
 
     int iCry = channelNumber;
 


### PR DESCRIPTION
This PR fixes `unused-but-set-variable` warnings which we get with LLVM14 in CLANG IBS