### PR TITLE
Update CPU service calls to ResourceInformationService  for non-Intel CPUs

### DIFF
--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -166,6 +166,9 @@ namespace edm {
               modelsSet.insert(entry.second);
             }
           }
+          if (modelsSet.empty()) {  // "model name" not found, try models string
+            modelsSet.insert(models);
+          }
           std::vector<std::string> modelsVector(modelsSet.begin(), modelsSet.end());
           resourceInformationService->setCPUModels(modelsVector);
         }

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -51,7 +51,7 @@ namespace edm {
     class CPU : public CPUServiceBase {
     public:
       CPU(ParameterSet const &, ActivityRegistry &);
-      ~CPU() = default;
+      ~CPU() override = default;
 
       static void fillDescriptions(ConfigurationDescriptions &descriptions);
 

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -9,6 +9,7 @@
 // CPU.cc: v 1.0 2009/01/08 11:31:07
 
 #include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -84,8 +85,8 @@ namespace edm {
       }
 
       void compressWhitespace(std::string &s) {
-        auto last = std::unique(
-            s.begin(), s.end(), [](unsigned char a, unsigned char b) -> bool { return std::isspace(a) && a == b; });
+        auto last =
+            std::unique(s.begin(), s.end(), [](const auto a, const auto b) { return std::isspace(a) && a == b; });
         s.erase(last, s.end());
       }
 
@@ -289,7 +290,11 @@ namespace edm {
       unsigned coreCount = 0;
       for (const auto &entry : info) {
         if (entry.first == "cpu MHz") {
-          averageCoreSpeed += std::stod(entry.second);
+          try {
+            averageCoreSpeed += std::stod(entry.second);
+          } catch (const std::logic_error &e) {
+            LogWarning("CPU::getAverageSpeed") << "stod(" << entry.second << ") conversion error: " << e.what();
+          }
           coreCount++;
         }
       }

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -212,8 +212,9 @@ namespace edm {
         reportSvc->reportPerformanceForModule("SystemCPU", "CPU-" + currentCore, currentCoreProperties);
       }
 
-      std::map<std::string, std::string> reportCPUProperties{
-          {"totalCPUs", i2str(totalNumberCPUs)}, {"averageCoreSpeed", d2str(getAverageSpeed(info))}, {"CPUModels", models}};
+      std::map<std::string, std::string> reportCPUProperties{{"totalCPUs", i2str(totalNumberCPUs)},
+                                                             {"averageCoreSpeed", d2str(getAverageSpeed(info))},
+                                                             {"CPUModels", models}};
       unsigned set_size = -1;
       if (getCpuSetSize(set_size)) {
         reportCPUProperties.insert(std::make_pair("cpusetCount", i2str(set_size)));


### PR DESCRIPTION
#### PR description:

The changes made to the CPU service in #37831 to fill the ResourceInformationService CPU models list fails on non-Intel CPUs where "model name" doesn't appear in `/proc/cpuinfo`.  This PR integrates the fallback to the cpufeatures library in a more transparent way that fixes the immediate problem and should reduce the possibility of future issues.

Fixes TestResourceInformationService unit test failures on non-Intel platforms.

#### PR validation:

aarch64 output of `FWCore/Services/test/test_resourceInformationService_cfg.py` before:
```
    cpu models:
        None
    gpu models:
        None
    acceleratorTypes:
        GPU
    nvidiaDriverVersion:
    cudaDriverVersion: 0
    cudaRuntimeVersion: 0
    cpuModelsFormatted: aarch64 0 0
    cpuAverageSpeed: 0
```
After:
```
    cpu models:
        aarch64 0 0
    gpu models:
        None
    acceleratorTypes:
        GPU
    nvidiaDriverVersion:
    cudaDriverVersion: 0
    cudaRuntimeVersion: 0
    cpuModelsFormatted: aarch64 0 0
    cpuAverageSpeed: 0
```