### PR TITLE
Allocate enough memory for the compressed data buffer in FileBlob

### DIFF
--- a/CondFormats/Common/src/FileBlob.cc
+++ b/CondFormats/Common/src/FileBlob.cc
@@ -42,8 +42,8 @@ void FileBlob::read(std::istream& is) {
     }
     std::cout<<std::endl;
     */
-    blob.resize(isize);
     uLongf destLen = compressBound(in.size());
+    blob.resize(destLen);
     int zerr = compress2(&*blob.begin(), &destLen, &*in.begin(), in.size(), 9);
     if (zerr != 0)
       edm::LogError("FileBlob") << "Compression error " << zerr;


### PR DESCRIPTION
#### PR description:

This PR proposes a minimal fix to https://github.com/cms-sw/cmssw/issues/40407 by allocating `destLen` characters for the compressed data buffer instead of `isize` (`destLen` can be larger than `isize`).

#### PR validation:

None.