### PR TITLE
Add a test for CUDA library build rules

### DIFF
--- a/HeterogeneousTest/CUDADevice/BuildFile.xml
+++ b/HeterogeneousTest/CUDADevice/BuildFile.xml
@@ -1,0 +1,6 @@
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</iftool>

--- a/HeterogeneousTest/CUDADevice/README.md
+++ b/HeterogeneousTest/CUDADevice/README.md
@@ -1,0 +1,54 @@
+# Introduction
+
+The packages `HeterogeneousTest/CUDADevice`, `HeterogeneousTest/CUDAKernel`,
+`HeterogeneousTest/CUDAWrapper` and `HeterogeneousTest/CUDAOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for CUDA.
+In particular, these tests show what is supported and what are the limitations implementing
+CUDA-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/CUDADevice`
+
+The package `HeterogeneousTest/CUDADevice` implements a library that defines and exports CUDA
+device-side functions:
+```c++
+namespace cms::cudatest {
+
+  __device__ void add_vectors_f(...);
+  __device__ void add_vectors_d(...);
+
+}  // namespace cms::cudatest
+```
+
+The `plugins` directory implements the `CUDATestDeviceAdditionModule` `EDAnalyzer` that launches a
+CUDA kernel using the functions defined in ths library. As a byproduct this plugin also shows how
+to split an `EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a
+device part (in a `.cu` file).
+
+The `test` directory implements the `testCudaDeviceAddition` binary that launches a CUDA kernel
+using these functions.
+It also contains the `testCUDATestDeviceAdditionModule.py` python configuration to exercise the
+`CUDATestDeviceAdditionModule` plugin.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/CUDA...` packages:
+  - [`HeterogeneousTest/CUDAKernel/README.md`](../../HeterogeneousTest/CUDAKernel/README.md)
+  - [`HeterogeneousTest/CUDAWrapper/README.md`](../../HeterogeneousTest/CUDAWrapper/README.md)
+  - [`HeterogeneousTest/CUDAOpaque/README.md`](../../HeterogeneousTest/CUDAOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/CUDAOpaque/test` contains the `testCUDATestAdditionModules.py` python
+configuration that tries to exercise all four plugins in a single application.
+Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugin and those used in
+the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
+```
+HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
+cudaCheck(cudaGetLastError());
+cudaErrorInvalidDeviceFunction: invalid device function
+```
+Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDADevice/interface/DeviceAddition.h
+++ b/HeterogeneousTest/CUDADevice/interface/DeviceAddition.h
@@ -1,0 +1,22 @@
+#ifndef HeterogeneousTest_CUDADevice_interface_DeviceAddition_h
+#define HeterogeneousTest_CUDADevice_interface_DeviceAddition_h
+
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+namespace cms::cudatest {
+
+  __device__ void add_vectors_f(const float* __restrict__ in1,
+                                const float* __restrict__ in2,
+                                float* __restrict__ out,
+                                size_t size);
+
+  __device__ void add_vectors_d(const double* __restrict__ in1,
+                                const double* __restrict__ in2,
+                                double* __restrict__ out,
+                                size_t size);
+
+}  // namespace cms::cudatest
+
+#endif  // HeterogeneousTest_CUDADevice_interface_DeviceAddition_h

--- a/HeterogeneousTest/CUDADevice/plugins/BuildFile.xml
+++ b/HeterogeneousTest/CUDADevice/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<iftool name="cuda-gcc-support">
+  <library file="*.cc *.cu" name="HeterogeneousTestCUDADevicePlugins">
+    <use name="cuda"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousTest/CUDADevice"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
@@ -1,0 +1,27 @@
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDADevice/interface/DeviceAddition.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "CUDATestDeviceAdditionAlgo.h"
+
+namespace HeterogeneousCoreCUDATestDevicePlugins {
+
+  __global__ void kernel_add_vectors_f(const float* __restrict__ in1,
+                                       const float* __restrict__ in2,
+                                       float* __restrict__ out,
+                                       size_t size) {
+    cms::cudatest::add_vectors_f(in1, in2, out, size);
+  }
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size) {
+    kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
+    cudaCheck(cudaGetLastError());
+  }
+
+}  // namespace HeterogeneousCoreCUDATestDevicePlugins

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.h
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.h
@@ -1,0 +1,15 @@
+#ifndef HeterogeneousTest_CUDADevice_plugins_CUDATestDeviceAdditionAlgo_h
+#define HeterogeneousTest_CUDADevice_plugins_CUDATestDeviceAdditionAlgo_h
+
+#include <cstddef>
+
+namespace HeterogeneousCoreCUDATestDevicePlugins {
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size);
+
+}  // namespace HeterogeneousCoreCUDATestDevicePlugins
+
+#endif  // HeterogeneousTest_CUDADevice_plugins_CUDATestDeviceAdditionAlgo_h

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
@@ -1,0 +1,106 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "CUDATestDeviceAdditionAlgo.h"
+
+class CUDATestDeviceAdditionModule : public edm::global::EDAnalyzer<> {
+public:
+  explicit CUDATestDeviceAdditionModule(edm::ParameterSet const& config);
+  ~CUDATestDeviceAdditionModule() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+private:
+  const uint32_t size_;
+};
+
+CUDATestDeviceAdditionModule::CUDATestDeviceAdditionModule(edm::ParameterSet const& config)
+    : size_(config.getParameter<uint32_t>("size")) {}
+
+void CUDATestDeviceAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<uint32_t>("size", 1024 * 1024);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void CUDATestDeviceAdditionModule::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const {
+  // require CUDA for running
+  edm::Service<CUDAService> cs;
+  if (not cs->enabled()) {
+    std::cout << "The CUDAService is disabled, the test will be skipped.\n";
+    return;
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size_);
+  std::vector<float> in2_h(size_);
+  std::vector<float> out_h(size_);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size_; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // allocate input and output buffers on the device
+  float* in1_d;
+  float* in2_d;
+  float* out_d;
+  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+
+  // copy the input data to the device
+  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+
+  // fill the output buffer with zeros
+  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+
+  // launch the 1-dimensional kernel for vector addition
+  HeterogeneousCoreCUDATestDevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+
+  // copy the results from the device to the host
+  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+
+  // wait for all the operations to complete
+  cudaCheck(cudaDeviceSynchronize());
+
+  // check the results
+  for (size_t i = 0; i < size_; ++i) {
+    float sum = in1_h[i] + in2_h[i];
+    assert(out_h[i] < sum + epsilon);
+    assert(out_h[i] > sum - epsilon);
+  }
+
+  std::cout << "All tests passed.\n";
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CUDATestDeviceAdditionModule);

--- a/HeterogeneousTest/CUDADevice/src/DeviceAddition.cu
+++ b/HeterogeneousTest/CUDADevice/src/DeviceAddition.cu
@@ -1,0 +1,34 @@
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDADevice/interface/DeviceAddition.h"
+
+namespace cms::cudatest {
+
+  __device__ void add_vectors_f(const float* __restrict__ in1,
+                                const float* __restrict__ in2,
+                                float* __restrict__ out,
+                                size_t size) {
+    uint32_t thread = threadIdx.x + blockIdx.x * blockDim.x;
+    uint32_t stride = blockDim.x * gridDim.x;
+
+    for (size_t i = thread; i < size; i += stride) {
+      out[i] = in1[i] + in2[i];
+    }
+  }
+
+  __device__ void add_vectors_d(const double* __restrict__ in1,
+                                const double* __restrict__ in2,
+                                double* __restrict__ out,
+                                size_t size) {
+    uint32_t thread = threadIdx.x + blockIdx.x * blockDim.x;
+    uint32_t stride = blockDim.x * gridDim.x;
+
+    for (size_t i = thread; i < size; i += stride) {
+      out[i] = in1[i] + in2[i];
+    }
+  }
+
+}  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDADevice/test/BuildFile.xml
+++ b/HeterogeneousTest/CUDADevice/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<iftool name="cuda-gcc-support">
+  <bin file="testDeviceAddition.cu" name="testCudaDeviceAddition">
+    <use name="catch2"/>
+    <use name="cuda"/>
+    <use name="HeterogeneousTest/CUDADevice"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+  </bin>
+
+  <test name="testCUDATestDeviceAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/CUDADevice/test/testCUDATestDeviceAdditionModule.py"/>
+</iftool>

--- a/HeterogeneousTest/CUDADevice/test/testCUDATestDeviceAdditionModule.py
+++ b/HeterogeneousTest/CUDADevice/test/testCUDATestDeviceAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestCUDATestDeviceAdditionModule')
+
+process.source = cms.Source('EmptySource')
+
+process.CUDAService = cms.Service('CUDAService')
+
+process.cudaTestDeviceAdditionModule = cms.EDAnalyzer('CUDATestDeviceAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.cudaTestDeviceAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
+++ b/HeterogeneousTest/CUDADevice/test/testDeviceAddition.cu
@@ -1,0 +1,80 @@
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDADevice/interface/DeviceAddition.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+__global__ void kernel_add_vectors_f(const float* __restrict__ in1,
+                                     const float* __restrict__ in2,
+                                     float* __restrict__ out,
+                                     size_t size) {
+  cms::cudatest::add_vectors_f(in1, in2, out, size);
+}
+
+TEST_CASE("HeterogeneousTest/CUDADevice test", "[cudaTestDeviceAddition]") {
+  cms::cudatest::requireDevices();
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr size_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  SECTION("Test add_vectors_f") {
+    // allocate input and output buffers on the device
+    float* in1_d;
+    float* in2_d;
+    float* out_d;
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+
+    // copy the input data to the device
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+
+    // fill the output buffer with zeros
+    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+
+    // launch the 1-dimensional kernel for vector addition
+    kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
+    REQUIRE_NOTHROW(cudaCheck(cudaGetLastError()));
+
+    // copy the results from the device to the host
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+
+    // wait for all the operations to complete
+    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+
+    // check the results
+    for (size_t i = 0; i < size; ++i) {
+      float sum = in1_h[i] + in2_h[i];
+      CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+    }
+  }
+}

--- a/HeterogeneousTest/CUDAKernel/BuildFile.xml
+++ b/HeterogeneousTest/CUDAKernel/BuildFile.xml
@@ -1,0 +1,7 @@
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <use name="HeterogeneousTest/CUDADevice"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</iftool>

--- a/HeterogeneousTest/CUDAKernel/README.md
+++ b/HeterogeneousTest/CUDAKernel/README.md
@@ -1,0 +1,54 @@
+# Introduction
+
+The packages `HeterogeneousTest/CUDADevice`, `HeterogeneousTest/CUDAKernel`,
+`HeterogeneousTest/CUDAWrapper` and `HeterogeneousTest/CUDAOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for CUDA.
+In particular, these tests show what is supported and what are the limitations implementing
+CUDA-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/CUDAKernel`
+
+The package `HeterogeneousTest/CUDAKernel` implements a library that defines and exports CUDA
+kernels that call the device functions defined in the `HeterogeneousTest/CUDADevice` library:
+```c++
+namespace cms::cudatest {
+
+  __global__ void kernel_add_vectors_f(...);
+  __global__ void kernel_add_vectors_d(...);
+
+}  // namespace cms::cudatest
+```
+
+The `plugins` directory implements the `CUDATestKernelAdditionModule` `EDAnalyzer` that launches the
+CUDA kernels defined in this library. As a byproduct this plugin also shows how to split an
+`EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a device part (in
+a `.cu` file).
+
+The `test` directory implements the `testCudaKernelAddition` test binary that launches the CUDA kernel
+defined in this library.
+It also contains the `testCUDATestKernelAdditionModule.py` python configuration to exercise the
+`CUDATestKernelAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/CUDA...` packages:
+  - [`HeterogeneousTest/CUDADevice/README.md`](../../HeterogeneousTest/CUDADevice/README.md)
+  - [`HeterogeneousTest/CUDAWrapper/README.md`](../../HeterogeneousTest/CUDAWrapper/README.md)
+  - [`HeterogeneousTest/CUDAOpaque/README.md`](../../HeterogeneousTest/CUDAOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/CUDAOpaque/test` contains the `testCUDATestAdditionModules.py` python
+configuration that tries to exercise all four plugins in a single application.
+Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugin and those used in
+the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
+```
+HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
+cudaCheck(cudaGetLastError());
+cudaErrorInvalidDeviceFunction: invalid device function
+```
+Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h
+++ b/HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h
@@ -1,0 +1,22 @@
+#ifndef HeterogeneousTest_CUDAKernel_interface_DeviceAdditionKernel_h
+#define HeterogeneousTest_CUDAKernel_interface_DeviceAdditionKernel_h
+
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+namespace cms::cudatest {
+
+  __global__ void kernel_add_vectors_f(const float* __restrict__ in1,
+                                       const float* __restrict__ in2,
+                                       float* __restrict__ out,
+                                       size_t size);
+
+  __global__ void kernel_add_vectors_d(const double* __restrict__ in1,
+                                       const double* __restrict__ in2,
+                                       double* __restrict__ out,
+                                       size_t size);
+
+}  // namespace cms::cudatest
+
+#endif  // HeterogeneousTest_CUDAKernel_interface_DeviceAdditionKernel_h

--- a/HeterogeneousTest/CUDAKernel/plugins/BuildFile.xml
+++ b/HeterogeneousTest/CUDAKernel/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<iftool name="cuda-gcc-support">
+  <library file="*.cc *.cu" name="HeterogeneousTestCUDAKernelPlugins">
+    <use name="cuda"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousTest/CUDAKernel"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
@@ -1,0 +1,20 @@
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "CUDATestKernelAdditionAlgo.h"
+
+namespace HeterogeneousCoreCUDATestKernelPlugins {
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size) {
+    cms::cudatest::kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
+    cudaCheck(cudaGetLastError());
+  }
+
+}  // namespace HeterogeneousCoreCUDATestKernelPlugins

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.h
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.h
@@ -1,0 +1,15 @@
+#ifndef HeterogeneousTest_CUDAKernel_plugins_CUDATestKernelAdditionAlgo_h
+#define HeterogeneousTest_CUDAKernel_plugins_CUDATestKernelAdditionAlgo_h
+
+#include <cstddef>
+
+namespace HeterogeneousCoreCUDATestKernelPlugins {
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size);
+
+}  // namespace HeterogeneousCoreCUDATestKernelPlugins
+
+#endif  // HeterogeneousTest_CUDAKernel_plugins_CUDATestKernelAdditionAlgo_h

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
@@ -1,0 +1,106 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "CUDATestKernelAdditionAlgo.h"
+
+class CUDATestKernelAdditionModule : public edm::global::EDAnalyzer<> {
+public:
+  explicit CUDATestKernelAdditionModule(edm::ParameterSet const& config);
+  ~CUDATestKernelAdditionModule() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+private:
+  const uint32_t size_;
+};
+
+CUDATestKernelAdditionModule::CUDATestKernelAdditionModule(edm::ParameterSet const& config)
+    : size_(config.getParameter<uint32_t>("size")) {}
+
+void CUDATestKernelAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<uint32_t>("size", 1024 * 1024);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void CUDATestKernelAdditionModule::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const {
+  // require CUDA for running
+  edm::Service<CUDAService> cs;
+  if (not cs->enabled()) {
+    std::cout << "The CUDAService is disabled, the test will be skipped.\n";
+    return;
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size_);
+  std::vector<float> in2_h(size_);
+  std::vector<float> out_h(size_);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size_; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // allocate input and output buffers on the device
+  float* in1_d;
+  float* in2_d;
+  float* out_d;
+  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+
+  // copy the input data to the device
+  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+
+  // fill the output buffer with zeros
+  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+
+  // launch the 1-dimensional kernel for vector addition
+  HeterogeneousCoreCUDATestKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+
+  // copy the results from the device to the host
+  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+
+  // wait for all the operations to complete
+  cudaCheck(cudaDeviceSynchronize());
+
+  // check the results
+  for (size_t i = 0; i < size_; ++i) {
+    float sum = in1_h[i] + in2_h[i];
+    assert(out_h[i] < sum + epsilon);
+    assert(out_h[i] > sum - epsilon);
+  }
+
+  std::cout << "All tests passed.\n";
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CUDATestKernelAdditionModule);

--- a/HeterogeneousTest/CUDAKernel/src/DeviceAdditionKernel.cu
+++ b/HeterogeneousTest/CUDAKernel/src/DeviceAdditionKernel.cu
@@ -1,0 +1,24 @@
+#include <cstddef>
+
+#include <cuda.h>
+
+#include "HeterogeneousTest/CUDADevice/interface/DeviceAddition.h"
+#include "HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h"
+
+namespace cms::cudatest {
+
+  __global__ void kernel_add_vectors_f(const float* __restrict__ in1,
+                                       const float* __restrict__ in2,
+                                       float* __restrict__ out,
+                                       size_t size) {
+    add_vectors_f(in1, in2, out, size);
+  }
+
+  __global__ void kernel_add_vectors_d(const double* __restrict__ in1,
+                                       const double* __restrict__ in2,
+                                       double* __restrict__ out,
+                                       size_t size) {
+    add_vectors_d(in1, in2, out, size);
+  }
+
+}  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDAKernel/test/BuildFile.xml
+++ b/HeterogeneousTest/CUDAKernel/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<iftool name="cuda-gcc-support">
+  <bin file="testDeviceAdditionKernel.cu" name="testCudaDeviceAdditionKernel">
+    <use name="catch2"/>
+    <use name="cuda"/>
+    <use name="HeterogeneousTest/CUDAKernel"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+  </bin>
+
+  <test name="testCUDATestKernelAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/CUDAKernel/test/testCUDATestKernelAdditionModule.py"/>
+</iftool>

--- a/HeterogeneousTest/CUDAKernel/test/testCUDATestKernelAdditionModule.py
+++ b/HeterogeneousTest/CUDAKernel/test/testCUDATestKernelAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestCUDATestKernelAdditionModule')
+
+process.source = cms.Source('EmptySource')
+
+process.CUDAService = cms.Service('CUDAService')
+
+process.cudaTestKernelAdditionModule = cms.EDAnalyzer('CUDATestKernelAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.cudaTestKernelAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
+++ b/HeterogeneousTest/CUDAKernel/test/testDeviceAdditionKernel.cu
@@ -1,0 +1,73 @@
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+TEST_CASE("HeterogeneousTest/CUDAKernel test", "[cudaTestKernelAdditionKernel]") {
+  cms::cudatest::requireDevices();
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr size_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  SECTION("Test add_vectors_f") {
+    // allocate input and output buffers on the device
+    float* in1_d;
+    float* in2_d;
+    float* out_d;
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+
+    // copy the input data to the device
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+
+    // fill the output buffer with zeros
+    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+
+    // launch the 1-dimensional kernel for vector addition
+    cms::cudatest::kernel_add_vectors_f<<<32, 32>>>(in1_d, in2_d, out_d, size);
+    REQUIRE_NOTHROW(cudaCheck(cudaGetLastError()));
+
+    // copy the results from the device to the host
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+
+    // wait for all the operations to complete
+    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+
+    // check the results
+    for (size_t i = 0; i < size; ++i) {
+      float sum = in1_h[i] + in2_h[i];
+      CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+    }
+  }
+}

--- a/HeterogeneousTest/CUDAOpaque/BuildFile.xml
+++ b/HeterogeneousTest/CUDAOpaque/BuildFile.xml
@@ -1,0 +1,8 @@
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <use name="HeterogeneousTest/CUDAWrapper"/>
+  <use name="HeterogeneousCore/CUDAUtilities" source_only="true"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</iftool>

--- a/HeterogeneousTest/CUDAOpaque/README.md
+++ b/HeterogeneousTest/CUDAOpaque/README.md
@@ -1,0 +1,54 @@
+# Introduction
+
+The packages `HeterogeneousTest/CUDADevice`, `HeterogeneousTest/CUDAKernel`,
+`HeterogeneousTest/CUDAWrapper` and `HeterogeneousTest/CUDAOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for CUDA.
+In particular, these tests show what is supported and what are the limitations implementing
+CUDA-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/CUDAOpaque`
+
+The package `HeterogeneousTest/CUDAOpaque` implements a non-CUDA aware library, with functions that
+call the wrappers defined in the `HeterogeneousTest/CUDAWrapper` library:
+```c++
+namespace cms::cudatest {
+
+  void opaque_add_vectors_f(...);
+  void opaque_add_vectors_d(...);
+
+}  // namespace cms::cudatest
+```
+
+The `plugins` directory implements the `CUDATestOpqaueAdditionModule` `EDAnalyzer` that calls the 
+function defined in this library. This plugin shows how the function can be used directly from a 
+host-only, non-CUDA aware plugin.
+
+The `test` directory implements the `testCudaDeviceAdditionOpqaue` test binary that calls the
+function defined in this library, and shows how they can be used directly from a host-only, non-CUDA
+aware application.
+It also contains the `testCUDATestOpqaueAdditionModule.py` python configuration to exercise the
+`CUDATestOpqaueAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/CUDA...` packages:
+  - [`HeterogeneousTest/CUDADevice/README.md`](../../HeterogeneousTest/CUDADevice/README.md)
+  - [`HeterogeneousTest/CUDAKernel/README.md`](../../HeterogeneousTest/CUDAKernel/README.md)
+  - [`HeterogeneousTest/CUDAWrapper/README.md`](../../HeterogeneousTest/CUDAWrapper/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/CUDAOpaque/test` contains also the `testCUDATestAdditionModules.py` python
+configuration that tries to exercise all four plugins in a single application.
+Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugin and those used in
+the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
+```
+HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
+cudaCheck(cudaGetLastError());
+cudaErrorInvalidDeviceFunction: invalid device function
+```
+Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h
+++ b/HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h
@@ -1,0 +1,14 @@
+#ifndef HeterogeneousTest_CUDAOpaque_interface_DeviceAdditionOpaque_h
+#define HeterogeneousTest_CUDAOpaque_interface_DeviceAdditionOpaque_h
+
+#include <cstddef>
+
+namespace cms::cudatest {
+
+  void opaque_add_vectors_f(const float* in1, const float* in2, float* out, size_t size);
+
+  void opaque_add_vectors_d(const double* in1, const double* in2, double* out, size_t size);
+
+}  // namespace cms::cudatest
+
+#endif  // HeterogeneousTest_CUDAOpaque_interface_DeviceAdditionOpaque_h

--- a/HeterogeneousTest/CUDAOpaque/plugins/BuildFile.xml
+++ b/HeterogeneousTest/CUDAOpaque/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<iftool name="cuda-gcc-support">
+  <library file="*.cc" name="HeterogeneousTestCUDAOpaquePlugins">
+    <use name="cuda"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousTest/CUDAOpaque"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>

--- a/HeterogeneousTest/CUDAOpaque/plugins/CUDATestOpaqueAdditionModule.cc
+++ b/HeterogeneousTest/CUDAOpaque/plugins/CUDATestOpaqueAdditionModule.cc
@@ -1,0 +1,81 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h"
+
+class CUDATestOpaqueAdditionModule : public edm::global::EDAnalyzer<> {
+public:
+  explicit CUDATestOpaqueAdditionModule(edm::ParameterSet const& config);
+  ~CUDATestOpaqueAdditionModule() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+private:
+  const uint32_t size_;
+};
+
+CUDATestOpaqueAdditionModule::CUDATestOpaqueAdditionModule(edm::ParameterSet const& config)
+    : size_(config.getParameter<uint32_t>("size")) {}
+
+void CUDATestOpaqueAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<uint32_t>("size", 1024 * 1024);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void CUDATestOpaqueAdditionModule::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const {
+  // require CUDA for running
+  edm::Service<CUDAService> cs;
+  if (not cs->enabled()) {
+    std::cout << "The CUDAService is disabled, the test will be skipped.\n";
+    return;
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // allocate input and output host buffers
+  std::vector<float> in1(size_);
+  std::vector<float> in2(size_);
+  std::vector<float> out(size_);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size_; ++i) {
+    in1[i] = dist(rand);
+    in2[i] = dist(rand);
+    out[i] = 0.;
+  }
+
+  // launch the 1-dimensional kernel for vector addition
+  cms::cudatest::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size_);
+
+  // check the results
+  for (size_t i = 0; i < size_; ++i) {
+    float sum = in1[i] + in2[i];
+    assert(out[i] < sum + epsilon);
+    assert(out[i] > sum - epsilon);
+  }
+
+  std::cout << "All tests passed.\n";
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CUDATestOpaqueAdditionModule);

--- a/HeterogeneousTest/CUDAOpaque/src/DeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/CUDAOpaque/src/DeviceAdditionOpaque.cc
@@ -1,0 +1,73 @@
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h"
+#include "HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h"
+
+namespace cms::cudatest {
+
+  void opaque_add_vectors_f(const float* in1_h, const float* in2_h, float* out_h, size_t size) {
+    // allocate input and output buffers on the device
+    float* in1_d;
+    float* in2_d;
+    float* out_d;
+    cudaCheck(cudaMalloc(&in1_d, size * sizeof(float)));
+    cudaCheck(cudaMalloc(&in2_d, size * sizeof(float)));
+    cudaCheck(cudaMalloc(&out_d, size * sizeof(float)));
+
+    // copy the input data to the device
+    cudaCheck(cudaMemcpy(in1_d, in1_h, size * sizeof(float), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(in2_d, in2_h, size * sizeof(float), cudaMemcpyHostToDevice));
+
+    // fill the output buffer with zeros
+    cudaCheck(cudaMemset(out_d, 0, size * sizeof(float)));
+
+    // launch the 1-dimensional kernel for vector addition
+    wrapper_add_vectors_f(in1_d, in2_d, out_d, size);
+
+    // copy the results from the device to the host
+    cudaCheck(cudaMemcpy(out_h, out_d, size * sizeof(float), cudaMemcpyDeviceToHost));
+
+    // wait for all the operations to complete
+    cudaCheck(cudaDeviceSynchronize());
+
+    // free the input and output buffers on the device
+    cudaCheck(cudaFree(in1_d));
+    cudaCheck(cudaFree(in2_d));
+    cudaCheck(cudaFree(out_d));
+  }
+
+  void opaque_add_vectors_d(const double* in1_h, const double* in2_h, double* out_h, size_t size) {
+    // allocate input and output buffers on the device
+    double* in1_d;
+    double* in2_d;
+    double* out_d;
+    cudaCheck(cudaMalloc(&in1_d, size * sizeof(double)));
+    cudaCheck(cudaMalloc(&in2_d, size * sizeof(double)));
+    cudaCheck(cudaMalloc(&out_d, size * sizeof(double)));
+
+    // copy the input data to the device
+    cudaCheck(cudaMemcpy(in1_d, in1_h, size * sizeof(double), cudaMemcpyHostToDevice));
+    cudaCheck(cudaMemcpy(in2_d, in2_h, size * sizeof(double), cudaMemcpyHostToDevice));
+
+    // fill the output buffer with zeros
+    cudaCheck(cudaMemset(out_d, 0, size * sizeof(double)));
+
+    // launch the 1-dimensional kernel for vector addition
+    wrapper_add_vectors_d(in1_d, in2_d, out_d, size);
+
+    // copy the results from the device to the host
+    cudaCheck(cudaMemcpy(out_h, out_d, size * sizeof(double), cudaMemcpyDeviceToHost));
+
+    // wait for all the operations to complete
+    cudaCheck(cudaDeviceSynchronize());
+
+    // free the input and output buffers on the device
+    cudaCheck(cudaFree(in1_d));
+    cudaCheck(cudaFree(in2_d));
+    cudaCheck(cudaFree(out_d));
+  }
+
+}  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDAOpaque/test/BuildFile.xml
+++ b/HeterogeneousTest/CUDAOpaque/test/BuildFile.xml
@@ -1,0 +1,11 @@
+<iftool name="cuda-gcc-support">
+  <bin file="testDeviceAdditionOpaque.cc" name="testCudaDeviceAdditionOpaque">
+    <use name="catch2"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousTest/CUDAOpaque"/>
+  </bin>
+
+  <test name="testCUDATestOpaqueAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/CUDAOpaque/test/testCUDATestOpaqueAdditionModule.py"/>
+
+  <test name="testCUDATestAdditionModules" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/CUDAOpaque/test/testCUDATestAdditionModules.py"/>
+</iftool>

--- a/HeterogeneousTest/CUDAOpaque/test/testCUDATestAdditionModules.py
+++ b/HeterogeneousTest/CUDAOpaque/test/testCUDATestAdditionModules.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestCUDATestOpaqueAdditionModule')
+
+process.source = cms.Source('EmptySource')
+
+process.CUDAService = cms.Service('CUDAService')
+
+process.cudaTestDeviceAdditionModule = cms.EDAnalyzer('CUDATestDeviceAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.cudaTestKernelAdditionModule = cms.EDAnalyzer('CUDATestKernelAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.cudaTestWrapperAdditionModule = cms.EDAnalyzer('CUDATestWrapperAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.cudaTestOpaqueAdditionModule = cms.EDAnalyzer('CUDATestOpaqueAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(
+    # this one fails with "cudaErrorInvalidDeviceFunction: invalid device function"
+    #process.cudaTestDeviceAdditionModule +
+    process.cudaTestKernelAdditionModule +
+    process.cudaTestWrapperAdditionModule +
+    process.cudaTestOpaqueAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDAOpaque/test/testCUDATestOpaqueAdditionModule.py
+++ b/HeterogeneousTest/CUDAOpaque/test/testCUDATestOpaqueAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestCUDATestOpaqueAdditionModule')
+
+process.source = cms.Source('EmptySource')
+
+process.CUDAService = cms.Service('CUDAService')
+
+process.cudaTestOpaqueAdditionModule = cms.EDAnalyzer('CUDATestOpaqueAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.cudaTestOpaqueAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDAOpaque/test/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/CUDAOpaque/test/testDeviceAdditionOpaque.cc
@@ -1,0 +1,48 @@
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+#include "HeterogeneousTest/CUDAOpaque/interface/DeviceAdditionOpaque.h"
+
+TEST_CASE("HeterogeneousTest/CUDAOpaque test", "[cudaTestOpaqueAdditionOpaque]") {
+  cms::cudatest::requireDevices();
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr size_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1(size);
+  std::vector<float> in2(size);
+  std::vector<float> out(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size; ++i) {
+    in1[i] = dist(rand);
+    in2[i] = dist(rand);
+    out[i] = 0.;
+  }
+
+  SECTION("Test add_vectors_f") {
+    // launch the 1-dimensional kernel for vector addition
+    REQUIRE_NOTHROW(cms::cudatest::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size));
+
+    // check the results
+    for (size_t i = 0; i < size; ++i) {
+      float sum = in1[i] + in2[i];
+      CHECK_THAT(out[i], Catch::Matchers::WithinAbs(sum, epsilon));
+    }
+  }
+}

--- a/HeterogeneousTest/CUDAWrapper/BuildFile.xml
+++ b/HeterogeneousTest/CUDAWrapper/BuildFile.xml
@@ -1,0 +1,8 @@
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <use name="HeterogeneousTest/CUDAKernel"/>
+  <use name="HeterogeneousCore/CUDAUtilities" source_only="true"/>
+  <export>
+    <lib name="1"/>
+  </export>
+</iftool>

--- a/HeterogeneousTest/CUDAWrapper/README.md
+++ b/HeterogeneousTest/CUDAWrapper/README.md
@@ -1,0 +1,56 @@
+# Introduction
+
+The packages `HeterogeneousTest/CUDADevice`, `HeterogeneousTest/CUDAKernel`,
+`HeterogeneousTest/CUDAWrapper` and `HeterogeneousTest/CUDAOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for CUDA.
+In particular, these tests show what is supported and what are the limitations implementing
+CUDA-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/CUDAWrapper`
+
+The package `HeterogeneousTest/CUDAWrapper` implements a library that defines and exports host-side
+wrappers that launch the kernels defined in the `HeterogeneousTest/CUDAKernel` library:
+```c++
+namespace cms::cudatest {
+
+  void wrapper_add_vectors_f(...);
+  void wrapper_add_vectors_d(...);
+
+}  // namespace cms::cudatest
+```
+These wrappers can be used from host-only, non-CUDA aware libraries, plugins and applications. They
+can be linked with the standard host linker.
+
+The `plugins` directory implements the `CUDATestWrapperAdditionModule` `EDAnalyzer` that calls the
+wrappers defined in this library. This plugin shows how the wrappers can be used directly from a
+host-only, non-CUDA aware plugin.
+
+The `test` directory implements the `testCudaDeviceAdditionWrapper` test binary that calls the
+wrappers defined in this library, and shows how they can be used directly from a host-only, non-CUDA
+aware application.
+It also contains the `testCUDATestWrapperAdditionModule.py` python configuration to exercise the
+`CUDATestWrapperAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/CUDA...` packages:
+  - [`HeterogeneousTest/CUDADevice/README.md`](../../HeterogeneousTest/CUDADevice/README.md)
+  - [`HeterogeneousTest/CUDAKernel/README.md`](../../HeterogeneousTest/CUDAKernel/README.md)
+  - [`HeterogeneousTest/CUDAOpaque/README.md`](../../HeterogeneousTest/CUDAOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/CUDAOpaque/test` contains the `testCUDATestAdditionModules.py` python
+configuration that tries to exercise all four plugins in a single application.
+Unfortunately, the CUDA kernels used in the `CUDATestDeviceAdditionModule` plugin and those used in
+the `HeterogeneousTest/CUDAKernel` library run into some kind of conflict, leading to the error
+```
+HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu, line 17:
+cudaCheck(cudaGetLastError());
+cudaErrorInvalidDeviceFunction: invalid device function
+```
+Using together the other three plugins does work correctly.

--- a/HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h
+++ b/HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h
@@ -1,0 +1,20 @@
+#ifndef HeterogeneousTest_CUDAWrapper_interface_DeviceAdditionWrapper_h
+#define HeterogeneousTest_CUDAWrapper_interface_DeviceAdditionWrapper_h
+
+#include <cstddef>
+
+namespace cms::cudatest {
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size);
+
+  void wrapper_add_vectors_d(const double* __restrict__ in1,
+                             const double* __restrict__ in2,
+                             double* __restrict__ out,
+                             size_t size);
+
+}  // namespace cms::cudatest
+
+#endif  // HeterogeneousTest_CUDAWrapper_interface_DeviceAdditionWrapper_h

--- a/HeterogeneousTest/CUDAWrapper/plugins/BuildFile.xml
+++ b/HeterogeneousTest/CUDAWrapper/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<iftool name="cuda-gcc-support">
+  <library file="*.cc" name="HeterogeneousTestCUDAWrapperPlugins">
+    <use name="cuda"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+    <use name="HeterogeneousTest/CUDAWrapper"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>

--- a/HeterogeneousTest/CUDAWrapper/plugins/CUDATestWrapperAdditionModule.cc
+++ b/HeterogeneousTest/CUDAWrapper/plugins/CUDATestWrapperAdditionModule.cc
@@ -1,0 +1,107 @@
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+class CUDATestWrapperAdditionModule : public edm::global::EDAnalyzer<> {
+public:
+  explicit CUDATestWrapperAdditionModule(edm::ParameterSet const& config);
+  ~CUDATestWrapperAdditionModule() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+private:
+  const uint32_t size_;
+};
+
+CUDATestWrapperAdditionModule::CUDATestWrapperAdditionModule(edm::ParameterSet const& config)
+    : size_(config.getParameter<uint32_t>("size")) {}
+
+void CUDATestWrapperAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<uint32_t>("size", 1024 * 1024);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void CUDATestWrapperAdditionModule::analyze(edm::StreamID,
+                                            edm::Event const& event,
+                                            edm::EventSetup const& setup) const {
+  // require CUDA for running
+  edm::Service<CUDAService> cs;
+  if (not cs->enabled()) {
+    std::cout << "The CUDAService is disabled, the test will be skipped.\n";
+    return;
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size_);
+  std::vector<float> in2_h(size_);
+  std::vector<float> out_h(size_);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size_; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // allocate input and output buffers on the device
+  float* in1_d;
+  float* in2_d;
+  float* out_d;
+  cudaCheck(cudaMalloc(&in1_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&in2_d, size_ * sizeof(float)));
+  cudaCheck(cudaMalloc(&out_d, size_ * sizeof(float)));
+
+  // copy the input data to the device
+  cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+  cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size_ * sizeof(float), cudaMemcpyHostToDevice));
+
+  // fill the output buffer with zeros
+  cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
+
+  // launch the 1-dimensional kernel for vector addition
+  cms::cudatest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+
+  // copy the results from the device to the host
+  cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));
+
+  // wait for all the operations to complete
+  cudaCheck(cudaDeviceSynchronize());
+
+  // check the results
+  for (size_t i = 0; i < size_; ++i) {
+    float sum = in1_h[i] + in2_h[i];
+    assert(out_h[i] < sum + epsilon);
+    assert(out_h[i] > sum - epsilon);
+  }
+
+  std::cout << "All tests passed.\n";
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CUDATestWrapperAdditionModule);

--- a/HeterogeneousTest/CUDAWrapper/src/DeviceAdditionWrapper.cu
+++ b/HeterogeneousTest/CUDAWrapper/src/DeviceAdditionWrapper.cu
@@ -1,0 +1,29 @@
+#include <cstddef>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDAKernel/interface/DeviceAdditionKernel.h"
+#include "HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+namespace cms::cudatest {
+
+  void wrapper_add_vectors_f(const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             size_t size) {
+    // launch the 1-dimensional kernel for vector addition
+    kernel_add_vectors_f<<<32, 32>>>(in1, in2, out, size);
+    cudaCheck(cudaGetLastError());
+  }
+
+  void wrapper_add_vectors_d(const double* __restrict__ in1,
+                             const double* __restrict__ in2,
+                             double* __restrict__ out,
+                             size_t size) {
+    // launch the 1-dimensional kernel for vector addition
+    kernel_add_vectors_d<<<32, 32>>>(in1, in2, out, size);
+    cudaCheck(cudaGetLastError());
+  }
+
+}  // namespace cms::cudatest

--- a/HeterogeneousTest/CUDAWrapper/test/BuildFile.xml
+++ b/HeterogeneousTest/CUDAWrapper/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<iftool name="cuda-gcc-support">
+  <bin file="testDeviceAdditionWrapper.cc" name="testCudaDeviceAdditionWrapper">
+    <use name="catch2"/>
+    <use name="cuda"/>
+    <use name="HeterogeneousTest/CUDAWrapper"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+  </bin>
+
+  <test name="testCUDATestWrapperAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/CUDAWrapper/test/testCUDATestWrapperAdditionModule.py"/>
+</iftool>

--- a/HeterogeneousTest/CUDAWrapper/test/testCUDATestWrapperAdditionModule.py
+++ b/HeterogeneousTest/CUDAWrapper/test/testCUDATestWrapperAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestCUDATestWrapperAdditionModule')
+
+process.source = cms.Source('EmptySource')
+
+process.CUDAService = cms.Service('CUDAService')
+
+process.cudaTestWrapperAdditionModule = cms.EDAnalyzer('CUDATestWrapperAdditionModule',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.cudaTestWrapperAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/CUDAWrapper/test/testDeviceAdditionWrapper.cc
@@ -1,0 +1,72 @@
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <cuda_runtime.h>
+
+#include "HeterogeneousTest/CUDAWrapper/interface/DeviceAdditionWrapper.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+TEST_CASE("HeterogeneousTest/CUDAWrapper test", "[cudaTestWrapperAdditionWrapper]") {
+  cms::cudatest::requireDevices();
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr size_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (size_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  SECTION("Test add_vectors_f") {
+    // allocate input and output buffers on the device
+    float* in1_d;
+    float* in2_d;
+    float* out_d;
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in1_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&in2_d, size * sizeof(float))));
+    REQUIRE_NOTHROW(cudaCheck(cudaMalloc(&out_d, size * sizeof(float))));
+
+    // copy the input data to the device
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in1_d, in1_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(in2_d, in2_h.data(), size * sizeof(float), cudaMemcpyHostToDevice)));
+
+    // fill the output buffer with zeros
+    REQUIRE_NOTHROW(cudaCheck(cudaMemset(out_d, 0, size * sizeof(float))));
+
+    // launch the 1-dimensional kernel for vector addition
+    REQUIRE_NOTHROW(cms::cudatest::wrapper_add_vectors_f(in1_d, in2_d, out_d, size));
+
+    // copy the results from the device to the host
+    REQUIRE_NOTHROW(cudaCheck(cudaMemcpy(out_h.data(), out_d, size * sizeof(float), cudaMemcpyDeviceToHost)));
+
+    // wait for all the operations to complete
+    REQUIRE_NOTHROW(cudaCheck(cudaDeviceSynchronize()));
+
+    // check the results
+    for (size_t i = 0; i < size; ++i) {
+      float sum = in1_h[i] + in2_h[i];
+      CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR adds new packages to test the implementation and usage of CUDA libraries for device code in CMSSW plugins and executables.

The package `HeterogeneousTest/CUDADevice` implements a library that defines and exports CUDA device-only functions, and a plugin and test that use them.

The package `HeterogeneousTest/CUDAKernel` implements a library that imports device functions from `HeterogeneousTest/CUDADevice` to define and export CUDA kernels, and a plugin and test that use them.

The package `HeterogeneousTest/CUDAWrapper` implements a library that imports kernels from `HeterogeneousTest/CUDAKernel` to define and export host-only wrappers around them, usable by non-CUDA libraries, plugins and applications, and implements a plugin and test that use them.

The package `HeterogeneousTest/CUDAOpaque` implements a library that use the wrappers from `HeterogeneousTest/CUDAKernel` to define and export host-only functions around the whole CUDA section, usable by libraries, plugins and applications that are not CUDA-aware, and implements a plugin and test that use them.

#### PR validation:

The new unit tests compile and pass.