### PR TITLE
[GEOMETRY-UPGRADE] [CLANG] Fixes warnings reported by clang 14

### DIFF
--- a/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
+++ b/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
@@ -136,7 +136,7 @@ public:
   bool isItEdgePixelInY(int iybin) const override { return ((iybin == 0) | (iybin == (m_ncols - 1))); }
 
   bool isItEdgePixel(int ixbin, int iybin) const override {
-    return (isItEdgePixelInX(ixbin) | isItEdgePixelInY(iybin));
+    return (isItEdgePixelInX(ixbin) || isItEdgePixelInY(iybin));
   }
 
   //-------------------------------------------------------------


### PR DESCRIPTION
This PR fixes clang 14 warnings about the use of bitwise '&' with boolean operands