### PR TITLE
Update 2017 UL realistic GT and 2022/2023 HI MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -48,7 +48,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '123X_mc2017_realistic_v2',
+    'phase1_2017_realistic'        : '130X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
     'phase1_2017_cosmics'          : '123X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
@@ -78,7 +78,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v1',
+    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '130X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v1',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

This PR is a forward port of #40473 with the addition of updated 2017 realistic GT. 
It updates the following MC GTs:

- realistic Heavy Ion MC GTs (`auto:phase1_2022_realistic_hi`, `auto:phase1_2023_realistic_hi`) with latest SiPixel bad component tags requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/125x-run-3-hi-gt-update-for-pixel-bad-components/19077) [1]. More details for the request can be found in [2]. 
- realistic 2017 GT (`auto:phase1_2017_realistic`) with correct UL 2017 JER tags requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/gt-update-wrong-ul-2017-jr-tags/19081) [3]. 

[1] https://cms-talk.web.cern.ch/t/125x-run-3-hi-gt-update-for-pixel-bad-components/19077
[2] https://cms-talk.web.cern.ch/t/request-alca-input-to-update-vertex-in-mc-of-2022-pbpb-test-run/18799/10
[3] https://cms-talk.web.cern.ch/t/gt-update-wrong-ul-2017-jr-tags/19081

**GT Differeces**
- **Phase1 2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mc2017_realistic_v2/130X_mc2017_realistic_v1
- **Phase1 2022 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_v1/130X_mcRun3_2022_realistic_HI_v2
- **Phase1 2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v1/130X_mcRun3_2023_realistic_HI_v2

#### PR validation:
Successfully ran:
`runTheMatrix.py -l 159.0,10024.0 -j10 --ibeos`
which consumes the  `auto:phase1_2017_realistic`  and `auto:phase1_2022_realistic_hi` conditions.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Forward port of #40473. No other backport expected.
