### PR TITLE
make `datafnPosition` parameter configurable in online-DQM clients

### DIFF
--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -15,6 +15,12 @@ options.register('runNumber',
                  VarParsing.VarParsing.varType.int,
                  "Run number.")
 
+options.register('datafnPosition',
+                 3, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Data filename position in the positional arguments array 'data' in json file.")
+
 options.register('runInputDir',
                  '/tmp',
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -31,7 +37,7 @@ options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.bool,
-                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the beginning of the processing.")
 
 options.register('noDB',
                  True, # default value
@@ -47,19 +53,19 @@ options.register('BeamSplashRun',
 
 # Parameters for runType
 
-options.register ('runkey',
-          'pp_run',
-          VarParsing.VarParsing.multiplicity.singleton,
-          VarParsing.VarParsing.varType.string,
-          "Run Keys of CMS")
+options.register('runkey',
+                 'pp_run',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Run Keys of CMS")
 
 # Parameter for frontierKey
 
-options.register ('runUniqueKey',
-          'InValid',
-          VarParsing.VarParsing.multiplicity.singleton,
-          VarParsing.VarParsing.varType.string,
-          "Unique run key from RCMS for Frontier")
+options.register('runUniqueKey',
+                 'InValid',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Unique run key from RCMS for Frontier")
 
 options.parseArguments()
 
@@ -88,6 +94,7 @@ if not options.inputFiles:
         SelectEvents = cms.untracked.vstring('*'),
         streamLabel = cms.untracked.string('streamDQM'),
         scanOnce = cms.untracked.bool(options.scanOnce),
+        datafnPosition = cms.untracked.uint32(options.datafnPosition),
         minEventsPerLumi = cms.untracked.int32(1),
         delayMillis = cms.untracked.uint32(500),
         nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
@@ -103,7 +110,7 @@ else:
         fileNames = cms.untracked.vstring(files),
         secondaryFileNames = cms.untracked.vstring()
     )
-    
+
 #source = cms.Source("PoolSource",
 #    fileNames = cms.untracked.vstring(
 #       '/store/user/tosi/STEAM/DQM/online/outputDQM_3.root'
@@ -119,9 +126,3 @@ def set_BeamSplashRun_settings( source ):
 if options.BeamSplashRun : set_BeamSplashRun_settings( source )
 
 print("Initial Source settings:", source)
-
-
-
-
-
-

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -14,6 +14,12 @@ options.register('runNumber',
                  VarParsing.VarParsing.varType.int,
                  "Run number.")
 
+options.register('datafnPosition',
+                 3, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Data filename position in the positional arguments array 'data' in json file.")
+
 options.register('runInputDir',
                  '/tmp',
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -30,7 +36,7 @@ options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.bool,
-                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the beginning of the processing.")
 
 options.register('BeamSplashRun',
                  False, # default value
@@ -40,19 +46,19 @@ options.register('BeamSplashRun',
 
 # Parameters for runType
 
-options.register ('runkey',
-          'pp_run',
-          VarParsing.VarParsing.multiplicity.singleton,
-          VarParsing.VarParsing.varType.string,
-          "Run Keys of CMS")
+options.register('runkey',
+                 'pp_run',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Run Keys of CMS")
 
 # Parameter for frontierKey
 
-options.register ('runUniqueKey',
-          'InValid',
-          VarParsing.VarParsing.multiplicity.singleton,
-          VarParsing.VarParsing.varType.string,
-          "Unique run key from RCMS for Frontier")
+options.register('runUniqueKey',
+                 'InValid',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Unique run key from RCMS for Frontier")
 
 options.parseArguments()
 
@@ -77,10 +83,9 @@ if options.scanOnce:
 source = cms.Source("DQMProtobufReader",
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
-
     streamLabel = cms.untracked.string('streamDQMHistograms'),
     scanOnce = cms.untracked.bool(options.scanOnce),
-
+    datafnPosition = cms.untracked.uint32(options.datafnPosition),
     delayMillis = cms.untracked.uint32(500),
     nextLumiTimeoutMillis = cms.untracked.int32(nextLumiTimeoutMillis),
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
@@ -97,5 +102,3 @@ def set_BeamSplashRun_settings( source ):
 if options.BeamSplashRun : set_BeamSplashRun_settings( source )
 
 print("Initial Source settings:", source)
-
-

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -16,20 +16,18 @@ from Configuration.Applications.ConfigBuilder import filesFromDASQuery
 
 options = VarParsing.VarParsing("analysis")
 
-options.register(
-    "runkey",
-    "pp_run",
-    VarParsing.VarParsing.multiplicity.singleton,
-    VarParsing.VarParsing.varType.string,
-    "Run Keys of CMS"
-)
+options.register("runkey",
+                 "pp_run",
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Run Keys of CMS")
 
 # Parameter for frontierKey
 options.register('runUniqueKey',
-    'InValid',
-    VarParsing.VarParsing.multiplicity.singleton,
-    VarParsing.VarParsing.varType.string,
-    "Unique run key from RCMS for Frontier")
+                 'InValid',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Unique run key from RCMS for Frontier")
 
 options.register('runNumber',
                  355380,

--- a/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
+++ b/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
@@ -12,11 +12,11 @@ from .dqmPythonTypes import *
 options = VarParsing.VarParsing("analysis")
 
 # Parameters for runType
-options.register ('runkey',
-          'pp_run',
-          VarParsing.VarParsing.multiplicity.singleton,
-          VarParsing.VarParsing.varType.string,
-          "Run Keys of CMS")
+options.register('runkey',
+                 'pp_run',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Run Keys of CMS")
 
 # Parameter for frontierKey
 options.register('runUniqueKey',
@@ -30,6 +30,12 @@ options.register('runNumber',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Run number. This run number has to be present in https://github.com/cms-data/DQM-Integration")
+
+options.register('datafnPosition',
+                 3, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Data filename position in the positional arguments array 'data' in json file.")
 
 options.register('streamLabel',
                  'streamDQM', # default DQM stream value
@@ -53,7 +59,7 @@ options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.bool,
-                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the beginning of the processing.")
 
 options.register('BeamSplashRun',
                  False, # default value
@@ -82,6 +88,7 @@ source = cms.Source("DQMStreamerReader",
     SelectEvents = cms.untracked.vstring('*'),
     streamLabel = cms.untracked.string(options.streamLabel),
     scanOnce = cms.untracked.bool(options.scanOnce),
+    datafnPosition = cms.untracked.uint32(options.datafnPosition),
     minEventsPerLumi = cms.untracked.int32(1000),
     delayMillis = cms.untracked.uint32(500),
     nextLumiTimeoutMillis = cms.untracked.int32(0),

--- a/DQMServices/StreamerIO/python/DQMProtobufReader_cff.py
+++ b/DQMServices/StreamerIO/python/DQMProtobufReader_cff.py
@@ -49,7 +49,7 @@ options.register('skipFirstLumis',
                  False, # default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.bool,
-                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of the processing. ")
+                 "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the beginning of the processing.")
 
 options.register('deleteDatFiles',
                  False, # default value
@@ -63,19 +63,27 @@ options.register('endOfRunKills',
                  VarParsing.VarParsing.varType.bool,
                  "Kill the processing as soon as the end-of-run file appears, even if there are/will be unprocessed lumisections.")
 
+options.register('loadFiles',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Tells the source to load the data files. If set to False, the source will create skeleton lumi transitions.")
+
 options.parseArguments()
 
 # Input source
 DQMProtobufReader = cms.Source("DQMProtobufReader",
+    # DQMFileIterator
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
     streamLabel = cms.untracked.string(options.streamLabel),
     scanOnce = cms.untracked.bool(options.scanOnce),
     datafnPosition = cms.untracked.uint32(options.datafnPosition),
-
     delayMillis = cms.untracked.uint32(options.delayMillis),
     nextLumiTimeoutMillis = cms.untracked.int32(options.nextLumiTimeoutMillis),
+    # DQMProtobufReader
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(options.deleteDatFiles),
-    endOfRunKills  = cms.untracked.bool(options.endOfRunKills),
+    endOfRunKills = cms.untracked.bool(options.endOfRunKills),
+    loadFiles = cms.untracked.bool(options.loadFiles),
 )

--- a/DQMServices/StreamerIO/python/DQMStreamerReader_cff.py
+++ b/DQMServices/StreamerIO/python/DQMStreamerReader_cff.py
@@ -81,16 +81,17 @@ options.parseArguments()
 
 # Input source
 DQMStreamerReader = cms.Source("DQMStreamerReader",
-    SelectEvents = cms.untracked.vstring("*"),
+    # DQMFileIterator
     runNumber = cms.untracked.uint32(options.runNumber),
     runInputDir = cms.untracked.string(options.runInputDir),
     streamLabel = cms.untracked.string(options.streamLabel),
     scanOnce = cms.untracked.bool(options.scanOnce),
     datafnPosition = cms.untracked.uint32(options.datafnPosition),
-
-    minEventsPerLumi = cms.untracked.int32(options.minEventsPerLumi),
     delayMillis = cms.untracked.uint32(options.delayMillis),
     nextLumiTimeoutMillis = cms.untracked.int32(options.nextLumiTimeoutMillis),
+    # DQMStreamerReader
+    SelectEvents = cms.untracked.vstring("*"),
+    minEventsPerLumi = cms.untracked.int32(options.minEventsPerLumi),
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(options.deleteDatFiles),
     endOfRunKills  = cms.untracked.bool(options.endOfRunKills),


### PR DESCRIPTION
#### PR description:

This PR allows to set the parameter `datafnPosition` from the command line when running the online-DQM clients, e.g.
```bash
cmsRun "${CMSSW_BASE}"/src/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py \
  runInputDir=. runNumber=361468 runkey=pp_run scanOnce=True \
  datafnPosition=4
```
This can be useful when testing the clients locally on inputs whose format differs (slightly) from the one used online.

(For outputs produced in `dat` format for a given stream and LS (for example, by the `GlobalEvFOutputModule` plugin), there is a JSON file which contains a dictionary with a list-of-strings named "data". `datafnPosition` (data file name position) corresponds to the index of this list where the name of the `dat` file is; its default value is `3`.)

In practise, this PR takes the command-line argument already defined in
https://github.com/cms-sw/cmssw/blob/321bee86659704bf8b36f6c772f6d5ff78064740/DQMServices/StreamerIO/python/DQMProtobufReader_cff.py#L12
https://github.com/cms-sw/cmssw/blob/321bee86659704bf8b36f6c772f6d5ff78064740/DQMServices/StreamerIO/python/DQMStreamerReader_cff.py#L12
and adds it to the following `cfi` files
```
DQM/Integration/python/config/inputsource_cfi.py
DQM/Integration/python/config/pbsource_cfi.py
DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
```

For completeness, the parameter `loadFiles` is also made configurable in `DQMProtobufReader_cff`. Minor code-formatting changes are included as well.

Merely technical. No changes expected. (This PR just adds a new functionality not used anywhere in CMSSW.)

#### PR validation:

The following test produces a ROOT file with the expected histograms only if `datafnPosition=4` is specified (using this PR, obviously).
```sh
#!/bin/bash -ex

INPUTFILE=root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/Run2022F_EphemeralHLTPhysics0_run361468/26ce1488-8c46-436b-becd-6b41535dda79.root

HLTMENU=/users/missirol/test/dev/CMSSW_13_0_0/tmp/test01/cmssw40334/HLT/V3

rm -rf run361468* upload
convertToRaw -f 100 -l 100 -r 361468:172 -o . -- "${INPUTFILE}"

tmpfile=$(mktemp)
hltConfigFromDB --configName "${HLTMENU}" > "${tmpfile}"
cat <<@EOF >> "${tmpfile}"
process.load('run361468_cff')
process.hltOnlineBeamSpotESProducer.timeThreshold = int(1e6)
@EOF
edmConfigDump "${tmpfile}" > hlt.py

cmsRun hlt.py &> hlt.log

cmsRun "${CMSSW_BASE}"/src/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py \
  runInputDir=. runNumber=361468 runkey=pp_run scanOnce=True \
  datafnPosition=4
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A