### PR TITLE
Fix warning in RZLine

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
@@ -9,6 +9,11 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<bin file="RZLine_catch2.cc" name="testRecoPixelVertexingPixelTrackFittingRZLine">
+  <use name="catch2"/>
+  <use name="RecoPixelVertexing/PixelTrackFitting"/>
+</bin>
+
 <bin file="testFits.cpp">
   <use name="cuda"/>
   <use name="eigen"/>

--- a/RecoPixelVertexing/PixelTrackFitting/test/RZLine_catch2.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/test/RZLine_catch2.cc
@@ -1,0 +1,110 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+#include <algorithm>
+#include "RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h"
+
+TEST_CASE("test RZLine", "[RZLine]") {
+  SECTION("Constructors") {
+    constexpr std::array<float, 2> r{{0.001, 0.003}};
+    constexpr std::array<float, 2> z{{0.1, 0.2}};
+    constexpr std::array<float, 2> errz{{0.01, 0.02}};
+    constexpr float cotTheta = 50.0f;
+    constexpr float intercept = 0.05f;
+    constexpr float covss = 124.99996f;
+    constexpr float covii = 0.0003249999136f;
+    constexpr float covsi = -0.175f;
+    constexpr float chi2 = 1.110223025e-12;
+
+    SECTION("array") {
+      RZLine l(r, z, errz);
+
+      REQUIRE(l.cotTheta() == Approx(cotTheta));
+      REQUIRE(l.intercept() == Approx(intercept));
+      REQUIRE(l.covss() == Approx(covss));
+      REQUIRE(l.covii() == Approx(covii));
+      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE(l.chi2() == Approx(chi2));
+    }
+
+    SECTION("vector") {
+      const std::vector<float> rv{r.begin(), r.end()};
+      const std::vector<float> zv{z.begin(), z.end()};
+      const std::vector<float> errzv{errz.begin(), errz.end()};
+      RZLine l(rv, zv, errzv);
+
+      REQUIRE(l.cotTheta() == Approx(cotTheta));
+      REQUIRE(l.intercept() == Approx(intercept));
+      REQUIRE(l.covss() == Approx(covss));
+      REQUIRE(l.covii() == Approx(covii));
+      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE(l.chi2() == Approx(chi2));
+    }
+
+    SECTION("vector ErrZ2_tag") {
+      const std::vector<float> rv{r.begin(), r.end()};
+      const std::vector<float> zv{z.begin(), z.end()};
+      std::vector<float> errzv;
+      std::transform(errz.begin(), errz.end(), std::back_inserter(errzv), [](float v) { return v * v; });
+      RZLine l(rv, zv, errzv, RZLine::ErrZ2_tag());
+
+      REQUIRE(l.cotTheta() == Approx(cotTheta));
+      REQUIRE(l.intercept() == Approx(intercept));
+      REQUIRE(l.covss() == Approx(covss));
+      REQUIRE(l.covii() == Approx(covii));
+      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE(l.chi2() == Approx(chi2));
+    }
+
+    SECTION("points&errors") {
+      struct Error {
+        float err_;
+        float czz() const { return err_ * err_; }
+        float rerr(const GlobalPoint&) const { return 0.f; }
+      };
+      const std::vector<GlobalPoint> p{{{std::abs(r[0]), 0., z[0]}, {std::abs(r[1]), 0., z[1]}}};
+      REQUIRE(p[0].perp() == std::abs(r[0]));
+      REQUIRE(p[0].z() == z[0]);
+      REQUIRE(p[1].perp() == std::abs(r[1]));
+      REQUIRE(p[1].z() == z[1]);
+      const std::vector<Error> err{{{errz[0]}, {errz[1]}}};
+      REQUIRE(err[0].czz() == errz[0] * errz[0]);
+      REQUIRE(err[1].czz() == errz[1] * errz[1]);
+      const std::vector<bool> barrel{{true, true}};
+      RZLine l(p, err, barrel);
+
+      REQUIRE(l.cotTheta() == Approx(cotTheta));
+      REQUIRE(l.intercept() == Approx(intercept));
+      REQUIRE(l.covss() == Approx(covss));
+      REQUIRE(l.covii() == Approx(covii));
+      REQUIRE(l.covsi() == Approx(covsi));
+      REQUIRE(l.chi2() == Approx(chi2));
+    }
+  }
+  SECTION("no points") {
+    const std::vector<float> rv;
+    const std::vector<float> zv;
+    std::vector<float> errzv;
+    RZLine l(rv, zv, errzv);
+
+    //NOTE a NaN is a number that is not equal to itself
+    REQUIRE(l.cotTheta() != l.cotTheta());
+    REQUIRE(l.intercept() != l.intercept());
+    REQUIRE(l.covss() != l.covss());
+    REQUIRE(l.covii() != l.covii());
+    REQUIRE(l.covsi() != l.covsi());
+    REQUIRE(l.chi2() == 0.0f);
+  }
+  SECTION("one point") {
+    const std::vector<float> rv = {0.001};
+    const std::vector<float> zv = {0.1};
+    const std::vector<float> errzv = {0.01};
+    RZLine l(rv, zv, errzv);
+
+    REQUIRE(l.cotTheta() == 0.0f);
+    REQUIRE(l.intercept() == Approx(0.125f));
+    REQUIRE(l.covss() == Approx(1310720000.0f));
+    REQUIRE(l.covii() == Approx(1310.72009f));
+    REQUIRE(l.covsi() == Approx(-1310720.0f));
+    REQUIRE(l.chi2() == Approx(6.25f));
+  }
+}


### PR DESCRIPTION
#### PR description:

The LTO build was warning about a possible uninitialized value usage. From inspection, that is not the case but the compiler was unable to reason about the placement new usage.
- Changed to use VLA directly
- Added unit test

#### PR validation:

Code compiles and new unit test passes.