### PR TITLE
Fix `BOOST_HEADER_DEPRECATED` msg and move to `boost/phoenix.hpp` in `FastSimulation` pkg

### DIFF
--- a/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
@@ -6,7 +6,7 @@
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_rule.hpp>
 #include <boost/spirit/include/qi_grammar.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 
 #define DETIDFCT(NAME) NAME, [](const TrackerTopology& trackerTopology, const DetId& detId) -> int
 


### PR DESCRIPTION
#### PR description:

I happen to ran into the compilation warning
```
/cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02766/slc7_amd64_gcc11/external/boost/1.80.0-a44ab822e2d2aa04100a5d9f1d2edd4d/include/boost/spirit/include/phoenix.hpp:12:1: note: '#pragma message: This header is deprecated. Use <boost/phoenix.hpp> instead.'
   12 | BOOST_HEADER_DEPRECATED("<boost/phoenix.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
```
when compiling `FastSimulation/TrackingRecHitProducer`.
It seemed easy to fix so here is the PR.

#### PR validation:

Code compiled w/o the error msg above.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

