### PR TITLE
Phase2-hgx335K The default topology builder file for HGCal is modified and correspondingly all scenarios now use this builder

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D86Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D86Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D88Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D88Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D91Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D91Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D92Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D92Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D93Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D93Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D94Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D94Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
 from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D95Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D95Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D96Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D96Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D97Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D97Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D86Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D86Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D88Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D88Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D91Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D91Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D92Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D92Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D93Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D93Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D94Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D94Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
 from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D95Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D95Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D96Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D96Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D97Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D97Reco_cff.py
@@ -14,7 +14,7 @@ from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *
 trackerGeometry.applyAlignment = False
 
 # calo
-from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
+from Geometry.CaloEventSetup.HGCalTopology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -368,7 +368,7 @@ caloDict = {
             'from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *'
         ],
         "reco" : [
-            'from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *',
+            'from Geometry.CaloEventSetup.HGCalTopology_cfi import *',
             'from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *',
             'from Geometry.CaloEventSetup.CaloTopology_cfi import *',
             'from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *',
@@ -442,7 +442,7 @@ caloDict = {
             'from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *'
         ],
         "reco" : [
-            'from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *',
+            'from Geometry.CaloEventSetup.HGCalTopology_cfi import *',
             'from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *',
             'from Geometry.CaloEventSetup.CaloTopology_cfi import *',
             'from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *',
@@ -515,7 +515,7 @@ caloDict = {
             'from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *'
         ],
         "reco" : [
-            'from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *',
+            'from Geometry.CaloEventSetup.HGCalTopology_cfi import *',
             'from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *',
             'from Geometry.CaloEventSetup.CaloTopology_cfi import *',
             'from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *',
@@ -598,7 +598,7 @@ caloDict = {
             'from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *',
         ],
         "reco" : [
-            'from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *',
+            'from Geometry.CaloEventSetup.HGCalTopology_cfi import *',
             'from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *',
             'from Geometry.CaloEventSetup.HFNoseTopology_cfi import *',
             'from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *',


### PR DESCRIPTION
#### PR description:

Effect of renaming the default topology builder file for HGCal. All phase2 scenaarios now use this builder. 

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special