### PR TITLE
Update L1Menu tag in data RelVal GTs and 2022/2023/2024, Phase2 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run3 HLT: identical to the online GT (126X_dataRun3_HLT_v1) but with snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_hlt'                     : '126X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v1',
+    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT) - identical to 126X_dataRun3_Express_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_data_express'            : '126X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 126X_dataRun3_Prompt_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_data'                    : '126X_dataRun3_v1',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '126X_dataRun3_relval_v1',
+    'run3_data_relval'             : '126X_dataRun3_relval_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -68,31 +68,31 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '130X_mcRun3_2022_design_v1',
+    'phase1_2022_design'           : '130X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v1',
+    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v1',
+    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v1',
+    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v1',
+    'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v2',
+    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v1',
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v2',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v1',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v1',
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v2',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v2',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '130X_mcRun4_realistic_v1'
+    'phase2_realistic'             : '130X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR updates the following Run3 GTs 
- `HLT` RelVal and `offline` RelVal data GTs  
- 2022, 2023, 2024 and Phase2 MC GTs 

with the latest L1 Menu tag`(v1_4_0)`, _i.e._  `L1Menu_Collisions2022_v1_4_0-d1_xml` as requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-4-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/19165) [1].

[1] https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-4-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/19165

**GT differences:**

- **Run 3 HLT relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/126X_dataRun3_HLT_relval_v1/126X_dataRun3_HLT_relval_v2

- **Run 3 offline relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/126X_dataRun3_relval_v1/126X_dataRun3_relval_v2

- **2022 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_design_v1/130X_mcRun3_2022_design_v2

- **2022 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_v1/130X_mcRun3_2022_realistic_v2

- **2022 realistic postEE**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_postEE_v1/130X_mcRun3_2022_realistic_postEE_v2

- **2022 cosmic realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_realistic_deco_v1/130X_mcRun3_2022cosmics_realistic_deco_v2

- **2022 cosmic design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_design_deco_v1/130X_mcRun3_2022cosmics_design_deco_v2

- **2022 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_v2/130X_mcRun3_2022_realistic_HI_v3

- **2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_v1/130X_mcRun3_2023_design_v2

- **2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v2/130X_mcRun3_2023_realistic_v3

- **2023 cosmic realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v1/130X_mcRun3_2023cosmics_realistic_deco_v2

- **2023 cosmic design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_v1/130X_mcRun3_2023cosmics_design_deco_v2

- **2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v2/130X_mcRun3_2023_realistic_HI_v3

- **2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v2/130X_mcRun3_2024_realistic_v3

- **Phase2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun4_realistic_v1/130X_mcRun4_realistic_v2

#### PR validation:
Successfully tested with:
`runTheMatrix.py -l 139.001,7.23,11634.0,12034.0,12834.0,312.0 -j10 --ibeos`
which consume the `auto:run3_hlt_relval`, `auto:run3_data_relval`, `auto:phase1_2022_cosmics`, `auto:phase1_2022_realistic`, `auto:phase1_2022_design`, `auto:phase1_2024_realistic`, `auto:phase1_2022_realistic_hi` keys.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport.
A backport to `12_6_X` with only data RelVal GTs will be opened soon.
