### PR TITLE
[ALCA] [CLANG] Fixes warnings reported by clang 14

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -2664,7 +2664,7 @@ void GlobalTrackerMuonAlignment::misalignMuon(
   MuGlShift = d;
   MuGlAngle = a;
 
-  if ((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)) {
+  if ((d(1) == 0.) && (d(2) == 0.) && (d(3) == 0.) && (a(1) == 0.) && (a(2) == 0.) && (a(3) == 0.)) {
     Rm = GRm;
     Pm = GPm;
     if (debug_)
@@ -2822,7 +2822,7 @@ void GlobalTrackerMuonAlignment::misalignMuonL(GlobalVector& GRm,
   MuGlShift = d;
   MuGlAngle = a;
 
-  if ((d(1) == 0.) & (d(2) == 0.) & (d(3) == 0.) & (a(1) == 0.) & (a(2) == 0.) & (a(3) == 0.)) {
+  if ((d(1) == 0.) && (d(2) == 0.) && (d(3) == 0.) && (a(1) == 0.) && (a(2) == 0.) && (a(3) == 0.)) {
     Rm = GRm;
     Pm = GPm;
     AlgebraicVector4 Vm0;

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalTestPulseAnalyzer.cc
@@ -704,11 +704,7 @@ void EcalTestPulseAnalyzer::endJob() {
     if (moduleID >= 20)
       moduleID -= 2;  // Trick to fix endcap specificity
 
-    Long64_t nbytes = 0, nb = 0;
     for (Long64_t jentry = 0; jentry < trees[iCry]->GetEntriesFast(); jentry++) {
-      nb = trees[iCry]->GetEntry(jentry);
-      nbytes += nb;
-
       // PN Means and RMS
 
       if (firstChanMod[iMod] == iCry) {

--- a/CalibCalorimetry/EcalLaserAnalyzer/src/TShapeAnalysis.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/src/TShapeAnalysis.cc
@@ -390,12 +390,10 @@ void TShapeAnalysis::computetmaxVal(int i, double *tm_val) {
   double tm_mean = 0;  //double tm_sig=0;
 
   double tm = 0.;
-  double sigtm = 0.;
   for (int k = 0; k < npass[i] - 1; k++) {
     if (1. < tm_val[k] && tm_val[k] < 10.) {
       npassok[i]++;
       tm += tm_val[k];
-      sigtm += tm_val[k] * tm_val[k];
     }
   }
   if (npassok[i] <= 0) {

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -273,8 +273,8 @@ void EcalLaserCondTools::fillDb(CorrReader& r) {
     int iline = 0;
     while (!feof(eventList_)) {
       //skips comment lines:
-      char c;
-      while (fscanf(eventList_, " %1[#]%*[^\n]\n", &c) == 1)
+      char c[2];
+      while (fscanf(eventList_, " %1[#]%*[^\n]\n", &c[0]) == 1)
         ++iline;
 
       int n = fscanf(eventList_, "%*d %*d %*d %d%*[^\n]\n", &t);

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.cc
@@ -56,7 +56,6 @@ void DTTTrigCorrectionFirst::endJob() {
   double average2 = 0.;
   double rms = 0.;
   double averageSigma = 0.;
-  double average2Sigma = 0.;
   double counter = 0.;
   double averagekfactor = 0;
   float kfactor = 0;
@@ -86,7 +85,6 @@ void DTTTrigCorrectionFirst::endJob() {
     tTrigMap->get((*sl)->id(), ttrigMean, ttrigSigma, kfactor, DTTimeUnits::ns);
     if (ttrigMean < ttrigMax && ttrigMean > ttrigMin) {
       average2 += (ttrigMean - average) * (ttrigMean - average);
-      average2Sigma += (ttrigSigma - averageSigma) * (ttrigSigma - averageSigma);
     }
   }  //End of loop on superlayers
 

--- a/Calibration/HcalCalibAlgos/src/hcalCalib.cc
+++ b/Calibration/HcalCalibAlgos/src/hcalCalib.cc
@@ -503,10 +503,8 @@ void hcalCalib::GetCoefFromMtrxInvOfAve() {
 
     std::map<Int_t, Float_t>::iterator n_it = (aveHitE[iEta]).begin();
 
-    Float_t sumRawE = 0;
     for (; n_it != (aveHitE[iEta]).end(); ++n_it) {
       (n_it->second) *= norm;
-      sumRawE += (n_it->second);
     }
 
   }  // end of scaling by number of entries

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -1129,7 +1129,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
       HERE("fill PF jet");
 
-      int types = 0;
       int ntypes = 0;
 
       /////////////////////////////////////////////
@@ -1385,7 +1384,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           float HFEM_E = 0;
           int HFHAD_n_ = 0;
           int HFEM_n_ = 0;
-          int HF_type_ = 0;
           int maxElement = (*it)->elementsInBlocks().size();
           if (debug_ > 1)
             edm::LogVerbatim("GammaJetAnalysis") << "maxElement=" << maxElement;
@@ -1402,7 +1400,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
             for (unsigned iEle = 0; iEle < elements.size(); iEle++) {
               if (elements[iEle].index() == (*it)->elementsInBlocks()[e].second) {
                 if (elements[iEle].type() == reco::PFBlockElement::HCAL) {  // Element is HB or HE
-                  HF_type_ |= 0x1;
                   // Get cluster and hits
                   reco::PFClusterRef clusterref = elements[iEle].clusterRef();
                   reco::PFCluster cluster = *clusterref;
@@ -1493,10 +1490,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                   }                                                               // Loop over hits
                 }                                                                 // Test if element is from HCAL
                 else if (elements[iEle].type() == reco::PFBlockElement::HFHAD) {  // Element is HF
-                  types |= 0x2;
                   ntypes++;
                   HFHAD_n_++;
-                  HF_type_ |= 0x2;
 
                   ////	h_etaHFHAD_->Fill((*it)->eta());
 
@@ -1547,10 +1542,8 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                     }
                   }
                 } else if (elements[iEle].type() == reco::PFBlockElement::HFEM) {  // Element is HF
-                  types |= 0x4;
                   ntypes++;
                   HFEM_n_++;
-                  HF_type_ |= 0x4;
 
                   for (edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith =
                            hfreco->begin();
@@ -1599,9 +1592,7 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                     }
                   }
                 } else if (elements[iEle].type() == reco::PFBlockElement::HO) {  // Element is HO
-                  types |= 0x8;
                   ntypes++;
-                  HF_type_ |= 0x8;
                   reco::PFClusterRef clusterref = elements[iEle].clusterRef();
                   reco::PFCluster cluster = *clusterref;
                   double cluster_dR = deltaR(ppfjet_eta_, ppfjet_phi_, cluster.eta(), cluster.phi());

--- a/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalHBHEMuonSimAnalyzer.cc
@@ -189,7 +189,7 @@ void HcalHBHEMuonSimAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
       unsigned int thisTrk = simTrkItr.trackId();
       spr::propagatedTrackDirection trkD = spr::propagateCALO(thisTrk, SimTk, SimVtx, geo, bField, debug);
 
-      double eEcal(0), eHcal(0), activeLengthTot(0), activeLengthHotTot(0);
+      double eEcal(0), eHcal(0), activeLengthHotTot(0);
       double eHcalDepth[depthMax_], eHcalDepthHot[depthMax_];
       double activeL[depthMax_], activeHotL[depthMax_];
       unsigned int isHot(0);
@@ -272,7 +272,6 @@ void HcalHBHEMuonSimAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
           HcalDetId hcid0(subdet0, ieta, iphi, ehdepth[i].second);
           double actL = activeLength(DetId(hcid0));
           activeL[ehdepth[i].second - 1] = actL;
-          activeLengthTot += actL;
 #ifdef EDM_ML_DEBUG
           if ((verbosity_ % 10) > 0)
             edm::LogVerbatim("HBHEMuon") << hcid0 << " E " << ehdepth[i].first << " L " << actL;


### PR DESCRIPTION
clang 14 warning fixes needed for `alca` packages
- removal of set but unused variables
- use of bitwise `&` for boolean operands