### PR TITLE
Remove TrackerAdditionalParametersPerDet_cfi from SiStripCommon unit test

### DIFF
--- a/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
+++ b/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
@@ -4,7 +4,6 @@ process = cms.Process("test")
 
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/cms-sw/cmssw/pull/40443#issuecomment-1399213245
As the title says: removed TrackerAdditionalParametersPerDet_cfi from SiStripCommon unit test

#### PR validation:

`scram b runtests` is successful`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport is needed