### PR TITLE
Include charge reweighting for Phase-2 IT planar sensors

### DIFF
--- a/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
@@ -5,7 +5,6 @@
 // September 2020 : Extraction of the code for cluster charge reweighting from SiPixelDigitizerAlgorithm to a new class
 // Jan 2023: Generalize so it can be used for Phase-2 IT as well (M. Musich, T.A. Vami)
 
-// forward declarations
 #include <map>
 #include <memory>
 #include <vector>
@@ -124,6 +123,7 @@ inline void SiPixelChargeReweightingAlgorithm::init(const edm::EventSetup& es) {
     SiPixelTemplate2D::pushfile(*dbobject_num, templateStores_);
 
     track.resize(6);
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Init SiPixelChargeReweightingAlgorithm";
   }
 }
 
@@ -148,14 +148,14 @@ inline SiPixelChargeReweightingAlgorithm::SiPixelChargeReweightingAlgorithm(cons
     SiPixel2DTemp_den_token_ = iC.esConsumes(edm::ESInputTag("", "denominator"));
     SiPixel2DTemp_num_token_ = iC.esConsumes(edm::ESInputTag("", "numerator"));
   }
-  edm::LogVerbatim("PixelDigitizer ") << "SiPixelChargeReweightingAlgorithm constructed"
-                                      << " with UseReweighting = " << UseReweighting
-                                      << " and applyLateReweighting_ = " << applyLateReweighting_;
+  LogDebug("SiPixelChargeReweightingAlgorithm")
+      << "SiPixelChargeReweightingAlgorithm constructed"
+      << " with UseReweighting = " << UseReweighting << " and applyLateReweighting_ = " << applyLateReweighting_;
 }
 
 //=========================================================================
 inline SiPixelChargeReweightingAlgorithm::~SiPixelChargeReweightingAlgorithm() {
-  LogDebug("PixelDigitizer") << "SiPixelChargeReweightingAlgorithm deleted";
+  LogDebug("SiPixelChargeReweightingAlgorithm") << "SiPixelChargeReweightingAlgorithm deleted";
 }
 
 //============================================================================
@@ -239,45 +239,40 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
     hitcol_max = exitPixel.second;
   }
 
-#ifdef TP_DEBUG
   LocalPoint CMSSWhitPosition = hit.localPosition();
+  LogDebug("SiPixelChargeReweightingAlgorithm")
+      << "\n"
+      << "Particle ID is: " << hit.particleType() << "\n"
+      << "Process type: " << hit.processType() << "\n"
+      << "HitPosition:"
+      << "\n"
+      << "Hit entry x/y/z: " << hit.entryPoint().x() << "  " << hit.entryPoint().y() << "  " << hit.entryPoint().z()
+      << "  "
+      << "Hit exit x/y/z: " << hit.exitPoint().x() << "  " << hit.exitPoint().y() << "  " << hit.exitPoint().z() << "  "
 
-  LogDebug("Pixel Digitizer") << "\n"
-                              << "Particle ID is: " << hit.particleType() << "\n"
-                              << "Process type: " << hit.processType() << "\n"
-                              << "HitPosition:"
-                              << "\n"
-                              << "Hit entry x/y/z: " << hit.entryPoint().x() << "  " << hit.entryPoint().y() << "  "
-                              << hit.entryPoint().z() << "  "
-                              << "Hit exit x/y/z: " << hit.exitPoint().x() << "  " << hit.exitPoint().y() << "  "
-                              << hit.exitPoint().z() << "  "
+      << "Pixel Pos - X: " << hitPositionPixel.x() << " Y: " << hitPositionPixel.y() << "\n"
+      << "Cart.Cor. - X: " << CMSSWhitPosition.x() << " Y: " << CMSSWhitPosition.y() << "\n"
+      << "Z=0 Pos - X: " << hitPosition.x() << " Y: " << hitPosition.y() << "\n"
 
-                              << "Pixel Pos - X: " << hitPositionPixel.x() << " Y: " << hitPositionPixel.y() << "\n"
-                              << "Cart.Cor. - X: " << CMSSWhitPosition.x() << " Y: " << CMSSWhitPosition.y() << "\n"
-                              << "Z=0 Pos - X: " << hitPosition.x() << " Y: " << hitPosition.y() << "\n"
+      << "Origin of the template:"
+      << "\n"
+      << "Pixel Pos - X: " << originPixel.x() << " Y: " << originPixel.y() << "\n"
+      << "Cart.Cor. - X: " << origin.x() << " Y: " << origin.y() << "\n"
+      << "\n"
+      << "Entry/Exit:"
+      << "\n"
+      << "Entry - X: " << hit.entryPoint().x() << " Y: " << hit.entryPoint().y() << " Z: " << hit.entryPoint().z()
+      << "\n"
+      << "Exit - X: " << hit.exitPoint().x() << " Y: " << hit.exitPoint().y() << " Z: " << hit.exitPoint().z() << "\n"
 
