### PR TITLE
use `removeSchedulingTokensFromModuleLabel` in `pat::TriggerObjectStandAlone`

### DIFF
--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -9,6 +9,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/path_configuration.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 using namespace pat;
@@ -416,7 +417,7 @@ std::vector<std::string> const *TriggerObjectStandAlone::allLabels(edm::Paramete
       if (pset->existsAs<vector<string>>(triggerNames.triggerName(i), true)) {
         auto const &modules = pset->getParameter<vector<string>>(triggerNames.triggerName(i));
         for (auto const &module : modules) {
-          auto const moduleStrip = module.front() != '-' and module.front() != '!' ? module : module.substr(1);
+          auto const moduleStrip = edm::path_configuration::removeSchedulingTokensFromModuleLabel(module);
           if (pset->exists(moduleStrip)) {
             const auto &modulePSet = pset->getParameterSet(moduleStrip);
             if (modulePSet.existsAs<bool>("saveTags", true) and modulePSet.getParameter<bool>("saveTags")) {


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #37181 (see also #37157 and #40007).

It updates `pat::TriggerObjectStandAlone` to use the centrally-provided method `edm::path_configuration::removeSchedulingTokensFromModuleLabel`, introduced in #40425.

Merely technical. No changes expected.

Requires #40425.

(On a quick look, I did not spot other obvious clients for `removeSchedulingTokensFromModuleLabel`.)

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A