### PR TITLE
`AlignmentValidation`: remove ROOT6 warning about `RooMinimizer`

### DIFF
--- a/Alignment/OfflineValidation/bin/FitWithRooFit.cc
+++ b/Alignment/OfflineValidation/bin/FitWithRooFit.cc
@@ -23,7 +23,7 @@
 #include "RooPolynomial.h"
 #include "RooCBShape.h"
 #include "RooChi2Var.h"
-#include "RooMinuit.h"
+#include "RooMinimizer.h"
 #include "RooBreitWigner.h"
 #include "RooFFTConvPdf.h"
 
@@ -126,7 +126,7 @@ public:
     // Fit with chi^2
     else {
       std::cout << "FITTING WITH CHI^2" << std::endl;
-      RooMinuit m(chi2);
+      RooMinimizer m(chi2);
       m.migrad();
       m.hesse();
       // RooFitResult* r_chi2_wgt = m.save();


### PR DESCRIPTION
#### PR description:

Title says it all, removes compilation warning 

```
warning: #warning "The deprecated RooMinuit class was replaced by the more general RooMinimizer. The RooMinuit class will be gone in ROOT 6.30! Migrating to the RooMinimizer is easy because the interface is backwards compatible. [-Wcpp]
     1 | #warning "The deprecated RooMinuit class was replaced by the more general RooMinimizer. \
      |  ^~~~~~~
```

seen in the [CMSSW_13_0_ROOT6X  compilation logs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_13_0_ROOT6_X_2023-01-08-2300/Alignment/OfflineValidation) .

#### PR validation:

Compiles in `CMSSW_13_0_ROOT6_X_2023-01-08-2300`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
