### PR TITLE
[12_6_X] Update L1Menu tag in data RelVal GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run3 HLT: identical to the online GT (126X_dataRun3_HLT_v1) but with snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_hlt'                     : '126X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v1',
+    'run3_hlt_relval'              : '126X_dataRun3_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT) - identical to 126X_dataRun3_Express_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_data_express'            : '126X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 126X_dataRun3_Prompt_v1 but with snapshot at 2023-01-06 18:15:00 (UTC)
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-01-06 18:15:00 (UTC)
     'run3_data'                    : '126X_dataRun3_v1',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '126X_dataRun3_relval_v1',
+    'run3_data_relval'             : '126X_dataRun3_relval_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

Partial backport of #40501 with only RelVal data GTs 

This PR updates the following Run3 GTs 
- `HLT` RelVal and `offline` RelVal data GTs  

with the latest L1 Menu tag`(v1_4_0)`, _i.e._  `L1Menu_Collisions2022_v1_4_0-d1_xml` as requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-4-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/19165) [1].

[1] https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-4-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/19165

**GT differences:**

- **Run 3 HLT relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/126X_dataRun3_HLT_relval_v1/126X_dataRun3_HLT_relval_v2

- **Run 3 offline relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/126X_dataRun3_relval_v1/126X_dataRun3_relval_v2

#### PR validation:
Successfully tested with:
`runTheMatrix.py -l 139.001 -j10 --ibeos`
which consume the `auto:run3_hlt_relval` and `auto:run3_data_relval` keys.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
 Backport of #40501

