### PR TITLE
[RECONSTRUCTION][CLANG]Fix warnings reported by clang 14

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/Multi5x5BremRecoveryClusterAlgo.cc
@@ -94,7 +94,7 @@ void Multi5x5BremRecoveryClusterAlgo::makeIslandSuperClusters(reco::CaloClusterP
       };
 
       auto match = [&](int i, int j) {
-        return (dphi(phi[i], phi[j]) < phiRoad) & (std::abs(eta[i] - eta[j]) < etaRoad);
+        return (dphi(phi[i], phi[j]) < phiRoad) && (std::abs(eta[i] - eta[j]) < etaRoad);
       };
 
       // does the cluster match the phi road for this candidate supercluster

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -23,7 +23,7 @@ bool PixelHitMatcher::ForwardMeasurementEstimator::operator()(const GlobalPoint 
   float rMin = theRMin;
   float rMax = theRMax;
   float myZ = gp.z();
-  if ((std::abs(myZ) > 70.f) & (std::abs(myZ) < 170.f)) {
+  if ((std::abs(myZ) > 70.f) && (std::abs(myZ) < 170.f)) {
     rMin = theRMinI;
     rMax = theRMaxI;
   }
@@ -47,7 +47,7 @@ bool PixelHitMatcher::BarrelMeasurementEstimator::operator()(const GlobalPoint &
   float zDiff = myZ - ts.z();
   float myZmax = theZMax;
   float myZmin = theZMin;
-  if ((std::abs(myZ) < 30.f) & (gp.perp() > 8.f)) {
+  if ((std::abs(myZ) < 30.f) && (gp.perp() > 8.f)) {
     myZmax = 0.09f;
     myZmin = -0.09f;
   }

--- a/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.cc
@@ -197,13 +197,9 @@ bool HFClusterAlgo::makeCluster(const HcalDetId& seedid,
                                 SuperCluster& Sclus) {
   double w = 0;  //sum over all log E's
   double wgt = 0;
-  double w_e = 0;  //sum over ieat*energy
   double w_x = 0;
   double w_y = 0;
   double w_z = 0;
-  double wp_e = 0;  //sum over iphi*energy
-  double e_e = 0;   //nonwieghted eta sum
-  double e_ep = 0;  //nonweighted phi sum
 
   double l_3 = 0;  //sum for enenergy in 3x3 long fibers etc.
   double s_3 = 0;
@@ -308,15 +304,10 @@ bool HFClusterAlgo::makeCluster(const HcalDetId& seedid,
             d_p += 2 * M_PI;
           while (d_p > M_PI)
             d_p -= 2 * M_PI;
-          double d_e = p.eta() - sp.eta();
 
           wgt = log((e_long));
           if (wgt > 0) {
             w += wgt;
-            w_e += (d_e)*wgt;
-            wp_e += (d_p)*wgt;
-            e_e += d_e;
-            e_ep += d_p;
 
             w_x += (p.x()) * wgt;  //(p.x()-sp.x())*wgt;
             w_y += (p.y()) * wgt;

--- a/RecoEgamma/ElectronIdentification/plugins/CutBasedElectronID.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/CutBasedElectronID.cc
@@ -385,11 +385,11 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
     }
 
     // ID part
-    if (cut_results[0] & cut_results[1] & cut_results[2] & cut_results[3] & cut_results[4])
+    if (cut_results[0] && cut_results[1] && cut_results[2] && cut_results[3] && cut_results[4])
       result = result + 1;
 
     // ISO part
-    if (cut_results[5] & cut_results[6])
+    if (cut_results[5] && cut_results[6])
       result = result + 2;
 
     // IP part
@@ -397,7 +397,7 @@ double CutBasedElectronID::cicSelection(const reco::GsfElectron* electron,
       result = result + 8;
 
     // Conversion part
-    if (cut_results[8] & cut_results[9])
+    if (cut_results[8] && cut_results[9])
       result = result + 4;
 
     return result;

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -122,7 +122,6 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
   int iphicell = 0;
   int kArray = 0;
 
-  double energy_total = 0.;
   int delt_ieta = 0;
   int delt_iphi = 0;
 
@@ -154,7 +153,6 @@ std::vector<double> PhotonMIPHaloTagger::GetMipTrailFit(const reco::Photon* phot
         ieta_cell.push_back(delt_ieta);
         iphi_cell.push_back(delt_iphi);
         energy_cell.push_back(it->energy());
-        energy_total += it->energy();
         kArray++;
       }
 


### PR DESCRIPTION
This PR fixes clang 14 warnings about
- Use of bitwise '&' with boolean operands
- Variable set but unused
