### PR TITLE
Speedup strip premix

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -44,8 +44,15 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
     adc = in[i].adc();
 
     SiStripThreshold::Data thresholds = threshold.getData(strip, detThRange);
-    theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
     theFEDhighThresh = static_cast<int16_t>(thresholds.getHth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
+
+    // do not bother with the rest if large enough
+    if (adc > theFEDhighThresh) {
+      selectedSignal.push_back(SiStripDigi(strip, adc));
+      return;
+    }
+
+    theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
 
     adcPrev = -9999;
     adcNext = -9999;

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -49,7 +49,7 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
     // do not bother with the rest if large enough
     if (adc > theFEDhighThresh) {
       selectedSignal.push_back(SiStripDigi(strip, adc));
-      return;
+      continue;
     }
 
     theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -13,12 +13,12 @@ public:
   DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
 
 private:
-  int convert(float in) { return truncate(in / electronperADC); }
-  int convertRaw(float in) { return truncateRaw(in / electronperADC); }
+  int convert(float in) { return truncate(in * ADCperElectron); }
+  int convertRaw(float in) { return truncateRaw(in * ADCperElectron); }
   int truncate(float in_adc) const;
   int truncateRaw(float in_adc) const;
 
-  const float electronperADC;
+  const float ADCperElectron;
   SiDigitalConverter::DigitalVecType _temp;
   SiDigitalConverter::DigitalRawVecType _tempRaw;
   bool PreMixing_;

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -80,8 +80,8 @@ private:
   typedef std::pair<uint16_t, Amplitude> RawDigi;  // Replacement for SiStripDigi with pulse height instead of integer ADC
   typedef std::vector<SiStripDigi> OneDetectorMap;  // maps by strip ID for later combination - can have duplicate strips
   typedef std::vector<RawDigi> OneDetectorRawMap;  // maps by strip ID for later combination - can have duplicate strips
-  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex;        // map to all data for each detector ID
-  typedef std::map<uint32_t, OneDetectorRawMap> SiGlobalRawIndex;  // map to all data for each detector ID
+  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex;                      // map to all data for each detector ID
+  typedef std::vector<std::pair<uint32_t, OneDetectorRawMap>> SiGlobalRawIndex;  // map to all data for each detector ID
 
   typedef SiDigitalConverter::DigitalVecType DigitalVecType;
 
@@ -89,10 +89,10 @@ private:
   SiGlobalRawIndex SiRawDigis_;
 
   // variables for temporary storage of mixed hits:
-  typedef std::map<int, Amplitude> SignalMapType;
+  typedef std::vector<std::pair<int, Amplitude>> SignalMapType;
   typedef std::map<uint32_t, SignalMapType> signalMaps;
 
-  const SignalMapType* getSignal(uint32_t detID) const {
+  SignalMapType const* getSignal(uint32_t detID) const {
     auto where = signals_.find(detID);
     if (where == signals_.end()) {
       return nullptr;
@@ -382,7 +382,6 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   }
 
   std::map<int, std::bitset<6>> DeadAPVList;
-  DeadAPVList.clear();
 
   // First, have to convert all ADC counts to raw pulse heights so that values can be added properly
   // In PreMixing, pulse heights are saved with ADC = sqrt(9.0*PulseHeight) - have to undo.
@@ -391,8 +390,6 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   // Simultaneously, merge lists of hit channels in each DetId.
   // Signal Digis are in the list first, have to merge lists of hit strips on the fly,
   // add signals on duplicates later
-
-  OneDetectorRawMap LocalRawMap;
 
   // Now, loop over hits and add them to the map in the proper sorted order
   // Note: We are assuming that the hits from the Signal events have been created in
@@ -407,32 +404,28 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   for (SiGlobalIndex::const_iterator IDet = SiHitStorage_.begin(); IDet != SiHitStorage_.end(); IDet++) {
     uint32_t detID = IDet->first;
 
-    OneDetectorMap LocalMap = IDet->second;
+    auto const& LocalMap = IDet->second;
 
     //loop over hit strips for this DetId, do conversion to pulse height, store.
-
-    LocalRawMap.clear();
-
-    OneDetectorMap::const_iterator iLocal = LocalMap.begin();
-    for (; iLocal != LocalMap.end(); ++iLocal) {
-      uint16_t currentStrip = iLocal->strip();
-      float signal = float(iLocal->adc());
-      if (iLocal->adc() == 1022)
-        signal = 1500.;  // average values for overflows
-      if (iLocal->adc() == 1023)
-        signal = 3000.;
+    SiRawDigis_.emplace_back(detID, OneDetectorRawMap());
+    auto& localRawMap = SiRawDigis_.back().second;
+    localRawMap.reserve(LocalMap.size());
+    for (auto const& iLocal : LocalMap) {
+      uint16_t currentStrip = iLocal.strip();
+      float signal = float(iLocal.adc());
+      if (iLocal.adc() == 1022)
+        signal = 1500.f;  // average values for overflows
+      if (iLocal.adc() == 1023)
+        signal = 3000.f;
 
       //convert signals back to raw counts
+      constexpr float inv9 = 1.f / 9.0f;
+      float ReSignal = signal * signal * inv9;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
 
-      float ReSignal = signal * signal / 9.0;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
+      // RawDigi NewRawDigi = std::make_pair(currentStrip, ReSignal);
 
-      RawDigi NewRawDigi = std::make_pair(currentStrip, ReSignal);
-
-      LocalRawMap.push_back(NewRawDigi);
+      localRawMap.emplace_back(currentStrip, ReSignal);
     }
-
-    // save information for this detiD into global map
-    SiRawDigis_.insert(SiGlobalRawIndex::value_type(detID, LocalRawMap));
   }
 
   // If we are killing APVs, merge list of dead ones before we digitize
@@ -492,13 +485,16 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   signals_.clear();
 
   // big loop over Detector IDs:
-  for (SiGlobalRawIndex::const_iterator IDet = SiRawDigis_.begin(); IDet != SiRawDigis_.end(); IDet++) {
-    uint32_t detID = IDet->first;
+  for (auto const& IDet : SiRawDigis_) {
+    uint32_t detID = IDet.first;
 
-    SignalMapType Signals;
-    Signals.clear();
+    // create merged map:
+    auto& lSignals = signals_[detID];
 
-    OneDetectorRawMap LocalMap = IDet->second;
+    auto const& LocalMap = IDet.second;
+
+    // guess max occupancy...
+    lSignals.reserve(std::min(LocalMap.size(), 512ul));
 
     //counter variables
     int formerStrip = -1;
@@ -517,7 +513,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         ADCSum += iLocal->second;  // raw pulse height is second element.
       } else {
         if (formerStrip != -1) {
-          Signals.insert(std::make_pair(formerStrip, ADCSum));
+          lSignals.emplace_back(formerStrip, ADCSum);
         }
         // save pointers for next iteration
         formerStrip = currentStrip;
@@ -526,11 +522,9 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
       iLocalchk = iLocal;
       if ((++iLocalchk) == LocalMap.end()) {  //make sure not to lose the last one
-        Signals.insert(std::make_pair(formerStrip, ADCSum));
+        lSignals.emplace_back(formerStrip, ADCSum);
       }
     }
-    // save merged map:
-    signals_.insert(std::make_pair(detID, Signals));
   }
 
   //Now, do noise, zero suppression, take into account bad channels, etc.
@@ -547,11 +541,11 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
       // see if there is some signal on this detector
 
-      const SignalMapType* theSignal(getSignal(detID));
+      auto const* lSignal = getSignal(detID);
 
       std::vector<float> detAmpl(numStrips, 0.);
-      if (theSignal) {
-        for (const auto& amp : *theSignal) {
+      if (lSignal) {
+        for (const auto& amp : *lSignal) {
           detAmpl[amp.first] = amp.second;
         }
       }

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -682,11 +682,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         }
       }
 
-      DigitalVecType digis;
       theSiZeroSuppress->suppress(
-          theSiDigitalConverter->convert(detAmpl, &gain, detID), digis, detID, noise, threshold);
-
-      SSD.data = digis;
+          theSiDigitalConverter->convert(detAmpl, &gain, detID), SSD.data, detID, noise, threshold);
 
       // stick this into the global vector of detector info
       vSiStripDigi.push_back(SSD);

--- a/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
+++ b/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
@@ -2,7 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix) : electronperADC(in), PreMixing_(PreMix) {
+SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix)
+    : ADCperElectron(1.f / in), PreMixing_(PreMix) {
   _temp.reserve(800);
   _tempRaw.reserve(800);
 }
@@ -18,7 +19,7 @@ SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std:
         continue;
       // convert analog amplitude to digital - special algorithm for PreMixing.
       // Need to keep all hits, including those at very low pulse heights.
-      int adc = truncate(sqrt(9.0 * analogSignal[i]));
+      int adc = truncate(std::sqrt(9.0f * analogSignal[i]));
       if (adc > 0)
         _temp.push_back(SiStripDigi(i, adc));
     }
@@ -77,7 +78,7 @@ SiDigitalConverter::DigitalRawVecType SiTrivialDigitalConverter::convertRaw(cons
 
 int SiTrivialDigitalConverter::truncate(float in_adc) const {
   //Rounding the ADC number instead of truncating it
-  int adc = int(in_adc + 0.5);
+  int adc = int(in_adc + 0.5f);
   /*
     254 ADC: 254  <= raw charge < 1023
     255 ADC: raw charge >= 1023
@@ -101,7 +102,7 @@ int SiTrivialDigitalConverter::truncate(float in_adc) const {
 
 int SiTrivialDigitalConverter::truncateRaw(float in_adc) const {
   //Rounding the ADC number
-  int adc = int(in_adc + 0.5);
+  int adc = int(in_adc + 0.5f);
   if (adc > 1023)
     return 1023;
   //Protection


### PR DESCRIPTION
PreMixingSiStripWorker is a major contribution to the time spent in the Premixing Module.
see http://innocent.web.cern.ch/innocent/perfResults/igprof-navigator/digiDebug1T_ori_CMSSW_13_0_X_2023-01-21-1100_slc7_amd64_gcc11/26

these trivial changes reduce the time spent in  ```SiStripFedZeroSuppression::suppress```
by almost a factor 3. 
Some minor additional speed up could be obtained with some restructuring of the class content.
I also took the opportunity to make some math consistent in single precision float (and remove a division)
see http://innocent.web.cern.ch/innocent/perfResults/igprof-navigator/digiDebug1T_speedStrip2_CMSSW_13_0_X_2023-01-24-1100_slc7_amd64_gcc11/26

purely technical, no regression expected.

I'm under the impression that using a single-precision random number generator may speed up all those gaussian noise generators by a large amount.
I think that this would require a dedicated "project".

