### PR TITLE
Phase2-hgx335A Take out the methods of HGCalGeometryMode from HGCalParametersFromDD.cc to enable clean separation of full HGCal and TB HGCal

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include "DetectorDescription/Core/interface/DDsvalues.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 template <typename T>
@@ -36,7 +37,16 @@ namespace HGCalGeometryMode {
     Hexagon8Cassette = 10,
     TrapezoidCassette = 11,
   };
+
   enum WaferMode { Polyhedra = 0, ExtrudedPolygon = 1 };
-}  // namespace HGCalGeometryMode
+
+  // Gets Geometry mode
+  GeometryMode getGeometryMode(const char* s, const DDsvalues_type& sv);
+  GeometryMode getGeometryMode(const std::string& s);
+  // Gets wafer mode
+  WaferMode getGeometryWaferMode(const char* s, const DDsvalues_type& sv);
+
+  WaferMode getGeometryWaferMode(std::string& s);
+}; // namespace HGCalGeometryMode
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
@@ -14,7 +14,7 @@ class HGCalStringToEnumParser {
 public:
   HGCalStringToEnumParser(void);
 
-  T parseString(const std::string &value) {
+  T parseString(const std::string& value) {
     typename std::map<std::string, T>::const_iterator itr = enumMap.find(value);
     if (itr == enumMap.end())
       throw cms::Exception("Configuration") << "the value " << value << " is not defined.";
@@ -47,6 +47,6 @@ namespace HGCalGeometryMode {
   WaferMode getGeometryWaferMode(const char* s, const DDsvalues_type& sv);
 
   WaferMode getGeometryWaferMode(std::string& s);
-}; // namespace HGCalGeometryMode
+};  // namespace HGCalGeometryMode
 
 #endif

--- a/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
@@ -1,4 +1,5 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
+#include "DetectorDescription/Core/interface/DDutils.h"
 
 template <>
 HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode>::HGCalStringToEnumParser() {
@@ -21,3 +22,47 @@ HGCalStringToEnumParser<HGCalGeometryMode::WaferMode>::HGCalStringToEnumParser()
   enumMap["HGCalGeometryMode::Polyhedra"] = HGCalGeometryMode::Polyhedra;
   enumMap["HGCalGeometryMode::ExtrudedPolygon"] = HGCalGeometryMode::ExtrudedPolygon;
 }
+
+HGCalGeometryMode::GeometryMode HGCalGeometryMode::getGeometryMode(const char* s, const DDsvalues_type& sv) {
+  DDValue val(s);
+  if (DDfetch(&sv, val)) {
+    const std::vector<std::string>& fvec = val.strings();
+    if (fvec.empty()) {
+      throw cms::Exception("HGCalGeom") << "getGeometryMode::Failed to get " << s << " tag.";
+    }
+    
+    HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode> eparser;
+    HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(fvec[0]);
+    return result;
+  } else {
+    throw cms::Exception("HGCalGeom") << "getGeometryMode::Failed to fetch " << s << " tag";
+  }
+};
+
+HGCalGeometryMode::GeometryMode HGCalGeometryMode::getGeometryMode(const std::string& s) {
+  HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode> eparser;
+  HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(s);
+  return result;
+};
+  
+HGCalGeometryMode::WaferMode HGCalGeometryMode::getGeometryWaferMode(const char* s, const DDsvalues_type& sv) {
+  DDValue val(s);
+  if (DDfetch(&sv, val)) {
+    const std::vector<std::string>& fvec = val.strings();
+    if (fvec.empty()) {
+      throw cms::Exception("HGCalGeom") << "getGeometryWaferMode::Failed to get " << s << " tag.";
+    }
+
+    HGCalStringToEnumParser<HGCalGeometryMode::WaferMode> eparser;
+    HGCalGeometryMode::WaferMode result = (HGCalGeometryMode::WaferMode)eparser.parseString(fvec[0]);
+    return result;
+  } else {
+    throw cms::Exception("HGCalGeom") << "getGeometryWaferMode::Failed to fetch " << s << " tag";
+  }
+};
+
+HGCalGeometryMode::WaferMode HGCalGeometryMode::getGeometryWaferMode(std::string& s) {
+  HGCalStringToEnumParser<HGCalGeometryMode::WaferMode> eparser;
+  HGCalGeometryMode::WaferMode result = (HGCalGeometryMode::WaferMode)eparser.parseString(s);
+  return result;
+};

--- a/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
@@ -30,7 +30,7 @@ HGCalGeometryMode::GeometryMode HGCalGeometryMode::getGeometryMode(const char* s
     if (fvec.empty()) {
       throw cms::Exception("HGCalGeom") << "getGeometryMode::Failed to get " << s << " tag.";
     }
-    
+
     HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode> eparser;
     HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(fvec[0]);
     return result;
@@ -44,7 +44,7 @@ HGCalGeometryMode::GeometryMode HGCalGeometryMode::getGeometryMode(const std::st
   HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(s);
   return result;
 };
-  
+
 HGCalGeometryMode::WaferMode HGCalGeometryMode::getGeometryWaferMode(const char* s, const DDsvalues_type& sv) {
   DDValue val(s);
   if (DDfetch(&sv, val)) {

--- a/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
@@ -11,49 +11,6 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-namespace {
-  HGCalGeometryMode::GeometryMode getGeometryMode(const char* s, const DDsvalues_type& sv) {
-    DDValue val(s);
-    if (DDfetch(&sv, val)) {
-      const std::vector<std::string>& fvec = val.strings();
-      if (fvec.empty()) {
-        throw cms::Exception("HGCalGeom") << "getGeometryMode::Failed to get " << s << " tag.";
-      }
-
-      HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode> eparser;
-      HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(fvec[0]);
-      return result;
-    } else {
-      throw cms::Exception("HGCalGeom") << "getGeometryMode::Failed to fetch " << s << " tag";
-    }
-  }
-  HGCalGeometryMode::GeometryMode getGeometryMode(const std::string& s) {
-    HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode> eparser;
-    HGCalGeometryMode::GeometryMode result = (HGCalGeometryMode::GeometryMode)eparser.parseString(s);
-    return result;
-  }
-  HGCalGeometryMode::WaferMode getGeometryWaferMode(const char* s, const DDsvalues_type& sv) {
-    DDValue val(s);
-    if (DDfetch(&sv, val)) {
-      const std::vector<std::string>& fvec = val.strings();
-      if (fvec.empty()) {
-        throw cms::Exception("HGCalGeom") << "getGeometryWaferMode::Failed to get " << s << " tag.";
-      }
-
-      HGCalStringToEnumParser<HGCalGeometryMode::WaferMode> eparser;
-      HGCalGeometryMode::WaferMode result = (HGCalGeometryMode::WaferMode)eparser.parseString(fvec[0]);
-      return result;
-    } else {
-      throw cms::Exception("HGCalGeom") << "getGeometryWaferMode::Failed to fetch " << s << " tag";
-    }
-  }
-  HGCalGeometryMode::WaferMode getGeometryWaferMode(std::string& s) {
-    HGCalStringToEnumParser<HGCalGeometryMode::WaferMode> eparser;
-    HGCalGeometryMode::WaferMode result = (HGCalGeometryMode::WaferMode)eparser.parseString(s);
-    return result;
-  }
-}  // namespace
-
 bool HGCalParametersFromDD::build(const DDCompactView* cpv,
                                   HGCalParameters& php,
                                   const std::string& name,
@@ -78,7 +35,7 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
 #endif
   if (ok) {
     DDsvalues_type sv(fv.mergedSpecifics());
-    php.mode_ = getGeometryMode("GeometryMode", sv);
+    php.mode_ = HGCalGeometryMode::getGeometryMode("GeometryMode", sv);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Volume " << name << " GeometryMode " << php.mode_ << ":"
                                   << HGCalGeometryMode::Hexagon << ":" << HGCalGeometryMode::HexagonFull << ":"
@@ -105,7 +62,7 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
       bool ok2 = fv2.firstChild();
       if (ok2) {
         DDsvalues_type sv2(fv2.mergedSpecifics());
-        mode = getGeometryWaferMode("WaferMode", sv2);
+        mode = HGCalGeometryMode::getGeometryWaferMode("WaferMode", sv2);
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCalGeom") << "WaferMode " << mode << ":" << HGCalGeometryMode::Polyhedra << ":"
                                       << HGCalGeometryMode::ExtrudedPolygon;
@@ -150,7 +107,7 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
       bool ok2 = fv2.firstChild();
       if (ok2) {
         DDsvalues_type sv2(fv2.mergedSpecifics());
-        mode = getGeometryWaferMode("WaferMode", sv2);
+        mode = HGCalGeometryMode::getGeometryWaferMode("WaferMode", sv2);
         php.nCellsFine_ = static_cast<int>(getDDDValue("NumberOfCellsFine", sv2));
         php.nCellsCoarse_ = static_cast<int>(getDDDValue("NumberOfCellsCoarse", sv2));
         php.waferSize_ = HGCalParameters::k_ScaleFromDDD * getDDDValue("WaferSize", sv2);
@@ -297,7 +254,7 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
 #endif
 
   if (ok) {
-    php.mode_ = getGeometryMode(sv);
+    php.mode_ = HGCalGeometryMode::getGeometryMode(sv);
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "Volume " << name << " GeometryMode " << php.mode_ << ":"
                                   << HGCalGeometryMode::Hexagon << ":" << HGCalGeometryMode::HexagonFull << ":"
@@ -317,7 +274,7 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
     if ((php.mode_ == HGCalGeometryMode::Hexagon) || (php.mode_ == HGCalGeometryMode::HexagonFull)) {
       tempS = fv.get<std::vector<std::string> >(namet, "WaferMode");
       std::string sv2 = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::Polyhedra";
-      mode = getGeometryWaferMode(sv2);
+      mode = HGCalGeometryMode::getGeometryWaferMode(sv2);
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("HGCalGeom") << "WaferMode " << mode << ":" << HGCalGeometryMode::Polyhedra << ":"
                                     << HGCalGeometryMode::ExtrudedPolygon;
@@ -365,7 +322,7 @@ bool HGCalParametersFromDD::build(const cms::DDCompactView* cpv,
 
       tempS = fv.get<std::vector<std::string> >(namet, "WaferMode");
       std::string sv2 = (!tempS.empty()) ? tempS[0] : "HGCalGeometryMode::ExtrudedPolygon";
-      mode = getGeometryWaferMode(sv2);
+      mode = HGCalGeometryMode::getGeometryWaferMode(sv2);
       tempD = fv.get<std::vector<double> >(namet, "NumberOfCellsFine");
       php.nCellsFine_ = static_cast<int>(tempD[0]);
       tempD = fv.get<std::vector<double> >(namet, "NumberOfCellsCoarse");


### PR DESCRIPTION
#### PR description:

Take out the methods of HGCalGeometryMode from HGCalParametersFromDD.cc to enable clean separation of full HGCal and TB HGCal

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special