### PR TITLE
[RECONSTRUCTION][CLANG] Fix clang llvm14 warnings

### DIFF
--- a/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
+++ b/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
@@ -226,7 +226,7 @@ void KDTreeLinkerAlgo<DATA, DIM>::recSearch(int current, const KDTreeBox<DIM> &t
       bool isInside = true;
       for (unsigned i = 0; i < DIM; ++i) {
         float dimCurr = nodePool_.dims[i][current];
-        isInside &= (dimCurr >= trackBox.dimmin[i]) & (dimCurr <= trackBox.dimmax[i]);
+        isInside &= (dimCurr >= trackBox.dimmin[i]) && (dimCurr <= trackBox.dimmax[i]);
       }
       if (isInside) {
         closestNeighbour->push_back(nodePool_.data[current]);

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.cc
@@ -143,15 +143,10 @@ void HiFJRhoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     double etaMax = mapEtaRangesOut->at(ieta + 1) - radius;
 
     int naccCur = 0;
-    double rhoCurSum = 0.;
-    double rhomCurSum = 0.;
     for (int i = 0; i < nacc; i++) {
       if (etaVec[i] >= etaMin && etaVec[i] < etaMax) {
         rhoVecCur.push_back(rhoVec[i]);
         rhomVecCur.push_back(rhomVec[i]);
-
-        rhoCurSum += rhoVec[i];
-        rhomCurSum += rhomVec[i];
         ++naccCur;
       }  //eta selection
     }    //accepted jet loop

--- a/RecoJets/JetProducers/src/MVAJetPuId.cc
+++ b/RecoJets/JetProducers/src/MVAJetPuId.cc
@@ -223,7 +223,7 @@ PileupJetIdentifier MVAJetPuId::computeIdVariables(const reco::Jet *jet,
 
   reco::TrackRef impactTrack;
   float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
-  float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
+  float sumPt = 0., sumPt2 = 0., sumPtCh = 0, sumPtNe = 0;
   float sum_deta = 0;
   float sum_dphi = 0;
   float sum_deta2 = 0;
@@ -299,7 +299,6 @@ PileupJetIdentifier MVAJetPuId::computeIdVariables(const reco::Jet *jet,
 
     if (icand->trackRef().isNonnull() && icand->trackRef().isAvailable()) {
       float tkpt = icand->trackRef()->pt();
-      sumTkPt += tkpt;
       bool inVtx0 =
           find(vtx->tracks_begin(), vtx->tracks_end(), reco::TrackBaseRef(icand->trackRef())) != vtx->tracks_end();
       bool inAnyOther = false;

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -316,8 +316,8 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo &channe
   double noiseADCArr[hcal::constants::maxSamples] = {};
   double noiseArrSq[hcal::constants::maxSamples] = {};
   double noisePHArr[hcal::constants::maxSamples] = {};
-  double tsTOT = 0, tstrig = 0;  // in fC
-  double tsTOTen = 0;            // in GeV
+  double tstrig = 0;   // in fC
+  double tsTOTen = 0;  // in GeV
 
   // go over the time slices
   for (unsigned int ip = 0; ip < cssize; ++ip) {
@@ -355,7 +355,6 @@ void PulseShapeFitOOTPileupCorrection::phase1Apply(const HBHEChannelInfo &channe
                      channelData.tsPedestalWidth(ip) * channelData.tsPedestalWidth(ip) +
                      noisePHArr[ip] * noisePHArr[ip];
 
-    tsTOT += charge - ped;
     tsTOTen += energy - peden;
     if (ip == soi || ip == soi + 1) {
       tstrig += charge - ped;

--- a/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/ZdcSimpleRecAlgo.cc
@@ -48,7 +48,6 @@ namespace ZdcSimpleRecAlgoImpl {
     double ta = 0;
     double fc_ampl = 0;
     double lowGEnergy = 0;
-    double lowGfc_ampl = 0;
     double TempLGAmp = 0;
     // TS increment for regular energy to lowGainEnergy
     // Signal in higher TS (effective "low Gain") has a fraction of the whole signal
@@ -78,9 +77,8 @@ namespace ZdcSimpleRecAlgoImpl {
     for (int iLG = (ifirst + lowGainOffset); iLG < tool.size() && iLG < topLowGain; iLG++) {
       int capid = digi[iLG].capid();
       TempLGAmp = (tool[iLG] - calibs.pedestal(capid));  // pedestal subtraction
-      lowGfc_ampl += TempLGAmp;
-      TempLGAmp *= calibs.respcorrgain(capid);  // fC --> GeV
-      TempLGAmp *= lowGainFrac;                 // TS (signalRegion) --> TS (lowGainRegion)
+      TempLGAmp *= calibs.respcorrgain(capid);           // fC --> GeV
+      TempLGAmp *= lowGainFrac;                          // TS (signalRegion) --> TS (lowGainRegion)
       lowGEnergy += TempLGAmp;
     }
     double time = -9999;
@@ -154,7 +152,6 @@ namespace ZdcSimpleRecAlgoImpl {
     double ta = 0;
     double fc_ampl = 0;
     double lowGEnergy = 0;
-    double lowGfc_ampl = 0;
     double TempLGAmp = 0;
     //  TS increment for regular energy to lowGainEnergy
     // Signal in higher TS (effective "low Gain") has a fraction of the whole signal
@@ -205,7 +202,6 @@ namespace ZdcSimpleRecAlgoImpl {
         continue;
       int capid = digi[CurrentTS].capid();
       TempLGAmp = tool[CurrentTS] - noise;
-      lowGfc_ampl += TempLGAmp;
       TempLGAmp *= calibs.respcorrgain(capid);  // fC --> GeV
       TempLGAmp *= lowGainFrac;                 // TS (signalRegion) --> TS (lowGainRegion)
       lowGEnergy += TempLGAmp;

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -521,14 +521,12 @@ void DTSegmentUpdator::rejectBadHits(DTChamberRecSegment2D* phiSeg) const {
   float Sx = 0.;
   float Sy = 0.;
   float Sx2 = 0.;
-  float Sy2 = 0.;
   float Sxy = 0.;
 
   for (size_t i = 0; i < N; ++i) {
     Sx += x.at(i);
     Sy += y.at(i);
     Sx2 += x.at(i) * x.at(i);
-    Sy2 += y.at(i) * y.at(i);
     Sxy += x.at(i) * y.at(i);
   }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -53,7 +53,7 @@ SiPixelDigisClustersFromSoAT<TrackerTraits>::SiPixelDigisClustersFromSoAT(const 
       clusterThresholds_{iConfig.getParameter<int>("clusterThreshold_layer1"),
                          iConfig.getParameter<int>("clusterThreshold_otherLayers")},
       produceDigis_(iConfig.getParameter<bool>("produceDigis")),
-      storeDigis_(iConfig.getParameter<bool>("produceDigis") & iConfig.getParameter<bool>("storeDigis")) {
+      storeDigis_(iConfig.getParameter<bool>("produceDigis") && iConfig.getParameter<bool>("storeDigis")) {
   if (produceDigis_)
     digiPutToken_ = produces<edm::DetSetVector<PixelDigi>>();
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -246,7 +246,7 @@ void PixelCPEBase::setTheClu(DetParam const& theDetParam, ClusterParam& theClust
   //if(theClusterParam.theCluster->pixelADC()[i] == 0) { hasBadPixels_ = true; break;}
   //}
 
-  theClusterParam.spansTwoROCs_ = theDetParam.theRecTopol->containsBigPixelInX(minInX, maxInX) |
+  theClusterParam.spansTwoROCs_ = theDetParam.theRecTopol->containsBigPixelInX(minInX, maxInX) ||
                                   theDetParam.theRecTopol->containsBigPixelInY(minInY, maxInY);
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -157,7 +157,7 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
     hits[i] = {p, (*p).energy(), float(hf.fraction())};
   }
 
-  bool resGiven = bool(_timeResolutionCalcBarrel) & bool(_timeResolutionCalcEndcap);
+  bool resGiven = bool(_timeResolutionCalcBarrel) && bool(_timeResolutionCalcEndcap);
   LHit mySeed = {};
   for (auto const& rhf : hits) {
     const reco::PFRecHit& refhit = *rhf.hit;

--- a/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
@@ -382,7 +382,7 @@ void TrajectorySegmentBuilder::updateWithInvalidHit(TempTrajectory& traj,
       auto const& measurements = gr.measurements();
       for (auto im = measurements.rbegin(); im != measurements.rend(); ++im) {
         auto const& hit = im->recHitR();
-        if ((hit.getType() == TrackingRecHit::valid) | (hit.getType() == TrackingRecHit::missing))
+        if ((hit.getType() == TrackingRecHit::valid) || (hit.getType() == TrackingRecHit::missing))
           continue;
         //
         // check, if the extrapolation traverses the Det or

--- a/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc
@@ -19,7 +19,7 @@ namespace {
     mva(const edm::ParameterSet &cfg, edm::ConsumesCollector iC)
         : forestLabel_(cfg.getParameter<std::string>("GBRForestLabel")),
           dbFileName_(cfg.getParameter<std::string>("GBRForestFileName")),
-          useForestFromDB_((!forestLabel_.empty()) & dbFileName_.empty()) {
+          useForestFromDB_((!forestLabel_.empty()) && dbFileName_.empty()) {
       if (useForestFromDB_) {
         forestToken_ = iC.esConsumes(edm::ESInputTag("", forestLabel_));
       }

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -126,7 +126,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts,
     return;
   }
 
-  if ((!monoHits.empty()) & (!stereoHits.empty())) {
+  if ((!monoHits.empty()) && (!stereoHits.empty())) {
     const GluedGeomDet* gluedDet = &specificGeomDet();
     LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal(position() - GlobalPoint(0, 0, 0)));
 

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -296,7 +296,7 @@ void SeedingLayerSetsBuilder::updateEventSetup(const edm::EventSetup& es) {
   // We want to evaluate both in the first invocation (to properly
   // initialize ESWatcher), and this way we avoid one branch compared
   // to || (should be tiny effect)
-  if (!(geometryWatcher_.check(es) | trhWatcher_.check(es)))
+  if (!(geometryWatcher_.check(es) || trhWatcher_.check(es)))
     return;
 
   const GeometricSearchTracker& tracker = es.getData(trackerToken_);

--- a/RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h
@@ -93,7 +93,7 @@ private:
       auto const &hit = *(*itm).recHit()->hit();
       if ((removeNoDet) & ((*itm).recHitR().det() == nullptr))
         continue;
-      if (trackerHitRTTI::isUndef(hit) | trackerHitRTTI::isNotFromCluster(hit) | (hit.dimension() != 2)) {
+      if (trackerHitRTTI::isUndef(hit) || trackerHitRTTI::isNotFromCluster(hit) || (hit.dimension() != 2)) {
         hits.push_back(hit.clone());
         continue;
       }

--- a/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
+++ b/TrackingTools/GsfTools/interface/CloseComponentsMerger.icc
@@ -73,7 +73,7 @@ MultiGaussianState<N> CloseComponentsMerger<N>::merge(const MultiState& mgs) con
       comp.push_back(ori[toMerge.top()]);
       comp.push_back(ori[ii]);
       active[ii] = false;
-      while ((!toMerge.empty()) & (!active[toMerge.top()])) {
+      while ((!toMerge.empty()) && (!active[toMerge.top()])) {
         toMerge.pop();
       }
       --nComp;


### PR DESCRIPTION
Hello,

This PR fixes the warnings due to unused but set variables and the use of bitwise '|' or '&' with boolean operands that we get with LLVM14 in CLANG IBs for the reconstruction modules.

Thanks,
Andrea.