### PR TITLE
Phase2-hgx334B Extend some of the calling sequences of Geometry to include zside which is needed to treat correctly cassette shifts

### DIFF
--- a/Geometry/CaloTopology/src/HGCalTopology.cc
+++ b/Geometry/CaloTopology/src/HGCalTopology.cc
@@ -473,7 +473,7 @@ bool HGCalTopology::valid(const DetId& idin) const {
   } else if (tileTrapezoid()) {
     flag = ((idin.det() == det_) && hdcons_.isValidTrap(id.zSide, id.iLay, id.iSec1, id.iCell1));
   } else {
-    flag = ((idin.det() == det_) && hdcons_.isValidHex8(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2));
+    flag = ((idin.det() == det_) && hdcons_.isValidHex8(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, false));
   }
   return flag;
 }
@@ -579,9 +579,9 @@ void HGCalTopology::addHGCSiliconId(
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "addHGCSiliconId " << det << ":" << zside << ":" << type << ":" << lay << ":"
                                 << waferU << ":" << waferV << ":" << cellU << ":" << cellV << " ==> Validity "
-                                << hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV);
+                                << hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV, false);
 #endif
-  if (hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV)) {
+  if (hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV, false)) {
     HGCSiliconDetId id((DetId::Detector)(det), zside, type, lay, waferU, waferV, cellU, cellV);
     ids.emplace_back(DetId(id));
   }

--- a/Geometry/HGCalCommonData/interface/HGCalCassette.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCassette.h
@@ -12,6 +12,7 @@ public:
 
   void setParameter(int cassette, const std::vector<double>& shifts);
   std::pair<double, double> getShift(int layer, int zside, int cassette) const;
+  static int cassetteIndex(int det, int layer, int zside, int cassette);
 
 private:
   const std::vector<int> positEE_ = {2, 1, 0, 5, 4, 3};
@@ -19,6 +20,7 @@ private:
   int cassette_;
   bool typeHE_;
   std::vector<double> shifts_;
+  static constexpr int32_t factor_ = 100;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -39,7 +39,7 @@ public:
 
   std::pair<int, int> assignCell(float x, float y, int lay, int subSec, bool reco) const;
   std::array<int, 5> assignCellHex(
-      float x, float y, int zside, int lay, bool reco, bool extend = false, bool debug = false) const;
+      float x, float y, int zside, int lay, bool reco, bool extend, bool debug) const;
   std::array<int, 3> assignCellTrap(float x, float y, float z, int lay, bool reco) const;
   std::pair<double, double> cellEtaPhiTrap(int type, int irad) const;
   bool cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, int zside, bool reco) const;
@@ -80,8 +80,8 @@ public:
   inline int getUVMax(int type) const { return ((type == 0) ? hgpar_->nCellsFine_ : hgpar_->nCellsCoarse_); }
   bool isHalfCell(int waferType, int cell) const;
   bool isValidHex(int lay, int mod, int cell, bool reco) const;
-  bool isValidHex8(int lay, int waferU, int waferV, bool fullAndPart = false) const;
-  bool isValidHex8(int lay, int modU, int modV, int cellU, int cellV, bool fullAndPart = false) const;
+  bool isValidHex8(int lay, int waferU, int waferV, bool fullAndPart) const;
+  bool isValidHex8(int lay, int modU, int modV, int cellU, int cellV, bool fullAndPart) const;
   bool isValidTrap(int zside, int lay, int ieta, int iphi) const;
   int lastLayer(bool reco) const;
   int layerIndex(int lay, bool reco) const;
@@ -101,12 +101,12 @@ public:
                                      int cellV,
                                      bool reco,
                                      bool all,
-                                     bool norot = false,
-                                     bool debug = false) const;
-  std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug = false) const;
-  std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug = false) const;
+                                     bool norot,
+                                     bool debug) const;
+  std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug) const;
+  std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;
-  std::pair<float, float> locateCellTrap(int zside, int lay, int ieta, int iphi, bool reco, bool debug = false) const;
+  std::pair<float, float> locateCellTrap(int zside, int lay, int ieta, int iphi, bool reco, bool debug) const;
   inline int levelTop(int ind = 0) const { return hgpar_->levelT_[ind]; }
   bool maskCell(const DetId& id, int corners) const;
   inline int maxCellUV() const { return (tileTrapezoid() ? hgpar_->nCellsFine_ : 2 * hgpar_->nCellsFine_); }
@@ -157,8 +157,8 @@ public:
                          int& cellV,
                          int& celltype,
                          double& wt,
-                         bool extend = false,
-                         bool debug = false) const;
+                         bool extend,
+                         bool debug) const;
   inline bool waferHexagon6() const {
     return ((mode_ == HGCalGeometryMode::Hexagon) || (mode_ == HGCalGeometryMode::HexagonFull));
   }
@@ -179,7 +179,7 @@ public:
   inline int waferMin() const { return waferMax_[0]; }
   std::pair<double, double> waferParameters(bool reco) const;
   std::pair<double, double> waferPosition(int wafer, bool reco) const;
-  std::pair<double, double> waferPosition(int lay, int waferU, int waferV, bool reco, bool debug = false) const;
+  std::pair<double, double> waferPosition(int lay, int waferU, int waferV, bool reco, bool debug) const;
   inline unsigned int waferFileSize() const { return hgpar_->waferInfoMap_.size(); }
   int waferFileIndex(unsigned int kk) const;
   std::tuple<int, int, int> waferFileInfo(unsigned int kk) const;
@@ -210,11 +210,11 @@ public:
   inline int waferTypeL(int wafer) const {
     return ((wafer >= 0) && (wafer < static_cast<int>(hgpar_->waferTypeL_.size()))) ? hgpar_->waferTypeL_[wafer] : 0;
   }
-  int waferType(DetId const& id, bool fromFile = false) const;
-  int waferType(int layer, int waferU, int waferV, bool fromFile = false) const;
-  std::tuple<int, int, int> waferType(HGCSiliconDetId const& id, bool fromFile = false) const;
+  int waferType(DetId const& id, bool fromFile) const;
+  int waferType(int layer, int waferU, int waferV, bool fromFile) const;
+  std::tuple<int, int, int> waferType(HGCSiliconDetId const& id, bool fromFile) const;
   std::pair<int, int> waferTypeRotation(
-      int layer, int waferU, int waferV, bool fromFile = false, bool debug = false) const;
+      int layer, int waferU, int waferV, bool fromFile, bool debug) const;
   inline int waferUVMax() const { return hgpar_->waferUVMax_; }
   bool waferVirtual(int layer, int waferU, int waferV) const;
   double waferZ(int layer, bool reco) const;
@@ -232,15 +232,15 @@ private:
                int part,
                int& cellU,
                int& cellV,
-               bool extend = false,
-               bool debug = false) const;
+               bool extend,
+               bool debug) const;
   std::pair<int, float> getIndex(int lay, bool reco) const;
   int layerFromIndex(int index, bool reco) const;
   bool isValidCell(int layindex, int wafer, int cell) const;
   bool isValidCell8(int lay, int waferU, int waferV, int cellU, int cellV, int type) const;
   int32_t waferIndex(int wafer, int index) const;
   bool waferInLayerTest(int wafer, int lay, bool full) const;
-  std::pair<double, double> waferPositionNoRot(int lay, int waferU, int waferV, bool reco, bool debug = false) const;
+  std::pair<double, double> waferPositionNoRot(int lay, int waferU, int waferV, bool reco, bool debug) const;
   std::pair<double, double> waferPosition(int waferU, int waferV, bool reco) const;
 
   HGCalCassette hgcassette_;

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -38,8 +38,7 @@ public:
   ~HGCalDDDConstants() = default;
 
   std::pair<int, int> assignCell(float x, float y, int lay, int subSec, bool reco) const;
-  std::array<int, 5> assignCellHex(
-      float x, float y, int zside, int lay, bool reco, bool extend, bool debug) const;
+  std::array<int, 5> assignCellHex(float x, float y, int zside, int lay, bool reco, bool extend, bool debug) const;
   std::array<int, 3> assignCellTrap(float x, float y, float z, int lay, bool reco) const;
   std::pair<double, double> cellEtaPhiTrap(int type, int irad) const;
   bool cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, int zside, bool reco) const;
@@ -93,16 +92,9 @@ public:
   std::pair<float, float> localToGlobal8(
       int zside, int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
   std::pair<float, float> locateCell(int cell, int lay, int type, bool reco) const;
-  std::pair<float, float> locateCell(int zside,
-                                     int lay,
-                                     int waferU,
-                                     int waferV,
-                                     int cellU,
-                                     int cellV,
-                                     bool reco,
-                                     bool all,
-                                     bool norot,
-                                     bool debug) const;
+  std::pair<float, float> locateCell(
+      int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug)
+      const;
   std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug) const;
   std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;
@@ -213,8 +205,7 @@ public:
   int waferType(DetId const& id, bool fromFile) const;
   int waferType(int layer, int waferU, int waferV, bool fromFile) const;
   std::tuple<int, int, int> waferType(HGCSiliconDetId const& id, bool fromFile) const;
