### PR TITLE
[HLT] [CLANG] Fix unused-but-set-variable warnings

### DIFF
--- a/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
+++ b/HLTrigger/JetMET/src/HLTMETCleanerUsingJetID.cc
@@ -53,7 +53,7 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
 
   double mex_jets = 0.;
   double mey_jets = 0.;
-  double sumet_jets = 0.;
+  //double sumet_jets = 0.;
   if (!jets->empty()) {
     for (auto const& j : *jets) {
       double pt = j.pt();
@@ -64,14 +64,14 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
       if (pt > minPt_ && std::abs(eta) < maxEta_) {
         mex_jets -= px;
         mey_jets -= py;
-        sumet_jets += pt;
+        //sumet_jets += pt;
       }
     }
   }
 
   double mex_goodJets = 0.;
   double mey_goodJets = 0.;
-  double sumet_goodJets = 0.;
+  //double sumet_goodJets = 0.;
   if (!goodJets->empty()) {
     for (auto const& j : *goodJets) {
       double pt = j.pt();
@@ -82,7 +82,7 @@ void HLTMETCleanerUsingJetID::produce(edm::Event& iEvent, const edm::EventSetup&
       if (pt > minPt_ && std::abs(eta) < maxEta_) {
         mex_goodJets -= px;
         mey_goodJets -= py;
-        sumet_goodJets += pt;
+        //sumet_goodJets += pt;
       }
     }
   }

--- a/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
@@ -46,8 +46,6 @@ void CaloTowerCreatorForTauHLT::produce(StreamID sid, Event& evt, const EventSet
   L1JetParticleCollection::const_iterator myL1Jet = jetsgen->begin();
   for (; myL1Jet != jetsgen->end(); myL1Jet++) {
     if (idTau == mTauId) {
-      double Sum08 = 0.;
-
       unsigned idx = 0;
       for (; idx < caloTowers->size(); idx++) {
         const CaloTower* cal = &((*caloTowers)[idx]);
@@ -63,7 +61,6 @@ void CaloTowerCreatorForTauHLT::produce(StreamID sid, Event& evt, const EventSet
 
           if (delta < mCone) {
             isAccepted = true;
-            Sum08 += cal->et();
             cands->push_back(*cal);
           }
         }

--- a/RecoTauTag/HLTProducers/src/CaloTowerFromL1TCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerFromL1TCreatorForTauHLT.cc
@@ -46,7 +46,6 @@ void CaloTowerFromL1TCreatorForTauHLT::produce(StreamID sid, Event& evt, const E
   if (jetsgen.isValid()) {
     for (auto myL1Jet = jetsgen->begin(mBX); myL1Jet != jetsgen->end(mBX); myL1Jet++) {
       if (idTau == mTauId) {
-        double Sum08 = 0.;
         unsigned idx = 0;
         for (; idx < caloTowers->size(); idx++) {
           const CaloTower* cal = &((*caloTowers)[idx]);
@@ -61,7 +60,6 @@ void CaloTowerFromL1TCreatorForTauHLT::produce(StreamID sid, Event& evt, const E
             double delta = ROOT::Math::VectorUtil::DeltaR((*myL1Jet).p4().Vect(), p);
             if (delta < mCone) {
               isAccepted = true;
-              Sum08 += cal->et();
               cands->push_back(*cal);
             }
           }


### PR DESCRIPTION
This PR fixes more unused-but-set-variable warnings which we get with LLVM14 in CLANG IBS for the HLT module.