### PR TITLE
Avoid including `RooChi2Var.h` in CMSSW

### DIFF
--- a/Alignment/OfflineValidation/bin/FitWithRooFit.cc
+++ b/Alignment/OfflineValidation/bin/FitWithRooFit.cc
@@ -22,7 +22,6 @@
 #include "RooAddModel.h"
 #include "RooPolynomial.h"
 #include "RooCBShape.h"
-#include "RooChi2Var.h"
 #include "RooMinimizer.h"
 #include "RooBreitWigner.h"
 #include "RooFFTConvPdf.h"
@@ -112,7 +111,7 @@ public:
     // Build the composite model
     RooAbsPdf* model = buildModel(&x, signalType, backgroundType);
 
-    RooChi2Var chi2("chi2", "chi2", *model, *dh, RooFit::DataError(RooAbsData::SumW2));
+    std::unique_ptr<RooAbsReal> chi2{model->createChi2(*dh, RooFit::DataError(RooAbsData::SumW2))};
 
     // Fit the composite model
     // -----------------------
@@ -126,7 +125,7 @@ public:
     // Fit with chi^2
     else {
       std::cout << "FITTING WITH CHI^2" << std::endl;
-      RooMinimizer m(chi2);
+      RooMinimizer m(*chi2);
       m.migrad();
       m.hesse();
       // RooFitResult* r_chi2_wgt = m.save();

--- a/DQMOffline/Trigger/plugins/GenericTnPFitter.h
+++ b/DQMOffline/Trigger/plugins/GenericTnPFitter.h
@@ -9,7 +9,6 @@
 #include "RooGlobalFunc.h"
 #include "RooCategory.h"
 #include "RooSimultaneous.h"
-#include "RooChi2Var.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH2F.h"
@@ -320,9 +319,10 @@ namespace dqmTnP {
       }
       RooDataHist dataFail("fail", "fail", mass, fail);
       RooDataHist dataPass("pass", "pass", mass, pass);
-      chi2 = (RooChi2Var("chi2Fail", "chi2Fail", pdfFail, dataFail, DataError(RooAbsData::Poisson)).getVal() +
-              RooChi2Var("chi2Pass", "chi2Pass", pdfPass, dataPass, DataError(RooAbsData::Poisson)).getVal()) /
-             (2 * pass->GetNbinsX() - 8);
+      using AbsRealPtr = std::unique_ptr<RooAbsReal>;
+      const double chi2Fail = AbsRealPtr(pdfFail.createChi2(dataFail, DataError(RooAbsData::Poisson)))->getVal();
+      const double chi2Pass = AbsRealPtr(pdfPass.createChi2(dataPass, DataError(RooAbsData::Poisson)))->getVal();
+      chi2 = (chi2Fail + chi2Pass) / (2 * pass->GetNbinsX() - 8);
       if (chi2 > 3) {
         efficiency.setVal(0.5);
         efficiency.setError(0.5);
@@ -396,9 +396,10 @@ namespace dqmTnP {
       }
       RooDataHist dataFail("fail", "fail", mass, fail);
       RooDataHist dataPass("pass", "pass", mass, pass);
-      chi2 = (RooChi2Var("chi2Fail", "chi2Fail", pdfFail, dataFail, DataError(RooAbsData::Poisson)).getVal() +
-              RooChi2Var("chi2Pass", "chi2Pass", pdfPass, dataPass, DataError(RooAbsData::Poisson)).getVal()) /
-             (2 * all->GetNbinsX() - 8);
+      using AbsRealPtr = std::unique_ptr<RooAbsReal>;
+      const double chi2Fail = AbsRealPtr(pdfFail.createChi2(dataFail, DataError(RooAbsData::Poisson)))->getVal();
+      const double chi2Pass = AbsRealPtr(pdfPass.createChi2(dataPass, DataError(RooAbsData::Poisson)))->getVal();
+      chi2 = (chi2Fail + chi2Pass) / (2 * all->GetNbinsX() - 8);
       if (chi2 > 3) {
         efficiency.setVal(0.5);
         efficiency.setError(0.5);

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
@@ -22,7 +22,6 @@
 #include "RooAddModel.h"
 #include "RooPolynomial.h"
 #include "RooCBShape.h"
-#include "RooChi2Var.h"
 #include "RooMinimizer.h"
 #include "RooBreitWigner.h"
 #include "RooFFTConvPdf.h"
@@ -112,7 +111,7 @@ public:
     // Build the composite model
     RooAbsPdf* model = buildModel(&x, signalType, backgroundType);
 
-    RooChi2Var chi2("chi2", "chi2", *model, *dh, RooFit::DataError(RooAbsData::SumW2));
+    std::unique_ptr<RooAbsReal> chi2{model->createChi2(*dh, RooFit::DataError(RooAbsData::SumW2))};
 
     // Fit the composite model
     // -----------------------
@@ -126,7 +125,7 @@ public:
     // Fit with chi^2
     else {
       std::cout << "FITTING WITH CHI^2" << std::endl;
-      RooMinimizer m(chi2);
+      RooMinimizer m(*chi2);
       m.migrad();
       m.hesse();
       // RooFitResult* r_chi2_wgt = m.save();


### PR DESCRIPTION
The direct inclusion of the `RooChi2Var.h` header will soon result in a warning with ROOT `master`.

Users will be encouraged to always use `RooAbsPdf::createChi2()` instead of instantiating the chi-square-representing objects themselves.