### PR TITLE
[12.6.X] fix `ClusterStorer::ClusterHitRecord<T>::rekey` for `Phase2TrackerRecHit1D`

### DIFF
--- a/CommonTools/RecoAlgos/src/ClusterStorer.cc
+++ b/CommonTools/RecoAlgos/src/ClusterStorer.cc
@@ -181,22 +181,22 @@ namespace helper {
   }
 
   // -------------------------------------------------------------
-  // Specific rekey for class template ClusterRefType = VectorHit::ClusterRef,
-  // RecHitType is not used.
+  // Specific rekey for class template ClusterRefType = Phase2TrackerRecHit1D::ClusterRef
   template <>
-  template <typename RecHitType>  // or template<> to specialise also here?
-  void ClusterStorer::ClusterHitRecord<VectorHit::ClusterRef>::rekey(const VectorHit::ClusterRef &newRef) {
+  template <typename RecHitType>
+  void ClusterStorer::ClusterHitRecord<Phase2TrackerRecHit1D::ClusterRef>::rekey(
+      const Phase2TrackerRecHit1D::ClusterRef &newRef) {
     TrackingRecHit &genericHit = (*hits_)[index_];
     const std::type_info &hit_type = typeid(genericHit);
 
     OmniClusterRef *cluRef = nullptr;
-    if (typeid(VectorHit) == hit_type) {
+    if (typeid(Phase2TrackerRecHit1D) == hit_type) {
+      cluRef = &static_cast<Phase2TrackerRecHit1D &>(genericHit).omniCluster();
+    } else if (typeid(VectorHit) == hit_type) {
       VectorHit &vHit = static_cast<VectorHit &>(genericHit);
       // FIXME: this essentially uses a hack
       // https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L291
       cluRef = (SiStripDetId(detid_).stereo() ? &vHit.upperClusterRef() : &vHit.lowerClusterRef());
-    } else {
-      return;
     }
 
     assert(cluRef != nullptr);            // to catch missing RecHit types


### PR DESCRIPTION
This is a follow-up to https://github.com/cms-sw/cmssw/pull/40394.
In the specialization of `ClusterStorer::ClusterHitRecord<T>::rekey` for `VectorHit`s introduced there, I overlooked that `VectorHit::ClusterRef` and `Phase2TrackerRecHit1D::ClusterRef` are `typedefs` of the exact same object:

https://github.com/cms-sw/cmssw/blob/815452524d636d715e5510d21783744aeb669031/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h#L13

https://github.com/cms-sw/cmssw/blob/815452524d636d715e5510d21783744aeb669031/DataFormats/TrackerRecHit2D/interface/VectorHit.h#L30

This leads to the fact that when this function was called here:

https://github.com/cms-sw/cmssw/blob/7661a799a8f287528cd57181b295bd84fab1979c/CommonTools/RecoAlgos/src/ClusterStorer.cc#L133

with  `Phase2TrackerRecHit1D::ClusterRef` specialization, it didn't capture any cluster reference but was just returning:

https://github.com/cms-sw/cmssw/blob/7661a799a8f287528cd57181b295bd84fab1979c/CommonTools/RecoAlgos/src/ClusterStorer.cc#L198-L200

This leads to broken cluster reference for `Phase2TrackerRecHit1D` in Phase-2 workflows.

#### PR validation:

Run successfully:

```
  runTheMatrix.py --what upgrade -l 11634.0,20818.9,20834.0 -t 4 -j 8 --ibeos
```

and tested that I can correctly refit the resulting tracks with the machinery introduced at https://github.com/cms-sw/cmssw/pull/40542.  

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/40548.
