### PR TITLE
Expanding HLT Configuration Proxy Support and Adding Tunnel Support : 13_X

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -50,7 +50,7 @@ class HLTProcess(object):
 
     # get the configuration from ConfdB
     from .confdbOfflineConverter import OfflineConverter
-    self.converter = OfflineConverter(version = self.config.menu.version, database = self.config.menu.database, proxy = self.config.proxy, proxyHost = self.config.proxy_host, proxyPort = self.config.proxy_port)
+    self.converter = OfflineConverter(version = self.config.menu.version, database = self.config.menu.database, proxy = self.config.proxy, proxyHost = self.config.proxy_host, proxyPort = self.config.proxy_port, tunnel = self.config.tunnel, tunnelPort = self.config.tunnel_port)
     self.buildPathList()
     self.buildOptions()
     self.getSetupConfigurationFromDB()

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -242,6 +242,14 @@ def help():
         --modules <p1[,p2]>         (include modules, referenced or not!)
         --blocks <m1::p1[,p2][,m2]> (generate parameter blocks)
 
+        Options to connect to target db via SOCKS proxy, or direct tunnel:
+          [the options --dbproxy and --dbtunnel are mutually exclusive]
+        --dbproxy                   (use a SOCKS proxy to connect outside CERN network [default: False])
+        --dbproxyhost <hostname>    (host of the SOCKS proxy [default: "localhost"])
+        --dbproxyport <port>        (port of the SOCKS proxy [default: 8080])
+        --dbtunnel                  (use direct tunnel to connect outside CERN network [default: False])
+        --dbtunnelport <port>       (port when using a direct tunnel on localhost [default: 10121])
+
         --verbose                   (print additional details)
 """)
 
@@ -294,8 +302,8 @@ def main():
         version = 'v3-test'
         db      = 'dev'
         args.remove('--v3-test')
-    
-    proxy=False
+
+    proxy = False
     proxy_host = "localhost"
     proxy_port = "8080"
     if '--dbproxy' in args:
@@ -347,11 +355,11 @@ def main():
             sys.exit(1)
 
     converter = OfflineConverter(version = version, database = db, verbose = verbose,
-                                 proxy = proxy, proxyHost = proxy_host, proxyPort=proxy_port,
+                                 proxy = proxy, proxyHost = proxy_host, proxyPort = proxy_port,
                                  tunnel = tunnel, tunnelPort = tunnel_port)
     out, err = converter.query( * args )
     if 'ERROR' in err:
-        sys.stderr.write( "%s: error while retriving the HLT menu\n\n%s\n\n" % (sys.argv[0], err) )
+        sys.stderr.write( "%s: error while retrieving the HLT menu\n\n%s\n\n" % (sys.argv[0], err) )
         sys.exit(1)
     else:
         sys.stdout.write( out )

--- a/HLTrigger/Configuration/python/Tools/options.py
+++ b/HLTrigger/Configuration/python/Tools/options.py
@@ -131,7 +131,9 @@ class HLTProcessOptions(object):
     self.setup      = None        #     if set, downlad the setup_cff from the specified configuration and load it.
     self.proxy      = False       #     use a socks proxy to connect
     self.proxy_host = 'localhost' #     host of the proxy server
-    self.proxy_port = '8080'        #     port of the proxy server
+    self.proxy_port = '8080'      #     port of the proxy server
+    self.tunnel     = False       #     use a direct tunnel on localhost to connect
+    self.tunnel_port = '10121'    #     port to connect to on localhost when tunneling
 
   # convert HLT and L1 menus to a dedicated object representation on the fly
   def __setattr__(self, name, value):

--- a/HLTrigger/Configuration/scripts/hltGetConfiguration
+++ b/HLTrigger/Configuration/scripts/hltGetConfiguration
@@ -75,11 +75,18 @@ parser.add_argument('--l1-emulator',
                     const   = 'Full',
                     help    = 'Run the Full stage-2 L1T emulator.' )
 
-parser.add_argument('--dbproxy',
+group = parser.add_mutually_exclusive_group()
+group.add_argument('--dbproxy',
                     dest    = 'proxy',
                     action  = 'store_true',
                     default = defaults.proxy,
                     help    = 'Use a socks proxy to connect outside CERN network (default: False)' )
+group.add_argument('--dbtunnel',
+                    dest    = 'tunnel',
+                    action  = 'store_true',
+                    default = defaults.tunnel,
+                    help    = 'Use direct tunnel to connect outside CERN network (default: False)' )
+
 parser.add_argument('--dbproxyport',
                     dest    = 'proxy_port',
                     action  = 'store',
@@ -92,6 +99,12 @@ parser.add_argument('--dbproxyhost',
                     metavar = 'PROXYHOST',
                     default = defaults.proxy_host,
                     help    = 'Host of the socks proxy (default: "localhost")' )
+parser.add_argument('--dbtunnelport',
+                    dest    = 'tunnel_port',
+                    action  = 'store',
+                    metavar = 'TUNNELPORT',
+                    default = defaults.tunnel_port,
+                    help    = 'Port when using a direct tunnel on localhost (default: 10121)' )
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--prescale',

--- a/HLTrigger/Configuration/scripts/hltGetConfiguration
+++ b/HLTrigger/Configuration/scripts/hltGetConfiguration
@@ -255,14 +255,14 @@ parser.add_argument('--help',
 # parse command line arguments and options
 config = parser.parse_args(namespace = options.HLTProcessOptions())
 
-# do not include db-proxy options in 1st-line comment
+# do not include db-proxy/tunnel options in 1st-line comment
 cmdArgs, skipNext = [], False
 for cmdArg in sys.argv:
   if skipNext:
     skipNext = False
     continue
-  if cmdArg.startswith('--dbproxy'):
-    if cmdArg.startswith('--dbproxyh') or cmdArg.startswith('--dbproxyp'):
+  if cmdArg.startswith('--dbproxy') or cmdArg.startswith('--dbtunnel'):
+    if cmdArg.startswith('--dbproxyh') or cmdArg.startswith('--dbproxyp') or cmdArg.startswith('--dbtunnelp'):
       skipNext = '=' not in cmdArg
     continue
   cmdArgs += [cmdArg]


### PR DESCRIPTION
#### PR description:

This is the reopening of https://github.com/cms-sw/cmssw/pull/40436 as I had to apply changes on top of existing 13_X changes thus one branch doesnt work for all now



From https://github.com/cms-sw/cmssw/pull/40436
Confdb access is restricted to within the CERN network and thus for users outside CERN they must connect via tunnels.

Currently hltGetConfiguration and hltConfigFromDB allow the use of a socks proxy to allow users outside CERN to download menus. However the IPs need to be harcoded due to DNS issues (an issue with Java which as far as we are aware is unsolvable).

Only the offline DB had its IPs hardcoded, we now add IPs for the online (p5 only) and online mirror (accessable outside p5) so users can also use a proxy for these dbs.

Finally to have a work around in the future, support for direct tunnels where a user specifically forwards a given port on their machine to a db has been added so we can always fall back on this.

Aim to back port to 12_4, 12_5, 12_6

