### PR TITLE
Add missing include in FWCore/Utilities/src/path_configuration.cc

### DIFF
--- a/FWCore/Utilities/src/path_configuration.cc
+++ b/FWCore/Utilities/src/path_configuration.cc
@@ -12,6 +12,7 @@
 
 // system include files
 #include <algorithm>
+#include <array>
 
 // user include files
 #include "FWCore/Utilities/interface/path_configuration.h"


### PR DESCRIPTION
#### PR description:

This should fix the issue reported in https://github.com/cms-sw/cmssw/pull/40425#issuecomment-1374635621 for gcc12
(Thank you @missirol for having checked and suggested)

#### PR validation:

It builds