### PR TITLE
Fix use-after-move in L1MuDTTrackFinder, and some additional modernization

### DIFF
--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -79,13 +79,13 @@ public:
   const L1MuDTSectorProcessor* sp(const L1MuDTSecProcId&) const;
 
   /// get a pointer to an Eta Processor, index [0-11]
-  inline const L1MuDTEtaProcessor* ep(int id) const { return m_epvec[id]; }
+  inline const L1MuDTEtaProcessor* ep(int id) const { return m_epvec[id].get(); }
 
   /// get a pointer to a Wedge Sorter, index [0-11]
-  inline const L1MuDTWedgeSorter* ws(int id) const { return m_wsvec[id]; }
+  inline const L1MuDTWedgeSorter* ws(int id) const { return m_wsvec[id].get(); }
 
   /// get a pointer to the DT Muon Sorter
-  inline const L1MuDTMuonSorter* ms() const { return m_ms; }
+  inline const L1MuDTMuonSorter* ms() const { return m_ms.get(); }
 
   /// get number of muon candidates found by the barrel MTTF
   int numberOfTracks();
@@ -116,10 +116,10 @@ private:
 private:
   std::vector<L1MuDTTrackCand> _cache0;
   std::vector<L1MuRegionalCand> _cache;
-  L1MuDTSecProcMap* m_spmap;                 ///< Sector Processors
-  std::vector<L1MuDTEtaProcessor*> m_epvec;  ///< Eta Processors
-  std::vector<L1MuDTWedgeSorter*> m_wsvec;   ///< Wedge Sorters
-  L1MuDTMuonSorter* m_ms;                    ///< DT Muon Sorter
+  std::unique_ptr<L1MuDTSecProcMap> m_spmap;                 ///< Sector Processors
+  std::vector<std::unique_ptr<L1MuDTEtaProcessor>> m_epvec;  ///< Eta Processors
+  std::vector<std::unique_ptr<L1MuDTWedgeSorter>> m_wsvec;   ///< Wedge Sorters
+  std::unique_ptr<L1MuDTMuonSorter> m_ms;                    ///< DT Muon Sorter
   edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
 
   static std::shared_ptr<L1MuDTTFConfig> m_config;  ///< Track Finder configuration

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -64,7 +64,7 @@ public:
   L1MuDTTrackFinder(const edm::ParameterSet& ps, edm::ConsumesCollector&& iC);
 
   /// destructor
-  virtual ~L1MuDTTrackFinder();
+  ~L1MuDTTrackFinder();
 
   /// build the structure of the barrel MTTF
   void setup(edm::ConsumesCollector&& iC);
@@ -105,13 +105,6 @@ public:
   std::vector<L1MuDTTrackCand>& getcache0() { return _cache0; }
 
   std::vector<L1MuRegionalCand>& getcache() { return _cache; }
-
-private:
-  /// run Track Finder and store candidates in cache
-  virtual void reconstruct(const edm::Event& e, const edm::EventSetup& c) {
-    reset();
-    run(e, c);
-  }
 
 private:
   std::vector<L1MuDTTrackCand> _cache0;

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -100,7 +100,7 @@ public:
   int numberOfTracks(int bx);
 
   /// return configuration
-  static L1MuDTTFConfig* config() { return m_config.get(); }
+  const L1MuDTTFConfig* config() const { return m_config.get(); }
 
   std::vector<L1MuDTTrackCand>& getcache0() { return _cache0; }
 
@@ -115,7 +115,7 @@ private:
   std::unique_ptr<L1MuDTMuonSorter> m_ms;                    ///< DT Muon Sorter
   edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
 
-  static std::shared_ptr<L1MuDTTFConfig> m_config;  ///< Track Finder configuration
+  std::unique_ptr<L1MuDTTFConfig> m_config;  ///< Track Finder configuration
 };
 
 #endif

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
@@ -60,7 +60,7 @@ using namespace std;
 // Constructors --
 //----------------
 
