### PR TITLE
Protection for n<=1 in RZLine.h

### DIFF
--- a/CommonTools/Statistics/src/LinearFit.cc
+++ b/CommonTools/Statistics/src/LinearFit.cc
@@ -11,7 +11,7 @@ void LinearFit::fit(const std::vector<float>& x,
                     float& covsi) const {
   float g1 = 0, g2 = 0;
   float s11 = 0, s12 = 0, s22 = 0;
-  for (int i = 0; i != ndat; i++) {
+  for (int i = 0; i < ndat; i++) {
     float sy2 = sigy[i] * sigy[i];
     g1 += y[i] / sy2;
     g2 += x[i] * y[i] / sy2;

--- a/RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h
@@ -38,7 +38,7 @@ public:
       z[i] = p.z();
     }
 
-    float simpleCot2 = sqr((z[n - 1] - z[0]) / (r[n - 1] - r[0]));
+    float simpleCot2 = n > 1 ? sqr((z[n - 1] - z[0]) / (r[n - 1] - r[0])) : 0.f;
     for (size_t i = 0; i < n; ++i) {
       errZ2[i] = (isBarrel[i]) ? errors[i].czz() : errors[i].rerr(points[i]) * simpleCot2;
     }


### PR DESCRIPTION
#### PR description:

#40498 fixed some uninitilized value warning issued during the LTO build, originated in case `n=0` in RecoPixelVertexing/PixelTrackFitting/interface/RZLine.h
In the same file, however, there was the possibility of another bad behaviour (either accessing a value of the vector outside its range, or division by 0) in case of either `n=0` or `n=1`. It is evident that such a possibility never happend, otherwise the code would have crashed there. However, to complete the fix initiated in #40498 another protection is added in the same file.

At the same time, a further protection is added to CommonTools/Statistics/src/LinearFit.cc, so that the code won't enter an infinite loop in case the ndat passed as argument is negative. Also this case evidently never happened so far, but since I noticed I put a protection also for it.

#### PR validation:

It compiles.
No differences exected anywhere