### PR TITLE
Disable header consistency checks for EDFilter.h EDProducer.h

### DIFF
--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -13,6 +13,8 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Version"/>
 <flags ADD_SUBDIR="1"/>
+<!-- Disable header consistency checks: https://github.com/cms-sw/cmssw/pull/39710 -->
+<flags IGNORE_HEADER_CHECK="EDFilter.h EDProducer.h"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
This should fix the header consistency check error in IBs. New build rules ( integrated in CMSSW_13_0_X_2023-01-11-0800 IBs) supports `IGNORE_HEADER_CHECK` flag which instruct scram to not run header consistency checks for selected files