### PR TITLE
Add function to refine FastSim DeepJet discriminators

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -369,15 +369,16 @@ def nanoAOD_refineFastSim_bTagDeepFlav(process):
     )
 
     fastSim.toModify( process.jetTable.externalVariables,
-      btagDeepFlavB = process.jetTable.variables.btagDeepFlavBunrefined.clone(src=cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavBrefined")),
-      btagDeepFlavCvB = process.jetTable.variables.btagDeepFlavCvBunrefined.clone(src=cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavCvBrefined")),
-      btagDeepFlavCvL = process.jetTable.variables.btagDeepFlavCvLunrefined.clone(src=cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavCvLrefined")),
-      btagDeepFlavQG = process.jetTable.variables.btagDeepFlavQGunrefined.clone(src=cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavQGrefined")),
+      btagDeepFlavB = ExtVar(cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavBrefined"), float, doc="DeepJet b+bb+lepb tag discriminator", precision=10),
+      btagDeepFlavCvB = ExtVar(cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavCvBrefined"), float, doc="DeepJet c vs b+bb+lepb discriminator", precision=10),
+      btagDeepFlavCvL = ExtVar(cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavCvLrefined"), float, doc="DeepJet c vs uds+g discriminator", precision=10),
+      btagDeepFlavQG = ExtVar(cms.InputTag("btagDeepFlavRefineNN:btagDeepFlavQGrefined"), float, doc="DeepJet g vs uds discriminator", precision=10),
     )
 
     process.btagDeepFlavRefineNN= cms.EDProducer("JetBaseMVAValueMapProducer",
         backend = cms.string("ONNX"),
         batch_eval = cms.bool(True),
+        disableONNXGraphOpt = cms.bool(True),
 
         src = cms.InputTag("linkedObjects","jets"),
 

--- a/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
@@ -55,7 +55,7 @@
 
 class BaseMVACache {
 public:
-  BaseMVACache(const std::string& model_path, const std::string& backend, const bool& disableONNXGraphOpt) {
+  BaseMVACache(const std::string& model_path, const std::string& backend, const bool disableONNXGraphOpt) {
     if (backend == "TF") {
       graph_.reset(tensorflow::loadGraphDef(model_path));
       tf_session_ = tensorflow::createSession(graph_.get());

--- a/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
@@ -55,12 +55,19 @@
 
 class BaseMVACache {
 public:
-  BaseMVACache(const std::string& model_path, const std::string& backend) {
+  BaseMVACache(const std::string& model_path, const std::string& backend, const bool& disableONNXGraphOpt) {
     if (backend == "TF") {
       graph_.reset(tensorflow::loadGraphDef(model_path));
       tf_session_ = tensorflow::createSession(graph_.get());
     } else if (backend == "ONNX") {
-      ort_ = std::make_unique<cms::Ort::ONNXRuntime>(model_path);
+      if (disableONNXGraphOpt) {
+        Ort::SessionOptions sess_opts;
+        sess_opts = cms::Ort::ONNXRuntime::defaultSessionOptions();
+        sess_opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_DISABLE_ALL);
+        ort_ = std::make_unique<cms::Ort::ONNXRuntime>(model_path, &sess_opts);
+      } else {
+        ort_ = std::make_unique<cms::Ort::ONNXRuntime>(model_path);
+      }
     }
   }
   ~BaseMVACache() { tensorflow::closeSession(tf_session_); }
@@ -270,7 +277,8 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
 template <typename T>
 std::unique_ptr<BaseMVACache> BaseMVAValueMapProducer<T>::initializeGlobalCache(const edm::ParameterSet& cfg) {
   return std::make_unique<BaseMVACache>(cfg.getParameter<edm::FileInPath>("weightFile").fullPath(),
-                                        cfg.getParameter<std::string>("backend"));
+                                        cfg.getParameter<std::string>("backend"),
+                                        cfg.getParameter<bool>("disableONNXGraphOpt"));
 }
 
 template <typename T>
@@ -295,6 +303,7 @@ edm::ParameterSetDescription BaseMVAValueMapProducer<T>::getDescription() {
   desc.add<std::vector<std::string>>("outputFormulas", std::vector<std::string>())
       ->setComment("Formulas to be used to post process the output");
   desc.add<bool>("batch_eval", false)->setComment("Run inference in batch instead of per-object");
+  desc.add<bool>("disableONNXGraphOpt", false)->setComment("Disable ONNX runtime graph optimization");
 
   return desc;
 }


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
Requires: https://github.com/cms-data/PhysicsTools-NanoAOD/pull/14

This PR adds a function that uses a regression neural network to refine the DeepJet discriminators of CHS jets in NanoAOD for FastSim to better match FullSim. The function can be called by including the option `--customise PhysicsTools/NanoAOD/jetsAK4_CHS_cff.nanoAOD_refineFastSim_bTagDeepFlav` in the cmsDriver command and requires the ONNX model added in the above mentioned PR to cms-data. The original values are copied to new variables named with the suffix "unrefined".

Due to a bug in ONNX runtime 1.10.0 (see [here](https://github.com/microsoft/onnxruntime/issues/10305)) graph optimization has to be disabled to evaluate the model. The corresponding option is implemented in BaseMVAValueMapProducer for the ONNX backend.

The technique has been presented at the [FastSim Days 2022 Workshop](https://indico.cern.ch/event/1191657/contributions/5016864/).

A complete set of commands to produce NanoAOD files with refined DeepJet discriminators is:

`cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi  --relval 100000,1000 -s GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,DIGI2RAW,L1Reco,RECO,VALIDATION:@standardValidation,DQM:@standardDQMFS -n 10 --conditions auto:run2_mc --beamspot Realistic25ns13TeV2016Collision --datatier GEN-SIM-DIGI-RECO,DQMIO --eventcontent FEVTDEBUGHLT,DQM --fast  --era Run2_2016
GEN,SIM,RECOBEFMIX,DIGI:pdigi_valid,L1,DIGI2RAW,L1Reco,RECO,VALIDATION:@standardValidation,DQM:@standardDQMFS`

`cmsDriver.py step3  -s PAT --era Run2_2016 -n -1 --conditions auto:run2_mc --mc  --datatier MINIAODSIM --eventcontent MINIAODSIM --filein file:TTbar_13TeV_TuneCUETP8M1_cfi_GEN_SIM_RECOBEFMIX_DIGI_L1_DIGI2RAW_L1Reco_RECO_VALIDATION_DQM.root --fast`

`cmsDriver.py  --python_filename NanoAODrefined_cfg.py --eventcontent NANOAODSIM --fast --customise Configuration/DataProcessing/Utils.addMonitoring,PhysicsTools/NanoAOD/jetsAK4_CHS_cff.nanoAOD_refineFastSim_bTagDeepFlav --datatier NANOAODSIM --fileout file:step3_NANO.root --conditions auto:run2_mc --step NANO --filein "file:step3_PAT.root" --era run2_nanoAOD_106Xv2 --mc -n -1`

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
The neural network has been trained on GEN-synchronized FastSim/FullSim jet pairs from SUSY simplified model T1tttt events and has been validated also in TTbar events. In both cases, considerably improved agreement with the FullSim output and an improvement in correlations among output observables and external parameters is seen.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
