### PR TITLE
remove memory-churn in SiPixelTemplate2D::pushfile

### DIFF
--- a/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h
@@ -61,7 +61,7 @@ public:
   int maxIndex() const { return maxIndex_; }
   int numOfTempl() const { return numOfTempl_; }
   float version() const { return version_; }
-  std::vector<float> sVector() const { return sVector_; }
+  std::vector<float> const& sVector() const { return sVector_; }
 
   //- Able to set the index for template header
   void incrementIndex(int i) { index_ += i; }
@@ -96,6 +96,44 @@ public:
           << "2Dtemplate ID for DetID " << detid << " is not stored" << std::endl;
     return 0;
   }
+
+  class Reader {
+  public:
+    Reader(SiPixel2DTemplateDBObject const& object) : object_(object), index_(0), isInvalid_(false) {}
+
+    bool fail() { return isInvalid_; }
+
+    int index() const { return index_; }
+    //- Able to set the index for template header
+    void incrementIndex(int i) { index_ += i; }
+
+    //- Fills integer from dbobject
+    Reader& operator>>(int& i) {
+      isInvalid_ = false;
+      if (index_ <= object_.maxIndex_) {
+        i = (int)object_.sVector_[index_];
+        index_++;
+      } else
+        isInvalid_ = true;
+      return *this;
+    }
+    //- Fills float from dbobject
+    Reader& operator>>(float& f) {
+      isInvalid_ = false;
+      if (index_ <= object_.maxIndex_) {
+        f = object_.sVector_[index_];
+        index_++;
+      } else
+        isInvalid_ = true;
+      return *this;
+    }
+
+  private:
+    SiPixel2DTemplateDBObject const& object_;
+    int index_;
+    bool isInvalid_;
+  };
+  friend class Reader;
 
 private:
   int index_;

