### PR TITLE
Add new ALCT-CLCT match algorithm for high pt muon  showers

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -108,7 +108,7 @@ protected:
   CSCShowerDigi cathode_showers_[CSCConstants::MAX_CLCT_TBINS];
   //CSCShowerDigi shower_;
 
- /* flag of shower around best CLCT in each BX */
+  /* flag of shower around best CLCT in each BX */
   bool localShowerFlag[CSCConstants::MAX_CLCT_TBINS];
 
   /** Access routines to comparator digis. */
@@ -169,8 +169,8 @@ protected:
       const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
 
   /* check whether there is a shower around best CLCT */
-  void checkLocalShower(int zone,
-    const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
+  void checkLocalShower(
+      int zone, const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
 
   void encodeHighMultiplicityBits();
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -166,11 +166,12 @@ protected:
 
   /** Dump half-strip digis */
   void dumpDigis(
-      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
 
   /* check whether there is a shower around best CLCT */
   void checkLocalShower(
-      int zone, const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
+      int zone,
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
 
   void encodeHighMultiplicityBits();
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -81,6 +81,9 @@ public:
   CSCCLCTDigi getBestCLCT(int bx) const;
   CSCCLCTDigi getSecondCLCT(int bx) const;
 
+  /* get the flag of local shower around best CLCT at bx */
+  bool getLocalShowerFlag(int bx) const;
+
   std::vector<int> preTriggerBXs() const { return thePreTriggerBXs; }
 
   /** read out CLCTs in ME1a , ME1b */
@@ -104,6 +107,9 @@ protected:
 
   CSCShowerDigi cathode_showers_[CSCConstants::MAX_CLCT_TBINS];
   //CSCShowerDigi shower_;
+
+ /* flag of shower around best CLCT in each BX */
+  bool localShowerFlag[CSCConstants::MAX_CLCT_TBINS];
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
@@ -162,6 +168,12 @@ protected:
   void dumpDigis(
       const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;
 
+  /* check whether there is a shower around best CLCT */
+  void checkLocalShower(int zone,
+    const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
+
+  void encodeHighMultiplicityBits();
+
   //--------------------------- Member variables -----------------------------
 
   PulseArray pulse_;
@@ -191,7 +203,6 @@ protected:
   std::vector<CSCCLCTPreTriggerDigi> thePreTriggerDigis;
 
   /* data members for high multiplicity triggers */
-  void encodeHighMultiplicityBits();
   std::vector<unsigned> thresholds_;
   unsigned showerNumTBins_;
   unsigned minLayersCentralTBin_;
@@ -209,6 +220,12 @@ protected:
 
   /** VK: some quick and dirty fix to reduce CLCT deadtime */
   int start_bx_shift;
+
+  /* define the region around best CLCT to check local shower */
+  int localShowerZone;
+
+  /* threshold of total hits for local shower */
+  int localShowerThresh;
 
   /** VK: separate handle for early time bins */
   int early_tbins;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -162,7 +162,7 @@ protected:
   std::vector<int> preferred_bx_match_;
 
   /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
-  bool sort_clct_bx_; 
+  bool sort_clct_bx_;
 
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -161,6 +161,9 @@ protected:
   */
   std::vector<int> preferred_bx_match_;
 
+  /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
+  bool sort_clct_bx_; 
+
   /** Default values of configuration parameters. */
   static const unsigned int def_mpc_block_me1a;
   static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
@@ -184,6 +187,10 @@ protected:
   /** Make sure that the parameter values are within the allowed range. */
   void checkConfigParameters();
 
+  /*sort CLCT by quality+bending and if CLCTs from different BX have
+    same quality+bending, then rank CLCT by timing
+   */
+  void sortCLCTByQualBend(int alct_bx, std::vector<unsigned>& clctBxVector);
   /*
      For valid ALCTs in the trigger time window, look for CLCTs within the
      match-time window. Valid CLCTs are matched in-time. If a match was found

--- a/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/clctParams.py
@@ -29,6 +29,10 @@ clctPhase1 = cms.PSet(
 
     # BX to start CLCT finding (poor man's dead-time shortening):
     clctStartBxShift  = cms.int32(0),
+    # local shower zone 
+    clctLocalShowerZone = cms.int32(25),
+    # local shower thresh 
+    clctLocalShowerThresh = cms.int32(12),
 )
 
 # Parameters for upgrade CLCT processors

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -15,6 +15,8 @@ tmbPhase1 = cms.PSet(
     # perfectly in-time CLCTs are preferred, followed by
     # first-early, first-late, second-early, second late, etc.
     preferredBxMatch = cms.vint32(0, -1, 1, -2, 2, -3, 3),
+    #use CLCT sorted by Bx only for ALCT-CLCTmatch
+    sortClctBx = cms.bool(True),
     # readout window for the DAQ
     # LCTs found in the window [5, 6, 7, 8, 9, 10, 11] are good
     tmbL1aWindowSize = cms.uint32(7),
@@ -49,6 +51,8 @@ tmbPhase1 = cms.PSet(
 tmbPhase2 = tmbPhase1.clone(
     # ALCT-CLCT stays at 7 for the moment
     matchTrigWindowSize = 7,
+    #use CLCT sorted by Bx only for ALCT-CLCTmatch for now
+    sortClctBx = cms.bool(True),
     # LCTs found in the window [5, 6, 7, 8, 9, 10, 11] are good
     tmbL1aWindowSize = 7,
     tmbDropUsedClcts = False,

--- a/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/tmbParams.py
@@ -52,7 +52,7 @@ tmbPhase2 = tmbPhase1.clone(
     # ALCT-CLCT stays at 7 for the moment
     matchTrigWindowSize = 7,
     #use CLCT sorted by Bx only for ALCT-CLCTmatch for now
-    sortClctBx = cms.bool(True),
+    sortClctBx = True,
     # LCTs found in the window [5, 6, 7, 8, 9, 10, 11] are good
     tmbL1aWindowSize = 7,
     tmbDropUsedClcts = False,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1278,14 +1278,16 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() const {
   return tmpV;
 }
 
-CSCALCTDigi CSCAnodeLCTProcessor::getBestALCT(int bx) const { 
-  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCALCTDigi();
-  return bestALCT[bx]; 
+CSCALCTDigi CSCAnodeLCTProcessor::getBestALCT(int bx) const {
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0)
+    return CSCALCTDigi();
+  return bestALCT[bx];
 }
 
-CSCALCTDigi CSCAnodeLCTProcessor::getSecondALCT(int bx) const { 
-  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCALCTDigi();
-  return secondALCT[bx]; 
+CSCALCTDigi CSCAnodeLCTProcessor::getSecondALCT(int bx) const {
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0)
+    return CSCALCTDigi();
+  return secondALCT[bx];
 }
 
 /** return vector of CSCShower digi **/

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -1278,9 +1278,15 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::getALCTs() const {
   return tmpV;
 }
 
-CSCALCTDigi CSCAnodeLCTProcessor::getBestALCT(int bx) const { return bestALCT[bx]; }
+CSCALCTDigi CSCAnodeLCTProcessor::getBestALCT(int bx) const { 
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCALCTDigi();
+  return bestALCT[bx]; 
+}
 
-CSCALCTDigi CSCAnodeLCTProcessor::getSecondALCT(int bx) const { return secondALCT[bx]; }
+CSCALCTDigi CSCAnodeLCTProcessor::getSecondALCT(int bx) const { 
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCALCTDigi();
+  return secondALCT[bx]; 
+}
 
 /** return vector of CSCShower digi **/
 std::vector<CSCShowerDigi> CSCAnodeLCTProcessor::getAllShower() const {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -417,10 +417,7 @@ void CSCCathodeLCTProcessor::checkLocalShower(
           totalHits++;
     }
 
-    if (totalHits >= localShowerThresh)
-      localShowerFlag[bx] = true;
-    else
-      localShowerFlag[bx] = false;
+    localShowerFlag[bx] = totalHits >= localShowerThresh;
     if (infoV > 1)
       LogDebug("CSCCathodeLCTProcessor") << " bx " << bx << " bestCLCT key HS " << keyHS
                                          << " localshower zone: " << minHS << ", " << maxHS << " totalHits "

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -44,7 +44,7 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
 
   localShowerZone = clctParams_.getParameter<int>("clctLocalShowerZone");
 
-  localShowerThresh = clctParams_.getParameter<int>("clctLocalShowerThresh"); 
+  localShowerThresh = clctParams_.getParameter<int>("clctLocalShowerThresh");
 
   // Motherboard parameters: common for all configurations.
   tmb_l1a_window_size =  // Common to CLCT and TMB
@@ -190,7 +190,7 @@ void CSCCathodeLCTProcessor::clear() {
     bestCLCT[bx].clear();
     secondCLCT[bx].clear();
     cathode_showers_[bx].clear();
-    localShowerFlag[bx] = false;//init with no shower around CLCT
+    localShowerFlag[bx] = false;  //init with no shower around CLCT
   }
 }
 
@@ -394,33 +394,40 @@ void CSCCathodeLCTProcessor::run(
   // ALCTs and then get sent to the MotherBoard.  -JM
 }
 
-void CSCCathodeLCTProcessor::checkLocalShower(int zone,
+void CSCCathodeLCTProcessor::checkLocalShower(
+    int zone,
     const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
-  //check local shower after pulse extension 
+  //check local shower after pulse extension
   pulseExtension(halfstrip);
 
   for (int bx = 0; bx < CSCConstants::MAX_CLCT_TBINS; bx++) {
-    if (not bestCLCT[bx].isValid()) continue; 
+    if (not bestCLCT[bx].isValid())
+      continue;
 
     //only check the region around best CLCT
     int keyHS = bestCLCT[bx].getKeyStrip();
-    int minHS = (keyHS - zone) >= stagger[CSCConstants::KEY_CLCT_LAYER - 1] ? keyHS-zone : stagger[CSCConstants::KEY_CLCT_LAYER - 1]; 
-    int maxHS = (keyHS + zone) >= numHalfStrips_ ?  numHalfStrips_ : keyHS+zone;
+    int minHS = (keyHS - zone) >= stagger[CSCConstants::KEY_CLCT_LAYER - 1] ? keyHS - zone
+                                                                            : stagger[CSCConstants::KEY_CLCT_LAYER - 1];
+    int maxHS = (keyHS + zone) >= numHalfStrips_ ? numHalfStrips_ : keyHS + zone;
     int totalHits = 0;
-    for (int hstrip = minHS; hstrip < maxHS; hstrip++){
+    for (int hstrip = minHS; hstrip < maxHS; hstrip++) {
       for (int this_layer = 0; this_layer < CSCConstants::NUM_LAYERS; this_layer++)
-        if (pulse_.isOneShotHighAtBX(this_layer, hstrip, bx+drift_delay)) totalHits++;
-    } 
+        if (pulse_.isOneShotHighAtBX(this_layer, hstrip, bx + drift_delay))
+          totalHits++;
+    }
 
-    if (totalHits >= localShowerThresh) localShowerFlag[bx] = true;
-    else localShowerFlag[bx] = false;
-    if (infoV > 1) std::cout <<" bx "<< bx <<" bestCLCT key HS "<< keyHS <<" localshower zone: "<< minHS <<", "<< maxHS
-                             << " totalHits "<< totalHits << (localShowerFlag[bx] ? " Validlocalshower ": " NolocalShower ") << std::endl;
+    if (totalHits >= localShowerThresh)
+      localShowerFlag[bx] = true;
+    else
+      localShowerFlag[bx] = false;
+    if (infoV > 1)
+      LogDebug("CSCCathodeLCTProcessor") << " bx " << bx << " bestCLCT key HS " << keyHS
+                                         << " localshower zone: " << minHS << ", " << maxHS << " totalHits "
+                                         << totalHits
+                                         << (localShowerFlag[bx] ? " Validlocalshower " : " NolocalShower ");
   }
-
-} 
-
+}
 
 bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc) {
   bool hasDigis = false;
@@ -1231,21 +1238,24 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() const {
 // to make a proper comparison with ALCTs we need
 // CLCT and ALCT to have the central BX in the same bin
 CSCCLCTDigi CSCCathodeLCTProcessor::getBestCLCT(int bx) const {
-  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCCLCTDigi();
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0)
+    return CSCCLCTDigi();
   CSCCLCTDigi lct = bestCLCT[bx];
   lct.setBX(lct.getBX() + CSCConstants::ALCT_CLCT_OFFSET);
   return lct;
 }
 
 CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const {
-  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCCLCTDigi();
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0)
+    return CSCCLCTDigi();
   CSCCLCTDigi lct = secondCLCT[bx];
   lct.setBX(lct.getBX() + CSCConstants::ALCT_CLCT_OFFSET);
   return lct;
 }
 
-bool CSCCathodeLCTProcessor::getLocalShowerFlag(int bx) const{
-  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return false;
+bool CSCCathodeLCTProcessor::getLocalShowerFlag(int bx) const {
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0)
+    return false;
   return localShowerFlag[bx];
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -42,6 +42,10 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
 
   start_bx_shift = clctParams_.getParameter<int>("clctStartBxShift");
 
+  localShowerZone = clctParams_.getParameter<int>("clctLocalShowerZone");
+
+  localShowerThresh = clctParams_.getParameter<int>("clctLocalShowerThresh"); 
+
   // Motherboard parameters: common for all configurations.
   tmb_l1a_window_size =  // Common to CLCT and TMB
       tmbParams_.getParameter<unsigned int>("tmbL1aWindowSize");
@@ -186,6 +190,7 @@ void CSCCathodeLCTProcessor::clear() {
     bestCLCT[bx].clear();
     secondCLCT[bx].clear();
     cathode_showers_[bx].clear();
+    localShowerFlag[bx] = false;//init with no shower around CLCT
   }
 }
 
@@ -384,9 +389,38 @@ void CSCCathodeLCTProcessor::run(
             << "\n";
     }
   }
+  checkLocalShower(localShowerZone, halfstrip);
   // Now that we have our best CLCTs, they get correlated with the best
   // ALCTs and then get sent to the MotherBoard.  -JM
 }
+
+void CSCCathodeLCTProcessor::checkLocalShower(int zone,
+    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
+  // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
+  //check local shower after pulse extension 
+  pulseExtension(halfstrip);
+
+  for (int bx = 0; bx < CSCConstants::MAX_CLCT_TBINS; bx++) {
+    if (not bestCLCT[bx].isValid()) continue; 
+
+    //only check the region around best CLCT
+    int keyHS = bestCLCT[bx].getKeyStrip();
+    int minHS = (keyHS - zone) >= stagger[CSCConstants::KEY_CLCT_LAYER - 1] ? keyHS-zone : stagger[CSCConstants::KEY_CLCT_LAYER - 1]; 
+    int maxHS = (keyHS + zone) >= numHalfStrips_ ?  numHalfStrips_ : keyHS+zone;
+    int totalHits = 0;
+    for (int hstrip = minHS; hstrip < maxHS; hstrip++){
+      for (int this_layer = 0; this_layer < CSCConstants::NUM_LAYERS; this_layer++)
+        if (pulse_.isOneShotHighAtBX(this_layer, hstrip, bx+drift_delay)) totalHits++;
+    } 
+
+    if (totalHits >= localShowerThresh) localShowerFlag[bx] = true;
+    else localShowerFlag[bx] = false;
+    if (infoV > 1) std::cout <<" bx "<< bx <<" bestCLCT key HS "<< keyHS <<" localshower zone: "<< minHS <<", "<< maxHS
+                             << " totalHits "<< totalHits << (localShowerFlag[bx] ? " Validlocalshower ": " NolocalShower ") << std::endl;
+  }
+
+} 
+
 
 bool CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc) {
   bool hasDigis = false;
@@ -1197,15 +1231,22 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::getCLCTs() const {
 // to make a proper comparison with ALCTs we need
 // CLCT and ALCT to have the central BX in the same bin
 CSCCLCTDigi CSCCathodeLCTProcessor::getBestCLCT(int bx) const {
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCCLCTDigi();
   CSCCLCTDigi lct = bestCLCT[bx];
   lct.setBX(lct.getBX() + CSCConstants::ALCT_CLCT_OFFSET);
   return lct;
 }
 
 CSCCLCTDigi CSCCathodeLCTProcessor::getSecondCLCT(int bx) const {
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return CSCCLCTDigi();
   CSCCLCTDigi lct = secondCLCT[bx];
   lct.setBX(lct.getBX() + CSCConstants::ALCT_CLCT_OFFSET);
   return lct;
+}
+
+bool CSCCathodeLCTProcessor::getLocalShowerFlag(int bx) const{
+  if (bx >= CSCConstants::MAX_CLCT_TBINS or bx < 0) return false;
+  return localShowerFlag[bx];
 }
 
 /** return vector of CSCShower digi **/

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -152,18 +152,35 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     // Find best and second CLCTs by preferred CLCT BX, taking into account that there is an offset in the simulation
 
     unsigned matchingBX = 0;
+    unsigned matching_clctbx = 0;
+    unsigned bx_clct = 0;
 
+    std::vector<unsigned> clctBx_qualbend_match;
+    sortCLCTByQualBend(bx_alct, clctBx_qualbend_match);
+
+    bool hasLocalShower = false;
+    for (unsigned ibx = 1; ibx <= match_trig_window_size/2; ibx++)
+      hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct-CSCConstants::ALCT_CLCT_OFFSET-ibx));
     // BestCLCT and secondCLCT
     for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
-      unsigned bx_clct = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
+      //bx_clct_run2 would be overflow when bx_alct is small but it is okay
+      unsigned bx_clct_run2 = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
+      unsigned bx_clct_qualbend = clctBx_qualbend_match[mbx];
+      bx_clct = (sort_clct_bx_ or not(hasLocalShower)) ? bx_clct_run2 : bx_clct_qualbend;
+      if (infoV > 1 and bx_clct_run2 != bx_clct_qualbend) 
+        std::cout <<"GEMCSCOTMB CLCT  bx sortting: run2 "<< bx_clct_run2 <<" qualbend "<< bx_clct_qualbend <<" selected "<< bx_clct << std::endl;
+      
       if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
         continue;
-      bestCLCT = clctProc->getBestCLCT(bx_clct);
-      secondCLCT = clctProc->getSecondCLCT(bx_clct);
       matchingBX = mbx;
-      if (bestCLCT.isValid())
+      matching_clctbx = mbx;
+
+      if ((clctProc->getBestCLCT(bx_clct)).isValid())
         break;
     }
+
+    bestCLCT = clctProc->getBestCLCT(bx_clct);
+    secondCLCT = clctProc->getSecondCLCT(bx_clct);
 
     if (!bestALCT.isValid() and !secondALCT.isValid() and !bestCLCT.isValid() and !secondCLCT.isValid())
       continue;
@@ -172,6 +189,10 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     if (!build_lct_from_alct_gem_ and !bestCLCT.isValid())
       continue;
 
+    if (infoV > 1)  LogTrace("CSCGEMMotherboard") << "GEMCSCOTMB: Successful ALCT-CLCT match: bx_alct = " << bx_alct
+                                << "; bx_clct = " <<matching_clctbx << "; mbx = " << matchingBX
+                                << " bestALCT "<< bestALCT << " secondALCT "<< secondALCT
+                                << " bestCLCT "<< bestCLCT << " secondCLCT "<< secondCLCT;
     // ALCT + CLCT + GEM
 
     for (unsigned gmbx = 0; gmbx < alct_gem_bx_window_size_; gmbx++) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -159,17 +159,15 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     sortCLCTByQualBend(bx_alct, clctBx_qualbend_match);
 
     bool hasLocalShower = false;
-    for (unsigned ibx = 1; ibx <= match_trig_window_size/2; ibx++)
-      hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct-CSCConstants::ALCT_CLCT_OFFSET-ibx));
+    for (unsigned ibx = 1; ibx <= match_trig_window_size / 2; ibx++)
+      hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct - CSCConstants::ALCT_CLCT_OFFSET - ibx));
     // BestCLCT and secondCLCT
     for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
       //bx_clct_run2 would be overflow when bx_alct is small but it is okay
       unsigned bx_clct_run2 = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
       unsigned bx_clct_qualbend = clctBx_qualbend_match[mbx];
       bx_clct = (sort_clct_bx_ or not(hasLocalShower)) ? bx_clct_run2 : bx_clct_qualbend;