-                              << "Origin of the template:"
-                              << "\n"
-                              << "Pixel Pos - X: " << originPixel.x() << " Y: " << originPixel.y() << "\n"
-                              << "Cart.Cor. - X: " << origin.x() << " Y: " << origin.y() << "\n"
-                              << "\n"
-                              << "Entry/Exit:"
-                              << "\n"
-                              << "Entry - X: " << hit.entryPoint().x() << " Y: " << hit.entryPoint().y()
-                              << " Z: " << hit.entryPoint().z() << "\n"
-                              << "Exit - X: " << hit.exitPoint().x() << " Y: " << hit.exitPoint().y()
-                              << " Z: " << hit.exitPoint().z() << "\n"
+      << "Entry - X Pixel: " << hitEntryPointPixel.x() << " Y Pixel: " << hitEntryPointPixel.y() << "\n"
+      << "Exit - X Pixel: " << hitExitPointPixel.x() << " Y Pixel: " << hitExitPointPixel.y() << "\n"
 
-                              << "Entry - X Pixel: " << hitEntryPointPixel.x() << " Y Pixel: " << hitEntryPointPixel.y()
-                              << "\n"
-                              << "Exit - X Pixel: " << hitExitPointPixel.x() << " Y Pixel: " << hitExitPointPixel.y()
-                              << "\n"
-
-                              << "row min: " << irow_min << " col min: " << icol_min << "\n";
-#endif
+      << "row min: " << irow_min << " col min: " << icol_min << "\n";
 
   if (!(irow_min <= hitrow_max && irow_max >= hitrow_min && icol_min <= hitcol_max && icol_max >= hitcol_min)) {
     // The clusters do not have an overlap, hence the hit is NOT reweighted
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Outside the row/col boundary, exit charge reweighting";
     return false;
   }
 
@@ -288,6 +283,7 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
   track[4] = direction.y();
   track[5] = direction.z();
 
+  LogDebug("SiPixelChargeReweightingAlgorithm") << "Init array of size x = " << TXSIZE << " and y = " << TYSIZE;
   array_2d pixrewgt(boost::extents[TXSIZE][TYSIZE]);
 
   for (int row = 0; row < TXSIZE; ++row) {
@@ -320,7 +316,7 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
   }
 
   if (PrintClusters) {
-    LogDebug("PixelDigitizer ") << "Cluster before reweighting: ";
+    LogDebug("SiPixelChargeReweightingAlgorithm ") << "Cluster before reweighting: ";
     printCluster(pixrewgt);
   }
 
@@ -339,14 +335,12 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
     ierr = PixelTempRewgt2D(IDden, IDden, pixrewgt);
   }
   if (ierr != 0) {
-#ifdef TP_DEBUG
-    LogDebug("PixelDigitizer ") << "Cluster Charge Reweighting did not work properly.";
-#endif
+    LogDebug("SiPixelChargeReweightingAlgorithm ") << "Cluster Charge Reweighting did not work properly.";
     return false;
   }
 
   if (PrintClusters) {
-    LogDebug("PixelDigitizer ") << "Cluster after reweighting: ";
+    LogDebug("SiPixelChargeReweightingAlgorithm ") << "Cluster after reweighting: ";
     printCluster(pixrewgt);
   }
 
@@ -372,8 +366,10 @@ bool SiPixelChargeReweightingAlgorithm::hitSignalReweight(const PSimHit& hit,
   }
 
   if (PrintClusters) {
-    LogDebug("PixelDigitizer ") << "Charges (before->after): " << chargeBefore << " -> " << chargeAfter;
-    LogDebug("PixelDigitizer ") << "Charge loss: " << (1 - chargeAfter / chargeBefore) * 100 << " % \n";
+    LogDebug("SiPixelChargeReweightingAlgorithm ")
+        << "Charges (before->after): " << chargeBefore << " -> " << chargeAfter;
+    LogDebug("SiPixelChargeReweightingAlgorithm ")
+        << "Charge loss: " << (1 - chargeAfter / chargeBefore) * 100 << " % \n";
   }
 
   return true;
