### PR TITLE
[RECONSTRUCTION] [CLANG] Fixes warnings reported by clang 14

### DIFF
--- a/CommonTools/Utils/test/testExpressionParser.cc
+++ b/CommonTools/Utils/test/testExpressionParser.cc
@@ -264,15 +264,7 @@ void testExpressionParser::checkAll() {
       std::cout << "Check for leaks in the " << (b ? "Lazy" : "standard") << " string parser" << std::endl;
       expr.reset();
       reco::parser::expressionParser<pat::Muon>("triggerObjectMatchesByPath('HLT_Something').size()", expr, b);
-      for (size_t i = 0; i < 10 * 1000; ++i) {
-        for (size_t j = 0; j < 100; ++j) {
-          expr->value(o);
-          break;
-        }
-        break;
-        if (i % 1000 == 999)
-          std::cout << "iter " << i << std::endl;
-      }
+      expr->value(o);
     }
   }
   reco::CandidatePtrVector ptrOverlaps;

--- a/CommonTools/Utils/test/testExpressionParser.cc
+++ b/CommonTools/Utils/test/testExpressionParser.cc
@@ -264,10 +264,9 @@ void testExpressionParser::checkAll() {
       std::cout << "Check for leaks in the " << (b ? "Lazy" : "standard") << " string parser" << std::endl;
       expr.reset();
       reco::parser::expressionParser<pat::Muon>("triggerObjectMatchesByPath('HLT_Something').size()", expr, b);
-      double res = 0;
       for (size_t i = 0; i < 10 * 1000; ++i) {
         for (size_t j = 0; j < 100; ++j) {
-          res += expr->value(o);
+          expr->value(o);
           break;
         }
         break;


### PR DESCRIPTION
This should fix the clang 14 warning. For now I have removed the unused `res` variable but if needed then I can just print out the `res` value so that  compiler do not complain about unused variable.