### PR TITLE
Unregister deprecated.ESRecordGetChecker; remove generation of eventsetuprecord-get.txt

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_statics_esd_reports.sh
@@ -46,12 +46,3 @@ edm-global-class.py >edm-global-classes.txt.unsorted
 sort -u edm-global-classes.txt.unsorted | grep -e"^EDM global class " | sort -u >edm-global-classes.txt
 sort -u edm-global-classes.txt.unsorted | grep -v -e"^EDM global class " >edm-global-classes.txt.extra
 
-if [ ! -f ./callgraph.py ]
-   then
-   cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/callgraph.py .
-   cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/module_to_package.yaml .
-   cp -pv ${CMSSW_BASE}/src/Utilities/StaticAnalyzers/scripts/modules_in_ib.yaml .
-fi
-curl -OL https://raw.githubusercontent.com/fwyzard/circles/master/web/groups/packages.json
-touch eventsetuprecord-get-all.txt eventsetuprecord-get.txt
-./callgraph.py 2>&1 | tee eventsetuprecord-get.txt

--- a/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
+++ b/Utilities/StaticAnalyzers/src/ClangCmsCheckerPluginRegister.cpp
@@ -91,8 +91,6 @@ extern "C" void clang_registerCheckers(clang::ento::CheckerRegistry &registry) {
       "optional.EDMPluginDumper", "Dumps macro DEFINE_EDM_PLUGIN types", "no docs");
   registry.addChecker<clangcms::ThrUnsafeFCallChecker>(
       "threadsafety.ThrUnsafeFCallChecker", "Reports calls of known thread unsafe functions", "no docs");
-  registry.addChecker<clangcms::ESRGetChecker>(
-      "deprecated.ESRecordGetChecker", "Checks for calls to EventSetupRecord::get", "no docs");
 }
 
 extern "C" const char clang_analyzerAPIVersionString[] = CLANG_ANALYZER_API_VERSION_STRING;


### PR DESCRIPTION
This removes the deprecated.ESRecordGetChecker that is no longer needed.