### PR TITLE
Remove deprecated EventSetup get functions

### DIFF
--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -22,7 +22,6 @@
 #include <cassert>
 #include <map>
 #include <optional>
-#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -38,13 +37,11 @@
 #include "FWCore/Framework/interface/data_default_record_trait.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
-#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 // forward declarations
 
 namespace edm {
 
-  class ESInputTag;
   template <class T, class R>
   class ESGetToken;
   class PileUp;
@@ -118,24 +115,6 @@ namespace edm {
     }
 
     /** can directly access data if data_default_record_trait<> is defined for this data type **/
-    template <typename T>
-    CMS_DEPRECATED bool getData(T& iHolder) const {
-      auto const& rec = this->get<eventsetup::default_record_t<T>>();
-      return rec.get(std::string{}, iHolder);
-    }
-
-    template <typename T>
-    CMS_DEPRECATED bool getData(const std::string& iLabel, T& iHolder) const {
-      auto const& rec = this->get<eventsetup::default_record_t<T>>();
-      return rec.get(iLabel, iHolder);
-    }
-
-    template <typename T>
-    CMS_DEPRECATED bool getData(const ESInputTag& iTag, T& iHolder) const {
-      auto const& rec = this->get<eventsetup::default_record_t<T>>();
-      return rec.get(iTag, iHolder);
-    }
-
     template <typename T, typename R>
     T const& getData(const ESGetToken<T, R>& iToken) const noexcept(false) {
       return this
@@ -193,30 +172,6 @@ namespace edm {
     ESParentContext const* m_context;
     unsigned int m_id;
   };
-
-  // Free functions to retrieve an object from the EventSetup.
-  // Will throw an exception if the record or  object are not found.
-
-  template <typename T, typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type>
-  T const& get(EventSetup const& setup) {
-    ESHandle<T> handle;
-    // throw if the record is not available
-    setup.get<R>().get(handle);
-    // throw if the handle is not valid
-    return *handle.product();
-  }
-
-  template <typename T,
-            typename R = typename eventsetup::data_default_record_trait<typename T::value_type>::type,
-            typename L>
-  T const& get(EventSetup const& setup, L&& label) {
-    ESHandle<T> handle;
-    // throw if the record is not available
-    setup.get<R>().get(std::forward(label), handle);
-    // throw if the handle is not valid
-    return *handle.product();
-  }
-
 }  // namespace edm
 
 #endif  // FWCore_Framework_EventSetup_h

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -46,10 +46,8 @@
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/ESGetTokenGeneric.h"
-#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
 #include "FWCore/Utilities/interface/Likely.h"
-#include "FWCore/Utilities/interface/deprecated_macro.h"
 
 // system include files
 #include <exception>
@@ -70,8 +68,6 @@ class testEventsetup;
 class testEventsetupRecord;
 
 namespace edm {
-  template <typename T>
-  class ESHandle;
   class ESHandleExceptionFactory;
   class ESInputTag;
   class EventSetupImpl;
@@ -104,27 +100,6 @@ namespace edm {
         getTokenIndices_ = getTokenIndices;
         eventSetupImpl_ = iEventSetupImpl;
         context_ = iContext;
-      }
-
-      template <typename HolderT>
-      CMS_DEPRECATED bool get(HolderT& iHolder) const {
-        return deprecated_get("", iHolder);
-      }
-
-      template <typename HolderT>
-      CMS_DEPRECATED bool get(char const* iName, HolderT& iHolder) const {
-        return deprecated_get(iName, iHolder);
-      }
-
-      template <typename HolderT>
-      CMS_DEPRECATED bool get(std::string const& iName, HolderT& iHolder) const {
-        return deprecated_get(iName.c_str(), iHolder);
-      }
-
-      template <typename HolderT>
-      CMS_DEPRECATED bool get(ESInputTag const& iTag, HolderT& iHolder) const {
-        throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iTag.data().c_str());
-        return false;
       }
 
       ///returns false if no data available for key
@@ -225,12 +200,6 @@ namespace edm {
       unsigned int transitionID() const { return transitionID_; }
 
     private:
-      template <typename HolderT>
-      bool deprecated_get(char const* iName, HolderT& iHolder) const {
-        throwCalledGetWithoutToken(heterocontainer::className<typename HolderT::value_type>(), iName);
-        return false;
-      }
-
       template <template <typename> typename H, typename T, typename R>
       H<T> invalidTokenHandle(ESGetToken<T, R> const& iToken) const {
         auto const key = this->key();
@@ -256,7 +225,7 @@ namespace edm {
       static std::exception_ptr makeUninitializedTokenException(EventSetupRecordKey const&, TypeTag const&);
       static std::exception_ptr makeInvalidTokenException(EventSetupRecordKey const&, TypeTag const&, unsigned int);
       void throwWrongTransitionID() const;
-      static void throwCalledGetWithoutToken(const char* iTypeName, const char* iLabel);
+
       // ---------- member data --------------------------------
       EventSetupRecordImpl const* impl_ = nullptr;
       EventSetupImpl const* eventSetupImpl_ = nullptr;

--- a/FWCore/Framework/interface/EventSetupRecordImplementation.h
+++ b/FWCore/Framework/interface/EventSetupRecordImplementation.h
@@ -68,8 +68,6 @@ namespace edm {
         return getHandleImpl<ESTransientHandle>(iToken);
       }
 
-      using EventSetupRecord::get;
-
       template <typename PRODUCT>
       PRODUCT const& get(ESGetToken<PRODUCT, T> const& iToken) const {
         return *getHandleImpl<ESHandle>(iToken);

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 namespace {
@@ -129,14 +130,6 @@ namespace edm {
          << "must be used in the function associated with the ESConsumesCollector\n"
          << "returned by the setWhatProduced function.";
       throw ex;
-    }
-
-    void EventSetupRecord::throwCalledGetWithoutToken(const char* iTypeName, const char* iLabel) {
-      throw cms::Exception("MustUseESGetToken")
-          << "Called EventSetupRecord::get without using a ESGetToken.\n While requesting data type:" << iTypeName
-          << " label:'" << iLabel << "'\n"
-          << "See https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES\n"
-          << "for instructions how to migrate the calling code";
     }
 
   }  // namespace eventsetup


### PR DESCRIPTION
#### PR description:

Remove deprecated EventSetup get functions. These are the ones that do not use a token. This code has been deprecated for a while and previously a lot of work has been done by many people to remove all the code that depended on the code deleted by this PR.

#### PR validation:

This is almost exclusively deletions. The fact that it successfully builds after running checkdeps eliminates almost all possibilities for errors. I also ran unit tests for FWCore/Framework and FWCore/Integration locally.
