### PR TITLE
[ROOT6] Fix int type in NanoAD plugins for ROOT6 IB

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputFields.cc
@@ -14,7 +14,7 @@ namespace {
         case nanoaod::FlatTable::ColumnType::Float:
           std::cout << "f32,";
           break;
-        case nanoaod::FlatTable::ColumnType::Int:
+        case nanoaod::FlatTable::ColumnType::Int32:
           std::cout << "i32,";
           break;
         case nanoaod::FlatTable::ColumnType::UInt8:
@@ -56,7 +56,7 @@ void TableOutputFields::createFields(const edm::EventForOutput& event, RNTupleMo
       case nanoaod::FlatTable::ColumnType::Float:
         m_floatFields.emplace_back(FlatTableField<float>(table, i, model));
         break;
-      case nanoaod::FlatTable::ColumnType::Int:
+      case nanoaod::FlatTable::ColumnType::Int32:
         m_intFields.emplace_back(FlatTableField<int>(table, i, model));
         break;
       case nanoaod::FlatTable::ColumnType::UInt8:
@@ -99,7 +99,7 @@ void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNT
       case nanoaod::FlatTable::ColumnType::Float:
         m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
         break;
-      case nanoaod::FlatTable::ColumnType::Int:
+      case nanoaod::FlatTable::ColumnType::Int32:
         m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
         break;
       case nanoaod::FlatTable::ColumnType::UInt8:


### PR DESCRIPTION
Hello,

Last [ROOT6 IB](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc11/www/mon/13.0.ROOT6-mon-23/CMSSW_13_0_ROOT6_X_2023-01-16-2300) was failing at [compilation](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_13_0_ROOT6_X_2023-01-16-2300/PhysicsTools/NanoAOD) after the merge of https://github.com/cms-sw/cmssw/pull/40478. The issue was not catch during the PR testing since the file where this error happens (`PhysicsTools/NanoAOD/plugins/TableOutputFields.cc`) is only part of ROOT6 branch.

This PR is to propose a solution by changing the type to `Int32`. As for the testing, I have created a development area with the latest ROOT6 IB to then apply these changes on top, and the module `PhysicsTools/NanoAOD` builds fine. 
Thanks,

Andrea.