### PR TITLE
[DQM] [CLANG] Fixed unused-but-set-variable warnings

### DIFF
--- a/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
+++ b/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
@@ -8013,7 +8013,6 @@ void CMTRawAnalyzer::fillDigiErrors(HBHEDigiCollection::const_iterator& digiItr)
   bool anydv = true;
   // for help:
   int firstcapid = 0;
-  int sumcapid = 0;
   int lastcapid = 0, capid = 0;
   int ERRORfiber = -10;
   int ERRORfiberChan = -10;
@@ -8044,7 +8043,6 @@ void CMTRawAnalyzer::fillDigiErrors(HBHEDigiCollection::const_iterator& digiItr)
 
     if (ii == 0)
       firstcapid = capid;
-    sumcapid += capid;
 
     if (er) {
       anyer = true;
@@ -8176,7 +8174,6 @@ void CMTRawAnalyzer::fillDigiErrorsQIE11(QIE11DataFrame qie11df) {
   //    bool anydv      =  true;
   // for help:
   int firstcapid = 0;
-  int sumcapid = 0;
   int lastcapid = 0, capid = 0;
   int repetedcapid = 0;
   // loop over the samples in the digi
@@ -8194,7 +8191,6 @@ void CMTRawAnalyzer::fillDigiErrorsQIE11(QIE11DataFrame qie11df) {
     lastcapid = capid;
     if (ii == 0)
       firstcapid = capid;
-    sumcapid += capid;
   }  // for
   ///////////////////////////////////////
   if (!anycapid)
@@ -8290,7 +8286,6 @@ void CMTRawAnalyzer::fillDigiErrorsHF(HFDigiCollection::const_iterator& digiItr)
   bool anydv = true;
   // for help:
   int firstcapid = 0;
-  int sumcapid = 0;
   int lastcapid = 0, capid = 0;
   int ERRORfiber = -10;
   int ERRORfiberChan = -10;
@@ -8320,7 +8315,6 @@ void CMTRawAnalyzer::fillDigiErrorsHF(HFDigiCollection::const_iterator& digiItr)
     lastcapid = capid;
     if (ii == 0)
       firstcapid = capid;
-    sumcapid += capid;
     if (er) {
       anyer = true;
       ERRORfiber = fiber;
@@ -8415,7 +8409,6 @@ void CMTRawAnalyzer::fillDigiErrorsHFQIE10(QIE10DataFrame qie10df) {
   //    bool anydv      =  true;
   // for help:
   int firstcapid = 0;
-  int sumcapid = 0;
   int lastcapid = 0, capid = 0;
   int repetedcapid = 0;
   // loop over the samples in the digi
@@ -8433,7 +8426,6 @@ void CMTRawAnalyzer::fillDigiErrorsHFQIE10(QIE10DataFrame qie10df) {
     lastcapid = capid;
     if (ii == 0)
       firstcapid = capid;
-    sumcapid += capid;
   }  // for
   ///////////////////////////////////////
   if (!anycapid)
@@ -8494,7 +8486,6 @@ void CMTRawAnalyzer::fillDigiErrorsHO(HODigiCollection::const_iterator& digiItr)
   bool anydv = true;
   // for help:
   int firstcapid = 0;
-  int sumcapid = 0;
   int lastcapid = 0, capid = 0;
   int ERRORfiber = -10;
   int ERRORfiberChan = -10;
@@ -8521,7 +8512,6 @@ void CMTRawAnalyzer::fillDigiErrorsHO(HODigiCollection::const_iterator& digiItr)
 
     if (ii == 0)
       firstcapid = capid;
-    sumcapid += capid;
 
     if (er) {
       anyer = true;
@@ -8644,10 +8634,12 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
   double difpedestal2 = 0.;
   double difpedestal3 = 0.;
 
+/*
   double amplitudewithPedSubtr1 = 0.;
   double amplitudewithPedSubtr2 = 0.;
   double amplitudewithPedSubtr3 = 0.;
   double amplitudewithPedSubtr4 = 0.;
+*/
   double amplitude = 0.;
   double absamplitude = 0.;
   double amplitude345 = 0.;
@@ -8751,6 +8743,7 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
       max_signal = ampldefault;
       ts_with_max_signal = ii;
     }
+    /*
     ///   for choice TSs, raddam only:
     //     TS = 1 to 10:  1  2  3  4  5  6  7  8  9  10
     //     ii = 0 to  9:  0  1  2  3  4  5  6  7  8   9
@@ -8772,6 +8765,7 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
     if (ii > 2 && ii < 6)
       amplitudewithPedSubtr4 += ampldefaultwithPedSubtr;  //
     //
+    */
     amplitude += ampldefault;          //
     absamplitude += abs(ampldefault);  //
 

--- a/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
+++ b/DPGAnalysis/HcalTools/plugins/CMTRawAnalyzer.cc
@@ -8634,7 +8634,7 @@ void CMTRawAnalyzer::fillDigiAmplitude(HBHEDigiCollection::const_iterator& digiI
   double difpedestal2 = 0.;
   double difpedestal3 = 0.;
 
-/*
+  /*
   double amplitudewithPedSubtr1 = 0.;
   double amplitudewithPedSubtr2 = 0.;
   double amplitudewithPedSubtr3 = 0.;

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -605,28 +605,6 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
     }
   }
 
-  //===========================================================================
-  // IN ALL other CASES : ieta-iphi maps
-  //===========================================================================
-  /*
-  // ECAL
-  if (ecalselector_ == "yes" && (subdet_ == 1 || subdet_ == 2 || subdet_ == 5)) {
-    Handle<EBRecHitCollection> rhitEB;
-    if (ev.getByToken(tok_EB_, rhitEB)) {
-      for (const auto &recHit : *(rhitEB.product())) {
-        double en = recHit.energy();
-      }
-    }
-
-    Handle<EERecHitCollection> rhitEE;
-    if (ev.getByToken(tok_EE_, rhitEE)) {
-      for (const auto &recHit : *(rhitEE.product())) {
-        double en = recHit.energy();
-      }
-    }
-  }  // end of ECAL selection
-  */
-
   // Counting, including ZS items
   // Filling HCAL maps  ----------------------------------------------------
   //   double maxE = -99999.;

--- a/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
+++ b/DQMOffline/Hcal/src/HcalRecHitsAnalyzer.cc
@@ -550,16 +550,11 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
   // cuts for each subdet_ector mimiking  "Scheme B"
   //  double cutHB = 0.9, cutHE = 1.4, cutHO = 1.1, cutHFL = 1.2, cutHFS = 1.8;
 
-  // energy in HCAL
-  double eHcal = 0.;
   // Total numbet of RecHits in HCAL, in the cone, above 1 GeV theshold
   int nrechits = 0;
   int nrechitsThresh = 0;
 
   // energy in ECAL
-  double eEcal = 0.;
-  double eEcalB = 0.;
-  double eEcalE = 0.;
   double eEcalCone = 0.;
 
   // HCAL energy around MC eta-phi at all depths;
@@ -613,15 +608,13 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
   //===========================================================================
   // IN ALL other CASES : ieta-iphi maps
   //===========================================================================
-
+  /*
   // ECAL
   if (ecalselector_ == "yes" && (subdet_ == 1 || subdet_ == 2 || subdet_ == 5)) {
     Handle<EBRecHitCollection> rhitEB;
     if (ev.getByToken(tok_EB_, rhitEB)) {
       for (const auto &recHit : *(rhitEB.product())) {
         double en = recHit.energy();
-        eEcal += en;
-        eEcalB += en;
       }
     }
 
@@ -629,11 +622,10 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
     if (ev.getByToken(tok_EE_, rhitEE)) {
       for (const auto &recHit : *(rhitEE.product())) {
         double en = recHit.energy();
-        eEcal += en;
-        eEcalE += en;
       }
     }
   }  // end of ECAL selection
+  */
 
   // Counting, including ZS items
   // Filling HCAL maps  ----------------------------------------------------
@@ -766,7 +758,6 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
 
     // 32-bit status word
     uint32_t statadd;
-    unsigned int isw67 = 0;
 
     // Statusword correlation
     unsigned int sw27 = 27;
@@ -800,10 +791,6 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
           RecHit_StatusWord_HO->Fill(isw);
         else if (sub == 4) {
           RecHit_StatusWord_HF->Fill(isw);
-          if (isw == 6)
-            isw67 += 1;
-          if (isw == 7)
-            isw67 += 2;
         }
       }
     }
@@ -882,7 +869,6 @@ void HcalRecHitsAnalyzer::analyze(edm::Event const &ev, edm::EventSetup const &i
       }
 
       nrechits++;
-      eHcal += en;
 
       if (en > 1.)
         nrechitsThresh++;

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -370,6 +370,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
         }
         nrechitsCone++;
 
+        HcalCone += en;
         // alternative: ietamax -> closest to MC eta  !!!
         float eta_diff = fabs(eta_MC - eta);
         if (eta_diff < etaMax) {

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -192,8 +192,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
   //  double cutHB = 0.9, cutHE = 1.4, cutHO = 1.1, cutHFL = 1.2, cutHFS = 1.8;
 
   // energy in HCAL
-  double eHcal = 0.;
-  double eHcalCone = 0.;
   double eHcalConeHB = 0.;
   double eHcalConeHE = 0.;
   double eHcalConeHO = 0.;
@@ -207,9 +205,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
   int nrechitsThresh = 0;
 
   // energy in ECAL
-  double eEcal = 0.;
-  double eEcalB = 0.;
-  double eEcalE = 0.;
   double eEcalCone = 0.;
   int numrechitsEcal = 0;
 
@@ -288,8 +283,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
         double en = RecHit->energy();
-        eEcal += en;
-        eEcalB += en;
 
         double r = dR(eta_MC, phi_MC, eta, phi);
         if (r < partR) {
@@ -312,8 +305,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
         double eta = cellGeometry->getPosition().eta();
         double phi = cellGeometry->getPosition().phi();
         double en = RecHit->energy();
-        eEcal += en;
-        eEcalE += en;
 
         double r = dR(eta_MC, phi_MC, eta, phi);
         if (r < partR) {
@@ -359,7 +350,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
         chi2_log10 = log10(chi2);
 
       nrechits++;
-      eHcal += en;
       if (en > 1.)
         nrechitsThresh++;
 
@@ -378,10 +368,7 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
           else
             eHcalConeHFS += en;
         }
-        eHcalCone += en;
         nrechitsCone++;
-
-        HcalCone += en;
 
         // alternative: ietamax -> closest to MC eta  !!!
         float eta_diff = fabs(eta_MC - eta);
@@ -444,7 +431,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
     if (hcalHits.isValid()) {
       const PCaloHitContainer *SimHitResult = hcalHits.product();
 
-      double enSimHits = 0.;
       double enSimHitsHB = 0.;
       double enSimHitsHE = 0.;
       double enSimHitsHO = 0.;
@@ -481,7 +467,6 @@ void HcalRecHitsValidation::analyze(edm::Event const &ev, edm::EventSetup const 
 
         if (r < partR) {  // just energy in the small cone
 
-          enSimHits += en;
           if (sub == static_cast<int>(HcalBarrel))
             enSimHitsHB += en;
           if (sub == static_cast<int>(HcalEndcap))

--- a/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcFakeValidator.cc
@@ -2497,14 +2497,11 @@ void ElectronMcFakeValidator::analyze(const edm::Event &iEvent, const edm::Event
   // get a vector with EB  & EE
   //===============================================
   std::vector<reco::GsfElectron> localCollection;
-  int iBarrels = 0;
-  int iEndcaps = 0;
 
   // looking for EB
   for (gsfIter = gsfElectrons->begin(); gsfIter != gsfElectrons->end(); gsfIter++) {
     if (gsfIter->isEB()) {
       localCollection.push_back(*gsfIter);
-      iBarrels += 1;
     }
   }
 
@@ -2512,7 +2509,6 @@ void ElectronMcFakeValidator::analyze(const edm::Event &iEvent, const edm::Event
   for (gsfIter = gsfElectronsEndcaps->begin(); gsfIter != gsfElectronsEndcaps->end(); gsfIter++) {
     if (gsfIter->isEE()) {
       localCollection.push_back(*gsfIter);
-      iEndcaps += 1;
     }
   }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcMiniAODSignalValidator.cc
@@ -445,14 +445,11 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
   // get a vector with EB  & EE
   //===============================================
   std::vector<pat::Electron> localCollection;
-  int iBarrels = 0;
-  int iEndcaps = 0;
 
   // looking for EB
   for (el1 = electrons->begin(); el1 != electrons->end(); el1++) {
     if (el1->isEB()) {
       localCollection.push_back(*el1);
-      iBarrels += 1;
     }
   }
 
@@ -460,7 +457,6 @@ void ElectronMcSignalValidatorMiniAOD::analyze(const edm::Event& iEvent, const e
   for (el1 = electrons_endcaps->begin(); el1 != electrons_endcaps->end(); el1++) {
     if (el1->isEE()) {
       localCollection.push_back(*el1);
-      iEndcaps += 1;
     }
   }
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -3310,14 +3310,11 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   // get a vector with EB  & EE
   //===============================================
   std::vector<reco::GsfElectron> localCollection;
-  int iBarrels = 0;
-  int iEndcaps = 0;
 
   // looking for EB
   for (gsfIter = gsfElectrons->begin(); gsfIter != gsfElectrons->end(); gsfIter++) {
     if (gsfIter->isEB()) {
       localCollection.push_back(*gsfIter);
-      iBarrels += 1;
     }
   }
 
@@ -3325,7 +3322,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
   for (gsfIter = gsfElectronsEndcaps->begin(); gsfIter != gsfElectronsEndcaps->end(); gsfIter++) {
     if (gsfIter->isEE()) {
       localCollection.push_back(*gsfIter);
-      iEndcaps += 1;
     }
   }
 


### PR DESCRIPTION
This PR fixes `unused-but-set-variable` warnings which we get with LLVM14 in CLANG IBS