### PR TITLE
Add more Pixel tracks SoA monitoring

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
@@ -89,6 +89,7 @@ private:
   MonitorElement* hnLayers_;
   MonitorElement* hnLayersVsPhi_;
   MonitorElement* hnLayersVsEta_;
+  MonitorElement* hCharge_;
   MonitorElement* hchi2_;
   MonitorElement* hChi2VsPhi_;
   MonitorElement* hChi2VsEta_;
@@ -101,10 +102,13 @@ private:
   MonitorElement* hquality_;
   //1D differences
   MonitorElement* hptdiffMatched_;
+  MonitorElement* hCurvdiffMatched_;
   MonitorElement* hetadiffMatched_;
   MonitorElement* hphidiffMatched_;
   MonitorElement* hzdiffMatched_;
-  //for matching eff vs region:dervie ration at harvesting
+  MonitorElement* htipdiffMatched_;
+
+  //for matching eff vs region: derive the ratio at harvesting
   MonitorElement* hpt_eta_tkAllCPU_;
   MonitorElement* hpt_eta_tkAllCPUMatched_;
   MonitorElement* hphi_z_tkAllCPU_;
@@ -213,9 +217,11 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     hz_->Fill(tsoaCPU.zip(it), tsoaGPU.zip(closestTkidx));
     htip_->Fill(tsoaCPU.tip(it), tsoaGPU.tip(closestTkidx));
     hptdiffMatched_->Fill(tsoaCPU.pt(it) - tsoaGPU.pt(closestTkidx));
+    hCurvdiffMatched_->Fill((tsoaCPU.charge(it) / tsoaCPU.pt(it)) - (tsoaGPU.charge(closestTkidx) / tsoaGPU.pt(closestTkidx)));
     hetadiffMatched_->Fill(etacpu - tsoaGPU.eta(closestTkidx));
     hphidiffMatched_->Fill(reco::deltaPhi(phicpu, tsoaGPU.phi(closestTkidx)));
     hzdiffMatched_->Fill(tsoaCPU.zip(it) - tsoaGPU.zip(closestTkidx));
+    htipdiffMatched_->Fill(tsoaCPU.tip(it) - tsoaGPU.tip(closestTkidx));
     hpt_eta_tkAllCPUMatched_->Fill(etacpu, tsoaCPU.pt(it));  //matched to gpu
     hphi_z_tkAllCPUMatched_->Fill(phicpu, tsoaCPU.zip(it));
   }
@@ -251,6 +257,9 @@ void SiPixelCompareTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
   toRep = "Track (quality #geq loose) #chi^{2}/ndof";
   hchi2_ = iBook.book2I("nChi2ndof", fmt::sprintf("%s;CPU;GPU",toRep), 40, 0., 20., 40, 0., 20.);
 
+  toRep = "Track (quality #geq loose) charge";
+  hCharge_ = iBook.book2I("charge",fmt::sprintf("%s;CPU;GPU",toRep),3, -1.5, 1.5, 3, -1.5, 1.5);
+
   hpt_ = iBook.book2I("pt", "Track (quality #geq loose) p_{T} [GeV];CPU;GPU", 200, 0., 200., 200, 0., 200.);
   hptLogLog_ = make2DIfLog(iBook, true, true, "ptLogLog", "Track (quality #geq loose) p_{T} [GeV];CPU;GPU", 200, log10(0.5), log10(200.), 200, log10(0.5), log10(200.));
   heta_ = iBook.book2I("eta", "Track (quality #geq loose) #eta;CPU;GPU", 30, -3., 3., 30, -3., 3.);
@@ -259,9 +268,11 @@ void SiPixelCompareTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
   htip_ = iBook.book2I("tip", "Track (quality #geq loose) TIP [cm];CPU;GPU", 100, -0.5, 0.5, 100, -0.5, 0.5);
   //1D difference plots
   hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 60, -30., 30.);
+  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV] between matched tracks; #Delta q/p_{T} [GeV]", 60, -30., 30.);
   hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 160, -0.04 ,0.04);
   hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  160, -0.04 ,0.04);
   hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 300, -1.5, 1.5);
