### PR TITLE
Enable Phase2 HLT with Digi and L1T step

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2339,7 +2339,7 @@ upgradeProperties[2026] = {
     },
     '2026D88' : {
         'Geom' : 'Extended2026D88',
-        'HLTmenu': '@fake2',
+        'HLTmenu': '@relval2026',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
@@ -2374,7 +2374,7 @@ upgradeProperties[2026] = {
     },
     '2026D95' : {
         'Geom' : 'Extended2026D95',
-        'HLTmenu': '@fake2',
+        'HLTmenu': '@relval2026',
         'GT' : 'auto:phase2_realistic_T21',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],


### PR DESCRIPTION
#### PR description:
This PR is to run `HLT@relval2026` with the DIGI and L1T steps. Technically, the new default workflow will be the same as XXXXX.76. The `.76` workflows will be removed later. Only D88 and D95 are included in this PR, as they are current and the next default geometry for validation.
 
This is the first step before enabling Phase-2 HLT DQM.

#### PR validation:
Run with 20834.0 (D88) and 23634.0 (D95)

The cross-check has been done between 20834.0 and 20834.76. Here is the log file and also the script used for comparison: `/eos/cms/store/group/offcomp_upgrade-sw/srimanob/phase2/HLT/Log`. Running HLT together with Digi,L1T is not difference than running with RECO.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.
