### PR TITLE
[RECONSTRUCTION] [CLANG] Fixes warnings reported by clang 14

### DIFF
--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h
@@ -181,9 +181,9 @@ namespace sistrip {
 
   inline bool FEDBuffer::doChecks(bool doCRC) const {
     //check that all channels were unpacked properly
-    return (validChannels_ == FEDCH_PER_FED) &
+    return (validChannels_ == FEDCH_PER_FED) &&
            //do checks from base class
-           (FEDBufferBase::doChecks()) &
+           (FEDBufferBase::doChecks()) &&
            // check crc if required
            (!doCRC || checkCRC());
   }

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -1430,7 +1430,7 @@ namespace sistrip {
 
   inline FEDReadoutMode FEDBufferBase::readoutMode() const { return specialHeader_.readoutMode(); }
 
-  inline bool FEDBufferBase::doChecks() const { return doTrackerSpecialHeaderChecks() & doDAQHeaderAndTrailerChecks(); }
+  inline bool FEDBufferBase::doChecks() const { return doTrackerSpecialHeaderChecks() && doDAQHeaderAndTrailerChecks(); }
 
   inline uint8_t FEDBufferBase::packetCode(bool legacy, const uint8_t internalFEDChannelNum) const {
     if (legacy) {

--- a/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
+++ b/EventFilter/SiStripRawToDigi/interface/SiStripFEDBufferComponents.h
@@ -1430,7 +1430,9 @@ namespace sistrip {
 
   inline FEDReadoutMode FEDBufferBase::readoutMode() const { return specialHeader_.readoutMode(); }
 
-  inline bool FEDBufferBase::doChecks() const { return doTrackerSpecialHeaderChecks() && doDAQHeaderAndTrailerChecks(); }
+  inline bool FEDBufferBase::doChecks() const {
+    return doTrackerSpecialHeaderChecks() && doDAQHeaderAndTrailerChecks();
+  }
 
   inline uint8_t FEDBufferBase::packetCode(bool legacy, const uint8_t internalFEDChannelNum) const {
     if (legacy) {


### PR DESCRIPTION
This Pr fixes clang 14 warnings about the use of bitwise '&' with boolean operands