### PR TITLE
[12_6_X] HCAL: make HBHE zero suppression simulation identical to the data-taking one for Run3

### DIFF
--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -43,8 +43,8 @@ run2_HE_2018.toModify( simHcalDigis,
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( simHcalDigis, 
                              use1ts = cms.bool(True),
-                             HBregion = cms.vint32(4,7),
-                             HEregion = cms.vint32(4,7)
+                             HBregion = cms.vint32(5,6),  # SOI in 10TS
+                             HEregion = cms.vint32(5,6)   # SOI in 10TS
 ) 
 
 

--- a/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
+++ b/SimCalorimetry/HcalZeroSuppressionProducers/python/hcalDigisRealistic_cfi.py
@@ -27,24 +27,24 @@ simHcalDigis = cms.EDProducer("HcalRealisticZS",
 
 from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
 run2_HF_2017.toModify( simHcalDigis,
-                             HFregion = cms.vint32(1,2)
+                             HFregion = [1,2]
 )
 
 from Configuration.Eras.Modifier_run2_HB_2018_cff import run2_HB_2018
 run2_HB_2018.toModify( simHcalDigis,
-                             HBregion = cms.vint32(2,5)
+                             HBregion = [2,5]
 )
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
 run2_HE_2018.toModify( simHcalDigis,
-                             HEregion = cms.vint32(2,5)
+                             HEregion = [2,5]
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( simHcalDigis, 
-                             use1ts = cms.bool(True),
-                             HBregion = cms.vint32(5,6),  # SOI in 10TS
-                             HEregion = cms.vint32(5,6)   # SOI in 10TS
+                             use1ts = True,
+                             HBregion = [5,6],  # SOI in 10TS
+                             HEregion = [5,6]   # SOI in 10TS
 ) 
 
 


### PR DESCRIPTION
#### PR description:

**Backport** of https://github.com/cms-sw/cmssw/pull/40444
In case TSG would need to use 12_6_X for 2023 MC studies with HCAL high-DC and corresponding (high-level) ZS conditions specially prepared for these studies. 
