### PR TITLE
[10_6_X] Fix JR conditions for UL 2017 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,7 +48,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v9',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector, for PP reference run
     'phase1_2017_realistic_ppref'    :  '106X_mc2017_realistic_forppRef5TeV_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

As requested in https://cms-talk.web.cern.ch/t/gt-update-wrong-ul-2017-jr-tags/19081
we updated the UL 2017 MC GT with 24 new JR tags.

The new GT is called `106X_mc2017_realistic_v10`

The difference between v9 and v10 can be seen here: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v9/106X_mc2017_realistic_v10

#### PR validation:

Tested with `1325.81`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a dedicated change to 10_6_X for UL, a forward port will be done soon by updating the relevant 13_0_X GT