### PR TITLE
Added removeSchedulingTokensFromModuleLabel function

### DIFF
--- a/FWCore/Utilities/interface/path_configuration.h
+++ b/FWCore/Utilities/interface/path_configuration.h
@@ -35,6 +35,9 @@ namespace edm::path_configuration {
   //Takes the Parameter associated to a given Path and converts it to the list of modules
   // in the same order as the Path's position bits
   std::vector<std::string> configurationToModuleBitPosition(std::vector<std::string>);
+
+  //removes any scheduling tokens from the module's label
+  std::string removeSchedulingTokensFromModuleLabel(std::string iLabel);
 }  // namespace edm::path_configuration
 
 #endif

--- a/FWCore/Utilities/src/path_configuration.cc
+++ b/FWCore/Utilities/src/path_configuration.cc
@@ -35,4 +35,17 @@ namespace edm::path_configuration {
     return iConfig;
   }
 
+  std::string removeSchedulingTokensFromModuleLabel(std::string iLabel) {
+    constexpr std::array<char, 4> s_tokens = {{'!', '-', '+', '|'}};
+    if (not iLabel.empty()) {
+      for (auto t : s_tokens) {
+        if (t == iLabel[0]) {
+          iLabel.erase(0, 1);
+          break;
+        }
+      }
+    }
+    return iLabel;
+  }
+
 }  // namespace edm::path_configuration

--- a/FWCore/Utilities/test/test_catch2_path_configuration.cc
+++ b/FWCore/Utilities/test/test_catch2_path_configuration.cc
@@ -1,0 +1,13 @@
+#include "FWCore/Utilities/interface/path_configuration.h"
+#include "catch.hpp"
+
+using namespace edm::path_configuration;
+TEST_CASE("Test path_configuration", "[path_configuration]") {
+  SECTION("removeSchedulingTokensFromModuleLabel") {
+    SECTION("no tokens") { REQUIRE("foo" == removeSchedulingTokensFromModuleLabel("foo")); }
+    SECTION("+") { REQUIRE("foo" == removeSchedulingTokensFromModuleLabel("+foo")); }
+    SECTION("-") { REQUIRE("foo" == removeSchedulingTokensFromModuleLabel("-foo")); }
+    SECTION("|") { REQUIRE("foo" == removeSchedulingTokensFromModuleLabel("|foo")); }
+    SECTION("!") { REQUIRE("foo" == removeSchedulingTokensFromModuleLabel("!foo")); }
+  }
+}


### PR DESCRIPTION
#### PR description:

Function removes tokens added by the framework to denote how to schedule a module.

#### PR validation:

Code compiles and new test passes.

fixes makortel/framework#458