### PR TITLE
Refactoring CalibratedClusterPtr to CalibratedPFCluster

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -61,8 +61,7 @@
   \date July 2012
 */
 
-typedef std::shared_ptr<CalibratedPFCluster> CalibratedClusterPtr;
-typedef std::vector<CalibratedClusterPtr> CalibratedClusterPtrVector;
+typedef std::vector<CalibratedPFCluster> CalibratedPFClusterVector;
 
 class PFECALSuperClusterAlgo {
 public:
@@ -142,19 +141,19 @@ private:
   const EcalMustacheSCParameters* mustacheSCParams_;
   const EcalSCDynamicDPhiParameters* scDynamicDPhiParams_;
 
-  CalibratedClusterPtrVector _clustersEB;
-  CalibratedClusterPtrVector _clustersEE;
+  CalibratedPFClusterVector _clustersEB;
+  CalibratedPFClusterVector _clustersEE;
   std::unique_ptr<reco::SuperClusterCollection> superClustersEB_;
   std::unique_ptr<reco::SuperClusterCollection> superClustersEE_;
   const reco::PFCluster::EEtoPSAssociation* EEtoPS_;
   std::shared_ptr<PFEnergyCalibration> _pfEnergyCalibration;
   clustering_type _clustype;
   energy_weight _eweight;
-  void buildAllSuperClusters(CalibratedClusterPtrVector&, double seedthresh);
-  void buildAllSuperClustersMustacheOrBox(CalibratedClusterPtrVector&, double seedthresh);
-  void buildAllSuperClustersDeepSC(CalibratedClusterPtrVector&, double seedthresh);
-  void buildSuperClusterMustacheOrBox(CalibratedClusterPtr&, CalibratedClusterPtrVector&);
-  void finalizeSuperCluster(CalibratedClusterPtr& seed, CalibratedClusterPtrVector& clustered, bool isEE);
+  void buildAllSuperClusters(CalibratedPFClusterVector&, double seedthresh);
+  void buildAllSuperClustersMustacheOrBox(CalibratedPFClusterVector&, double seedthresh);
+  void buildAllSuperClustersDeepSC(CalibratedPFClusterVector&, double seedthresh);
+  void buildSuperClusterMustacheOrBox(CalibratedPFCluster&, CalibratedPFClusterVector&);
+  void finalizeSuperCluster(CalibratedPFCluster& seed, CalibratedPFClusterVector& clustered, bool isEE);
 
   bool verbose_;
 

--- a/RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h
@@ -52,11 +52,10 @@ namespace reco {
 
   class EcalClustersGraph {
   public:
-    typedef std::shared_ptr<CalibratedPFCluster> CalibratedClusterPtr;
-    typedef std::vector<CalibratedClusterPtr> CalibratedClusterPtrVector;
-    typedef std::vector<std::pair<CalibratedClusterPtr, CalibratedClusterPtrVector>> EcalGraphOutput;
+    typedef std::vector<CalibratedPFCluster> CalibratedPFClusterVector;
+    typedef std::vector<std::pair<CalibratedPFCluster, CalibratedPFClusterVector>> EcalGraphOutput;
 
-    EcalClustersGraph(CalibratedClusterPtrVector clusters,
+    EcalClustersGraph(CalibratedPFClusterVector clusters,
                       int nSeeds,
                       const CaloTopology* topology,
                       const CaloSubdetectorGeometry* ebGeom,
@@ -95,7 +94,7 @@ namespace reco {
     std::pair<double, double> computeCovariances(const CaloCluster* cluster);
     std::vector<double> computeShowerShapes(const CaloCluster* cluster, bool full5x5);
 
-    CalibratedClusterPtrVector clusters_;
+    CalibratedPFClusterVector clusters_;
     uint nSeeds_;
     uint nCls_;
 

--- a/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
@@ -5,10 +5,9 @@ using namespace std;
 using namespace reco;
 using namespace reco::DeepSCInputs;
 
-typedef std::shared_ptr<CalibratedPFCluster> CalibratedClusterPtr;
-typedef std::vector<CalibratedClusterPtr> CalibratedClusterPtrVector;
+typedef std::vector<CalibratedPFCluster> CalibratedPFClusterVector;
 
-EcalClustersGraph::EcalClustersGraph(CalibratedClusterPtrVector clusters,
+EcalClustersGraph::EcalClustersGraph(CalibratedPFClusterVector clusters,
                                      int nSeeds,
                                      const CaloTopology* topology,
                                      const CaloSubdetectorGeometry* ebGeom,
@@ -135,9 +134,9 @@ std::array<double, 3> EcalClustersGraph::dynamicWindow(double seedEta) const {
 
 void EcalClustersGraph::initWindows() {
   for (uint is = 0; is < nSeeds_; is++) {
-    const auto& seedLocal = clusterPosition((*clusters_[is]).ptr().get());
-    double seed_eta = clusters_[is]->eta();
-    double seed_phi = clusters_[is]->phi();
+    const auto& seedLocal = clusterPosition((clusters_[is]).ptr().get());
+    double seed_eta = clusters_[is].eta();
+    double seed_phi = clusters_[is].phi();
     const auto& width = dynamicWindow(seed_eta);
     // Add a self loop on the seed node
     graphMap_.addEdge(is, is);
@@ -151,9 +150,9 @@ void EcalClustersGraph::initWindows() {
     for (uint icl = is + 1; icl < nCls_; icl++) {
       if (is == icl)
         continue;
-      const auto& clusterLocal = clusterPosition((*clusters_[icl]).ptr().get());
-      double cl_eta = clusters_[icl]->eta();
-      double cl_phi = clusters_[icl]->phi();
+      const auto& clusterLocal = clusterPosition((clusters_[icl]).ptr().get());
+      double cl_eta = clusters_[icl].eta();
+      double cl_phi = clusters_[icl].phi();
       double dphi = deltaPhi(seed_phi, cl_phi);
       double deta = deltaEta(seed_eta, cl_eta);
 
@@ -365,7 +364,7 @@ void EcalClustersGraph::fillVariables() {
 
   // Looping on all the seeds (window)
   for (uint is = 0; is < nSeeds_; is++) {
-    const auto seedPointer = (*clusters_[is]).ptr().get();
+    const auto seedPointer = (clusters_[is]).ptr().get();
     std::vector<DeepSCInputs::FeaturesMap> unscaledClusterFeatures;
     const auto& outEdges = graphMap_.getOutEdges(is);
     size_t ncls = outEdges.size();
@@ -377,7 +376,7 @@ void EcalClustersGraph::fillVariables() {
     // Loop on all the clusters
     for (const auto ic : outEdges) {
       LogTrace("EcalClustersGraph") << "seed: " << is << ", out edge --> " << ic;
-      const auto clPointer = (*clusters_[ic]).ptr().get();
+      const auto clPointer = (clusters_[ic]).ptr().get();
       const auto& clusterFeatures = computeVariables(seedPointer, clPointer);
       for (const auto& [key, val] : clusterFeatures) {
         LogTrace("EcalCluster") << key << "=" << val;
@@ -427,8 +426,8 @@ EcalClustersGraph::EcalGraphOutput EcalClustersGraph::getGraphOutput() {
   EcalClustersGraph::EcalGraphOutput finalWindows_;
   const auto& finalSuperClusters_ = graphMap_.getGraphOutput();
   for (const auto& [is, cls] : finalSuperClusters_) {
-    CalibratedClusterPtr seed = clusters_[is];
-    CalibratedClusterPtrVector clusters_inWindow;
+    CalibratedPFCluster seed = clusters_[is];
+    CalibratedPFClusterVector clusters_inWindow;
     for (const auto& ic : cls) {
       clusters_inWindow.push_back(clusters_[ic]);
     }


### PR DESCRIPTION
#### PR description:

As suggested in the issue https://github.com/cms-sw/cmssw/issues/38059, the type `typedef std::shared_ptr<CalibratedPFCluster> CalibratedClusterPtr`, which  is essentially a `shared_ptr<edm::Ptr<reco::PFCluster>>`   can be replaced by just using `CalibratedPFCluster` by value.  This type is heavily used in PFEcalSuperCluster code.

The second part of the issue https://github.com/cms-sw/cmssw/issues/38059 about the use of `vector<CalibratedPFCluster>` instead of `edm::PtrVector<>` is postponed to a later PR.  For the moment, the `CalibratedClusterPtrVector` has been changed from `vector<shared_ptr<CalibratedPFCluster>>` to `vector<CalibratedPFCluster>`.

#### PR validation:
This PR should not have any side effect. It would be interesting to trigger the profiling ON to check for any memory/timing improvement.
