### PR TITLE
Payload Inspector: introduce maps for `SiPixelDynamicInefficiency` input factors 

### DIFF
--- a/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelDynamicInefficiency.sh
@@ -27,6 +27,15 @@ getPayloadData.py \
 
 getPayloadData.py \
     --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
+    --plot plot_SiPixelDynamicInefficiencyGeomFactorMap \
+    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+getPayloadData.py \
+    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
     --plot plot_SiPixelBPixIneffROCfromDynIneffMap \
     --tag SiPixelDynamicInefficiency_PhaseI_v9 \
     --time_type Run \

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -221,6 +221,10 @@ int main(int argc, char** argv) {
   histo27.process(connectionString, PI::mk_input(tag, start, start, tag2, start2, start2));
   edm::LogPrint("testSiPixelPayloadInspector") << histo27.data() << std::endl;
 
+  SiPixelDynamicInefficiencyPUPixelMaps histo28;
+  histo28.process(connectionString, PI::mk_input(tag2, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo28.data() << std::endl;
+
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3
   // TODO I don't know why this Py_INCREF is necessary...

--- a/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
@@ -79,6 +79,8 @@ public:
   void createTrackerBaseMap();
   void printTrackerMap(TCanvas& canvas, const float topMargin = 0.02);
   bool fillTrackerMap(unsigned int id, double value);
+  void setZAxisRange(const double min, const double max);
+  const std::pair<float, float> getZAxisRange() const;
 
 protected:
   void addNamedBins(edm::FileInPath geoFile, int tX, int tY, int sX, int sY, bool applyModuleRotation = false);

--- a/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
@@ -77,7 +77,7 @@ public:
 
   void resetOption(const char* option);
   void createTrackerBaseMap();
-  void printTrackerMap(TCanvas& canvas, const float topMargin = 0.02);
+  void printTrackerMap(TCanvas& canvas, const float topMargin = 0.02, int index = 0);
   bool fillTrackerMap(unsigned int id, double value);
   void setZAxisRange(const double min, const double max);
   const std::pair<float, float> getZAxisRange() const;

--- a/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
@@ -543,6 +543,10 @@ void Phase1PixelMaps::rescaleAllBarrel(const std::string& currentHistoName) {
   auto globalMax = *std::max_element(maxima.begin(), maxima.end());
   auto globalMin = *std::min_element(minima.begin(), minima.end());
 
+  // in case the two coincide do not rescale
+  if (globalMax == globalMin)
+    return;
+
   for (auto& histo : pxbTh2PolyBarrel[currentHistoName]) {
     histo->GetZaxis()->SetRangeUser(globalMin, globalMax);
   }
@@ -568,6 +572,10 @@ void Phase1PixelMaps::rescaleAllForward(const std::string& currentHistoName) {
 
   auto globalMax = *std::max_element(maxima.begin(), maxima.end());
   auto globalMin = *std::min_element(minima.begin(), minima.end());
+
+  // in case the two coincide do not rescale
+  if (globalMax == globalMin)
+    return;
 
   for (auto& histo : pxfTh2PolyForward[currentHistoName]) {
     histo->GetZaxis()->SetRangeUser(globalMin, globalMax);

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -81,13 +81,26 @@ void Phase1PixelSummaryMap::createTrackerBaseMap() {
 }
 
 //============================================================================
-void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas, const float topMargin) {
+void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas, const float topMargin, int index) {
   //canvas = TCanvas("c1","c1",plotWidth,plotHeight);
-  canvas.cd();
-  canvas.SetTopMargin(topMargin);
-  canvas.SetBottomMargin(0.02);
-  canvas.SetLeftMargin(0.02);
-  canvas.SetRightMargin(0.14);
+  if (index != 0)
+    canvas.cd(index);
+  else
+    canvas.cd();
+
+  if (index == 0) {
+    canvas.SetTopMargin(topMargin);
+    canvas.SetBottomMargin(0.02);
+    canvas.SetLeftMargin(0.02);
+    canvas.SetRightMargin(0.14);
+  } else {
+    m_BaseTrackerMap->GetZaxis()->SetTitleOffset(1.5);
+    canvas.cd(index)->SetTopMargin(topMargin);
+    canvas.cd(index)->SetBottomMargin(0.02);
+    canvas.cd(index)->SetLeftMargin(0.02);
+    canvas.cd(index)->SetRightMargin(0.14);
+  }
+
   m_BaseTrackerMap->Draw("AL");
   m_BaseTrackerMap->Draw("AC COLZ0 L SAME");
 
@@ -123,7 +136,7 @@ void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas, const float topMarg
 
   //# draw new-style title
   txt.SetTextSize((topMargin == 0.02) ? 0.05 : 0.03);
-  txt.DrawLatex(0.5, 0.95, (fmt::sprintf("Pixel Tracker Map: %s", m_title)).c_str());
+  txt.DrawLatex(0.5, ((index == 0) ? 0.95 : 0.93), (fmt::sprintf("Pixel Tracker Map: %s", m_title)).c_str());
   txt.SetTextSize(0.03);
 
   txt.DrawLatex(0.55, 0.125, "-DISK");
@@ -131,8 +144,8 @@ void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas, const float topMarg
 
   txt.DrawLatex(0.08, 0.28, "+z");
   txt.DrawLatex(0.25, 0.70, "+phi");
-  txt.DrawLatex(0.31, 0.78, "+x");
-  txt.DrawLatex(0.21, 0.96, "+y");
+  txt.DrawLatex((index == 0) ? 0.31 : 0.33, 0.78, "+x");
+  txt.DrawLatex((index == 0) ? 0.21 : 0.22, ((index == 0) ? 0.96 : 0.94), "+y");
 
   txt.SetTextAngle(90);
   txt.DrawLatex(0.04, 0.5, "BARREL");

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -154,6 +154,16 @@ bool Phase1PixelSummaryMap::fillTrackerMap(unsigned int id, double value) {
 }
 
 //============================================================================
+const std::pair<float, float> Phase1PixelSummaryMap::getZAxisRange() const {
+  return std::make_pair(m_BaseTrackerMap->GetMinimum(), m_BaseTrackerMap->GetMaximum());
+}
+
+//============================================================================
+void Phase1PixelSummaryMap::setZAxisRange(const double min, const double max) {
+  m_BaseTrackerMap->GetZaxis()->SetRangeUser(min, max);
+}
+
+//============================================================================
 void Phase1PixelSummaryMap::addNamedBins(
     edm::FileInPath geoFile, int tX, int tY, int sX, int sY, bool applyModuleRotation) {
   auto cornerFileName = geoFile.fullPath();


### PR DESCRIPTION
#### PR description:

The purpose of this PR is introduce Pixel Tracker Maps (via `Phase1PixelSummaryMap`) of the input factors for the computation of the dynamic inefficiency used in the pixel digitizer. This is done separately for geometrical and PU factors.
Provision for the further expansion are laid out, but currently not used (and therefore commented)
The package unit tests are also expanded accordingly.

#### PR validation:

Run the following script:

```bash
#!/bin/bash
# Save current working dir so img can be outputted there later
W_DIR=$(pwd);
source /afs/cern.ch/cms/cmsset_default.sh;
eval `scram run -sh`;
# Go back to original working directory
cd $W_DIR;

if [ -d $W_DIR/plots_DynIneff ]; then
    rm -fr $W_DIR/plots_DynIneff
fi

mkdir -p $W_DIR/plots_DynIneff

tags=(SiPixelDynamicInefficiency_PhaseI_v9 SiPixelDynamicInefficiency_PhaseI_v8 SiPixelDynamicInefficiency_PhaseI_Run3Studies_v2 SiPixelDynamicInefficiency_PhaseI_Run3Studies SiPixelDynamicInefficiency_P
haseI_v6 SiPixelDynamicInefficiency_PhaseI_v5 SiPixelDynamicInefficiency_PhaseI_v4 SiPixelDynamicInefficiency_PhaseI_relvals_v2 SiPixelDynamicInefficiency_PhaseI_relvals_v1 SiPixelDynamicInefficiency_Pha
seI_v3 SiPixelDynamicInefficiency_Phase1_v4 SiPixelDynamicInefficiency_Phase1_v3 SiPixelDynamicInefficiency_13TeV_v3_mc SiPixelDynamicInefficiency_FakeInefficiency_0999_mc SiPixelDynamicInefficiency_Phas
eI_v2 SiPixelDynamicInefficiency_PhaseI_v1 SiPixelDynamicInefficiency_13TeV_v2_mc SiPixelDynamicInefficiency_8TeV_v2_mc SiPixelDynamicInefficiency_13TeV_50ns_v2_mc SiPixelDynamicInefficiency_8TeV_v1_mc S
iPixelDynamicInefficiency_13TeV_v1_mc SiPixelDynamicInefficiency_13TeV_50ns_v1_mc)
plots=(Geom ColGeom ChipGeom)

for i in "${tags[@]}" 
do
    for j in "${plots[@]}" 
    do
    	getPayloadData.py \
    	    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
    	    --plot plot_SiPixelDynamicInefficiency${j}FactorMap \
    	    --tag ${i} \
    	    --time_type Run \
    	    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    	    --db Prod \
    	    --test;

    	mv *.png $W_DIR/plots_DynIneff/${j}_${i}.png
    done

    getPayloadData.py \
     	--plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
	--plot plot_SiPixelDynamicInefficiencyPUPixelMaps \
	--tag ${i} \
     	--time_type Run \
     	--iovs '{"start_iov": "1", "end_iov": "1"}' \
     	--db Prod \
     	--test;
    
    mv *.png $W_DIR/plots_DynIneff/PU_${i}.png
done
```

and obtained sensible plots. An example is the following plot:

![image](https://user-images.githubusercontent.com/5082376/212071912-e4d012b9-a525-48d8-95eb-15d1f66abc64.png)

Also tested the package unit tests via `scram b runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A