### PR TITLE
remove PSet-based ctor of `EventSelector`

### DIFF
--- a/FWCore/Framework/interface/EventSelector.h
+++ b/FWCore/Framework/interface/EventSelector.h
@@ -40,8 +40,6 @@ namespace edm {
 
     explicit EventSelector(Strings const& pathspecs);
 
-    EventSelector(edm::ParameterSet const& pset, Strings const& pathNames);
-
     bool wantAll() const { return accept_all_; }
     bool acceptEvent(TriggerResults const&);
     bool acceptEvent(unsigned char const*, int) const;

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -32,12 +32,13 @@
 //
 
 #include "FWCore/Framework/interface/EventSelector.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
-#include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/RegexMatch.h"
 
 #include <algorithm>
 #include <cctype>
@@ -70,20 +71,6 @@ namespace edm {
         all_must_fail_noex_(),
         psetID_(),
         nPathNames_(0) {}
-
-  EventSelector::EventSelector(ParameterSet const& config, Strings const& pathNames)
-      : pathspecs_(config.empty() ? Strings() : initPathSpecs(config.getParameter<Strings>("SelectEvents"))),
-        results_from_current_process_(true),
-        accept_all_(initAcceptAll()),
-        absolute_acceptors_(),
-        conditional_acceptors_(),
-        exception_acceptors_(),
-        all_must_fail_(),
-        all_must_fail_noex_(),
-        psetID_(),
-        nPathNames_(0) {
-    initPathNames(pathNames);
-  }
 
   Strings EventSelector::initPathSpecs(Strings const& pathSpecs) {
     Strings trimmedPathSpecs(pathSpecs);
@@ -509,11 +496,11 @@ namespace edm {
       std::vector<bool> aFailAbs = expandDecisionList(a.absolute_acceptors_, false, N);
       std::vector<bool> aFailCon = expandDecisionList(a.conditional_acceptors_, false, N);
       std::vector<bool> aExc = expandDecisionList(a.exception_acceptors_, true, N);
-      std::vector<std::vector<bool> > aMustFail;
+      std::vector<std::vector<bool>> aMustFail;
       for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
         aMustFail.push_back(expandDecisionList(a.all_must_fail_[m], false, N));
       }
-      std::vector<std::vector<bool> > aMustFailNoex;
+      std::vector<std::vector<bool>> aMustFailNoex;
       for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
         aMustFailNoex.push_back(expandDecisionList(a.all_must_fail_noex_[m], false, N));
       }
@@ -523,11 +510,11 @@ namespace edm {
       std::vector<bool> bFailAbs = expandDecisionList(b.absolute_acceptors_, false, N);
       std::vector<bool> bFailCon = expandDecisionList(b.conditional_acceptors_, false, N);
       std::vector<bool> bExc = expandDecisionList(b.exception_acceptors_, true, N);
-      std::vector<std::vector<bool> > bMustFail;
+      std::vector<std::vector<bool>> bMustFail;
       for (unsigned int m = 0; m != b.all_must_fail_.size(); ++m) {
         bMustFail.push_back(expandDecisionList(b.all_must_fail_[m], false, N));
       }
-      std::vector<std::vector<bool> > bMustFailNoex;
+      std::vector<std::vector<bool>> bMustFailNoex;
       for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
         bMustFailNoex.push_back(expandDecisionList(b.all_must_fail_noex_[m], false, N));
       }
@@ -874,19 +861,19 @@ namespace edm {
     if (a.all_must_fail_.size() != b.all_must_fail_.size())
       return false;
 
-    std::vector<std::vector<bool> > aMustFail;
+    std::vector<std::vector<bool>> aMustFail;
     for (unsigned int m = 0; m != a.all_must_fail_.size(); ++m) {
       aMustFail.push_back(expandDecisionList(a.all_must_fail_[m], false, N));
     }
-    std::vector<std::vector<bool> > aMustFailNoex;
+    std::vector<std::vector<bool>> aMustFailNoex;
     for (unsigned int m = 0; m != a.all_must_fail_noex_.size(); ++m) {
       aMustFailNoex.push_back(expandDecisionList(a.all_must_fail_noex_[m], false, N));
     }
-    std::vector<std::vector<bool> > bMustFail;
+    std::vector<std::vector<bool>> bMustFail;
     for (unsigned int m = 0; m != b.all_must_fail_.size(); ++m) {
       bMustFail.push_back(expandDecisionList(b.all_must_fail_[m], false, N));
     }
-    std::vector<std::vector<bool> > bMustFailNoex;
+    std::vector<std::vector<bool>> bMustFailNoex;
     for (unsigned int m = 0; m != b.all_must_fail_noex_.size(); ++m) {
       bMustFailNoex.push_back(expandDecisionList(b.all_must_fail_noex_[m], false, N));
     }
@@ -993,7 +980,7 @@ namespace edm {
 
   void EventSelector::fillDescription(ParameterSetDescription& desc) {
     ParameterSetDescription selector;
-    selector.addOptional<std::vector<std::string> >("SelectEvents");
+    selector.addOptional<std::vector<std::string>>("SelectEvents");
     desc.addUntracked<ParameterSetDescription>("SelectEvents", selector);
   }
 

--- a/FWCore/Framework/test/EventSelExc_t.cpp
+++ b/FWCore/Framework/test/EventSelExc_t.cpp
@@ -173,13 +173,8 @@ Bools toBools(std::array<bool, nb> const& t) {
 }
 
 void evSelTest(PathSpecifiers const& ps, TrigResults const& tr, bool ans) {
-  ParameterSet pset;
-  pset.addParameter<Strings>("SelectEvents", ps.path);
-  pset.registerIt();
-
-  // There are 3 different ways to build the EventSelector.  All
-  // should give the same result.  We exercise all 3 here.
-  EventSelector select_based_on_pset(pset, trigger_path_names);
+  // There are 2 different ways to build the EventSelector.
+  // Both should give the same result.  We exercise both here.
   EventSelector select_based_on_path_specifiers_and_names(ps.path, trigger_path_names);
   EventSelector select_based_on_path_specifiers_only(ps.path);
 
@@ -203,19 +198,17 @@ void evSelTest(PathSpecifiers const& ps, TrigResults const& tr, bool ans) {
 
   TriggerResults results(bm, trigger_path_names);
 
-  bool a = select_based_on_pset.acceptEvent(results);
-  bool b = select_based_on_path_specifiers_and_names.acceptEvent(results);
-  bool c = select_based_on_path_specifiers_only.acceptEvent(results);
-  bool ab = select_based_on_pset.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
-  bool bb = select_based_on_path_specifiers_and_names.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
+  bool a = select_based_on_path_specifiers_and_names.acceptEvent(results);
+  bool b = select_based_on_path_specifiers_only.acceptEvent(results);
+  bool aa = select_based_on_path_specifiers_and_names.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
   // select_based_on_path_specifiers_only.acceptEvent(&(bitArray[0]),
   //                                     number_of_trigger_paths);
   // is not a valid way to use acceptEvent.
 
-  if (a != ans || b != ans || c != ans || ab != ans || bb != ans) {
+  if (a != ans || b != ans || aa != ans) {
     std::cerr << "failed to compare path specifiers with trigger results: "
               << "correct=" << ans << " "
-              << "results=" << a << "  " << b << "  " << c << "  " << ab << "  " << bb << "\n"
+              << "results=" << a << "  " << b << "  " << aa << "\n"
               << "pathspecs = " << ps.path << "\n"
               << "trigger results = " << tr << "\n";
     abort();
@@ -230,14 +223,13 @@ void evSelTest(PathSpecifiers const& ps, TrigResults const& tr, bool ans) {
 
   TriggerResults results_id(bm, trigger_pset.id());
 
-  bool x = select_based_on_pset.acceptEvent(results_id);
-  bool y = select_based_on_path_specifiers_and_names.acceptEvent(results_id);
-  bool z = select_based_on_path_specifiers_only.acceptEvent(results_id);
+  bool x = select_based_on_path_specifiers_and_names.acceptEvent(results_id);
+  bool y = select_based_on_path_specifiers_only.acceptEvent(results_id);
 
-  if (x != ans || y != ans || z != ans) {
+  if (x != ans || y != ans) {
     std::cerr << "failed to compare pathspecs with trigger results using pset ID: "
               << "correct=" << ans << " "
-              << "results=" << x << "  " << y << "  " << z << "\n"
+              << "results=" << x << "  " << y << "\n"
               << "pathspecs =" << ps.path << "\n"
               << "trigger results = " << tr << "\n";
     abort();

--- a/FWCore/Framework/test/EventSelWildcard_t.cpp
+++ b/FWCore/Framework/test/EventSelWildcard_t.cpp
@@ -49,15 +49,8 @@ Bools toBools(std::array<bool, nb> const& t) {
 }
 
 void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bool answer, int jmask) {
-  ParameterSet pset;  //, parent;
-  pset.addParameter<Strings>("SelectEvents", pattern);
-  pset.registerIt();
-  //parent.addUntrackedParameter<ParameterSet>("SelectEvents",pset);
-  //parent.registerIt();
-
-  // There are 3 different ways to build the EventSelector.  All
-  // should give the same result.  We exercise all 3 here.
-  EventSelector select_based_on_pset(pset, paths);
+  // There are 2 different ways to build the EventSelector.
+  // Both should give the same result.  We exercise both here.
   EventSelector select_based_on_pattern_paths(pattern, paths);
   EventSelector select_based_on_pattern(pattern);
 
@@ -93,19 +86,17 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
 
   TriggerResults results(bm, paths);
 
-  bool a = select_based_on_pset.acceptEvent(results);
-  bool b = select_based_on_pattern_paths.acceptEvent(results);
-  bool c = select_based_on_pattern.acceptEvent(results);
-  bool ab = select_based_on_pset.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
-  bool bb = select_based_on_pattern_paths.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
+  bool a = select_based_on_pattern_paths.acceptEvent(results);
+  bool b = select_based_on_pattern.acceptEvent(results);
+  bool aa = select_based_on_pattern_paths.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
   // select_based_on_pattern.acceptEvent(&(bitArray[0]),
   //                                     number_of_trigger_paths);
   // is not a valid way to use acceptEvent.
 
-  if (a != answer || b != answer || c != answer || ab != answer || bb != answer) {
+  if (a != answer || b != answer || aa != answer) {
     std::cerr << "failed to compare pattern with mask: "
               << "correct=" << answer << " "
-              << "results=" << a << "  " << b << "  " << c << "  " << ab << "  " << bb << "\n"
+              << "results=" << a << "  " << b << "  " << aa << "\n"
               << "pattern=" << pattern << "\n"
               << "mask=" << mask << "\n"
               << "jmask = " << jmask << "\n";
@@ -121,14 +112,13 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
 
   TriggerResults results_id(bm, trigger_pset.id());
 
-  bool x = select_based_on_pset.acceptEvent(results_id);
-  bool y = select_based_on_pattern_paths.acceptEvent(results_id);
-  bool z = select_based_on_pattern.acceptEvent(results_id);
+  bool x = select_based_on_pattern_paths.acceptEvent(results_id);
+  bool y = select_based_on_pattern.acceptEvent(results_id);
 
-  if (x != answer || y != answer || z != answer) {
+  if (x != answer || y != answer) {
     std::cerr << "failed to compare pattern with mask using pset ID: "
               << "correct=" << answer << " "
-              << "results=" << x << "  " << y << "  " << z << "\n"
+              << "results=" << x << "  " << y << "\n"
               << "pattern=" << pattern << "\n"
               << "mask=" << mask << "\n"
               << "jmask = " << jmask << "\n";

--- a/FWCore/Framework/test/EventSelector_t.cpp
+++ b/FWCore/Framework/test/EventSelector_t.cpp
@@ -41,14 +41,8 @@ std::ostream& operator<<(std::ostream& ost, const Bools& b) {
 }
 
 void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bool answer, int jmask) {
-  ParameterSet pset;  //, parent;
-  pset.addParameter<Strings>("SelectEvents", pattern);
-  //parent.addUntrackedParameter<ParameterSet>("SelectEvents",pset);
-  pset.registerIt();
-
-  // There are 3 different ways to build the EventSelector.  All
-  // should give the same result.  We exercise all 3 here.
-  EventSelector select(pset, paths);
+  // There are 2 different ways to build the EventSelector.
+  // Both should give the same result.  We exercise both here.
   EventSelector select1(pattern, paths);
   EventSelector select2(pattern);
 
@@ -87,8 +81,6 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
   //        std::cerr << "pattern=" << pattern
   //	 	  << "mask=" << mask << "\n";  // DBG
 
-  //  	std:: cerr << "a \n";
-  bool a = select.acceptEvent(results);
   //  	std:: cerr << "a1 \n";
   bool a1 = select1.acceptEvent(results);
   //  	std:: cerr << "a2 \n";
@@ -98,10 +90,10 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
   //  	std:: cerr << "c1 \n";
   bool c1 = select1.acceptEvent(&(bitArray[0]), number_of_trigger_paths);
 
-  if (a != answer || a1 != answer || a2 != answer || b2 != answer || c1 != answer) {
+  if (a1 != answer || a2 != answer || b2 != answer || c1 != answer) {
     std::cerr << "failed to compare pattern with mask: "
               << "correct=" << answer << " "
-              << "results=" << a << "  " << a1 << "  " << a2 << "  " << b2 << "  " << c1 << "\n"
+              << "results=" << a1 << "  " << a2 << "  " << b2 << "  " << c1 << "\n"
               << "pattern=" << pattern << "\n"
               << "mask=" << mask << "\n"
               << "jmask = " << jmask << "\n";
@@ -118,18 +110,16 @@ void testone(const Strings& paths, const Strings& pattern, const Bools& mask, bo
   TriggerResults results_id(bm, trigger_pset.id());
 
   //  	std:: cerr << "a11 \n";
-  bool a11 = select.acceptEvent(results_id);
+  bool a11 = select1.acceptEvent(results_id);
   //  	std:: cerr << "a12 \n";
-  bool a12 = select1.acceptEvent(results_id);
+  bool a12 = select2.acceptEvent(results_id);
   //  	std:: cerr << "a13 \n";
   bool a13 = select2.acceptEvent(results_id);
-  //  	std:: cerr << "a14 \n";
-  bool a14 = select2.acceptEvent(results_id);
 
-  if (a11 != answer || a12 != answer || a13 != answer || a14 != answer) {
+  if (a11 != answer || a12 != answer || a13 != answer) {
     std::cerr << "failed to compare pattern with mask using pset ID: "
               << "correct=" << answer << " "
-              << "results=" << a11 << "  " << a12 << "  " << a13 << "  " << a14 << "\n"
+              << "results=" << a11 << "  " << a12 << "  " << a13 << "\n"
               << "pattern=" << pattern << "\n"
               << "mask=" << mask << "\n"
               << "jmask = " << jmask << "\n";


### PR DESCRIPTION
#### PR description:

After the cleanup being done in #40420, the PSet-based constructor of `EventSelector` would only be used in 3 unit tests of `FWCore/Framework`.

This PR removes said ctor (and updates the unit tests accordingly), following the discussion in https://github.com/cms-sw/cmssw/pull/40420#discussion_r1062571869.

Merely technical. No changes expected.

Requires #40420.

#### PR validation:

The unit tests of `FWCore/Framework` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A