### PR TITLE
L1T: Add jet quality and isolation data vs. emu comparisons and ignore object index

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h
+++ b/DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h
@@ -210,11 +210,11 @@ private:
     SUMMISMATCH     // no. events failed due to a sum mismatch
   };
 
-  enum jetVars { NJETS = 1, JETGOOD, JETPOSOFF, JETETOFF };
+  enum jetVars { NJETS = 1, JETGOOD, JETPOSOFF, JETETOFF, JETQUALOFF };
 
-  enum egVars { NEGS = 1, EGGOOD, EGPOSOFF, EGETOFF, NISOEGS, ISOEGGOOD, ISOEGPOSOFF, ISOEGETOFF };
+  enum egVars { NEGS = 1, EGGOOD, EGPOSOFF, EGETOFF, NISOEGS, ISOEGGOOD, ISOEGPOSOFF, ISOEGETOFF, EGISOOFF};
 
-  enum tauVars { NTAUS = 1, TAUGOOD, TAUPOSOFF, TAUETOFF, NISOTAUS, ISOTAUGOOD, ISOTAUPOSOFF, ISOTAUETOFF };
+  enum tauVars { NTAUS = 1, TAUGOOD, TAUPOSOFF, TAUETOFF, NISOTAUS, ISOTAUGOOD, ISOTAUPOSOFF, ISOTAUETOFF, TAUISOOFF};
 
   enum sumVars {
     NSUMS = 1,
@@ -249,9 +249,11 @@ private:
   MonitorElement* jetEtData;
   MonitorElement* jetEtaData;
   MonitorElement* jetPhiData;
+  MonitorElement* jetQualData;
   MonitorElement* jetEtEmul;
   MonitorElement* jetEtaEmul;
   MonitorElement* jetPhiEmul;
+  MonitorElement* jetQualEmul;
   MonitorElement* jet2DEtaPhiData;  // This histogram will be filled only if enable2DComp is true
   MonitorElement* jet2DEtaPhiEmul;  // This histogram will be filled only if enable2DComp is true
 
@@ -259,9 +261,11 @@ private:
   MonitorElement* egEtData;
   MonitorElement* egEtaData;
   MonitorElement* egPhiData;
+  MonitorElement* egIsoData;
   MonitorElement* egEtEmul;
   MonitorElement* egEtaEmul;
   MonitorElement* egPhiEmul;
+  MonitorElement* egIsoEmul;
   MonitorElement* eg2DEtaPhiData;  // This histogram will be filled only if enable2DComp is true
   MonitorElement* eg2DEtaPhiEmul;  // This histogram will be filled only if enable2DComp is true
 
@@ -279,9 +283,11 @@ private:
   MonitorElement* tauEtData;
   MonitorElement* tauEtaData;
   MonitorElement* tauPhiData;
+  MonitorElement* tauIsoData;
   MonitorElement* tauEtEmul;
   MonitorElement* tauEtaEmul;
   MonitorElement* tauPhiEmul;
+  MonitorElement* tauIsoEmul;
   MonitorElement* tau2DEtaPhiData;  // This histogram will be filled only if enable2DComp is true
   MonitorElement* tau2DEtaPhiEmul;  // This histogram will be filled only if enable2DComp is true
 

--- a/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2CaloLayer2.cc
@@ -30,9 +30,11 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   jetEtData = ibooker.book1D("Problematic Data Jet iEt", "Jet iE_{T}", 1400, 0, 1399);
   jetEtaData = ibooker.book1D("Problematic Data Jet iEta", "Jet i#eta", 227, -113.5, 113.5);
   jetPhiData = ibooker.book1D("Problematic Data Jet iPhi", "Jet i#phi", 288, -0.5, 143.5);
+  jetQualData = ibooker.book1D("Problematic Data Jet Quality", "Jet quality", 16, 0, 16);
   jetEtEmul = ibooker.book1D("Problematic Emul Jet iEt", "Jet iE_{T}", 1400, 0, 1399);
   jetEtaEmul = ibooker.book1D("Problematic Emul Jet iEta", "Jet i#eta", 227, -113.5, 113.5);
   jetPhiEmul = ibooker.book1D("Problematic Emul Jet iPhi", "Jet i#phi", 288, -0.5, 143.5);
+  jetQualEmul = ibooker.book1D("Problematic Emul Jet Quality", "Jet quality", 16, 0, 16);
   //if enable2DComp is true book also 2D eta-phi plots
   if (enable2DComp) {
     jet2DEtaPhiData =
@@ -52,9 +54,11 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   egEtData = ibooker.book1D("Problematic Data Eg iEt", "Eg iE_{T}", 1400, 0, 1399);
   egEtaData = ibooker.book1D("Problematic Data Eg iEta", "Eg i#eta", 227, -113.5, 113.5);
   egPhiData = ibooker.book1D("Problematic Data Eg iPhi", "Eg i#phi", 288, -0.5, 143.5);
+  egIsoData = ibooker.book1D("Problematic Data Eg iso", "Eg iso", 4, 0, 4);
   egEtEmul = ibooker.book1D("Problematic Emul Eg iEt", "Eg iE_{T}", 1400, 0, 1399);
   egEtaEmul = ibooker.book1D("Problematic Emul Eg iEta", "Eg i#eta", 227, -113.5, 113.5);
   egPhiEmul = ibooker.book1D("Problematic Emul Eg iPhi", "Eg i#phi", 288, -0.5, 143.5);
+  egIsoEmul = ibooker.book1D("Problematic Emul Eg iso", "Eg iso", 4, 0, 4);
   //if enable2DComp is true book also 2D eta-phi plots
   if (enable2DComp) {
     eg2DEtaPhiData = ibooker.book2D("Problematic Data Eg Eta - Phi", "Eg #eta - #phi map", 30, -3., 3., 25, -3.2, 3.2);
@@ -89,9 +93,11 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   tauEtData = ibooker.book1D("Problematic Data Tau iEt", "Tau iE_{T}", 1400, 0, 1399);
   tauEtaData = ibooker.book1D("Problematic Data Tau iEta", "Tau i#eta", 227, -113.5, 113.5);
   tauPhiData = ibooker.book1D("Problematic Data Tau iPhi", "Tau i#phi", 288, -0.5, 143.5);
+  tauIsoData = ibooker.book1D("Problematic Data Tau iso", "Tau iso", 4, 0, 4);
   tauEtEmul = ibooker.book1D("Problematic Emul Tau iEt", "Tau iE_{T}", 1400, 0, 1399);
   tauEtaEmul = ibooker.book1D("Problematic Emul Tau iEta", "Tau i#eta", 227, -113.5, 113.5);
   tauPhiEmul = ibooker.book1D("Problematic Emul Tau iPhi", "Tau i#phi", 288, -0.5, 143.5);
+  tauIsoEmul = ibooker.book1D("Problematic Emul Tau iso", "Tau iso", 4, 0, 4);
   // enable2DComp is true book also 2D eta-phi plots
   if (enable2DComp) {
     tau2DEtaPhiData =
@@ -211,13 +217,14 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   agreementSummary->setBinLabel(NSUMS_S, "total sums");
   agreementSummary->setBinLabel(SUMGOOD_S, "good sums");
 
-  jetSummary = ibooker.book1D("Jet Agreement Summary", "Jet Agreement Summary", 4, 1, 5);
+  jetSummary = ibooker.book1D("Jet Agreement Summary", "Jet Agreement Summary", 5, 1, 6);
   jetSummary->setBinLabel(NJETS, "total jets");
   jetSummary->setBinLabel(JETGOOD, "good jets");
   jetSummary->setBinLabel(JETPOSOFF, "jets pos off only");
   jetSummary->setBinLabel(JETETOFF, "jets Et off only ");
+  jetSummary->setBinLabel(JETQUALOFF, "jets Qual off only ");
 
-  egSummary = ibooker.book1D("EG Agreement Summary", "EG Agreement Summary", 8, 1, 9);
+  egSummary = ibooker.book1D("EG Agreement Summary", "EG Agreement Summary", 9, 1, 10);
   egSummary->setBinLabel(NEGS, "total non-iso e/gs");
   egSummary->setBinLabel(EGGOOD, "good non-iso e/gs");
   egSummary->setBinLabel(EGPOSOFF, "non-iso e/gs pos off");
@@ -226,8 +233,9 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   egSummary->setBinLabel(ISOEGGOOD, "good iso e/gs");
   egSummary->setBinLabel(ISOEGPOSOFF, "iso e/gs pos off");
   egSummary->setBinLabel(ISOEGETOFF, "iso e/gs Et off");
+  egSummary->setBinLabel(EGISOOFF, "e/gs Iso off");
 
-  tauSummary = ibooker.book1D("Tau Agreement Summary", "Tau Agreement Summary", 8, 1, 9);
+  tauSummary = ibooker.book1D("Tau Agreement Summary", "Tau Agreement Summary", 9, 1, 10);
   tauSummary->setBinLabel(NTAUS, "total taus");
   tauSummary->setBinLabel(TAUGOOD, "good non-iso taus");
   tauSummary->setBinLabel(TAUPOSOFF, "non-iso taus pos off");
@@ -236,6 +244,7 @@ void L1TdeStage2CaloLayer2::bookHistograms(DQMStore::IBooker& ibooker, edm::Run 
   tauSummary->setBinLabel(ISOTAUGOOD, "good iso taus");
   tauSummary->setBinLabel(ISOTAUPOSOFF, "iso taus pos off");
   tauSummary->setBinLabel(ISOTAUETOFF, "iso taus Et off");
+  tauSummary->setBinLabel(TAUISOOFF, "tau Iso off");
 
   sumSummary = ibooker.book1D("Energy Sum Agreement Summary", "Sum Agreement Summary", 18, 1, 19);
   sumSummary->setBinLabel(NSUMS, "total sums");
@@ -379,6 +388,7 @@ bool L1TdeStage2CaloLayer2::compareJets(const edm::Handle<l1t::JetBxCollection>&
         jetEtData->Fill(dataIt->hwPt());
         jetEtaData->Fill(dataIt->hwEta());
         jetPhiData->Fill(dataIt->hwPhi());
+        jetQualData->Fill(dataIt->hwQual());
         if (enable2DComp)
           jet2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
@@ -396,6 +406,7 @@ bool L1TdeStage2CaloLayer2::compareJets(const edm::Handle<l1t::JetBxCollection>&
         jetEtEmul->Fill(emulIt->hwPt());
         jetEtaEmul->Fill(emulIt->hwEta());
         jetPhiEmul->Fill(emulIt->hwPhi());
+        jetQualEmul->Fill(emulIt->hwQual());
         if (enable2DComp)
           jet2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 
@@ -417,39 +428,60 @@ bool L1TdeStage2CaloLayer2::compareJets(const edm::Handle<l1t::JetBxCollection>&
 
       bool posGood = true;
       bool etGood = true;
+      bool qualGood = true;
 
       // object pt mismatch
       if (dataIt->hwPt() != emulIt->hwPt()) {
         etGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (phi)
       if (dataIt->hwPhi() != emulIt->hwPhi()) {
         posGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (eta)
       if (dataIt->hwEta() != emulIt->hwEta()) {
         posGood = false;
-        eventGood = false;
       }
 
-      // if both position and energy agree, jet is good
-      if (etGood && posGood) {
+      // object quality mismatch
+      if (dataIt->hwQual() != emulIt->hwQual()) {
+        qualGood = false;
+      }
+
+      //bypass sorting bug
+      if (etGood && !posGood) {
+        l1t::JetBxCollection::const_iterator emulItCheckSort;
+        for (emulItCheckSort = emulCol->begin(currBx); emulItCheckSort != emulCol->end(currBx); ++emulItCheckSort) {
+	  if (dataIt->hwPt() == emulItCheckSort->hwPt() && dataIt->hwPhi() == emulItCheckSort->hwPhi() &&
+	      dataIt->hwEta() == emulItCheckSort->hwEta()){
+	    posGood = true;
+	    if (dataIt->hwQual() == emulItCheckSort->hwQual())
+	      qualGood = true;
+	    else
+	      qualGood = false;
+	  }
+	}
+      }
+
+      // if position, energy & qual agree, jet is good
+      if (etGood && posGood && qualGood) {
         agreementSummary->Fill(JETGOOD_S);
         jetSummary->Fill(JETGOOD);
       } else {
+	eventGood = false;
         jetEtData->Fill(dataIt->hwPt());
         jetEtaData->Fill(dataIt->hwEta());
         jetPhiData->Fill(dataIt->hwPhi());
+        jetQualData->Fill(dataIt->hwQual());
         if (enable2DComp)
           jet2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
 
         jetEtEmul->Fill(emulIt->hwPt());
         jetEtaEmul->Fill(emulIt->hwEta());
         jetPhiEmul->Fill(emulIt->hwPhi());
+        jetQualEmul->Fill(emulIt->hwQual());
         if (enable2DComp)
           jet2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
 
@@ -461,18 +493,25 @@ bool L1TdeStage2CaloLayer2::compareJets(const edm::Handle<l1t::JetBxCollection>&
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul jet phi = " << emulIt->hwPhi() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "data jet eta = " << dataIt->hwEta() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul jet eta = " << emulIt->hwEta() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "data jet qual = " << dataIt->hwQual() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "emul jet qual = " << emulIt->hwQual() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "---" << std::endl;
         }
       }
 
-      // if only position agrees
+      // if energy is wrong
       if (posGood && !etGood) {
         jetSummary->Fill(JETETOFF);
       }
 
-      // if only energy agrees
+      // if position is wrong
       if (!posGood && etGood) {
         jetSummary->Fill(JETPOSOFF);
+      }
+
+      // if only qual is wrong
+      if (posGood && etGood && !qualGood) {
+        jetSummary->Fill(JETQUALOFF);
       }
 
       // keep track of jets
@@ -526,6 +565,7 @@ bool L1TdeStage2CaloLayer2::compareEGs(const edm::Handle<l1t::EGammaBxCollection
           if (enable2DComp)
             eg2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
         }
+	egIsoData->Fill(dataIt->hwIso());
 
         ++dataIt;
 
@@ -551,7 +591,7 @@ bool L1TdeStage2CaloLayer2::compareEGs(const edm::Handle<l1t::EGammaBxCollection
           if (enable2DComp)
             eg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
         }
-
+	egIsoEmul->Fill(emulIt->hwIso());
         ++emulIt;
 
         if (emulIt == emulCol->end(currBx))
@@ -568,38 +608,57 @@ bool L1TdeStage2CaloLayer2::compareEGs(const edm::Handle<l1t::EGammaBxCollection
     while (true) {
       bool posGood = true;
       bool etGood = true;
-      bool iso = dataIt->hwIso();
+      bool isoGood = true;
+      bool hwIso = dataIt->hwIso();
 
       // object pt mismatch
       if (dataIt->hwPt() != emulIt->hwPt()) {
         etGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (phi)
       if (dataIt->hwPhi() != emulIt->hwPhi()) {
         posGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (eta)
       if (dataIt->hwEta() != emulIt->hwEta()) {
         posGood = false;
-        eventGood = false;
       }
 
-      // if both position and energy agree, object is good
-      if (posGood && etGood) {
+      // object isolation mismatch
+      if (dataIt->hwIso() != emulIt->hwIso()) {
+        isoGood = false;
+      }
+
+      //bypass sorting bug
+      if (etGood && !posGood) {
+        l1t::EGammaBxCollection::const_iterator emulItCheckSort;
+        for (emulItCheckSort = emulCol->begin(currBx); emulItCheckSort != emulCol->end(currBx); ++emulItCheckSort) {
+	  if (dataIt->hwPt() == emulItCheckSort->hwPt() && dataIt->hwPhi() == emulItCheckSort->hwPhi() &&
+	      dataIt->hwEta() == emulItCheckSort->hwEta()){
+	    posGood = true;
+	    if (dataIt->hwIso() == emulItCheckSort->hwIso())
+	      isoGood = true;
+	    else
+	      isoGood = false;
+	  }
+	}
+      }
+
+      // if position, energy and isolation agree, object is good
+      if (posGood && etGood && isoGood) {
         agreementSummary->Fill(EGGOOD_S);
 
-        if (iso) {
+        if (hwIso) {
           egSummary->Fill(ISOEGGOOD);
         } else {
           egSummary->Fill(EGGOOD);
         }
 
       } else {
-        if (iso) {
+	eventGood = false;
+        if (hwIso) {
           isoEgEtData->Fill(dataIt->hwPt());
           isoEgEtaData->Fill(dataIt->hwEta());
           isoEgPhiData->Fill(dataIt->hwPhi());
@@ -624,6 +683,8 @@ bool L1TdeStage2CaloLayer2::compareEGs(const edm::Handle<l1t::EGammaBxCollection
           if (enable2DComp)
             eg2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
         }
+	egIsoData->Fill(dataIt->hwIso());
+	egIsoEmul->Fill(emulIt->hwIso());
 
         if (verbose) {
           edm::LogInfo("L1TdeStage2CaloLayer2") << "--- eg ---" << std::endl;
@@ -633,30 +694,37 @@ bool L1TdeStage2CaloLayer2::compareEGs(const edm::Handle<l1t::EGammaBxCollection
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul eg phi = " << emulIt->hwPhi() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "data eg eta = " << dataIt->hwEta() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul eg eta = " << emulIt->hwEta() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "data eg iso = " << dataIt->hwIso() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "emul eg iso = " << emulIt->hwIso() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "---" << std::endl;
         }
       }
 
-      // if only position agrees
+      // if energy is wrong
       if (posGood && !etGood) {
-        if (iso) {
+        if (hwIso) {
           egSummary->Fill(ISOEGETOFF);
         } else {
           egSummary->Fill(EGETOFF);
         }
       }
 
-      // if only energy agrees
+      // if position wrong
       if (!posGood && etGood) {
-        if (iso) {
+        if (hwIso) {
           egSummary->Fill(ISOEGPOSOFF);
         } else {
           egSummary->Fill(EGPOSOFF);
         }
       }
 
+      // if only isolation wrong
+      if (posGood && etGood && !isoGood) {
+	egSummary->Fill(EGISOOFF);
+      }
+
       // keep track of number of objects
-      if (iso) {
+      if (hwIso) {
         egSummary->Fill(NISOEGS);
       } else {
         egSummary->Fill(NEGS);
@@ -712,6 +780,7 @@ bool L1TdeStage2CaloLayer2::compareTaus(const edm::Handle<l1t::TauBxCollection>&
           if (enable2DComp)
             tau2DEtaPhiData->Fill(dataIt->eta(), dataIt->phi());
         }
+	tauIsoData->Fill(dataIt->hwIso());
 
         ++dataIt;
 
@@ -740,6 +809,7 @@ bool L1TdeStage2CaloLayer2::compareTaus(const edm::Handle<l1t::TauBxCollection>&
           if (enable2DComp)
             tau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
         }
+	tauIsoEmul->Fill(emulIt->hwIso());
 
         ++emulIt;
 
@@ -757,37 +827,56 @@ bool L1TdeStage2CaloLayer2::compareTaus(const edm::Handle<l1t::TauBxCollection>&
     while (true) {
       bool posGood = true;
       bool etGood = true;
-      bool iso = dataIt->hwIso();
+      bool isoGood = true;
+      bool hwIso = dataIt->hwIso();
 
       // object Et mismatch
       if (dataIt->hwPt() != emulIt->hwPt()) {
         etGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (phi)
       if (dataIt->hwPhi() != emulIt->hwPhi()) {
         posGood = false;
-        eventGood = false;
       }
 
       // object position mismatch (eta)
       if (dataIt->hwEta() != emulIt->hwEta()) {
         posGood = false;
-        eventGood = false;
       }
 
-      // if both position and energy agree, object is good
-      if (posGood && etGood) {
+      // object isolation mismatch
+      if (dataIt->hwIso() != emulIt->hwIso()) {
+        isoGood = false;
+      }
+
+      //bypass sorting bug
+      if (etGood && !posGood) {
+        l1t::TauBxCollection::const_iterator emulItCheckSort;
+        for (emulItCheckSort = emulCol->begin(currBx); emulItCheckSort != emulCol->end(currBx); ++emulItCheckSort) {
+	  if (dataIt->hwPt() == emulItCheckSort->hwPt() && dataIt->hwPhi() == emulItCheckSort->hwPhi() &&
+	      dataIt->hwEta() == emulItCheckSort->hwEta()){
+	    posGood = true;
+	    if (dataIt->hwIso() == emulItCheckSort->hwIso())
+	      isoGood = true;
+	    else
+	      isoGood = false;
+	  }
+	}
+      }
+
+      // if position, energy and isolation agree, object is good
+      if (posGood && etGood && isoGood) {
         agreementSummary->Fill(TAUGOOD_S);
 
-        if (iso) {
+        if (hwIso) {
           tauSummary->Fill(ISOTAUGOOD);
         } else {
           tauSummary->Fill(TAUGOOD);
         }
       } else {
-        if (iso) {
+	eventGood = false;
+        if (hwIso) {
           isoTauEtData->Fill(dataIt->hwPt());
           isoTauEtaData->Fill(dataIt->hwEta());
           isoTauPhiData->Fill(dataIt->hwPhi());
@@ -813,6 +902,8 @@ bool L1TdeStage2CaloLayer2::compareTaus(const edm::Handle<l1t::TauBxCollection>&
           if (enable2DComp)
             tau2DEtaPhiEmul->Fill(emulIt->eta(), emulIt->phi());
         }
+	tauIsoData->Fill(dataIt->hwIso());
+	tauIsoEmul->Fill(emulIt->hwIso());
 
         if (verbose) {
           edm::LogInfo("L1TdeStage2CaloLayer2") << "--- tau ---" << std::endl;
@@ -822,30 +913,37 @@ bool L1TdeStage2CaloLayer2::compareTaus(const edm::Handle<l1t::TauBxCollection>&
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul tau phi = " << emulIt->hwPhi() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "data tau eta = " << dataIt->hwEta() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "emul tau eta = " << emulIt->hwEta() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "data tau iso = " << dataIt->hwIso() << std::endl;
+          edm::LogInfo("L1TdeStage2CaloLayer2") << "emul tau iso = " << emulIt->hwIso() << std::endl;
           edm::LogInfo("L1TdeStage2CaloLayer2") << "---" << std::endl;
         }
       }
 
-      // if only position agrees
+      // if energy is wrong
       if (posGood && !etGood) {
-        if (iso) {
+        if (hwIso) {
           tauSummary->Fill(ISOTAUETOFF);
         } else {
           tauSummary->Fill(TAUETOFF);
         }
       }
 
-      // if only energy agrees
+      // if position is wrong
       if (!posGood && etGood) {
-        if (iso) {
+        if (hwIso) {
           tauSummary->Fill(ISOTAUPOSOFF);
         } else {
           tauSummary->Fill(TAUPOSOFF);
         }
       }
 
+      // if only isolation is wrong
+      if (posGood && etGood && !isoGood) {
+          tauSummary->Fill(TAUISOOFF);
+      }
+
       // keep track of number of objects
-      if (iso) {
+      if (hwIso) {
         tauSummary->Fill(NISOTAUS);
       } else {
         tauSummary->Fill(NTAUS);

--- a/DQM/L1TMonitorClient/src/L1TStage2CaloLayer2DEClientSummary.cc
+++ b/DQM/L1TMonitorClient/src/L1TStage2CaloLayer2DEClientSummary.cc
@@ -37,34 +37,37 @@ void L1TStage2CaloLayer2DEClientSummary::book(DQMStore::IBooker &ibooker) {
   }
 
   if (jetSummary == nullptr) {
-    jetSummary = ibooker.book1D("Jet Agreement Summary", "Jet Agreement Summary", 3, 1, 4);
+    jetSummary = ibooker.book1D("Jet Agreement Summary", "Jet Agreement Summary", 4, 1, 5);
     jetSummary->setBinLabel(1, "good jets");
     jetSummary->setBinLabel(2, "jets pos off only");
     jetSummary->setBinLabel(3, "jets Et off only ");
+    jetSummary->setBinLabel(4, "jets qual off only ");
   } else {
     jetSummary->Reset();
   }
 
   if (egSummary == nullptr) {
-    egSummary = ibooker.book1D("EG Agreement Summary", "EG Agreement Summary", 6, 1, 7);
+    egSummary = ibooker.book1D("EG Agreement Summary", "EG Agreement Summary", 7, 1, 8);
     egSummary->setBinLabel(1, "good non-iso e/gs");
     egSummary->setBinLabel(2, "non-iso e/gs pos off");
     egSummary->setBinLabel(3, "non-iso e/gs Et off");
     egSummary->setBinLabel(4, "good iso e/gs");
     egSummary->setBinLabel(5, "iso e/gs pos off");
     egSummary->setBinLabel(6, "iso e/gs Et off");
+    egSummary->setBinLabel(7, "e/gs Iso off");
   } else {
     egSummary->Reset();
   }
 
   if (tauSummary == nullptr) {
-    tauSummary = ibooker.book1D("Tau Agreement Summary", "Tau Agremeent Summary", 6, 1, 7);
+    tauSummary = ibooker.book1D("Tau Agreement Summary", "Tau Agremeent Summary", 7, 1, 8);
     tauSummary->setBinLabel(1, "good non-iso taus");
     tauSummary->setBinLabel(2, "non-iso taus pos off");
     tauSummary->setBinLabel(3, "non-iso taus Et off");
     tauSummary->setBinLabel(4, "good iso taus");
     tauSummary->setBinLabel(5, "iso taus pos off");
     tauSummary->setBinLabel(6, "iso taus Et off");
+    tauSummary->setBinLabel(7, "taus Iso off");
   } else {
     tauSummary->Reset();
   }
@@ -152,7 +155,7 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     // double totalJets = 0, goodJets = 0, jetPosOff = 0, jetEtOff = 0;
 
     // by default show 0% agreement (for edge case when no objects are found)
-    double goodRatio = 0, posOffRatio = 0, etOffRatio = 0;
+    double goodRatio = 0, posOffRatio = 0, etOffRatio = 0, qualOffRatio = 0;
 
     // hist = jetSummary_->getTH1F();
     // newHist = jetSummary->getTH1F();
@@ -161,16 +164,19 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     double goodJets = jetSummary_->getBinContent(2);
     double jetPosOff = jetSummary_->getBinContent(3);
     double jetEtOff = jetSummary_->getBinContent(4);
+    double jetQualOff = jetSummary_->getBinContent(5);
 
     if (totalJets != 0) {
       goodRatio = goodJets / totalJets;
       posOffRatio = jetPosOff / totalJets;
       etOffRatio = jetEtOff / totalJets;
+      qualOffRatio = jetQualOff / totalJets;
     }
 
     jetSummary->setBinContent(1, goodRatio);
     jetSummary->setBinContent(2, posOffRatio);
     jetSummary->setBinContent(3, etOffRatio);
+    jetSummary->setBinContent(4, qualOffRatio);
   }
 
   if (egSummary_) {
@@ -179,7 +185,7 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
 
     // by default show 0% agreement (for edge case when no objects are found)
     double goodEgRatio = 0, egPosOffRatio = 0, egEtOffRatio = 0, goodIsoEgRatio = 0, isoEgPosOffRatio = 0,
-           isoEgEtOffRatio = 0;
+      isoEgEtOffRatio = 0, egIsoOffRatio = 0;
 
     // hist = egSummary_->getTH1F();
     // newHist = egSummary->getTH1F();
@@ -194,6 +200,8 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     double isoEgPosOff = egSummary_->getBinContent(7);
     double isoEgEtOff = egSummary_->getBinContent(8);
 
+    double egIsoOff = egSummary_->getBinContent(9);
+
     if (totalEgs != 0) {
       goodEgRatio = goodEgs / totalEgs;
       egPosOffRatio = egPosOff / totalEgs;
@@ -206,6 +214,9 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
       isoEgEtOffRatio = isoEgEtOff / totalIsoEgs;
     }
 
+    if((totalEgs + totalIsoEgs) > 0)
+      egIsoOffRatio = egIsoOff / (totalEgs+totalIsoEgs);
+
     egSummary->setBinContent(1, goodEgRatio);
     egSummary->setBinContent(2, egPosOffRatio);
     egSummary->setBinContent(3, egEtOffRatio);
@@ -213,6 +224,8 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     egSummary->setBinContent(4, goodIsoEgRatio);
     egSummary->setBinContent(5, isoEgPosOffRatio);
     egSummary->setBinContent(6, isoEgEtOffRatio);
+
+    egSummary->setBinContent(7, egIsoOffRatio);
   }
 
   if (tauSummary_) {
@@ -221,7 +234,7 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
 
     // by default show 0% agreement (for edge case when no objects are found)
     double goodTauRatio = 0, tauPosOffRatio = 0, tauEtOffRatio = 0, goodIsoTauRatio = 0, isoTauPosOffRatio = 0,
-           isoTauEtOffRatio = 0;
+      isoTauEtOffRatio = 0, tauIsoOffRatio = 0;
 
     // hist = tauSummary_->getTH1F();
     // newHist = tauSummary->getTH1F();
@@ -236,6 +249,8 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     double isoTauPosOff = tauSummary_->getBinContent(7);
     double isoTauEtOff = tauSummary_->getBinContent(8);
 
+    double tauIsoOff = tauSummary_->getBinContent(9);
+
     if (totalTaus != 0) {
       goodTauRatio = goodTaus / totalTaus;
       tauPosOffRatio = tauPosOff / totalTaus;
@@ -248,6 +263,9 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
       isoTauEtOffRatio = isoTauEtOff / totalIsoTaus;
     }
 
+    if((totalTaus + totalIsoTaus) > 0)
+      tauIsoOffRatio = tauIsoOff / (totalTaus+totalIsoTaus);
+
     tauSummary->setBinContent(1, goodTauRatio);
     tauSummary->setBinContent(2, tauPosOffRatio);
     tauSummary->setBinContent(3, tauEtOffRatio);
@@ -255,6 +273,8 @@ void L1TStage2CaloLayer2DEClientSummary::processHistograms(DQMStore::IGetter &ig
     tauSummary->setBinContent(4, goodIsoTauRatio);
     tauSummary->setBinContent(5, isoTauPosOffRatio);
     tauSummary->setBinContent(6, isoTauEtOffRatio);
+
+    tauSummary->setBinContent(7, tauIsoOffRatio);
   }
 
   if (sumSummary_) {


### PR DESCRIPTION
#### PR description:

- Adds jet quality and eg/tau isolation to the CaloL2 data vs emulator plots in the online DQM
- Bug fix to ignore the ordering of CaloL2 objects for data vs emulator comparisons

#### PR validation:

- Ran locally on lxplus with recent ExpressPhysics data and checked histogram outputs are as expected
- Ran unit tests with `cmsRun DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py unitTest=True`
