### PR TITLE
guard `TriggerRatesMonitor` against unavailable trigger paths

### DIFF
--- a/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
+++ b/DQM/HLTEvF/plugins/TriggerRatesMonitor.cc
@@ -1,43 +1,38 @@
-// Note to self: the implementation uses TH1F's to store the L1 and HLT rates.
+// Note to self: the implementation uses TH1F's to store the L1T and HLT rates.
 // Assuming a maximum rate of 100 kHz times a period of 23.31 s, one needs to store counts up to ~2.3e6.
 // A "float" has 24 bits of precision, so it can store up to 2**24 ~ 16.7e6 without loss of precision.
 
 // C++ headers
+#include <algorithm>
 #include <string>
-#include <cstring>
+#include <vector>
 
 #include <fmt/printf.h>
 
 // boost headers
 #include <boost/regex.hpp>
 
-// Root headers
-#include <TH1F.h>
-
 // CMSSW headers
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Provenance/interface/ProcessHistory.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 namespace {
 
+  using dqm::reco::MonitorElement;
+
   struct RunBasedHistograms {
-    typedef dqm::reco::MonitorElement MonitorElement;
     // HLT configuration
     struct HLTIndices {
       unsigned int index_l1_seed;
@@ -56,28 +51,28 @@ namespace {
 
     // per-path HLT plots
     struct HLTRatesPlots {
-      dqm::reco::MonitorElement *pass_l1_seed;
-      dqm::reco::MonitorElement *pass_prescale;
-      dqm::reco::MonitorElement *accept;
-      dqm::reco::MonitorElement *reject;
-      dqm::reco::MonitorElement *error;
+      MonitorElement *pass_l1_seed;
+      MonitorElement *pass_prescale;
+      MonitorElement *accept;
+      MonitorElement *reject;
+      MonitorElement *error;
     };
 
     // overall event count and event types
-    dqm::reco::MonitorElement *events_processed;
-    std::vector<dqm::reco::MonitorElement *> tcds_counts;
+    MonitorElement *events_processed;
+    std::vector<MonitorElement *> tcds_counts;
 
     // L1T triggers
-    std::vector<dqm::reco::MonitorElement *> l1t_counts;
+    std::vector<MonitorElement *> l1t_counts;
 
     // HLT triggers
     std::vector<std::vector<HLTRatesPlots>> hlt_by_dataset_counts;
 
     // datasets
-    std::vector<dqm::reco::MonitorElement *> dataset_counts;
+    std::vector<MonitorElement *> dataset_counts;
 
     // streams
-    std::vector<dqm::reco::MonitorElement *> stream_counts;
+    std::vector<MonitorElement *> stream_counts;
 
     RunBasedHistograms()
         :  // L1T and HLT configuration
@@ -169,7 +164,7 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const &run,
   histograms.tcds_counts.clear();
   histograms.tcds_counts.resize(sizeof(s_tcds_trigger_types) / sizeof(const char *));
 
-  // cache the L1 trigger menu
+  // cache the L1T trigger menu
   histograms.l1t_counts.clear();
   histograms.l1t_counts.resize(GlobalAlgBlk::maxPhysicsTriggers);
 
@@ -178,32 +173,50 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const &run,
   edm::EDConsumerBase::Labels labels;
   labelsForToken(m_hlt_results, labels);
   if (histograms.hltConfig.init(run, setup, labels.process, changed)) {
-    histograms.hltIndices.resize(histograms.hltConfig.size());
+    // number of trigger paths in labels.process
+    auto const nTriggers = histograms.hltConfig.size();
+    histograms.hltIndices.resize(nTriggers);
 
-    unsigned int datasets = histograms.hltConfig.datasetNames().size();
+    unsigned int const nDatasets = histograms.hltConfig.datasetNames().size();
     histograms.hlt_by_dataset_counts.clear();
-    histograms.hlt_by_dataset_counts.resize(datasets);
+    histograms.hlt_by_dataset_counts.resize(nDatasets);
 
     histograms.datasets.clear();
-    histograms.datasets.resize(datasets);
-    for (unsigned int i = 0; i < datasets; ++i) {
+    histograms.datasets.resize(nDatasets);
+    for (unsigned int i = 0; i < nDatasets; ++i) {
       auto const &paths = histograms.hltConfig.datasetContent(i);
       histograms.hlt_by_dataset_counts[i].resize(paths.size());
       histograms.datasets[i].reserve(paths.size());
       for (auto const &path : paths) {
-        histograms.datasets[i].push_back(histograms.hltConfig.triggerIndex(path));
+        auto const triggerIdx = histograms.hltConfig.triggerIndex(path);
+        if (triggerIdx < nTriggers)
+          histograms.datasets[i].push_back(triggerIdx);
+        else
+          LogDebug("TriggerRatesMonitor")
+              << "The rates of the HLT path \"" << path << "\" (dataset: \"" << histograms.hltConfig.datasetName(i)
+              << "\") will not be monitored for this run.\nThis HLT path is not available in the process \""
+              << labels.process << "\", but it is listed in its \"datasets\" PSet.";
       }
     }
     histograms.dataset_counts.clear();
-    histograms.dataset_counts.resize(datasets);
+    histograms.dataset_counts.resize(nDatasets);
 
-    unsigned int streams = histograms.hltConfig.streamNames().size();
+    unsigned int const nStreams = histograms.hltConfig.streamNames().size();
     histograms.streams.clear();
-    histograms.streams.resize(streams);
-    for (unsigned int i = 0; i < streams; ++i) {
+    histograms.streams.resize(nStreams);
+    for (unsigned int i = 0; i < nStreams; ++i) {
       for (auto const &dataset : histograms.hltConfig.streamContent(i)) {
-        for (auto const &path : histograms.hltConfig.datasetContent(dataset))
-          histograms.streams[i].push_back(histograms.hltConfig.triggerIndex(path));
+        for (auto const &path : histograms.hltConfig.datasetContent(dataset)) {
+          auto const triggerIdx = histograms.hltConfig.triggerIndex(path);
+          if (triggerIdx < nTriggers)
+            histograms.streams[i].push_back(triggerIdx);
+          else
+            LogDebug("TriggerRatesMonitor")
+                << "The rates of the HLT path \"" << path << "\" (stream: \"" << histograms.hltConfig.streamName(i)
+                << "\", dataset: \"" << dataset << "\") will not be monitored for this run.\n"
+                << "This HLT path is not available in the process \"" << labels.process
+                << "\", but it is listed in its \"datasets\" PSet.";
+        }
       }
       std::sort(histograms.streams[i].begin(), histograms.streams[i].end());
       auto unique_end = std::unique(histograms.streams[i].begin(), histograms.streams[i].end());
@@ -211,11 +224,11 @@ void TriggerRatesMonitor::dqmBeginRun(edm::Run const &run,
       histograms.streams[i].shrink_to_fit();
     }
     histograms.stream_counts.clear();
-    histograms.stream_counts.resize(streams);
+    histograms.stream_counts.resize(nStreams);
   } else {
     // HLTConfigProvider not initialised, skip the the HLT monitoring
-    edm::LogError("TriggerRatesMonitor")
-        << "failed to initialise HLTConfigProvider, the HLT trigger and datasets rates will not be monitored";
+    edm::LogError("TriggerRatesMonitor") << "Failed to initialise HLTConfigProvider: the rates of HLT triggers, "
+                                            "datasets and streams will not be monitored for this run.";
   }
 }
 
@@ -223,37 +236,50 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker &booker,
                                          edm::Run const &run,
                                          edm::EventSetup const &setup,
                                          RunBasedHistograms &histograms) const {
-  // book the overall event count and event types histograms
+  // book histograms for the overall event count, and trigger types
   booker.setCurrentFolder(m_dqm_path);
   histograms.events_processed = booker.book1D(
       "events", "Processed events vs. lumisection", m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
   booker.setCurrentFolder(m_dqm_path + "/TCDS");
-  for (unsigned int i = 0; i < sizeof(s_tcds_trigger_types) / sizeof(const char *); ++i)
-    if (s_tcds_trigger_types[i]) {
-      std::string const &title = fmt::sprintf("%s events vs. lumisection", s_tcds_trigger_types[i]);
-      histograms.tcds_counts[i] =
-          booker.book1D(s_tcds_trigger_types[i], title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
-    }
+  unsigned int const sizeof_tcds_trigger_types = sizeof(s_tcds_trigger_types) / sizeof(const char *);
+  if (sizeof_tcds_trigger_types == histograms.tcds_counts.size()) {
+    for (unsigned int i = 0; i < sizeof_tcds_trigger_types; ++i)
+      if (s_tcds_trigger_types[i]) {
+        std::string const &title = fmt::sprintf("%s events vs. lumisection", s_tcds_trigger_types[i]);
+        histograms.tcds_counts[i] =
+            booker.book1D(s_tcds_trigger_types[i], title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
+      }
+  } else
+    edm::LogError("TriggerRatesMonitor")
+        << "This should never happen: size of \"s_tcds_trigger_types\" array (" << sizeof_tcds_trigger_types
+        << ") differs from size of \"histograms.tcds_counts\" vector (size=" << histograms.tcds_counts.size()
+        << ").\nRate histograms of TCDS trigger types will not be booked for this run.";
 
-  // book the rate histograms for the L1 triggers that are included in the L1 menu
+  // book the rate histograms for the L1T triggers that are included in the L1T menu
   booker.setCurrentFolder(m_dqm_path + "/L1T");
   auto const &l1tMenu = setup.getData(m_l1tMenuToken);
   for (auto const &keyval : l1tMenu.getAlgorithmMap()) {
-    unsigned int bit = keyval.second.getIndex();
-    bool masked = false;  // FIXME read L1 masks once they will be avaiable in the EventSetup
+    unsigned int const bit = keyval.second.getIndex();
+    if (bit >= histograms.l1t_counts.size()) {
+      edm::LogError("TriggerRatesMonitor")
+          << "This should never happen: bit of L1T algorithm (bit=" << bit << ", name=\"" << keyval.first
+          << "\") is not smaller than size of \"histograms.l1t_counts\" vector (size=" << histograms.l1t_counts.size()
+          << ").\nRate histogram of this L1T algorithm will not be booked for this run.";
+      continue;
+    }
+    bool masked = false;  // FIXME read L1T masks once they will be avaiable in the EventSetup
     std::string const &name = fmt::sprintf("%s (bit %d)", keyval.first, bit);
     std::string const &title =
         fmt::sprintf("%s (bit %d)%s vs. lumisection", keyval.first, bit, (masked ? " (masked)" : ""));
-    histograms.l1t_counts.at(bit) =
-        booker.book1D(name, title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
+    histograms.l1t_counts[bit] = booker.book1D(name, title, m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
   }
 
   if (histograms.hltConfig.inited()) {
-    auto const &datasets = histograms.hltConfig.datasetNames();
+    auto const &datasetNames = histograms.hltConfig.datasetNames();
 
     // book the rate histograms for the HLT triggers
-    for (unsigned int d = 0; d < datasets.size(); ++d) {
-      booker.setCurrentFolder(m_dqm_path + "/HLT/" + datasets[d]);
+    for (unsigned int d = 0; d < datasetNames.size(); ++d) {
+      booker.setCurrentFolder(m_dqm_path + "/HLT/" + datasetNames[d]);
       for (unsigned int i = 0; i < histograms.datasets[d].size(); ++i) {
         unsigned int index = histograms.datasets[d][i];
         std::string const &name = histograms.hltConfig.triggerName(index);
@@ -284,9 +310,8 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker &booker,
                                                                      m_lumisections_range + 0.5);
       }
 
-      //      booker.setCurrentFolder( m_dqm_path + "/HLT/" + datasets[d]);
       for (unsigned int i : histograms.datasets[d]) {
-        // look for the index of the (last) L1 seed and prescale module in each path
+        // look for the index of the (last) L1T seed and prescale module in each path
         histograms.hltIndices[i].index_l1_seed = histograms.hltConfig.size(i);
         histograms.hltIndices[i].index_prescale = histograms.hltConfig.size(i);
         for (unsigned int j = 0; j < histograms.hltConfig.size(i); ++j) {
@@ -294,11 +319,11 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker &booker,
           std::string const &type = histograms.hltConfig.moduleType(label);
           if (type == "HLTL1TSeed" or type == "HLTLevel1GTSeed" or type == "HLTLevel1Activity" or
               type == "HLTLevel1Pattern") {
-            // there might be more L1 seed filters in sequence
+            // there might be more L1T seed filters in sequence
             // keep looking and store the index of the last one
             histograms.hltIndices[i].index_l1_seed = j;
           } else if (type == "HLTPrescaler") {
-            // there should be only one prescaler in a path, and it should follow all L1 seed filters
+            // there should be only one prescaler in a path, and it should follow all L1T seed filters
             histograms.hltIndices[i].index_prescale = j;
             break;
           }
@@ -306,18 +331,18 @@ void TriggerRatesMonitor::bookHistograms(DQMStore::IBooker &booker,
       }
     }
 
-    // book the HLT datasets rate histograms
+    // book the rate histograms for the HLT datasets
     booker.setCurrentFolder(m_dqm_path + "/Datasets");
-    for (unsigned int i = 0; i < datasets.size(); ++i)
+    for (unsigned int i = 0; i < datasetNames.size(); ++i)
       histograms.dataset_counts[i] =
-          booker.book1D(datasets[i], datasets[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
+          booker.book1D(datasetNames[i], datasetNames[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
 
-    // book the HLT streams rate histograms
+    // book the rate histograms for the HLT streams
     booker.setCurrentFolder(m_dqm_path + "/Streams");
-    auto const &streams = histograms.hltConfig.streamNames();
-    for (unsigned int i = 0; i < streams.size(); ++i)
+    auto const &streamNames = histograms.hltConfig.streamNames();
+    for (unsigned int i = 0; i < streamNames.size(); ++i)
       histograms.stream_counts[i] =
-          booker.book1D(streams[i], streams[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
+          booker.book1D(streamNames[i], streamNames[i], m_lumisections_range + 1, -0.5, m_lumisections_range + 0.5);
   }
 }
 
@@ -331,7 +356,7 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
   if (histograms.tcds_counts[event.experimentType()])
     histograms.tcds_counts[event.experimentType()]->Fill(lumisection);
 
-  // monitor the L1 triggers rates
+  // monitor the rates of L1T triggers
   auto const &bxvector = event.get(m_l1t_results);
   if (not bxvector.isEmpty(0)) {
     auto const &results = bxvector.at(0, 0);
@@ -341,24 +366,27 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
           histograms.l1t_counts[i]->Fill(lumisection);
   }
 
-  // monitor the HLT triggers and datsets rates
+  // monitor the rates of HLT triggers, datasets and streams
   if (histograms.hltConfig.inited()) {
     auto const &hltResults = event.get(m_hlt_results);
     if (hltResults.size() != histograms.hltIndices.size()) {
-      edm::LogWarning("TriggerRatesMonitor")
-          << "This should never happen: the number of HLT paths has changed since the beginning of the run";
+      edm::LogError("TriggerRatesMonitor")
+          << "This should never happen: the number of HLT paths has changed since the beginning of the run"
+          << " (from " << histograms.hltIndices.size() << " to " << hltResults.size() << ").\n"
+          << "Histograms for rates of HLT paths, datasets and streams will not be filled for this event.";
+      return;
     }
 
     for (unsigned int d = 0; d < histograms.datasets.size(); ++d) {
       for (unsigned int i : histograms.datasets[d])
-        if (hltResults.at(i).accept()) {
+        if (hltResults[i].accept()) {
           histograms.dataset_counts[d]->Fill(lumisection);
           // ensure each dataset is incremented only once per event
           break;
         }
       for (unsigned int i = 0; i < histograms.datasets[d].size(); ++i) {
-        unsigned int index = histograms.datasets[d][i];
-        edm::HLTPathStatus const &path = hltResults.at(index);
+        unsigned int const index = histograms.datasets[d][i];
+        edm::HLTPathStatus const &path = hltResults[index];
 
         if (path.index() > histograms.hltIndices[index].index_l1_seed)
           histograms.hlt_by_dataset_counts[d][i].pass_l1_seed->Fill(lumisection);
@@ -375,7 +403,7 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
 
     for (unsigned int i = 0; i < histograms.streams.size(); ++i)
       for (unsigned int j : histograms.streams[i])
-        if (hltResults.at(j).accept()) {
+        if (hltResults[j].accept()) {
           histograms.stream_counts[i]->Fill(lumisection);
           // ensure each stream is incremented only once per event
           break;
@@ -383,6 +411,6 @@ void TriggerRatesMonitor::dqmAnalyze(edm::Event const &event,
   }
 }
 
-//define this as a plug-in
+// define this as a plugin
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TriggerRatesMonitor);


### PR DESCRIPTION
#### PR description:

This PR includes a small improvement to the plugin `TriggerRatesMonitor`, in order to support configurations using it with a subset of Paths of a HLT menu. Details on the original issue can be found in [CMSHLT-2577](https://its.cern.ch/jira/browse/CMSHLT-2577).

Minor unrelated changes to the plugin in question are also included.

No changes expected in the outputs of PR tests.

#### PR validation:

Private tests, e.g.
```sh
#!/bin/bash

# tested in CMSSW_13_0_X_2023-01-05-1100

hltGetConfiguration run:360991 \
  --globaltag 124X_dataRun3_HLT_v4 \
  --input root://eoscms.cern.ch//store/data/Run2022F/HLTPhysics/RAW/v1/000/360/991/00000/69592673-b357-4478-b6c8-fb4fb2bcb980.root \
  --paths HLTrigger*,HLT_PFMETNoMu110_* \
  --output minimal \
  > hlt.py

cat <<@EOF >> hlt.py
process.hltLumiMonitor.folderName = process.hltLumiMonitor.FolderName
del process.hltLumiMonitor.FolderName
del process.hltEcalUncalibRecHitGPU.maxNumberHitsEB
del process.hltEcalUncalibRecHitGPU.maxNumberHitsEE
del process.hltHbherecoGPU.maxChannels
process.MessageLogger.cerr.threshold = 'DEBUG'
process.MessageLogger.debugModules = ['hltTriggerRatesMonitor']
@EOF

cmsRun hlt.py &> hlt.log
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A