### PR TITLE
[125X] Update realistic Heavy Ion MC GT 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v7',
+    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:
This PR updates the realistic Heavy Ion MC GT (`auto:phase1_2022_realistic_hi`) with latest SiPixel bad component tags requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/125x-run-3-hi-gt-update-for-pixel-bad-components/19077) [1]. More details for the request can be found in [2].

[1] https://cms-talk.web.cern.ch/t/125x-run-3-hi-gt-update-for-pixel-bad-components/19077
[2] https://cms-talk.web.cern.ch/t/request-alca-input-to-update-vertex-in-mc-of-2022-pbpb-test-run/18799/10

**GT Difference**
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/125X_mcRun3_2022_realistic_HI_v7/125X_mcRun3_2022_realistic_HI_v8

#### PR validation:
Successfully ran:
`runTheMatrix.py -l 159.0 -j10 --ibeos`
which consumes the `auto:phase1_2022_realistic_hi` conditions.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This will soon be followed up by a forward port in master, once #40445 and #40464 are merged. No other backport expected,