### PR TITLE
Update data files for DropBoxMetadata tag

### DIFF
--- a/CondFormats/Common/data/BeamSpotObjectsRcdByLumi_prep.json
+++ b/CondFormats/Common/data/BeamSpotObjectsRcdByLumi_prep.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "BeamSpotObjects_PCL_byLumi_v1_prompt": {}
+        "BeamSpotObjects_PCL_byLumi_prep_prompt": {}
     }, 
     "inputTag": "BeamSpotObject_ByLumi", 
     "since": null, 

--- a/CondFormats/Common/data/BeamSpotObjectsRcdByRun_prep.json
+++ b/CondFormats/Common/data/BeamSpotObjectsRcdByRun_prep.json
@@ -3,7 +3,7 @@
     "destinationTags": {
         "BeamSpotObjects_PCL_byRun_v1_express": {}, 
         "BeamSpotObjects_PCL_byRun_v1_hlt": {}, 
-        "BeamSpotObjects_PCL_byRun_v1_prompt": {}
+        "BeamSpotObjects_PCL_byRun_prep_prompt": {}
     }, 
     "inputTag": "BeamSpotObject_ByRun", 
     "since": null, 

--- a/CondFormats/Common/data/CTPPSRPAlignmentCorrectionsDataRcd_prep.json
+++ b/CondFormats/Common/data/CTPPSRPAlignmentCorrectionsDataRcd_prep.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "CTPPSRPAlignment_byPCL_v1_prompt": {}
+        "CTPPSRPAlignment_byPCL_prep_prompt": {}
     }, 
     "inputTag": "CTPPSRPAlignment_real_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/PPSTimingCalibrationRcd_Sampic_prep.json
+++ b/CondFormats/Common/data/PPSTimingCalibrationRcd_Sampic_prep.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "CTPPPSTimingCalibration_SAMPIC_byPCL_v1_prompt": {}
+        "CTPPPSTimingCalibration_SAMPIC_byPCL_prep_prompt": {}
     }, 
     "inputTag": "PPSDiamondSampicCalibration_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/PPSTimingCalibrationRcd_prep.json
+++ b/CondFormats/Common/data/PPSTimingCalibrationRcd_prep.json
@@ -1,7 +1,7 @@
 {
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
-        "CTPPPSTimingCalibration_HPTDC_byPCL_v1_prompt": {}
+        "CTPPPSTimingCalibration_HPTDC_byPCL_prep_prompt": {}
     }, 
     "inputTag": "PPSDiamondTimingCalibration_pcl", 
     "since": null, 

--- a/CondFormats/Common/data/SiStripBadStripRcd_prep.json
+++ b/CondFormats/Common/data/SiStripBadStripRcd_prep.json
@@ -2,7 +2,7 @@
     "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
     "destinationTags": {
         "SiStripBadChannel_PCL_v1_hlt": {}, 
-        "SiStripBadChannel_PCL_v1_prompt": {}
+        "SiStripBadChannel_PCL_prep_prompt": {}
     }, 
     "inputTag": "SiStripBadStrip_pcl", 
     "since": null, 


### PR DESCRIPTION
#### PR description:

This is to update the json files that are used to produce the DropBoxMetada tag. Some of the tags (`SiStripBadChannel_PCL_v1_prompt`, `BeamSpotObjects_PCL_byRun_v1_prompt`, `BeamSpotObjects_PCL_byLumi_v1_prompt`) had pcl synchronisation in Prep DB and this was preventing upload from Tier0 replays. This PR replaces the faulty tags and also updates a few other ones to have a different name between Prod and Prep tags to try avoid such a case of wrong synch in Prep DB in the future.

The difference between the new DMD tag produced with the changes introduced here and the previous one can be seen in https://cern.ch/go/LC9S 

The new DMD tag has been included in the 126X_dataRun3_Express_Queue and will be picked up when a new Express GT is created.

#### PR validation:

- created a Candidate GT by queueing the new tag to `126X_dataRun3_Express_Queue`
- ran RTM the workflow 1001.3 with the candidate GT from above

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 