### PR TITLE
partial technical cleanup of `DQMServices/StreamerIO/plugins`

### DIFF
--- a/DQMServices/StreamerIO/plugins/BuildFile.xml
+++ b/DQMServices/StreamerIO/plugins/BuildFile.xml
@@ -1,9 +1,16 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/ServiceRegistry"/>
-<use name="IOPool/Streamer"/>
-<use name="IOPool/Output"/>
-<use name="DQMServices/Core"/>
 <use name="DQMServices/Components"/>
+<use name="DQMServices/Core"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Histograms"/>
+<use name="DataFormats/Provenance"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Sources"/>
+<use name="FWCore/Utilities"/>
+<use name="IOPool/Output"/>
+<use name="IOPool/Streamer"/>
 <use name="stdcxx-fs"/>
 <use name="boost_regex"/>
 <library file="*.cc" name="DQMServicesStreamerIOPlugins">

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.cc
@@ -1,19 +1,20 @@
+#include "DQMFileIterator.h"
+#include "DQMMonitoringService.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/TimeOfDay.h"
+
 #include <filesystem>
-#include <iterator>
-#include <memory>
-#include <string>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <boost/range.hpp>
 #include <boost/regex.hpp>
-#include <fmt/printf.h>
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/TimeOfDay.h"
-#include "DQMFileIterator.h"
+#include <fmt/printf.h>
 
 namespace dqmservices {
 
@@ -86,8 +87,6 @@ namespace dqmservices {
     reset();
   }
 
-  DQMFileIterator::~DQMFileIterator() {}
-
   void DQMFileIterator::reset() {
     runPath_.clear();
 
@@ -110,15 +109,13 @@ namespace dqmservices {
     update_state();
 
     if (mon_.isAvailable()) {
-      ptree doc;
+      boost::property_tree::ptree doc;
       doc.put("run", runNumber_);
       doc.put("next_lumi", nextLumiNumber_);
       doc.put("fi_state", std::to_string(state_));
       mon_->outputUpdate(doc);
     }
   }
-
-  DQMFileIterator::State DQMFileIterator::state() { return state_; }
 
   DQMFileIterator::LumiEntry DQMFileIterator::open() {
     LumiEntry& lumi = lumiSeen_[nextLumiNumber_];
@@ -134,8 +131,6 @@ namespace dqmservices {
     return false;
   }
 
-  unsigned int DQMFileIterator::runNumber() { return runNumber_; }
-
   unsigned int DQMFileIterator::lastLumiFound() {
     if (!lumiSeen_.empty()) {
       return lumiSeen_.rbegin()->first;
@@ -145,9 +140,6 @@ namespace dqmservices {
   }
 
   void DQMFileIterator::advanceToLumi(unsigned int lumi, std::string reason) {
-    using boost::str;
-    using boost::property_tree::ptree;
-
     unsigned int currentLumi = nextLumiNumber_;
 
     nextLumiNumber_ = lumi;
@@ -164,7 +156,7 @@ namespace dqmservices {
 
     if (mon_.isAvailable()) {
       // report the successful lumi file open
-      ptree doc;
+      boost::property_tree::ptree doc;
       doc.put("next_lumi", nextLumiNumber_);
       mon_->outputUpdate(doc);
     }
@@ -174,7 +166,7 @@ namespace dqmservices {
     if (!mon_.isAvailable())
       return;
 
-    ptree doc;
+    boost::property_tree::ptree doc;
     doc.put(fmt::sprintf("extra.lumi_seen.lumi%06d", lumi.file_ls), lumi.state);
     mon_->outputUpdate(doc);
   }
@@ -365,7 +357,7 @@ namespace dqmservices {
       logFileAction("Streamer state changed: ", std::to_string(old_state) + "->" + std::to_string(state_));
 
       if (mon_) {
-        ptree doc;
+        boost::property_tree::ptree doc;
         doc.put("fi_state", std::to_string(state_));
         mon_->outputUpdate(doc);
       }

--- a/DQMServices/StreamerIO/plugins/DQMFileIterator.h
+++ b/DQMServices/StreamerIO/plugins/DQMFileIterator.h
@@ -1,19 +1,22 @@
-#ifndef IOPool_DQMStreamer_DQMFilerIterator_h
-#define IOPool_DQMStreamer_DQMFilerIterator_h
+#ifndef DQMServices_StreamerIO_DQMFileIterator_h
+#define DQMServices_StreamerIO_DQMFileIterator_h
+
+#include <chrono>
+#include <map>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-#include <filesystem>
-
-#include <map>
-#include <unordered_set>
-#include <chrono>
-
-#include "DQMMonitoringService.h"
+namespace edm {
+  class ParameterSet;
+  class ParameterSetDescription;
+}  // namespace edm
 
 namespace dqmservices {
+
+  class DQMMonitoringService;
 
   class DQMFileIterator {
   public:
@@ -54,10 +57,10 @@ namespace dqmservices {
     };
 
     DQMFileIterator(edm::ParameterSet const& pset);
-    ~DQMFileIterator();
+    ~DQMFileIterator() = default;
     void initialise(int run, const std::string&, const std::string&);
 
-    State state();
+    State state() const { return state_; }
 
     /* methods to iterate the actual files */
 
@@ -83,7 +86,7 @@ namespace dqmservices {
 
     void delay();
 
-    unsigned int runNumber();
+    unsigned int runNumber() const { return runNumber_; }
     unsigned int lastLumiFound();
     void advanceToLumi(unsigned int lumi, std::string reason);
 
@@ -127,4 +130,4 @@ namespace dqmservices {
 
 }  // namespace dqmservices
 
-#endif
+#endif  // DQMServices_StreamerIO_DQMFileIterator_h

--- a/DQMServices/StreamerIO/plugins/DQMMonitoringService.h
+++ b/DQMServices/StreamerIO/plugins/DQMMonitoringService.h
@@ -1,59 +1,38 @@
 #ifndef DQMServices_StreamerIO_DQMMonitoringService_h
 #define DQMServices_StreamerIO_DQMMonitoringService_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
-#include "DataFormats/Provenance/interface/EventID.h"
-#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
-#include "DataFormats/Provenance/interface/Timestamp.h"
-#include "DataFormats/Provenance/interface/ModuleDescription.h"
-#include "DataFormats/Provenance/interface/ParameterSetID.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/StreamContext.h"
-#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
-#include "FWCore/Utilities/interface/StreamID.h"
-#include <filesystem>
-
-#include <string>
-#include <vector>
-#include <map>
-#include <queue>
-#include <sstream>
 #include <chrono>
-#include <unordered_map>
 
-#include <filesystem>
-#include <boost/format.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 /*
  * This service is very similar to the FastMonitoringService in the HLT,
  * except that it is used for monitoring online DQM applications
  */
 
+namespace edm {
+  class ActivityRegistry;
+  class GlobalContext;
+  class ParameterSet;
+  class StreamID;
+}  // namespace edm
+
 namespace dqmservices {
-
-  using boost::property_tree::ptree;
-
-  using edm::GlobalContext;
-  using edm::StreamContext;
-  using edm::StreamID;
 
   class DQMMonitoringService {
   public:
     DQMMonitoringService(const edm::ParameterSet&, edm::ActivityRegistry&);
-    ~DQMMonitoringService();
+    ~DQMMonitoringService() = default;
 
     void connect();
     void keepAlive();
 
     void outputLumiUpdate();
-    void outputUpdate(ptree& doc);
+    void outputUpdate(boost::property_tree::ptree& doc);
 
-    void evLumi(GlobalContext const&);
-    void evEvent(StreamID const&);
+    void evLumi(edm::GlobalContext const&);
+    void evEvent(edm::StreamID const&);
 
     void tryUpdate();
 
@@ -63,13 +42,12 @@ namespace dqmservices {
     // global number of events processed
     long nevents_;
 
-    // time point, number of events and the lumi number at the time we switched to
-    // it
-    unsigned long last_lumi_;  // last lumi (we report stats for it, after we
-                               // switch to the next one)
+    // time point, number of events and lumi number at the time we switched to it
     std::chrono::high_resolution_clock::time_point last_lumi_time_;
     std::chrono::high_resolution_clock::time_point last_update_time_;
     long last_lumi_nevents_;
+    // last lumi (we report stats for it, after we switch to the next one)
+    unsigned long last_lumi_;
 
     unsigned long run_;   // current run
     unsigned long lumi_;  // current lumi
@@ -77,4 +55,4 @@ namespace dqmservices {
 
 }  // namespace dqmservices
 
-#endif
+#endif  // DQMServices_StreamerIO_DQMMonitoringService_h

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -1,38 +1,42 @@
 #include "DQMProtobufReader.h"
 
-#include "FWCore/MessageLogger/interface/JobReport.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Histograms/interface/DQMToken.h"
-
-#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
-// #include "FWCore/Sources/interface/ProducerSourceBase.h"
-
 #include "DQMServices/Core/interface/ROOTFilePB.pb.h"
+#include "DataFormats/Histograms/interface/DQMToken.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Sources/interface/ProducerSourceBase.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
+
+#include <cstdlib>
+#include <fcntl.h>
+#include <filesystem>
+#include <regex>
+
+#include <TBufferFile.h>
+
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/gzip_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#include "TBufferFile.h"
-
-#include <regex>
-#include <cstdlib>
-
 using namespace dqmservices;
 
 DQMProtobufReader::DQMProtobufReader(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
-    : PuttableSourceBase(pset, desc), fiterator_(pset) {
-  flagSkipFirstLumis_ = pset.getUntrackedParameter<bool>("skipFirstLumis");
-  flagEndOfRunKills_ = pset.getUntrackedParameter<bool>("endOfRunKills");
-  flagDeleteDatFiles_ = pset.getUntrackedParameter<bool>("deleteDatFiles");
-  flagLoadFiles_ = pset.getUntrackedParameter<bool>("loadFiles");
-
+    : PuttableSourceBase(pset, desc),
+      fiterator_(pset),
+      flagSkipFirstLumis_(pset.getUntrackedParameter<bool>("skipFirstLumis")),
+      flagEndOfRunKills_(pset.getUntrackedParameter<bool>("endOfRunKills")),
+      flagDeleteDatFiles_(pset.getUntrackedParameter<bool>("deleteDatFiles")),
+      flagLoadFiles_(pset.getUntrackedParameter<bool>("loadFiles")) {
   produces<std::string, edm::Transition::BeginLuminosityBlock>("sourceDataPath");
   produces<std::string, edm::Transition::BeginLuminosityBlock>("sourceJsonPath");
   produces<DQMToken, edm::Transition::BeginRun>("DQMGenerationRecoRun");
   produces<DQMToken, edm::Transition::BeginLuminosityBlock>("DQMGenerationRecoLumi");
 }
-
-DQMProtobufReader::~DQMProtobufReader() {}
 
 edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
   typedef DQMFileIterator::State State;
@@ -282,31 +286,26 @@ void DQMProtobufReader::readEvent_(edm::EventPrincipal&){};
 void DQMProtobufReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.setComment(
-      "Creates runs and lumis and fills the dqmstore from protocol buffer "
-      "files.");
+  desc.setComment("Creates runs and lumis and fills the dqmstore from protocol buffer files.");
   edm::ProducerSourceBase::fillDescription(desc);
 
   desc.addUntracked<bool>("skipFirstLumis", false)
       ->setComment(
-          "Skip (and ignore the minEventsPerLumi parameter) for the files "
-          "which have been available at the begining of the processing. "
-          "If set to true, the reader will open last available file for "
-          "processing.");
+          "Skip (and ignore the minEventsPerLumi parameter) for the files which have been available at the begining of "
+          "the processing. If set to true, the reader will open last available file for processing.");
 
   desc.addUntracked<bool>("deleteDatFiles", false)
-      ->setComment(
-          "Delete data files after they have been closed, in order to "
-          "save disk space.");
+      ->setComment("Delete data files after they have been closed, in order to save disk space.");
 
   desc.addUntracked<bool>("endOfRunKills", false)
       ->setComment(
-          "Kill the processing as soon as the end-of-run file appears, even if "
-          "there are/will be unprocessed lumisections.");
+          "Kill the processing as soon as the end-of-run file appears, even if there are/will be unprocessed "
+          "lumisections.");
 
   desc.addUntracked<bool>("loadFiles", true)
       ->setComment(
-          "Tells the source load the data files. If set to false, source will create skeleton lumi transitions.");
+          "Tells the source to load the data files. If set to False, the source will create skeleton lumi "
+          "transitions.");
 
   DQMFileIterator::fillDescription(desc);
   descriptions.add("source", desc);

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
@@ -1,18 +1,11 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/InputSourceMacros.h"
-#include "FWCore/Framework/interface/RunPrincipal.h"
-#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Sources/interface/ProducerSourceBase.h"
-#include "FWCore/Sources/interface/PuttableSourceBase.h"
+#ifndef DQMServices_StreamerIO_DQMProtobufReader_h
+#define DQMServices_StreamerIO_DQMProtobufReader_h
 
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Sources/interface/PuttableSourceBase.h"
 
 #include "DQMFileIterator.h"
-#include "DQMMonitoringService.h"
 
 namespace dqmservices {
 
@@ -22,7 +15,8 @@ namespace dqmservices {
     typedef dqm::legacy::DQMStore DQMStore;
 
     explicit DQMProtobufReader(edm::ParameterSet const&, edm::InputSourceDescription const&);
-    ~DQMProtobufReader() override;
+    ~DQMProtobufReader() override = default;
+
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
@@ -40,16 +34,15 @@ namespace dqmservices {
     void logFileAction(char const* msg, char const* fileName) const;
     bool prepareNextFile();
 
-    bool flagSkipFirstLumis_;
-    bool flagEndOfRunKills_;
-    bool flagDeleteDatFiles_;
-    bool flagLoadFiles_;
-
-    std::unique_ptr<double> streamReader_;
     DQMFileIterator fiterator_;
     DQMFileIterator::LumiEntry currentLumi_;
 
-    InputSource::ItemType nextItemType;
+    bool const flagSkipFirstLumis_;
+    bool const flagEndOfRunKills_;
+    bool const flagDeleteDatFiles_;
+    bool const flagLoadFiles_;
   };
 
 }  // namespace dqmservices
+
+#endif  // DQMServices_StreamerIO_DQMProtobufReader_h

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
@@ -10,14 +10,9 @@
 #include "DQMMonitoringService.h"
 #include "TriggerSelector.h"
 
-#include <filesystem>
-
 #include <memory>
 #include <string>
 #include <vector>
-#include <iterator>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 
 namespace dqmservices {
 
@@ -26,10 +21,9 @@ namespace dqmservices {
     DQMStreamerReader(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc);
     ~DQMStreamerReader() override;
 
-    bool newHeader();
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    typedef std::vector<std::string> Strings;
+    bool newHeader();
 
   protected:
     Next checkNext() override;      /* from raw input source */
@@ -51,28 +45,25 @@ namespace dqmservices {
     EventMsgView const* getEventMsg();
 
     EventMsgView const* prepareNextEvent();
+
+    bool isFirstFile_ = true;
     bool prepareNextFile();
     bool acceptEvent(const EventMsgView*);
 
-    bool triggerSel();
-    bool matchTriggerSel(Strings const& tnames);
-    bool acceptAllEvt_;
-    bool matchTriggerSel_;
-    bool isFirstFile_ = true;
-
-    unsigned int runNumber_;
-    std::string runInputDir_;
-    std::string streamLabel_;
-    Strings hltSel_;
-
-    unsigned int processedEventPerLs_;
-    unsigned int minEventsPerLs_;
-
-    bool flagSkipFirstLumis_;
-    bool flagEndOfRunKills_;
-    bool flagDeleteDatFiles_;
-
     DQMFileIterator fiterator_;
+    unsigned int processedEventPerLs_ = 0;
+
+    unsigned int const minEventsPerLs_;
+    bool const flagSkipFirstLumis_;
+    bool const flagEndOfRunKills_;
+    bool const flagDeleteDatFiles_;
+    std::vector<std::string> const hltSel_;
+
+    bool acceptAllEvt_ = false;
+    bool setAcceptAllEvt();
+
+    bool matchTriggerSel_ = false;
+    bool setMatchTriggerSel(std::vector<std::string> const& tnames);
 
     struct OpenFile {
       std::unique_ptr<edm::StreamerInputFile> streamFile_;
@@ -83,7 +74,7 @@ namespace dqmservices {
     } file_;
 
     std::shared_ptr<edm::EventSkipperByID> eventSkipperByID_;
-    std::shared_ptr<TriggerSelector> eventSelector_;
+    std::shared_ptr<TriggerSelector> triggerSelector_;
 
     /* this is for monitoring */
     edm::Service<DQMMonitoringService> mon_;
@@ -91,4 +82,4 @@ namespace dqmservices {
 
 }  // namespace dqmservices
 
-#endif
+#endif  // DQMServices_StreamerIO_DQMStreamerReader_h

--- a/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
+++ b/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
@@ -1,23 +1,24 @@
-#include <filesystem>
-
-#include <fmt/printf.h>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include "JsonWritingTimeoutPoolOutputModule.h"
 
 #include "DQMServices/Components/interface/fillJson.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "JsonWritingTimeoutPoolOutputModule.h"
+
+#include <filesystem>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <fmt/printf.h>
 
 namespace dqmservices {
 
   JsonWritingTimeoutPoolOutputModule::JsonWritingTimeoutPoolOutputModule(edm::ParameterSet const& ps)
-      : edm::one::OutputModuleBase::OutputModuleBase(ps), edm::TimeoutPoolOutputModule(ps) {
-    runNumber_ = ps.getUntrackedParameter<uint32_t>("runNumber");
-    outputPath_ = ps.getUntrackedParameter<std::string>("outputPath");
-    streamLabel_ = ps.getUntrackedParameter<std::string>("streamLabel");
-
-    sequence_ = 0;
-  }
+      : edm::one::OutputModuleBase::OutputModuleBase(ps),
+        edm::TimeoutPoolOutputModule(ps),
+        runNumber_(ps.getUntrackedParameter<uint32_t>("runNumber")),
+        streamLabel_(ps.getUntrackedParameter<std::string>("streamLabel")),
+        outputPath_(ps.getUntrackedParameter<std::string>("outputPath")),
+        sequence_(0) {}
 
   std::pair<std::string, std::string> JsonWritingTimeoutPoolOutputModule::physicalAndLogicalNameForNewFile() {
     sequence_++;

--- a/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.h
+++ b/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.h
@@ -3,15 +3,20 @@
 
 #include "IOPool/Output/interface/TimeoutPoolOutputModule.h"
 
-namespace dqmservices {
+#include <string>
+#include <utility>
 
-  class ModuleCallingContext;
+namespace edm {
+  class ConfigurationDescriptions;
   class ParameterSet;
+}  // namespace edm
+
+namespace dqmservices {
 
   class JsonWritingTimeoutPoolOutputModule : public edm::TimeoutPoolOutputModule {
   public:
     explicit JsonWritingTimeoutPoolOutputModule(edm::ParameterSet const& ps);
-    ~JsonWritingTimeoutPoolOutputModule() override{};
+    ~JsonWritingTimeoutPoolOutputModule() override = default;
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
@@ -20,15 +25,15 @@ namespace dqmservices {
     void doExtrasAfterCloseFile() override;
 
   protected:
-    uint32_t sequence_;
-    uint32_t runNumber_;
-    std::string streamLabel_;
-    std::string outputPath_;
+    uint32_t const runNumber_;
+    std::string const streamLabel_;
+    std::string const outputPath_;
 
+    uint32_t sequence_;
     std::string currentFileName_;
     std::string currentJsonName_;
   };
 
 }  // namespace dqmservices
 
-#endif
+#endif  // DQMServices_StreamerIO_JsonWritingTimeoutPoolOutputModule_h

--- a/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
+++ b/DQMServices/StreamerIO/plugins/RamdiskMonitor.cc
@@ -1,31 +1,37 @@
+#include <exception>
 #include <filesystem>
 #include <map>
-#include <vector>
+#include <memory>
+#include <string>
 #include <sys/stat.h>
+#include <vector>
 
-#include <fmt/printf.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range.hpp>
 #include <boost/regex.hpp>
 
+#include <fmt/printf.h>
+
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DQMServices/StreamerIO/plugins/DQMFileIterator.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DQMFileIterator.h"
 
 namespace dqm {
+
   namespace rdm {
     struct Empty {};
   }  // namespace rdm
+
   class RamdiskMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<rdm::Empty>> {
   public:
     RamdiskMonitor(const edm::ParameterSet &ps);
-    ~RamdiskMonitor() override;
+    ~RamdiskMonitor() override = default;
     static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   protected:
@@ -33,7 +39,7 @@ namespace dqm {
     std::shared_ptr<rdm::Empty> globalBeginLuminosityBlock(edm::LuminosityBlock const &lumi,
                                                            edm::EventSetup const &eSetup) const override;
     void globalEndLuminosityBlock(edm::LuminosityBlock const &lumi, edm::EventSetup const &eSetup) final {}
-    void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override{};
+    void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override {}
 
     void analyzeFile(std::string fn, unsigned int run, unsigned int lumi, std::string label) const;
     double getRunTimestamp() const;
@@ -62,11 +68,7 @@ namespace dqm {
       : runNumber_{ps.getUntrackedParameter<unsigned int>("runNumber")},
         runInputDir_{ps.getUntrackedParameter<std::string>("runInputDir")},
         streamLabels_{ps.getUntrackedParameter<std::vector<std::string>>("streamLabels")},
-        runPath_{fmt::sprintf("%s/run%06d", runInputDir_, runNumber_)}
-
-  {}
-
-  RamdiskMonitor::~RamdiskMonitor(){};
+        runPath_{fmt::sprintf("%s/run%06d", runInputDir_, runNumber_)} {}
 
   void RamdiskMonitor::bookHistograms(DQMStore::IBooker &ib, edm::Run const &, edm::EventSetup const &) {
     for (const auto &stream : streamLabels_) {
@@ -241,6 +243,5 @@ namespace dqm {
 }  // namespace dqm
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 typedef dqm::RamdiskMonitor RamdiskMonitor;
 DEFINE_FWK_MODULE(RamdiskMonitor);

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.cc
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.cc
@@ -1,58 +1,24 @@
 #include "TriggerSelector.h"
 
+#include "DataFormats/Common/interface/HLTPathStatus.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Framework/interface/EventSelector.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
-#include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/RegexMatch.h"
 
 #include <iostream>
-#include <boost/regex.hpp>
 #include <algorithm>
-#include <cassert>
+
+#include <boost/regex.hpp>
 
 namespace dqmservices {
 
   // compatibility constructor
 
-  TriggerSelector::TriggerSelector(Strings const& pathspecs, Strings const& names) : useOld_(true) {
+  TriggerSelector::TriggerSelector(Strings const& pathspecs, Strings const& triggernames) : useOld_(true) {
     acceptAll_ = false;
-    eventSelector_.reset(new edm::EventSelector(pathspecs, names));
-  }
-
-  TriggerSelector::TriggerSelector(edm::ParameterSet const& config, Strings const& triggernames, bool old_)
-      : useOld_(old_) {
-    acceptAll_ = false;
-    if (old_) {
-      // old mode forced
-      acceptAll_ = false;
-      eventSelector_.reset(new edm::EventSelector(config, triggernames));
-      return;
-    }
-    if (!config.empty()) {
-      // let's see if non empty TriggerSelector is present
-      try {
-        std::string myPath = trim(config.getParameter<std::string>("TriggerSelector"));
-        if (!myPath.empty()) {
-          init(myPath, triggernames);
-          return;
-        }
-      } catch (...) {
-      }
-
-      // now try with the SelectEvents
-      try {
-        Strings paths;
-        paths = config.getParameter<Strings>("SelectEvents");
-        if (!paths.empty()) {
-          useOld_ = true;
-          eventSelector_.reset(new edm::EventSelector(config, triggernames));
-          return;
-        }
-      } catch (...) {
-      }
-    }
-    // if selection parameters aren't present, don't do selection
-    // log
-    acceptAll_ = true;
+    eventSelector_.reset(new edm::EventSelector(pathspecs, triggernames));
   }
 
   TriggerSelector::TriggerSelector(std::string const& expression, Strings const& triggernames) : useOld_(false) {
@@ -82,13 +48,6 @@ namespace dqmservices {
 
     // build decision tree
     masterElement_.reset(new TreeElement(expression_, triggernames));
-  }
-
-  /*
-      Obsolete
-*/
-  std::vector<std::string> TriggerSelector::getEventSelectionVString(edm::ParameterSet const& pset) {
-    return edm::EventSelector::getEventSelectionVString(pset);
   }
 
   bool TriggerSelector::acceptEvent(edm::TriggerResults const& tr) const {
@@ -142,7 +101,7 @@ namespace dqmservices {
     bool occurrences_ = false;
 
     if (str_.empty())
-      throw edm::Exception(edm::errors::Configuration) << "Syntax Error (empty element)" << std::endl;
+      throw edm::Exception(edm::errors::Configuration) << "Syntax Error (empty element)";
 
     static const size_t bopsSize_ = 2;
     static const std::string binaryOperators_[bopsSize_] = {"||", "&&"};
@@ -295,7 +254,7 @@ namespace dqmservices {
       std::vector<Strings::const_iterator> matches = edm::regexMatch(tr, str_);
       if (matches.empty()) {
         if (!ignore_if_missing)  // && !edm::is_glob(str_))
-          throw edm::Exception(edm::errors::Configuration) << "Trigger name (or match) not present" << std::endl;
+          throw edm::Exception(edm::errors::Configuration) << "Trigger name (or match) not present";
         else {
           if (debug_)
             std::cout << "TriggerSelector: Couldn't match any triggers from: " << str_ << std::endl
@@ -354,7 +313,7 @@ namespace dqmservices {
         return true;
 
       if (trigBit_ < 0 || (unsigned int)trigBit_ >= trStatus.size())
-        throw edm::Exception(edm::errors::Configuration) << "Internal Error: array out of bounds " << std::endl;
+        throw edm::Exception(edm::errors::Configuration) << "Internal Error: array out of bounds.";
 
       if ((trStatus[trigBit_]).state() == edm::hlt::Pass)
         return true;
@@ -380,7 +339,7 @@ namespace dqmservices {
       return status;
     }
     throw edm::Exception(edm::errors::Configuration)
-        << "Internal error: reached end of returnStatus(...)  op:state= " << op_ << std::endl;
+        << "Internal error: reached end of returnStatus(...), op:state = " << op_;
     return false;
   }
 

--- a/DQMServices/StreamerIO/plugins/TriggerSelector.h
+++ b/DQMServices/StreamerIO/plugins/TriggerSelector.h
@@ -1,14 +1,15 @@
 #ifndef DQMServices_StreamerIO_TriggerSelector_h
 #define DQMServices_StreamerIO_TriggerSelector_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/HLTPathStatus.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/Provenance/interface/ParameterSetID.h"
-#include "FWCore/Framework/interface/EventSelector.h"
-
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
+
+namespace edm {
+  class EventSelector;
+  class HLTGlobalStatus;
+  class TriggerResults;
+}  // namespace edm
 
 namespace dqmservices {
   /**
@@ -21,32 +22,21 @@ namespace dqmservices {
     typedef std::vector<std::string> Strings;
 
     /**
-   * Obsolete: Initializes TriggerSelector to use edm::EventSelector for
-   * selection.
+   * Initializes TriggerSelector to use edm::EventSelector for selection.
    */
     TriggerSelector(Strings const& pathspecs, Strings const& names);
-
-    /**
-   * Takes ParameterSet wth TriggerSelector string or EventSelection list, and a
-   * list of triggers.
-   * if old_ is true, it is forced to use EventSelection.
-   */
-    TriggerSelector(edm::ParameterSet const& pset, Strings const& triggernames, bool old_ = false);
 
     /**
    * Takes selection string and list of triggers
    */
     TriggerSelector(std::string const& expression, Strings const& triggernames);
 
-    ~TriggerSelector(){};
+    ~TriggerSelector() = default;
 
     /**
    * Returns status of always positive bit
    */
-    bool wantAll() const {
-      //	if (useOld_) return eventSelector_->wantAll();
-      return acceptAll_;
-    }
+    bool wantAll() const { return acceptAll_; }
 
     /**
    * Evaluates if trigger results pass selection
@@ -69,11 +59,6 @@ namespace dqmservices {
    * Does XMl compatible formatting of the selection string
    */
     static std::string makeXMLString(std::string const& input);
-
-    /*
-   * Obsolete: Returns SelectedEvents vector from ParameterSet
-   */
-    static std::vector<std::string> getEventSelectionVString(edm::ParameterSet const& pset);
 
   private:
     bool acceptAll_;
@@ -135,6 +120,7 @@ namespace dqmservices {
 
     static const bool debug_ = false;
   };
+
 }  // namespace dqmservices
 
-#endif
+#endif  // DQMServices_StreamerIO_TriggerSelector_h


### PR DESCRIPTION
#### PR description:

This PR applies a partial technical cleanup of the classes in `DQMServices/StreamerIO/plugins`.

The initial goal was to remove unused class members (e.g.
https://github.com/cms-sw/cmssw/blob/9eb6ddb56d8ead1a0d6a07eac1deafe4d03cb3e6/DQMServices/StreamerIO/plugins/DQMStreamerReader.cc#L27-L28
); then, further technical changes were also included, mainly to clean up `#include <header>` directives, introduce some `const` correctness, simplify/modernise small portions of code, and limit (ab)use of `using namespace` calls.

Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
