### PR TITLE
[L1][CLANG]Fix warnings reported by clang 14

### DIFF
--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackAssembler.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackAssembler.cc
@@ -270,71 +270,71 @@ void L1MuDTTrackAssembler::run() {
 
   // Main equations (68)
 
-  m_thePriorityTable1[67] = (b_adr12_8[0] & b_adr13_8[0] & b_adr23_8[0] & n_1234_888.any());
-  m_thePriorityTable1[66] = (b_adr12_8[0] & b_adr13_8[1] & b_adr23_8[1] & n_1234_889.any());
-  m_thePriorityTable1[65] = (b_adr12_8[0] & b_adr13_8[2] & b_adr23_8[2] & n_1234_880.any());
-  m_thePriorityTable1[64] = (b_adr12_8[0] & b_adr13_8[3] & b_adr23_8[3] & n_1234_881.any());
-  m_thePriorityTable1[63] = (b_adr12_8[1] & b_adr13_8[0] & b_adr23_9[0] & n_1234_898.any());
-  m_thePriorityTable1[62] = (b_adr12_8[1] & b_adr13_8[1] & b_adr23_9[1] & n_1234_899.any());
-  m_thePriorityTable1[61] = (b_adr12_8[1] & b_adr13_8[2] & b_adr23_9[2] & n_1234_890.any());
-  m_thePriorityTable1[60] = (b_adr12_8[1] & b_adr13_8[3] & b_adr23_9[3] & n_1234_891.any());
-  m_thePriorityTable1[59] = (b_adr12_8[2] & b_adr13_8[2] & b_adr23_0[2] & n_1234_800.any());
-  m_thePriorityTable1[58] = (b_adr12_8[2] & b_adr13_8[3] & b_adr23_0[3] & n_1234_801.any());
-  m_thePriorityTable1[57] = (b_adr12_8[3] & b_adr13_8[2] & b_adr23_1[2] & n_1234_810.any());
-  m_thePriorityTable1[56] = (b_adr12_8[3] & b_adr13_8[3] & b_adr23_1[3] & n_1234_811.any());
+  m_thePriorityTable1[67] = (b_adr12_8[0] && b_adr13_8[0] && b_adr23_8[0] && n_1234_888.any());
+  m_thePriorityTable1[66] = (b_adr12_8[0] && b_adr13_8[1] && b_adr23_8[1] && n_1234_889.any());
+  m_thePriorityTable1[65] = (b_adr12_8[0] && b_adr13_8[2] && b_adr23_8[2] && n_1234_880.any());
+  m_thePriorityTable1[64] = (b_adr12_8[0] && b_adr13_8[3] && b_adr23_8[3] && n_1234_881.any());
+  m_thePriorityTable1[63] = (b_adr12_8[1] && b_adr13_8[0] && b_adr23_9[0] && n_1234_898.any());
+  m_thePriorityTable1[62] = (b_adr12_8[1] && b_adr13_8[1] && b_adr23_9[1] && n_1234_899.any());
+  m_thePriorityTable1[61] = (b_adr12_8[1] && b_adr13_8[2] && b_adr23_9[2] && n_1234_890.any());
+  m_thePriorityTable1[60] = (b_adr12_8[1] && b_adr13_8[3] && b_adr23_9[3] && n_1234_891.any());
+  m_thePriorityTable1[59] = (b_adr12_8[2] && b_adr13_8[2] && b_adr23_0[2] && n_1234_800.any());
+  m_thePriorityTable1[58] = (b_adr12_8[2] && b_adr13_8[3] && b_adr23_0[3] && n_1234_801.any());
+  m_thePriorityTable1[57] = (b_adr12_8[3] && b_adr13_8[2] && b_adr23_1[2] && n_1234_810.any());
+  m_thePriorityTable1[56] = (b_adr12_8[3] && b_adr13_8[3] && b_adr23_1[3] && n_1234_811.any());
 
-  m_thePriorityTable1[55] = (b_adr12_9[0] & b_adr13_9[0] & b_adr23_8[0] & n_1234_988.any());
-  m_thePriorityTable1[54] = (b_adr12_9[0] & b_adr13_9[1] & b_adr23_8[1] & n_1234_989.any());
-  m_thePriorityTable1[53] = (b_adr12_9[0] & b_adr13_9[2] & b_adr23_8[2] & n_1234_980.any());
-  m_thePriorityTable1[52] = (b_adr12_9[0] & b_adr13_9[3] & b_adr23_8[3] & n_1234_981.any());
-  m_thePriorityTable1[51] = (b_adr12_9[1] & b_adr13_9[0] & b_adr23_9[0] & n_1234_998.any());
-  m_thePriorityTable1[50] = (b_adr12_9[1] & b_adr13_9[1] & b_adr23_9[1] & n_1234_999.any());
-  m_thePriorityTable1[49] = (b_adr12_9[1] & b_adr13_9[2] & b_adr23_9[2] & n_1234_990.any());
-  m_thePriorityTable1[48] = (b_adr12_9[1] & b_adr13_9[3] & b_adr23_9[3] & n_1234_991.any());
-  m_thePriorityTable1[47] = (b_adr12_9[2] & b_adr13_9[2] & b_adr23_0[2] & n_1234_900.any());
-  m_thePriorityTable1[46] = (b_adr12_9[2] & b_adr13_9[3] & b_adr23_0[3] & n_1234_901.any());
-  m_thePriorityTable1[45] = (b_adr12_9[3] & b_adr13_9[2] & b_adr23_1[2] & n_1234_910.any());
-  m_thePriorityTable1[44] = (b_adr12_9[3] & b_adr13_9[3] & b_adr23_1[3] & n_1234_911.any());
+  m_thePriorityTable1[55] = (b_adr12_9[0] && b_adr13_9[0] && b_adr23_8[0] && n_1234_988.any());
+  m_thePriorityTable1[54] = (b_adr12_9[0] && b_adr13_9[1] && b_adr23_8[1] && n_1234_989.any());
+  m_thePriorityTable1[53] = (b_adr12_9[0] && b_adr13_9[2] && b_adr23_8[2] && n_1234_980.any());
+  m_thePriorityTable1[52] = (b_adr12_9[0] && b_adr13_9[3] && b_adr23_8[3] && n_1234_981.any());
+  m_thePriorityTable1[51] = (b_adr12_9[1] && b_adr13_9[0] && b_adr23_9[0] && n_1234_998.any());
+  m_thePriorityTable1[50] = (b_adr12_9[1] && b_adr13_9[1] && b_adr23_9[1] && n_1234_999.any());
+  m_thePriorityTable1[49] = (b_adr12_9[1] && b_adr13_9[2] && b_adr23_9[2] && n_1234_990.any());
+  m_thePriorityTable1[48] = (b_adr12_9[1] && b_adr13_9[3] && b_adr23_9[3] && n_1234_991.any());
+  m_thePriorityTable1[47] = (b_adr12_9[2] && b_adr13_9[2] && b_adr23_0[2] && n_1234_900.any());
+  m_thePriorityTable1[46] = (b_adr12_9[2] && b_adr13_9[3] && b_adr23_0[3] && n_1234_901.any());
+  m_thePriorityTable1[45] = (b_adr12_9[3] && b_adr13_9[2] && b_adr23_1[2] && n_1234_910.any());
+  m_thePriorityTable1[44] = (b_adr12_9[3] && b_adr13_9[3] && b_adr23_1[3] && n_1234_911.any());
 
-  m_thePriorityTable1[43] = (b_adr12_8[0] & n_123_88.any());
-  m_thePriorityTable1[42] = (b_adr12_8[1] & n_123_89.any());
-  m_thePriorityTable1[41] = (b_adr12_8[2] & n_123_80.any());
-  m_thePriorityTable1[40] = (b_adr12_8[3] & n_123_81.any());
+  m_thePriorityTable1[43] = (b_adr12_8[0] && n_123_88.any());
+  m_thePriorityTable1[42] = (b_adr12_8[1] && n_123_89.any());
+  m_thePriorityTable1[41] = (b_adr12_8[2] && n_123_80.any());
+  m_thePriorityTable1[40] = (b_adr12_8[3] && n_123_81.any());
 
-  m_thePriorityTable1[39] = (b_adr12_9[0] & n_123_98.any());
-  m_thePriorityTable1[38] = (b_adr12_9[1] & n_123_99.any());
-  m_thePriorityTable1[37] = (b_adr12_9[2] & n_123_90.any());
-  m_thePriorityTable1[36] = (b_adr12_9[3] & n_123_91.any());
+  m_thePriorityTable1[39] = (b_adr12_9[0] && n_123_98.any());
+  m_thePriorityTable1[38] = (b_adr12_9[1] && n_123_99.any());
+  m_thePriorityTable1[37] = (b_adr12_9[2] && n_123_90.any());
+  m_thePriorityTable1[36] = (b_adr12_9[3] && n_123_91.any());
 
-  m_thePriorityTable1[35] = (b_adr12_8[0] & n_124_88.any());
-  m_thePriorityTable1[34] = (b_adr12_8[1] & n_124_89.any());
-  m_thePriorityTable1[33] = (b_adr12_8[2] & n_124_80.any());
-  m_thePriorityTable1[32] = (b_adr12_8[3] & n_124_81.any());
+  m_thePriorityTable1[35] = (b_adr12_8[0] && n_124_88.any());
+  m_thePriorityTable1[34] = (b_adr12_8[1] && n_124_89.any());
+  m_thePriorityTable1[33] = (b_adr12_8[2] && n_124_80.any());
+  m_thePriorityTable1[32] = (b_adr12_8[3] && n_124_81.any());
 
-  m_thePriorityTable1[31] = (b_adr12_9[0] & n_124_98.any());
-  m_thePriorityTable1[30] = (b_adr12_9[1] & n_124_99.any());
-  m_thePriorityTable1[29] = (b_adr12_9[2] & n_124_90.any());
-  m_thePriorityTable1[28] = (b_adr12_9[3] & n_124_91.any());
+  m_thePriorityTable1[31] = (b_adr12_9[0] && n_124_98.any());
+  m_thePriorityTable1[30] = (b_adr12_9[1] && n_124_99.any());
+  m_thePriorityTable1[29] = (b_adr12_9[2] && n_124_90.any());
+  m_thePriorityTable1[28] = (b_adr12_9[3] && n_124_91.any());
 
-  m_thePriorityTable1[27] = (b_adr13_8[0] & n_134_88.any());
-  m_thePriorityTable1[26] = (b_adr13_8[1] & n_134_89.any());
-  m_thePriorityTable1[25] = (b_adr13_8[2] & n_134_80.any());
-  m_thePriorityTable1[24] = (b_adr13_8[3] & n_134_81.any());
+  m_thePriorityTable1[27] = (b_adr13_8[0] && n_134_88.any());
+  m_thePriorityTable1[26] = (b_adr13_8[1] && n_134_89.any());
+  m_thePriorityTable1[25] = (b_adr13_8[2] && n_134_80.any());
+  m_thePriorityTable1[24] = (b_adr13_8[3] && n_134_81.any());
 
-  m_thePriorityTable1[23] = (b_adr13_9[0] & n_134_98.any());
-  m_thePriorityTable1[22] = (b_adr13_9[1] & n_134_99.any());
-  m_thePriorityTable1[21] = (b_adr13_9[2] & n_134_90.any());
-  m_thePriorityTable1[20] = (b_adr13_9[3] & n_134_91.any());
+  m_thePriorityTable1[23] = (b_adr13_9[0] && n_134_98.any());
+  m_thePriorityTable1[22] = (b_adr13_9[1] && n_134_99.any());
+  m_thePriorityTable1[21] = (b_adr13_9[2] && n_134_90.any());
+  m_thePriorityTable1[20] = (b_adr13_9[3] && n_134_91.any());
 
-  m_thePriorityTable1[19] = (b_adr23_8[0] & n_234_88.any());
-  m_thePriorityTable1[18] = (b_adr23_8[1] & n_234_89.any());
-  m_thePriorityTable1[17] = (b_adr23_8[2] & n_234_80.any());
-  m_thePriorityTable1[16] = (b_adr23_8[3] & n_234_81.any());
+  m_thePriorityTable1[19] = (b_adr23_8[0] && n_234_88.any());
+  m_thePriorityTable1[18] = (b_adr23_8[1] && n_234_89.any());
+  m_thePriorityTable1[17] = (b_adr23_8[2] && n_234_80.any());
+  m_thePriorityTable1[16] = (b_adr23_8[3] && n_234_81.any());
 
-  m_thePriorityTable1[15] = (b_adr23_9[0] & n_234_98.any());
-  m_thePriorityTable1[14] = (b_adr23_9[1] & n_234_99.any());
-  m_thePriorityTable1[13] = (b_adr23_9[2] & n_234_90.any());
-  m_thePriorityTable1[12] = (b_adr23_9[3] & n_234_91.any());
+  m_thePriorityTable1[15] = (b_adr23_9[0] && n_234_98.any());
+  m_thePriorityTable1[14] = (b_adr23_9[1] && n_234_99.any());
+  m_thePriorityTable1[13] = (b_adr23_9[2] && n_234_90.any());
+  m_thePriorityTable1[12] = (b_adr23_9[3] && n_234_91.any());
 
   m_thePriorityTable1[11] = n_12_8.any();
   m_thePriorityTable1[10] = n_12_9.any();

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -172,7 +172,6 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   CaloTowerBxCollection towersColl;
   L1CaloRegionCollection rgnCollection;
 
-  uint32_t expectedTotalET = 0;
   if (!layer1->clearEvent()) {
     LOG_ERROR << "UCT: Failed to clear event" << std::endl;
     return;
@@ -190,7 +189,6 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       LOG_ERROR << "UCT: Failed loading an ECAL tower" << std::endl;
       return;
     }
-    expectedTotalET += et;
   }
 
   if (hcalTPs.isValid()) {
@@ -230,7 +228,6 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             LOG_ERROR << "UCT: Failed loading an HCAL tower" << std::endl;
             return;
           }
