### PR TITLE
get rid of `Phase2TrackerRecHit1D::CluRef`

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h
+++ b/DataFormats/TrackerRecHit2D/interface/ClusterRemovalInfo.h
@@ -14,7 +14,7 @@ namespace reco {
   public:
     typedef SiStripRecHit2D::ClusterRef::product_type SiStripClusters;
     typedef SiPixelRecHit::ClusterRef::product_type SiPixelClusters;
-    typedef Phase2TrackerRecHit1D::CluRef::product_type Phase2TrackerCluster1Ds;
+    typedef Phase2TrackerRecHit1D::ClusterRef::product_type Phase2TrackerCluster1Ds;
     typedef edm::RefProd<SiStripClusters> SiStripClusterRefProd;
     typedef edm::RefProd<SiPixelClusters> SiPixelClusterRefProd;
     typedef edm::RefProd<Phase2TrackerCluster1Ds> Phase2TrackerCluster1DRefProd;

--- a/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h
@@ -9,21 +9,20 @@
 
 class Phase2TrackerRecHit1D final : public TrackerSingleRecHit {
 public:
-  typedef OmniClusterRef::Phase2Cluster1DRef CluRef;
   typedef OmniClusterRef::Phase2Cluster1DRef ClusterRef;
 
   Phase2TrackerRecHit1D() {}
 
   ~Phase2TrackerRecHit1D() override {}
 
-  Phase2TrackerRecHit1D(const LocalPoint& pos, const LocalError& err, GeomDet const& idet, CluRef const& clus)
+  Phase2TrackerRecHit1D(const LocalPoint& pos, const LocalError& err, GeomDet const& idet, ClusterRef const& clus)
       : TrackerSingleRecHit(pos, err, idet, clus) {}
 
   Phase2TrackerRecHit1D* clone() const override { return new Phase2TrackerRecHit1D(*this); }
   RecHitPointer cloneSH() const override { return std::make_shared<Phase2TrackerRecHit1D>(*this); }
 
-  CluRef cluster() const { return cluster_phase2OT(); }
-  void setClusterRef(CluRef const& ref) { setClusterPhase2Ref(ref); }
+  ClusterRef cluster() const { return cluster_phase2OT(); }
+  void setClusterRef(ClusterRef const& ref) { setClusterPhase2Ref(ref); }
 
   bool isPhase2() const override { return true; }
   //FIXME::check dimension of this!!

--- a/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/SeedClusterRemoverPhase2.cc
@@ -115,7 +115,7 @@ void SeedClusterRemoverPhase2::process(const TrackingRecHit *hit, float chi2, co
     const Phase2TrackerRecHit1D *ph2OThit = static_cast<const Phase2TrackerRecHit1D *>(hit);
     LogDebug("SeedClusterRemoverPhase2") << "Plain Phase2TrackerRecHit1D in det " << detid.rawId();
 
-    Phase2TrackerRecHit1D::CluRef cluster = ph2OThit->cluster();
+    Phase2TrackerRecHit1D::ClusterRef cluster = ph2OThit->cluster();
     if (cluster.id() != outerTrackerSourceProdID)
       throw cms::Exception("Inconsistent Data")
           << "SeedClusterRemoverPhase2: strip cluster ref from Product ID = " << cluster.id()
@@ -135,7 +135,7 @@ void SeedClusterRemoverPhase2::process(const TrackingRecHit *hit, float chi2, co
     LogDebug("SeedClusterRemoverPhase2") << "Plain VectorHit in det " << detid.rawId();
 
     //lower cluster
-    Phase2TrackerRecHit1D::CluRef cluster = vhit->lowerCluster();
+    Phase2TrackerRecHit1D::ClusterRef cluster = vhit->lowerCluster();
     if (cluster.id() != outerTrackerSourceProdID)
       throw cms::Exception("Inconsistent Data")
           << "SeedClusterRemoverPhase2: strip cluster ref from Product ID = " << cluster.id()

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -518,7 +518,7 @@ void TrackerHitAssociator::associatePhase2TrackerRecHit(const Phase2TrackerRecHi
   auto isearch = ph2trackerdigisimlink->find(detID);
   if (isearch != ph2trackerdigisimlink->end()) {  //if it is not empty
     auto link_detset = (*isearch);
-    Phase2TrackerRecHit1D::CluRef const& cluster = rechit->cluster();
+    Phase2TrackerRecHit1D::ClusterRef const& cluster = rechit->cluster();
 
     //check the reference is valid
     if (!(cluster.isNull())) {  //if the cluster is valid


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/pull/40323 `Phase2TrackerRecHit1D::ClusterRef` had to be introduced in order to resolve this line:

https://github.com/cms-sw/cmssw/blob/79e79bde806393fcb46c9d91b111e9cc8a76bdf6/CommonTools/RecoAlgos/src/ClusterStorer.cc#L108

correctly when `HitType` is a `Phase2TrackerRecHit1D`. 
This PR drops the preexisting typedef `Phase2TrackerRecHit1D::CluRef` in favour of the new one, making the nomenclature uniform among different tracking rechit types.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A