### PR TITLE
[L1] [CLANG] Fixes warnings reported by clang 14

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
@@ -111,6 +111,7 @@ namespace l1t {
         }
 
         //Redetermine Final (multiboard)  FINOR
+        //be explicit and must set to false if we find a board with veto set.
         alg.setFinalOR(alg.getFinalORPreVeto() && !alg.getFinalORVeto());
 
         // Put the object back into place (Must be better way)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
@@ -111,11 +111,7 @@ namespace l1t {
         }
 
         //Redetermine Final (multiboard)  FINOR
-        if (alg.getFinalORPreVeto() & !alg.getFinalORVeto()) {
-          alg.setFinalOR(true);
-        } else {
-          alg.setFinalOR(false);  //be explicit and must set to false if we find a board with veto set.
-        }
+        alg.setFinalOR(alg.getFinalORPreVeto() && !alg.getFinalORVeto());
 
         // Put the object back into place (Must be better way)
         res_->set(bx, 0, alg);


### PR DESCRIPTION
This Pr fixes clang 14 warnings about the use of bitwise '&' with boolean operands