### PR TITLE
Introduce macros to use reflex attributes

### DIFF
--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,13 +1,4 @@
 <lcgdict>
-  <class name="portabletest::TestSoA">
-    <field name="mem_" comment="!"/>
-    <field name="byteSize_" comment="!"/>
-    <field name="x_" comment="[elements_]"/>
-    <field name="y_" comment="[elements_]"/>
-    <field name="z_" comment="[elements_]"/>
-    <field name="id_" comment="[elements_]"/>
-    <field name="m_" comment="[mElementsWithPadding_]"/>
-    <field name="r_" comment="[scalar_]"/>
-  </class>
+  <class name="portabletest::TestSoA"/>
   <class name="portabletest::TestSoA::View"/>
 </lcgdict>

--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,2 +1,3 @@
 <use name="boost_header"/>
+<use name="FWCore/Reflection" source_only="1"/>
 <use name="FWCore/Utilities" source_only="1"/>

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -8,6 +8,8 @@
 
 #include <cassert>
 
+#include "FWCore/Reflection/interface/reflex.h"
+
 #include "SoACommon.h"
 #include "SoAView.h"
 
@@ -386,14 +388,14 @@
 #define _DECLARE_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
   _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
       /* Scalar */                                                                                                     \
-      CPP_TYPE* BOOST_PP_CAT(NAME, _) = nullptr;                                                                       \
+      CPP_TYPE* BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(scalar_) = nullptr;                                              \
       ,                                                                                                                \
       /* Column */                                                                                                     \
-      CPP_TYPE * BOOST_PP_CAT(NAME, _) = nullptr;                                                                      \
+      CPP_TYPE * BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(elements_) = nullptr;                                           \
       ,                                                                                                                \
       /* Eigen column */                                                                                               \
-      size_type BOOST_PP_CAT(NAME, ElementsWithPadding_); /* For ROOT serialization, (displikes the default value) */  \
-      CPP_TYPE::Scalar * BOOST_PP_CAT(NAME, _) = nullptr;                                                              \
+      size_type BOOST_PP_CAT(NAME, ElementsWithPadding_) = 0; /* For ROOT serialization */                             \
+      CPP_TYPE::Scalar * BOOST_PP_CAT(NAME, _) EDM_REFLEX_SIZE(BOOST_PP_CAT(NAME, ElementsWithPadding_)) = nullptr;    \
       byte_size_type BOOST_PP_CAT(NAME, Stride_) = 0;                                                                  \
   )
 // clang-format on
@@ -582,10 +584,10 @@
     }                                                                                                                  \
                                                                                                                        \
     /* Data members */                                                                                                 \
-    std::byte* mem_;                                                                                                   \
+    std::byte* mem_ EDM_REFLEX_TRANSIENT;                                                                              \
     size_type elements_;                                                                                               \
     size_type const scalar_ = 1;                                                                                       \
-    byte_size_type byteSize_;                                                                                          \
+    byte_size_type byteSize_ EDM_REFLEX_TRANSIENT;                                                                     \
     _ITERATE_ON_ALL(_DECLARE_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                          \
     /* Making the code conditional is problematic in macros as the commas will interfere with parameter lisings     */ \
     /* So instead we make the code unconditional with paceholder names which are protected by a private protection. */ \

--- a/FWCore/Reflection/interface/reflex.h
+++ b/FWCore/Reflection/interface/reflex.h
@@ -1,0 +1,41 @@
+#ifndef FWCore_Reflection_interface_reflex_h
+#define FWCore_Reflection_interface_reflex_h
+
+/* These macros can be used to annotate the data members of DataFormats classes
+ * and achieve the same effect of ROOT-style comments or reflex dictionaries:
+ * 
+ * private:
+ *   int size_;
+ *   float* data_;       //[size_]
+ *   float* transient_;  //!
+ * 
+ * can be expressed as
+ * 
+ * private:
+ *   int size_;
+ *   float* data_ EDM_REFLEX_SIZE(size_);
+ *   float* transient_ EDM_REFLEX_TRANSIENT;
+ * 
+ * The main advantage is that - unlike comments - these macros can be used inside
+ * other macros.
+ *
+ * To avoid warning about unrecognised attributes, these macros expand to nothing
+ * unless __CLING__ is defined.
+ */
+
+#include "FWCore/Utilities/interface/stringize.h"
+
+#ifdef __CLING__
+
+// Macros used to annotate class members for the generation of ROOT dictionaries
+#define EDM_REFLEX_TRANSIENT [[clang::annotate("!")]]
+#define EDM_REFLEX_SIZE(SIZE) [[clang::annotate("[" EDM_STRINGIZE(SIZE) "]")]]
+
+#else
+
+#define EDM_REFLEX_TRANSIENT
+#define EDM_REFLEX_SIZE(SIZE)
+
+#endif  // __CLING__
+
+#endif  // FWCore_Reflection_interface_reflex_h


### PR DESCRIPTION
#### PR description:

The way dictionary informations are propagated from the C++ code or XML dictionaries to reflex and cling is rather roundabout:
  - `<field name="data_" comment="!"/>` tags in XML dictionaries are parsed by `genreflex` and injected into the LLVM AST of the corresponding C++ code as comments `//!`;
  - C++ comments like `//!` or `//[size_]` are converted by `genreflex`/`rootcling` into LLVM AST annotations;
  - `cling` parses the LLVM annotations and uses them to generate the desired behaviour in the dictionaries.

This approach does not work well with macro-generated data members:
  - macros cannot generate comments, so `//!` or `//[size_]` cannot be used directly;
  - macros cannot easily be used to generate the `class_def.xml` file, requiring manual intervention for their implementation and maintenance.

However, it turns out that dictionaries can bypass the comments and use LLVM annotations directly within the C++ code. So
```c++
private:
  int size_;
  float* data_;       //[size_]
  float* transient_;  //!
```
can be also expressed as
```c++
private:
  int size_;
  float* data_ [[clang::annotate("[size_]")]];
  float* transient_ [[clang::annotate("!")]];
```
and annotations _can_ be generated by macros.

A new header file, `FWCore/Reflection/interface/reflex.h`, currently implements two macros:
  - `EDM_REFLEX_TRANSIENT` can be used to annotate transient data members, like `//!`
  - `EDM_REFLEX_SIZE(SIZE)` can be used to annotate dynamic arrays, like `//[SIZE]`

To avoid warning about unrecognised attributes, these macros expand to nothing unless `__CLING__` is defined.

The changes to `DataFormats/SoATemplate/interface/SoALayout.h` add these macros to the SoA data members, so they do not need to be explicitly added by hand to the various `classes_def.xml` files.

#### PR validation:

The SoA unit tests under `HeterogeneousCore/AlpakaTest` and `HeterogeneousCore/CUDATest` pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport expected.