### PR TITLE
Enable "alternative module loading" approach for Alpaka modules

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
@@ -30,11 +30,13 @@ namespace edm {
   typedef edmplugin::PluginFactory<ParameterSetDescriptionFillerBase*(void)> ParameterSetDescriptionFillerPluginFactory;
 }
 
-#define DEFINE_FWK_PSET_DESC_FILLER(type)                                                                         \
+#define DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, name)                                                              \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::ParameterSetDescriptionFiller<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
+      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
 //NOTE: Can't do the below since this appears on the same line as another factory and w'ed have two variables with the same name
 //DEFINE_EDM_PLUGIN (edm::ParameterSetDescriptionFillerPluginFactory,type,#type)
+
+#define DEFINE_FWK_PSET_DESC_FILLER(type) DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, #type)
 
 // Define another analogous macro to handle the special case of services.
 
@@ -42,13 +44,15 @@ namespace edm {
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForServices<serviceType> > \
       EDM_PLUGIN_SYM(s_filler, __LINE__)(#pluginName)
 
-#define DEFINE_DESC_FILLER_FOR_ESSOURCES(type)                                                                    \
+#define DEFINE_DESC_FILLER_FOR_ESSOURCES_IMPL(type, name)                                                         \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESSources<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
+      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
+#define DEFINE_DESC_FILLER_FOR_ESSOURCES(type) DEFINE_DESC_FILLER_FOR_ESSOURCES_IMPL(type, #type)
 
-#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type)                                                                    \
+#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, name)                                                         \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESProducers<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
+      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
+#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type) DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, #type)
 
 #define DEFINE_DESC_FILLER_FOR_EDLOOPERS(type)                                                                    \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForEDLoopers<type> > \

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
@@ -30,13 +30,13 @@ namespace edm {
   typedef edmplugin::PluginFactory<ParameterSetDescriptionFillerBase*(void)> ParameterSetDescriptionFillerPluginFactory;
 }
 
-#define DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, name)                                                              \
+#define DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, name, postfix)                                                     \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::ParameterSetDescriptionFiller<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
+      EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
 //NOTE: Can't do the below since this appears on the same line as another factory and w'ed have two variables with the same name
 //DEFINE_EDM_PLUGIN (edm::ParameterSetDescriptionFillerPluginFactory,type,#type)
 
-#define DEFINE_FWK_PSET_DESC_FILLER(type) DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, #type)
+#define DEFINE_FWK_PSET_DESC_FILLER(type) DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, #type, _0)
 
 // Define another analogous macro to handle the special case of services.
 
@@ -49,10 +49,10 @@ namespace edm {
       EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
 #define DEFINE_DESC_FILLER_FOR_ESSOURCES(type) DEFINE_DESC_FILLER_FOR_ESSOURCES_IMPL(type, #type)
 
-#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, name)                                                         \
+#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, name, postfix)                                                \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESProducers<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
-#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type) DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, #type)
+      EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
+#define DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type) DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, #type, _0)
 
 #define DEFINE_DESC_FILLER_FOR_EDLOOPERS(type)                                                                    \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForEDLoopers<type> > \

--- a/FWCore/ParameterSet/src/defaultModuleLabel.cc
+++ b/FWCore/ParameterSet/src/defaultModuleLabel.cc
@@ -7,6 +7,9 @@ namespace edm {
     // remove all colons (module type may contain namespace)
     label.erase(std::remove(label.begin(), label.end(), ':'), label.end());
 
+    // remove everything after first '@' (used for module alternatives)
+    label.erase(std::find(label.begin(), label.end(), '@'), label.end());
+
     // the following code originates from HLTrigger/HLTcore/interface/defaultModuleLabel.h
     // if the label is all uppercase, change it to all lowercase
     // if the label starts with more than one uppercase letter, change n-1 to lowercase

--- a/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
+++ b/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
@@ -7,15 +7,12 @@
 // force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification
 // use the serial_sync variant for cfi file generation with the type@alpaka C++ type
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define DEFINE_FWK_ALPAKA_MODULE3(name_ns, name)                                   \
-  DEFINE_EDM_PLUGIN(edm::MakerPluginFactory, edm::WorkerMaker<name_ns>, #name_ns); \
-  DEFINE_FWK_PSET_DESC_FILLER_IMPL(name_ns, #name "@alpaka")
-#define DEFINE_FWK_ALPAKA_MODULE2(name_ns, name) DEFINE_FWK_ALPAKA_MODULE3(name_ns, name)
+#define DEFINE_FWK_ALPAKA_MODULE2(name_ns, name) \
+  DEFINE_FWK_MODULE(name_ns);                    \
+  DEFINE_FWK_PSET_DESC_FILLER_IMPL(name_ns, #name "@alpaka", _1)
 #define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name, name)
 #else
-#define DEFINE_FWK_ALPAKA_MODULE3(name_ns) \
-  DEFINE_EDM_PLUGIN(edm::MakerPluginFactory, edm::WorkerMaker<name_ns>, #name_ns)
-#define DEFINE_FWK_ALPAKA_MODULE2(name_ns) DEFINE_FWK_ALPAKA_MODULE3(name_ns)
+#define DEFINE_FWK_ALPAKA_MODULE2(name_ns) DEFINE_FWK_MODULE(name_ns)
 #define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name)
 #endif
 

--- a/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
+++ b/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
@@ -4,8 +4,19 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
-// force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification inside DEFINE_FWK_MODULE
-#define DEFINE_FWK_ALPAKA_MODULE2(name) DEFINE_FWK_MODULE(name)
+// force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification
+// use the serial_sync variant for cfi file generation with the type@alpaka C++ type
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#define DEFINE_FWK_ALPAKA_MODULE3(name_ns, name)                                   \
+  DEFINE_EDM_PLUGIN(edm::MakerPluginFactory, edm::WorkerMaker<name_ns>, #name_ns); \
+  DEFINE_FWK_PSET_DESC_FILLER_IMPL(name_ns, #name "@alpaka")
+#define DEFINE_FWK_ALPAKA_MODULE2(name_ns, name) DEFINE_FWK_ALPAKA_MODULE3(name_ns, name)
+#define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name, name)
+#else
+#define DEFINE_FWK_ALPAKA_MODULE3(name_ns) \
+  DEFINE_EDM_PLUGIN(edm::MakerPluginFactory, edm::WorkerMaker<name_ns>, #name_ns)
+#define DEFINE_FWK_ALPAKA_MODULE2(name_ns) DEFINE_FWK_ALPAKA_MODULE3(name_ns)
 #define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name)
+#endif
 
 #endif  // HeterogeneousCore_AlpakaCore_interface_MakerMacros_h

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Framework/interface/produce_helpers.h"
+#include "HeterogeneousCore/AlpakaCore/interface/module_backend_config.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESDeviceProduct.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Record.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
@@ -22,6 +23,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class ESProducer : public edm::ESProducer {
     using Base = edm::ESProducer;
+
+  public:
+    static void prevalidate(edm::ConfigurationDescriptions& descriptions) {
+      Base::prevalidate(descriptions);
+      cms::alpakatools::module_backend_config(descriptions);
+    }
 
   protected:
     template <typename T>

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h
@@ -4,9 +4,21 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
-// force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification inside DEFINE_FWK_EVENTSETUP_MODULE
-#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type) DEFINE_FWK_EVENTSETUP_MODULE(type)
+// force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification
+// use the serial_sync variant for cfi file generation with the type@alpaka C++ type
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns, type)                                                 \
+  DEFINE_EDM_PLUGIN(edm::eventsetup::ModulePluginFactory, edm::eventsetup::ModuleMaker<type_ns>, #type_ns); \
+  DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type_ns, #type "@alpaka")
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns, type) DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns, type)
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(type) \
+  DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::type, type)
+#else
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns) \
+  DEFINE_EDM_PLUGIN(edm::eventsetup::ModulePluginFactory, edm::eventsetup::ModuleMaker<type_ns>, #type_ns);
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns) DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns)
 #define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(type) \
   DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::type)
+#endif
 
 #endif

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h
@@ -7,16 +7,13 @@
 // force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification
 // use the serial_sync variant for cfi file generation with the type@alpaka C++ type
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns, type)                                                 \
-  DEFINE_EDM_PLUGIN(edm::eventsetup::ModulePluginFactory, edm::eventsetup::ModuleMaker<type_ns>, #type_ns); \
-  DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type_ns, #type "@alpaka")
-#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns, type) DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns, type)
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns, type) \
+  DEFINE_FWK_EVENTSETUP_MODULE(type_ns);                    \
+  DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type_ns, #type "@alpaka", _1)
 #define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(type) \
   DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::type, type)
 #else
-#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns) \
-  DEFINE_EDM_PLUGIN(edm::eventsetup::ModulePluginFactory, edm::eventsetup::ModuleMaker<type_ns>, #type_ns);
-#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns) DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE3(type_ns)
+#define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(type_ns) DEFINE_FWK_EVENTSETUP_MODULE(type_ns)
 #define DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(type) \
   DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::type)
 #endif

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -2,12 +2,14 @@
 #define HeterogeneousCore_AlpakaCore_interface_ProducerBase_h
 
 #include "DataFormats/Common/interface/DeviceProduct.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/moduleAbilities.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataAcquireSentry.h"
 #include "HeterogeneousCore/AlpakaCore/interface/EventCache.h"
 #include "HeterogeneousCore/AlpakaCore/interface/QueueCache.h"
+#include "HeterogeneousCore/AlpakaCore/interface/module_backend_config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/TransferToHost.h"
 
 #include <memory>
@@ -49,6 +51,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template <edm::Transition Tr = edm::Transition::Event>
     [[nodiscard]] auto produces(std::string instanceName) noexcept {
       return ProducerBaseAdaptor<ProducerBase, Tr>(*this, std::move(instanceName));
+    }
+
+    static void prevalidate(edm::ConfigurationDescriptions& descriptions) {
+      Base::prevalidate(descriptions);
+      cms::alpakatools::module_backend_config(descriptions);
     }
 
   private:

--- a/HeterogeneousCore/AlpakaCore/interface/module_backend_config.h
+++ b/HeterogeneousCore/AlpakaCore/interface/module_backend_config.h
@@ -1,0 +1,10 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_module_backend_config_h
+#define HeterogeneousCore_AlpakaCore_interface_module_backend_config_h
+
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+
+namespace cms::alpakatools {
+  void module_backend_config(edm::ConfigurationDescriptions& iDesc);
+}
+
+#endif

--- a/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
@@ -1,0 +1,7 @@
+<library file="*.cc" name="HeterogeneousCoreAlpakaCorePlugins">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousCore/AlpakaCore/plugins/ModuleTypeResolverAlpaka.cc
+++ b/HeterogeneousCore/AlpakaCore/plugins/ModuleTypeResolverAlpaka.cc
@@ -1,0 +1,66 @@
+#include "FWCore/Framework/interface/ModuleTypeResolverMaker.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
+
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+
+class ModuleTypeResolverAlpaka : public edm::ModuleTypeResolverBase {
+public:
+  ModuleTypeResolverAlpaka(std::string backendPrefix) : backendPrefix_(std::move(backendPrefix)) {}
+
+  std::pair<std::string, int> resolveType(std::string basename, int index) const final {
+    assert(index == kInitialIndex);
+    constexpr auto kAlpaka = "@alpaka";
+    auto found = basename.find(kAlpaka);
+    if (found != std::string::npos) {
+      if (backendPrefix_.empty()) {
+        throw edm::Exception(edm::errors::LogicError)
+            << "AlpakaModuleTypeResolver encountered a module with type name " << basename
+            << " but the backend prefix was empty. This should not happen. Please contact framework developers.";
+      }
+      basename.replace(found, std::strlen(kAlpaka), "");
+      basename = backendPrefix_ + basename;
+    }
+    return {basename, kLastIndex};
+  }
+
+private:
+  std::string const backendPrefix_;
+};
+
+class ModuleTypeResolverMakerAlpaka : public edm::ModuleTypeResolverMaker {
+public:
+  ModuleTypeResolverMakerAlpaka() {}
+
+  std::shared_ptr<edm::ModuleTypeResolverBase const> makeResolver(edm::ParameterSet const& modulePSet) const final {
+    std::string prefix = "";
+    if (modulePSet.existsAs<edm::ParameterSet>("alpaka", false)) {
+      auto const& backend =
+          modulePSet.getUntrackedParameter<edm::ParameterSet>("alpaka").getUntrackedParameter<std::string>("backend");
+      prefix = fmt::format("alpaka_{}::", backend);
+
+      LogDebug("AlpakaModuleTypeResolver")
+          .format("AlpakaModuleTypeResolver: module {} backend prefix {}",
+                  modulePSet.getParameter<std::string>("@module_label"),
+                  prefix);
+    }
+    auto found = cache_.find(prefix);
+    if (found == cache_.end()) {
+      bool inserted;
+      std::tie(found, inserted) = cache_.emplace(prefix, std::make_shared<ModuleTypeResolverAlpaka>(prefix));
+    }
+    return found->second;
+  }
+
+private:
+  // no protection needed because this object is used only in single-thread context
+  CMS_SA_ALLOW mutable std::unordered_map<std::string, std::shared_ptr<ModuleTypeResolverAlpaka const>> cache_;
+};
+
+#include "FWCore/Framework/interface/ModuleTypeResolverMakerFactory.h"
+DEFINE_EDM_PLUGIN(edm::ModuleTypeResolverMakerFactory, ModuleTypeResolverMakerAlpaka, "ModuleTypeResolverAlpaka");

--- a/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
+++ b/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka.py
@@ -1,0 +1,70 @@
+import FWCore.ParameterSet.Config as cms
+
+class ModuleTypeResolverAlpaka:
+    def __init__(self, accelerators, backend):
+        # first element is used as the default is nothing is set
+        self._valid_backends = []
+        if "gpu-nvidia" in accelerators:
+            self._valid_backends.append("cuda_async")
+        if "cpu" in accelerators:
+            self._valid_backends.append("serial_sync")
+        if len(self._valid_backends) == 0:
+            raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "ModuleTypeResolverAlpaka had no backends available because of the combination of the job configuration and accelerator availability of on the machine. The job sees {} accelerators.".format(", ".join(accelerators)))
+        if backend is not None:
+            if not backend in self._valid_backends:
+                raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "The ProcessAcceleratorAlpaka was configured to use {} backend, but that backend is not available because of the combination of the job configuration and accelerator availability on the machine. The job was configured to use {} accelerators, which translates to {} Alpaka backends.".format(
+                    backend, ", ".join(accelerators), ", ".join(self._valid_backends)))
+            if backend != self._valid_backends[0]:
+                self._valid_backends.remove(backend)
+                self._valid_backends.insert(0, backend)
+
+    def plugin(self):
+        return "ModuleTypeResolverAlpaka"
+
+    def setModuleVariant(self, module):
+        if module.type_().endswith("@alpaka"):
+            defaultBackend = self._valid_backends[0]
+            if hasattr(module, "alpaka"):
+                if hasattr(module.alpaka, "backend"):
+                    if module.alpaka.backend == "":
+                        module.alpaka.backend = defaultBackend
+                    elif module.alpaka.backend.value() not in self._valid_backends:
+                        raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Module {} has the Alpaka backend set explicitly, but its accelerator is not available for the job because of the combination of the job configuration and accelerator availability on the machine. The following Alpaka backends are available for the job {}.".format(module.label_(), ", ".join(self._valid_backends)))
+                else:
+                    module.alpaka.backend = cms.untracked.string(defaultBackend)
+            else:
+                module.alpaka = cms.untracked.PSet(
+                    backend = cms.untracked.string(defaultBackend)
+                )
+
+class ProcessAcceleratorAlpaka(cms.ProcessAccelerator):
+    """ProcessAcceleratorAlpaka itself does not define or inspect
+    availability of any accelerator devices. It merely sets up
+    necessary Alpaka infrastructure based on the availability of
+    accelerators that the concrete ProcessAccelerators (like
+    ProcessAcceleratorCUDA) define.
+    """
+    def __init__(self):
+        super(ProcessAcceleratorAlpaka,self).__init__()
+        self._backend = None
+    # User-facing interface
+    def setBackend(self, backend):
+        self._backend = backend
+    # Framework-facing interface
+    def moduleTypeResolver(self, accelerators):
+        return ModuleTypeResolverAlpaka(accelerators, self._backend)
+    def apply(self, process, accelerators):
+        if not hasattr(process, "AlpakaServiceSerialSync"):
+            from HeterogeneousCore.AlpakaServices.AlpakaServiceSerialSync_cfi import AlpakaServiceSerialSync
+            process.add_(AlpakaServiceSerialSync)
+        if not hasattr(process, "AlpakaServiceCudaAsync"):
+            from HeterogeneousCore.AlpakaServices.AlpakaServiceCudaAsync_cfi import AlpakaServiceCudaAsync
+            process.add_(AlpakaServiceCudaAsync)
+
+        if not hasattr(process.MessageLogger, "AlpakaService"):
+            process.MessageLogger.AlpakaService = cms.untracked.PSet()
+
+        process.AlpakaServiceSerialSync.enabled = "cpu" in accelerators
+        process.AlpakaServiceCudaAsync.enabled = "gpu-nvidia" in accelerators
+
+cms.specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorAlpaka, "from HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka import ProcessAcceleratorAlpaka")

--- a/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka_cfi.py
+++ b/HeterogeneousCore/AlpakaCore/python/ProcessAcceleratorAlpaka_cfi.py
@@ -1,0 +1,3 @@
+from HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka import ProcessAcceleratorAlpaka as _ProcessAcceleratorAlpaka
+
+ProcessAcceleratorAlpaka = _ProcessAcceleratorAlpaka()

--- a/HeterogeneousCore/AlpakaCore/src/module_backend_config.cc
+++ b/HeterogeneousCore/AlpakaCore/src/module_backend_config.cc
@@ -1,0 +1,33 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/AlpakaCore/interface/module_backend_config.h"
+
+namespace {
+  const std::string kPSetName("alpaka");
+  const char* const kComment = "PSet allows to override the Alpaka backend per module instance";
+}  // namespace
+
+namespace cms::alpakatools {
+  void module_backend_config(edm::ConfigurationDescriptions& iDesc) {
+    // the code below leads to 'alpaka = untracked.PSet(backend = untracked.string)' to be added to the generated cfi files
+    // TODO: I don't know if this is a desired behavior for HLT
+    edm::ParameterSetDescription descAlpaka;
+    descAlpaka.addUntracked<std::string>("backend", "")
+        ->setComment(
+            "Alpaka backend for this module. Can be empty string (for the global default), 'serial_sync', or "
+            "'cuda_async'");
+
+    if (iDesc.defaultDescription()) {
+      if (iDesc.defaultDescription()->isLabelUnused(kPSetName)) {
+        iDesc.defaultDescription()
+            ->addUntracked<edm::ParameterSetDescription>(kPSetName, descAlpaka)
+            ->setComment(kComment);
+      }
+    }
+    for (auto& v : iDesc) {
+      if (v.second.isLabelUnused(kPSetName)) {
+        v.second.addUntracked<edm::ParameterSetDescription>(kPSetName, descAlpaka)->setComment(kComment);
+      }
+    }
+  }
+}  // namespace cms::alpakatools

--- a/HeterogeneousCore/AlpakaCore/src/module_backend_config.cc
+++ b/HeterogeneousCore/AlpakaCore/src/module_backend_config.cc
@@ -4,7 +4,9 @@
 
 namespace {
   const std::string kPSetName("alpaka");
-  const char* const kComment = "PSet allows to override the Alpaka backend per module instance";
+  const char* const kComment =
+      "PSet allows to override the Alpaka backend per module instance. Has an effect only when the module class name "
+      "has '@alpaka' suffix, i.e. has no effect when the Alpaka backend namespace is used explicitly.";
 }  // namespace
 
 namespace cms::alpakatools {

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -21,7 +21,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlpakaGlobalProducer : public global::EDProducer<> {
   public:
     TestAlpakaGlobalProducer(edm::ParameterSet const& config)
-        : esToken_(esConsumes()), deviceToken_{produces()}, size_{config.getParameter<int32_t>("size")} {}
+        : esToken_(esConsumes()),
+          deviceToken_{produces()},
+          size_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {}
 
     void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
@@ -36,7 +39,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<int32_t>("size");
+
+      edm::ParameterSetDescription psetSize;
+      psetSize.add<int32_t>("alpaka_serial_sync");
+      psetSize.add<int32_t>("alpaka_cuda_async");
+      desc.add("size", psetSize);
+
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -22,7 +22,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class TestAlpakaStreamProducer : public stream::EDProducer<> {
   public:
-    TestAlpakaStreamProducer(edm::ParameterSet const& config) : size_{config.getParameter<int32_t>("size")} {
+    TestAlpakaStreamProducer(edm::ParameterSet const& config)
+        : size_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {
       getToken_ = consumes(config.getParameter<edm::InputTag>("source"));
       esToken_ = esConsumes();
       devicePutToken_ = produces();
@@ -43,7 +45,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("source");
-      desc.add<int32_t>("size");
+
+      edm::ParameterSetDescription psetSize;
+      psetSize.add<int32_t>("alpaka_serial_sync");
+      psetSize.add<int32_t>("alpaka_cuda_async");
+      desc.add("size", psetSize);
+
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules.sh
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules.sh
@@ -19,13 +19,32 @@ elif [ "$1" = "cpu" ]; then
         TARGET=cpu
     fi
 else
-    die "Argument needs to be 'cpu' or 'cpu', got $1" 1
+    die "Argument needs to be 'cpu' or 'cuda', got $1" 1
 fi
 
-echo "cmsRun testAlpakaModules_cfg.py"
-cmsRun ${TEST_DIR}/testAlpakaModules_cfg.py || die "cmsRun testAlpakaModules_cfg.py" $?
+function runSuccess {
+    echo "cmsRun testAlpakaModules_cfg.py $1"
+    cmsRun ${TEST_DIR}/testAlpakaModules_cfg.py $1 || die "cmsRun testAlpakaModules_cfg.py $1" $?
+    echo
+}
+function runFailure {
+    echo "cmsRun testAlpakaModules_cfg.py $1 (job itself is expected to fail)"
+    cmsRun -j testAlpakaModules_jobreport.xml ${TEST_DIR}/testAlpakaModules_cfg.py $1 && die "cmsRun testAlpakaModules_cfg.py $1 did not fail" 1
+    EXIT_CODE=$(edmFjrDump --exitCode testAlpakaModules_jobreport.xml)
+    if [ "x${EXIT_CODE}" != "x8035" ]; then
+        echo "Alpaka module test for unavailable accelerator reported exit code ${EXIT_CODE} which is different from the expected 8035"
+        exit 1
+    fi
+    echo
+}
 
-if [ "x${TARGET}" == "xcuda" ]; then
-    echo "cmsRun testAlpakaModules_cfg.py --cuda"
-    cmsRun ${TEST_DIR}/testAlpakaModules_cfg.py -- --cuda || die "cmsRun testAlpakaModules_cfg.py --cuda" $?
+runSuccess ""
+runSuccess "-- --accelerators=cpu"
+runSuccess "-- --moduleBackend=serial_sync"
+
+if [ "${TARGET}" == "cpu" ]; then
+    runFailure "-- --moduleBackend=cuda_async"
+
+elif [ "${TARGET}" == "cuda" ]; then
+    runSuccess "-- --moduleBackend=cuda_async"
 fi

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules.sh
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules.sh
@@ -38,13 +38,20 @@ function runFailure {
     echo
 }
 
-runSuccess ""
-runSuccess "-- --accelerators=cpu"
-runSuccess "-- --moduleBackend=serial_sync"
+runSuccess "-- --accelerators=cpu --expectBackend=serial_sync"
+runSuccess "-- --moduleBackend=serial_sync --expectBackend=serial_sync"
 
 if [ "${TARGET}" == "cpu" ]; then
-    runFailure "-- --moduleBackend=cuda_async"
+    runSuccess "-- --expectBackend=serial_sync"
+
+    runFailure "-- --accelerators=gpu-nvidia --expectBackend=cuda_async"
+    runFailure "-- --moduleBackend=cuda_async --expectBackend=cuda_async"
 
 elif [ "${TARGET}" == "cuda" ]; then
-    runSuccess "-- --moduleBackend=cuda_async"
+    runSuccess "-- --expectBackend=cuda_async"
+    runSuccess "-- --accelerators=gpu-nvidia --expectBackend=cuda_async"
+    runSuccess "-- --moduleBackend=cuda_async --expectBackend=cuda_async"
+
+    runFailure "-- --accelerators=gpu-nvidia --moduleBackend=serial_sync --expectBackend=serial_sync"
+    runFailure "-- --accelerators=cpu --moduleBackend=cuda_async --expectBackend=cuda_async"
 fi

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -4,18 +4,14 @@ import argparse
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test various Alpaka module types')
 
-parser.add_argument("--cuda", help="Use CUDA backend", action="store_true")
+parser.add_argument("--accelerators", type=str, help="Set process.options.accelerators (comma-separated string, default is to use default)", default="")
+parser.add_argument("--moduleBackend", type=str, help="Set Alpaka backend for module instances", default="")
 parser.add_argument("--run", type=int, help="Run number (default: 1)", default=1)
 
 argv = sys.argv[:]
 if '--' in argv:
     argv.remove("--")
 args, unknown = parser.parse_known_args(argv)
-
-# TODO: just a temporary mechanism until we get something better that
-# works also for ES modules. Absolutely NOT for wider use.
-def setToCUDA(m):
-    m._TypedParameterizable__type = m._TypedParameterizable__type.replace("alpaka_serial_sync", "alpaka_cuda_async")
 
 process = cms.Process('TEST')
 
@@ -25,11 +21,12 @@ process.source = cms.Source('EmptySource',
 
 process.maxEvents.input = 10
 
+if len(args.accelerators) != 0:
+    process.options.accelerators = args.accelerators.split(",")
+
 process.load('Configuration.StandardSequences.Accelerators_cff')
-process.AlpakaServiceSerialSync = cms.Service('AlpakaServiceSerialSync')
-if args.cuda:
-    process.AlpakaServiceSerialSync.enabled = cms.untracked.bool(False)
-    process.AlpakaServiceCudaAsync = cms.Service('AlpakaServiceCudaAsync')
+process.load("HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi")
+process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
 
 process.alpakaESRecordASource = cms.ESSource("EmptyESSource",
     recordName = cms.string('AlpakaESTestRecordA'),
@@ -51,32 +48,23 @@ process.esProducerA = cms.ESProducer("cms::alpakatest::TestESProducerA", value =
 process.esProducerB = cms.ESProducer("cms::alpakatest::TestESProducerB", value = cms.int32(314159))
 process.esProducerC = cms.ESProducer("cms::alpakatest::TestESProducerC", value = cms.int32(27))
 
-process.alpakaESProducerA = cms.ESProducer("alpaka_serial_sync::TestAlpakaESProducerA")
-process.alpakaESProducerB = cms.ESProducer("alpaka_serial_sync::TestAlpakaESProducerB")
-process.alpakaESProducerC = cms.ESProducer("alpaka_serial_sync::TestAlpakaESProducerC")
-process.alpakaESProducerD = cms.ESProducer("alpaka_serial_sync::TestAlpakaESProducerD")
-if args.cuda:
-    setToCUDA(process.alpakaESProducerA)
-    setToCUDA(process.alpakaESProducerB)
-    setToCUDA(process.alpakaESProducerC)
-    setToCUDA(process.alpakaESProducerD)
+process.alpakaESProducerA = cms.ESProducer("TestAlpakaESProducerA@alpaka")
+process.alpakaESProducerB = cms.ESProducer("TestAlpakaESProducerB@alpaka")
+process.alpakaESProducerC = cms.ESProducer("TestAlpakaESProducerC@alpaka")
+process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka")
 
 process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
 
-process.alpakaGlobalProducer = cms.EDProducer("alpaka_serial_sync::TestAlpakaGlobalProducer",
+process.alpakaGlobalProducer = cms.EDProducer("TestAlpakaGlobalProducer@alpaka",
     size = cms.int32(10)
 )
-process.alpakaStreamProducer = cms.EDProducer("alpaka_serial_sync::TestAlpakaStreamProducer",
+process.alpakaStreamProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",
     source = cms.InputTag("intProduct"),
     size = cms.int32(5)
 )
-process.alpakaStreamSynchronizingProducer = cms.EDProducer("alpaka_serial_sync::TestAlpakaStreamSynchronizingProducer",
+process.alpakaStreamSynchronizingProducer = cms.EDProducer("TestAlpakaStreamSynchronizingProducer@alpaka",
     source = cms.InputTag("alpakaGlobalProducer")
 )
-if args.cuda:
-    setToCUDA(process.alpakaGlobalProducer)
-    setToCUDA(process.alpakaStreamProducer)
-    setToCUDA(process.alpakaStreamSynchronizingProducer)
 
 process.alpakaGlobalConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaGlobalProducer")
@@ -87,6 +75,12 @@ process.alpakaStreamConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
 process.alpakaStreamSynchronizingConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaStreamSynchronizingProducer")
 )
+
+if args.moduleBackend != "":
+    for name in ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD",
+                 "GlobalProducer", "StreamProducer", "StreamSynchronizingProducer"]:
+        mod = getattr(process, "alpaka"+name)
+        mod.alpaka = cms.untracked.PSet(backend = cms.untracked.string(args.moduleBackend))
 
 process.output = cms.OutputModule('PoolOutputModule',
     fileName = cms.untracked.string('testAlpaka.root'),

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -49,17 +49,19 @@ process.esProducerA = cms.ESProducer("cms::alpakatest::TestESProducerA", value =
 process.esProducerB = cms.ESProducer("cms::alpakatest::TestESProducerB", value = cms.int32(314159))
 process.esProducerC = cms.ESProducer("cms::alpakatest::TestESProducerC", value = cms.int32(27))
 
-process.alpakaESProducerA = cms.ESProducer("TestAlpakaESProducerA@alpaka")
+from HeterogeneousCore.AlpakaTest.testAlpakaESProducerA_cfi import testAlpakaESProducerA 
+process.alpakaESProducerA = testAlpakaESProducerA.clone()
 process.alpakaESProducerB = cms.ESProducer("TestAlpakaESProducerB@alpaka")
 process.alpakaESProducerC = cms.ESProducer("TestAlpakaESProducerC@alpaka")
 process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka")
 
 process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
 
-process.alpakaGlobalProducer = cms.EDProducer("TestAlpakaGlobalProducer@alpaka",
-    size = cms.PSet(
-        alpaka_serial_sync = cms.int32(10),
-        alpaka_cuda_async = cms.int32(20)
+from HeterogeneousCore.AlpakaTest.testAlpakaGlobalProducer_cfi import testAlpakaGlobalProducer
+process.alpakaGlobalProducer = testAlpakaGlobalProducer.clone(
+    size = dict(
+        alpaka_serial_sync = 10,
+        alpaka_cuda_async = 20
     )
 )
 process.alpakaStreamProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",


### PR DESCRIPTION
#### PR description:

This PR enables the "alternative module loading" functionality for Alpaka modules (following what I presented in https://indico.cern.ch/event/1208060/#16-portable-configuration-with). In order to use this mechanism, the configuration needs to load `HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi`, and define the modules in the configuration with `@alpaka` postfix in the type name along
```py
# selects at run time whether alpaka_serial_sync::FooProducer or alpaka_cuda_async::FooProducer is used
process.foo = cms.EDProducer("FooProducer@alpaka", ...)
```
The syntax works for EDProducers, EDAnalyzers, EDFilters, and ESProducers.

The backend can also be set explicitly via
```
process.foo = cms.EDProducer("FooProducer@alpaka",
    ...,
    alpaka = cms.untracked.PSet(
        backend = cms.untracked.string("serial_sync") # or cuda_async
    )
)
```
The validity of the explicitly chosen backend is checked at the time the configuration is processed at the worker node, and value that is incompatible with the node hardware (or `process.options.accelerators`) leads to an exception being thrown. It follows that this approach of defining Alpaka modules with explicitly selected backend does not really work with `SwitchProducer` (where all modules need to be constructed in the C++ side).

An alternative design that was considered was to encode the backend selection information in the C++ type field (e.g. after `@alpaka`). Expressing it in the configuration parameters instead allows the backend selection to be easily customized after the module definition (e.g. with a `Modifier`), and allows the selection logic to be extended with little technical constraints in the future (e.g. selected modules could use TBB when running on CPU). 

The benefits of this model over `SwitchProducer` include
* works also with `SCRAM_ARCH`s that don't support all accelerator backends (or anything beyond CPU)
* works also for `EDAnalyzer`, `EDFilter`, and `ESProducer` in addition of `EDProducer`
* reduces the duplication of module parameters (at least in simple cases)
* allows all module member functions (including constructors) to use backend device specific functionality without any explicit checks about "if the backend is enabled"


##### Potential discussion points

* The nomenclature for declaring "Alpaka modules" with `@alpaka` suffix
* The nomenclature for setting the module's backend explicitly
* Whether the backend selection PSet should be visible in the generated `cfi` file (and thus be visible for ConfDB parsing)
* For what exactly the `cfi` files should be generated?
   * This PR takes a perhaps too big step of generating `cfi` file only for `FooProducer@alpaka`. An alternative could be to generate `cfi` files also for `serial_sync::FooProducer` and `cuda_async::FooProducer` for some amount of time.
* When to add the loading of `HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi` to `Configuration.StandardSequences.Accelerators_cff`

#### PR validation:

Unit tests run.