@@ -414,7 +410,7 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
     cotalpha = track[3] / track[5];  //if track[5] (direction in z) is 0 the hit is not processed by re-weighting
     cotbeta = track[4] / track[5];
   } else {
-    LogDebug("Pixel Digitizer") << "Reweighting angle is not good! \n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Reweighting angle is not good! \n";
     return 9;  //returned value here indicates that no reweighting was done in this case
   }
 
@@ -444,14 +440,12 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
     success = 1;
   }
   if (success != 0) {
-#ifdef TP_DEBUG
-    LogDebug("Pixel Digitizer") << "No matching template found \n";
-#endif
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "No matching template found \n";
     return 2;
   }
 
   if (PrintTemplates) {
-    LogDebug("Pixel Digitizer") << "Template unirrad: \n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Template unirrad: \n";
     printCluster(xy_in);
   }
 
@@ -462,18 +456,19 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   // Check that the cluster container is a 13x21 matrix
 
   if (cluster.num_dimensions() != 2) {
-    edm::LogWarning("Pixel Digitizer") << "Cluster is not 2-dimensional. Return. \n";
+    edm::LogWarning("SiPixelChargeReweightingAlgorithm") << "Cluster is not 2-dimensional. Return. \n";
     return 3;
   }
   nclusx = (int)cluster.shape()[0];
   nclusy = (int)cluster.shape()[1];
   if (nclusx != TXSIZE || xdouble.size() != TXSIZE) {
-    edm::LogWarning("Pixel Digitizer") << "Sizes in x do not match: nclusx=" << nclusx
-                                       << "  xdoubleSize=" << xdouble.size() << "  TXSIZE=" << TXSIZE << ". Return. \n";
+    edm::LogWarning("SiPixelChargeReweightingAlgorithm")
+        << "Sizes in x do not match: nclusx=" << nclusx << "  xdoubleSize=" << xdouble.size() << "  TXSIZE=" << TXSIZE
+        << ". Return. \n";
     return 4;
   }
   if (nclusy != TYSIZE || ydouble.size() != TYSIZE) {
-    edm::LogWarning("Pixel Digitizer") << "Sizes in y do not match. Return. \n";
+    edm::LogWarning("SiPixelChargeReweightingAlgorithm") << "Sizes in y do not match. Return. \n";
     return 5;
   }
 
@@ -498,7 +493,7 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   }
 
   if (PrintTemplates) {
-    LogDebug("Pixel Digitizer") << "Template irrad: \n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Template irrad: \n";
     printCluster(xy_rewgt);
   }
 
@@ -551,7 +546,7 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   }
 
   if (PrintTemplates) {
-    LogDebug("Pixel Digitizer") << "Weights: \n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Weights: \n";
     printCluster(xy_clust);
   }
 
@@ -614,27 +609,27 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
 inline void SiPixelChargeReweightingAlgorithm::printCluster(array_2d& cluster) {
   for (int col = 0; col < TYSIZE; ++col) {
     for (int row = 0; row < TXSIZE; ++row) {
-      LogDebug("Pixel Digitizer") << cluster[row][col];
+      LogDebug("SiPixelChargeReweightingAlgorithm") << cluster[row][col];
     }
-    LogDebug("Pixel Digitizer") << "\n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "\n";
   }
 }
 
 inline void SiPixelChargeReweightingAlgorithm::printCluster(float arr[BXM2][BYM2]) {
   for (int col = 0; col < BYM2; ++col) {
     for (int row = 0; row < BXM2; ++row) {
-      LogDebug("Pixel Digitizer") << arr[row][col];
+      LogDebug("SiPixelChargeReweightingAlgorithm") << arr[row][col];
     }
-    LogDebug("Pixel Digitizer") << "\n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "\n";
   }
 }
 
 inline void SiPixelChargeReweightingAlgorithm::printCluster(float arr[TXSIZE][TYSIZE]) {
   for (int col = 0; col < TYSIZE; ++col) {
     for (int row = 0; row < TXSIZE; ++row) {
-      LogDebug("Pixel Digitizer") << arr[row][col];
+      LogDebug("SiPixelChargeReweightingAlgorithm") << arr[row][col];
     }
-    LogDebug("Pixel Digitizer") << "\n";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "\n";
   }
 }
 
