### PR TITLE
don't run CSVv2 b-tagger in JMECustomNanoAOD for post-LS2 eras

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -18,7 +18,7 @@ from PhysicsTools.PatAlgos.tools.jetCollectionTools import GenJetAdder, RecoJetA
 from PhysicsTools.PatAlgos.tools.jetTools import supportedJetAlgos
 from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 
-import copy
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 
 bTagCSVV2    = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
 bTagDeepCSV  = ['pfDeepCSVJetTags:probb','pfDeepCSVJetTags:probbb','pfDeepCSVJetTags:probc']
@@ -27,7 +27,9 @@ bTagDeepJet  = [
   'pfDeepFlavourJetTags:probc','pfDeepFlavourJetTags:probuds','pfDeepFlavourJetTags:probg'
 ]
 from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll
-bTagDiscriminatorsForAK4 = bTagCSVV2+bTagDeepCSV+bTagDeepJet+_pfParticleNetAK4JetTagsAll
+bTagDiscriminatorsForAK4 = cms.PSet(foo = cms.vstring(bTagCSVV2+bTagDeepCSV+bTagDeepJet+_pfParticleNetAK4JetTagsAll))
+run3_common.toModify(bTagDiscriminatorsForAK4, foo = bTagDeepCSV+bTagDeepJet+_pfParticleNetAK4JetTagsAll)
+bTagDiscriminatorsForAK4 = bTagDiscriminatorsForAK4.foo.value()
 
 from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import _pfDeepBoostedJetTagsAll
 from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsAll


### PR DESCRIPTION
#### PR description:

This PR is the minimal change to fix wf `11634.15`, required to build the next pre-release (see https://github.com/cms-sw/cmssw/pull/40485#issuecomment-1383689283).

Further, future, improvements are left to JME/BTV experts.

#### PR validation:

Wf `11634.15` passes locally.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