-      if (infoV > 1 and bx_clct_run2 != bx_clct_qualbend) 
-        std::cout <<"GEMCSCOTMB CLCT  bx sortting: run2 "<< bx_clct_run2 <<" qualbend "<< bx_clct_qualbend <<" selected "<< bx_clct << std::endl;
-      
+
       if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
         continue;
       matchingBX = mbx;
@@ -189,10 +187,11 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     if (!build_lct_from_alct_gem_ and !bestCLCT.isValid())
       continue;
 
-    if (infoV > 1)  LogTrace("CSCGEMMotherboard") << "GEMCSCOTMB: Successful ALCT-CLCT match: bx_alct = " << bx_alct
-                                << "; bx_clct = " <<matching_clctbx << "; mbx = " << matchingBX
-                                << " bestALCT "<< bestALCT << " secondALCT "<< secondALCT
-                                << " bestCLCT "<< bestCLCT << " secondCLCT "<< secondCLCT;
+    if (infoV > 1)
+      LogTrace("CSCGEMMotherboard") << "GEMCSCOTMB: Successful ALCT-CLCT match: bx_alct = " << bx_alct
+                                    << "; bx_clct = " << matching_clctbx << "; mbx = " << matchingBX << " bestALCT "
+                                    << bestALCT << " secondALCT " << secondALCT << " bestCLCT " << bestCLCT
+                                    << " secondCLCT " << secondCLCT;
     // ALCT + CLCT + GEM
 
     for (unsigned gmbx = 0; gmbx < alct_gem_bx_window_size_; gmbx++) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -201,14 +201,15 @@ void CSCMotherboard::matchALCTCLCT() {
       // need to access "full BX" words, which are not readily
       // available.
       bool is_matched = false;
-      // we can use single value to best CLCT but here use vector to keep the 
+      // we can use single value to best CLCT but here use vector to keep the
       // the future option to do multiple ALCT-CLCT matches wiht CLCT from different bx
       std::vector<unsigned> clctBx_qualbend_match;
       sortCLCTByQualBend(bx_alct, clctBx_qualbend_match);
 
       bool hasLocalShower = false;
-      for (unsigned ibx = 1; ibx <= match_trig_window_size/2; ibx++)
-        hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct-CSCConstants::ALCT_CLCT_OFFSET-ibx));
+      for (unsigned ibx = 1; ibx <= match_trig_window_size / 2; ibx++)
+        hasLocalShower =
+            (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct - CSCConstants::ALCT_CLCT_OFFSET - ibx));
 
       // loop on the preferred "delta BX" array
       for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
