### PR TITLE
Add GPU backend option for TensorFlow session

### DIFF
--- a/PhysicsTools/TensorFlow/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="FWCore/ServiceRegistry"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -25,6 +25,11 @@
 
 namespace tensorflow {
 
+  enum class Backend {
+    cpu,
+    cuda,
+  };
+
   typedef std::pair<std::string, Tensor> NamedTensor;
   typedef std::vector<NamedTensor> NamedTensorList;
 
@@ -39,6 +44,10 @@ namespace tensorflow {
   // since the threading configuration is done per run() call as of 2.1
   void setThreading(SessionOptions& sessionOptions, int nThreads, const std::string& singleThreadPool);
 
+  // Set the backend option cpu/cuda
+  // The gpu memory is set to "allow_growth" to avoid TF getting all the CUDA memory at once.
+  void setBackend(SessionOptions& sessionOptions, Backend backend = Backend::cpu);
+
   // loads a meta graph definition saved at exportDir using the SavedModel interface for a tag and
   // predefined sessionOptions
   // transfers ownership
@@ -52,11 +61,13 @@ namespace tensorflow {
   // transfers ownership
   MetaGraphDef* loadMetaGraphDef(const std::string& exportDir,
                                  const std::string& tag = kSavedModelTagServe,
+                                 Backend backend = Backend::cpu,
                                  int nThreads = 1);
 
   // deprecated in favor of loadMetaGraphDef
   MetaGraphDef* loadMetaGraph(const std::string& exportDir,
                               const std::string& tag = kSavedModelTagServe,
+                              Backend backend = Backend::cpu,
                               int nThreads = 1);
 
   // loads a graph definition saved as a protobuf file at pbFile
@@ -67,9 +78,9 @@ namespace tensorflow {
   // transfers ownership
   Session* createSession(SessionOptions& sessionOptions);
 
-  // return a new, empty session with nThreads
+  // return a new, empty session with nThreads and selected backend
   // transfers ownership
-  Session* createSession(int nThreads = 1);
+  Session* createSession(Backend backend = Backend::cpu, int nThreads = 1);
 
   // return a new session that will contain an already loaded meta graph whose exportDir must be
   // given in order to load and initialize the variables, sessionOptions are predefined
@@ -83,7 +94,10 @@ namespace tensorflow {
   // in order to load and initialize the variables, threading options are inferred from nThreads
   // an error is thrown when metaGraphDef is a nullptr or when the graph has no nodes
   // transfers ownership
-  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads = 1);
+  Session* createSession(const MetaGraphDef* metaGraphDef,
+                         const std::string& exportDir,
+                         Backend backend = Backend::cpu,
+                         int nThreads = 1);
 
   // return a new session that will contain an already loaded graph def, sessionOptions are predefined
   // an error is thrown when graphDef is a nullptr or when the graph has no nodes
@@ -94,7 +108,7 @@ namespace tensorflow {
   // inferred from nThreads
   // an error is thrown when graphDef is a nullptr or when the graph has no nodes
   // transfers ownership
-  Session* createSession(const GraphDef* graphDef, int nThreads = 1);
+  Session* createSession(const GraphDef* graphDef, Backend backend = Backend::cpu, int nThreads = 1);
 
   // closes a session, calls its destructor, resets the pointer, and returns true on success
   bool closeSession(Session*& session);

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -25,10 +25,7 @@
 
 namespace tensorflow {
 
-  enum class Backend {
-    cpu,
-    cuda,
-  };
+  enum class Backend { cpu, cuda, rocm, intel, best };
 
   typedef std::pair<std::string, Tensor> NamedTensor;
   typedef std::vector<NamedTensor> NamedTensorList;

--- a/PhysicsTools/TensorFlow/plugins/TfGraphDefProducer.cc
+++ b/PhysicsTools/TensorFlow/plugins/TfGraphDefProducer.cc
@@ -48,7 +48,7 @@ TfGraphDefProducer::TfGraphDefProducer(const edm::ParameterSet& iConfig)
 // ------------ method called to produce the data  ------------
 TfGraphDefProducer::ReturnType TfGraphDefProducer::produce(const TfGraphRecord& iRecord) {
   auto* graph = tensorflow::loadGraphDef(filename_);
-  return std::make_unique<TfGraphDefWrapper>(tensorflow::createSession(graph, 1), graph);
+  return std::make_unique<TfGraphDefWrapper>(tensorflow::createSession(graph), graph);
 }
 
 void TfGraphDefProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -85,6 +85,10 @@ namespace tensorflow {
     // objects to create the session
     Status status;
 
+    // hotfix: disable GPU usage whatsoever for now, add a convenient interface in a future PR
+    (*sessionOptions.config.mutable_device_count())["GPU"] = 0;
+    sessionOptions.config.mutable_gpu_options()->set_visible_device_list("");
+
     // create a new, empty session
     Session* session = nullptr;
     status = NewSession(sessionOptions, &session);

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -56,7 +56,7 @@ namespace tensorflow {
       throw ex;
     }
     // Get NVidia GPU if possible or fallback to CPU
-    else if ((backend == Backend::best)) {
+    else if (backend == Backend::best) {
       // Check if a Nvidia GPU is availabl
       if (not ri->nvidiaDriverVersion().empty()) {
         // Take only the first GPU in the CUDA_VISIBLE_DEVICE list

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -133,6 +133,29 @@
 </bin>
 </iftool>
 
+<bin name="testTFVisibleDevices" file="testRunner.cpp,testVisibleDevices.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+
+<iftool name="cuda">
+<bin name="testTFVisibleDevicesCUDA" file="testRunner.cpp,testVisibleDevicesCUDA.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
+</bin>
+</iftool>
+
 <!-- <ifarchitecture name="!_ppc64le_">
 <bin name="testTFAOT" file="testRunner.cpp,testAOT.cc">
   <flags DNN_NAME="testAOT_add" />

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -3,43 +3,93 @@
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
+
+<iftool name="cuda-gcc-support">
+  <bin name="testTFHelloWorldCUDA" file="testRunner.cpp,testHelloWorldCUDA.cc">
+    <use name="tensorflow-cc"/>
+    <use name="boost_filesystem"/>
+    <use name="cppunit"/>
+    <use name="PhysicsTools/TensorFlow"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+  </bin>
+</iftool>
+
 
 <bin name="testTFMetaGraphLoading" file="testRunner.cpp,testMetaGraphLoading.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+<iftool name="cuda-gcc-support">
+<bin name="testTFMetaGraphLoadingCUDA" file="testRunner.cpp,testMetaGraphLoadingCUDA.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
+</iftool>
 
 <bin name="testTFGraphLoading" file="testRunner.cpp,testGraphLoading.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+<iftool name="cuda-gcc-support">
+<bin name="testTFGraphLoadingCUDA" file="testRunner.cpp,testGraphLoadingCUDA.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
+</iftool>
 
 <bin name="testTFConstSession" file="testRunner.cpp,testConstSession.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+<iftool name="cuda-gcc-support">
+<bin name="testTFConstSessionCUDA" file="testRunner.cpp,testConstSessionCUDA.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
+</iftool>
 
 <bin name="testTFSessionCache" file="testRunner.cpp,testSessionCache.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
-<bin name="testTFThreadPools" file="testRunner.cpp,testThreadPools.cc">
+<iftool name="cuda-gcc-support">
+<bin name="testTFSessionCacheCUDA" file="testRunner.cpp,testSessionCacheCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
+</iftool>
+
+<bin name="testTFThreadPools" file="testRunner.cpp,testThreadPools.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+<iftool name="cuda-gcc-support">
+<bin name="testTFThreadPoolsCUDA" file="testRunner.cpp,testThreadPoolsCUDA.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
+</bin>
+</iftool>
 
 <!-- <ifarchitecture name="!_ppc64le_">
 <bin name="testTFAOT" file="testRunner.cpp,testAOT.cc">

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -12,6 +12,7 @@
     <use name="cppunit"/>
     <use name="PhysicsTools/TensorFlow"/>
     <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="catch2"/>
     <use name="FWCore/ParameterSet"/>
     <use name="FWCore/ParameterSetReader"/>
@@ -35,6 +36,7 @@
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ParameterSetReader"/>
@@ -57,6 +59,7 @@
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ParameterSetReader"/>
@@ -78,7 +81,8 @@
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-<use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ParameterSetReader"/>
@@ -101,6 +105,7 @@
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ParameterSetReader"/>
@@ -123,6 +128,7 @@
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="catch2"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ParameterSetReader"/>

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -2,36 +2,43 @@
   <use name="tensorflow-cc"/>
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <bin name="testTFMetaGraphLoading" file="testRunner.cpp,testMetaGraphLoading.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <bin name="testTFGraphLoading" file="testRunner.cpp,testGraphLoading.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <bin name="testTFConstSession" file="testRunner.cpp,testConstSession.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <bin name="testTFSessionCache" file="testRunner.cpp,testSessionCache.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <bin name="testTFThreadPools" file="testRunner.cpp,testThreadPools.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 </bin>
 
 <!-- <ifarchitecture name="!_ppc64le_">

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -5,13 +5,20 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <bin name="testTFHelloWorldCUDA" file="testRunner.cpp,testHelloWorldCUDA.cc">
     <use name="tensorflow-cc"/>
     <use name="boost_filesystem"/>
     <use name="cppunit"/>
     <use name="PhysicsTools/TensorFlow"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="catch2"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ParameterSetReader"/>
+    <use name="FWCore/PluginManager"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="FWCore/Utilities"/>
+    <use name="cuda"/>
   </bin>
 </iftool>
 
@@ -22,12 +29,19 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
 <bin name="testTFMetaGraphLoadingCUDA" file="testRunner.cpp,testMetaGraphLoadingCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
 </bin>
 </iftool>
 
@@ -37,12 +51,19 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
 <bin name="testTFGraphLoadingCUDA" file="testRunner.cpp,testGraphLoadingCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
 </bin>
 </iftool>
 
@@ -52,12 +73,19 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
 <bin name="testTFConstSessionCUDA" file="testRunner.cpp,testConstSessionCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
+<use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
 </bin>
 </iftool>
 
@@ -67,12 +95,19 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
 <bin name="testTFSessionCacheCUDA" file="testRunner.cpp,testSessionCacheCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
 </bin>
 </iftool>
 
@@ -82,12 +117,19 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
 <bin name="testTFThreadPoolsCUDA" file="testRunner.cpp,testThreadPoolsCUDA.cc">
   <use name="boost_filesystem"/>
   <use name="cppunit"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="catch2"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="cuda"/>
 </bin>
 </iftool>
 

--- a/PhysicsTools/TensorFlow/test/createconstantgraph.py
+++ b/PhysicsTools/TensorFlow/test/createconstantgraph.py
@@ -34,7 +34,12 @@ b = tf.Variable(tf.ones([1]))
 h = tf.add(tf.matmul(x_, W), b)
 y = tf.multiply(h, scale_, name="output")
 
-sess = tf.Session()
+
+# Setup the script to run on CPU only
+config = tf.ConfigProto(
+        device_count = {'GPU': 0}
+    )
+sess = tf.Session(config=config)
 sess.run(tf.global_variables_initializer())
 
 print(sess.run(y, feed_dict={scale_: 1.0, x_: [range(10)]})[0][0])

--- a/PhysicsTools/TensorFlow/test/creategraph.py
+++ b/PhysicsTools/TensorFlow/test/creategraph.py
@@ -34,7 +34,11 @@ b = tf.Variable(tf.ones([1]))
 h = tf.add(tf.matmul(x_, W), b)
 y = tf.multiply(h, scale_, name="output")
 
-sess = tf.Session()
+# Setup the script to run on CPU only
+config = tf.ConfigProto(
+        device_count = {'GPU': 0}
+    )
+sess = tf.Session(config=config)
 sess.run(tf.global_variables_initializer())
 
 print(sess.run(y, feed_dict={scale_: 1.0, x_: [range(10)]})[0][0])

--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -11,6 +11,8 @@
 #include <filesystem>
 #include <cppunit/extensions/HelperMacros.h>
 #include <stdexcept>
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
 class testBase : public CppUnit::TestFixture {
 public:
@@ -20,7 +22,10 @@ public:
   void tearDown();
   std::string cmsswPath(std::string path);
 
-  virtual void checkAll() = 0;
+  virtual void test(tensorflow::Backend backend) = 0;
+  void checkCPU();
+  void checkGPU();
+
   virtual std::string pyScript() const = 0;
 };
 
@@ -48,6 +53,14 @@ void testBase::setUp() {
 void testBase::tearDown() {
   if (std::filesystem::exists(dataPath_)) {
     std::filesystem::remove_all(dataPath_);
+  }
+}
+
+void testBase::checkCPU() { test(tensorflow::Backend::cpu); }
+
+void testBase::checkGPU() {
+  if (cms::cudatest::testDevices()) {
+    test(tensorflow::Backend::cuda);
   }
 }
 

--- a/PhysicsTools/TensorFlow/test/testBase.h
+++ b/PhysicsTools/TensorFlow/test/testBase.h
@@ -11,8 +11,6 @@
 #include <filesystem>
 #include <cppunit/extensions/HelperMacros.h>
 #include <stdexcept>
-#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
-#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
 class testBase : public CppUnit::TestFixture {
 public:
@@ -22,9 +20,7 @@ public:
   void tearDown();
   std::string cmsswPath(std::string path);
 
-  virtual void test(tensorflow::Backend backend) = 0;
-  void checkCPU();
-  void checkGPU();
+  virtual void test() = 0;
 
   virtual std::string pyScript() const = 0;
 };
@@ -53,14 +49,6 @@ void testBase::setUp() {
 void testBase::tearDown() {
   if (std::filesystem::exists(dataPath_)) {
     std::filesystem::remove_all(dataPath_);
-  }
-}
-
-void testBase::checkCPU() { test(tensorflow::Backend::cpu); }
-
-void testBase::checkGPU() {
-  if (cms::cudatest::testDevices()) {
-    test(tensorflow::Backend::cuda);
   }
 }
 

--- a/PhysicsTools/TensorFlow/test/testBaseCUDA.h
+++ b/PhysicsTools/TensorFlow/test/testBaseCUDA.h
@@ -1,0 +1,88 @@
+/*
+ * Base class for tests.
+ *
+ * Author: Marcel Rieger
+ */
+
+#ifndef PHYSICSTOOLS_TENSORFLOW_TEST_TESTBASECUDA_H
+#define PHYSICSTOOLS_TENSORFLOW_TEST_TESTBASECUDA_H
+
+#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <cppunit/extensions/HelperMacros.h>
+#include <stdexcept>
+#include "catch.hpp"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ResourceInformation.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+
+namespace {
+  CUDAService makeCUDAService(edm::ParameterSet ps) {
+    auto desc = edm::ConfigurationDescriptions("Service", "CUDAService");
+    CUDAService::fillDescriptions(desc);
+    desc.validate(ps, "CUDAService");
+    return CUDAService(ps);
+  }
+}  // namespace
+
+class testBaseCUDA : public CppUnit::TestFixture {
+public:
+  std::string dataPath_;
+
+  void setUp();
+  void tearDown();
+  std::string cmsswPath(std::string path);
+
+  virtual void test() = 0;
+
+  virtual std::string pyScript() const = 0;
+};
+
+void testBaseCUDA::setUp() {
+  dataPath_ =
+      cmsswPath("/test/" + std::string(std::getenv("SCRAM_ARCH")) + "/" + boost::filesystem::unique_path().string());
+
+  // create the graph
+  std::string testPath = cmsswPath("/src/PhysicsTools/TensorFlow/test");
+  std::string cmd = "python3 -W ignore " + testPath + "/" + pyScript() + " " + dataPath_;
+  std::array<char, 128> buffer;
+  std::string result;
+  std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+  if (!pipe) {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (!feof(pipe.get())) {
+    if (fgets(buffer.data(), 128, pipe.get()) != NULL) {
+      result += buffer.data();
+    }
+  }
+  std::cout << std::endl << result << std::endl;
+}
+
+void testBaseCUDA::tearDown() {
+  if (std::filesystem::exists(dataPath_)) {
+    std::filesystem::remove_all(dataPath_);
+  }
+}
+
+std::string testBaseCUDA::cmsswPath(std::string path) {
+  if (path.size() > 0 && path.substr(0, 1) != "/") {
+    path = "/" + path;
+  }
+
+  std::string base = std::string(std::getenv("CMSSW_BASE"));
+  std::string releaseBase = std::string(std::getenv("CMSSW_RELEASE_BASE"));
+
+  return (std::filesystem::exists(base.c_str()) ? base : releaseBase) + path;
+}
+
+#endif  // PHYSICSTOOLS_TENSORFLOW_TEST_TESTBASECUDA_H

--- a/PhysicsTools/TensorFlow/test/testBaseCUDA.h
+++ b/PhysicsTools/TensorFlow/test/testBaseCUDA.h
@@ -24,6 +24,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 
 namespace {
   CUDAService makeCUDAService(edm::ParameterSet ps) {

--- a/PhysicsTools/TensorFlow/test/testConstSession.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSession.cc
@@ -14,19 +14,20 @@
 
 class testConstSession : public testBase {
   CPPUNIT_TEST_SUITE(testConstSession);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testConstSession);
 
 std::string testConstSession::pyScript() const { return "createconstantgraph.py"; }
 
-void testConstSession::checkAll() {
+void testConstSession::test(tensorflow::Backend backend) {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   // load the graph
@@ -35,7 +36,7 @@ void testConstSession::checkAll() {
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  const tensorflow::Session* session = tensorflow::createSession(graphDef);
+  const tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
   CPPUNIT_ASSERT(session != nullptr);
 
   // example evaluation

--- a/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
@@ -12,8 +12,8 @@
 
 #include "testBase.h"
 
-class testConstSession : public testBase {
-  CPPUNIT_TEST_SUITE(testConstSession);
+class testConstSessionCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testConstSessionCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -22,15 +22,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testConstSession);
+CPPUNIT_TEST_SUITE_REGISTRATION(testConstSessionCUDA);
 
-std::string testConstSession::pyScript() const { return "createconstantgraph.py"; }
+std::string testConstSessionCUDA::pyScript() const { return "createconstantgraph.py"; }
 
-void testConstSession::test() {
+void testConstSessionCUDA::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // load the graph
   tensorflow::setLogging();

--- a/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
@@ -27,6 +27,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testConstSessionCUDA);
 std::string testConstSessionCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testConstSessionCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoading.cc
@@ -14,19 +14,20 @@
 
 class testGraphLoading : public testBase {
   CPPUNIT_TEST_SUITE(testGraphLoading);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
 
 std::string testGraphLoading::pyScript() const { return "createconstantgraph.py"; }
 
-void testGraphLoading::checkAll() {
+void testGraphLoading::test(tensorflow::Backend backend) {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   // load the graph
@@ -35,11 +36,11 @@ void testGraphLoading::checkAll() {
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
   CPPUNIT_ASSERT(session != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoading.cc
@@ -14,21 +14,23 @@
 
 class testGraphLoading : public testBase {
   CPPUNIT_TEST_SUITE(testGraphLoading);
-  CPPUNIT_TEST(checkCPU);
-  CPPUNIT_TEST(checkGPU);
+  CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void test(tensorflow::Backend backend) override;
+  void test() override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
 
 std::string testGraphLoading::pyScript() const { return "createconstantgraph.py"; }
 
-void testGraphLoading::test(tensorflow::Backend backend) {
+void testGraphLoading::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
+
+  std::cout << "Testing CPU backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cpu;
 
   // load the graph
   tensorflow::setLogging();

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -10,9 +10,9 @@
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-#include "testBase.h"
+#include "testBaseCUDA.h"
 
-class testGraphLoadingCUDA : public testBase {
+class testGraphLoadingCUDA : public testBaseCUDA {
   CPPUNIT_TEST_SUITE(testGraphLoadingCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
@@ -27,6 +27,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testGraphLoadingCUDA::test() {
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
+
+  // Setup the CUDA Service
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+process.add_(cms.Service('CUDAService'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate2(tempToken);
+
+  auto cs = makeCUDAService(edm::ParameterSet{});
+  std::cout << "CUDA service enabled: " << cs.enabled() << std::endl;
+
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   std::cout << "Testing CUDA backend" << std::endl;

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -27,6 +27,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testGraphLoadingCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -1,5 +1,5 @@
 /*
- * Tests for working with constant sessions.
+ * Tests for loading graphs via the converted protobuf files.
  * For more info, see https://gitlab.cern.ch/mrieger/CMSSW-DNN.
  *
  * Author: Marcel Rieger
@@ -12,8 +12,8 @@
 
 #include "testBase.h"
 
-class testConstSession : public testBase {
-  CPPUNIT_TEST_SUITE(testConstSession);
+class testGraphLoadingCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testGraphLoadingCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -22,15 +22,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testConstSession);
+CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 
-std::string testConstSession::pyScript() const { return "createconstantgraph.py"; }
+std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
-void testConstSession::test() {
+void testGraphLoadingCUDA::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // load the graph
   tensorflow::setLogging();
@@ -38,8 +38,11 @@ void testConstSession::test() {
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  const tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
   CPPUNIT_ASSERT(session != nullptr);
+
+  // check for exception
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});
@@ -49,9 +52,20 @@ void testConstSession::test() {
   }
   tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
   scale.scalar<float>()() = 1.0;
-  std::vector<tensorflow::Tensor> outputs;
 
-  // run using the convenience helper
+  std::vector<tensorflow::Tensor> outputs;
+  tensorflow::Status status = session->Run({{"input", input}, {"scale", scale}}, {"output"}, {}, &outputs);
+  if (!status.ok()) {
+    std::cout << status.ToString() << std::endl;
+    CPPUNIT_ASSERT(false);
+  }
+
+  // check the output
+  CPPUNIT_ASSERT(outputs.size() == 1);
+  std::cout << outputs[0].DebugString() << std::endl;
+  CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
+
+  // run again using the convenience helper
   outputs.clear();
   tensorflow::run(session, {{"input", input}, {"scale", scale}}, {"output"}, &outputs);
   CPPUNIT_ASSERT(outputs.size() == 1);

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -10,29 +10,32 @@
 
 #include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/cc/saved_model/tag_constants.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
 #include "testBase.h"
 
 class testHelloWorld : public testBase {
   CPPUNIT_TEST_SUITE(testHelloWorld);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testHelloWorld);
 
 std::string testHelloWorld::pyScript() const { return "creategraph.py"; }
 
-void testHelloWorld::checkAll() {
+void testHelloWorld::test(tensorflow::Backend backend) {
   std::string modelDir = dataPath_ + "/simplegraph";
 
   // object to load and run the graph / session
   tensorflow::Status status;
   tensorflow::SessionOptions sessionOptions;
+  tensorflow::setBackend(sessionOptions, backend);
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;
 

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -12,9 +12,9 @@
 #include "tensorflow/cc/saved_model/tag_constants.h"
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-#include "testBase.h"
+#include "testBaseCUDA.h"
 
-class testHelloWorldCUDA : public testBase {
+class testHelloWorldCUDA : public testBaseCUDA {
   CPPUNIT_TEST_SUITE(testHelloWorldCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
@@ -29,6 +29,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testHelloWorldCUDA);
 std::string testHelloWorldCUDA::pyScript() const { return "creategraph.py"; }
 
 void testHelloWorldCUDA::test() {
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
+
+  // Setup the CUDA Service
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+process.add_(cms.Service('CUDAService'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate2(tempToken);
+
+  auto cs = makeCUDAService(edm::ParameterSet{});
+  std::cout << "CUDA service enabled: " << cs.enabled() << std::endl;
+
   std::string modelDir = dataPath_ + "/simplegraph";
   // Testing CPU
   std::cout << "Testing CUDA backend" << std::endl;

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -14,8 +14,8 @@
 
 #include "testBase.h"
 
-class testHelloWorld : public testBase {
-  CPPUNIT_TEST_SUITE(testHelloWorld);
+class testHelloWorldCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testHelloWorldCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -24,15 +24,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testHelloWorld);
+CPPUNIT_TEST_SUITE_REGISTRATION(testHelloWorldCUDA);
 
-std::string testHelloWorld::pyScript() const { return "creategraph.py"; }
+std::string testHelloWorldCUDA::pyScript() const { return "creategraph.py"; }
 
-void testHelloWorld::test() {
+void testHelloWorldCUDA::test() {
   std::string modelDir = dataPath_ + "/simplegraph";
   // Testing CPU
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // object to load and run the graph / session
   tensorflow::Status status;

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -29,6 +29,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testHelloWorldCUDA);
 std::string testHelloWorldCUDA::pyScript() const { return "creategraph.py"; }
 
 void testHelloWorldCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
@@ -14,19 +14,20 @@
 
 class testMetaGraphLoading : public testBase {
   CPPUNIT_TEST_SUITE(testMetaGraphLoading);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testMetaGraphLoading);
 
 std::string testMetaGraphLoading::pyScript() const { return "creategraph.py"; }
 
-void testMetaGraphLoading::checkAll() {
+void testMetaGraphLoading::test(tensorflow::Backend backend) {
   std::string exportDir = dataPath_ + "/simplegraph";
 
   // load the graph
@@ -35,15 +36,15 @@ void testMetaGraphLoading::checkAll() {
   CPPUNIT_ASSERT(metaGraphDef != nullptr);
 
   // create a new, empty session
-  tensorflow::Session* session1 = tensorflow::createSession();
+  tensorflow::Session* session1 = tensorflow::createSession(backend);
   CPPUNIT_ASSERT(session1 != nullptr);
 
   // create a new session, using the meta graph
-  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir);
+  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir, backend);
   CPPUNIT_ASSERT(session2 != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir, backend), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
@@ -12,8 +12,8 @@
 
 #include "testBase.h"
 
-class testMetaGraphLoading : public testBase {
-  CPPUNIT_TEST_SUITE(testMetaGraphLoading);
+class testMetaGraphLoadingCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testMetaGraphLoadingCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -22,15 +22,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testMetaGraphLoading);
+CPPUNIT_TEST_SUITE_REGISTRATION(testMetaGraphLoadingCUDA);
 
-std::string testMetaGraphLoading::pyScript() const { return "creategraph.py"; }
+std::string testMetaGraphLoadingCUDA::pyScript() const { return "creategraph.py"; }
 
-void testMetaGraphLoading::test() {
+void testMetaGraphLoadingCUDA::test() {
   std::string exportDir = dataPath_ + "/simplegraph";
 
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // load the graph
   tensorflow::setLogging();

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
@@ -27,6 +27,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testMetaGraphLoadingCUDA);
 std::string testMetaGraphLoadingCUDA::pyScript() const { return "creategraph.py"; }
 
 void testMetaGraphLoadingCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testSessionCache.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCache.cc
@@ -13,25 +13,26 @@
 
 class testSessionCache : public testBase {
   CPPUNIT_TEST_SUITE(testSessionCache);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCache);
 
 std::string testSessionCache::pyScript() const { return "createconstantgraph.py"; }
 
-void testSessionCache::checkAll() {
+void testSessionCache::test(tensorflow::Backend backend) {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   tensorflow::setLogging();
 
   // load the graph and the session
-  tensorflow::SessionCache cache(pbFile);
+  tensorflow::SessionCache cache(pbFile, backend);
   CPPUNIT_ASSERT(cache.graph.load() != nullptr);
   CPPUNIT_ASSERT(cache.session.load() != nullptr);
 

--- a/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
@@ -9,9 +9,9 @@
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-#include "testBase.h"
+#include "testBaseCUDA.h"
 
-class testSessionCacheCUDA : public testBase {
+class testSessionCacheCUDA : public testBaseCUDA {
   CPPUNIT_TEST_SUITE(testSessionCacheCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
@@ -26,6 +26,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCacheCUDA);
 std::string testSessionCacheCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testSessionCacheCUDA::test() {
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
+
+  // Setup the CUDA Service
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+process.add_(cms.Service('CUDAService'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate2(tempToken);
+
+  auto cs = makeCUDAService(edm::ParameterSet{});
+  std::cout << "CUDA service enabled: " << cs.enabled() << std::endl;
+
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   std::cout << "Testing CUDA backend" << std::endl;

--- a/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
@@ -11,8 +11,8 @@
 
 #include "testBase.h"
 
-class testSessionCache : public testBase {
-  CPPUNIT_TEST_SUITE(testSessionCache);
+class testSessionCacheCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testSessionCacheCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -21,15 +21,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCache);
+CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCacheCUDA);
 
-std::string testSessionCache::pyScript() const { return "createconstantgraph.py"; }
+std::string testSessionCacheCUDA::pyScript() const { return "createconstantgraph.py"; }
 
-void testSessionCache::test() {
+void testSessionCacheCUDA::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   tensorflow::setLogging();
 

--- a/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
@@ -26,6 +26,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testSessionCacheCUDA);
 std::string testSessionCacheCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testSessionCacheCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testThreadPools.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPools.cc
@@ -14,19 +14,20 @@
 
 class testGraphLoading : public testBase {
   CPPUNIT_TEST_SUITE(testGraphLoading);
-  CPPUNIT_TEST(checkAll);
+  CPPUNIT_TEST(checkCPU);
+  CPPUNIT_TEST(checkGPU);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   std::string pyScript() const override;
-  void checkAll() override;
+  void test(tensorflow::Backend backend) override;
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
 
 std::string testGraphLoading::pyScript() const { return "createconstantgraph.py"; }
 
-void testGraphLoading::checkAll() {
+void testGraphLoading::test(tensorflow::Backend backend) {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   // initialize the TBB threadpool
@@ -39,7 +40,7 @@ void testGraphLoading::checkAll() {
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
   CPPUNIT_ASSERT(session != nullptr);
 
   // prepare inputs
@@ -66,7 +67,7 @@ void testGraphLoading::checkAll() {
   CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
   // tensorflow defaut pool using a new session
-  tensorflow::Session* session2 = tensorflow::createSession(graphDef, nThreads);
+  tensorflow::Session* session2 = tensorflow::createSession(graphDef, backend, nThreads);
   CPPUNIT_ASSERT(session != nullptr);
   outputs.clear();
   tensorflow::run(session2, {{"input", input}, {"scale", scale}}, {"output"}, &outputs, "tensorflow");

--- a/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
@@ -10,9 +10,9 @@
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 
-#include "testBase.h"
+#include "testBaseCUDA.h"
 
-class testGraphLoadingCUDA : public testBase {
+class testGraphLoadingCUDA : public testBaseCUDA {
   CPPUNIT_TEST_SUITE(testGraphLoadingCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
@@ -27,6 +27,26 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testGraphLoadingCUDA::test() {
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
+
+  // Setup the CUDA Service
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+process.add_(cms.Service('CUDAService'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate2(tempToken);
+
+  auto cs = makeCUDAService(edm::ParameterSet{});
+  std::cout << "CUDA service enabled: " << cs.enabled() << std::endl;
+
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
   std::cout << "Testing CUDA backend" << std::endl;

--- a/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
@@ -27,6 +27,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
 void testGraphLoadingCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
@@ -12,8 +12,8 @@
 
 #include "testBase.h"
 
-class testGraphLoading : public testBase {
-  CPPUNIT_TEST_SUITE(testGraphLoading);
+class testGraphLoadingCUDA : public testBase {
+  CPPUNIT_TEST_SUITE(testGraphLoadingCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -22,15 +22,15 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoading);
+CPPUNIT_TEST_SUITE_REGISTRATION(testGraphLoadingCUDA);
 
-std::string testGraphLoading::pyScript() const { return "createconstantgraph.py"; }
+std::string testGraphLoadingCUDA::pyScript() const { return "createconstantgraph.py"; }
 
-void testGraphLoading::test() {
+void testGraphLoadingCUDA::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
 
-  std::cout << "Testing CPU backend" << std::endl;
-  tensorflow::Backend backend = tensorflow::Backend::cpu;
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
 
   // initialize the TBB threadpool
   int nThreads = 4;

--- a/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
@@ -1,0 +1,65 @@
+/*
+ * Tests visible device interface 
+ * For more info,
+ * https://github.com/tensorflow/tensorflow/blob/3bc73f5e2ac437b1d9d559751af789c8c965a7f9/tensorflow/core/framework/device_attributes.proto
+ * https://stackoverflow.com/questions/74110853/how-to-check-if-tensorflow-is-using-the-cpu-with-the-c-api\
+ *
+ * Author: Davide Valsecchi
+ */
+
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "tensorflow/core/framework/device_attributes.pb.h"
+
+#include "testBase.h"
+
+class testVisibleDevices : public testBase {
+  CPPUNIT_TEST_SUITE(testVisibleDevices);
+  CPPUNIT_TEST(test);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  std::string pyScript() const override;
+  void test() override;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testVisibleDevices);
+
+std::string testVisibleDevices::pyScript() const { return "createconstantgraph.py"; }
+
+void testVisibleDevices::test() {
+  std::string pbFile = dataPath_ + "/constantgraph.pb";
+  tensorflow::Backend backend = tensorflow::Backend::cpu;
+
+  // load the graph
+  tensorflow::setLogging();
+  tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
+  CPPUNIT_ASSERT(graphDef != nullptr);
+
+  // create a new session and add the graphDef
+  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  CPPUNIT_ASSERT(session != nullptr);
+
+  // check for exception
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+
+  std::vector<tensorflow::DeviceAttributes> response;
+  tensorflow::Status status = session->ListDevices(&response);
+  CPPUNIT_ASSERT(status.ok());
+
+  // If a single device is found, we assume that it's the CPU.
+  // You can check that name if you want to make sure that this is the case
+  std::cout << "Available devices: " << response.size() << std::endl;
+  CPPUNIT_ASSERT(response.size() == 1);
+
+  for (unsigned int i = 0; i < response.size(); ++i) {
+    std::cout << i << " " << response[i].name() << " type: " << response[i].device_type() << std::endl;
+  }
+
+  // cleanup
+  CPPUNIT_ASSERT(tensorflow::closeSession(session));
+  CPPUNIT_ASSERT(session == nullptr);
+  delete graphDef;
+}

--- a/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
@@ -1,0 +1,86 @@
+/*
+ * Tests visible device interface 
+ * For more info,
+ * https://github.com/tensorflow/tensorflow/blob/3bc73f5e2ac437b1d9d559751af789c8c965a7f9/tensorflow/core/framework/device_attributes.proto
+ * https://stackoverflow.com/questions/74110853/how-to-check-if-tensorflow-is-using-the-cpu-with-the-c-api\
+ *
+ * Author: Davide Valsecchi
+ */
+
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "tensorflow/core/framework/device_attributes.pb.h"
+
+#include "testBaseCUDA.h"
+
+class testVisibleDevices : public testBaseCUDA {
+  CPPUNIT_TEST_SUITE(testVisibleDevices);
+  CPPUNIT_TEST(test);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  std::string pyScript() const override;
+  void test() override;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testVisibleDevices);
+
+std::string testVisibleDevices::pyScript() const { return "createconstantgraph.py"; }
+
+void testVisibleDevices::test() {
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
+
+  // Setup the CUDA Service
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+process.add_(cms.Service('CUDAService'))
+)_";
+  std::unique_ptr<edm::ParameterSet> params;
+  edm::makeParameterSets(config, params);
+  edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+  edm::ServiceRegistry::Operate operate2(tempToken);
+
+  auto cs = makeCUDAService(edm::ParameterSet{});
+  std::cout << "CUDA service enabled: " << cs.enabled() << std::endl;
+
+  std::string pbFile = dataPath_ + "/constantgraph.pb";
+
+  std::cout << "Testing CUDA backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cuda;
+
+  // load the graph
+  tensorflow::setLogging();
+  tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
+  CPPUNIT_ASSERT(graphDef != nullptr);
+
+  // create a new session and add the graphDef
+  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  CPPUNIT_ASSERT(session != nullptr);
+
+  // check for exception
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+
+  std::vector<tensorflow::DeviceAttributes> response;
+  tensorflow::Status status = session->ListDevices(&response);
+  CPPUNIT_ASSERT(status.ok());
+
+  // If a single device is found, we assume that it's the CPU.
+  // You can check that name if you want to make sure that this is the case
+  std::cout << "Available devices: " << response.size() << std::endl;
+  CPPUNIT_ASSERT(response.size() == 2);
+  for (unsigned int i = 0; i < response.size(); ++i) {
+    std::cout << i << " " << response[i].name() << " type: " << response[i].device_type() << std::endl;
+  }
+
+  // cleanup
+  CPPUNIT_ASSERT(tensorflow::closeSession(session));
+  CPPUNIT_ASSERT(session == nullptr);
+  delete graphDef;
+}

--- a/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
@@ -15,8 +15,8 @@
 
 #include "testBaseCUDA.h"
 
-class testVisibleDevices : public testBaseCUDA {
-  CPPUNIT_TEST_SUITE(testVisibleDevices);
+class testVisibleDevicesCUDA : public testBaseCUDA {
+  CPPUNIT_TEST_SUITE(testVisibleDevicesCUDA);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
@@ -25,11 +25,14 @@ public:
   void test() override;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(testVisibleDevices);
+CPPUNIT_TEST_SUITE_REGISTRATION(testVisibleDevicesCUDA);
 
-std::string testVisibleDevices::pyScript() const { return "createconstantgraph.py"; }
+std::string testVisibleDevicesCUDA::pyScript() const { return "createconstantgraph.py"; }
 
-void testVisibleDevices::test() {
+void testVisibleDevicesCUDA::test() {
+  if (!cms::cudatest::testDevices())
+    return;
+
   std::vector<edm::ParameterSet> psets;
   edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
   edm::ServiceRegistry::Operate operate(serviceToken);

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -216,6 +216,8 @@ namespace deep_tau {
     for (const auto& graph_entry : graph_names) {
       tensorflow::SessionOptions options;
       tensorflow::setThreading(options, 1);
+      // To be parametrized from the python config
+      tensorflow::setBackend(options, tensorflow::Backend::cpu);
 
       const std::string& entry_name = graph_entry.first;
       const std::string& graph_file = graph_entry.second;


### PR DESCRIPTION
#### PR description:

This PR introduces a GPU backend option for TensorFlow sessions. (The interface is similar to the ONNX GPU support one https://github.com/cms-sw/cmssw/pull/36963)

The GPU session can be activated by user code by requesting `tensorflow::Backend::cuda` in the session creation. 
This is needed to be able to compile TF with GPU support in the cmssw-dist (see https://github.com/cms-sw/cmsdist/pull/7648).

By default the CPU backend is used for all the standard workflows. 
Moreover, TensorFlow has been setup to avoid occupying all the cuda memory of a GPU, but just the necessary one (`allow_growth=true` option).  

Tests have been modified to run both a CPU and a GPU version, if a device is available. 

#### PR validation 
We are working to provide a  test with the GPU backend active in a reconstruction sequence. 


@yongbinfeng @riga  @tvami @smuzaffar 