### PR TITLE
[`Alignment/OfflineValidation`] restructure the primary-vertex related unit tests

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -14,21 +14,16 @@ filesDefaultMC_TTBarPU = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/PU_125X_mcRun3_2022_realistic_v3-v1/10000/0136c33f-3ff9-4602-8578-906ae6e0160b.root'
 )
 
-filesDefaultMC_TTBarPUPhase2 = cms.untracked.vstring(
+filesDefaultMC_MinBiasPUPhase2 = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/27b7ab93-1d2b-4f4a-a98e-68386c314b5e.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/45b3c086-a3ac-429e-845f-4796ba8f2d3f.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/b82f7b2d-1e7f-43ce-a7bc-dc44ce3b2358.root'
 )
 
-filesDefaultMC_TTBarPUPhase2RECO = cms.untracked.vstring(
+filesDefaultMC_MinBiasPUPhase2RECO = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/22e22ae6-a353-4f2e-815e-cc5efee37af9.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/87ea36b3-b17a-4f5a-ab5a-0973e684db1b.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/e9de823f-35f7-4493-ba4a-c1d9671d2d70.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/9c5055d6-5f74-4e26-8166-1f65cc7e6e5c.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/678538ab-9e17-4880-b27a-b7b5b045124d.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/7f9af44d-aff5-41be-9d0d-3cbbd35b19dd.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/d8d6b261-4897-4ee4-9210-d68041b3dd67.root',
-    '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/04fa3331-7c8a-420d-b07a-d677e2caf992.root'
+)
+
+filesDefaultMC_TTbarPhase2RECO = cms.untracked.vstring(
+    '/store/relval/CMSSW_12_6_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88noPU-v1/2590000/57cbe250-487d-4a47-998b-48f9028a0058.root',
 )
 
 filesDefaultData_JetHTRun2018D = cms.untracked.vstring(

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -27,12 +27,12 @@
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>
   </bin>
-  <bin file="testAlignmentOfflineValidation.cpp" name="GeneralTrackAnalyser">
-    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testingScripts/test_unitGeneralTrackAnalyser.sh"/>
+  <bin file="testAlignmentOfflineValidation.cpp" name="PrimaryVertex">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testingScripts/test_unitPrimaryVertex.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
   <bin file="testPVPlotting.cpp" name="testPVPlotting">
-    <flags PRE_TEST="GeneralTrackAnalyser"/>
+    <flags PRE_TEST="PrimaryVertex"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitGeneralTrackAnalyser.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitGeneralTrackAnalyser.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-function die { echo $1: status $2 ; exit $2; }
-
-echo "TESTING Alignment/OfflineValidation ..."
-cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_all_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/test_all_Phase2_cfg.py || die "Failure running test_all_Phase2_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
-

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
@@ -1,8 +1,11 @@
 #! /bin/bash
 function die { echo $1: status $2 ; exit $2; }
 
+echo "TESTING inspect ALCARECO data ..."
+cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
+
 echo "TESTING G4e refitter ..."
-cmsRun ${LOCAL_TEST_DIR}/testG4Refitter_cfg.py maxEvents=50  || die "Failure running testG4Refitter_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/testG4Refitter_cfg.py maxEvents=10  || die "Failure running testG4Refitter_cfg.py" $?
 
 echo "TESTING Pixel BaryCenter Analyser ..."
 cmsRun ${LOCAL_TEST_DIR}/PixelBaryCentreAnalyzer_cfg.py unitTest=True || die "Failure running PixelBaryCentreAnalyzer_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitPrimaryVertex.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitPrimaryVertex.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Primary Vertex Validation: phase-1 setup ..."
+cmsRun ${LOCAL_TEST_DIR}/testPrimaryVertexRelatedValidations_cfg.py isPhase2=False maxEvents=100 || die "Failure running testPrimaryVertexRelatedValidations_cfg.py isPhase2=False" $?
+
+echo "TESTING Primary Vertex Validation: phase-2 setup ..."
+cmsRun ${LOCAL_TEST_DIR}/testPrimaryVertexRelatedValidations_cfg.py isPhase2=True maxEvents=10 || die "Failure running testPrimaryVertexRelatedValidations_cfg.py isPhase2=True" $?


### PR DESCRIPTION
#### PR description:

In (partial) response of the https://github.com/cms-sw/cmssw/pull/40567#issuecomment-1402055015:
   * further lowering down the amount of event used in the phase-2 flavor of unit test (from 100 to 10)
   * merge phase-1 and phase-2 test configurations in the same file
   * rename the unit test to be more descriptive

#### PR validation:

Run successfully `scram b runtests_PrimaryVertex`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
