### PR TITLE
fix GEM inputs for `L1REPACK:FullMC` [`12_5_X`]

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_CalouGT_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK CalouGT : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:CalouGT (intended for 2016/2017 data) only supports Stage 2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:CalouGT (intended for 2016/2017 data), reemulates the Calo part, uses unpacked Muons, and reemulates uGT."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full2015Data_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK Full2015Data : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full2015Data only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:Full2015Data only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:Full2015Data will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.DTTFRawToDigi.dttfunpacker_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_FullSimTP_cff.py
@@ -1,15 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK FullSimTP : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:FullSimTP (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:FullSimTP (intended for 2016 data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:FullSimTP (intended for data) only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:FullSimTP (intended for data) will unpack all L1T inputs, re-emulate Trigger Primitives, re-emulate L1T (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 import EventFilter.L1TRawToDigi.bmtfDigis_cfi

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
+## L1REPACK Full : Re-Emulate all of L1 and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:Full (intended for 2016 & 2017 data) will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:Full only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:Full will unpack all L1T inputs, re-emulated (Stage-2), and pack uGT, uGMT, and Calo Stage-2 output."))
 
 # First, Unpack all inputs to L1:
 
@@ -97,7 +97,7 @@ simTwinMuxDigis.RPC_Source         = 'unpackRPCTwinMux'
 simTwinMuxDigis.DTDigi_Source      = "unpackTwinMux:PhIn"
 simTwinMuxDigis.DTThetaDigi_Source = "unpackTwinMux:ThIn"
 
-run3_GEM.toModify(simMuonGEMPadDigis,
+(stage2L1Trigger & run3_GEM).toModify(simMuonGEMPadDigis,
     InputCollection = 'unpackGEM'
 )
 

--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -1,16 +1,14 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-## L1REPACK FULL:  Re-Emulate all of L1 and repack into RAW
-
+## L1REPACK uGT : Re-Emulate L1 uGT and repack into RAW
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-def _print(ignored):
-    print("# L1T WARN:  L1REPACK:Full (intended for 2016 data) only supports Stage 2 eras for now.")
-    print("# L1T WARN:  Use a legacy version of L1REPACK for now.")
-stage2L1Trigger.toModify(None, _print)
-(~stage2L1Trigger).toModify(None, lambda x: print("# L1T INFO:  L1REPACK:uGT (intended for 2016 data) will unpack uGMT and CaloLaye2 outputs and re-emulate uGT"))
 
+(~stage2L1Trigger).toModify(None, lambda x:
+    print("# L1T WARN:  L1REPACK:uGT only supports Stage-2 eras for now.\n# L1T WARN:  Use a legacy version of L1REPACK for now."))
+stage2L1Trigger.toModify(None, lambda x:
+    print("# L1T INFO:  L1REPACK:uGT will unpack uGMT and CaloLayer2 outputs, and re-emulate uGT"))
 
 # First, inputs to uGT:
 import EventFilter.L1TRawToDigi.gtStage2Digis_cfi


### PR DESCRIPTION
backport of #40461
(verbatim backport)

#### PR description:

This PR fixes the `L1REPACK:FullMC` step (full simulation of trigger primitives + emulation of L1T from RAW in MC events [[ref]](https://indico.cern.ch/event/1060362/contributions/4455932/attachments/2286815/3937192/L1T_Tutorial_Emulator.pdf)), where GEM inputs are currently misconfigured. This type of configuration is used in offline trigger studies, even though it is untested in CMSSW.

For further details, please the description of the original PR, i.e. #40461.

Small edits are applied to other L1REPACK `cff`s, to fix a few print-outs (see https://github.com/cms-sw/cmssw/pull/40461#discussion_r1065857148 for details).

#### PR validation:

None beyond the checks done for #40461.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40461

Trigger studies in `12_5_X`.
