### PR TITLE
Avoid defining the unused numSignalAll variable in TagProbeFitter.cc

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -765,8 +765,6 @@ void TagProbeFitter::createPdf(RooWorkspace* w, vector<string>& pdfCommands) {
 
 void TagProbeFitter::setInitialValues(RooWorkspace* w) {
   // calculate initial values
-  double signalEfficiency = w->var("efficiency")->getVal();
-  double signalFractionInPassing = w->var("signalFractionInPassing")->getVal();
   double totPassing = w->data("data")->sumEntries("_efficiencyCategory_==_efficiencyCategory_::Passed");
   double totFailing = w->data("data")->sumEntries("_efficiencyCategory_==_efficiencyCategory_::Failed");
   //std::cout << "Number of probes: " << totPassing+totFailing << std::endl;
@@ -786,10 +784,6 @@ void TagProbeFitter::setInitialValues(RooWorkspace* w) {
   } else {
     w->var("efficiency")->setConstant(false);
   }
-
-  // if signal fraction is 1 then set the number of background events to 0.
-  //RooRealVar* fBkgPass = w->var("numBackgroundPass");
-  //if(signalFractionInPassing==1.0) { fBkgPass->setVal(0.0); fBkgPass->setConstant(true); }
 
   // save initial state for reference
   w->saveSnapshot("initialState", w->components());

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -768,23 +768,18 @@ void TagProbeFitter::setInitialValues(RooWorkspace* w) {
   double signalEfficiency = w->var("efficiency")->getVal();
   double signalFractionInPassing = w->var("signalFractionInPassing")->getVal();
   double totPassing = w->data("data")->sumEntries("_efficiencyCategory_==_efficiencyCategory_::Passed");
-  double totFailinging = w->data("data")->sumEntries("_efficiencyCategory_==_efficiencyCategory_::Failed");
-  double numSignalAll = totPassing * signalFractionInPassing / signalEfficiency;
+  double totFailing = w->data("data")->sumEntries("_efficiencyCategory_==_efficiencyCategory_::Failed");
+  //std::cout << "Number of probes: " << totPassing+totFailing << std::endl;
 
-  //std::cout << "Number of probes: " << totPassing+totFailinging << std::endl;
-
-  // check if this value is inconsistent on the failing side
-  if (numSignalAll * (1 - signalEfficiency) > totFailinging)
-    numSignalAll = totFailinging;
   // now set the values
-  w->var("numTot")->setVal(totPassing + totFailinging);
-  w->var("numTot")->setMax(2.0 * (totPassing + totFailinging) + 10);  //wiggle room in case of 0 events in bin
+  w->var("numTot")->setVal(totPassing + totFailing);
+  w->var("numTot")->setMax(2.0 * (totPassing + totFailing) + 10);  //wiggle room in case of 0 events in bin
 
   if (totPassing == 0) {
     w->var("efficiency")->setVal(0.0);
     w->var("efficiency")->setAsymError(0, 1);
     w->var("efficiency")->setConstant(false);
-  } else if (totFailinging == 0) {
+  } else if (totFailing == 0) {
     w->var("efficiency")->setVal(1.0);
     w->var("efficiency")->setAsymError(-1, 0);
     w->var("efficiency")->setConstant(false);


### PR DESCRIPTION
#### PR description

All usage of the variable `numSignalAll` was already removed from TagProbeFitter.cc with #9512 (9 years ago!), but it remained uselessly defined and computed in the code. All the related dead code is removed here.

I also took the opportunity to rename another variable in the same file (`totFailinging`) that had an evident typo in its name.

#### PR validation

It compiles