-          expectedTotalET += et;
         } else {
           LOG_ERROR << "Illegal Tower: caloEta = " << caloEta << "; caloPhi =" << caloPhi << "; et = " << et
                     << std::endl;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -497,7 +497,6 @@ namespace l1t {
       }
     }
 
-
     // get sums
     if (m_doMPSums) {
       Handle<BXVector<l1t::EtSum> > mpsums;

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -448,7 +448,6 @@ namespace l1t {
     }
 
     // get jet
-    int njetmp = 0;
     std::vector<l1t::Jet> thejets_poseta;
     std::vector<l1t::Jet> thejets_negeta;
 
@@ -464,7 +463,6 @@ namespace l1t {
           continue;
 
         for (auto itr = mpjets->begin(ibx); itr != mpjets->end(ibx); ++itr) {
-          njetmp += 1;
           hbx_.at(MPJet)->Fill(ibx);
           het_.at(MPJet)->Fill(itr->hwPt());
           heta_.at(MPJet)->Fill(itr->hwEta());
@@ -499,7 +497,6 @@ namespace l1t {
       }
     }
 
-    //std::cout<<"njetmp "<<njetmp<<std::endl;
 
     // get sums
     if (m_doMPSums) {
@@ -631,7 +628,6 @@ namespace l1t {
     }
 
     // get jet
-    int njetdem = 0;
     std::vector<l1t::Jet> thejets;
 
     if (m_doJets) {
@@ -643,7 +639,6 @@ namespace l1t {
           continue;
 
         for (auto itr = jets->begin(ibx); itr != jets->end(ibx); ++itr) {
-          njetdem += 1;
           hbx_.at(Jet)->Fill(ibx);
           het_.at(Jet)->Fill(itr->hwPt());
           heta_.at(Jet)->Fill(itr->hwEta());

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -395,10 +395,8 @@ void L1TMuonProducer::sortMuons(MicroGMTConfiguration::InterMuonList& muons, uns
     (*mu1)->setHwWins(0);
   }
 
-  int nCancelled = 0;
   for (mu1 = muons.begin(); mu1 != muons.end(); ++mu1) {
     int mu1CancelBit = (*mu1)->hwCancelBit();
-    nCancelled += mu1CancelBit;
     auto mu2 = mu1;
     mu2++;
     for (; mu2 != muons.end(); ++mu2) {

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackAssembler.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackAssembler.cc
@@ -270,71 +270,71 @@ void L1MuBMTrackAssembler::run() {
 
   // Main equations (68)
 
-  m_thePriorityTable1[67] = (b_adr12_8[0] & b_adr13_8[0] & b_adr23_8[0] & n_1234_888.any());
-  m_thePriorityTable1[66] = (b_adr12_8[0] & b_adr13_8[1] & b_adr23_8[1] & n_1234_889.any());
-  m_thePriorityTable1[65] = (b_adr12_8[0] & b_adr13_8[2] & b_adr23_8[2] & n_1234_880.any());
-  m_thePriorityTable1[64] = (b_adr12_8[0] & b_adr13_8[3] & b_adr23_8[3] & n_1234_881.any());
-  m_thePriorityTable1[63] = (b_adr12_8[1] & b_adr13_8[0] & b_adr23_9[0] & n_1234_898.any());
-  m_thePriorityTable1[62] = (b_adr12_8[1] & b_adr13_8[1] & b_adr23_9[1] & n_1234_899.any());
-  m_thePriorityTable1[61] = (b_adr12_8[1] & b_adr13_8[2] & b_adr23_9[2] & n_1234_890.any());
-  m_thePriorityTable1[60] = (b_adr12_8[1] & b_adr13_8[3] & b_adr23_9[3] & n_1234_891.any());
-  m_thePriorityTable1[59] = (b_adr12_8[2] & b_adr13_8[2] & b_adr23_0[2] & n_1234_800.any());
-  m_thePriorityTable1[58] = (b_adr12_8[2] & b_adr13_8[3] & b_adr23_0[3] & n_1234_801.any());
-  m_thePriorityTable1[57] = (b_adr12_8[3] & b_adr13_8[2] & b_adr23_1[2] & n_1234_810.any());
-  m_thePriorityTable1[56] = (b_adr12_8[3] & b_adr13_8[3] & b_adr23_1[3] & n_1234_811.any());
+  m_thePriorityTable1[67] = (b_adr12_8[0] && b_adr13_8[0] && b_adr23_8[0] && n_1234_888.any());
+  m_thePriorityTable1[66] = (b_adr12_8[0] && b_adr13_8[1] && b_adr23_8[1] && n_1234_889.any());
+  m_thePriorityTable1[65] = (b_adr12_8[0] && b_adr13_8[2] && b_adr23_8[2] && n_1234_880.any());
+  m_thePriorityTable1[64] = (b_adr12_8[0] && b_adr13_8[3] && b_adr23_8[3] && n_1234_881.any());
+  m_thePriorityTable1[63] = (b_adr12_8[1] && b_adr13_8[0] && b_adr23_9[0] && n_1234_898.any());
+  m_thePriorityTable1[62] = (b_adr12_8[1] && b_adr13_8[1] && b_adr23_9[1] && n_1234_899.any());
+  m_thePriorityTable1[61] = (b_adr12_8[1] && b_adr13_8[2] && b_adr23_9[2] && n_1234_890.any());
+  m_thePriorityTable1[60] = (b_adr12_8[1] && b_adr13_8[3] && b_adr23_9[3] && n_1234_891.any());
+  m_thePriorityTable1[59] = (b_adr12_8[2] && b_adr13_8[2] && b_adr23_0[2] && n_1234_800.any());
+  m_thePriorityTable1[58] = (b_adr12_8[2] && b_adr13_8[3] && b_adr23_0[3] && n_1234_801.any());
+  m_thePriorityTable1[57] = (b_adr12_8[3] && b_adr13_8[2] && b_adr23_1[2] && n_1234_810.any());
+  m_thePriorityTable1[56] = (b_adr12_8[3] && b_adr13_8[3] && b_adr23_1[3] && n_1234_811.any());
 
-  m_thePriorityTable1[55] = (b_adr12_9[0] & b_adr13_9[0] & b_adr23_8[0] & n_1234_988.any());
-  m_thePriorityTable1[54] = (b_adr12_9[0] & b_adr13_9[1] & b_adr23_8[1] & n_1234_989.any());
-  m_thePriorityTable1[53] = (b_adr12_9[0] & b_adr13_9[2] & b_adr23_8[2] & n_1234_980.any());
-  m_thePriorityTable1[52] = (b_adr12_9[0] & b_adr13_9[3] & b_adr23_8[3] & n_1234_981.any());
-  m_thePriorityTable1[51] = (b_adr12_9[1] & b_adr13_9[0] & b_adr23_9[0] & n_1234_998.any());
-  m_thePriorityTable1[50] = (b_adr12_9[1] & b_adr13_9[1] & b_adr23_9[1] & n_1234_999.any());
-  m_thePriorityTable1[49] = (b_adr12_9[1] & b_adr13_9[2] & b_adr23_9[2] & n_1234_990.any());
-  m_thePriorityTable1[48] = (b_adr12_9[1] & b_adr13_9[3] & b_adr23_9[3] & n_1234_991.any());
-  m_thePriorityTable1[47] = (b_adr12_9[2] & b_adr13_9[2] & b_adr23_0[2] & n_1234_900.any());
-  m_thePriorityTable1[46] = (b_adr12_9[2] & b_adr13_9[3] & b_adr23_0[3] & n_1234_901.any());
-  m_thePriorityTable1[45] = (b_adr12_9[3] & b_adr13_9[2] & b_adr23_1[2] & n_1234_910.any());
-  m_thePriorityTable1[44] = (b_adr12_9[3] & b_adr13_9[3] & b_adr23_1[3] & n_1234_911.any());
+  m_thePriorityTable1[55] = (b_adr12_9[0] && b_adr13_9[0] && b_adr23_8[0] && n_1234_988.any());
+  m_thePriorityTable1[54] = (b_adr12_9[0] && b_adr13_9[1] && b_adr23_8[1] && n_1234_989.any());
+  m_thePriorityTable1[53] = (b_adr12_9[0] && b_adr13_9[2] && b_adr23_8[2] && n_1234_980.any());
+  m_thePriorityTable1[52] = (b_adr12_9[0] && b_adr13_9[3] && b_adr23_8[3] && n_1234_981.any());
+  m_thePriorityTable1[51] = (b_adr12_9[1] && b_adr13_9[0] && b_adr23_9[0] && n_1234_998.any());
+  m_thePriorityTable1[50] = (b_adr12_9[1] && b_adr13_9[1] && b_adr23_9[1] && n_1234_999.any());
+  m_thePriorityTable1[49] = (b_adr12_9[1] && b_adr13_9[2] && b_adr23_9[2] && n_1234_990.any());
+  m_thePriorityTable1[48] = (b_adr12_9[1] && b_adr13_9[3] && b_adr23_9[3] && n_1234_991.any());
+  m_thePriorityTable1[47] = (b_adr12_9[2] && b_adr13_9[2] && b_adr23_0[2] && n_1234_900.any());
+  m_thePriorityTable1[46] = (b_adr12_9[2] && b_adr13_9[3] && b_adr23_0[3] && n_1234_901.any());
+  m_thePriorityTable1[45] = (b_adr12_9[3] && b_adr13_9[2] && b_adr23_1[2] && n_1234_910.any());
+  m_thePriorityTable1[44] = (b_adr12_9[3] && b_adr13_9[3] && b_adr23_1[3] && n_1234_911.any());
 
-  m_thePriorityTable1[43] = (b_adr12_8[0] & n_123_88.any());
-  m_thePriorityTable1[42] = (b_adr12_8[1] & n_123_89.any());
-  m_thePriorityTable1[41] = (b_adr12_8[2] & n_123_80.any());
-  m_thePriorityTable1[40] = (b_adr12_8[3] & n_123_81.any());
+  m_thePriorityTable1[43] = (b_adr12_8[0] && n_123_88.any());
+  m_thePriorityTable1[42] = (b_adr12_8[1] && n_123_89.any());
+  m_thePriorityTable1[41] = (b_adr12_8[2] && n_123_80.any());
+  m_thePriorityTable1[40] = (b_adr12_8[3] && n_123_81.any());
 
-  m_thePriorityTable1[39] = (b_adr12_9[0] & n_123_98.any());
-  m_thePriorityTable1[38] = (b_adr12_9[1] & n_123_99.any());
-  m_thePriorityTable1[37] = (b_adr12_9[2] & n_123_90.any());
-  m_thePriorityTable1[36] = (b_adr12_9[3] & n_123_91.any());
+  m_thePriorityTable1[39] = (b_adr12_9[0] && n_123_98.any());
+  m_thePriorityTable1[38] = (b_adr12_9[1] && n_123_99.any());
+  m_thePriorityTable1[37] = (b_adr12_9[2] && n_123_90.any());
+  m_thePriorityTable1[36] = (b_adr12_9[3] && n_123_91.any());
 
-  m_thePriorityTable1[35] = (b_adr12_8[0] & n_124_88.any());
-  m_thePriorityTable1[34] = (b_adr12_8[1] & n_124_89.any());
-  m_thePriorityTable1[33] = (b_adr12_8[2] & n_124_80.any());
-  m_thePriorityTable1[32] = (b_adr12_8[3] & n_124_81.any());
+  m_thePriorityTable1[35] = (b_adr12_8[0] && n_124_88.any());
+  m_thePriorityTable1[34] = (b_adr12_8[1] && n_124_89.any());
+  m_thePriorityTable1[33] = (b_adr12_8[2] && n_124_80.any());
+  m_thePriorityTable1[32] = (b_adr12_8[3] && n_124_81.any());
 
-  m_thePriorityTable1[31] = (b_adr12_9[0] & n_124_98.any());
-  m_thePriorityTable1[30] = (b_adr12_9[1] & n_124_99.any());
-  m_thePriorityTable1[29] = (b_adr12_9[2] & n_124_90.any());
-  m_thePriorityTable1[28] = (b_adr12_9[3] & n_124_91.any());
+  m_thePriorityTable1[31] = (b_adr12_9[0] && n_124_98.any());
+  m_thePriorityTable1[30] = (b_adr12_9[1] && n_124_99.any());
+  m_thePriorityTable1[29] = (b_adr12_9[2] && n_124_90.any());
+  m_thePriorityTable1[28] = (b_adr12_9[3] && n_124_91.any());
 
-  m_thePriorityTable1[27] = (b_adr13_8[0] & n_134_88.any());
-  m_thePriorityTable1[26] = (b_adr13_8[1] & n_134_89.any());
-  m_thePriorityTable1[25] = (b_adr13_8[2] & n_134_80.any());
-  m_thePriorityTable1[24] = (b_adr13_8[3] & n_134_81.any());
+  m_thePriorityTable1[27] = (b_adr13_8[0] && n_134_88.any());
+  m_thePriorityTable1[26] = (b_adr13_8[1] && n_134_89.any());
+  m_thePriorityTable1[25] = (b_adr13_8[2] && n_134_80.any());
+  m_thePriorityTable1[24] = (b_adr13_8[3] && n_134_81.any());
 
-  m_thePriorityTable1[23] = (b_adr13_9[0] & n_134_98.any());
-  m_thePriorityTable1[22] = (b_adr13_9[1] & n_134_99.any());
-  m_thePriorityTable1[21] = (b_adr13_9[2] & n_134_90.any());
-  m_thePriorityTable1[20] = (b_adr13_9[3] & n_134_91.any());
+  m_thePriorityTable1[23] = (b_adr13_9[0] && n_134_98.any());
+  m_thePriorityTable1[22] = (b_adr13_9[1] && n_134_99.any());
+  m_thePriorityTable1[21] = (b_adr13_9[2] && n_134_90.any());
+  m_thePriorityTable1[20] = (b_adr13_9[3] && n_134_91.any());
 
-  m_thePriorityTable1[19] = (b_adr23_8[0] & n_234_88.any());
-  m_thePriorityTable1[18] = (b_adr23_8[1] & n_234_89.any());
-  m_thePriorityTable1[17] = (b_adr23_8[2] & n_234_80.any());
-  m_thePriorityTable1[16] = (b_adr23_8[3] & n_234_81.any());
+  m_thePriorityTable1[19] = (b_adr23_8[0] && n_234_88.any());
+  m_thePriorityTable1[18] = (b_adr23_8[1] && n_234_89.any());
+  m_thePriorityTable1[17] = (b_adr23_8[2] && n_234_80.any());
+  m_thePriorityTable1[16] = (b_adr23_8[3] && n_234_81.any());
 
-  m_thePriorityTable1[15] = (b_adr23_9[0] & n_234_98.any());
-  m_thePriorityTable1[14] = (b_adr23_9[1] & n_234_99.any());
-  m_thePriorityTable1[13] = (b_adr23_9[2] & n_234_90.any());
-  m_thePriorityTable1[12] = (b_adr23_9[3] & n_234_91.any());
+  m_thePriorityTable1[15] = (b_adr23_9[0] && n_234_98.any());
+  m_thePriorityTable1[14] = (b_adr23_9[1] && n_234_99.any());
+  m_thePriorityTable1[13] = (b_adr23_9[2] && n_234_90.any());
+  m_thePriorityTable1[12] = (b_adr23_9[3] && n_234_91.any());
 
   m_thePriorityTable1[11] = n_12_8.any();
   m_thePriorityTable1[10] = n_12_9.any();

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanStubProcessor.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanStubProcessor.cc
@@ -125,19 +125,19 @@ L1MuKBMTCombinedStubCollection L1TMuonBarrelKalmanStubProcessor::makeStubs(const
           bool phiMask = false;
           bool etaMask = false;
           if (station == 1) {
-            phiMask = msks.get_inrec_chdis_st1(lwheel1, sector) | msks.get_inrec_chdis_st1(lwheel2, sector);
-            etaMask = msks.get_etsoc_chdis_st1(lwheel1, sector) | msks.get_etsoc_chdis_st1(lwheel2, sector);
+            phiMask = msks.get_inrec_chdis_st1(lwheel1, sector) || msks.get_inrec_chdis_st1(lwheel2, sector);
+            etaMask = msks.get_etsoc_chdis_st1(lwheel1, sector) || msks.get_etsoc_chdis_st1(lwheel2, sector);
           }
           if (station == 2) {
-            phiMask = msks.get_inrec_chdis_st2(lwheel1, sector) | msks.get_inrec_chdis_st2(lwheel2, sector);
-            etaMask = msks.get_etsoc_chdis_st2(lwheel1, sector) | msks.get_etsoc_chdis_st2(lwheel2, sector);
+            phiMask = msks.get_inrec_chdis_st2(lwheel1, sector) || msks.get_inrec_chdis_st2(lwheel2, sector);
+            etaMask = msks.get_etsoc_chdis_st2(lwheel1, sector) || msks.get_etsoc_chdis_st2(lwheel2, sector);
           }
           if (station == 3) {
-            phiMask = msks.get_inrec_chdis_st3(lwheel1, sector) | msks.get_inrec_chdis_st3(lwheel2, sector);
-            etaMask = msks.get_etsoc_chdis_st3(lwheel1, sector) | msks.get_etsoc_chdis_st3(lwheel2, sector);
+            phiMask = msks.get_inrec_chdis_st3(lwheel1, sector) || msks.get_inrec_chdis_st3(lwheel2, sector);
+            etaMask = msks.get_etsoc_chdis_st3(lwheel1, sector) || msks.get_etsoc_chdis_st3(lwheel2, sector);
           }
           if (station == 4) {
-            phiMask = msks.get_inrec_chdis_st4(lwheel1, sector) | msks.get_inrec_chdis_st4(lwheel2, sector);
+            phiMask = msks.get_inrec_chdis_st4(lwheel1, sector) || msks.get_inrec_chdis_st4(lwheel2, sector);
           }
 
           if (disableMasks_) {

--- a/L1Trigger/L1TMuonEndCap/src/BestTrackSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/BestTrackSelection.cc
@@ -164,7 +164,7 @@ void BestTrackSelection::cancel_one_bx(const std::deque<EMTFTrackCollection>& ex
   // remove ghosts according to kill mask
   //exists = exists & (~kill1);
   for (i = 0; i < max_zn; ++i) {
-    exists[i] = exists[i] & (!killed[i]);
+    exists[i] = exists[i] && (!killed[i]);
   }
 
   bool anything_exists = (std::find(exists.begin(), exists.end(), 1) != exists.end());
@@ -177,7 +177,7 @@ void BestTrackSelection::cancel_one_bx(const std::deque<EMTFTrackCollection>& ex
       //if  (exists[i]) larger[i] = larger[i] | (~exists); // if this track exists make it larger than all non-existing tracks
       //else  larger[i] = 0; // else make it smaller than anything
       if (exists[i])
-        larger[i][j] = larger[i][j] | (!exists[j]);
+        larger[i][j] = larger[i][j] || (!exists[j]);
       else
         larger[i][j] = false;
     }
@@ -371,7 +371,7 @@ void BestTrackSelection::cancel_multi_bx(const std::deque<EMTFTrackCollection>& 
   // remove ghosts according to kill mask
   //exists = exists & (~kill1);
   for (i = 0; i < max_hzn; ++i) {
-    exists[i] = exists[i] & (!killed[i]);
+    exists[i] = exists[i] && (!killed[i]);
   }
 
   // remove tracks that are not at correct BX number
@@ -390,7 +390,7 @@ void BestTrackSelection::cancel_multi_bx(const std::deque<EMTFTrackCollection>& 
       //if  (exists[i]) larger[i] = larger[i] | (~exists); // if this track exists make it larger than all non-existing tracks
       //else  larger[i] = 0; // else make it smaller than anything
       if (exists[i])
-        larger[i][j] = larger[i][j] | (!exists[j]);
+        larger[i][j] = larger[i][j] || (!exists[j]);
       else
         larger[i][j] = false;
     }

--- a/L1Trigger/TrackFindingTMTT/src/ChiSquaredFit4.cc
+++ b/L1Trigger/TrackFindingTMTT/src/ChiSquaredFit4.cc
@@ -108,8 +108,6 @@ namespace tmtt {
     double t = x[T];
     double z0 = x[Z0];
 
-    double chiSq = 0.0;
-
     unsigned int j = 0;
 
     largestresid_ = -1.0;
@@ -154,8 +152,6 @@ namespace tmtt {
         delta[j++] = (r_track - ri) / sigmaPar;
         delta[j++] = Delta / sigmaPerp;
       }
-
-      chiSq += delta[j - 2] * delta[j - 2] + delta[j - 1] * delta[j - 1];
 
       if (std::abs(delta[j - 2]) > largestresid_) {
         largestresid_ = std::abs(delta[j - 2]);

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -217,7 +217,6 @@ namespace tmtt {
     // If user asked to add up to 7 layers to track, increase number of iterations by 1.
     const unsigned int maxIterations = std::max(nTypicalLayers, settings_->kalmanMaxNumStubs());
     for (unsigned iteration = 0; iteration < maxIterations; iteration++) {
-      int combinations_per_iteration = 0;
 
       bool easy = (l1track3D.numStubs() < settings_->kalmanMaxStubsEasy());
       unsigned int kalmanMaxSkipLayers =
@@ -303,8 +302,6 @@ namespace tmtt {
           thislay_stubs = temp_thislaystubs;
           nextlay_stubs = temp_nextlaystubs;
         }
-
-        combinations_per_iteration += thislay_stubs.size() + nextlay_stubs.size();
 
         // loop over each stub in this layer and check for compatibility with this state
         for (unsigned i = 0; i < thislay_stubs.size(); i++) {

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -217,7 +217,6 @@ namespace tmtt {
     // If user asked to add up to 7 layers to track, increase number of iterations by 1.
     const unsigned int maxIterations = std::max(nTypicalLayers, settings_->kalmanMaxNumStubs());
     for (unsigned iteration = 0; iteration < maxIterations; iteration++) {
-
       bool easy = (l1track3D.numStubs() < settings_->kalmanMaxStubsEasy());
       unsigned int kalmanMaxSkipLayers =
           easy ? settings_->kalmanMaxSkipLayersEasy() : settings_->kalmanMaxSkipLayersHard();

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -543,7 +543,6 @@ void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std:
   double tseedexact = tracklet->t();
   double z0seedexact = tracklet->z0();
 
-  double chisqseed = 0.0;
   double chisqseedexact = 0.0;
 
   double delta[2 * N_FITSTUB];
@@ -579,7 +578,6 @@ void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std:
     delta[j] = zresid[i];
     deltaexact[j++] = zresidexact[i];
 
-    chisqseed += (delta[j - 2] * delta[j - 2] + delta[j - 1] * delta[j - 1]);
     chisqseedexact += (deltaexact[j - 2] * deltaexact[j - 2] + deltaexact[j - 1] * deltaexact[j - 1]);
   }
   assert(j <= 12);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -236,17 +236,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
   unsigned int countpass = 0;
   unsigned int countpass_ = 0;
   // unsigned int nThirdStubs = 0;
-  unsigned int nInnerStubs = 0;
   // unsigned int nOuterStubs = 0;
   count_ = 0;
 
   phimin_ = phimin;
   phimax_ = phimax;
   iSector_ = iSector;
-
-  for (unsigned int iInnerMem = 0; iInnerMem < middleallstubs_.size();
-       nInnerStubs += middleallstubs_.at(iInnerMem)->nStubs(), iInnerMem++)
-    ;
 
   assert(!innerallstubs_.empty());
   assert(!middleallstubs_.empty());

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -125,20 +125,16 @@ void TripletEngine::execute() {
 
   print = print && nThirdStubs > 0;
 
-  int hacksum = 0;
   if (print) {
     edm::LogVerbatim("Tracklet") << "In TripletEngine::execute : " << getName() << " " << nThirdStubs << ":";
     for (unsigned int i = 0; i < thirdvmstubs_.size(); ++i) {
       edm::LogVerbatim("Tracklet") << thirdvmstubs_.at(i)->getName() << " " << thirdvmstubs_.at(i)->nVMStubs();
     }
-    int s = 0;
     std::string oss = "";
     for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
       oss += std::to_string(stubpairs_.at(i)->nStubPairs());
       oss += " ";
-      s += stubpairs_.at(i)->nStubPairs();
     }
-    hacksum += nThirdStubs * s;
     edm::LogVerbatim("Tracklet") << oss;
     for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
       edm::LogVerbatim("Tracklet") << "                                          " << stubpairs_.at(i)->getName();


### PR DESCRIPTION
This PR fixes clang 14 warnings about
- Use of bitwise '&' with boolean operands
- Variable set but unused