@@ -570,33 +571,34 @@ void CSCMotherboard::selectLCTs() {
   }
 }
 
-void CSCMotherboard::sortCLCTByQualBend(int bx_alct, std::vector<unsigned>& clctBxVector){
+void CSCMotherboard::sortCLCTByQualBend(int bx_alct, std::vector<unsigned>& clctBxVector) {
   //find clct bx range in [centerbx-window_size/2, center_bx+window_size/2]
   //Then sort CLCT based quality+bend within the match window
   //if two CLCTs from different BX has same qual+bend, the in-time one has higher priority
   clctBxVector.clear();
-  int clctQualBendArray[CSCConstants::MAX_CLCT_TBINS+1] = {0};
-  for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++){
-    unsigned bx_clct = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET; 
+  int clctQualBendArray[CSCConstants::MAX_CLCT_TBINS + 1] = {0};
+  for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
+    unsigned bx_clct = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
     int tempQualBend = 0;
     if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
       continue;
-    if (!clctProc->getBestCLCT(bx_clct).isValid()){
+    if (!clctProc->getBestCLCT(bx_clct).isValid()) {
       clctQualBendArray[bx_clct] = tempQualBend;
       continue;
     }
     CSCCLCTDigi bestCLCT = clctProc->getBestCLCT(bx_clct);
     //for run2 pattern, ignore direction and use &0xe
     //for run3, slope=0 is straighest pattern
-    int clctBend = bestCLCT.isRun3() ? (16-bestCLCT.getSlope()) : (bestCLCT.getPattern() & 0xe);
+    int clctBend = bestCLCT.isRun3() ? (16 - bestCLCT.getSlope()) : (bestCLCT.getPattern() & 0xe);
     //shift quality to left for 4 bits
     int clctQualBend = clctBend | (bestCLCT.getQuality() << 5);
     clctQualBendArray[bx_clct] = clctQualBend;
-    if (clctBxVector.size() == 0) clctBxVector.push_back(bx_clct);
-    else{
-      for (auto it=clctBxVector.begin(); it != clctBxVector.end(); it++)
-        if (clctQualBend > clctQualBendArray[*it]){ //insert the 
-          clctBxVector.insert(it, bx_clct);  
+    if (clctBxVector.empty())
+      clctBxVector.push_back(bx_clct);
+    else {
+      for (auto it = clctBxVector.begin(); it != clctBxVector.end(); it++)
+        if (clctQualBend > clctQualBendArray[*it]) {  //insert the Bx with better clct
+          clctBxVector.insert(it, bx_clct);
           break;
         }
     }
@@ -604,7 +606,6 @@ void CSCMotherboard::sortCLCTByQualBend(int bx_alct, std::vector<unsigned>& clct
   //fill rest of vector with MAX_CLCT_TBINS
   for (unsigned bx = clctBxVector.size(); bx < match_trig_window_size; bx++)
     clctBxVector.push_back(CSCConstants::MAX_CLCT_TBINS);
-  
 }
 
 void CSCMotherboard::checkConfigParameters() {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -57,6 +57,9 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
   // get the preferred CLCT BX match array
   preferred_bx_match_ = tmbParams_.getParameter<std::vector<int>>("preferredBxMatch");
 
+  // sort CLCT only by bx or by quality+bending for  ALCT-CLCT match
+  sort_clct_bx_ = tmbParams_.getParameter<bool>("sortClctBx");
+
   // quality assignment
   qualityAssignment_ = std::make_unique<LCTQualityAssignment>(endcap, station, sector, subsector, chamber, conf);
 
@@ -198,12 +201,24 @@ void CSCMotherboard::matchALCTCLCT() {
       // need to access "full BX" words, which are not readily
       // available.
       bool is_matched = false;
+      // we can use single value to best CLCT but here use vector to keep the 
+      // the future option to do multiple ALCT-CLCT matches wiht CLCT from different bx
+      std::vector<unsigned> clctBx_qualbend_match;
+      sortCLCTByQualBend(bx_alct, clctBx_qualbend_match);
+
+      bool hasLocalShower = false;
+      for (unsigned ibx = 1; ibx <= match_trig_window_size/2; ibx++)
+        hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct-CSCConstants::ALCT_CLCT_OFFSET-ibx));
+
       // loop on the preferred "delta BX" array
       for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
         // evaluate the preffered CLCT BX, taking into account that there is an offset in the simulation
-        int bx_clct = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
+        //bx_clct_run2 would be overflow when bx_alct is small but it is okay
+        unsigned bx_clct_run2 = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
+        unsigned bx_clct_qualbend = clctBx_qualbend_match[mbx];
+        unsigned bx_clct = (sort_clct_bx_ or not(hasLocalShower)) ? bx_clct_run2 : bx_clct_qualbend;
         // check that the CLCT BX is valid
-        if (bx_clct >= CSCConstants::MAX_CLCT_TBINS or bx_clct < 0)
+        if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
           continue;
         // do not consider previously matched CLCTs
         if (drop_used_clcts && used_clct_mask[bx_clct])
@@ -553,6 +568,43 @@ void CSCMotherboard::selectLCTs() {
       LogDebug("CSCMotherboard") << "Selected LCT" << lct;
     }
   }
+}
+
+void CSCMotherboard::sortCLCTByQualBend(int bx_alct, std::vector<unsigned>& clctBxVector){
+  //find clct bx range in [centerbx-window_size/2, center_bx+window_size/2]
+  //Then sort CLCT based quality+bend within the match window
+  //if two CLCTs from different BX has same qual+bend, the in-time one has higher priority
+  clctBxVector.clear();
+  int clctQualBendArray[CSCConstants::MAX_CLCT_TBINS+1] = {0};
+  for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++){
+    unsigned bx_clct = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET; 
+    int tempQualBend = 0;
+    if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
+      continue;
+    if (!clctProc->getBestCLCT(bx_clct).isValid()){
+      clctQualBendArray[bx_clct] = tempQualBend;
+      continue;
+    }
+    CSCCLCTDigi bestCLCT = clctProc->getBestCLCT(bx_clct);
+    //for run2 pattern, ignore direction and use &0xe
+    //for run3, slope=0 is straighest pattern
+    int clctBend = bestCLCT.isRun3() ? (16-bestCLCT.getSlope()) : (bestCLCT.getPattern() & 0xe);
+    //shift quality to left for 4 bits
+    int clctQualBend = clctBend | (bestCLCT.getQuality() << 5);
+    clctQualBendArray[bx_clct] = clctQualBend;
+    if (clctBxVector.size() == 0) clctBxVector.push_back(bx_clct);
+    else{
+      for (auto it=clctBxVector.begin(); it != clctBxVector.end(); it++)
+        if (clctQualBend > clctQualBendArray[*it]){ //insert the 
+          clctBxVector.insert(it, bx_clct);  
+          break;
+        }
+    }
+  }
+  //fill rest of vector with MAX_CLCT_TBINS
+  for (unsigned bx = clctBxVector.size(); bx < match_trig_window_size; bx++)
+    clctBxVector.push_back(CSCConstants::MAX_CLCT_TBINS);
+  
 }
 
 void CSCMotherboard::checkConfigParameters() {


### PR DESCRIPTION
#### PR description:
Last year we found that current CSC trigger efficiency drops around 5% per station in the inner ring.  The root cause is: when high pT muons showered in the CSC chamber, the cathode hits produced by high pT muon is prefired, 1 or 2BX earlier than nominal case, while anode hits are still in-time. Conventional ALCT(built from anode hits)-CLCT(built from cathode hits) match algorithm would be inefficient as CLCTs from high pT muon are also prefired and CLCTs built from secondary hits are more in-time.  Therefore we proposed the upgraded ALCT-CLCT match algorithm for muon showers:
1. define a local zone around the CLCT key halfstrip to flag the local shower if total hits in the local zone is over threshold
2. if local shower is valid, then ALCT-CLCT match would pick up earlier CLCT, rather than in-time CLCT.  if local shower is not found, then it rolls back to conventional ALCT-CLCT match: ALCT would pick up more in-time CLCT, namely CLCT in the center of match window
3. local shower definition is configurable: both the shower zone and shower threshold. Right now local shower feature is not enabled in the default configuration
4. it is NOT included in firmware yet but MC studies with TeV muons showed that new ALCT-CLCT match would improve trigger efficiency when muon showers in the CSC station.

#### PR validation:
presentation on CSC meeting: 
https://indico.cern.ch/event/1197553/contributions/5035258/attachments/2504761/4304563/TaoOTMBStatus_TAMU_20220907_EMTFEff.pdf
https://indico.cern.ch/event/1199888/contributions/5047438/attachments/2508640/4311202/TaoOTMBStatus_TAMU_20220907_EMTFEfffollowup.pdf

presentation on L1 DPG meeting:  slide16-19
https://indico.cern.ch/event/1216605/contributions/5117665/attachments/2538591/4369875/Tao_OTMB_L1TDPG_20221031.pdf




