### PR TITLE
use `std::vector<T>::operator[]` in `edm::HLTGlobalStatus::operator[]`

### DIFF
--- a/DataFormats/Common/interface/HLTGlobalStatus.h
+++ b/DataFormats/Common/interface/HLTGlobalStatus.h
@@ -18,10 +18,12 @@
 #include "DataFormats/Common/interface/HLTenums.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
 
-#include <vector>
+#include <string>
 #include <ostream>
+#include <vector>
 
 namespace edm {
+
   class HLTGlobalStatus {
   private:
     /// Status of each HLT path
@@ -50,12 +52,12 @@ namespace edm {
     /// Has any path encountered an error (exception)
     bool error() const { return State(2); }
 
-    // get hold of individual elements, using safe indexing with "at" which throws!
+    // accessors to ith element of paths_
 
     const HLTPathStatus& at(const unsigned int i) const { return paths_.at(i); }
     HLTPathStatus& at(const unsigned int i) { return paths_.at(i); }
-    const HLTPathStatus& operator[](const unsigned int i) const { return paths_.at(i); }
-    HLTPathStatus& operator[](const unsigned int i) { return paths_.at(i); }
+    const HLTPathStatus& operator[](const unsigned int i) const { return paths_[i]; }
+    HLTPathStatus& operator[](const unsigned int i) { return paths_[i]; }
 
     /// Was ith path run?
     bool wasrun(const unsigned int i) const { return at(i).wasrun(); }
@@ -102,7 +104,7 @@ namespace edm {
   /// Free swap function
   inline void swap(HLTGlobalStatus& lhs, HLTGlobalStatus& rhs) { lhs.swap(rhs); }
 
-  /// Formatted printout of trigger tbale
+  /// Formatted printout of trigger table
   inline std::ostream& operator<<(std::ostream& ost, const HLTGlobalStatus& hlt) {
     std::vector<std::string> text(4);
     text[0] = "n";
@@ -111,7 +113,7 @@ namespace edm {
     text[3] = "e";
     const unsigned int n(hlt.size());
     for (unsigned int i = 0; i != n; ++i)
-      ost << text.at(hlt.state(i));
+      ost << text[hlt.state(i)];
     return ost;
   }
 

--- a/FWCore/Framework/src/EventSelector.cc
+++ b/FWCore/Framework/src/EventSelector.cc
@@ -370,7 +370,7 @@ namespace edm {
     bool lookForException = (s == hlt::Exception);
     for (auto const& bit : b) {
       hlt::HLTState bstate = lookForException ? hlt::Exception : bit.accept_state_ ? hlt::Pass : hlt::Fail;
-      if (tr[bit.pos_].state() == bstate)
+      if (tr.at(bit.pos_).state() == bstate)
         return true;
     }
     return false;
@@ -381,7 +381,7 @@ namespace edm {
   bool EventSelector::acceptAllBits(Bits const& b, HLTGlobalStatus const& tr) const {
     for (auto const& bit : b) {
       hlt::HLTState bstate = bit.accept_state_ ? hlt::Pass : hlt::Fail;
-      if (tr[bit.pos_].state() != bstate)
+      if (tr.at(bit.pos_).state() != bstate)
         return false;
     }
     return true;

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -174,7 +174,7 @@ namespace edm {
 
   void Path::recordStatus(int nwrwue, hlt::HLTState state) {
     if (trptr_) {
-      (*trptr_)[bitpos_] = HLTPathStatus(state, nwrwue);
+      trptr_->at(bitpos_) = HLTPathStatus(state, nwrwue);
     }
   }
 

--- a/FWCore/Framework/test/stubs/TestTriggerNames.cc
+++ b/FWCore/Framework/test/stubs/TestTriggerNames.cc
@@ -239,6 +239,11 @@ namespace edmtest {
 
     if (expectedTriggerResultsHLT_.size() > 0) {
       if (e.getByLabel(tag, hTriggerResults)) {
+        if (hTriggerResults->size() == 0) {
+          throw cms::Exception("Test Failure") << "TestTriggerNames: TriggerResults object from the Event "
+                                                  "(InputTag = \"TriggerResults::HLT\") is empty (size == 0)";
+        }
+
         edm::TriggerResultsByName resultsByNameHLT = e.triggerResultsByName(*hTriggerResults);
 
         if (hTriggerResults->parameterSetID() != resultsByNameHLT.parameterSetID() ||
@@ -263,9 +268,8 @@ namespace edmtest {
             hTriggerResults->error(0) != resultsByNameHLT.error(0) ||
             hTriggerResults->state(0) != resultsByNameHLT.state(0) ||
             hTriggerResults->index(0) != resultsByNameHLT.index(0)) {
-          throw cms::Exception("Test Failure")
-              << "TestTriggerNames: While testing TriggerResultsByName class\n"
-              << "TriggerResults values do not match TriggerResultsByName values" << std::endl;
+          throw cms::Exception("Test Failure") << "TestTriggerNames: While testing TriggerResultsByName class\n"
+                                               << "TriggerResults values do not match TriggerResultsByName values";
         }
         edm::TriggerNames const& names = e.triggerNames(*hTriggerResults);
         if (names.triggerNames() != resultsByNameHLT.triggerNames() || names.size() != resultsByNameHLT.size() ||


### PR DESCRIPTION
#### PR description:

This PR modifies the implementation of the methods `edm::HLTGlobalStatus::operator[]`, to use `std::vector<T>::operator[]` rather than `std::vector<T>::at` (the methods `edm::HLTGlobalStatus::at` remain available, and use `std::vector<T>::at`).

Arguably, the DataFormat should allow access to the faster `std::vector<T>::operator[]`, leaving it to users to choose the method (`at` or `[]`) most appropriate to their use case.

Reminder: `edm::HLTGlobalStatus` is a base class of `edm::TriggerResults`.

FYI: @cms-sw/hlt-l2

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
