### PR TITLE
Remove a seemingly useless vector definition

### DIFF
--- a/DataFormats/NanoAOD/src/classes.h
+++ b/DataFormats/NanoAOD/src/classes.h
@@ -4,5 +4,3 @@
 #include "DataFormats/NanoAOD/interface/MergeableCounterTable.h"
 #include "DataFormats/NanoAOD/interface/UniqueString.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-
-std::vector<int8_t> svi8;


### PR DESCRIPTION
#### PR description:

The removed line in classes.h seems useless to me, but perhaps @lgray remembers why it wass added in #36037

#### PR validation:

Scram build gives no error
