### PR TITLE
FW fix: declare FWCoreIntegrationValueExample as library

### DIFF
--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -47,6 +47,7 @@
 
   <library file="ValueExample.cc" name="FWCoreIntegrationValueExample">
     <use name="FWCore/ParameterSet"/>
+    <flags EDM_PLUGIN="0"/>
   </library>
 
   <library file="ValueExamplePlugin.cc" name="FWCoreIntegrationValueExamplePlugin">


### PR DESCRIPTION
By default every library in package/plugins directory is built as plugin. `FWCoreIntegrationValueExample` should be a shared library which is used by few plugins in FWCore/Integration/plugin. https://github.com/cms-sw/cmssw/pull/40448 PR tests worked as the `libFWCoreIntegrationValueExample.so` was picked up from release area. This should fix the build errors we are getting in 
- https://github.com/cms-sw/cmsdist/pull/8247 
- https://github.com/cms-sw/cmsdist/pull/8248

Also with this change full cmssw build will fail too.