### PR TITLE
HCAL: make HBHE zero suppression simulation identical to the data-taking one for Run3

### DIFF
--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -43,8 +43,8 @@ run2_HE_2018.toModify( simHcalDigis,
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( simHcalDigis, 
                              use1ts = cms.bool(True),
-                             HBregion = cms.vint32(4,7),
-                             HEregion = cms.vint32(4,7)
+                             HBregion = cms.vint32(5,6),  # SOI in 10TS
+                             HEregion = cms.vint32(5,6)   # SOI in 10TS
 ) 
 
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -27,24 +27,24 @@ simHcalDigis = cms.EDProducer("HcalRealisticZS",
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify( simHcalDigis,
-                             HFregion = cms.vint32(1,2)
+                             HFregion = [1,2]
 )
 
 from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
 run2_HB_2018.toModify( simHcalDigis,
-                             HBregion = cms.vint32(2,5)
+                             HBregion = [2,5]
 )
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify( simHcalDigis,
-                             HEregion = cms.vint32(2,5)
+                             HEregion = [2,5]
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( simHcalDigis, 
-                             use1ts = cms.bool(True),
-                             HBregion = cms.vint32(5,6),  # SOI in 10TS
-                             HEregion = cms.vint32(5,6)   # SOI in 10TS
+                             use1ts = True,
+                             HBregion = [5,6],  # SOI in 10TS
+                             HEregion = [5,6]   # SOI in 10TS
 ) 
 
 


### PR DESCRIPTION
#### PR description:

It's a trivial fix (of long-lasting omission) 
to make HBHE ZS simulation _identical_ to what's actually in the HCAL firmware at P5 since early 2022... 
The effect on 2022 MC (with yet fairly low DC noise) is small, see default 2022 single-pion (noPU) comparison w/wo this PR
 https://cms-docs.web.cern.ch/hcal-sw-validation/calo_scan_single_pi/13_0_X/13_0_0_pre2_run3_ZS_SOI_vs_13_0_0_pre2_run3_SinglePi/   

A priori expectations for
(1) regular Run3 wfs:  decrease of the number of very low-e hits (<50-100 MeV in RecHits energy equivalent)
     naturally PU wfs are somewhat more affected than noPU ones; 
(2) Phase2 wfs without aging: similar to (1);
(3) Phase2 wfs with the regular 1000/fb aging: **no changes** .

#### PR validation:

runTheMatrix.py -l limited

#### If this PR is a backport 

No. But for any 2023/2024-related MC studies using 12_6_X  with (projected) **high DC noise** conditions, a backport https://github.com/cms-sw/cmssw/pull/40447 would be needed. 