@@ -649,15 +644,15 @@ bool SiPixelChargeReweightingAlgorithm::lateSignalReweight(const PixelGeomDetUni
   const PixelTopology* topol = &pixdet->specificTopology();
 
   if (UseReweighting) {
-    edm::LogError("Pixel Digitizer") << " ******************************** \n";
-    edm::LogError("Pixel Digitizer") << " ******************************** \n";
-    edm::LogError("Pixel Digitizer") << " ******************************** \n";
-    edm::LogError("Pixel Digitizer") << " *****  INCONSISTENCY !!!   ***** \n";
-    edm::LogError("Pixel Digitizer")
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ******************************** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ******************************** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ******************************** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " *****  INCONSISTENCY !!!   ***** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm")
         << " applyLateReweighting_ and UseReweighting can not be true at the same time for PU ! \n";
-    edm::LogError("Pixel Digitizer") << " ---> DO NOT APPLY CHARGE REWEIGHTING TWICE !!! \n";
-    edm::LogError("Pixel Digitizer") << " ******************************** \n";
-    edm::LogError("Pixel Digitizer") << " ******************************** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ---> DO NOT APPLY CHARGE REWEIGHTING TWICE !!! \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ******************************** \n";
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << " ******************************** \n";
     return false;
   }
 
@@ -681,7 +676,6 @@ bool SiPixelChargeReweightingAlgorithm::lateSignalReweight(const PixelGeomDetUni
         edm::LogError("SiPixelChargeReweightingAlgorithm")
             << "Phase-2 late charge reweighting not supported (not sure we need it at all)";
         return false;
-        //theDigiSignal[chan] += AmplitudeType(corresponding_charge, &hit, corresponding_charge, 0., hitIndex, tofBin);
       } else {
         theDigiSignal[chan] += AmplitudeType(corresponding_charge, corresponding_charge);
       }
@@ -776,7 +770,7 @@ bool SiPixelChargeReweightingAlgorithm::lateSignalReweight(const PixelGeomDetUni
   }
 
   if (PrintClusters) {
-    LogDebug("Pixel Digitizer") << " Cluster before reweighting: ";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << " Cluster before reweighting: ";
     printCluster(pixrewgt);
   }
 
