### PR TITLE
Fix of the L1uGTTreeProducer to handle exceptions in case of a missing collection

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -87,8 +87,13 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
 
   edm::Handle<GlobalAlgBlkBxCollection> ugt;
   event.getByToken(ugtToken_, ugt);
-  if (ugt.isValid()) {
+  if (ugt.isValid() && ugt.product()->size() != 0) {
     results_ = &ugt->at(0, 0);
+  } else {
+    edm::LogWarning("MissingProduct")
+        << "L1uGTTree or L1uGTTestcrateTree GlobalAlgBlkBxCollection not found. Branch will not be filled.\n"
+        << "Please note that the L1uGTTestcrateTree is not expected to exist in MC, so this warning can be ignored!"
+        << std::endl;
   }
 
   tree_->Fill();


### PR DESCRIPTION
#### PR description:
In the process of validating the [L1TNtuple recipe based on CMSSW_13_0_X](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TStage2Instructions#Environment_Setup_with_Integrati) and running on Run 3 MC samples, an error [1] related the inclusion of _l1uGTTestcrateTree_ in the L1NtupleRAW sequence equally for data and MC was occurring. In fact, the emulation for the uGT test crate does not exist and the _l1uGTTestcrateTree_ is not present in MC. 
The changes to include the uGT test crate information in L1NTuples are part of [PR#39104](https://github.com/cms-sw/cmssw/commit/855bda3f1801bf870a40be01daceec10a6dac561) and were introduced in CMSSW_12_6_X_2023-01-09-1100 and CMSSW_13_0_0_pre3, so they did not create any issue with the previous L1TNtuple recipe based on CMSSW_12_6_0_pre1.

The _cmsDriver_ command used for the tests is reported as reference:
`cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=mc_130X.py -n -1 --no_output --era=Run3 --mc --conditions=130X_mcRun3_2022_realistic_v2 --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulMCFromRAWSimHcalTP --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --customise=L1Trigger/Configuration/customiseSettings.L1TSettingsToCaloParams_2022_v0_6 --filein=/store/mc/Run3Winter22DR/SingleNeutrino_E-10-gun/GEN-SIM-DIGI-RAW/L1TPU0to99FEVT_SNB_122X_mcRun3_2021_realistic_v9-v2/70007/231dda73-3ef0-44ae-86b4-f6088c6a6018.root`

The current fix of the L1uGTTreeProducer allows to handle exceptions in case of a missing collection without breaking.
[Tagging @eyigitba who helped with the issue.]

[1]
----- Begin Fatal Exception 16-Jan-2023 12:43:01 CET-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 1 lumi: 40173 event: 4017203 stream: 0
   [1] Running path 'l1ntupleraw'
   [2] Calling method for module L1uGTTreeProducer/'l1uGTTestcrateTree'
Exception Message:
A std::exception was thrown.
vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
----- End Fatal Exception ------------------------------------------------- 



#### PR validation:
Basic tests performed successfully starting from CMSSW_13_0_X_2023-01-23-1100.
> cmsrel CMSSW_13_0_X_2023-01-23-1100
> cd CMSSW_13_0_X_2023-01-23-1100/src
> cmsenv
> git cms-addpkg L1Trigger/L1TNtuples
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests 
> scram build code-checks
> scram build code-format