-  std::pair<int, int> waferTypeRotation(
-      int layer, int waferU, int waferV, bool fromFile, bool debug) const;
+  std::pair<int, int> waferTypeRotation(int layer, int waferU, int waferV, bool fromFile, bool debug) const;
   inline int waferUVMax() const { return hgpar_->waferUVMax_; }
   bool waferVirtual(int layer, int waferU, int waferV) const;
   double waferZ(int layer, bool reco) const;
@@ -225,15 +216,9 @@ private:
               const double& cellR,
               const std::vector<double>& posX,
               const std::vector<double>& posY) const;
-  void cellHex(double xloc,
-               double yloc,
-               int cellType,
-               int place,
-               int part,
-               int& cellU,
-               int& cellV,
-               bool extend,
-               bool debug) const;
+  void cellHex(
+      double xloc, double yloc, int cellType, int place, int part, int& cellU, int& cellV, bool extend, bool debug)
+      const;
   std::pair<int, float> getIndex(int lay, bool reco) const;
   int layerFromIndex(int index, bool reco) const;
   bool isValidCell(int layindex, int wafer, int cell) const;

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -38,10 +38,11 @@ public:
   ~HGCalDDDConstants() = default;
 
   std::pair<int, int> assignCell(float x, float y, int lay, int subSec, bool reco) const;
-  std::array<int, 5> assignCellHex(float x, float y, int lay, bool reco, bool extend = false, bool debug = false) const;
+  std::array<int, 5> assignCellHex(
+      float x, float y, int zside, int lay, bool reco, bool extend = false, bool debug = false) const;
   std::array<int, 3> assignCellTrap(float x, float y, float z, int lay, bool reco) const;
   std::pair<double, double> cellEtaPhiTrap(int type, int irad) const;
