### PR TITLE
[ANALYSIS][CLANG] Fix warnings reported by clang 14

### DIFF
--- a/PhysicsTools/Heppy/src/Apc.cc
+++ b/PhysicsTools/Heppy/src/Apc.cc
@@ -22,22 +22,7 @@ namespace heppy {
     const double ht = accumulate(et.begin(), et.end(), 0.);
 
     // jets are pt-sorted
-    double firstjet_phi = atan2(py[0], px[0]);
-
-    double apcjet(0.), apcmet(0.), apcjetmet(0.);
     double apcjetmetmin(0.);
-
-    for (size_t i = 0; i < et.size(); i++) {
-      double jet_phi = atan2(py[i], px[i]);
-      double met_phi = atan2(mety, metx);
-
-      double dphisignaljet = fabs(deltaPhi(jet_phi, firstjet_phi));
-      double dphimet = fabs(deltaPhi(jet_phi, met_phi));
-
-      apcjet += et[i] * cos(dphisignaljet / 2.0);
-      apcmet += et[i] * sin(dphimet / 2.0);
-      apcjetmet += et[i] * cos(dphisignaljet / 2.0) * sin(dphimet / 2.0);
-    }
 
     std::vector<double> apcjetvector;
     std::vector<double> apcjetmetvector;

--- a/TopQuarkAnalysis/TopHitFit/src/Fourvec_Constrainer.cc
+++ b/TopQuarkAnalysis/TopHitFit/src/Fourvec_Constrainer.cc
@@ -1637,15 +1637,12 @@ namespace hitfit {
     int nobjs = ev.nobjs();
     int n_measured_vars = nobjs * 3;
     int n_unmeasured_vars = 0;
-    int n_constraints = _constraints.size();
 
     if (use_kt) {
       n_measured_vars += 2;
 
       if (ev.has_neutrino())
         n_unmeasured_vars = 1;
-      else
-        n_constraints += 2;
     }
 
     Matrix G_i(n_measured_vars, n_measured_vars);


### PR DESCRIPTION
LLVM 14 based CLANG IBs show a lot of build warnings about definition of unused variables. This PR fixes these warnings for analysis modules.
