### PR TITLE
Properly remove shared memory when finished

### DIFF
--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -69,7 +69,20 @@ namespace edm::shared_memory {
     char* buffer_;
     BufferInfo* bufferInfo_;
     std::array<std::string, 2> bufferNames_;
-    std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+    struct SMOwner {
+      SMOwner() = default;
+      SMOwner(std::string const& iName, std::size_t iLength);
+      ~SMOwner();
+      SMOwner& operator=(SMOwner&&) = default;
+      boost::interprocess::managed_shared_memory* operator->() { return sm_.get(); }
+      boost::interprocess::managed_shared_memory* get() { return sm_.get(); }
+      operator bool() const { return bool(sm_); }
+      void reset();
+
+    private:
+      std::string name_;
+      std::unique_ptr<boost::interprocess::managed_shared_memory> sm_;
+    } sm_;
   };
 }  // namespace edm::shared_memory
 

--- a/FWCore/SharedMemory/src/WorkerChannel.cc
+++ b/FWCore/SharedMemory/src/WorkerChannel.cc
@@ -39,14 +39,14 @@ namespace {
 
 WorkerChannel::WorkerChannel(std::string const& iName, const std::string& iUniqueID)
     : managed_shm_{open_only, iName.c_str()},
-      mutex_{open_or_create, unique_name(channel_names::kMutex, iUniqueID).c_str()},
-      cndFromController_{open_or_create, unique_name(channel_names::kConditionFromMain, iUniqueID).c_str()},
+      mutex_{open_only, unique_name(channel_names::kMutex, iUniqueID).c_str()},
+      cndFromController_{open_only, unique_name(channel_names::kConditionFromMain, iUniqueID).c_str()},
       stop_{managed_shm_.find<bool>(channel_names::kStop).first},
       transitionType_{managed_shm_.find<edm::Transition>(channel_names::kTransitionType).first},
       transitionID_{managed_shm_.find<unsigned long long>(channel_names::kTransitionID).first},
       toWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kToWorkerBufferInfo).first},
       fromWorkerBufferInfo_{managed_shm_.find<BufferInfo>(channel_names::kFromWorkerBufferInfo).first},
-      cndToController_{open_or_create, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
+      cndToController_{open_only, unique_name(channel_names::kConditionToMain, iUniqueID).c_str()},
       keepEvent_{managed_shm_.find<bool>(channel_names::kKeepEvent).first},
       lock_{mutex_} {
   assert(stop_);


### PR DESCRIPTION
#### PR description:

Need to explicitly call remove for all shared memory objects created in a job. Also do a remove before doing the create to avoid problems with a previusly failed job.

#### PR validation:

Code compiles and unit tests pass. Also forced job failures to prove the changes work.