-  bool cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, bool reco) const;
+  bool cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, int zside, bool reco) const;
   double cellSizeHex(int type) const;
   inline std::pair<double, double> cellSizeTrap(int type, int irad) const {
     return std::make_pair(hgpar_->radiusLayer_[type][irad - 1], hgpar_->radiusLayer_[type][irad]);
@@ -90,9 +91,10 @@ public:
     return ((hgpar_->layerType_.empty()) ? HGCalTypes::WaferCenter : hgpar_->layerType_[lay - hgpar_->firstLayer_]);
   }
   std::pair<float, float> localToGlobal8(
-      int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
+      int zside, int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
   std::pair<float, float> locateCell(int cell, int lay, int type, bool reco) const;
-  std::pair<float, float> locateCell(int lay,
+  std::pair<float, float> locateCell(int zside,
+                                     int lay,
                                      int waferU,
                                      int waferV,
                                      int cellU,
@@ -104,7 +106,7 @@ public:
   std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug = false) const;
   std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug = false) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;
-  std::pair<float, float> locateCellTrap(int lay, int ieta, int iphi, bool reco, bool debug = false) const;
+  std::pair<float, float> locateCellTrap(int zside, int lay, int ieta, int iphi, bool reco, bool debug = false) const;
   inline int levelTop(int ind = 0) const { return hgpar_->levelT_[ind]; }
   bool maskCell(const DetId& id, int corners) const;
   inline int maxCellUV() const { return (tileTrapezoid() ? hgpar_->nCellsFine_ : 2 * hgpar_->nCellsFine_); }
@@ -147,6 +149,7 @@ public:
   void waferFromPosition(const double x, const double y, int& wafer, int& icell, int& celltyp) const;
   void waferFromPosition(const double x,
                          const double y,
+                         const int zside,
                          const int layer,
                          int& waferU,
                          int& waferV,

--- a/Geometry/HGCalCommonData/src/HGCalCassette.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCassette.cc
@@ -1,5 +1,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/HGCalCommonData/interface/HGCalCassette.h"
+#include <algorithm>
 #include <sstream>
 
 //#define EDM_ML_DEBUG
@@ -10,11 +11,17 @@ void HGCalCassette::setParameter(int cassette, const std::vector<double>& shifts
   shifts_.insert(shifts_.end(), shifts.begin(), shifts.end());
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "# of cassettes = " << cassette_ << " Type " << typeHE_;
-  std::ostringstream st1;
-  st1 << " Shifts:";
-  for (const auto& s : shifts_)
-    st1 << ":" << s;
-  edm::LogVerbatim("HGCalGeom") << st1.str();
+  for (uint32_t j1 = 0; j1 < shifts.size(); j1 += 12) {
+    std::ostringstream st1;
+    if (j1 == 0)
+      st1 << " Shifts:";
+    else
+      st1 << "        ";
+    uint32_t j2 = std::min((j1 + 12), static_cast<uint32_t>(shifts.size()));
+    for (uint32_t j = j1; j < j2; ++j)
+      st1 << ":" << shifts[j];
+    edm::LogVerbatim("HGCalGeom") << st1.str();
+  }
 #endif
 }
 
@@ -28,4 +35,9 @@ std::pair<double, double> HGCalCassette::getShift(int layer, int zside, int cass
                                 << xy.second;
 #endif
   return xy;
+}
+
+int HGCalCassette::cassetteIndex(int det, int layer, int side, int cassette) {
+  int zs = (side > 0) ? factor_ : 0;
+  return (((zs + det) * factor_ + layer) * factor_ + cassette);
 }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -164,7 +164,7 @@ std::pair<int, int> HGCalDDDConstants::assignCell(float x, float y, int lay, int
 }
 
 std::array<int, 5> HGCalDDDConstants::assignCellHex(
-    float x, float y, int lay, bool reco, bool extend, bool debug) const {
+    float x, float y, int zside, int lay, bool reco, bool extend, bool debug) const {
   int waferU(0), waferV(0), waferType(-1), cellU(0), cellV(0);
   if (waferHexagon8()) {
     double xx = (reco) ? HGCalParameters::k_ScaleToDDD * x : x;
@@ -173,7 +173,7 @@ std::array<int, 5> HGCalDDDConstants::assignCellHex(
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "assignCellHex x " << x << ":" << xx << " y " << y << ":" << yy << " Lay " << lay;
 #endif
-    waferFromPosition(xx, yy, lay, waferU, waferV, cellU, cellV, waferType, wt, extend, debug);
+    waferFromPosition(xx, yy, zside, lay, waferU, waferV, cellU, cellV, waferType, wt, extend, debug);
   }
   return std::array<int, 5>{{waferU, waferV, waferType, cellU, cellV}};
 }
@@ -226,7 +226,7 @@ std::pair<double, double> HGCalDDDConstants::cellEtaPhiTrap(int type, int irad) 
   return std::make_pair(dr, df);
 }
 
-bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, bool reco) const {
+bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV, int lay, int zside, bool reco) const {
   const auto& indx = getIndex(lay, true);
   if (indx.first >= 0) {
     if (mode_ == HGCalGeometryMode::Hexagon8Cassette) {
@@ -246,7 +246,7 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
       int ncell = (thck == HGCalTypes::WaferFineThin) ? hgpar_->nCellsFine_ : hgpar_->nCellsCoarse_;
       return HGCalWaferMask::goodCell(cellU, cellV, ncell, part, rotn);
     } else if (waferHexagon8() || waferHexagon6()) {
-      const auto& xy = ((waferHexagon8()) ? locateCell(lay, waferU, waferV, cellU, cellV, reco, true, false, false)
+      const auto& xy = ((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false)
                                           : locateCell(cellU, lay, waferU, reco));
       double rpos = sqrt(xy.first * xy.first + xy.second * xy.second);
       return ((rpos >= hgpar_->rMinLayHex_[indx.first]) && (rpos <= hgpar_->rMaxLayHex_[indx.first]));
@@ -607,7 +607,6 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
                                 << " Tests " << (cellU >= 0) << ":" << (cellU < 2 * N) << ":" << (cellV >= 0) << ":"
                                 << (cellV < 2 * N) << ":" << ((cellV - cellU) < N) << ":" << ((cellU - cellV) <= N);
 #endif
-  //  if (mode_ != HGCalGeometryMode::Hexagon8Cassette) {
   if ((cellU < 0) || (cellU >= 2 * N) || (cellV < 0) || (cellV >= 2 * N)) {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "HGCalDDDConstants:: Cannot statisfy Cell 1 condition " << cellU << ":" << cellV
@@ -622,7 +621,6 @@ bool HGCalDDDConstants::isValidHex8(int layer, int modU, int modV, int cellU, in
 #endif
     return false;
   }
-  //  }
   return isValidCell8(layer, modU, modV, cellU, cellV, type);
 }
 
@@ -660,7 +658,7 @@ unsigned int HGCalDDDConstants::layersInit(bool reco) const {
 }
 
 std::pair<float, float> HGCalDDDConstants::localToGlobal8(
-    int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const {
+    int zside, int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const {
   double x(localX), y(localY);
   bool rotx =
       ((!hgpar_->layerType_.empty()) && (hgpar_->layerType_[lay - hgpar_->firstLayer_] == HGCalTypes::WaferCenterR));
@@ -726,7 +724,7 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int cell, int lay, int typ
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(
-    int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug) const {
+    int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug) const {
   double x(0), y(0);
   int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
   auto itr = hgpar_->typesInLayers_.find(indx);
@@ -803,7 +801,7 @@ std::pair<float, float> HGCalDDDConstants::locateCell(
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCSiliconDetId& id, bool debug) const {
-  return locateCell(id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, debug);
+  return locateCell(id.zside(), id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, debug);
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCScintillatorDetId& id, bool debug) const {
@@ -826,7 +824,7 @@ std::pair<float, float> HGCalDDDConstants::locateCellHex(int cell, int wafer, bo
   return std::make_pair(x, y);
 }
 
-std::pair<float, float> HGCalDDDConstants::locateCellTrap(int lay, int irad, int iphi, bool reco, bool debug) const {
+std::pair<float, float> HGCalDDDConstants::locateCellTrap(int zside, int lay, int irad, int iphi, bool reco, bool debug) const {
   float x(0), y(0);
   const auto& indx = getIndex(lay, reco);
   if (indx.first >= 0) {
@@ -1322,6 +1320,7 @@ void HGCalDDDConstants::waferFromPosition(const double x, const double y, int& w
 
 void HGCalDDDConstants::waferFromPosition(const double x,
                                           const double y,
+                                          const int zside,
                                           const int layer,
                                           int& waferU,
                                           int& waferV,

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -246,8 +246,9 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
       int ncell = (thck == HGCalTypes::WaferFineThin) ? hgpar_->nCellsFine_ : hgpar_->nCellsCoarse_;
       return HGCalWaferMask::goodCell(cellU, cellV, ncell, part, rotn);
     } else if (waferHexagon8() || waferHexagon6()) {
-      const auto& xy = ((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false)
-                                          : locateCell(cellU, lay, waferU, reco));
+      const auto& xy =
+          ((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false)
+                             : locateCell(cellU, lay, waferU, reco));
       double rpos = sqrt(xy.first * xy.first + xy.second * xy.second);
       return ((rpos >= hgpar_->rMinLayHex_[indx.first]) && (rpos <= hgpar_->rMaxLayHex_[indx.first]));
     } else {
@@ -724,7 +725,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int cell, int lay, int typ
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(
-    int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug) const {
+    int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug)
+    const {
   double x(0), y(0);
   int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
   auto itr = hgpar_->typesInLayers_.find(indx);
@@ -824,7 +826,8 @@ std::pair<float, float> HGCalDDDConstants::locateCellHex(int cell, int wafer, bo
   return std::make_pair(x, y);
 }
 
-std::pair<float, float> HGCalDDDConstants::locateCellTrap(int zside, int lay, int irad, int iphi, bool reco, bool debug) const {
+std::pair<float, float> HGCalDDDConstants::locateCellTrap(
+    int zside, int lay, int irad, int iphi, bool reco, bool debug) const {
   float x(0), y(0);
   const auto& indx = getIndex(lay, reco);
   if (indx.first >= 0) {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -807,7 +807,7 @@ std::pair<float, float> HGCalDDDConstants::locateCell(const HGCSiliconDetId& id,
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCScintillatorDetId& id, bool debug) const {
-  return locateCellTrap(id.layer(), id.iradius(), id.iphi(), true, debug);
+  return locateCellTrap(id.zside(), id.layer(), id.iradius(), id.iphi(), true, debug);
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCellHex(int cell, int wafer, bool reco) const {

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -129,6 +129,8 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
   for (unsigned int k = 0; k < positionX_.size(); ++k) {
     float localx(positionX_[k]), localy(positionY_[k]);
     for (unsigned int i = 0; i < hgdc.layers(reco_); ++i) {
+      double zpos = hgdc.waferZ(i + loff, reco_);
+      int zside = (zpos > 0) ? 1 : -1;
       if (detType_ == 1) {
         std::pair<int, int> kxy, lxy;
         kxy = hgdc.assignCell(localx, localy, i + loff, subsec, reco_);
@@ -149,9 +151,8 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << lxy.first << ", " << lxy.second << ")" << flg;
       } else if (detType_ == 0) {
         std::array<int, 3> kxy, lxy;
-        double zpos = hgdc.waferZ(i + loff, reco_);
         kxy = hgdc.assignCellTrap(localx, localy, zpos, i + loff, reco_);
-        xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
+        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff
@@ -160,7 +161,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
                                       << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellTrap(-localx, -localy, zpos, i + loff, reco_);
-        xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
+        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff
@@ -170,20 +171,19 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
       } else {
         std::array<int, 5> kxy, lxy;
-        kxy = hgdc.assignCellHex(localx, localy, i + loff, reco_);
-        xy = hgdc.locateCell(i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
-        lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
+        kxy = hgdc.assignCellHex(localx, localy, zside, i + loff, reco_);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
+        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        double zpos = hgdc.waferZ(i + loff, reco_);
         edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff
                                       << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"
                                       << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", "
                                       << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":"
                                       << lxy[3] << ":" << lxy[4] << ") Dist "
                                       << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
-        kxy = hgdc.assignCellHex(-localx, -localy, i + loff, reco_);
-        xy = hgdc.locateCell(i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
-        lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
+        kxy = hgdc.assignCellHex(-localx, -localy, zside, i + loff, reco_);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
+        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff
                                       << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -152,7 +152,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
       } else if (detType_ == 0) {
         std::array<int, 3> kxy, lxy;
         kxy = hgdc.assignCellTrap(localx, localy, zpos, i + loff, reco_);
-        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_);
+        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_, false);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff
@@ -161,7 +161,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
                                       << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellTrap(-localx, -localy, zpos, i + loff, reco_);
-        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_);
+        xy = hgdc.locateCellTrap(zside, i + loff, kxy[0], kxy[1], reco_, false);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff
@@ -171,9 +171,9 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
       } else {
         std::array<int, 5> kxy, lxy;
-        kxy = hgdc.assignCellHex(localx, localy, zside, i + loff, reco_);
-        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
-        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_);
+        kxy = hgdc.assignCellHex(localx, localy, zside, i + loff, reco_, false, false);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false);
+        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_, false, false);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff
                                       << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"
@@ -181,9 +181,9 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":"
                                       << lxy[3] << ":" << lxy[4] << ") Dist "
                                       << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
-        kxy = hgdc.assignCellHex(-localx, -localy, zside, i + loff, reco_);
-        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
-        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_);
+        kxy = hgdc.assignCellHex(-localx, -localy, zside, i + loff, reco_, false, false);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false);
+        lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_, false, false);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff
                                       << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"

--- a/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
@@ -105,11 +105,14 @@ void HGCalPartialWaferTester::analyze(const edm::Event&, const edm::EventSetup& 
           if ((ui < 2 * nCells) && (vi < 2 * nCells) && ((vi - ui) < nCells) && ((ui - vi) <= nCells) &&
               HGCalWaferMask::goodCell(ui, vi, partialType)) {
             ++alltry;
+            double zpos = hgdc.waferZ(layer, reco);
+            int zside = (zpos > 0) ? 1 : -1;
             auto xy = hgdc.locateCell(layer, waferU, waferV, ui, vi, reco, all, norot, debug1);
             int lay(layer), cU(0), cV(0), wType(-1), wU(0), wV(0);
             double wt(0);
             hgdc.waferFromPosition(HGCalParameters::k_ScaleToDDD * xy.first,
                                    HGCalParameters::k_ScaleToDDD * xy.second,
+                                   zside,
                                    lay,
                                    wU,
                                    wV,

--- a/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
@@ -107,7 +107,7 @@ void HGCalPartialWaferTester::analyze(const edm::Event&, const edm::EventSetup& 
             ++alltry;
             double zpos = hgdc.waferZ(layer, reco);
             int zside = (zpos > 0) ? 1 : -1;
-            auto xy = hgdc.locateCell(layer, waferU, waferV, ui, vi, reco, all, norot, debug1);
+            auto xy = hgdc.locateCell(zside, layer, waferU, waferV, ui, vi, reco, all, norot, debug1);
             int lay(layer), cU(0), cV(0), wType(-1), wU(0), wV(0);
             double wt(0);
             hgdc.waferFromPosition(HGCalParameters::k_ScaleToDDD * xy.first,

--- a/Geometry/HGCalCommonData/test/HGCalValidHexTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalValidHexTester.cc
@@ -96,7 +96,7 @@ void HGCalValidHexTester::analyze(const edm::Event& iEvent, const edm::EventSetu
     for (int u = 0; u < 2 * nCells; ++u) {
       for (int v = 0; v < 2 * nCells; ++v) {
         if (((v - u) < nCells) && (u - v) <= nCells) {
-          std::string state = hgdc.isValidHex8(layers_[k], moduleU_[k], moduleV_[k], u, v) ? "within" : "outside of";
+          std::string state = hgdc.isValidHex8(layers_[k], moduleU_[k], moduleV_[k], u, v, false) ? "within" : "outside of";
           edm::LogVerbatim("HGCalGeom") << "Cell[" << k << "," << ncell << "] "
                                         << HGCSiliconDetId(
                                                det, 1, types_[k], layers_[k], moduleU_[k], moduleV_[k], u, v)

--- a/Geometry/HGCalCommonData/test/HGCalValidHexTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalValidHexTester.cc
@@ -96,7 +96,8 @@ void HGCalValidHexTester::analyze(const edm::Event& iEvent, const edm::EventSetu
     for (int u = 0; u < 2 * nCells; ++u) {
       for (int v = 0; v < 2 * nCells; ++v) {
         if (((v - u) < nCells) && (u - v) <= nCells) {
-          std::string state = hgdc.isValidHex8(layers_[k], moduleU_[k], moduleV_[k], u, v, false) ? "within" : "outside of";
+          std::string state =
+              hgdc.isValidHex8(layers_[k], moduleU_[k], moduleV_[k], u, v, false) ? "within" : "outside of";
           edm::LogVerbatim("HGCalGeom") << "Cell[" << k << "," << ncell << "] "
                                         << HGCSiliconDetId(
                                                det, 1, types_[k], layers_[k], moduleU_[k], moduleV_[k], u, v)

--- a/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
@@ -173,22 +173,19 @@ void HGCalValidityTester::beginRun(edm::Run const &iRun, edm::EventSetup const &
       HGCScintillatorDetId id(detIds_[k].first);
       layer = id.layer();
       zside = id.zside();
-      xy = cons->locateCellTrap(layer, id.ring(), id.iphi(), true, false);
-      if (zside < 0)
-        xy.first = -xy.first;
+      xy = cons->locateCellTrap(zside, layer, id.ring(), id.iphi(), true, false);
+      double z = zside * (cons->waferZ(layer, true));
       valid = cons->isValidTrap(zside, layer, id.ring(), id.iphi());
-      auto cell = cons->assignCellTrap(xy.first, xy.second, layer, true, false);
+      auto cell = cons->assignCellTrap(zside * xy.first, xy.second, z, layer, true);
       HGCScintillatorDetId newId(cell[2], layer, zside * cell[0], cell[1], id.trigger(), id.sipm());
       st1 << "Old: " << id << " New: " << newId << " OK " << (id.rawId() == newId.rawId());
     } else {
       HGCSiliconDetId id(detIds_[k].first);
       layer = id.layer();
       zside = id.zside();
-      xy = cons->locateCell(layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
-      if (zside < 0)
-        xy.first = -xy.first;
+      xy = cons->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
       valid = cons->isValidHex8(layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false);
-      auto cell = cons->assignCellHex(xy.first, xy.second, layer, true, false, false);
+      auto cell = cons->assignCellHex(zside * xy.first, xy.second, zside, layer, true, false, false);
       HGCSiliconDetId newId(id.det(), id.zside(), cell[2], id.layer(), cell[0], cell[1], cell[3], cell[4]);
       st1 << "Old: " << id << " New: " << newId << " OK " << (id.rawId() == newId.rawId());
     }

--- a/Geometry/HGCalCommonData/test/HGCalWaferIDTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalWaferIDTester.cc
@@ -121,7 +121,8 @@ void HGCalWaferIDTester::analyze(const edm::Event& iEvent, const edm::EventSetup
     double xx = posXY_[k].first;
     double yy = posXY_[k].second;
     int layer = detIds_[k].layer();
-    hgdc.waferFromPosition(xx, yy, layer, waferU, waferV, cellU, cellV, waferType, wt, false, debug);
+    int zside = detIds_[k].zside();
+    hgdc.waferFromPosition(xx, yy, zside, layer, waferU, waferV, cellU, cellV, waferType, wt, false, debug);
     HGCSiliconDetId id(detIds_[k].det(), detIds_[k].zside(), waferType, layer, waferU, waferV, cellU, cellV);
     if (id.rawId() != detIds_[k].rawId())
       edm::LogVerbatim("HGCalGeom") << "Non-matching DetId for [" << k << "] Original " << detIds_[k] << " New " << id;

--- a/Geometry/HGCalCommonData/test/HGCalWaferTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalWaferTester.cc
@@ -80,13 +80,13 @@ void HGCalWaferTester::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   if (hgdc.waferHexagon8()) {
     int layer = hgdc.firstLayer();
     for (int u = -12; u <= 12; ++u) {
-      std::pair<double, double> xy = hgdc.waferPosition(layer, u, 0, reco_);
+      std::pair<double, double> xy = hgdc.waferPosition(layer, u, 0, reco_, false);
       edm::LogVerbatim("HGCalGeom") << " iz = +, u = " << u << ", v = 0: x = " << xy.first << " y = " << xy.second
                                     << "\n"
                                     << " iz = -, u = " << u << ", v = 0: x = " << -xy.first << " y = " << xy.second;
     }
     for (int v = -12; v <= 12; ++v) {
-      std::pair<double, double> xy = hgdc.waferPosition(layer, 0, v, reco_);
+      std::pair<double, double> xy = hgdc.waferPosition(layer, 0, v, reco_, false);
       edm::LogVerbatim("HGCalGeom") << " iz = +, u = 0, v = " << v << ": x = " << xy.first << " y = " << xy.second
                                     << "\n"
                                     << " iz = -, u = 0, v = " << v << ": x = " << -xy.first << " y = " << xy.second;

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -550,7 +550,8 @@ DetId HGCalGeometry::getClosestCell(const GlobalPoint& r) const {
       edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
                                     << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, false, true);
+      const auto& kxy =
+          m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, false, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];
@@ -593,7 +594,8 @@ DetId HGCalGeometry::getClosestCellHex(const GlobalPoint& r, bool extend) const 
       edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
                                     << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, extend, true);
+      const auto& kxy =
+          m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, extend, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -550,7 +550,7 @@ DetId HGCalGeometry::getClosestCell(const GlobalPoint& r) const {
       edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
                                     << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, false, true);
+      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, false, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];
@@ -593,7 +593,7 @@ DetId HGCalGeometry::getClosestCellHex(const GlobalPoint& r, bool extend) const 
       edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
                                     << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, extend, true);
+      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, true, extend, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -132,7 +132,7 @@ void HGCalGeometry::newCell(
 #ifdef EDM_ML_DEBUG
           ++cellAll;
 #endif
-          if (m_topology.dddConstants().cellInLayer(id.iSec1, id.iSec2, u, v, id.iLay, true)) {
+          if (m_topology.dddConstants().cellInLayer(id.iSec1, id.iSec2, u, v, id.iLay, id.zSide, true)) {
             m_validIds.emplace_back(idc);
 #ifdef EDM_ML_DEBUG
             ++cellSelect;
@@ -222,7 +222,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                       << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
                                       << id.iCell2;
       xy = m_topology.dddConstants().locateCell(
-          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);
@@ -309,7 +309,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
       }
     } else {
       xy = m_topology.dddConstants().locateCell(
-          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       float dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
@@ -319,7 +319,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
       static const int signz[] = {-1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1, 1};
       for (unsigned int i = 0; i < ncorner; ++i) {
         auto xyglob = m_topology.dddConstants().localToGlobal8(
-            id.iLay, id.iSec1, id.iSec2, (xy.first + signx[i] * dx), (xy.second + signy[i] * dy), true, false);
+            id.zSide, id.iLay, id.iSec1, id.iSec2, (xy.first + signx[i] * dx), (xy.second + signy[i] * dy), true, false);
         double xx = id.zSide * xyglob.first;
         co[i] = GlobalPoint(xx, xyglob.second, id.zSide * (zz + signz[i] * dz));
       }
@@ -366,14 +366,14 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
       }
     } else {
       xy = m_topology.dddConstants().locateCell(
-          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
       dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
       float dz = -id.zSide * m_cellVec[cellIndex].param()[FlatHexagon::k_dZ];
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       for (unsigned int i = 0; i < ncorner; ++i) {
         auto xyglob = m_topology.dddConstants().localToGlobal8(
-            id.iLay, id.iSec1, id.iSec2, (xy.first + signx[i] * dx), (xy.second + signy[i] * dy), true, false);
+            id.zSide, id.iLay, id.iSec1, id.iSec2, (xy.first + signx[i] * dx), (xy.second + signy[i] * dy), true, false);
         double xx = id.zSide * xyglob.first;
         co[i] = GlobalPoint(xx, xyglob.second, id.zSide * (zz + signz[i] * dz));
       }
@@ -427,7 +427,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
       }
     } else {
       xy = m_topology.dddConstants().locateCell(
-          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debug);
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debug);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       for (unsigned int i = 0; i < ncorner; ++i) {
         double xloc = xy.first + signx[i] * dx;
@@ -437,7 +437,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
           edm::LogVerbatim("HGCalGeom") << "Corner " << i << " x " << xy.first << ":" << xloc << " y " << xy.second
                                         << ":" << yloc << " z " << zz << ":" << id.zSide * (zz + dz);
 #endif
-        auto xyglob = m_topology.dddConstants().localToGlobal8(id.iLay, id.iSec1, id.iSec2, xloc, yloc, true, debug);
+        auto xyglob =
+            m_topology.dddConstants().localToGlobal8(id.zSide, id.iLay, id.iSec1, id.iSec2, xloc, yloc, true, debug);
         double xx = id.zSide * xyglob.first;
         co[i] = GlobalPoint(xx, xyglob.second, id.zSide * (zz + dz));
       }
@@ -544,10 +545,12 @@ DetId HGCalGeometry::getClosestCell(const GlobalPoint& r) const {
       id.iType = kxy[2];
     } else {
       id.iLay = m_topology.dddConstants().getLayer(r.z(), true);
+      int zside = (r.z() > 0) ? 1 : -1;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << " Layer " << id.iLay << " Global " << r << "  Local " << local;
+      edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
+                                    << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), id.iLay, false, true);
+      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, false, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];
@@ -585,10 +588,12 @@ DetId HGCalGeometry::getClosestCellHex(const GlobalPoint& r, bool extend) const 
     }
     if (m_topology.waferHexagon8()) {
       id.iLay = m_topology.dddConstants().getLayer(r.z(), true);
+      int zside = (r.z() > 0) ? 1 : -1;
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << " Layer " << id.iLay << " Global " << r << "  Local " << local;
+      edm::LogVerbatim("HGCalGeom") << "ZZ " << r.z() << ":" << zside << " Layer " << id.iLay << " Global " << r
+                                    << "  Local " << local;
 #endif
-      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), id.iLay, extend, true);
+      const auto& kxy = m_topology.dddConstants().assignCellHex(local.x(), local.y(), zside, id.iLay, extend, true);
       id.iSec1 = kxy[0];
       id.iSec2 = kxy[1];
       id.iType = kxy[2];

--- a/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometryLoader.cc
@@ -107,7 +107,7 @@ HGCalGeometry* HGCalGeometryLoader::build(const HGCalTopology& topology) {
 #endif
           if (ok) {
             DetId detId = static_cast<DetId>(id);
-            const auto& w = topology.dddConstants().locateCellTrap(layer, ring, iphi, true, false);
+            const auto& w = topology.dddConstants().locateCellTrap(zside, layer, ring, iphi, true, false);
             double xx = (zside > 0) ? w.first : -w.first;
             CLHEP::Hep3Vector h3v(xx, w.second, mytr.h3v.z());
             const HepGeom::Transform3D ht3d(mytr.hr, h3v);

--- a/Geometry/HGCalGeometry/test/HGCalGeometryNewCornersTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryNewCornersTest.cc
@@ -77,7 +77,7 @@ void HGCalGeometryNewCornersTest::beginRun(const edm::Run&, const edm::EventSetu
       HGCSiliconDetId detId(det, 1, types_[k], lay - layerOff, waferU_[k], waferV_[k], 0, 0);
       GlobalPoint global = geom->getPosition(DetId(detId), debug_);
       double phi2 = global.phi();
-      auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], debug_);
+      auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], true, debug_);
       double phi1 = std::atan2(xy.second, xy.first);
       edm::LogVerbatim("HGCalGeom") << "Layer: " << lay << " U " << waferU_[k] << " V " << waferV_[k] << " Position ("
                                     << xy.first << ", " << xy.second << ") phi " << convertRadToDeg(phi1);

--- a/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryRotTest.cc
@@ -81,7 +81,7 @@ void HGCalGeometryRotTest::beginRun(const edm::Run&, const edm::EventSetup& iSet
       HGCSiliconDetId detId(det, 1, types_[k], lay - layerOff, waferU_[k], waferV_[k], cellU_[k], cellV_[k]);
       GlobalPoint global = geom->getPosition(DetId(detId));
       double phi2 = global.phi();
-      auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], true);
+      auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], true, false);
       double phi1 = std::atan2(xy.second, xy.first);
       edm::LogVerbatim("HGCalGeom") << "Layer: " << lay << " U " << waferU_[k] << " V " << waferV_[k] << " Position ("
                                     << xy.first << ", " << xy.second << ") phi " << convertRadToDeg(phi1);

--- a/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
@@ -77,7 +77,7 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     for (int layer = 1; layer <= 2; ++layer) {
       for (int waferU = -12; waferU <= 12; ++waferU) {
         int waferV(0);
-        int type = hgdc.waferType(layer, waferU, waferV);
+        int type = hgdc.waferType(layer, waferU, waferV, false);
         int cell = (type == 0) ? 12 : 8;
         HGCSiliconDetId id1(det, 1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id1))
@@ -88,7 +88,7 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
       }
       for (int waferV = -12; waferV <= 12; ++waferV) {
         int waferU(0);
-        int type = hgdc.waferType(layer, waferU, waferV);
+        int type = hgdc.waferType(layer, waferU, waferV, false);
         int cell = (type == 0) ? 12 : 8;
         HGCSiliconDetId id1(det, 1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id1))

--- a/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
@@ -125,7 +125,7 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
     int all(0), total(0), good(0), bad(0);
     for (auto id : ids) {
       HGCSiliconDetId hid(id);
-      auto type = hgdc.waferTypeRotation(hid.layer(), hid.waferU(), hid.waferV());
+      auto type = hgdc.waferTypeRotation(hid.layer(), hid.waferU(), hid.waferV(), false, false);
       if (hid.zside() > 0)
         ++all;
       // Not a full wafer
@@ -139,7 +139,7 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
       }
       if (part > 0 && part < 10 && hid.zside() > 0) {
         ++total;
-        int wtype = hgdc.waferType(hid.layer(), hid.waferU(), hid.waferV());
+        int wtype = hgdc.waferType(hid.layer(), hid.waferU(), hid.waferV(), false);
         int indx = (part - 1) * 6 + type.second;
         GlobalPoint xyz = geom->getWaferPosition(id);
         auto range = hgdc.rangeRLayer(hid.layer(), true);
@@ -189,7 +189,7 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
         if (!match) {
           ++bad;
           // Need debug information here
-          hgdc.waferTypeRotation(hid.layer(), hid.waferU(), hid.waferV(), true);
+          hgdc.waferTypeRotation(hid.layer(), hid.waferU(), hid.waferV(), true, false);
           HGCalWaferMask::getTypeMode(xyz.x(), xyz.y(), r, R, range.first, range.second, wtype, 0, true);
           for (unsigned int i = 0; i < 24; ++i) {
             double rp = std::sqrt((xyz.x() + dx[i]) * (xyz.x() + dx[i]) + (xyz.y() + dy[i]) * (xyz.y() + dy[i]));

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalUncalibRecHitRecWeightsAlgo.h
@@ -87,7 +87,7 @@ public:
       jitter_ = double(sample.toa()) * toaLSBToNS_ - dist2center / c_cm_ns - tofDelay_;
     }
 
-    int thickness = (ddd_ != nullptr) ? ddd_->waferType(dataFrame.id()) : 0;
+    int thickness = (ddd_ != nullptr) ? ddd_->waferType(dataFrame.id(), false) : 0;
     amplitude_ = amplitude_ / fCPerMIP_[thickness];
 
     LogDebug("HGCUncalibratedRecHit") << "isSiFESim_: " << isSiFESim_ << " ADC+: set the charge to: " << amplitude_

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsFiller.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HeterogeneousHGCalHEFCellPositionsFiller.cc
@@ -48,7 +48,7 @@ void HeterogeneousHGCalHEFCellPositionsFiller::set_conditions_() {
 
       for (int iwaferV = posmap_->waferMin; iwaferV < posmap_->waferMax; ++iwaferV) {
         //0: fine; 1: coarseThin; 2: coarseThick (as defined in DataFormats/ForwardDetId/interface/HGCSiliconDetId.h)
-        int type_ = ddd_->waferType(ilayer, iwaferU, iwaferV);
+        int type_ = ddd_->waferType(ilayer, iwaferU, iwaferV, false);
 
         int nCellsHexSide = ddd_->numberCellsHexagon(ilayer, iwaferU, iwaferV, false);
         int nCellsHexTotal = ddd_->numberCellsHexagon(ilayer, iwaferU, iwaferV, true);

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -158,8 +158,8 @@ typename HGCalSiNoiseMap<T>::SiCellOpCharacteristics HGCalSiNoiseMap<T>::getSiCe
 
   //location of the cell
   int subdet = cellId.subdet();
-  const auto &xy(
-      ddd()->locateCell(cellId.layer(), cellId.waferU(), cellId.waferV(), cellId.cellU(), cellId.cellV(), true, true));
+  const auto &xy(ddd()->locateCell(
+      cellId.zside(), cellId.layer(), cellId.waferU(), cellId.waferV(), cellId.cellU(), cellId.cellV(), true, true));
   double radius = sqrt(std::pow(xy.first, 2) + std::pow(xy.second, 2));  //in cm
 
   //call baseline method and add to cache

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -158,8 +158,16 @@ typename HGCalSiNoiseMap<T>::SiCellOpCharacteristics HGCalSiNoiseMap<T>::getSiCe
 
   //location of the cell
   int subdet = cellId.subdet();
-  const auto &xy(ddd()->locateCell(
-      cellId.zside(), cellId.layer(), cellId.waferU(), cellId.waferV(), cellId.cellU(), cellId.cellV(), true, true, false, false));
+  const auto &xy(ddd()->locateCell(cellId.zside(),
+                                   cellId.layer(),
+                                   cellId.waferU(),
+                                   cellId.waferV(),
+                                   cellId.cellU(),
+                                   cellId.cellV(),
+                                   true,
+                                   true,
+                                   false,
+                                   false));
   double radius = sqrt(std::pow(xy.first, 2) + std::pow(xy.second, 2));  //in cm
 
   //call baseline method and add to cache

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -159,7 +159,7 @@ typename HGCalSiNoiseMap<T>::SiCellOpCharacteristics HGCalSiNoiseMap<T>::getSiCe
   //location of the cell
   int subdet = cellId.subdet();
   const auto &xy(ddd()->locateCell(
-      cellId.zside(), cellId.layer(), cellId.waferU(), cellId.waferV(), cellId.cellU(), cellId.cellV(), true, true));
+      cellId.zside(), cellId.layer(), cellId.waferU(), cellId.waferV(), cellId.cellU(), cellId.cellV(), true, true, false, false));
   double radius = sqrt(std::pow(xy.first, 2) + std::pow(xy.second, 2));  //in cm
 
   //call baseline method and add to cache

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h
@@ -36,7 +36,7 @@ namespace hgc_digi_utils {
                        : false);
     //base time samples for each DetId, initialized to 0
     info.size = (isHalf ? 0.5 : 1.0);
-    info.thickness = 1 + dddConst.waferType(detid);
+    info.thickness = 1 + dddConst.waferType(detid, false);
   }
 
   inline void addCellMetadata(HGCCellInfo& info, const CaloSubdetectorGeometry* geom, const DetId& detid) {

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizer.cc
@@ -34,7 +34,7 @@ namespace {
 
   int getCellThickness(const HGCalGeometry* geom, const DetId& detid) {
     const auto& dddConst = geom->topology().dddConstants();
-    return (1 + dddConst.waferType(detid));
+    return (1 + dddConst.waferType(detid, false));
   }
 
   void getValidDetIds(const HGCalGeometry* geom, std::unordered_set<DetId>& valid) {

--- a/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCalNumberingScheme.h
@@ -38,8 +38,9 @@ private:
   const DetId::Detector det_;
   const std::string name_;
   int firstLayer_;
-  std::vector<int> dumpDets_;
   std::vector<int> indices_;
+  std::vector<int> dumpDets_;
+  std::vector<int> dumpCassette_;
 };
 
 #endif

--- a/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestPartialWaferHits.cc
@@ -140,7 +140,7 @@ void HGCalTestPartialWaferHits::analyze(const edm::Event& e, const edm::EventSet
             ++good;
             GlobalPoint pos = geom->getPosition(id);
             bool valid1 = geom->topology().valid(id);
-            bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV());
+            bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV(), false);
             edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << allSi << ":" << good << "]" << HGCSiliconDetId(id)
                                          << " Wafer Type:Part:Orient:Cassette " << info.type << ":" << info.part << ":"
                                          << info.orient << ":" << info.cassette << " at (" << pos.x() << ", " << pos.y()

--- a/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
@@ -59,7 +59,8 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
   } else if ((DetId(index).det() == DetId::Forward) && (DetId(index).subdetId() == static_cast<int>(HFNose))) {
     HFNoseDetId id = HFNoseDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
+    xy = hgcons_.locateCell(
+        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
   }

--- a/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
@@ -30,7 +30,7 @@ uint32_t HFNoseNumberingScheme::getUnitID(
   } else if (mode_ == HGCalGeometryMode::Hexagon8Full) {
     int zside = (pos.z() > 0) ? 1 : -1;
     double xx = zside * pos.x();
-    hgcons_.waferFromPosition(xx, pos.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt);
+    hgcons_.waferFromPosition(xx, pos.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt, false, false);
   }
   if (waferType >= 0) {
     index = HFNoseDetId(iz, waferType, layer, waferU, waferV, cellU, cellV).rawId();
@@ -59,7 +59,7 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
   } else if ((DetId(index).det() == DetId::Forward) && (DetId(index).subdetId() == static_cast<int>(HFNose))) {
     HFNoseDetId id = HFNoseDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
+    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
   }
@@ -87,8 +87,8 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
         int zside = (pos.z() > 0) ? 1 : -1;
         double wt = 0, xx = (zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
-        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, true);
-        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, true);
+        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, true);
         edm::LogVerbatim("HGCSim") << "HFNoseNumberingScheme " << HFNoseDetId(index) << " position " << xy.first << ":"
                                    << xy.second;
       }

--- a/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
@@ -28,8 +28,9 @@ uint32_t HFNoseNumberingScheme::getUnitID(
     cellU = HGCalTypes::getUnpackedCellU(cell);
     cellV = HGCalTypes::getUnpackedCellV(cell);
   } else if (mode_ == HGCalGeometryMode::Hexagon8Full) {
-    double xx = (pos.z() > 0) ? pos.x() : -pos.x();
-    hgcons_.waferFromPosition(xx, pos.y(), layer, waferU, waferV, cellU, cellV, waferType, wt);
+    int zside = (pos.z() > 0) ? 1 : -1;
+    double xx = zside * pos.x();
+    hgcons_.waferFromPosition(xx, pos.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt);
   }
   if (waferType >= 0) {
     index = HFNoseDetId(iz, waferType, layer, waferU, waferV, cellU, cellV).rawId();
@@ -58,7 +59,7 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
   } else if ((DetId(index).det() == DetId::Forward) && (DetId(index).subdetId() == static_cast<int>(HFNose))) {
     HFNoseDetId id = HFNoseDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
+    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
   }
@@ -83,10 +84,11 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
       edm::LogVerbatim("HGCSim") << "Original " << pos.x() << ":" << pos.y() << " return " << xy.first << ":"
                                  << xy.second;
       if ((DetId(index).det() == DetId::Forward) && (DetId(index).subdetId() == static_cast<int>(HFNose))) {
-        double wt = 0, xx = ((pos.z() > 0) ? pos.x() : -pos.x());
+        int zside = (pos.z() > 0) ? 1 : -1;
+        double wt = 0, xx = (zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
-        hgcons_.waferFromPosition(xx, pos.y(), lay, waferU, waferV, cellU, cellV, waferType, wt, true);
-        xy = hgcons_.locateCell(lay, waferU, waferV, cellU, cellV, false, true, true);
+        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, true);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, true);
         edm::LogVerbatim("HGCSim") << "HFNoseNumberingScheme " << HFNoseDetId(index) << " position " << xy.first << ":"
                                    << xy.second;
       }

--- a/SimG4CMS/Calo/src/HGCMouseBite.cc
+++ b/SimG4CMS/Calo/src/HGCMouseBite.cc
@@ -25,7 +25,7 @@ bool HGCMouseBite::exclude(G4ThreeVector& point, int zside, int waferU, int wafe
   bool check(false);
   int lay = hgcons_.getLayer(point.z(), false);
   std::pair<double, double> xy =
-      (modeUV_ ? hgcons_.waferPosition(lay, waferU, waferV, false) : hgcons_.waferPosition(waferU, false));
+      (modeUV_ ? hgcons_.waferPosition(lay, waferU, waferV, false, false) : hgcons_.waferPosition(waferU, false));
   double xx = (zside > 0) ? xy.first : -xy.first;
   double dx(0), dy(0);
   if (rot_) {

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -201,7 +201,8 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
   } else if (DetId(index).det() == DetId::HGCalHSi) {
     HGCSiliconDetId id = HGCSiliconDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
+    xy = hgcons_.locateCell(
+        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 14.0;

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCassette.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTileIndex.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
@@ -41,7 +42,7 @@ HGCalNumberingScheme::HGCalNumberingScheme(const HGCalDDDConstants& hgc,
       char buffer[80];
       while (fInput.getline(buffer, 80)) {
         std::vector<std::string> items = CaloSimUtils::splitString(std::string(buffer));
-        if (items.size() > 2) {
+        if (items.size() == 3) {
           if (hgcons_.waferHexagon8File()) {
             int layer = std::atoi(items[0].c_str());
             int waferU = std::atoi(items[1].c_str());
@@ -56,11 +57,18 @@ HGCalNumberingScheme::HGCalNumberingScheme(const HGCalDDDConstants& hgc,
         } else if (items.size() == 1) {
           int dumpdet = std::atoi(items[0].c_str());
           dumpDets_.emplace_back(dumpdet);
+        } else if (items.size() == 4) {
+          int idet = std::atoi(items[0].c_str());
+          int layer = std::atoi(items[1].c_str());
+          int zside = std::atoi(items[2].c_str());
+          int cassette = std::atoi(items[3].c_str());
+          dumpCassette_.emplace_back(HGCalCassette::cassetteIndex(idet, layer, zside, cassette));
         }
       }
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalSim") << "Reads in " << indices_.size() << ":" << dumpDets_.size()
-                                   << " component information from " << filetmp2 << " Layer Offset " << firstLayer_;
+      edm::LogVerbatim("HGCalSim") << "Reads in " << indices_.size() << ":" << dumpDets_.size() << ":"
+                                   << dumpCassette_.size() << " component information from " << filetmp2
+                                   << " Layer Offset " << firstLayer_;
 #endif
       fInput.close();
     }
@@ -90,7 +98,8 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
       cellU = HGCalTypes::getUnpackedCellU(cell);
       cellV = HGCalTypes::getUnpackedCellV(cell);
     } else if (mode_ != HGCalGeometryMode::Hexagon8) {
-      double xx = (pos.z() > 0) ? pos.x() : -pos.x();
+      int zside = (pos.z() > 0) ? 1 : -1;
+      double xx = zside * pos.x();
       int wU = HGCalTypes::getUnpackedU(module);
       int wV = HGCalTypes::getUnpackedV(module);
       bool debug(false);
@@ -104,7 +113,18 @@ uint32_t HGCalNumberingScheme::getUnitID(int layer, int module, int cell, int iz
             (hgcons_.waferInfo(layer, wU, wV).part != HGCalTypes::WaferFull))
           debug = true;
       }
-      hgcons_.waferFromPosition(xx, pos.y(), layer, waferU, waferV, cellU, cellV, waferType, wt, false, debug);
+      if (!dumpCassette_.empty()) {
+        int indx = HGCalWaferIndex::waferIndex(firstLayer_ + layer, wU, wV, false);
+        auto ktr = hgcons_.getParameter()->waferInfoMap_.find(indx);
+        if (ktr != hgcons_.getParameter()->waferInfoMap_.end()) {
+          if (std::find(dumpCassette_.begin(),
+                        dumpCassette_.end(),
+                        HGCalCassette::cassetteIndex(det_, firstLayer_ + layer, zside, (ktr->second).cassette)) !=
+              dumpCassette_.end())
+            debug = true;
+        }
+      }
+      hgcons_.waferFromPosition(xx, pos.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt, false, debug);
     }
     if (waferType >= 0) {
       if (hgcons_.waferHexagon8File()) {
@@ -181,7 +201,7 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
   } else if (DetId(index).det() == DetId::HGCalHSi) {
     HGCSiliconDetId id = HGCSiliconDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
+    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 14.0;
@@ -189,7 +209,7 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
   } else if (DetId(index).det() == DetId::HGCalHSc) {
     HGCScintillatorDetId id = HGCScintillatorDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCellTrap(lay, id.ietaAbs(), id.iphi(), false);
+    xy = hgcons_.locateCellTrap(id.zside(), lay, id.ietaAbs(), id.iphi(), false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 50.0;
@@ -218,10 +238,11 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
       edm::LogVerbatim("HGCSim") << "Original " << pos.x() << ":" << pos.y() << " return " << xy.first << ":"
                                  << xy.second;
       if ((DetId(index).det() == DetId::HGCalEE) || (DetId(index).det() == DetId::HGCalHSi)) {
-        double wt = 0, xx = ((pos.z() > 0) ? pos.x() : -pos.x());
+        int zside = (pos.z() > 0) ? 1 : -1;
+        double wt(0), xx(zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
-        hgcons_.waferFromPosition(xx, pos.y(), lay, waferU, waferV, cellU, cellV, waferType, wt, false, false);
-        xy = hgcons_.locateCell(lay, waferU, waferV, cellU, cellV, false, true, true);
+        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, false);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, true);
         double dx = (xx - xy.first);
         double dy = (pos.y() - xy.second);
         double dR = std::sqrt(dx * dx + dy * dy);

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -201,7 +201,7 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
   } else if (DetId(index).det() == DetId::HGCalHSi) {
     HGCSiliconDetId id = HGCSiliconDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true);
+    xy = hgcons_.locateCell(id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 14.0;
@@ -209,7 +209,7 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
   } else if (DetId(index).det() == DetId::HGCalHSc) {
     HGCScintillatorDetId id = HGCScintillatorDetId(index);
     lay = id.layer();
-    xy = hgcons_.locateCellTrap(id.zside(), lay, id.ietaAbs(), id.iphi(), false);
+    xy = hgcons_.locateCellTrap(id.zside(), lay, id.ietaAbs(), id.iphi(), false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 50.0;
@@ -241,8 +241,8 @@ void HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
         int zside = (pos.z() > 0) ? 1 : -1;
         double wt(0), xx(zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
-        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, false);
-        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, true);
+        hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, true);
         double dx = (xx - xy.first);
         double dy = (pos.y() - xy.second);
         double dR = std::sqrt(dx * dx + dy * dy);

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -217,8 +217,9 @@ uint32_t HGCalSD::setDetUnitId(const G4Step* aStep) {
       bool valid1 = hgcons_->isValidHex8(hid1.layer(), hid1.waferU(), hid1.waferV(), hid1.cellU(), hid1.cellV(), true);
       int cellU(0), cellV(0), waferType(-1), waferU(0), waferV(0);
       double wt1(0);
-      xx = (hid1.zside() > 0) ? hitPoint.x() : -hitPoint.x();
-      hgcons_->waferFromPosition(xx, hitPoint.y(), layer, waferU, waferV, cellU, cellV, waferType, wt1, false, false);
+      int zside = (hid1.zside() > 0) ? 1 : -1;
+      xx = zside * hitPoint.x();
+      hgcons_->waferFromPosition(xx, hitPoint.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt1, false, false);
       HGCSiliconDetId hid2(hid1.det(), hid1.zside(), waferType, layer, waferU, waferV, cellU, cellV);
       bool valid2 = hgcons_->isValidHex8(hid2.layer(), hid2.waferU(), hid2.waferV(), hid2.cellU(), hid2.cellV(), true);
       auto partn = hgcons_->waferTypeRotation(hid1.layer(), hid1.waferU(), hid1.waferV(), false, false);

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -219,7 +219,8 @@ uint32_t HGCalSD::setDetUnitId(const G4Step* aStep) {
       double wt1(0);
       int zside = (hid1.zside() > 0) ? 1 : -1;
       xx = zside * hitPoint.x();
-      hgcons_->waferFromPosition(xx, hitPoint.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt1, false, false);
+      hgcons_->waferFromPosition(
+          xx, hitPoint.y(), zside, layer, waferU, waferV, cellU, cellV, waferType, wt1, false, false);
       HGCSiliconDetId hid2(hid1.det(), hid1.zside(), waferType, layer, waferU, waferV, cellU, cellV);
       bool valid2 = hgcons_->isValidHex8(hid2.layer(), hid2.waferU(), hid2.waferV(), hid2.cellU(), hid2.cellV(), true);
       auto partn = hgcons_->waferTypeRotation(hid1.layer(), hid1.waferU(), hid1.waferV(), false, false);

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -199,13 +199,13 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent, const edm::EventSe
         layer = id.layer();
         zside = id.zside();
         xy =
-            hgcGeometry_[dtype]->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true);
+	  hgcGeometry_[dtype]->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
       } else {
         HGCScintillatorDetId id(hitIdx[i]);
         dtype = 2;
         layer = id.layer();
         zside = id.zside();
-        xy = hgcGeometry_[dtype]->locateCellTrap(zside, layer, id.ietaAbs(), id.iphi(), true);
+        xy = hgcGeometry_[dtype]->locateCellTrap(zside, layer, id.ietaAbs(), id.iphi(), true, false);
       }
       double zz = hgcGeometry_[dtype]->waferZ(layer, true);  //cm
       if (zside < 0)

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -198,7 +198,8 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent, const edm::EventSe
         dtype = (id.det() == DetId::HGCalEE) ? 0 : 1;
         layer = id.layer();
         zside = id.zside();
-        xy = hgcGeometry_[dtype]->locateCell(zside,  layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true);
+        xy =
+            hgcGeometry_[dtype]->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true);
       } else {
         HGCScintillatorDetId id(hitIdx[i]);
         dtype = 2;

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -198,8 +198,8 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent, const edm::EventSe
         dtype = (id.det() == DetId::HGCalEE) ? 0 : 1;
         layer = id.layer();
         zside = id.zside();
-        xy =
-	  hgcGeometry_[dtype]->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
+        xy = hgcGeometry_[dtype]->locateCell(
+            zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
       } else {
         HGCScintillatorDetId id(hitIdx[i]);
         dtype = 2;

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -198,13 +198,13 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent, const edm::EventSe
         dtype = (id.det() == DetId::HGCalEE) ? 0 : 1;
         layer = id.layer();
         zside = id.zside();
-        xy = hgcGeometry_[dtype]->locateCell(layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true);
+        xy = hgcGeometry_[dtype]->locateCell(zside,  layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true);
       } else {
         HGCScintillatorDetId id(hitIdx[i]);
         dtype = 2;
         layer = id.layer();
         zside = id.zside();
-        xy = hgcGeometry_[dtype]->locateCellTrap(layer, id.ietaAbs(), id.iphi(), true);
+        xy = hgcGeometry_[dtype]->locateCellTrap(zside, layer, id.ietaAbs(), id.iphi(), true);
       }
       double zz = hgcGeometry_[dtype]->waferZ(layer, true);  //cm
       if (zside < 0)

--- a/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
@@ -169,7 +169,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->waferHexagon8()) {
@@ -182,7 +182,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->tileTrapezoid()) {
@@ -193,7 +193,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCellTrap(zside, layer, sector, cell, false);
+      xy = hgcons_[ih]->locateCellTrap(zside, layer, sector, cell, false, false);
     } else {
       edm::LogError("HGCalValidation") << "HGCalSimHitStudy: Wrong geometry mode " << hgcons_[ih]->geomMode();
       continue;

--- a/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
@@ -169,7 +169,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(layer, sector, sector2, cell, cell2, false, true);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->waferHexagon8()) {
@@ -182,7 +182,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(layer, sector, sector2, cell, cell2, false, true);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->tileTrapezoid()) {
@@ -193,7 +193,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCellTrap(layer, sector, cell, false);
+      xy = hgcons_[ih]->locateCellTrap(zside, layer, sector, cell, false);
     } else {
       edm::LogError("HGCalValidation") << "HGCalSimHitStudy: Wrong geometry mode " << hgcons_[ih]->geomMode();
       continue;

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -206,9 +206,9 @@ void HGCalSimHitValidation::analyzeHits(std::vector<PCaloHit>& hits) {
     HepGeom::Point3D<float> gcoord;
     std::pair<float, float> xy;
     if (hgcons_->waferHexagon8()) {
-      xy = hgcons_->locateCell(layer, sector, subsector, cell, cell2, false, true);
+      xy = hgcons_->locateCell(zside, layer, sector, subsector, cell, cell2, false, true);
     } else {
-      xy = hgcons_->locateCellTrap(layer, sector, cell, false);
+      xy = hgcons_->locateCellTrap(zside, layer, sector, cell, false);
     }
     double zp = hgcons_->waferZ(layer, false);
     if (zside < 0)

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -206,9 +206,9 @@ void HGCalSimHitValidation::analyzeHits(std::vector<PCaloHit>& hits) {
     HepGeom::Point3D<float> gcoord;
     std::pair<float, float> xy;
     if (hgcons_->waferHexagon8()) {
-      xy = hgcons_->locateCell(zside, layer, sector, subsector, cell, cell2, false, true);
+      xy = hgcons_->locateCell(zside, layer, sector, subsector, cell, cell2, false, true, false, false);
     } else {
-      xy = hgcons_->locateCellTrap(zside, layer, sector, cell, false);
+      xy = hgcons_->locateCellTrap(zside, layer, sector, cell, false, false);
     }
     double zp = hgcons_->waferZ(layer, false);
     if (zside < 0)
@@ -264,7 +264,7 @@ void HGCalSimHitValidation::analyzeHits(std::vector<PCaloHit>& hits) {
     int partialType = -1;
     if ((nameDetector_ == "HGCalEESensitive") || (nameDetector_ == "HGCalHESiliconSensitive")) {
       HGCSiliconDetId detId = HGCSiliconDetId((*itr).first);
-      std::tie(type, part, orient) = hgcons_->waferType(detId);
+      std::tie(type, part, orient) = hgcons_->waferType(detId, false);
       partialType = part;
     }
 

--- a/Validation/HGCalValidation/plugins/HGCalTestPartialWaferRecHits.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTestPartialWaferRecHits.cc
@@ -130,7 +130,7 @@ void HGCalTestPartialWaferRecHits::analyze(const edm::Event& e, const edm::Event
           ++good;
           GlobalPoint pos = geom->getPosition(id);
           bool valid1 = geom->topology().valid(id);
-          bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV());
+          bool valid2 = hgc.isValidHex8(hid.layer(), hid.waferU(), hid.waferV(), hid.cellU(), hid.cellV(), false);
           edm::LogVerbatim("HGCalSim") << "Hit[" << all << ":" << allSi << ":" << good << "]" << hid
                                        << " Wafer Type:Part:Orient:Cassette " << info.type << ":" << info.part << ":"
                                        << info.orient << ":" << info.cassette << " at (" << pos.x() << ", " << pos.y()

--- a/Validation/HGCalValidation/test/HGCHitValidation.cc
+++ b/Validation/HGCalValidation/test/HGCHitValidation.cc
@@ -483,7 +483,7 @@ void HGCHitValidation::analyzeHGCalSimHit(edm::Handle<std::vector<PCaloHit>> con
       celltype = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcCons_[idet]->locateCell(zside, layer, wafer, wafer2, cell, cell2, false, true);
+      xy = hgcCons_[idet]->locateCell(zside, layer, wafer, wafer2, cell, cell2, false, true, false, false);
     } else if (hgcCons_[idet]->tileTrapezoid()) {
       HGCScintillatorDetId detId = HGCScintillatorDetId(id);
       subdet = (int)(detId.det());
@@ -492,7 +492,7 @@ void HGCHitValidation::analyzeHGCalSimHit(edm::Handle<std::vector<PCaloHit>> con
       celltype = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcCons_[idet]->locateCellTrap(zside, layer, wafer, cell, false);
+      xy = hgcCons_[idet]->locateCellTrap(zside, layer, wafer, cell, false, false);
     } else {
       HGCalTestNumbering::unpackHexagonIndex(simHit.id(), subdet, zside, layer, wafer, celltype, cell);
       xy = hgcCons_[idet]->locateCell(cell, layer, wafer, false);

--- a/Validation/HGCalValidation/test/HGCHitValidation.cc
+++ b/Validation/HGCalValidation/test/HGCHitValidation.cc
@@ -483,7 +483,7 @@ void HGCHitValidation::analyzeHGCalSimHit(edm::Handle<std::vector<PCaloHit>> con
       celltype = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcCons_[idet]->locateCell(layer, wafer, wafer2, cell, cell2, false, true);
+      xy = hgcCons_[idet]->locateCell(zside, layer, wafer, wafer2, cell, cell2, false, true);
     } else if (hgcCons_[idet]->tileTrapezoid()) {
       HGCScintillatorDetId detId = HGCScintillatorDetId(id);
       subdet = (int)(detId.det());
@@ -492,7 +492,7 @@ void HGCHitValidation::analyzeHGCalSimHit(edm::Handle<std::vector<PCaloHit>> con
       celltype = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcCons_[idet]->locateCellTrap(layer, wafer, cell, false);
+      xy = hgcCons_[idet]->locateCellTrap(zside, layer, wafer, cell, false);
     } else {
       HGCalTestNumbering::unpackHexagonIndex(simHit.id(), subdet, zside, layer, wafer, celltype, cell);
       xy = hgcCons_[idet]->locateCell(cell, layer, wafer, false);

--- a/Validation/HGCalValidation/test/HGCalWaferStudy.cc
+++ b/Validation/HGCalValidation/test/HGCalWaferStudy.cc
@@ -166,13 +166,15 @@ void HGCalWaferStudy::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+          xy = hgcons_[k]->locateCell(
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
         } else if (hgcons_[k]->waferHexagon8()) {
           HGCSiliconDetId detId = HGCSiliconDetId(id);
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+          xy = hgcons_[k]->locateCell(
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
         } else {
           int subdet, sector, type, cell;
           HGCalTestNumbering::unpackHexagonIndex(id, subdet, zside, layer, sector, type, cell);

--- a/Validation/HGCalValidation/test/HGCalWaferStudy.cc
+++ b/Validation/HGCalValidation/test/HGCalWaferStudy.cc
@@ -167,14 +167,14 @@ void HGCalWaferStudy::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
           xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false);
         } else if (hgcons_[k]->waferHexagon8()) {
           HGCSiliconDetId detId = HGCSiliconDetId(id);
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
           xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false);
         } else {
           int subdet, sector, type, cell;
           HGCalTestNumbering::unpackHexagonIndex(id, subdet, zside, layer, sector, type, cell);

--- a/Validation/HGCalValidation/test/HGCalWaferStudy.cc
+++ b/Validation/HGCalValidation/test/HGCalWaferStudy.cc
@@ -166,13 +166,13 @@ void HGCalWaferStudy::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+          xy = hgcons_[k]->locateCell(zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
         } else if (hgcons_[k]->waferHexagon8()) {
           HGCSiliconDetId detId = HGCSiliconDetId(id);
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
+          xy = hgcons_[k]->locateCell(zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true);
         } else {
           int subdet, sector, type, cell;
           HGCalTestNumbering::unpackHexagonIndex(id, subdet, zside, layer, sector, type, cell);


### PR DESCRIPTION
#### PR description:

Extend some of the calling sequences of Geometry to include zside which is needed to treat correctly cassette shifts. There were several internal calls which were wrong in earlier versions. This may cause differences in predictions. Now all internal calls are checked and corrected.

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special