### PR TITLE
Update GTs for 2023

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v9',
+    # GlobalTag for Run3 HLT: identical to the online GT (126X_dataRun3_HLT_v1) but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_hlt'                     : '126X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v4',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v9',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v10 but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v8',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-12-15 07:25:06 (UTC)
-    'run3_data'                    : '124X_dataRun3_v14',
-    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2022-12-15 07:28:44 (UTC)
-    'run3_data_relval'             : '125X_dataRun3_relval_v6',
+    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v1',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 126X_dataRun3_Express_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data_express'            : '126X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 126X_dataRun3_Prompt_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data_prompt'             : '126X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data'                    : '126X_dataRun3_v1',
+    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
+    'run3_data_relval'             : '126X_dataRun3_relval_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -79,8 +79,16 @@ autoCond = {
     'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v1',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v2',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v1',
+    # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v1',
+    # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,23 +68,23 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '125X_mcRun3_2022_design_v6',
+    'phase1_2022_design'           : '130X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v5',
+    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '124X_mcRun3_2022_realistic_postEE_v1',
+    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v5',
+    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v7',
+    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v1',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v1',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '125X_mcRun4_realistic_v5'
+    'phase2_realistic'             : '130X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR updates the GTs for 2023:
 - **Data** 
    - Online, offline and relval data GTs are updated to `126X` version since (AFAIU) this will be the CMSSW release used for the cosmics data-taking (MWGR, CRUZET and CRAFT) in 2023
      - no real change in these GTs, only update in the name
 - **MC**
   - 2022, 2023, 2024 and Phase2 MC GTs are updated to `130X` version since (AFAIU) this is the release that will be used for 2023 MC
     - the MC GTs are copied from the last version in `autoCond` + a cleanup of the old/unused b-tagging tags as detailed in https://github.com/cms-AlCaDB/AlCaTools/issues/58 (this cleanup is now possible since #39808, #40043, #40058, #40100 have been merged, FYI @yuanchao)
     - I also profited of this PR to remove from `phase1_2022_realistic_postEE` some deprecated tracking MVA tags (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/proposal-of-removal-of-bdt-based-gbrwrapperrcd-tags-for-tracking-selection-from-run-3-globaltags/16757)) which were not removed in #40010 (since the `postEE` key was not yet included in `autoCond` 😄)
        - I did not find any relval in the matrix that consumes the `postEE` GT, @cms-sw/pdmv-l2 is there a wf testing it?
   - Added a few keys in `autoCond` for the 2023 MC GTs
      - Namely: `phase1_2023_design`, `phase1_2023_cosmics`, `phase1_2023_cosmics_design` and `phase1_2023_realistic_hi`
      - I let @cms-sw/pdmv-l2 add the necessary matrix wfs to test these new 2023 MC GTs when the time comes, for now they are untested (but also identical to the 2022 ones, so no harm in not testing them)

GT differences:
- **Run 3 HLT** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_v7/126X_dataRun3_HLT_v1
- **Run 3 HLT frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v9/126X_dataRun3_HLT_frozen_v1
- **Run 3 HLT relval** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_HLT_relval_v4/126X_dataRun3_HLT_relval_v1
- **Run 3 Express** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_v9/126X_dataRun3_Express_v1
- **Run 3 Express frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v9/126X_dataRun3_Express_frozen_v1
- **Run 3 Prompt** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_v10/126X_dataRun3_Prompt_v1
- **Run 3 Prompt frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v8/126X_dataRun3_Prompt_frozen_v1
- **Run 3 offline** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v14/126X_dataRun3_v1
- **Run 3 offline relval** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_relval_v6/126X_dataRun3_relval_v1
- **2022 design** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_design_Candidate_2023_01_07_10_08_42/130X_mcRun3_2022_design_v1
- **2022 realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_Candidate_2023_01_07_10_08_42/130X_mcRun3_2022_realistic_v1
- **2022 realistic postEE** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_postEE_Candidate_2023_01_07_14_28_36/130X_mcRun3_2022_realistic_postEE_v1
- **2022 cosmic realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_realistic_deco_Candidate_2023_01_07_10_08_42/130X_mcRun3_2022cosmics_realistic_deco_v1
- **2022 cosmic design** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_design_deco_Candidate_2023_01_07_10_08_42/130X_mcRun3_2022cosmics_design_deco_v1
- **2022 realistic HI** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_Candidate_2023_01_07_10_08_42/130X_mcRun3_2022_realistic_HI_v1
- **2023 design** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_Candidate_2023_01_07_10_08_42/130X_mcRun3_2023_design_v1
- **2023 realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_Candidate_2023_01_07_10_08_42/130X_mcRun3_2023_realistic_v2
- **2023 cosmic realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_Candidate_2023_01_07_10_08_42/130X_mcRun3_2023cosmics_realistic_deco_v1
- **2023 cosmic design** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_Candidate_2023_01_07_10_08_42/130X_mcRun3_2023cosmics_design_deco_v1
- **2023 realistic HI** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_Candidate_2023_01_07_10_08_42/130X_mcRun3_2023_realistic_HI_v1
- **2024 realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_Candidate_2023_01_07_10_08_42/130X_mcRun3_2024_realistic_v2
- **Phase 2 realistic** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun4_realistic_Candidate_2023_01_07_10_08_42/130X_mcRun4_realistic_v1

#### PR validation:
Successfully tested with:
`runTheMatrix.py -l 136.731,138.5,138.4,139.001,136.899,12034.0,11634.0,7.23,312.0,12834.0,20834.0 -j10 --ibeos`

#### Backport:
Not a backport.
A backport to 12_6_X with **data GTs only** will be opened soon.