### PR TITLE
[SIMULATION-UPGRADE][CLANG]  Fix warnings reported by clang 14 IB

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -407,7 +407,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
     for (int it = 0; it < (int)(chargeColl.size()); ++it) {
       //if busy, charge has been already integrated
       //if(debug) edm::LogVerbatim("HGCFE") << "\t SARS ADC pulse activated @ " << it << " : ";
-      if (!totFlags[it] & !busyFlags[it]) {
+      if (!totFlags[it] && !busyFlags[it]) {
         const int start = std::max(0, 2 - it);
         const int stop = std::min((int)adcPulse.size(), (int)newCharge.size() - it + 2);
         for (ipulse = start; ipulse < stop; ++ipulse) {
@@ -415,7 +415,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
           //notice that if the channel is already busy,
           //it has already been affected by the leakage of the SARS ADC
           //if(totFlags[itoffset] || busyFlags[itoffset]) continue;
-          if (!totFlags[itoffset] & !busyFlags[itoffset]) {
+          if (!totFlags[itoffset] && !busyFlags[itoffset]) {
             newCharge[itoffset] += chargeColl[it] * adcPulse[ipulse];
           }
           //if(debug) edm::LogVerbatim("HGCFE") << " | " << itoffset << " " << chargeColl[it]*adcPulse[ipulse] << "( " << chargeColl[it] << "->";


### PR DESCRIPTION
This PR fixes clang 14 warnings about the use of bitwise '|' with boolean operands.
