### PR TITLE
[12_6_X] Update GTs for 2023

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v7) but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v9',
+    # GlobalTag for Run3 HLT: identical to the online GT (126X_dataRun3_HLT_v1) but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_hlt'                     : '126X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v4',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v9 but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v9',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v10 but with snapshot at 2022-12-19 18:00:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v8',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-12-15 07:25:06 (UTC)
-    'run3_data'                    : '124X_dataRun3_v14',
-    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2022-12-15 07:28:44 (UTC)
-    'run3_data_relval'             : '125X_dataRun3_relval_v6',
+    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v1',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 126X_dataRun3_Express_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data_express'            : '126X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 126X_dataRun3_Prompt_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data_prompt'             : '126X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-01-06 18:15:00 (UTC)
+    'run3_data'                    : '126X_dataRun3_v1',
+    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
+    'run3_data_relval'             : '126X_dataRun3_relval_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
Partial backport of #40445:
This PR backports to `12_6_X` the updated data GTs (online, offline and relval) for 2023.

GT differences:
- **Run 3 HLT** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_v7/126X_dataRun3_HLT_v1
- **Run 3 HLT frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v9/126X_dataRun3_HLT_frozen_v1
- **Run 3 HLT relval** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_HLT_relval_v4/126X_dataRun3_HLT_relval_v1
- **Run 3 Express** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_v9/126X_dataRun3_Express_v1
- **Run 3 Express frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v9/126X_dataRun3_Express_frozen_v1
- **Run 3 Prompt** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_v10/126X_dataRun3_Prompt_v1
- **Run 3 Prompt frozen** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v8/126X_dataRun3_Prompt_frozen_v1
- **Run 3 offline** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v14/126X_dataRun3_v1
- **Run 3 offline relval** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_dataRun3_relval_v6/126X_dataRun3_relval_v1


#### PR validation:
Successfully tested with:
`runTheMatrix.py -l 136.731,138.5,138.4,139.001,136.899 -j10 --ibeos`

#### Backport:
Backport of #40445 