+  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 300, -1.5, 1.5);
   //2D plots for eff
   hpt_eta_tkAllCPU_ = iBook.book2I("ptetatrkAllCPU", "Track (quality #geq loose) on CPU; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
   hpt_eta_tkAllCPUMatched_ = iBook.book2I("ptetatrkAllCPUmatched", "Track (quality #geq loose) on CPU matched to GPU track; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
@@ -208,6 +208,7 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     nLooseAndAboveTracksCPU_matchedGPU++;
 
     hchi2_->Fill(tsoaCPU.chi2(it), tsoaGPU.chi2(closestTkidx));
+    hCharge_->Fill(tsoaCPU.charge(it), tsoaGPU.charge(closestTkidx));
     hnHits_->Fill(tsoaCPU.nHits(it), tsoaGPU.nHits(closestTkidx));
     hnLayers_->Fill(tsoaCPU.nLayers(it), tsoaGPU.nLayers(closestTkidx));
     hpt_->Fill(tsoaCPU.pt(it), tsoaGPU.pt(closestTkidx));
@@ -217,7 +218,8 @@ void SiPixelCompareTrackSoA<T>::analyze(const edm::Event& iEvent, const edm::Eve
     hz_->Fill(tsoaCPU.zip(it), tsoaGPU.zip(closestTkidx));
     htip_->Fill(tsoaCPU.tip(it), tsoaGPU.tip(closestTkidx));
     hptdiffMatched_->Fill(tsoaCPU.pt(it) - tsoaGPU.pt(closestTkidx));
-    hCurvdiffMatched_->Fill((tsoaCPU.charge(it) / tsoaCPU.pt(it)) - (tsoaGPU.charge(closestTkidx) / tsoaGPU.pt(closestTkidx)));
+    hCurvdiffMatched_->Fill((tsoaCPU.charge(it) / tsoaCPU.pt(it)) -
+                            (tsoaGPU.charge(closestTkidx) / tsoaGPU.pt(closestTkidx)));
     hetadiffMatched_->Fill(etacpu - tsoaGPU.eta(closestTkidx));
     hphidiffMatched_->Fill(reco::deltaPhi(phicpu, tsoaGPU.phi(closestTkidx)));
     hzdiffMatched_->Fill(tsoaCPU.zip(it) - tsoaGPU.zip(closestTkidx));
@@ -242,7 +244,7 @@ void SiPixelCompareTrackSoA<T>::bookHistograms(DQMStore::IBooker& iBook,
 
   // clang-format off
   std::string toRep = "Number of tracks";
-  // FIXME: all the 2D correlation plots are quite heavy in terms of memory consumption, so a as soon as DQM supports either TH2I or THnSparse
+  // FIXME: all the 2D correlation plots are quite heavy in terms of memory consumption, so a as soon as DQM supports THnSparse
   // these should be moved to a less resource consuming format
   hnTracks_ = iBook.book2I("nTracks", fmt::sprintf("%s per event; CPU; GPU",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
   hnLooseAndAboveTracks_ = iBook.book2I("nLooseAndAboveTracks", fmt::sprintf("%s (quality #geq loose) per event; CPU; GPU",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelTrackComparisonHarvester.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelTrackComparisonHarvester.cc
@@ -7,12 +7,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+
+// for string manipulations
+#include <fmt/printf.h>
+
 class SiPixelTrackComparisonHarvester : public DQMEDHarvester {
 public:
   explicit SiPixelTrackComparisonHarvester(const edm::ParameterSet&);
   ~SiPixelTrackComparisonHarvester() override = default;
   void dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) override;
-
+  void project2DalongDiagonal(MonitorElement* input2D, DQMStore::IBooker& ibooker);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -45,6 +49,55 @@ void SiPixelTrackComparisonHarvester::dqmEndJob(DQMStore::IBooker& ibooker, DQMS
 
   hpt_eta_matchRatio->divide(hpt_eta_tkAllCPUmatched, hpt_eta_tkAllCPU, 1., 1., "B");
   hphi_z_matchRatio->divide(hphi_z_tkAllCPUmatched, hphi_z_tkAllCPU, 1., 1., "B");
+
+  // now create the 1D projection from the 2D histograms
+  std::vector<std::string> listOfMEsToProject = {"nTracks",
+                                                 "nLooseAndAboveTracks",
+                                                 "nLooseAndAboveTracks_matched",
+                                                 "nRecHits",
+                                                 "nLayers",
+                                                 "nChi2ndof",
+                                                 "charge",
+                                                 "pt",
+                                                 "eta",
+                                                 "phi",
+                                                 "z",
+                                                 "tip"};
+  for (const auto& me : listOfMEsToProject) {
+    MonitorElement* input2D = igetter.get(topFolder_ + "/" + me);
+    this->project2DalongDiagonal(input2D, ibooker);
+  }
+}
+
+void SiPixelTrackComparisonHarvester::project2DalongDiagonal(MonitorElement* input2D, DQMStore::IBooker& ibooker) {
+  if (input2D == nullptr) {
+    edm::LogError("SiPixelTrackComparisonHarvester")
+        << "MEs needed for diagonal projection are not found in the input file. Skipping.";
+    return;
+  }
+
+  ibooker.cd();
+  ibooker.setCurrentFolder(topFolder_ + "/projectedDifferences");
+  const auto& h_name = fmt::sprintf("%s_proj", input2D->getName());
+  const auto& h_title = fmt::sprintf(";%s CPU -GPU difference", input2D->getTitle());
+  const auto& span = (input2D->getAxisMax() - input2D->getAxisMin());
+  const auto& b_w = span / input2D->getNbinsX();
+  const auto& nbins = ((input2D->getNbinsX() % 2) == 0) ? input2D->getNbinsX() + 1 : input2D->getNbinsX();
+
+  MonitorElement* diagonalized = ibooker.book1D(h_name, h_title, nbins, -span / 2., span / 2.);
+
+  // collect all the entry on each diagonal of the 2D histogram
+  for (int i = 1; i <= input2D->getNbinsX(); i++) {
+    for (int j = 1; j <= input2D->getNbinsY(); j++) {
+      diagonalized->Fill((i - j) * b_w, input2D->getBinContent(i, j));
+    }
+  }
+
+  // zero the error on the bin as it's sort of meaningless for the way we fill it
+  // by collecting the entry on each diagonal
+  for (int bin = 1; bin <= diagonalized->getNbinsX(); bin++) {
+    diagonalized->setBinError(bin, 0.f);
+  }
 }
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"


### PR DESCRIPTION
#### PR description:

The goal of this PR is two-fold:
   * add more monitoring histograms for SoA Tracks (done in commit 218cbd4153bab0cddc8928f9c127d6e5919b044a)
   * add 1D projections of the 2D scatter plot histograms of GPU vs CPU quantities for selected variables (done in commit 6a143ccddcdb267eb603a9ab97a397714a2abd8c).

#### PR validation:

Run successfully: `runTheMatrix.py -l 21034.507, 20834.507 -t 4 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