@@ -787,18 +781,16 @@ bool SiPixelChargeReweightingAlgorithm::lateSignalReweight(const PixelGeomDetUni
   int ID0 = dbobject_den->getTemplateID(detID);
 
   if (ID0 == ID1) {
-    LogDebug("Pixel Digitizer") << " same template for num and den ";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << " same template for num and den ";
     return false;
   }
   ierr = PixelTempRewgt2D(ID0, ID1, pixrewgt);
   if (ierr != 0) {
-#ifdef TP_DEBUG
-    LogDebug("PixelDigitizer ") << "Cluster Charge Reweighting did not work properly.";
-#endif
+    edm::LogError("SiPixelChargeReweightingAlgorithm") << "Cluster Charge Reweighting did not work properly.";
     return false;
   }
   if (PrintClusters) {
-    LogDebug("Pixel Digitizer") << " Cluster after reweighting: ";
+    LogDebug("SiPixelChargeReweightingAlgorithm") << " Cluster after reweighting: ";
     printCluster(pixrewgt);
   }
 
@@ -826,15 +818,15 @@ bool SiPixelChargeReweightingAlgorithm::lateSignalReweight(const PixelGeomDetUni
   }
 
   if (PrintClusters) {
-    LogDebug("Pixel Digitizer") << "Charges (before->after): " << chargeBefore << " -> " << chargeAfter;
-    LogDebug("Pixel Digitizer") << "Charge loss: " << (1 - chargeAfter / chargeBefore) * 100 << " %";
+    LogDebug("SiPixelChargeReweightingAlgorithm")
+        << "Charges (before->after): " << chargeBefore << " -> " << chargeAfter;
+    LogDebug("SiPixelChargeReweightingAlgorithm") << "Charge loss: " << (1 - chargeAfter / chargeBefore) * 100 << " %";
   }
 
   // need to store the digi out of the 21x13 box.
   for (auto& i : theDigiSignal) {
     // check if in the 21x13 box
     int chanDigi = i.first;
-    //int chanDigi = i;
     std::pair<int, int> ip = PixelDigi::channelToPixel(chanDigi);
     int row_digi = ip.first;
     int col_digi = ip.second;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -1,5 +1,5 @@
-#ifndef _SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
-#define _SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
+#ifndef SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
+#define SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
 
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
@@ -1,5 +1,5 @@
-#ifndef _SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
-#define _SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
+#ifndef SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
+#define SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
 
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -1,5 +1,5 @@
-#ifndef __SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
-#define __SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
+#ifndef SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
+#define SimTracker_SiPhase2Digitizer_Phase2TrackerDigitizerAlgorithm_h
 
 #include <map>
 #include <memory>
@@ -14,6 +14,7 @@
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 
 #include "SimTracker/Common/interface/DigitizerUtility.h"
+#include "SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 
 // Units and Constants
@@ -39,6 +40,7 @@ class SiPixelQuality;
 class SiPhase2OuterTrackerLorentzAngle;
 class TrackerGeometry;
 class TrackerTopology;
+class SiPixelChargeReweightingAlgorithm;
 
 // REMEMBER CMS conventions:
 // -- Energy: GeV
@@ -168,6 +170,11 @@ protected:
   const double pseudoRadDamage_;        // Decrease the amount off freed charge that reaches the collector
   const double pseudoRadDamageRadius_;  // Only apply pseudoRadDamage to pixels with radius<=pseudoRadDamageRadius
 
+  // charge reweighting
+  const bool useChargeReweighting_;
+  // access 2D templates from DB. Only gets initialized if useChargeReweighting_ is set to true
+  const std::unique_ptr<SiPixelChargeReweightingAlgorithm> theSiPixelChargeReweightingAlgorithm_;
+
   // The PDTable
   // HepPDTable *particleTable;
   // ParticleDataTable *particleTable;
@@ -190,8 +197,10 @@ protected:
       const Phase2TrackerGeomDetUnit* pixdet,
       const GlobalVector& bfield,
       const std::vector<digitizerUtility::EnergyDepositUnit>& ionization_points) const;
-  virtual void induce_signal(const PSimHit& hit,
+  virtual void induce_signal(std::vector<PSimHit>::const_iterator inputBegin,
+                             const PSimHit& hit,
                              const size_t hitIndex,
+                             const size_t firstHitIndex,
                              const uint32_t tofBin,
                              const Phase2TrackerGeomDetUnit* pixdet,
                              const std::vector<digitizerUtility::SignalPoint>& collection_points);
@@ -208,7 +217,8 @@ protected:
 
   // access to the gain calibration payloads in the db. Only gets initialized if check_dead_pixels_ is set to true.
   const std::unique_ptr<SiPixelGainCalibrationOfflineSimService> theSiPixelGainCalibrationService_;
-  LocalVector DriftDirection(const Phase2TrackerGeomDetUnit* pixdet,
+
+  LocalVector driftDirection(const Phase2TrackerGeomDetUnit* pixdet,
                              const GlobalVector& bfield,
                              const DetId& detId) const;
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -1,20 +1,13 @@
-#include "SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h"
-
-// Framework infrastructure
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-// Calibration & Conditions
-#include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h"
-
-// Geometry
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-
-//#include <iostream>
 #include <cmath>
 #include <vector>
 #include <algorithm>
+
+#include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h"
 
 using namespace sipixelobjects;
 
@@ -343,8 +336,10 @@ std::vector<digitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
 // Signal is already "induced" (actually electrons transported to the
 // n-column) at the electrode. Just collecting and adding-up all pixel
 // signal and linking it to the simulated energy deposit (hit)
-void Pixel3DDigitizerAlgorithm::induce_signal(const PSimHit& hit,
+void Pixel3DDigitizerAlgorithm::induce_signal(std::vector<PSimHit>::const_iterator inputBegin,
+                                              const PSimHit& hit,
                                               const size_t hitIndex,
+                                              const size_t firstHitIndex,
                                               const uint32_t tofBin,
                                               const Phase2TrackerGeomDetUnit* pixdet,
                                               const std::vector<digitizerUtility::SignalPoint>& collection_points) {
@@ -372,7 +367,7 @@ void Pixel3DDigitizerAlgorithm::induce_signal(const PSimHit& hit,
       the_signal[channel] += digitizerUtility::Ph2Amplitude(pt.amplitude(), nullptr, pt.amplitude());
     }
 
-    LogDebug("Pixel3DDigitizerAlgorithm::induce_signal")
+    LogDebug("Pixel3DDigitizerAlgorithm")
         << " Induce charge at row,col:" << pt.position() << " N_electrons:" << pt.amplitude() << " [Channel:" << channel
         << "]\n   [Accumulated signal in this channel:" << the_signal[channel].ampl() << "] "
         << " Global index linked PSimHit:" << hitIndex;

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -1,5 +1,5 @@
-#ifndef _SimTracker_SiPhase2Digitizer_Pixel3DDigitizerAlgorithm_h
-#define _SimTracker_SiPhase2Digitizer_Pixel3DDigitizerAlgorithm_h
+#ifndef SimTracker_SiPhase2Digitizer_Pixel3DDigitizerAlgorithm_h
+#define SimTracker_SiPhase2Digitizer_Pixel3DDigitizerAlgorithm_h
 
 //-------------------------------------------------------------
 // class Pixel3DDigitizerAlgorithm
@@ -52,8 +52,10 @@ public:
                                                              const std::pair<float, float> pitches,
                                                              const float& thickness) const;
   // Specific for 3D-pixel
-  void induce_signal(const PSimHit& hit,
+  void induce_signal(std::vector<PSimHit>::const_iterator inputBegin,
+                     const PSimHit& hit,
                      const size_t hitIndex,
+                     const size_t firstHitIndex,
                      const uint32_t tofBin,
                      const Phase2TrackerGeomDetUnit* pixdet,
                      const std::vector<digitizerUtility::SignalPoint>& collection_points) override;

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.cc
@@ -50,8 +50,10 @@ PixelBrickedDigitizerAlgorithm::PixelBrickedDigitizerAlgorithm(const edm::Parame
 PixelBrickedDigitizerAlgorithm::~PixelBrickedDigitizerAlgorithm() {
   LogDebug("PixelBrickedDigitizerAlgorithm") << "Algorithm deleted";
 }
-void PixelBrickedDigitizerAlgorithm::induce_signal(const PSimHit& hit,
+void PixelBrickedDigitizerAlgorithm::induce_signal(std::vector<PSimHit>::const_iterator inputBegin,
+                                                   const PSimHit& hit,
                                                    const size_t hitIndex,
+                                                   const size_t firstHitIndex,
                                                    const uint32_t tofBin,
                                                    const Phase2TrackerGeomDetUnit* pixdet,
                                                    const std::vector<digitizerUtility::SignalPoint>& collection_points) {

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h
@@ -17,8 +17,10 @@ public:
   ~PixelBrickedDigitizerAlgorithm() override;
 
   // Specific for bricked pixel
-  void induce_signal(const PSimHit& hit,
+  void induce_signal(std::vector<PSimHit>::const_iterator inputBegin,
+                     const PSimHit& hit,
                      const size_t hitIndex,
+                     const size_t firstHitIndex,
                      const unsigned int tofBin,
                      const Phase2TrackerGeomDetUnit* pixdet,
                      const std::vector<digitizerUtility::SignalPoint>& collection_points) override;

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -35,6 +35,9 @@ void PixelDigitizerAlgorithm::init(const edm::EventSetup& es) {
   // gets the map and geometry from the DB (to kill ROCs)
   fedCablingMap_ = &es.getData(fedCablingMapToken_);
   geom_ = &es.getData(geomToken_);
+  if (useChargeReweighting_) {
+    theSiPixelChargeReweightingAlgorithm_->init(es);
+  }
 }
 
 PixelDigitizerAlgorithm::PixelDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
@@ -70,7 +73,9 @@ PixelDigitizerAlgorithm::PixelDigitizerAlgorithm(const edm::ParameterSet& conf, 
                                       << " The delta cut-off is set to " << tMax_ << " pix-inefficiency "
                                       << addPixelInefficiency_;
 }
+
 PixelDigitizerAlgorithm::~PixelDigitizerAlgorithm() { LogDebug("PixelDigitizerAlgorithm") << "Algorithm deleted"; }
+
 //
 // -- Select the Hit for Digitization
 //

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -35,6 +35,7 @@ PixelDigitizerAlgorithmCommon = cms.PSet(
     DeadModules = cms.VPSet(),
     AddInefficiency = cms.bool(False),
     Inefficiency_DB = cms.bool(False),				
+    UseReweighting = cms.bool(False),
     EfficiencyFactors_Barrel = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999 ),
     EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
                                            0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
@@ -81,13 +82,16 @@ phase2TrackerDigitizer = cms.PSet(
     ),
 # Specific parameters
 #Pixel Digitizer Algorithm
-    PixelDigitizerAlgorithm   = PixelDigitizerAlgorithmCommon.clone(),
+    PixelDigitizerAlgorithm   = PixelDigitizerAlgorithmCommon.clone(
+       UseReweighting = cms.bool(False), # will be True for realistic simulations
+    ),
 #Pixel-3D Digitizer Algorithm
     Pixel3DDigitizerAlgorithm = PixelDigitizerAlgorithmCommon.clone(
         SigmaCoeff = cms.double(1.80),
         NPColumnRadius = cms.double(4.0),
         OhmicColumnRadius = cms.double(4.0),
-        NPColumnGap = cms.double(46.0)
+        NPColumnGap = cms.double(46.0),
+        UseReweighting = cms.bool(False),  # will be True for realistic simulations
     ),
 #Pixel-Bricked Digitizer Algorithm
     PixelBrickedDigitizerAlgorithm   = PixelDigitizerAlgorithmCommon.clone(),
@@ -103,7 +107,7 @@ phase2TrackerDigitizer = cms.PSet(
       HIPThresholdInElectrons_Barrel = cms.double(1.0e10), # very high value to avoid Over threshold bit
       HIPThresholdInElectrons_Endcap = cms.double(1.0e10), # very high value to avoid Over threshold bit
       NoiseInElectrons = cms.double(200),	         # 30% of the readout noise (should be changed in future)
-      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
+      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1)), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
       AdcFullScale = cms.int32(255),
       TofUpperCut = cms.double(12.5),
       TofLowerCut = cms.double(-12.5),
@@ -127,7 +131,8 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
       CellsToKill = cms.VPSet(),
-      BiasRailInefficiencyFlag = cms.int32(1) # Flag to decide BiasRail inefficiency : no inefficency(0) : inefficiency with optimistic(AND) scenario(1) : inefficiency with pessimistic(OR) scenario(2)
+      BiasRailInefficiencyFlag = cms.int32(1), # Flag to decide BiasRail inefficiency : no inefficency(0) : inefficiency with optimistic(AND) scenario(1) : inefficiency with pessimistic(OR) scenario(2)
+      UseReweighting = cms.bool(False),
     ),
 #Strip in PS module
     PSSDigitizerAlgorithm = cms.PSet(
@@ -142,7 +147,7 @@ phase2TrackerDigitizer = cms.PSet(
       HIPThresholdInElectrons_Barrel = cms.double(21000.), # 1.4 MIP considered as HIP
       HIPThresholdInElectrons_Endcap = cms.double(21000.), # 1.4 MIP considered as HIP 
       NoiseInElectrons = cms.double(1010), # threshold = 4800e, noise=4800e/4.75=1010 (4.75 sigma=>occupancy =1e-6)
-      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
+      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1)), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
       AdcFullScale = cms.int32(255),
       TofUpperCut = cms.double(12.5),
       TofLowerCut = cms.double(-12.5),
@@ -165,7 +170,8 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Barrel = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999 ),
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
-      CellsToKill = cms.VPSet()
+      CellsToKill = cms.VPSet(),
+      UseReweighting = cms.bool(False),
     ),
 #Two Strip Module
     SSDigitizerAlgorithm = cms.PSet(
@@ -180,7 +186,7 @@ phase2TrackerDigitizer = cms.PSet(
       HIPThresholdInElectrons_Barrel = cms.double(1.0e10), # very high value to avoid Over threshold bit
       HIPThresholdInElectrons_Endcap = cms.double(1.0e10), # very high value to avoid Over threshold bit
       NoiseInElectrons = cms.double(1263), # threshold = 6000e, noise=6000e/4.75=1263e (4.75 sigma=>occupancy =1e-6)
-      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
+      Phase2ReadoutMode = cms.int32(0), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1)), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
       AdcFullScale = cms.int32(255),
       TofUpperCut = cms.double(12.5),
       TofLowerCut = cms.double(-12.5),
@@ -206,7 +212,8 @@ phase2TrackerDigitizer = cms.PSet(
       CellsToKill = cms.VPSet(),
       HitDetectionMode = cms.int32(0),  # (0/1/2/3/4 => SquareWindow/SampledMode/LatchedMode/SampledOrLachedMode/HIPFindingMode)
       PulseShapeParameters = cms.vdouble(-3.0, 16.043703, 99.999857, 40.571650, 2.0, 1.2459094),
-        CBCDeadTime = cms.double(0.0) # (2.7 ns deadtime in latched mode)
+      CBCDeadTime = cms.double(0.0), # (2.7 ns deadtime in latched mode)
+      UseReweighting = cms.bool(False),
     )
 )
 
@@ -242,7 +249,7 @@ _premixStage1ModifyDict = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
-        Phase2ReadoutMode = -1
+        Phase2ReadoutMode = -1,
     ),
     SSDigitizerAlgorithm = dict(
         AddNoisyPixels = False,

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -1454,8 +1454,8 @@ void SiPixelDigitizerAlgorithm::induce_signal(std::vector<PSimHit>::const_iterat
     int IPixLeftDownY = int(floor(mp.y()));
 
 #ifdef TP_DEBUG
-    emd::LogDebug("Pixel Digitizer") << " left-down " << PointLeftDown << " " << mp.x() << " " << mp.y() << " "
-                                     << IPixLeftDownX << " " << IPixLeftDownY;
+    LogDebug("Pixel Digitizer") << " left-down " << PointLeftDown << " " << mp.x() << " " << mp.y() << " "
+                                << IPixLeftDownX << " " << IPixLeftDownY;
 #endif
 
     // Check detector limits to correct for pixels outside range.
@@ -1564,7 +1564,7 @@ void SiPixelDigitizerAlgorithm::induce_signal(std::vector<PSimHit>::const_iterat
   if (UseReweighting) {
     if (hit.processType() == 0) {
       ReferenceIndex4CR = hitIndex;
-      reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->hitSignalReweight(
+      reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->hitSignalReweight<digitizerUtility::Amplitude>(
           hit, hit_signal, hitIndex, ReferenceIndex4CR, tofBin, topol, detID, theSignal, hit.processType(), makeDSLinks);
     } else {
       std::vector<PSimHit>::const_iterator crSimHit = inputBegin;
@@ -1587,16 +1587,17 @@ void SiPixelDigitizerAlgorithm::induce_signal(std::vector<PSimHit>::const_iterat
         }
       }
 
-      reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->hitSignalReweight((*crSimHit),
-                                                                                   hit_signal,
-                                                                                   hitIndex,
-                                                                                   ReferenceIndex4CR,
-                                                                                   tofBin,
-                                                                                   topol,
-                                                                                   detID,
-                                                                                   theSignal,
-                                                                                   hit.processType(),
-                                                                                   makeDSLinks);
+      reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->hitSignalReweight<digitizerUtility::Amplitude>(
+          (*crSimHit),
+          hit_signal,
+          hitIndex,
+          ReferenceIndex4CR,
+          tofBin,
+          topol,
+          detID,
+          theSignal,
+          hit.processType(),
+          makeDSLinks);
     }
   }
   if (!reweighted) {
@@ -2556,7 +2557,7 @@ void SiPixelDigitizerAlgorithm::lateSignalReweight(const PixelGeomDetUnit* pixde
   for (loopTempSH = newClass_Sim_extra.begin(); loopTempSH != newClass_Sim_extra.end(); ++loopTempSH) {
     signal_map_type theDigiSignal;
     PixelSimHitExtraInfo TheNewInfo = *loopTempSH;
-    reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->lateSignalReweight(
+    reweighted = TheNewSiPixelChargeReweightingAlgorithmClass->lateSignalReweight<digitizerUtility::Amplitude>(
         pixdet, digis, TheNewInfo, theDigiSignal, tTopo, engine);
     if (!reweighted) {
       // loop on the non-reweighthed digis associated to the considered SimHit


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/cms-sw/cmssw/pull/40349
Add the boolean `UseReweighting` to Phase-2 Tracker digitizers in order to simulate charge loss due to irradiation. This uses the same (now generalized) method that is use in the Phase-0/1 simulations. For now it's set to False by default. For now I didn't touch the late charge reweighting, I believe it's not (yet) relevant for Phase-2

#### PR validation:

`20834.0` ran fine with the default `False` value.
After the compilation issue for Phase-1, I also ran `250202.184` which tests the late charge rew (this failed with some input error), and `11634.0` which is for realistic 2021.

when `UseReweighting = True`, I used the `20834.0`  wf but modified the step2 to 
```
cmsDriver.py step2 -s DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:@fake2 --conditions 125X_mcRun4_realistic_Candidate_2023_01_03_23_47_45 --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry Extended2026D88 --era Phase2C17I13M9 --filein file:step1.root --fileout file:step2.root
```
where `125X_mcRun4_realistic_Candidate_2023_01_03_23_47_45` contains the 2D templates needed for the charge reweighting. This runs fine as well.

Run LA trees and showed the charge vs depth profiles with the `True` option, the outcome looks as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport is needed.