### PR TITLE
fix GEM inputs for `L1REPACK:FullMC`

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK CalouGT : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK Full2015Data : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full2015Data only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:Full2015Data only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.DTTFRawToDigi.dttfunpacker_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK FullSimTP : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:FullSimTP (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:FullSimTP (intended for data) only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:FullSimTP (intended for data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
+## L1REPACK Full : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:Full only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 
@@ -97,7 +97,7 @@ simTwinMuxDigis.RPC_Source         = 'unpackRPCTwinMux'
 simTwinMuxDigis.DTDigi_Source      = "unpackTwinMux:PhIn"
 simTwinMuxDigis.DTThetaDigi_Source = "unpackTwinMux:ThIn"
 
-run3_GEM.toModify(simMuonGEMPadDigis,
+(stage2L1Trigger & run3_GEM).toModify(simMuonGEMPadDigis,
     InputCollection = 'unpackGEM'
 )
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -1,16 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK uGT : Re-Emulate L1 uGT and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT"))
 
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:uGT only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:uGT will unpack uGMT and CaloLayer2 outputs, and re-emulate uGT"))
 
 # First, inputs to uGT:
 import EventFilter.L1TRawToDigi.gtStage2Digis_cfi


### PR DESCRIPTION
#### PR description:

It looks like `L1REPACK:FullMC` does not work as expected on EDM inputs without the DIGI data tier, as [1] returns [2].

(This would suggest that, up to now, users were simply reading the GEM digis from the EDM inputs when running `L1REPACK:FullMC`.)

This PR is a tentative fix (I'm not a domain expert). It is based on what is currently done for `L1REPACK:Full` (which is for real data, as opposed to `L1REPACK:FullMC` which is for MC), e.g.
https://github.com/cms-sw/cmssw/blob/a8e4ccae45c0e50fba6f716327e0ef4bfd1f145f/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py#L168-L170
(`L1REPACK:Full` was fixed in #36133, based on https://github.com/cms-sw/cmssw/pull/36133#issuecomment-971473027)

[1]
```
cmsDriver.py step2 -s L1REPACK:FullMC --conditions auto:phase1_2022_realistic_postEE --era Run3 \
  --datatier RAW --eventcontent RAW --geometry DB:Extended --nThreads 1 --nStreams 0 -n 10 \
  --filein /store/mc/Run3Summer22EEDR/QCD_Pt-120To170_TuneCP5_13p6TeV-pythia8/GEN-SIM-RAW/Poisson70KeepRAW_124X_mcRun3_2022_realistic_postEE_v1-v1/80000/55194757-7f7a-4fac-83b2-fc6e0b5fe7f5.root
```

[2]
```
----- Begin Fatal Exception 09-Jan-2023 18:08:53 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 104 event: 103002 stream: 0
   [1] Running path 'RAWoutput_step'
   [2] Prefetching for module PoolOutputModule/'RAWoutput'
   [3] Prefetching for module RawDataCollectorByLabel/'rawDataCollector'
   [4] Prefetching for module L1TDigiToRaw/'packGmtStage2'
   [5] Prefetching for module L1TMuonOverlapPhase1TrackProducer/'simOmtfDigis'
   [6] Prefetching for module CSCTriggerPrimitivesProducer/'simCscTriggerPrimitiveDigis'
   [7] Prefetching for module GEMPadDigiClusterProducer/'simMuonGEMPadDigiClusters'
   [8] Calling method for module GEMPadDigiProducer/'simMuonGEMPadDigis'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: MuonDigiCollection<GEMDetId,GEMDigi>
Looking for module label: simMuonGEMDigis
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "SkipEvent = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

Nothing beyond the use case described in the PR description.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

~~Plan to backport to (at least) `12_6_X` to aid HLT studies.~~

`CMSSW_12_4_X`
`CMSSW_12_5_X`
`CMSSW_12_6_X`