### PR TITLE
include `MAXFEDID` in FED-ID loops

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalNoiseProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalNoiseProducer.cc
@@ -254,7 +254,7 @@ void AlCaHcalNoiseProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     //   if ( ( rawData[i].provenance()->processName() != e.processHistory().rbegin()->processName() ) )
     //       continue ; // skip all raw collections not produced by the current process
 
-    for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+    for (int j = 0; j <= FEDNumbering::MAXFEDID; ++j) {
       bool rightFED = false;
       for (uint32_t k = 0; k < selFEDs.size(); k++) {
         if (j == selFEDs[k]) {

--- a/Calibration/HcalIsolatedTrackReco/plugins/ECALRegFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/ECALRegFEDSelector.cc
@@ -86,7 +86,7 @@ void ECALRegFEDSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
     const FEDRawDataCollection* rdc = rawIn.product();
 
-    for (int j = 0; j < FEDNumbering::MAXFEDID; j++) {
+    for (int j = 0; j <= FEDNumbering::MAXFEDID; j++) {
       bool rightFED = false;
       for (uint32_t k = 0; k < EC_FED_IDs.size(); k++) {
         if (j == EcalRegionCabling::fedIndex(EC_FED_IDs[k])) {

--- a/Calibration/HcalIsolatedTrackReco/plugins/SiStripRegFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/SiStripRegFEDSelector.cc
@@ -118,7 +118,7 @@ void SiStripRegFEDSelector::produce(edm::StreamID, edm::Event& iEvent, const edm
   //   if ( ( rawData[i].provenance()->processName() != e.processHistory().rbegin()->processName() ) )
   //       continue ; // skip all raw collections not produced by the current process
 
-  for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+  for (int j = 0; j <= FEDNumbering::MAXFEDID; ++j) {
     bool rightFED = false;
     for (uint32_t k = 0; k < stripFEDVec.size(); k++) {
       if (j == stripFEDVec[k]) {

--- a/Calibration/HcalIsolatedTrackReco/plugins/SubdetFEDSelector.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/SubdetFEDSelector.cc
@@ -169,7 +169,7 @@ void SubdetFEDSelector::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   //   if ( ( rawData[i].provenance()->processName() != e.processHistory().rbegin()->processName() ) )
   //       continue ; // skip all raw collections not produced by the current process
 
-  for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+  for (int j = 0; j <= FEDNumbering::MAXFEDID; ++j) {
     bool rightFED = false;
     for (uint32_t k = 0; k < selFEDs.size(); k++) {
       if (j == selFEDs[k]) {

--- a/DataFormats/FEDRawData/src/FEDNumbering.cc
+++ b/DataFormats/FEDRawData/src/FEDNumbering.cc
@@ -10,11 +10,11 @@ using namespace std;
 namespace {
 
   constexpr std::array<bool, FEDNumbering::FEDNumbering::MAXFEDID + 1> initIn() {
-    std::array<bool, FEDNumbering::MAXFEDID + 1> in = {{false}};
-
+    std::array<bool, FEDNumbering::MAXFEDID + 1> in = {};
     int i = 0;
-    for (i = 0; i < FEDNumbering::lastFEDId(); i++)
+    for (i = 0; i <= FEDNumbering::MAXFEDID; i++) {
       in[i] = false;
+    }
     for (i = FEDNumbering::MINSiPixelFEDID; i <= FEDNumbering::MAXSiPixelFEDID; i++) {
       in[i] = true;
     }

--- a/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCalibFEDSelector.cc
@@ -73,7 +73,7 @@ void HcalCalibFEDSelector::produce(edm::StreamID, edm::Event& iEvent, const edm:
   // Copying:
   const FEDRawDataCollection* rdc = rawIn.product();
 
-  for (int j = 0; j < FEDNumbering::lastFEDId(); ++j) {
+  for (int j = 0; j <= FEDNumbering::lastFEDId(); ++j) {
     bool rightFED = false;
     for (uint32_t k = 0; k < selFEDs.size(); k++) {
       if (j == selFEDs[k]) {

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc
@@ -48,7 +48,7 @@ void Phase2Tracker::Phase2TrackerCommissioningDigiProducer::produce(edm::StreamI
 
   // Analyze strip tracker FED buffers in data
   size_t fedIndex;
-  for (fedIndex = 0; fedIndex < Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
+  for (fedIndex = 0; fedIndex <= Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
     const FEDRawData& fed = buffers->FEDData(fedIndex);
     if (fed.size() != 0 && fedIndex >= Phase2Tracker::FED_ID_MIN && fedIndex <= Phase2Tracker::FED_ID_MAX) {
       // construct buffer

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -90,7 +90,7 @@ namespace Phase2Tracker {
 
     // Analyze strip tracker FED buffers in data
     size_t fedIndex;
-    for (fedIndex = Phase2Tracker::FED_ID_MIN; fedIndex < Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
+    for (fedIndex = Phase2Tracker::FED_ID_MIN; fedIndex <= Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
       const FEDRawData& fed = buffers->FEDData(fedIndex);
       if (fed.size() != 0) {
         // construct buffer

--- a/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2TrackerFEDTestAnalyzer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2TrackerFEDTestAnalyzer.cc
@@ -84,7 +84,7 @@ void Phase2TrackerFEDTestAnalyzer::analyze(const edm::Event& event, const edm::E
 
   // Analyze strip tracker FED buffers in data
   size_t fedIndex;
-  for (fedIndex = 0; fedIndex < Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
+  for (fedIndex = 0; fedIndex <= Phase2Tracker::CMS_FED_ID_MAX; ++fedIndex) {
     const FEDRawData& fed = buffers->FEDData(fedIndex);
     if (fed.size() != 0 && fedIndex >= Phase2Tracker::FED_ID_MIN && fedIndex <= Phase2Tracker::FED_ID_MAX) {
       // construct buffer

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
@@ -56,7 +56,7 @@ void RawDataCollectorByLabel::produce(Event &e, const EventSetup &c) {
       std::cout << "process index = " << rawData[i].provenance()->productID().processIndex() << std::endl;
     }
 
-    for (int j = 0; j < FEDNumbering::MAXFEDID; ++j) {
+    for (int j = 0; j <= FEDNumbering::MAXFEDID; ++j) {
       const FEDRawData &fedData = rdc->FEDData(j);
       size_t size = fedData.size();
 


### PR DESCRIPTION
#### PR description:

This PR fixes cases where loops over FED IDs are done only up to `FEDNumbering::MAXFEDID - 1`, rather than up to `FEDNumbering::MAXFEDID`.

`FEDNumbering::MAXFEDID` corresponds to 4096, and it is a valid FED ID:
https://github.com/cms-sw/cmssw/blob/038eb56268f2fb41e45e46828e556c174dc1f589/DataFormats/FEDRawData/interface/FEDNumbering.h#L26
https://github.com/cms-sw/cmssw/blob/038eb56268f2fb41e45e46828e556c174dc1f589/DataFormats/FEDRawData/interface/FEDNumbering.h#L19
https://github.com/cms-sw/cmssw/blob/038eb56268f2fb41e45e46828e556c174dc1f589/DataFormats/FEDRawData/src/FEDRawDataCollection.cc#L14

As far as I know, this FED ID is not actually used at the moment (no data), so this fix likely has no visible consequences.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A