### PR TITLE
[SIMULATION][CLANG] Fix warnings reported by clang 14 IB

### DIFF
--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB04Analysis.cc
@@ -483,7 +483,9 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
   int idHC, j;
   CaloG4HitCollection* theHC;
   std::map<int, float, std::less<int> > primaries;
+#ifdef EDM_ML_DEBUG
   double etot1 = 0, etot2 = 0;
+#endif
 
   // Look for the Hit Collection of HCal
   G4HCofThisEvent* allHC = (*evt)()->GetHCofThisEvent();
@@ -521,8 +523,8 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
       CaloHit hitl(det, layer, escl, eta, phi, jitter, id);
       hhitl.push_back(hitl);
       primaries[aHit->getTrackID()] += e;
-      etot1 += escl;
 #ifdef EDM_ML_DEBUG
+      etot1 += escl;
       edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Hcal Hit i/p " << j << "  ID 0x" << std::hex << id << " 0x"
                                     << idx << std::dec << " time " << std::setw(6) << time << " " << std::setw(6)
                                     << jitter << " theta " << std::setw(8) << theta << " eta " << std::setw(8) << eta
@@ -558,9 +560,9 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
     nhit++;
     CaloHit hit(det, layer, ehit, eta, phi, jitter, unitID);
     hcalHitCache.push_back(hit);
-    etot2 += ehit;
     k1 += jump;
 #ifdef EDM_ML_DEBUG
+    etot2 += ehit;
     edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Hcal Hit store " << nhit << "  ID 0x" << std::hex << unitID
                                   << std::dec << " time " << std::setw(6) << jitter << " eta " << std::setw(8) << eta
                                   << " phi " << std::setw(8) << phi << " e " << std::setw(8) << ehit;
@@ -576,7 +578,9 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
   }
   sort(hits.begin(), hits.end(), CaloHitIdMore());
   int nhitl = 0;
+#ifdef EDM_ML_DEBUG
   double etotl = 0;
+#endif
   for (k1 = hits.begin(); k1 != hits.end(); k1++) {
     int det = (**k1).det();
     int layer = (**k1).layer();
@@ -593,7 +597,9 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
     nhitl++;
     CaloHit hit(det, layer, ehit, eta, phi, jitter, unitID);
     hcalHitLayer.push_back(hit);
+#ifdef EDM_ML_DEBUG
     etotl += ehit;
+#endif
     k1 += jump;
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Hcal Hit store " << nhitl << "  ID 0x" << std::hex << unitID
@@ -610,8 +616,8 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
   sdName = names[1];
   idHC = G4SDManager::GetSDMpointer()->GetCollectionID(sdName);
   theHC = (CaloG4HitCollection*)allHC->GetHC(idHC);
-  etot1 = etot2 = 0;
 #ifdef EDM_ML_DEBUG
+  etot1 = etot2 = 0;
   edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Hit Collection for " << sdName << " of ID " << idHC
                                 << " is obtained at " << theHC << " with " << theHC->entries() << " entries";
 #endif
@@ -635,8 +641,8 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
         CaloHit hit(det, 0, e, eta, phi, time, id);
         ehits.push_back(hit);
         primaries[aHit->getTrackID()] += e;
-        etot1 += e;
 #ifdef EDM_ML_DEBUG
+        etot1 += e;
         edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Ecal Hit i/p " << j << "  ID 0x" << std::hex << id
                                       << std::dec << " time " << std::setw(6) << time << " theta " << std::setw(8)
                                       << theta << " eta " << std::setw(8) << eta << " phi " << std::setw(8) << phi
@@ -670,9 +676,9 @@ void HcalTB04Analysis::fillBuffer(const EndOfEvent* evt) {
     nhit++;
     CaloHit hit(det, layer, ehit, eta, phi, jitter, unitID);
     ecalHitCache.push_back(hit);
-    etot2 += ehit;
     k1 += jump;
 #ifdef EDM_ML_DEBUG
+    etot2 += ehit;
     edm::LogVerbatim("HcalTBSim") << "HcalTB04Analysis:: Ecal Hit store " << nhit << "  ID 0x" << std::hex << unitID
                                   << std::dec << " time " << std::setw(6) << jitter << " eta " << std::setw(8) << eta
                                   << " phi " << std::setw(8) << phi << " e " << std::setw(8) << ehit;

--- a/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
+++ b/SimG4CMS/ShowerLibraryProducer/plugins/HcalForwardLibWriter.cc
@@ -90,10 +90,8 @@ void HcalForwardLibWriter::analyze(const edm::Event& iEvent, const edm::EventSet
     theTree->SetBranchAddress("primZ", &primZ);  // added
     int nentries = int(theTree->GetEntries());
     int ngood = 0;
-    int nbytes = 0;
     // cycle over showers ====================================================
     for (int iev = 0; iev < nentries; iev++) {
-      nbytes += theTree->GetEntry(iev);
       if (primZ < 990.)
         continue;  // exclude showers with interactions in front of HF (1m of air)
       ngood++;

--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -512,18 +512,6 @@ const std::vector<double>& RPCSimSetUp::getAsymmetricClsDistribution(uint32_t id
     }
   }
 
-  double control = 0;
-  for (int j = 0; j < distributionFewStrips; j++) {
-    control += sliceVsFewStripsDistribution[0][j];
-  }
-
-  double control1 = 0;
-  for (int j = 0; j < distributionFewStrips; j++) {
-    for (int i = 0; i < slices; i++) {
-      control1 += dataForAsymmCls[j * slices + i];
-    }
-  }
-
   int i = slice;
   double sum = 0;
   int counter = 0;

--- a/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
+++ b/SimTracker/TrackHistory/interface/VertexClassifierByProxy.h
@@ -78,7 +78,7 @@ public:
 
       // Combine OR the flag information
       for (std::size_t i = 0; i < flags_.size(); ++i)
-        flags_[i] = flags_[i] | flags[i];
+        flags_[i] = flags_[i] || flags[i];
     }
 
     return *this;

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -7,9 +7,9 @@
 
 #include "SimTracker/TrackHistory/interface/TrackClassifier.h"
 
-#define update(a, b) \
-  do {               \
-    (a) = (a) | (b); \
+#define update(a, b)  \
+  do {                \
+    (a) = (a) || (b); \
   } while (0)
 
 TrackClassifier::TrackClassifier(edm::ParameterSet const &config, edm::ConsumesCollector &&collector)

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -10,9 +10,9 @@
 
 #include "SimTracker/TrackHistory/interface/VertexClassifier.h"
 
-#define update(a, b) \
-  do {               \
-    (a) = (a) | (b); \
+#define update(a, b)  \
+  do {                \
+    (a) = (a) || (b); \
   } while (0)
 
 VertexClassifier::VertexClassifier(edm::ParameterSet const &config, edm::ConsumesCollector collector)

--- a/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
+++ b/SimTransport/TotemRPProtonTransportParametrization/src/TMultiDimFet.cc
@@ -680,11 +680,6 @@ void TMultiDimFet::MakeCandidates() {
     // Number of funcs selected
     Int_t numberFunctions = 0;
 
-    // Absolute max number of functions
-    Int_t maxNumberFunctions = 1;
-    for (i = 0; i < fNVariables; i++)
-      maxNumberFunctions *= fMaxPowers[i];
-
     while (kTRUE) {
       // Get the control value for this function
       Double_t s = EvalControl(iv);


### PR DESCRIPTION
LLVM 14 based CLANG IBs show a lot of build warnings about use of bitwise operator instead of logical and definition of unused variables. This PR follows up https://github.com/cms-sw/cmssw/pull/40242 to fix some of these warnings.