--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate2D.h
@@ -100,10 +100,24 @@ struct SiPixelTemplateHeader2D {  //!< template header structure
 };
 
 struct SiPixelTemplateStore2D {  //!< template storage structure
+
+  void resize(int ny, int nx) {
+    entry.resize(ny);
+    store.resize(nx * ny);
+    int off = 0;
+    for (int i = 0; i < ny; ++i) {
+      entry[i] = store.data() + off;
+      off += nx;
+    }
+    assert(nx * ny == off);
+  }
+
   SiPixelTemplateHeader2D head;  //!< Header information
 
-  //!< use 2d entry to store BPix and FPix entries [dynamically allocated]
-  std::vector<std::vector<SiPixelTemplateEntry2D>> entry;
+  //!< use 2d entry to store BPix and FPix entries [dynamically allocated
+  std::vector<SiPixelTemplateEntry2D*> entry;
+
+  std::vector<SiPixelTemplateEntry2D> store;
 };
 
 // ******************************************************************************************

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate2D.cc
@@ -167,9 +167,7 @@ bool SiPixelTemplate2D::pushfile(int filenum, std::vector<SiPixelTemplateStore2D
 
     // next, layout the 2-d structure needed to store template
 
-    theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
-    for (auto& item : theCurrentTemp.entry)
-      item.resize(theCurrentTemp.head.NTxx);
+    theCurrentTemp.resize(theCurrentTemp.head.NTyx, theCurrentTemp.head.NTxx);
 
     // Read in the file info
 
@@ -316,215 +314,220 @@ bool SiPixelTemplate2D::pushfile(const SiPixel2DTemplateDBObject& dbobject,
 
   const int code_version = {21};
 
-  // We must create a new object because dbobject must be a const and our stream must not be
-  SiPixel2DTemplateDBObject db = dbobject;
+  // We must use a reader because dbobject must be a const and its stream must not be
+  SiPixel2DTemplateDBObject::Reader reader(dbobject);
 
-  // Create a local template storage entry
-  SiPixelTemplateStore2D theCurrentTemp;
+  struct Failed {};
 
   // Fill the template storage for each template calibration stored in the db
-  for (int m = 0; m < db.numOfTempl(); ++m) {
-    // Read-in a header string first and print it
+  for (int m = 0; m < dbobject.numOfTempl(); ++m) {
+    // Create a template storage entry
+    // SiPixelTemplateStore2D
+    pixelTemp.emplace_back();
+    auto& theCurrentTemp = pixelTemp.back();
 
-    SiPixel2DTemplateDBObject::char2float temp;
-    for (int i = 0; i < 20; ++i) {
-      temp.f = db.sVector()[db.index()];
-      theCurrentTemp.head.title[4 * i] = temp.c[0];
-      theCurrentTemp.head.title[4 * i + 1] = temp.c[1];
-      theCurrentTemp.head.title[4 * i + 2] = temp.c[2];
-      theCurrentTemp.head.title[4 * i + 3] = temp.c[3];
-      db.incrementIndex(1);
-    }
-    theCurrentTemp.head.title[79] = '\0';
-    LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
+    try {
+      // Read-in a header string first and print it
 
-    // next, the header information
-
-    db >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
-        theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >> theCurrentTemp.head.Dtype >>
-        theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >> theCurrentTemp.head.fluence >>
-        theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >> theCurrentTemp.head.lorywidth >>
-        theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >> theCurrentTemp.head.xsize >>
-        theCurrentTemp.head.zsize;
-
-    if (db.fail()) {
-      LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL;
-      return false;
-    }
-
-    LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title
-                                 << " code version = " << code_version << " object version "
-                                 << theCurrentTemp.head.templ_version << ENDL;
-
-    if (theCurrentTemp.head.templ_version > 17) {
-      db >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
-          theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
-
-      if (db.fail()) {
-        LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load" << ENDL;
-        return false;
+      SiPixel2DTemplateDBObject::char2float temp;
+      for (int i = 0; i < 20; ++i) {
+        temp.f = dbobject.sVector()[reader.index()];
+        theCurrentTemp.head.title[4 * i] = temp.c[0];
+        theCurrentTemp.head.title[4 * i + 1] = temp.c[1];
+        theCurrentTemp.head.title[4 * i + 2] = temp.c[2];
+        theCurrentTemp.head.title[4 * i + 3] = temp.c[3];
+        reader.incrementIndex(1);
       }
-    } else {
-      // This is for older [legacy] payloads and the numbers are indeed magic [they are part of the payload for v>17]
-      theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
-      theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
-      theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
-      theCurrentTemp.head.fbin[0] = 1.50f;
-      theCurrentTemp.head.fbin[1] = 1.00f;
-      theCurrentTemp.head.fbin[2] = 0.85f;
-    }
+      theCurrentTemp.head.title[79] = '\0';
+      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title << ENDL;
 
-    LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
-                                 << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
-                                 << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
-                                 << ", NTxx = " << theCurrentTemp.head.NTxx << ", Dtype = " << theCurrentTemp.head.Dtype
-                                 << ", Bias voltage " << theCurrentTemp.head.Vbias << ", temperature "
-                                 << theCurrentTemp.head.temperature << ", fluence " << theCurrentTemp.head.fluence
-                                 << ", Q-scaling factor " << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
-                                 << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
-                                 << theCurrentTemp.head.ss50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth
-                                 << ", y Lorentz Bias " << theCurrentTemp.head.lorybias << ", x Lorentz width "
-                                 << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias " << theCurrentTemp.head.lorxbias
-                                 << ", Q/Q_avg fractions for Qbin defs " << theCurrentTemp.head.fbin[0] << ", "
-                                 << theCurrentTemp.head.fbin[1] << ", " << theCurrentTemp.head.fbin[2]
-                                 << ", pixel x-size " << theCurrentTemp.head.xsize << ", y-size "
-                                 << theCurrentTemp.head.ysize << ", zsize " << theCurrentTemp.head.zsize << ENDL;
+      // next, the header information
 
-    if (theCurrentTemp.head.templ_version < code_version) {
-      LOGINFO("SiPixelTemplate2D") << "code expects version " << code_version << " finds "
-                                   << theCurrentTemp.head.templ_version << ", load anyway " << ENDL;
-    }
+      reader >> theCurrentTemp.head.ID >> theCurrentTemp.head.templ_version >> theCurrentTemp.head.Bfield >>
+          theCurrentTemp.head.NTy >> theCurrentTemp.head.NTyx >> theCurrentTemp.head.NTxx >>
+          theCurrentTemp.head.Dtype >> theCurrentTemp.head.Vbias >> theCurrentTemp.head.temperature >>
+          theCurrentTemp.head.fluence >> theCurrentTemp.head.qscale >> theCurrentTemp.head.s50 >>
+          theCurrentTemp.head.lorywidth >> theCurrentTemp.head.lorxwidth >> theCurrentTemp.head.ysize >>
+          theCurrentTemp.head.xsize >> theCurrentTemp.head.zsize;
 
-    if (theCurrentTemp.head.NTy != 0) {
-      LOGERROR("SiPixelTemplate2D")
-          << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL;
-      return false;
-    }
+      if (reader.fail()) {
+        LOGERROR("SiPixelTemplate2D") << "Error reading file 0A, no template load" << ENDL;
+        throw Failed();
+      }
 
-    // next, layout the 2-d structure needed to store template
+      LOGINFO("SiPixelTemplate2D") << "Loading Pixel Template File - " << theCurrentTemp.head.title
+                                   << " code version = " << code_version << " object version "
+                                   << theCurrentTemp.head.templ_version << ENDL;
 
-    theCurrentTemp.entry.resize(theCurrentTemp.head.NTyx);
-    for (auto& item : theCurrentTemp.entry)
-      item.resize(theCurrentTemp.head.NTxx);
+      if (theCurrentTemp.head.templ_version > 17) {
+        reader >> theCurrentTemp.head.ss50 >> theCurrentTemp.head.lorybias >> theCurrentTemp.head.lorxbias >>
+            theCurrentTemp.head.fbin[0] >> theCurrentTemp.head.fbin[1] >> theCurrentTemp.head.fbin[2];
 
-    // Read in the file info
-
-    for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy) {
-      for (int jx = 0; jx < theCurrentTemp.head.NTxx; ++jx) {
-        db >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0] >>
-            theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
-
-        if (db.fail()) {
-          LOGERROR("SiPixelTemplate2D") << "Error reading file 1, no template load, run # "
-                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          return false;
+        if (reader.fail()) {
+          LOGERROR("SiPixelTemplate2D") << "Error reading file 0B, no template load" << ENDL;
+          throw Failed();
         }
+      } else {
+        // This is for older [legacy] payloads and the numbers are indeed magic [they are part of the payload for v>17]
+        theCurrentTemp.head.ss50 = theCurrentTemp.head.s50;
+        theCurrentTemp.head.lorybias = theCurrentTemp.head.lorywidth / 2.f;
+        theCurrentTemp.head.lorxbias = theCurrentTemp.head.lorxwidth / 2.f;
+        theCurrentTemp.head.fbin[0] = 1.50f;
+        theCurrentTemp.head.fbin[1] = 1.00f;
+        theCurrentTemp.head.fbin[2] = 0.85f;
+      }
 
-        // Calculate cot(alpha) and cot(beta) for this entry
+      LOGINFO("SiPixelTemplate2D") << "Template ID = " << theCurrentTemp.head.ID << ", Template Version "
+                                   << theCurrentTemp.head.templ_version << ", Bfield = " << theCurrentTemp.head.Bfield
+                                   << ", NTy = " << theCurrentTemp.head.NTy << ", NTyx = " << theCurrentTemp.head.NTyx
+                                   << ", NTxx = " << theCurrentTemp.head.NTxx
+                                   << ", Dtype = " << theCurrentTemp.head.Dtype << ", Bias voltage "
+                                   << theCurrentTemp.head.Vbias << ", temperature " << theCurrentTemp.head.temperature
+                                   << ", fluence " << theCurrentTemp.head.fluence << ", Q-scaling factor "
+                                   << theCurrentTemp.head.qscale << ", 1/2 multi dcol threshold "
+                                   << theCurrentTemp.head.s50 << ", 1/2 single dcol threshold "
+                                   << theCurrentTemp.head.ss50 << ", y Lorentz Width " << theCurrentTemp.head.lorywidth
+                                   << ", y Lorentz Bias " << theCurrentTemp.head.lorybias << ", x Lorentz width "
+                                   << theCurrentTemp.head.lorxwidth << ", x Lorentz Bias "
+                                   << theCurrentTemp.head.lorxbias << ", Q/Q_avg fractions for Qbin defs "
+                                   << theCurrentTemp.head.fbin[0] << ", " << theCurrentTemp.head.fbin[1] << ", "
+                                   << theCurrentTemp.head.fbin[2] << ", pixel x-size " << theCurrentTemp.head.xsize
+                                   << ", y-size " << theCurrentTemp.head.ysize << ", zsize "
+                                   << theCurrentTemp.head.zsize << ENDL;
 
-        theCurrentTemp.entry[iy][jx].cotalpha =
-            theCurrentTemp.entry[iy][jx].costrk[0] / theCurrentTemp.entry[iy][jx].costrk[2];
+      if (theCurrentTemp.head.templ_version < code_version) {
+        LOGINFO("SiPixelTemplate2D") << "code expects version " << code_version << " finds "
+                                     << theCurrentTemp.head.templ_version << ", load anyway " << ENDL;
+      }
 
-        theCurrentTemp.entry[iy][jx].cotbeta =
-            theCurrentTemp.entry[iy][jx].costrk[1] / theCurrentTemp.entry[iy][jx].costrk[2];
+      if (theCurrentTemp.head.NTy != 0) {
+        LOGERROR("SiPixelTemplate2D")
+            << "Trying to load 1-d template info into the 2-d template object, check your DB/global tag!" << ENDL;
+        throw Failed();
+      }
 
-        db >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >>
-            theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin >>
-            theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >>
-            theCurrentTemp.entry[iy][jx].jxmax;
+      // next, layout the 2-d structure needed to store template
+      theCurrentTemp.resize(theCurrentTemp.head.NTyx, theCurrentTemp.head.NTxx);
 
-        if (db.fail()) {
-          LOGERROR("SiPixelTemplate2D") << "Error reading file 2, no template load, run # "
-                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          return false;
-        }
+      // Read in the file info
 
-        for (int k = 0; k < 2; ++k) {
-          db >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1] >>
-              theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >>
-              theCurrentTemp.entry[iy][jx].xypar[k][4];
+      for (int iy = 0; iy < theCurrentTemp.head.NTyx; ++iy) {
+        for (int jx = 0; jx < theCurrentTemp.head.NTxx; ++jx) {
+          reader >> theCurrentTemp.entry[iy][jx].runnum >> theCurrentTemp.entry[iy][jx].costrk[0] >>
+              theCurrentTemp.entry[iy][jx].costrk[1] >> theCurrentTemp.entry[iy][jx].costrk[2];
 
-          if (db.fail()) {
+          if (reader.fail()) {
             LOGERROR("SiPixelTemplate2D")
-                << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            return false;
+                << "Error reading file 1, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            throw Failed();
           }
-        }
 
-        for (int k = 0; k < 2; ++k) {
-          db >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1] >>
-              theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >>
-              theCurrentTemp.entry[iy][jx].lanpar[k][4];
+          // Calculate cot(alpha) and cot(beta) for this entry
 
-          if (db.fail()) {
+          theCurrentTemp.entry[iy][jx].cotalpha =
+              theCurrentTemp.entry[iy][jx].costrk[0] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+          theCurrentTemp.entry[iy][jx].cotbeta =
+              theCurrentTemp.entry[iy][jx].costrk[1] / theCurrentTemp.entry[iy][jx].costrk[2];
+
+          reader >> theCurrentTemp.entry[iy][jx].qavg >> theCurrentTemp.entry[iy][jx].pixmax >>
+              theCurrentTemp.entry[iy][jx].sxymax >> theCurrentTemp.entry[iy][jx].iymin >>
+              theCurrentTemp.entry[iy][jx].iymax >> theCurrentTemp.entry[iy][jx].jxmin >>
+              theCurrentTemp.entry[iy][jx].jxmax;
+
+          if (reader.fail()) {
             LOGERROR("SiPixelTemplate2D")
-                << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-            return false;
+                << "Error reading file 2, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            throw Failed();
           }
-        }
 
-        //  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+          for (int k = 0; k < 2; ++k) {
+            reader >> theCurrentTemp.entry[iy][jx].xypar[k][0] >> theCurrentTemp.entry[iy][jx].xypar[k][1] >>
+                theCurrentTemp.entry[iy][jx].xypar[k][2] >> theCurrentTemp.entry[iy][jx].xypar[k][3] >>
+                theCurrentTemp.entry[iy][jx].xypar[k][4];
 
-        float dummy[T2YSIZE];
-        for (int l = 0; l < 7; ++l) {
-          for (int k = 0; k < 7; ++k) {
-            for (int j = 0; j < T2XSIZE; ++j) {
-              for (int i = 0; i < T2YSIZE; ++i) {
-                db >> dummy[i];
-              }
-              if (db.fail()) {
-                LOGERROR("SiPixelTemplate2D")
-                    << "Error reading file 5, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-                return false;
-              }
-              for (int i = 0; i < T2YSIZE; ++i) {
-                theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];
+            if (reader.fail()) {
+              LOGERROR("SiPixelTemplate2D")
+                  << "Error reading file 3, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+              throw Failed();
+            }
+          }
+
+          for (int k = 0; k < 2; ++k) {
+            reader >> theCurrentTemp.entry[iy][jx].lanpar[k][0] >> theCurrentTemp.entry[iy][jx].lanpar[k][1] >>
+                theCurrentTemp.entry[iy][jx].lanpar[k][2] >> theCurrentTemp.entry[iy][jx].lanpar[k][3] >>
+                theCurrentTemp.entry[iy][jx].lanpar[k][4];
+
+            if (reader.fail()) {
+              LOGERROR("SiPixelTemplate2D")
+                  << "Error reading file 4, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+              throw Failed();
+            }
+          }
+
+          //  Read the 2D template entries as floats [they are formatted that way] and cast to short ints
+
+          float dummy[T2YSIZE];
+          for (int l = 0; l < 7; ++l) {
+            for (int k = 0; k < 7; ++k) {
+              for (int j = 0; j < T2XSIZE; ++j) {
+                for (int i = 0; i < T2YSIZE; ++i) {
+                  reader >> dummy[i];
+                }
+                if (reader.fail()) {
+                  LOGERROR("SiPixelTemplate2D") << "Error reading file 5, no template load, run # "
+                                                << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+                  throw Failed();
+                }
+                for (int i = 0; i < T2YSIZE; ++i) {
+                  theCurrentTemp.entry[iy][jx].xytemp[k][l][i][j] = (short int)dummy[i];
+                }
               }
             }
           }
-        }
 
-        db >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >>
-            theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1] >>
-            theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3] >>
-            theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1] >>
-            theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
+          reader >> theCurrentTemp.entry[iy][jx].chi2ppix >> theCurrentTemp.entry[iy][jx].chi2scale >>
+              theCurrentTemp.entry[iy][jx].offsetx[0] >> theCurrentTemp.entry[iy][jx].offsetx[1] >>
+              theCurrentTemp.entry[iy][jx].offsetx[2] >> theCurrentTemp.entry[iy][jx].offsetx[3] >>
+              theCurrentTemp.entry[iy][jx].offsety[0] >> theCurrentTemp.entry[iy][jx].offsety[1] >>
+              theCurrentTemp.entry[iy][jx].offsety[2] >> theCurrentTemp.entry[iy][jx].offsety[3];
 
-        if (db.fail()) {
-          LOGERROR("SiPixelTemplate2D") << "Error reading file 6, no template load, run # "
-                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          return false;
-        }
+          if (reader.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 6, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            throw Failed();
+          }
 
-        db >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >>
-            theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav >>
-            theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >>
-            theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >>
-            theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
+          reader >> theCurrentTemp.entry[iy][jx].clsleny >> theCurrentTemp.entry[iy][jx].clslenx >>
+              theCurrentTemp.entry[iy][jx].mpvvav >> theCurrentTemp.entry[iy][jx].sigmavav >>
+              theCurrentTemp.entry[iy][jx].kappavav >> theCurrentTemp.entry[iy][jx].scalexavg >>
+              theCurrentTemp.entry[iy][jx].scaleyavg >> theCurrentTemp.entry[iy][jx].delyavg >>
+              theCurrentTemp.entry[iy][jx].delysig >> theCurrentTemp.entry[iy][jx].spare[0];
 
-        if (db.fail()) {
-          LOGERROR("SiPixelTemplate2D") << "Error reading file 7, no template load, run # "
-                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          return false;
-        }
+          if (reader.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 7, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            throw Failed();
+          }
 
-        db >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >>
-            theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3] >>
-            theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >>
-            theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3] >>
-            theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2];
+          reader >> theCurrentTemp.entry[iy][jx].scalex[0] >> theCurrentTemp.entry[iy][jx].scalex[1] >>
+              theCurrentTemp.entry[iy][jx].scalex[2] >> theCurrentTemp.entry[iy][jx].scalex[3] >>
+              theCurrentTemp.entry[iy][jx].scaley[0] >> theCurrentTemp.entry[iy][jx].scaley[1] >>
+              theCurrentTemp.entry[iy][jx].scaley[2] >> theCurrentTemp.entry[iy][jx].scaley[3] >>
+              theCurrentTemp.entry[iy][jx].spare[1] >> theCurrentTemp.entry[iy][jx].spare[2];
 
-        if (db.fail()) {
-          LOGERROR("SiPixelTemplate2D") << "Error reading file 8, no template load, run # "
-                                        << theCurrentTemp.entry[iy][jx].runnum << ENDL;
-          return false;
+          if (reader.fail()) {
+            LOGERROR("SiPixelTemplate2D")
+                << "Error reading file 8, no template load, run # " << theCurrentTemp.entry[iy][jx].runnum << ENDL;
+            throw Failed();
+          }
         }
       }
+
+    } catch (Failed&) {
+      pixelTemp.pop_back();
+      return false;
     }
-
-    // Add this template to the store
-
-    pixelTemp.push_back(theCurrentTemp);
   }
 
   return true;


### PR DESCRIPTION
PreMIx workflow was affected by a huge "memmove" storm during initialization (first event).
It was easy to locate it in SiPixelTemplate2D::pushfile.
In this purely technical PR all copies of vectors (of vectors (eventually of vectors)) have been removed.

running just initialization using
```
cmsDriver tt_digi --no_exec --datamix PreMix --conditions auto:phase1_2022_realistic --pileup_input file:pu.root -n 16 --era Run3 --eventcontent RAWSIM --procModifiers premix_stage2 --filein file:gensim.root -s DIGI,DATAMIX,L1,DIGI2RAW,HLT:@relval2022 --datatier GEN-SIM-DIGI-RAW --geometry DB:Extended --nThreads 8 --suffix -j JobReport.xml --customise Validation/Performance/TimeMemorySummary.customiseWithTimeMemorySummary
```

memory allocation is reduced
from 
         5017054      kmem:mm_page_alloc
          5835471      kmem:mm_page_free
to
          1341162      kmem:mm_page_alloc
          2126517      kmem:mm_page_free

while the system time goes down from
61.298107000 seconds
to
21.264676000 seconds


I made minimal changes preserving previous behavior.
I leave to code owners any eventual further cleanup.

No change expected.

