### PR TITLE
[12.4.X] re-initialize geometry in g4e propagator as required at beginning of propagation and for each step

### DIFF
--- a/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
+++ b/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
@@ -30,6 +30,7 @@
 #include "G4TransportationManager.hh"
 #include "G4Tubs.hh"
 #include "G4UImanager.hh"
+#include "G4ErrorPropagationNavigator.hh"
 
 // CLHEP
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
@@ -311,10 +312,17 @@ std::pair<TrajectoryStateOnSurface, double> Geant4ePropagator::propagateGeneric(
 
   theG4eManager->InitTrackPropagation();
 
+  // re-initialize navigator to avoid mismatches and/or segfaults
+  theG4eManager->GetErrorPropagationNavigator()->LocateGlobalPointAndSetup(
+      g4InitPos, &g4InitMom, /*pRelativeSearch = */ false, /*ignoreDirection = */ false);
+
   bool continuePropagation = true;
   while (continuePropagation) {
     iterations++;
     LogDebug("Geant4e") << std::endl << "step count " << iterations << " step length " << finalPathLength;
+
+    // re-initialize navigator to avoid mismatches and/or segfaults
+    theG4eManager->GetErrorPropagationNavigator()->LocateGlobalPointWithinVolume(g4eTrajState.GetPosition());
 
     const int ierr = theG4eManager->PropagateOneStep(&g4eTrajState, mode);
 


### PR DESCRIPTION
#### PR description:

Adds necessary re-initialization of the geometry navigation to the G4e propagator to avoid seg-faults/undefined behaviour.
This should fix the underlying cause of https://github.com/cms-sw/cmssw/issues/31920

#### PR validation:

These initialization changes were verified to prevent segfaults in a customized version of the propagator in CMSSW_10_6_X in the context of muon calibration for mW.

For this PR directly, only checked that `TrackPropagation/Geant4e/test/simpleTestPropagator_cfg.py` still runs. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/40543 for 2022 data analysis. 