### PR TITLE
Fixes for vertex fits in the muon system

### DIFF
--- a/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
@@ -187,6 +187,11 @@ void ParticleKinematicLinearizedTrackState::computeChargedJacobians() const {
   double ptAtEP = thePredState.theState().globalMomentum().perp();
   double transverseCurvatureAtEP = field / ptAtEP * signTC;
 
+  // Fix calculation for case where magnetic field swaps sign between previous state and current state
+  if (field/part->currentState().magneticField()->inInverseGeV(part->currentState().globalPosition()).z() < 0.) {
+    signTC = -signTC;
+  }
+
   double x_v = thePredState.theState().globalPosition().x();
   double y_v = thePredState.theState().globalPosition().y();
   double z_v = thePredState.theState().globalPosition().z();

--- a/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
@@ -188,7 +188,7 @@ void ParticleKinematicLinearizedTrackState::computeChargedJacobians() const {
   double transverseCurvatureAtEP = field / ptAtEP * signTC;
 
   // Fix calculation for case where magnetic field swaps sign between previous state and current state
-  if (field/part->currentState().magneticField()->inInverseGeV(part->currentState().globalPosition()).z() < 0.) {
+  if (field * part->currentState().magneticField()->inInverseGeV(part->currentState().globalPosition()).z() < 0.) {
     signTC = -signTC;
   }
 

--- a/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -164,6 +164,22 @@ public:
 
   const AbstractLTSFactory<N>* linearizedTrackStateFactory() const { return theLTrackFactory; }
 
+  /**
+  * Method checking whether a point is within the "tracker" bounds.
+  * The default values are set to the CMS inner tracker and vertices
+  * outsides these bounds will be rejected.
+  * To reconstruct vertices within the full detector including the 
+  * muon system, set the tracker bounds to larger values.
+  */
+  const bool insideTrackerBounds(const GlobalPoint& point) const {
+    return ((point.transverse() < trackerBoundsRadius) && (abs(point.z()) < trackerBoundsHalfLength));
+  }
+
+  void setTrackerBounds(float radius, float halfLength) {
+    trackerBoundsRadius = radius;
+    trackerBoundsHalfLength = halfLength;
+  }
+
 protected:
   /**
    *   Default constructor. Is here, as we do not want anybody to use it.
@@ -225,6 +241,9 @@ private:
 
   float theMaxShift;
   int theMaxStep;
+
+  float trackerBoundsRadius{112.};
+  float trackerBoundsHalfLength{273.5};
 
   edm::ParameterSet thePSet;
   LinearizationPointFinder* theLinP;

--- a/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
+++ b/RecoVertex/VertexTools/interface/SequentialVertexFitter.h
@@ -242,6 +242,7 @@ private:
   float theMaxShift;
   int theMaxStep;
 
+  // FIXME using hard-coded tracker bounds as default instead of taking them from geometry service
   float trackerBoundsRadius{112.};
   float trackerBoundsHalfLength{273.5};
 

--- a/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
+++ b/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
@@ -102,6 +102,11 @@ void PerigeeLinearizedTrackState::computeChargedJacobians() const {
   double ptAtEP = thePredState.pt();
   double transverseCurvatureAtEP = field / ptAtEP * signTC;
 
+  // Fix calculation for case where magnetic field swaps sign between previous state and current state
+  if (field * theTrack.field()->inInverseGeV(theTSOS.globalPosition()).z() < 0.) {
+    signTC = -signTC;
+  }
+
   double x_v = thePredState.theState().position().x();
   double y_v = thePredState.theState().position().y();
   double z_v = thePredState.theState().position().z();

--- a/RecoVertex/VertexTools/src/SequentialVertexFitter.cc
+++ b/RecoVertex/VertexTools/src/SequentialVertexFitter.cc
@@ -6,17 +6,6 @@
 using namespace std;
 using namespace reco;
 
-namespace {
-  // FIXME
-  // hard-coded tracker bounds
-  // workaround while waiting for Geometry service
-  const float TrackerBoundsRadius = 112;
-  const float TrackerBoundsHalfLength = 273.5;
-  bool insideTrackerBounds(const GlobalPoint& point) {
-    return ((point.transverse() < TrackerBoundsRadius) && (abs(point.z()) < TrackerBoundsHalfLength));
-  }
-}  // namespace
-
 template <unsigned int N>
 SequentialVertexFitter<N>::SequentialVertexFitter(const LinearizationPointFinder& linP,
                                                   const VertexUpdator<N>& updator,


### PR DESCRIPTION
#### PR description:

Problem addressed: In EXO long-lived analyses, it was observed that using CMSSW vertex fitting code to reconstruct the decay vertex of resonances decaying beyond around 300 cm had much worse efficiency than for lower values, and the covariance matrix entries remained at their default values.

This was identified as coming from an issue in the fitting code when the sign of the magnetic field switches sign between two extrapolated track states. A report given in the context of the related Muon POG studies can be found here: https://indico.cern.ch/event/1220371/#6-dsa-vertex-inefficiency-stud
Another report will be given at a tracking POG meeting: https://indico.cern.ch/event/1232392/

The PR also includes a minimal change to the SequentialVertexFitter such that user code can update the boundaries in which the fit is considered valid. Up to now, users were updating these hard-coded values manually. We leave more involved updates (like taking the default values from a database or making it configurable at the EDProducer level) to future studies.

Changes to output: No changes to outputs are expected since this PR only affects the special use case of searches for long-lived particles using the CMSSW vertex fitting code to reconstruct secondary vertices outside of the inner tracker.

Other PRs: There is no interference with other PRs that we are aware of.

#### PR validation:

The proposed fixes lead to a large increase of efficiency for vertex fits beyond around 300 cm, and also to reasonable values of the covariance matrix entries, as reported in the slides above.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

@annamasce @jalimena @aescalante 
