### PR TITLE
[DQM] [CLANG] Fix bitwise-instead-of-logical warnings

### DIFF
--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -162,7 +162,7 @@ class Primary4DVertexValidation : public DQMEDAnalyzer {
         return wosmatch;
       return -1;
     }
-    bool other_fake() { return (is_fake() & (split_from() < 0)); }
+    bool other_fake() { return (is_fake() && (split_from() < 0)); }
 
     void addTrack(unsigned int iev, double twos, double wt) {
       sumwnt += wt;

--- a/Validation/MuonME0Validation/src/ME0DigisValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0DigisValidation.cc
@@ -166,7 +166,7 @@ void ME0DigisValidation::analyze(const edm::Event &e, const edm::EventSetup &iSe
   edm::Handle<ME0DigiPreRecoCollection> ME0Digis;
   e.getByToken(InputTagToken_Digi, ME0Digis);
 
-  if (!ME0Hits.isValid() | !ME0Digis.isValid()) {
+  if (!ME0Hits.isValid() || !ME0Digis.isValid()) {
     edm::LogError("ME0DigisValidation") << "Cannot get ME0Hits/ME0Digis by Token simInputTagToken";
     return;
   }

--- a/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
+++ b/Validation/MuonME0Validation/src/ME0RecHitsValidation.cc
@@ -67,7 +67,7 @@ void ME0RecHitsValidation::analyze(const edm::Event &e, const edm::EventSetup &i
   edm::Handle<ME0RecHitCollection> ME0RecHits;
   e.getByToken(InputTagToken_RecHit, ME0RecHits);
 
-  if (!ME0Hits.isValid() | !ME0RecHits.isValid()) {
+  if (!ME0Hits.isValid() || !ME0RecHits.isValid()) {
     edm::LogError("ME0RecHitsValidation") << "Cannot get ME0Hits/ME0RecHits by Token simInputTagToken";
     return;
   }


### PR DESCRIPTION
This PR fixes bitwise-instead-of-logical warnings which we get with LLVM14 in CLANG IBS