### PR TITLE
Backport RNTuple NanoAOD output module from ROOT6 branch

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -27,3 +27,8 @@
 <library file="*.cc" name="PhysicsToolsNanoAODPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="rntuple/*.cc" name="PhysicsToolsNanoAODRNuplePlugins">
+  <use name="rootntuple"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.cc
@@ -1,0 +1,24 @@
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "EventStringOutputFields.h"
+
+void EventStringOutputFields::registerToken(const edm::EDGetToken &token) { m_tokens.push_back(token); }
+
+void EventStringOutputFields::createFields(RNTupleModel &model) {
+  m_evstrings = RNTupleFieldPtr<std::vector<std::string>>("EventStrings", "", model);
+}
+
+void EventStringOutputFields::fill(const edm::EventForOutput &iEvent) {
+  std::vector<std::string> evstrings;
+  if (m_lastLumi != iEvent.id().luminosityBlock()) {
+    edm::Handle<std::string> handle;
+    for (const auto &t : m_tokens) {
+      iEvent.getByToken(t, handle);
+      const std::string &evstr = *handle;
+      if (!evstr.empty()) {
+        evstrings.push_back(evstr);
+      }
+    }
+    m_lastLumi = iEvent.id().luminosityBlock();
+  }
+  m_evstrings.fill(evstrings);
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/EventStringOutputFields.h
@@ -1,0 +1,27 @@
+#ifndef PhysicsTools_NanoAOD_EventStringOutputFields_h
+#define PhysicsTools_NanoAOD_EventStringOutputFields_h
+
+#include <string>
+#include <vector>
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RNTupleModel;
+
+#include "RNTupleFieldPtr.h"
+
+class EventStringOutputFields {
+private:
+  std::vector<edm::EDGetToken> m_tokens;
+  RNTupleFieldPtr<std::vector<std::string>> m_evstrings;
+  long m_lastLumi = -1;
+
+public:
+  EventStringOutputFields() = default;
+
+  void registerToken(const edm::EDGetToken &token);
+  void createFields(RNTupleModel &model);
+  void fill(const edm::EventForOutput &iEvent);
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -1,0 +1,289 @@
+// -*- C++ -*-
+//
+// Package:     PhysicsTools/NanoAODOutput
+// Class  :     NanoAODRNTupleOutputModule
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Max Orok
+//         Created:  Wed, 13 Jan 2021 14:21:41 GMT
+//
+
+#include <cstdint>
+#include <string>
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Detail::RPageSinkFile;
+
+#include "TObjString.h"
+
+#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/Utilities/interface/Digest.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "DataFormats/NanoAOD/interface/UniqueString.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+
+#include "NanoAODRNTuples.h"
+
+class NanoAODRNTupleOutputModule : public edm::one::OutputModule<> {
+public:
+  NanoAODRNTupleOutputModule(edm::ParameterSet const& pset);
+  ~NanoAODRNTupleOutputModule() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void openFile(edm::FileBlock const&) override;
+  bool isFileOpen() const override;
+  void write(edm::EventForOutput const& e) override;
+  void writeLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
+  void writeRun(edm::RunForOutput const&) override;
+  void reallyCloseFile() override;
+  void writeProvenance();
+
+  void initializeNTuple(edm::EventForOutput const& e);
+
+  std::string m_fileName;
+  std::string m_logicalFileName;
+  std::string m_compressionAlgorithm;
+  int m_compressionLevel;
+  bool m_writeProvenance;
+  edm::ProcessHistoryRegistry m_processHistoryRegistry;
+  edm::JobReport::Token m_jrToken;
+
+  std::unique_ptr<TFile> m_file;
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  TableCollectionSet m_tables;
+  std::vector<TriggerOutputFields> m_triggers;
+  EventStringOutputFields m_evstrings;
+
+  class CommonEventFields {
+  public:
+    void createFields(RNTupleModel& model) {
+      model.AddField<UInt_t>("run", &m_run);
+      model.AddField<UInt_t>("luminosityBlock", &m_luminosityBlock);
+      model.AddField<std::uint64_t>("event", &m_event);
+    }
+    void fill(const edm::EventID& id) {
+      m_run = id.run();
+      m_luminosityBlock = id.luminosityBlock();
+      m_event = id.event();
+    }
+
+  private:
+    UInt_t m_run;
+    UInt_t m_luminosityBlock;
+    std::uint64_t m_event;
+  } m_commonFields;
+
+  LumiNTuple m_lumi;
+  RunNTuple m_run;
+
+  std::vector<std::pair<std::string, edm::EDGetToken>> m_nanoMetadata;
+};
+
+NanoAODRNTupleOutputModule::NanoAODRNTupleOutputModule(edm::ParameterSet const& pset)
+    : edm::one::OutputModuleBase::OutputModuleBase(pset),
+      edm::one::OutputModule<>(pset),
+      m_fileName(pset.getUntrackedParameter<std::string>("fileName")),
+      m_logicalFileName(pset.getUntrackedParameter<std::string>("logicalFileName")),
+      m_compressionAlgorithm(pset.getUntrackedParameter<std::string>("compressionAlgorithm")),
+      m_compressionLevel(pset.getUntrackedParameter<int>("compressionLevel")),
+      m_writeProvenance(pset.getUntrackedParameter<bool>("saveProvenance", true)),
+      m_processHistoryRegistry() {}
+
+NanoAODRNTupleOutputModule::~NanoAODRNTupleOutputModule() {}
+
+void NanoAODRNTupleOutputModule::writeLuminosityBlock(edm::LuminosityBlockForOutput const& iLumi) {
+  edm::Service<edm::JobReport> jr;
+  jr->reportLumiSection(m_jrToken, iLumi.id().run(), iLumi.id().value());
+  m_lumi.fill(iLumi.id(), *m_file);
+  m_processHistoryRegistry.registerProcessHistory(iLumi.processHistory());
+}
+
+void NanoAODRNTupleOutputModule::writeRun(edm::RunForOutput const& iRun) {
+  edm::Service<edm::JobReport> jr;
+  jr->reportRunNumber(m_jrToken, iRun.id().run());
+
+  m_run.fill(iRun, *m_file);
+
+  edm::Handle<nanoaod::UniqueString> hstring;
+  for (const auto& p : m_nanoMetadata) {
+    iRun.getByToken(p.second, hstring);
+    TObjString* tos = dynamic_cast<TObjString*>(m_file->Get(p.first.c_str()));
+    if (tos && hstring->str() != tos->GetString()) {
+      throw cms::Exception("LogicError", "Inconsistent nanoMetadata " + p.first + " (" + hstring->str() + ")");
+    } else {
+      auto ostr = std::make_unique<TObjString>(hstring->str().c_str());
+      m_file->WriteTObject(ostr.release(), p.first.c_str());
+    }
+  }
+  m_processHistoryRegistry.registerProcessHistory(iRun.processHistory());
+}
+
+bool NanoAODRNTupleOutputModule::isFileOpen() const { return nullptr != m_ntuple.get(); }
+
+void NanoAODRNTupleOutputModule::openFile(edm::FileBlock const&) {
+  m_file = std::make_unique<TFile>(m_fileName.c_str(), "RECREATE", "", m_compressionLevel);
+  edm::Service<edm::JobReport> jr;
+  cms::Digest branchHash;
+  m_jrToken = jr->outputFileOpened(m_fileName,
+                                   m_logicalFileName,
+                                   std::string(),
+                                   // TODO check if needed
+                                   //m_fakeName ? "PoolOutputModule" : "NanoAODOutputModule",
+                                   "NanoAODRNTupleOutputModule",
+                                   description().moduleLabel(),
+                                   edm::createGlobalIdentifier(),
+                                   std::string(),
+                                   branchHash.digest().toString(),
+                                   std::vector<std::string>());
+
+  if (m_compressionAlgorithm == "ZLIB") {
+    m_file->SetCompressionAlgorithm(ROOT::kZLIB);
+  } else if (m_compressionAlgorithm == "LZMA") {
+    m_file->SetCompressionAlgorithm(ROOT::kLZMA);
+  } else {
+    throw cms::Exception("Configuration")
+        << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
+        << "Allowed compression algorithms are ZLIB and LZMA\n";
+  }
+
+  const auto& keeps = keptProducts();
+  for (const auto& keep : keeps[edm::InRun]) {
+    if (keep.first->className() == "nanoaod::MergeableCounterTable") {
+      m_run.registerToken(keep.second);
+    } else if (keep.first->className() == "nanoaod::UniqueString" && keep.first->moduleLabel() == "nanoMetadata") {
+      m_nanoMetadata.emplace_back(keep.first->productInstanceName(), keep.second);
+    } else {
+      throw cms::Exception(
+          "Configuration",
+          "NanoAODRNTupleOutputModule cannot handle class " + keep.first->className() + " in Run branch");
+    }
+  }
+}
+
+void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEvent) {
+  // set up RNTuple schema
+  auto model = RNTupleModel::Create();
+  m_commonFields.createFields(*model);
+
+  const auto& keeps = keptProducts();
+  for (const auto& keep : keeps[edm::InEvent]) {
+    if (keep.first->className() == "nanoaod::FlatTable") {
+      edm::Handle<nanoaod::FlatTable> handle;
+      const auto& token = keep.second;
+      iEvent.getByToken(token, handle);
+      m_tables.add(token, *handle);
+    } else if (keep.first->className() == "edm::TriggerResults") {
+      m_triggers.emplace_back(TriggerOutputFields(keep.first->processName(), keep.second));
+    } else if (keep.first->className() == "std::basic_string<char,std::char_traits<char> >" &&
+               keep.first->productInstanceName() == "genModel") {
+      m_evstrings.registerToken(keep.second);
+    } else {
+      throw cms::Exception("Configuration", "NanoAODOutputModule cannot handle class " + keep.first->className());
+    }
+  }
+  m_tables.createFields(iEvent, *model);
+  for (auto& trigger : m_triggers) {
+    trigger.createFields(iEvent, *model);
+  }
+  m_evstrings.createFields(*model);
+  // TODO use Append
+  RNTupleWriteOptions options;
+  options.SetCompression(m_file->GetCompressionSettings());
+  m_ntuple =
+      std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkFile>("Events", *m_file, options));
+}
+
+void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {
+  if (!m_ntuple) {
+    initializeNTuple(iEvent);
+  }
+
+  edm::Service<edm::JobReport> jr;
+  jr->eventWrittenToFile(m_jrToken, iEvent.id().run(), iEvent.id().event());
+
+  m_commonFields.fill(iEvent.id());
+  m_tables.fill(iEvent);
+  for (auto& trigger : m_triggers) {
+    trigger.fill(iEvent);
+  }
+  m_evstrings.fill(iEvent);
+  m_ntuple->Fill();
+  m_processHistoryRegistry.registerProcessHistory(iEvent.processHistory());
+}
+
+void NanoAODRNTupleOutputModule::reallyCloseFile() {
+  if (m_writeProvenance) {
+    writeProvenance();
+  }
+  // write ntuple to disk by calling the RNTupleWriter destructor
+  m_ntuple.reset();
+  m_lumi.finalizeWrite();
+  m_run.finalizeWrite();
+  m_file->Write();
+  m_file->Close();
+
+  edm::Service<edm::JobReport> jr;
+  jr->outputFileClosed(m_jrToken);
+}
+
+void NanoAODRNTupleOutputModule::writeProvenance() {
+  PSetNTuple pntuple;
+  pntuple.fill(edm::pset::Registry::instance(), *m_file);
+  pntuple.finalizeWrite();
+
+  MetadataNTuple mdntuple;
+  mdntuple.fill(m_processHistoryRegistry, *m_file);
+  mdntuple.finalizeWrite();
+}
+
+void NanoAODRNTupleOutputModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.addUntracked<std::string>("fileName");
+  desc.addUntracked<std::string>("logicalFileName", "");
+  desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
+  desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
+      ->setComment(
+          "Algorithm used to "
+          "compress data in the ROOT output file, allowed values are ZLIB and LZMA");
+  desc.addUntracked<bool>("saveProvenance", true)
+      ->setComment("Save process provenance information, e.g. for edmProvDump");
+  const std::vector<std::string> keep = {"drop *",
+                                         "keep nanoaodFlatTable_*Table_*_*",
+                                         "keep edmTriggerResults_*_*_*",
+                                         "keep String_*_genModel_*",
+                                         "keep nanoaodMergeableCounterTable_*Table_*_*",
+                                         "keep nanoaodUniqueString_nanoMetadata_*_*"};
+  edm::one::OutputModule<>::fillDescription(desc, keep);
+
+  //Used by Workflow management for their own meta data
+  edm::ParameterSetDescription dataSet;
+  dataSet.setAllowAnything();
+  desc.addUntracked<edm::ParameterSetDescription>("dataset", dataSet)
+      ->setComment("PSet is only used by Data Operations and not by this module.");
+
+  edm::ParameterSetDescription branchSet;
+  branchSet.setAllowAnything();
+  desc.add<edm::ParameterSetDescription>("branches", branchSet);
+
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(NanoAODRNTupleOutputModule);

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
@@ -1,0 +1,135 @@
+#include "NanoAODRNTuples.h"
+
+#include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+#include <ROOT/RPageStorageFile.hxx>
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriteOptions;
+using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Detail::RPageSinkFile;
+
+#include "RNTupleFieldPtr.h"
+#include "SummaryTableOutputFields.h"
+
+void LumiNTuple::createFields(const edm::LuminosityBlockID& id, TFile& file) {
+  auto model = RNTupleModel::Create();
+  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
+  m_luminosityBlock = RNTupleFieldPtr<UInt_t>("luminosityBlock", "", *model);
+  // TODO use Append when we bump our RNTuple version:
+  // m_ntuple = RNTupleWriter::Append(std::move(model), "LuminosityBlocks", file);
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
+  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model),
+                                             std::make_unique<RPageSinkFile>("LuminosityBlocks", file, options));
+}
+
+void LumiNTuple::fill(const edm::LuminosityBlockID& id, TFile& file) {
+  if (!m_ntuple) {
+    createFields(id, file);
+  }
+  m_run.fill(id.run());
+  m_luminosityBlock.fill(id.value());
+  m_ntuple->Fill();
+}
+
+void LumiNTuple::finalizeWrite() { m_ntuple.reset(); }
+
+void RunNTuple::registerToken(const edm::EDGetToken& token) { m_tokens.push_back(token); }
+
+void RunNTuple::createFields(const edm::RunForOutput& iRun, TFile& file) {
+  auto model = RNTupleModel::Create();
+  m_run = RNTupleFieldPtr<UInt_t>("run", "", *model);
+
+  edm::Handle<nanoaod::MergeableCounterTable> handle;
+  for (const auto& token : m_tokens) {
+    iRun.getByToken(token, handle);
+    const nanoaod::MergeableCounterTable& tab = *handle;
+    m_tables.push_back(SummaryTableOutputFields(tab, *model));
+  }
+
+  // TODO use Append when we bump our RNTuple version
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
+  m_ntuple = std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkFile>("Runs", file, options));
+}
+
+void RunNTuple::fill(const edm::RunForOutput& iRun, TFile& file) {
+  if (!m_ntuple) {
+    createFields(iRun, file);
+  }
+  m_run.fill(iRun.id().run());
+  edm::Handle<nanoaod::MergeableCounterTable> handle;
+  for (std::size_t i = 0; i < m_tokens.size(); i++) {
+    iRun.getByToken(m_tokens.at(i), handle);
+    const nanoaod::MergeableCounterTable& tab = *handle;
+    m_tables.at(i).fill(tab);
+  }
+  m_ntuple->Fill();
+}
+
+void RunNTuple::finalizeWrite() { m_ntuple.reset(); }
+
+void PSetNTuple::createFields(TFile& file) {
+  // use a collection to emulate std::pair
+  auto pairModel = RNTupleModel::Create();
+  m_psetId = RNTupleFieldPtr<std::string>("first", "", *pairModel);
+  m_psetBlob = RNTupleFieldPtr<std::string>("second", "", *pairModel);
+  auto model = RNTupleModel::Create();
+  m_collection = model->MakeCollection(edm::poolNames::idToParameterSetBlobsBranchName(), std::move(pairModel));
+  // TODO use Append when we bump our RNTuple version
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
+  m_ntuple = std::make_unique<RNTupleWriter>(
+      std::move(model), std::make_unique<RPageSinkFile>(edm::poolNames::parameterSetsTreeName(), file, options));
+}
+
+void PSetNTuple::fill(edm::pset::Registry* pset, TFile& file) {
+  if (!pset) {
+    throw cms::Exception("LogicError", "null edm::pset::Registry::Instance pointer");
+  }
+  if (!m_ntuple) {
+    createFields(file);
+  }
+  for (const auto& ps : *pset) {
+    std::ostringstream oss;
+    oss << ps.first;
+    m_psetId.fill(oss.str());
+    m_psetBlob.fill(ps.second.toString());
+    m_collection->Fill();
+    m_ntuple->Fill();
+  }
+}
+
+void PSetNTuple::finalizeWrite() { m_ntuple.reset(); }
+
+// TODO blocked on RNTuple typedef member field support
+void MetadataNTuple::createFields(TFile& file) {
+  auto procHistModel = RNTupleModel::Create();
+  // ProcessHistory.transients_.phid_ replacement
+  m_phId = RNTupleFieldPtr<std::string>("transients_phid_", "", *procHistModel);
+  auto model = RNTupleModel::Create();
+  m_procHist = model->MakeCollection(edm::poolNames::processHistoryBranchName(), std::move(procHistModel));
+  RNTupleWriteOptions options;
+  options.SetCompression(file.GetCompressionSettings());
+  m_ntuple = std::make_unique<RNTupleWriter>(
+      std::move(model), std::make_unique<RPageSinkFile>(edm::poolNames::metaDataTreeName(), file, options));
+}
+
+void MetadataNTuple::fill(const edm::ProcessHistoryRegistry& procHist, TFile& file) {
+  if (!m_ntuple) {
+    createFields(file);
+  }
+  for (const auto& ph : procHist) {
+    std::string phid;
+    ph.second.id().toString(phid);
+    m_phId.fill(phid);
+    m_procHist->Fill();
+  }
+  m_ntuple->Fill();
+}
+
+void MetadataNTuple::finalizeWrite() { m_ntuple.reset(); }

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -1,0 +1,87 @@
+#ifndef PhysicsTools_NanoAOD_NanoAODRNTuples_h
+#define PhysicsTools_NanoAOD_NanoAODRNTuples_h
+
+#include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/ParameterSetBlob.h"
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "TFile.h"
+#include <ROOT/RNTuple.hxx>
+using ROOT::Experimental::RCollectionNTupleWriter;
+using ROOT::Experimental::RNTupleWriter;
+
+#include "EventStringOutputFields.h"
+#include "RNTupleFieldPtr.h"
+#include "SummaryTableOutputFields.h"
+#include "TableOutputFields.h"
+#include "TriggerOutputFields.h"
+
+class LumiNTuple {
+public:
+  LumiNTuple() = default;
+  void fill(const edm::LuminosityBlockID& id, TFile& file);
+  void finalizeWrite();
+
+private:
+  void createFields(const edm::LuminosityBlockID& id, TFile& file);
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<UInt_t> m_run;
+  RNTupleFieldPtr<UInt_t> m_luminosityBlock;
+};
+
+class RunNTuple {
+public:
+  RunNTuple() = default;
+  void registerToken(const edm::EDGetToken& token);
+  void fill(const edm::RunForOutput& iRun, TFile& file);
+  void finalizeWrite();
+
+private:
+  void createFields(const edm::RunForOutput& iRun, TFile& file);
+  std::vector<edm::EDGetToken> m_tokens;
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+  RNTupleFieldPtr<UInt_t> m_run;
+  std::vector<SummaryTableOutputFields> m_tables;
+};
+
+class PSetNTuple {
+public:
+  PSetNTuple() = default;
+  void fill(edm::pset::Registry* pset, TFile& file);
+  void finalizeWrite();
+
+private:
+  // TODO blocked on RNTuple std::pair support
+  // using PSetType = std::pair<edm::ParameterSetID, edm::ParameterSetBlob>;
+  // RNTupleFieldPtr<PSetType> m_pset;
+  void createFields(TFile& file);
+  // TODO blocked on RNTuple typedef member field support:
+  // https://github.com/root-project/root/issues/7861
+  // RNTupleFieldPtr<edm::ParameterSetID> m_psetId;
+  // RNTupleFieldPtr<edm::ParameterSetBlob> m_psetBlob;
+  std::shared_ptr<RCollectionNTupleWriter> m_collection;
+  RNTupleFieldPtr<std::string> m_psetId;
+  RNTupleFieldPtr<std::string> m_psetBlob;
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+};
+
+class MetadataNTuple {
+public:
+  MetadataNTuple() = default;
+  void fill(const edm::ProcessHistoryRegistry& procHist, TFile& file);
+  void finalizeWrite();
+
+private:
+  void createFields(TFile& file);
+  std::shared_ptr<RCollectionNTupleWriter> m_procHist;
+
+  RNTupleFieldPtr<std::string> m_phId;
+  std::unique_ptr<RNTupleWriter> m_ntuple;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/RNTupleFieldPtr.h
@@ -1,0 +1,22 @@
+#ifndef PhysicsTools_NanoAOD_RNTupleFieldPtr_h
+#define PhysicsTools_NanoAOD_RNTupleFieldPtr_h
+
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RNTupleModel;
+
+template <typename T>
+class RNTupleFieldPtr {
+public:
+  RNTupleFieldPtr() = default;
+  explicit RNTupleFieldPtr(const std::string& name, const std::string& desc, RNTupleModel& model) : m_name(name) {
+    m_field = model.MakeField<T>({m_name, desc});
+  }
+  void fill(const T& value) { *m_field = value; }
+  const std::string& getFieldName() const { return m_name; }
+
+private:
+  std::string m_name;
+  std::shared_ptr<T> m_field;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.cc
@@ -1,0 +1,64 @@
+#include "SummaryTableOutputFields.h"
+
+template <typename T, typename Col>
+std::vector<RNTupleFieldPtr<T>> SummaryTableOutputFields::makeFields(const std::vector<Col> &tabcols,
+                                                                     RNTupleModel &model) {
+  std::vector<RNTupleFieldPtr<T>> fields;
+  fields.reserve(tabcols.size());
+  for (const auto &col : tabcols) {
+    // TODO field description
+    fields.emplace_back(RNTupleFieldPtr<T>(col.name, col.doc, model));
+  }
+  return fields;
+}
+
+template <typename T, typename Col>
+void SummaryTableOutputFields::fillScalarFields(const std::vector<Col> &tabcols,
+                                                std::vector<RNTupleFieldPtr<T>> fields) {
+  if (tabcols.size() != fields.size()) {
+    throw cms::Exception("LogicError", "Mismatch in table columns");
+  }
+  for (std::size_t i = 0; i < tabcols.size(); ++i) {
+    if (tabcols[i].name != fields[i].getFieldName()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    fields[i].fill(tabcols[i].value);
+  }
+}
+
+template <typename T, typename Col>
+void SummaryTableOutputFields::fillVectorFields(const std::vector<Col> &tabcols,
+                                                std::vector<RNTupleFieldPtr<T>> fields) {
+  if (tabcols.size() != fields.size()) {
+    throw cms::Exception("LogicError", "Mismatch in table columns");
+  }
+  for (std::size_t i = 0; i < tabcols.size(); ++i) {
+    if (tabcols[i].name != fields[i].getFieldName()) {
+      throw cms::Exception("LogicError", "Mismatch in table columns");
+    }
+    auto data = tabcols[i].values;
+    // TODO remove this awful hack when std::int64_t is supported
+    // -- turns std::vector<int64_t> into std::vector<uint64_t>
+    T casted_data(data.begin(), data.end());
+    fields[i].fill(casted_data);
+  }
+}
+
+SummaryTableOutputFields::SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model) {
+  // TODO use std::int64_t when supported
+  m_intFields = makeFields<std::uint64_t>(tab.intCols(), model);
+  m_floatFields = makeFields<double>(tab.floatCols(), model);
+  m_floatWithNormFields = makeFields<double>(tab.floatWithNormCols(), model);
+  m_vintFields = makeFields<std::vector<std::uint64_t>>(tab.vintCols(), model);
+  m_vfloatFields = makeFields<std::vector<double>>(tab.vfloatCols(), model);
+  m_vfloatWithNormFields = makeFields<std::vector<double>>(tab.vfloatWithNormCols(), model);
+}
+
+void SummaryTableOutputFields::fill(const nanoaod::MergeableCounterTable &tab) {
+  fillScalarFields(tab.intCols(), m_intFields);
+  fillScalarFields(tab.floatCols(), m_floatFields);
+  fillScalarFields(tab.floatWithNormCols(), m_floatWithNormFields);
+  fillVectorFields(tab.vintCols(), m_vintFields);
+  fillVectorFields(tab.vfloatCols(), m_vfloatFields);
+  fillVectorFields(tab.vfloatWithNormCols(), m_vfloatWithNormFields);
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/SummaryTableOutputFields.h
@@ -1,0 +1,30 @@
+#ifndef PhysicsTools_NanoAOD_SummaryTableOutputFields_h
+#define PhysicsTools_NanoAOD_SummaryTableOutputFields_h
+
+#include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
+
+#include "RNTupleFieldPtr.h"
+
+class SummaryTableOutputFields {
+public:
+  SummaryTableOutputFields() = default;
+  SummaryTableOutputFields(const nanoaod::MergeableCounterTable &tab, RNTupleModel &model);
+  void fill(const nanoaod::MergeableCounterTable &tab);
+
+private:
+  template <typename T, typename Col>
+  std::vector<RNTupleFieldPtr<T>> makeFields(const std::vector<Col> &tabcols, RNTupleModel &model);
+  template <typename T, typename Col>
+  static void fillScalarFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
+  template <typename T, typename Col>
+  static void fillVectorFields(const std::vector<Col> &tabcols, std::vector<RNTupleFieldPtr<T>> fields);
+
+  std::vector<RNTupleFieldPtr<std::uint64_t>> m_intFields;
+  std::vector<RNTupleFieldPtr<double>> m_floatFields;
+  std::vector<RNTupleFieldPtr<double>> m_floatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatFields;
+  std::vector<RNTupleFieldPtr<std::vector<double>>> m_vfloatWithNormFields;
+  std::vector<RNTupleFieldPtr<std::vector<std::uint64_t>>> m_vintFields;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.cc
@@ -1,0 +1,284 @@
+#include "TableOutputFields.h"
+
+namespace {
+  void printTable(const nanoaod::FlatTable& table) {
+    std::cout << "FlatTable {\n";
+    std::cout << "  name: " << (table.name().empty() ? "// anon" : table.name()) << "\n";
+    std::cout << "  singleton: " << (table.singleton() ? "true" : "false") << "\n";
+    std::cout << "  size: " << table.size() << "\n";
+    std::cout << "  extension: " << (table.extension() ? "true" : "false") << "\n";
+    std::cout << "  fields: {\n";
+    for (std::size_t i = 0; i < table.nColumns(); i++) {
+      std::cout << "    " << (table.columnName(i).empty() ? "// anon" : table.columnName(i)) << ": ";
+      switch (table.columnType(i)) {
+        case nanoaod::FlatTable::ColumnType::Float:
+          std::cout << "f32,";
+          break;
+        case nanoaod::FlatTable::ColumnType::Int32:
+          std::cout << "i32,";
+          break;
+        case nanoaod::FlatTable::ColumnType::UInt8:
+          std::cout << "u8,";
+          break;
+        case nanoaod::FlatTable::ColumnType::Bool:
+          std::cout << "bool,";
+          break;
+        default:
+          throw cms::Exception("LogicError", "Unsupported type");
+      }
+      std::cout << "\n";
+    }
+    std::cout << "  }\n}\n";
+  }
+}  // anonymous namespace
+
+void TableOutputFields::print() const {
+  for (const auto& field : m_floatFields) {
+    std::cout << "  " << field.getFlatTableName() << ": f32,\n";
+  }
+  for (const auto& field : m_intFields) {
+    std::cout << "  " << field.getFlatTableName() << ": i32,\n";
+  }
+  for (const auto& field : m_uint8Fields) {
+    std::cout << "  " << field.getFlatTableName() << ": u8,\n";
+  }
+  for (const auto& field : m_boolFields) {
+    std::cout << "  " << field.getFlatTableName() << ": bool,\n";
+  }
+}
+
+void TableOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const nanoaod::FlatTable& table = *handle;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    switch (table.columnType(i)) {
+      case nanoaod::FlatTable::ColumnType::Float:
+        m_floatFields.emplace_back(FlatTableField<float>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Int32:
+        m_intFields.emplace_back(FlatTableField<int>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::UInt8:
+        m_uint8Fields.emplace_back(FlatTableField<std::uint8_t>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Bool:
+        m_boolFields.emplace_back(FlatTableField<bool>(table, i, model));
+        break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
+    }
+  }
+}
+
+void TableOutputFields::fillEntry(const nanoaod::FlatTable& table, std::size_t i) {
+  for (auto& field : m_floatFields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_intFields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_uint8Fields) {
+    field.fill(table, i);
+  }
+  for (auto& field : m_boolFields) {
+    field.fill(table, i);
+  }
+}
+
+const edm::EDGetToken& TableOutputFields::getToken() const { return m_token; }
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableOutputVectorFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const nanoaod::FlatTable& table = *handle;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    switch (table.columnType(i)) {
+      case nanoaod::FlatTable::ColumnType::Float:
+        m_vfloatFields.emplace_back(FlatTableField<std::vector<float>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Int32:
+        m_vintFields.emplace_back(FlatTableField<std::vector<int>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::UInt8:
+        m_vuint8Fields.emplace_back(FlatTableField<std::vector<std::uint8_t>>(table, i, model));
+        break;
+      case nanoaod::FlatTable::ColumnType::Bool:
+        m_vboolFields.emplace_back(FlatTableField<std::vector<bool>>(table, i, model));
+        break;
+      default:
+        throw cms::Exception("LogicError", "Unsupported type");
+    }
+  }
+}
+void TableOutputVectorFields::fill(const edm::EventForOutput& event) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_token, handle);
+  const auto& table = *handle;
+  for (auto& field : m_vfloatFields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vintFields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vuint8Fields) {
+    field.fillVectored(table);
+  }
+  for (auto& field : m_vboolFields) {
+    field.fillVectored(table);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableCollection::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
+  if (m_collectionName.empty()) {
+    m_collectionName = table.name();
+  }
+  if (table.extension()) {
+    m_extensions.emplace_back(TableOutputFields(table_token));
+    return;
+  }
+  if (hasMainTable()) {
+    throw cms::Exception("LogicError", "Trying to save multiple main tables for " + m_collectionName + "\n");
+  }
+  m_main = TableOutputFields(table_token);
+}
+
+void TableCollection::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+  auto collectionModel = RNTupleModel::Create();
+  m_main.createFields(event, *collectionModel);
+  for (auto& extension : m_extensions) {
+    extension.createFields(event, *collectionModel);
+  }
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_main.getToken(), handle);
+  const nanoaod::FlatTable& table = *handle;
+  collectionModel->SetDescription(table.doc());
+  m_collection = eventModel.MakeCollection(m_collectionName, std::move(collectionModel));
+}
+
+void TableCollection::fill(const edm::EventForOutput& event) {
+  edm::Handle<nanoaod::FlatTable> handle;
+  event.getByToken(m_main.getToken(), handle);
+  const auto& main_table = *handle;
+  auto table_size = main_table.size();
+  for (std::size_t i = 0; i < table_size; i++) {
+    m_main.fillEntry(main_table, i);
+    for (auto& ext : m_extensions) {
+      edm::Handle<nanoaod::FlatTable> handle;
+      event.getByToken(ext.getToken(), handle);
+      const auto& ext_table = *handle;
+      if (ext_table.size() != table_size) {
+        throw cms::Exception("LogicError",
+                             "Mismatch in number of entries between extension and main table for " + m_collectionName);
+      }
+      ext.fillEntry(ext_table, i);
+    }
+    m_collection->Fill();
+  }
+}
+
+void TableCollection::print() const {
+  std::cout << "Collection: " << m_collectionName << " {\n";
+  m_main.print();
+  for (const auto& ext : m_extensions) {
+    ext.print();
+  }
+  std::cout << "}\n";
+}
+
+bool TableCollection::hasMainTable() { return !m_main.getToken().isUninitialized(); }
+
+const std::string& TableCollection::getCollectionName() const { return m_collectionName; }
+
+///////////////////////////////////////////////////////////////////////////////
+
+void TableCollectionSet::add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table) {
+  // skip empty tables -- requirement of RNTuple to define schema before filling
+  if (table.nColumns() == 0) {
+    std::cout << "Warning: skipping empty table: \n";
+    printTable(table);
+    return;
+  }
+  // Can handle either anonymous table or anonymous column but not both
+  // - anonymous table: use column names directly as top-level fields
+  // - anonymous column: use the table name as the field name
+  if (table.name().empty() && hasAnonymousColumn(table)) {
+    throw cms::Exception("LogicError", "Anonymous FlatTable and anonymous field");
+  }
+  // case 1: create a top-level RNTuple field for each table column
+  if (table.name().empty() || hasAnonymousColumn(table)) {
+    if (table.singleton()) {
+      m_singletonFields.emplace_back(TableOutputFields(table_token));
+    } else {
+      m_vectorFields.emplace_back(TableOutputVectorFields(table_token));
+    }
+    return;
+  }
+  // case 2: Named singleton and vector tables are both written as RNTuple collections.
+  auto collection = std::find_if(m_collections.begin(), m_collections.end(), [&](const TableCollection& c) {
+    return c.getCollectionName() == table.name();
+  });
+  if (collection == m_collections.end()) {
+    m_collections.emplace_back(TableCollection());
+    m_collections.back().add(table_token, table);
+    return;
+  }
+  collection->add(table_token, table);
+}
+
+void TableCollectionSet::print() const {
+  for (const auto& collection : m_collections) {
+    collection.print();
+    std::cout << "\n";
+  }
+}
+
+void TableCollectionSet::createFields(const edm::EventForOutput& event, RNTupleModel& eventModel) {
+  for (auto& collection : m_collections) {
+    if (!collection.hasMainTable()) {
+      throw cms::Exception("LogicError",
+                           "Trying to save an extension table for " + collection.getCollectionName() +
+                               " without the corresponding main table\n");
+    }
+    collection.createFields(event, eventModel);
+  }
+  for (auto& table : m_singletonFields) {
+    table.createFields(event, eventModel);
+  }
+  for (auto& table : m_vectorFields) {
+    table.createFields(event, eventModel);
+  }
+}
+
+void TableCollectionSet::fill(const edm::EventForOutput& event) {
+  for (auto& collection : m_collections) {
+    collection.fill(event);
+  }
+  for (auto& fields : m_singletonFields) {
+    edm::Handle<nanoaod::FlatTable> handle;
+    event.getByToken(fields.getToken(), handle);
+    const auto& table = *handle;
+    fields.fillEntry(table, 0);
+  }
+  for (auto& fields : m_vectorFields) {
+    fields.fill(event);
+  }
+}
+
+bool TableCollectionSet::hasAnonymousColumn(const nanoaod::FlatTable& table) {
+  int num_anon = 0;
+  for (std::size_t i = 0; i < table.nColumns(); i++) {
+    if (table.columnName(i).empty()) {
+      num_anon++;
+    }
+  }
+  if (num_anon > 1) {
+    throw cms::Exception("LogicError",
+                         "FlatTable `" + table.name() + "` has " + std::to_string(num_anon) + "anonymous fields");
+  }
+  return num_anon;
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -1,0 +1,134 @@
+#ifndef PhysicsTools_NanoAOD_TableOutputFields_h
+#define PhysicsTools_NanoAOD_TableOutputFields_h
+
+#include "RNTupleFieldPtr.h"
+
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include <algorithm>
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleModel.hxx>
+using ROOT::Experimental::RCollectionNTupleWriter;
+using ROOT::Experimental::RNTupleModel;
+using ROOT::Experimental::RNTupleWriter;
+
+template <typename T>
+class FlatTableField {
+public:
+  FlatTableField() = default;
+  FlatTableField(const nanoaod::FlatTable& table, std::size_t i, RNTupleModel& model) {
+    m_flatTableName = table.columnName(i);
+    // case 1: field has a name (table may or may not have a name)
+    if (!table.columnName(i).empty()) {
+      m_field = RNTupleFieldPtr<T>(table.columnName(i), table.columnDoc(i), model);
+      return;
+    }
+    // case 2: field doesn't have a name: use the table name as the RNTuple field name
+    if (table.name().empty()) {
+      throw cms::Exception("LogicError", "Empty FlatTable name and field name");
+    }
+    m_field = RNTupleFieldPtr<T>(table.name(), table.doc(), model);
+  }
+  // For collection fields and singleton fields
+  void fill(const nanoaod::FlatTable& table, std::size_t i) {
+    int col_idx = table.columnIndex(m_flatTableName);
+    if (col_idx == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
+    }
+    m_field.fill(table.columnData<T>(col_idx)[i]);
+  }
+  // For vector fields without a collection, we have to buffer the results
+  // internally and then fill the RNTuple field
+  void fillVectored(const nanoaod::FlatTable& table) {
+    int col_idx = table.columnIndex(m_flatTableName);
+    if (col_idx == -1) {
+      throw cms::Exception("LogicError", "Missing column in input for " + table.name() + "_" + m_flatTableName);
+    }
+    std::vector<typename T::value_type> buf(table.size());
+    for (std::size_t i = 0; i < table.size(); i++) {
+      buf[i] = table.columnData<typename T::value_type>(col_idx)[i];
+    }
+    m_field.fill(buf);
+  }
+  const std::string& getFlatTableName() const { return m_flatTableName; }
+
+private:
+  RNTupleFieldPtr<T> m_field;
+  std::string m_flatTableName;
+};
+
+class TableOutputFields {
+public:
+  TableOutputFields() = default;
+  explicit TableOutputFields(const edm::EDGetToken& token) : m_token(token) {}
+  void print() const;
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fillEntry(const nanoaod::FlatTable& table, std::size_t i);
+  const edm::EDGetToken& getToken() const;
+
+private:
+  edm::EDGetToken m_token;
+  std::vector<FlatTableField<float>> m_floatFields;
+  std::vector<FlatTableField<int>> m_intFields;
+  std::vector<FlatTableField<std::uint8_t>> m_uint8Fields;
+  std::vector<FlatTableField<bool>> m_boolFields;
+};
+
+class TableOutputVectorFields {
+public:
+  TableOutputVectorFields() = default;
+  explicit TableOutputVectorFields(const edm::EDGetToken& token) : m_token(token) {}
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fill(const edm::EventForOutput& event);
+
+private:
+  edm::EDGetToken m_token;
+  std::vector<FlatTableField<std::vector<float>>> m_vfloatFields;
+  std::vector<FlatTableField<std::vector<int>>> m_vintFields;
+  std::vector<FlatTableField<std::vector<std::uint8_t>>> m_vuint8Fields;
+  std::vector<FlatTableField<std::vector<bool>>> m_vboolFields;
+};
+
+class TableCollection {
+public:
+  TableCollection() = default;
+  // Invariants:
+  // * table has a non-empty base name
+  // * table has at least one column
+  void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
+  // Invariants:
+  // * m_main not null
+  // * m_collectionName not empty
+  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void fill(const edm::EventForOutput& event);
+  void print() const;
+  bool hasMainTable();
+  const std::string& getCollectionName() const;
+
+private:
+  std::string m_collectionName;
+  std::shared_ptr<RCollectionNTupleWriter> m_collection;
+  TableOutputFields m_main;
+  std::vector<TableOutputFields> m_extensions;
+};
+
+class TableCollectionSet {
+public:
+  void add(const edm::EDGetToken& table_token, const nanoaod::FlatTable& table);
+  void createFields(const edm::EventForOutput& event, RNTupleModel& eventModel);
+  void fill(const edm::EventForOutput& event);
+  void print() const;
+
+private:
+  // Returns true if the FlatTable has an anonymous column. Throws a cms::Exception
+  // if there is more than one anonymous column.
+  static bool hasAnonymousColumn(const nanoaod::FlatTable& table);
+  std::vector<TableCollection> m_collections;
+  std::vector<TableOutputFields> m_singletonFields;
+  std::vector<TableOutputVectorFields> m_vectorFields;
+};
+
+#endif

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -1,0 +1,147 @@
+#include "TriggerOutputFields.h"
+
+#include "RNTupleFieldPtr.h"
+
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <algorithm>
+
+namespace {
+
+  void trimVersionSuffix(std::string& trigger_name) {
+    // HLT and L1 triggers have version suffixes we trim before filling the RNTuple
+    if (trigger_name.compare(0, 3, "HLT") != 0 && trigger_name.compare(0, 2, "L1") != 0) {
+      return;
+    }
+    auto vfound = trigger_name.rfind("_v");
+    if (vfound == std::string::npos) {
+      return;
+    }
+    trigger_name.replace(vfound, trigger_name.size() - vfound, "");
+  }
+
+  bool isNanoaodTrigger(const std::string& name) {
+    return name.compare(0, 3, "HLT") == 0 || name.compare(0, 4, "Flag") == 0 || name.compare(0, 2, "L1") == 0;
+  }
+
+}  // anonymous namespace
+
+TriggerFieldPtr::TriggerFieldPtr(
+    std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model)
+    : m_triggerName(name), m_triggerIndex(index) {
+  m_field = RNTupleFieldPtr<bool>(fieldName, fieldDesc, model);
+}
+
+void TriggerFieldPtr::fill(const edm::TriggerResults& triggers) {
+  if (m_triggerIndex == -1) {
+    m_field.fill(false);
+  }
+  m_field.fill(triggers.accept(m_triggerIndex));
+}
+
+std::vector<std::string> TriggerOutputFields::getTriggerNames(const edm::TriggerResults& triggerResults) {
+  // Trigger names are either stored in the TriggerResults object (e.g. L1) or
+  // need to be looked up in the registry (e.g. HLT)
+  auto triggerNames = triggerResults.getTriggerNames();
+  if (!triggerNames.empty()) {
+    return triggerNames;
+  }
+  edm::pset::Registry* psetRegistry = edm::pset::Registry::instance();
+  edm::ParameterSet const* pset = psetRegistry->getMapped(triggerResults.parameterSetID());
+  if (nullptr == pset || !pset->existsAs<std::vector<std::string>>("@trigger_paths", true)) {
+    return {};
+  }
+  edm::TriggerNames names(*pset);
+  if (names.size() != triggerResults.size()) {
+    throw cms::Exception("LogicError") << "TriggerOutputFields::getTriggerNames "
+                                          "Encountered vector\n of trigger names and a TriggerResults object with\n"
+                                          "different sizes.  This should be impossible.\n"
+                                          "Please send information to reproduce this problem to\nthe edm developers.\n";
+  }
+  return names.triggerNames();
+}
+
+void TriggerOutputFields::createFields(const edm::EventForOutput& event, RNTupleModel& model) {
+  m_lastRun = event.id().run();
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  const edm::TriggerResults& triggerResults = *handle;
+  std::vector<std::string> triggerNames(TriggerOutputFields::getTriggerNames(triggerResults));
+  m_triggerFields.reserve(triggerNames.size());
+  for (std::size_t i = 0; i < triggerNames.size(); i++) {
+    auto& name = triggerNames[i];
+    if (!isNanoaodTrigger(name)) {
+      continue;
+    }
+    trimVersionSuffix(name);
+    std::string modelName = name;
+    makeUniqueFieldName(model, modelName);
+    std::string desc = std::string("Trigger/flag bit (process: ") + m_processName + ")";
+    m_triggerFields.emplace_back(TriggerFieldPtr(name, i, modelName, desc, model));
+  }
+}
+
+// Worst case O(n^2) to adjust the triggers
+void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& triggers) {
+  std::vector<std::string> newNames(TriggerOutputFields::getTriggerNames(triggers));
+  // adjust existing trigger indices
+  for (auto& t : m_triggerFields) {
+    t.setIndex(-1);
+    for (std::size_t j = 0; j < newNames.size(); j++) {
+      auto& name = newNames[j];
+      if (!isNanoaodTrigger(name)) {
+        continue;
+      }
+      trimVersionSuffix(name);
+      if (name == t.getTriggerName()) {
+        t.setIndex(j);
+      }
+    }
+  }
+  // find new triggers
+  for (std::size_t j = 0; j < newNames.size(); j++) {
+    auto& name = newNames[j];
+    if (!isNanoaodTrigger(name)) {
+      continue;
+    }
+    trimVersionSuffix(name);
+    if (std::none_of(m_triggerFields.cbegin(), m_triggerFields.cend(), [&](const TriggerFieldPtr& t) {
+          return t.getTriggerName() == name;
+        })) {
+      // TODO backfill / friend ntuples
+      edm::LogWarning("TriggerOutputFields") << "Skipping output of TriggerField " << name << "\n";
+    }
+  }
+}
+
+void TriggerOutputFields::makeUniqueFieldName(RNTupleModel& model, std::string& name) {
+  // Could also use a cache of names in a higher-level object, don't ask the RNTupleModel each time
+  const auto* existing_field = model.Get<bool>(name);
+  if (!existing_field) {
+    return;
+  }
+  edm::LogWarning("TriggerOutputFields") << "Found a branch with name " << name
+                                         << " already present. Will add suffix _p" << m_processName
+                                         << " to the new branch.\n";
+  name += std::string("_p") + m_processName;
+}
+
+void TriggerOutputFields::fill(const edm::EventForOutput& event) {
+  edm::Handle<edm::TriggerResults> handle;
+  event.getByToken(m_token, handle);
+  const edm::TriggerResults& triggers = *handle;
+  if (m_lastRun != event.id().run()) {
+    m_lastRun = event.id().run();
+    updateTriggerFields(triggers);
+  }
+  for (auto& t : m_triggerFields) {
+    t.fill(triggers);
+  }
+}

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.h
@@ -1,0 +1,48 @@
+#ifndef PhysicsTools_NanoAOD_TriggerOutputFields_h
+#define PhysicsTools_NanoAOD_TriggerOutputFields_h
+
+#include "RNTupleFieldPtr.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+namespace edm {
+  class EventForOutput;
+  class TriggerResults;
+}  // namespace edm
+
+class TriggerFieldPtr {
+public:
+  TriggerFieldPtr() = default;
+  TriggerFieldPtr(std::string name, int index, std::string fieldName, std::string fieldDesc, RNTupleModel& model);
+  void fill(const edm::TriggerResults& triggers);
+  const std::string& getTriggerName() const { return m_triggerName; }
+  void setIndex(int newIndex) { m_triggerIndex = newIndex; }
+
+private:
+  RNTupleFieldPtr<bool> m_field;
+  // The trigger results name extracted from the TriggerResults with version suffixes trimmed
+  std::string m_triggerName;
+  int m_triggerIndex = -1;
+};
+
+class TriggerOutputFields {
+public:
+  TriggerOutputFields() = default;
+  explicit TriggerOutputFields(const std::string& processName, const edm::EDGetToken& token)
+      : m_token(token), m_lastRun(-1), m_processName(processName) {}
+  void createFields(const edm::EventForOutput& event, RNTupleModel& model);
+  void fill(const edm::EventForOutput& event);
+
+private:
+  static std::vector<std::string> getTriggerNames(const edm::TriggerResults& triggerResults);
+  // Update trigger field information on run boundaries
+  void updateTriggerFields(const edm::TriggerResults& triggerResults);
+  void makeUniqueFieldName(/*const*/ RNTupleModel& model, std::string& name);
+
+  edm::EDGetToken m_token;
+  long m_lastRun;
+  std::string m_processName;
+  std::vector<TriggerFieldPtr> m_triggerFields;
+};
+
+#endif


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/33825
#33825 was included in 12.0.ROOT6 (which was based on root 6.24) to add new output module that generates ROOT RNTuple NanoAODs. As cmssw 13.0.X now uses root 6.26, so lets backport these changes to  master branch.

FYI @mxxo