### PR TITLE
Fix unit test failure related to moving the file ProducerWithPSetDesc.cc

### DIFF
--- a/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
@@ -304,8 +304,8 @@ namespace edmtest {
     assert(vESInputTag[2] == esinputTag3);
 
     // For purposes of the test, this just needs to point to any file
-    // that exists.  I guess pointing to itself cannot ever fail ...
-    edm::FileInPath fileInPath("FWCore/Integration/test/ProducerWithPSetDesc.cc");
+    // that exists.
+    edm::FileInPath fileInPath("FWCore/Integration/plugins/ProducerWithPSetDesc.cc");
     assert(fileInPath == ps.getParameter<edm::FileInPath>("fileInPath"));
 
     edm::ParameterSet const& pset = ps.getParameterSet("bar");
@@ -687,8 +687,8 @@ namespace edmtest {
     iDesc.add<std::vector<edm::ESInputTag>>("vESInputTagv4", vESInputTag);
 
     // For purposes of the test, this just needs to point to any file
-    // that exists.  I guess pointing to itself cannot ever fail ...
-    edm::FileInPath fileInPath("FWCore/Integration/test/ProducerWithPSetDesc.cc");
+    // that exists.
+    edm::FileInPath fileInPath("FWCore/Integration/plugins/ProducerWithPSetDesc.cc");
     iDesc.add<edm::FileInPath>("fileInPath", fileInPath);
 
     edm::EmptyGroupDescription emptyGroup;

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_briefdoc.txt
@@ -159,7 +159,7 @@
       [0]: 'One:Two'
       [1]: 'One:'
       [2]: ':Two'
-    fileInPath              FileInPath                     'FWCore/Integration/test/ProducerWithPSetDesc.cc'
+    fileInPath              FileInPath                     'FWCore/Integration/plugins/ProducerWithPSetDesc.cc'
     Empty group description
     bar                     PSet                           see Section 1.1.2
     test101                 PSet                  optional see Section 1.1.3 (do not write to cfi)

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
@@ -179,7 +179,7 @@ testProducerWithPsetDesc = cms.EDProducer('ProducerWithPSetDesc',
     'One:',
     ':Two'
   ),
-  fileInPath = cms.FileInPath('FWCore/Integration/test/ProducerWithPSetDesc.cc'),
+  fileInPath = cms.FileInPath('FWCore/Integration/plugins/ProducerWithPSetDesc.cc'),
   bar = cms.PSet(
     Drinks = cms.uint32(5),
     uDrinks = cms.untracked.uint32(5),

--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_doc.txt
@@ -433,7 +433,7 @@ generated for each configuration with a module label.
 
     fileInPath
                         type: FileInPath 
-                        default: 'FWCore/Integration/test/ProducerWithPSetDesc.cc'
+                        default: 'FWCore/Integration/plugins/ProducerWithPSetDesc.cc'
 
     Empty group description
 


### PR DESCRIPTION
#### PR description:

Fix unit test failure related to moving the file ProducerWithPSetDesc.cc. A test of the FileInPath type in the ParameterSet validation system relies on the location of this file in FWCore/Integration and we just moved that file from the test subdirectory to the plugin subdirectory. Update the unit test to reflect the new location.

#### PR validation:

Unit test now passes. This change only affects the unit test.