-L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id, edm::ConsumesCollector&& iC)
+L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id, edm::ConsumesCollector iC)
     : m_tf(tf),
       m_epid(id),
       m_foundPattern(0),

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
@@ -58,7 +58,7 @@ class L1MuDTQualPatternLutRcd;
 class L1MuDTEtaProcessor {
 public:
   /// constructor
-  L1MuDTEtaProcessor(const L1MuDTTrackFinder&, int id, edm::ConsumesCollector&& iC);
+  L1MuDTEtaProcessor(const L1MuDTTrackFinder&, int id, edm::ConsumesCollector iC);
 
   /// destructor
   virtual ~L1MuDTEtaProcessor();

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.cc
@@ -55,7 +55,7 @@ L1MuDTSecProcMap::~L1MuDTSecProcMap() = default;
 //
 // return Sector Processor
 //
-L1MuDTSectorProcessor* L1MuDTSecProcMap::sp(const L1MuDTSecProcId& id) const {
+const L1MuDTSectorProcessor* L1MuDTSecProcMap::sp(const L1MuDTSecProcId& id) const {
   SPmap::const_iterator it = m_map.find(id);
   if (it == m_map.end()) {
     //    cerr << "Error: Sector Processor not in the map" << endl;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.cc
@@ -46,14 +46,7 @@ L1MuDTSecProcMap::L1MuDTSecProcMap() : m_map() {}
 // Destructor --
 //--------------
 
-L1MuDTSecProcMap::~L1MuDTSecProcMap() {
-  SPmap_iter iter = m_map.begin();
-  while (iter != m_map.end()) {
-    delete (*iter).second;
-    iter++;
-  }
-  m_map.clear();
-}
+L1MuDTSecProcMap::~L1MuDTSecProcMap() = default;
 
 //--------------
 // Operations --
@@ -68,16 +61,16 @@ L1MuDTSectorProcessor* L1MuDTSecProcMap::sp(const L1MuDTSecProcId& id) const {
     //    cerr << "Error: Sector Processor not in the map" << endl;
     return nullptr;
   }
-  return (*it).second;
+  return (*it).second.get();
 }
 
 //
 // insert Sector Processor into container
 //
-void L1MuDTSecProcMap::insert(const L1MuDTSecProcId& id, L1MuDTSectorProcessor* sp) {
+void L1MuDTSecProcMap::insert(const L1MuDTSecProcId& id, std::unique_ptr<L1MuDTSectorProcessor> sp) {
   //SPmap::const_iterator it = m_map.find(id);
   //  if ( it != m_map.end() )
   //    cerr << "Error: More than one Sector Processor with same identifier"
   //         << endl;
-  m_map[id] = sp;
+  m_map[id] = std::move(sp);
 }

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
@@ -45,7 +45,7 @@ public:
   L1MuDTSecProcMap();
 
   /// destructor
-  virtual ~L1MuDTSecProcMap();
+  ~L1MuDTSecProcMap();
 
   /// return pointer to Sector Processor
   const L1MuDTSectorProcessor* sp(const L1MuDTSecProcId&) const;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
@@ -48,7 +48,7 @@ public:
   virtual ~L1MuDTSecProcMap();
 
   /// return pointer to Sector Processor
-  L1MuDTSectorProcessor* sp(const L1MuDTSecProcId&) const;
+  const L1MuDTSectorProcessor* sp(const L1MuDTSecProcId&) const;
 
   /// insert a Sector Processor into the container
   void insert(const L1MuDTSecProcId&, std::unique_ptr<L1MuDTSectorProcessor> sp);

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSecProcMap.h
@@ -19,6 +19,7 @@
 //---------------
 
 #include <map>
+#include <memory>
 
 //----------------------
 // Base Class Headers --
@@ -37,7 +38,7 @@ class L1MuDTSectorProcessor;
 
 class L1MuDTSecProcMap {
 public:
-  typedef std::map<L1MuDTSecProcId, L1MuDTSectorProcessor*, std::less<L1MuDTSecProcId> > SPmap;
+  typedef std::map<L1MuDTSecProcId, std::unique_ptr<L1MuDTSectorProcessor>> SPmap;
   typedef SPmap::iterator SPmap_iter;
 
   /// constructor
@@ -50,7 +51,7 @@ public:
   L1MuDTSectorProcessor* sp(const L1MuDTSecProcId&) const;
 
   /// insert a Sector Processor into the container
-  void insert(const L1MuDTSecProcId&, L1MuDTSectorProcessor* sp);
+  void insert(const L1MuDTSecProcId&, std::unique_ptr<L1MuDTSectorProcessor> sp);
 
   /// return number of entries present in the container
   inline int size() const { return m_map.size(); }

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -158,15 +158,13 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
     reset();
 
     // run sector processors
-    L1MuDTSecProcMap::SPmap_iter it_sp = m_spmap->begin();
-    while (it_sp != m_spmap->end()) {
+    for (auto& sp : *m_spmap) {
       if (m_config->Debug(2))
-        cout << "running " << (*it_sp).second->id() << endl;
-      if ((*it_sp).second)
-        (*it_sp).second->run(bx, e, c);
-      if (m_config->Debug(2) && (*it_sp).second)
-        (*it_sp).second->print();
-      it_sp++;
+        cout << "running " << sp.second->id() << endl;
+      if (sp.second)
+        sp.second->run(bx, e, c);
+      if (m_config->Debug(2) && sp.second)
+        sp.second->print();
     }
 
     // run eta processors
@@ -180,12 +178,11 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
     }
 
     // read sector processors
-    it_sp = m_spmap->begin();
-    while (it_sp != m_spmap->end()) {
+    for (auto& sp : *m_spmap) {
       if (m_config->Debug(2))
-        cout << "reading " << (*it_sp).second->id() << endl;
+        cout << "reading " << sp.second->id() << endl;
       for (int number = 0; number < 2; number++) {
-        const L1MuDTTrack* cand = (*it_sp).second->tracK(number);
+        const L1MuDTTrack* cand = sp.second->tracK(number);
         if (cand && !cand->empty())
           _cache0.push_back(L1MuDTTrackCand(cand->getDataWord(),
                                             cand->bx(),
@@ -198,7 +195,6 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
                                             cand->address(4),
                                             cand->tc()));
       }
-      it_sp++;
     }
 
     // run wedge sorters
@@ -221,11 +217,9 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
 
     // store found track candidates in container (cache)
     if (m_ms->numberOfTracks() > 0) {
-      const vector<const L1MuDTTrack*>& mttf_cont = m_ms->tracks();
-      vector<const L1MuDTTrack*>::const_iterator iter;
-      for (iter = mttf_cont.begin(); iter != mttf_cont.end(); iter++) {
-        if (*iter)
-          _cache.push_back(L1MuRegionalCand((*iter)->getDataWord(), (*iter)->bx()));
+      for (auto const& mttf : m_ms->tracks()) {
+        if (mttf)
+          _cache.push_back(L1MuRegionalCand(mttf->getDataWord(), mttf->bx()));
       }
     }
   }
@@ -235,11 +229,9 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
 // reset MTTF
 //
 void L1MuDTTrackFinder::reset() {
-  L1MuDTSecProcMap::SPmap_iter it_sp = m_spmap->begin();
-  while (it_sp != m_spmap->end()) {
-    if ((*it_sp).second)
-      (*it_sp).second->reset();
-    it_sp++;
+  for (auto& sp : *m_spmap) {
+    if (sp.second)
+      sp.second->reset();
   }
 
   for (auto& ep : m_epvec) {
@@ -280,8 +272,8 @@ void L1MuDTTrackFinder::clear() {
 //
 int L1MuDTTrackFinder::numberOfTracks(int bx) {
   int number = 0;
-  for (TFtracks_const_iter it = _cache.begin(); it != _cache.end(); it++) {
-    if ((*it).bx() == bx)
+  for (auto const& elem : _cache) {
+    if (elem.bx() == bx)
       number++;
   }
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -53,11 +53,7 @@ using namespace std;
 
 L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet& ps, edm::ConsumesCollector&& iC) {
   // set configuration parameters
-  if (not m_config) {
-    auto temp = std::make_shared<L1MuDTTFConfig>(ps);
-    std::shared_ptr<L1MuDTTFConfig> empty;
-    std::atomic_compare_exchange_strong(&m_config, &empty, temp);
-  }
+  m_config = std::make_unique<L1MuDTTFConfig>(ps);
 
   if (m_config->Debug(1))
     cout << endl;
@@ -291,7 +287,3 @@ int L1MuDTTrackFinder::numberOfTracks(int bx) {
 
   return number;
 }
-
-// static data members
-
-std::shared_ptr<L1MuDTTFConfig> L1MuDTTrackFinder::m_config;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -124,7 +124,7 @@ void L1MuDTTrackFinder::setup(edm::ConsumesCollector&& iC) {
       continue;
     for (int sc = 0; sc < 12; sc++) {
       L1MuDTSecProcId tmpspid(wh, sc);
-      L1MuDTSectorProcessor* sp = new L1MuDTSectorProcessor(*this, tmpspid, std::move(iC));
+      L1MuDTSectorProcessor* sp = new L1MuDTSectorProcessor(*this, tmpspid, iC);
       if (m_config->Debug(2))
         cout << "creating " << tmpspid << endl;
       m_spmap->insert(tmpspid, sp);
@@ -133,7 +133,7 @@ void L1MuDTTrackFinder::setup(edm::ConsumesCollector&& iC) {
 
   // create new eta processors and wedge sorters
   for (int sc = 0; sc < 12; sc++) {
-    L1MuDTEtaProcessor* ep = new L1MuDTEtaProcessor(*this, sc, std::move(iC));
+    L1MuDTEtaProcessor* ep = new L1MuDTEtaProcessor(*this, sc, iC);
     if (m_config->Debug(2))
       cout << "creating Eta Processor " << sc << endl;
     m_epvec.push_back(ep);


### PR DESCRIPTION
#### PR description:

This PR fixes a use-after-move of `edm::ConsumesCollector` in `L1MuDTTrackFinder::setup()` that was reported by the static analyzer. While doing that I made some additional modernization to the code
- replaced owning raw pointers with `std::unique_ptr`
- removed unnecessary `virtual` function specifiers (nothing inherits from the affected classes)
- made `config()` a non-`static` member function (nothing required it to be `static`)
- replaced explicit loops over iterators with range-based `for` loop

#### PR validation:

Code compiles