### PR TITLE
Mask more old b-taggers for run3_common

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -80,6 +80,13 @@ def applySubstructure( process, postfix="" ) :
         groomedFatJets=cms.InputTag('ak8PFJetsPuppiSoftDrop') # needed for subjet flavor clustering
     )
 
+    from Configuration.Eras.Modifier_run3_common_cff import run3_common
+    run3_common.toModify(process.patJetsAK8PFPuppiSoftDropSubjets,
+                         discriminatorSources = cms.VInputTag(
+                            cms.InputTag("pfDeepCSVJetTagsAK8PFPuppiSoftDropSubjets","probb"),
+                            cms.InputTag("pfDeepCSVJetTagsAK8PFPuppiSoftDropSubjets","probbb")
+                         )
+    )
 
     # add groomed ECFs and N-subjettiness to soft dropped pat::Jets for fat jets and subjets
     process.load('RecoJets.JetProducers.ECF_cff')
@@ -130,6 +137,16 @@ def applySubstructure( process, postfix="" ) :
     getattr(process,"selectedPatJetsAK8Puppi"+postfix).cut = cms.string("pt > 100")
     getattr(process,"selectedPatJetsAK8Puppi"+postfix).cutLoose = cms.string("pt > 30")
     getattr(process,"selectedPatJetsAK8Puppi"+postfix).nLoose = cms.uint32(3)
+
+    from Configuration.Eras.Modifier_run3_common_cff import run3_common
+    run3_common.toModify(process.patJetsAK8Puppi,
+                         discriminatorSources = cms.VInputTag(
+                            cms.InputTag("pfDeepCSVJetTagsAK8Puppi","probb"),
+                            cms.InputTag("pfDeepCSVJetTagsAK8Puppi","probc"),
+                            cms.InputTag("pfDeepCSVJetTagsAK8Puppi","probudsg"),
+                            cms.InputTag("pfDeepCSVJetTagsAK8Puppi","probbb")
+                         )
+    )
 
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
     addToProcessAndTask('ak8PFJetsPuppiTracksAssociatorAtVertex'+postfix, cms.EDProducer("JetTracksAssociatorAtVertex",

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVAComputers_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVAComputers_cff.py
@@ -45,3 +45,11 @@ positiveSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
     softPFMuonCommon,
     ipSign = cms.string("positive")
 )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(softPFElectronComputer,
+                     useCondDB = cms.bool(False),
+)
+run3_common.toModify(softPFMuonComputer,
+                     useCondDB = cms.bool(False),
+)


### PR DESCRIPTION
#### PR description:
This PR is part of https://github.com/cms-AlCaDB/AlCaTools/issues/58 to clean-up old b-tagging tags that are deprecated for Run3 (similar to #40043) and which are giving errors in the tests of #40445 (which actually removes the b-tagging tags from the Run3 MC GTs).
Namely:
 - in `SoftLeptonByMVAComputers_cff.py` the `useCondDB` flag is set to `False` for Run3 so that the BDT loads the weights from the xml and not from the CondDB tag.
 - in `applySubstructure_cff.py` only the `DeepCSV` taggers are kept for `patJetsAK8PFPuppiSoftDropSubjets` and `patJetsAK8Puppi`

I'd like to ask @cms-sw/btv-pog-l2 and @AlexDeMoor (who were previously involved in the review of similar PRs) if they agree with the proposed solution, or they have a different suggestion?

FYI @cms-sw/alca-l2 @yuanchao 

#### PR validation:
I have successfully run some of the wfs failing in #40445 (including the GTs proposed in that PR) with:
`runTheMatrix.py -l 312.0,13234.0 -j9 --ibeos`

#### Backport:
Not a backport, no backport needed