### PR TITLE
Speedup strip digitization

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -44,8 +44,15 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
     adc = in[i].adc();
 
     SiStripThreshold::Data thresholds = threshold.getData(strip, detThRange);
-    theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
     theFEDhighThresh = static_cast<int16_t>(thresholds.getHth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
+
+    // do not bother with the rest if large enough
+    if (adc > theFEDhighThresh) {
+      selectedSignal.push_back(SiStripDigi(strip, adc));
+      return;
+    }
+
+    theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
 
     adcPrev = -9999;
     adcNext = -9999;

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -38,6 +38,12 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
   selectedSignal.clear();
   selectedSignal.reserve(inSize);
   for (i = 0; i < inSize; i++) {
+    // if algo is "5" just do it here
+    if (5 == theFEDalgorithm && adc > 0) {
+      selectedSignal.emplace_back(in[i]);
+      continue;
+    }
+
     //Find adc values for neighbouring strips
     const uint32_t strip = (uint32_t)in[i].strip();
 

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -49,7 +49,7 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
     // do not bother with the rest if large enough
     if (adc > theFEDhighThresh) {
       selectedSignal.push_back(SiStripDigi(strip, adc));
-      return;
+      continue;
     }
 
     theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -18,6 +18,60 @@ void SiStripFedZeroSuppression::init(const edm::EventSetup& es) {
   }
 }
 
+namespace {
+
+  constexpr uint8_t zeroTh = 0;
+  constexpr uint8_t lowTh = 1;
+  constexpr uint8_t highTh = 2;
+
+  struct Payload {
+    uint8_t stat;
+    uint8_t statPrev;
+    uint8_t statNext;
+    uint8_t statMaxNeigh;
+    uint8_t statPrev2;
+    uint8_t statNext2;
+  };
+
+  constexpr bool isDigiValid(Payload const& data, uint16_t FEDalgorithm) {
+    // Decide if this strip should be accepted.
+    bool accept = false;
+    switch (FEDalgorithm) {
+      case 1:
+        accept = (data.stat >= lowTh);
+        break;
+      case 2:
+        accept = (data.stat >= highTh || (data.stat >= lowTh && data.statMaxNeigh >= lowTh));
+        break;
+      case 3:
+        accept = (data.stat >= highTh || (data.stat >= lowTh && data.statMaxNeigh >= highTh));
+        break;
+      case 4:
+        accept = ((data.stat >= highTh)     //Test for adc>highThresh (same as algorithm 2)
+                  || ((data.stat >= lowTh)  //Test for adc>lowThresh, with neighbour adc>lowThresh (same as algorithm 2)
+                      && (data.statMaxNeigh >= lowTh)) ||
+                  ((data.stat < lowTh)             //Test for adc<lowThresh
+                   && (((data.statPrev >= highTh)  //with both neighbours>highThresh
+                        && (data.statNext >= highTh)) ||
+                       ((data.statPrev >= highTh)    //OR with previous neighbour>highThresh and
+                        && (data.statNext >= lowTh)  //both the next neighbours>lowThresh
+                        && (data.statNext2 >= lowTh)) ||
+                       ((data.statNext >= highTh)    //OR with next neighbour>highThresh and
+                        && (data.statPrev >= lowTh)  //both the previous neighbours>lowThresh
+                        && (data.statPrev2 >= lowTh)) ||
+                       ((data.statNext >= lowTh)      //OR with both next neighbours>lowThresh and
+                        && (data.statNext2 >= lowTh)  //both the previous neighbours>lowThresh
+                        && (data.statPrev >= lowTh) && (data.statPrev2 >= lowTh)))));
+        break;
+      case 5:
+        accept = true;  // zero removed in conversion
+        break;
+    }
+    return accept;
+  }
+
+}  // namespace
+
 void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
                                          std::vector<SiStripDigi>& selectedSignal,
                                          uint32_t detID) {
@@ -29,7 +83,6 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
                                          uint32_t detID,
                                          const SiStripNoises& noise,
                                          const SiStripThreshold& threshold) {
-  int i;
   int inSize = in.size();
   SiStripNoises::Range detNoiseRange = noise.getRange(detID);
   SiStripThreshold::Range detThRange = threshold.getRange(detID);
@@ -37,104 +90,66 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
   // reserving more than needed, but quicker than one at a time
   selectedSignal.clear();
   selectedSignal.reserve(inSize);
-  for (i = 0; i < inSize; i++) {
-    // if algo is "5" just do it here
-    if (5 == theFEDalgorithm && adc > 0) {
-      selectedSignal.emplace_back(in[i]);
-      continue;
-    }
 
-    //Find adc values for neighbouring strips
-    const uint32_t strip = (uint32_t)in[i].strip();
+  // load status
+  uint8_t stat[inSize];
+  for (int i = 0; i < inSize; i++) {
+    auto strip = (uint32_t)in[i].strip();
 
-    adc = in[i].adc();
+    auto ladc = in[i].adc();
+    assert(ladc > 0);
 
-    SiStripThreshold::Data thresholds = threshold.getData(strip, detThRange);
-    theFEDhighThresh = static_cast<int16_t>(thresholds.getHth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
+    auto thresholds = threshold.getData(strip, detThRange);
 
-    // do not bother with the rest if large enough
-    if (adc > theFEDhighThresh) {
-      selectedSignal.push_back(SiStripDigi(strip, adc));
-      continue;
-    }
+    auto highThresh = static_cast<int16_t>(thresholds.getHth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5f);
+    auto lowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5f);
 
-    theFEDlowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5);
+    assert(lowThresh > 0);
+    assert(lowThresh <= highThresh);
 
-    adcPrev = -9999;
-    adcNext = -9999;
-    adcPrev2 = -9999;
-    adcNext2 = -9999;
+    stat[i] = zeroTh;
+    if (ladc >= lowThresh)
+      stat[i] = lowTh;
+    if (ladc >= highThresh)
+      stat[i] = highTh;
+  }
 
-    /*
-      Since we are not running on 
-      Raw data we need to initialize
-      all the FED threshold
-    */
+  for (int i = 0; i < inSize; i++) {
+    auto strip = (uint32_t)in[i].strip();
+    Payload ldata;
 
-    theNextFEDlowThresh = theFEDlowThresh;
-    theNext2FEDlowThresh = theFEDlowThresh;
-    thePrevFEDlowThresh = theFEDlowThresh;
-    thePrev2FEDlowThresh = theFEDlowThresh;
-    theNeighFEDlowThresh = theFEDlowThresh;
-
-    theNextFEDhighThresh = theFEDhighThresh;
-    thePrevFEDhighThresh = theFEDhighThresh;
-    theNeighFEDhighThresh = theFEDhighThresh;
+    ldata.stat = stat[i];
+    ldata.statPrev = zeroTh;
+    ldata.statNext = zeroTh;
+    ldata.statPrev2 = zeroTh;
+    ldata.statNext2 = zeroTh;
 
     if (((strip) % 128) == 127) {
-      adcNext = 0;
-      theNextFEDlowThresh = 9999;
-      theNextFEDhighThresh = 9999;
+      ldata.statNext = zeroTh;
     } else if (i + 1 < inSize && in[i + 1].strip() == strip + 1) {
-      adcNext = in[i + 1].adc();
-      SiStripThreshold::Data thresholds_1 = threshold.getData(strip + 1, detThRange);
-      theNextFEDlowThresh =
-          static_cast<int16_t>(thresholds_1.getLth() * noise.getNoiseFast(strip + 1, detNoiseRange) + 0.5);
-      theNextFEDhighThresh =
-          static_cast<int16_t>(thresholds_1.getHth() * noise.getNoiseFast(strip + 1, detNoiseRange) + 0.5);
+      ldata.statNext = stat[i + 1];
       if (((strip) % 128) == 126) {
-        adcNext2 = 0;
-        theNext2FEDlowThresh = 9999;
+        ldata.statNext2 = zeroTh;
       } else if (i + 2 < inSize && in[i + 2].strip() == strip + 2) {
-        adcNext2 = in[i + 2].adc();
-        theNext2FEDlowThresh = static_cast<int16_t>(
-            threshold.getData(strip + 2, detThRange).getLth() * noise.getNoiseFast(strip + 2, detNoiseRange) + 0.5);
+        ldata.statNext2 = stat[i + 2];
       }
     }
 
     if (((strip) % 128) == 0) {
-      adcPrev = 0;
-      thePrevFEDlowThresh = 9999;
-      thePrevFEDhighThresh = 9999;
+      ldata.statPrev = zeroTh;
     } else if (i - 1 >= 0 && in[i - 1].strip() == strip - 1) {
-      adcPrev = in[i - 1].adc();
-      SiStripThreshold::Data thresholds_1 = threshold.getData(strip - 1, detThRange);
-      thePrevFEDlowThresh =
-          static_cast<int16_t>(thresholds_1.getLth() * noise.getNoiseFast(strip - 1, detNoiseRange) + 0.5);
-      thePrevFEDhighThresh =
-          static_cast<int16_t>(thresholds_1.getHth() * noise.getNoiseFast(strip - 1, detNoiseRange) + 0.5);
+      ldata.statPrev = stat[i - 1];
       if (((strip) % 128) == 1) {
-        adcPrev2 = 0;
-        thePrev2FEDlowThresh = 9999;
+        ldata.statPrev2 = zeroTh;
       } else if (i - 2 >= 0 && in[i - 2].strip() == strip - 2) {
-        adcPrev2 = in[i - 2].adc();
-        thePrev2FEDlowThresh = static_cast<int16_t>(
-            threshold.getData(strip - 2, detThRange).getLth() * noise.getNoiseFast(strip - 2, detNoiseRange) + 0.5);
+        ldata.statPrev2 = stat[i - 2];
       }
     }
 
-    if (adcNext <= adcPrev) {
-      adcMaxNeigh = adcPrev;
-      theNeighFEDlowThresh = thePrevFEDlowThresh;
-      theNeighFEDhighThresh = thePrevFEDhighThresh;
-    } else {
-      adcMaxNeigh = adcNext;
-      theNeighFEDlowThresh = theNextFEDlowThresh;
-      theNeighFEDhighThresh = theNextFEDhighThresh;
-    }
+    ldata.statMaxNeigh = std::max(ldata.statPrev, ldata.statNext);
 
-    if (isAValidDigi()) {
-      selectedSignal.push_back(SiStripDigi(strip, adc));
+    if (isDigiValid(ldata, theFEDalgorithm)) {
+      selectedSignal.push_back(SiStripDigi(strip, in[i].adc()));
     }
   }
 }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/SiStripFedZeroSuppression.cc
@@ -104,7 +104,7 @@ void SiStripFedZeroSuppression::suppress(const std::vector<SiStripDigi>& in,
     auto highThresh = static_cast<int16_t>(thresholds.getHth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5f);
     auto lowThresh = static_cast<int16_t>(thresholds.getLth() * noise.getNoiseFast(strip, detNoiseRange) + 0.5f);
 
-    assert(lowThresh > 0);
+    assert(lowThresh >= 0);
     assert(lowThresh <= highThresh);
 
     stat[i] = zeroTh;

--- a/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
@@ -14,8 +14,8 @@ public:
   typedef std::vector<SiStripRawDigi> DigitalRawVecType;
 
   virtual ~SiDigitalConverter() {}
-  virtual DigitalVecType convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
-  virtual DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
+  virtual DigitalVecType const& convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
+  virtual DigitalRawVecType const& convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -5,16 +5,16 @@
 /**
  * Concrete implementation of SiDigitalConverter.
  */
-class SiTrivialDigitalConverter : public SiDigitalConverter {
+class SiTrivialDigitalConverter final : public SiDigitalConverter {
 public:
   SiTrivialDigitalConverter(float in, bool PreMix);
 
-  DigitalVecType convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
-  DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
+  DigitalVecType const& convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
+  DigitalRawVecType const& convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
 
 private:
-  int convert(float in) { return truncate(in * ADCperElectron); }
-  int convertRaw(float in) { return truncateRaw(in * ADCperElectron); }
+  int convert(float in) const { return truncate(in * ADCperElectron); }
+  int convertRaw(float in) const { return truncateRaw(in * ADCperElectron); }
   int truncate(float in_adc) const;
   int truncateRaw(float in_adc) const;
 

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -13,12 +13,12 @@ public:
   DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
 
 private:
-  int convert(float in) { return truncate(in / electronperADC); }
-  int convertRaw(float in) { return truncateRaw(in / electronperADC); }
+  int convert(float in) { return truncate(in * ADCperElectron); }
+  int convertRaw(float in) { return truncateRaw(in * ADCperElectron); }
   int truncate(float in_adc) const;
   int truncateRaw(float in_adc) const;
 
-  const float electronperADC;
+  const float ADCperElectron;
   SiDigitalConverter::DigitalVecType _temp;
   SiDigitalConverter::DigitalRawVecType _tempRaw;
   bool PreMixing_;

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -174,6 +174,7 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
       apv_fCPerElectron_(ps.getParameter<double>("apvfCPerElectron"))
 
 {
+  std::cout << "Fed Algo " << theFedAlgo << std::endl;
   // declare the products to produce
 
   SistripLabelSig_ = ps.getParameter<edm::InputTag>("SistripLabelSig");
@@ -682,8 +683,14 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         }
       }
 
-      theSiZeroSuppress->suppress(
-          theSiDigitalConverter->convert(detAmpl, &gain, detID), SSD.data, detID, noise, threshold);
+      auto const& data = theSiDigitalConverter->convert(detAmpl, &gain, detID);
+      // if suppression is trival just copy data
+      if (5 == theFedAlgo)
+        SSD.data = data;
+      else
+        theSiZeroSuppress->suppress(data, SSD.data, detID, noise, threshold);
+
+      std::cout << detID << " " << detAmpl.size() << ' ' << SSD.data.size() << std::endl;
 
       // stick this into the global vector of detector info
       vSiStripDigi.push_back(SSD);

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -174,7 +174,6 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
       apv_fCPerElectron_(ps.getParameter<double>("apvfCPerElectron"))
 
 {
-  std::cout << "Fed Algo " << theFedAlgo << std::endl;
   // declare the products to produce
 
   SistripLabelSig_ = ps.getParameter<edm::InputTag>("SistripLabelSig");
@@ -690,7 +689,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
       else
         theSiZeroSuppress->suppress(data, SSD.data, detID, noise, threshold);
 
-      std::cout << detID << " " << detAmpl.size() << ' ' << SSD.data.size() << std::endl;
+      LogDebug("PreMixingSiStripWorker") << detID << " " << data.size() << ' ' << SSD.data.size();
 
       // stick this into the global vector of detector info
       vSiStripDigi.push_back(SSD);

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -80,8 +80,8 @@ private:
   typedef std::pair<uint16_t, Amplitude> RawDigi;  // Replacement for SiStripDigi with pulse height instead of integer ADC
   typedef std::vector<SiStripDigi> OneDetectorMap;  // maps by strip ID for later combination - can have duplicate strips
   typedef std::vector<RawDigi> OneDetectorRawMap;  // maps by strip ID for later combination - can have duplicate strips
-  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex;        // map to all data for each detector ID
-  typedef std::map<uint32_t, OneDetectorRawMap> SiGlobalRawIndex;  // map to all data for each detector ID
+  typedef std::map<uint32_t, OneDetectorMap> SiGlobalIndex;                      // map to all data for each detector ID
+  typedef std::vector<std::pair<uint32_t, OneDetectorRawMap>> SiGlobalRawIndex;  // map to all data for each detector ID
 
   typedef SiDigitalConverter::DigitalVecType DigitalVecType;
 
@@ -89,10 +89,10 @@ private:
   SiGlobalRawIndex SiRawDigis_;
 
   // variables for temporary storage of mixed hits:
-  typedef std::map<int, Amplitude> SignalMapType;
+  typedef std::vector<std::pair<int, Amplitude>> SignalMapType;
   typedef std::map<uint32_t, SignalMapType> signalMaps;
 
-  const SignalMapType* getSignal(uint32_t detID) const {
+  SignalMapType const* getSignal(uint32_t detID) const {
     auto where = signals_.find(detID);
     if (where == signals_.end()) {
       return nullptr;
@@ -382,7 +382,6 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   }
 
   std::map<int, std::bitset<6>> DeadAPVList;
-  DeadAPVList.clear();
 
   // First, have to convert all ADC counts to raw pulse heights so that values can be added properly
   // In PreMixing, pulse heights are saved with ADC = sqrt(9.0*PulseHeight) - have to undo.
@@ -391,8 +390,6 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   // Simultaneously, merge lists of hit channels in each DetId.
   // Signal Digis are in the list first, have to merge lists of hit strips on the fly,
   // add signals on duplicates later
-
-  OneDetectorRawMap LocalRawMap;
 
   // Now, loop over hits and add them to the map in the proper sorted order
   // Note: We are assuming that the hits from the Signal events have been created in
@@ -407,32 +404,28 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   for (SiGlobalIndex::const_iterator IDet = SiHitStorage_.begin(); IDet != SiHitStorage_.end(); IDet++) {
     uint32_t detID = IDet->first;
 
-    OneDetectorMap LocalMap = IDet->second;
+    auto const& LocalMap = IDet->second;
 
     //loop over hit strips for this DetId, do conversion to pulse height, store.
-
-    LocalRawMap.clear();
-
-    OneDetectorMap::const_iterator iLocal = LocalMap.begin();
-    for (; iLocal != LocalMap.end(); ++iLocal) {
-      uint16_t currentStrip = iLocal->strip();
-      float signal = float(iLocal->adc());
-      if (iLocal->adc() == 1022)
-        signal = 1500.;  // average values for overflows
-      if (iLocal->adc() == 1023)
-        signal = 3000.;
+    SiRawDigis_.emplace_back(detID, OneDetectorRawMap());
+    auto& localRawMap = SiRawDigis_.back().second;
+    localRawMap.reserve(LocalMap.size());
+    for (auto const& iLocal : LocalMap) {
+      uint16_t currentStrip = iLocal.strip();
+      float signal = float(iLocal.adc());
+      if (iLocal.adc() == 1022)
+        signal = 1500.f;  // average values for overflows
+      if (iLocal.adc() == 1023)
+        signal = 3000.f;
 
       //convert signals back to raw counts
+      constexpr float inv9 = 1.f / 9.0f;
+      float ReSignal = signal * signal * inv9;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
 
-      float ReSignal = signal * signal / 9.0;  // The PreMixing conversion is adc = sqrt(9.0*pulseHeight)
+      // RawDigi NewRawDigi = std::make_pair(currentStrip, ReSignal);
 
-      RawDigi NewRawDigi = std::make_pair(currentStrip, ReSignal);
-
-      LocalRawMap.push_back(NewRawDigi);
+      localRawMap.emplace_back(currentStrip, ReSignal);
     }
-
-    // save information for this detiD into global map
-    SiRawDigis_.insert(SiGlobalRawIndex::value_type(detID, LocalRawMap));
   }
 
   // If we are killing APVs, merge list of dead ones before we digitize
@@ -492,13 +485,16 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   signals_.clear();
 
   // big loop over Detector IDs:
-  for (SiGlobalRawIndex::const_iterator IDet = SiRawDigis_.begin(); IDet != SiRawDigis_.end(); IDet++) {
-    uint32_t detID = IDet->first;
+  for (auto const& IDet : SiRawDigis_) {
+    uint32_t detID = IDet.first;
 
-    SignalMapType Signals;
-    Signals.clear();
+    // create merged map:
+    auto& lSignals = signals_[detID];
 
-    OneDetectorRawMap LocalMap = IDet->second;
+    auto const& LocalMap = IDet.second;
+
+    // guess max occupancy...
+    lSignals.reserve(std::min(LocalMap.size(), 512ul));
 
     //counter variables
     int formerStrip = -1;
@@ -517,7 +513,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         ADCSum += iLocal->second;  // raw pulse height is second element.
       } else {
         if (formerStrip != -1) {
-          Signals.insert(std::make_pair(formerStrip, ADCSum));
+          lSignals.emplace_back(formerStrip, ADCSum);
         }
         // save pointers for next iteration
         formerStrip = currentStrip;
@@ -526,11 +522,9 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
       iLocalchk = iLocal;
       if ((++iLocalchk) == LocalMap.end()) {  //make sure not to lose the last one
-        Signals.insert(std::make_pair(formerStrip, ADCSum));
+        lSignals.emplace_back(formerStrip, ADCSum);
       }
     }
-    // save merged map:
-    signals_.insert(std::make_pair(detID, Signals));
   }
 
   //Now, do noise, zero suppression, take into account bad channels, etc.
@@ -547,11 +541,11 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
       // see if there is some signal on this detector
 
-      const SignalMapType* theSignal(getSignal(detID));
+      auto const* lSignal = getSignal(detID);
 
       std::vector<float> detAmpl(numStrips, 0.);
-      if (theSignal) {
-        for (const auto& amp : *theSignal) {
+      if (lSignal) {
+        for (const auto& amp : *lSignal) {
           detAmpl[amp.first] = amp.second;
         }
       }

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -682,11 +682,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         }
       }
 
-      DigitalVecType digis;
       theSiZeroSuppress->suppress(
-          theSiDigitalConverter->convert(detAmpl, &gain, detID), digis, detID, noise, threshold);
-
-      SSD.data = digis;
+          theSiDigitalConverter->convert(detAmpl, &gain, detID), SSD.data, detID, noise, threshold);
 
       // stick this into the global vector of detector info
       vSiStripDigi.push_back(SSD);

--- a/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
+++ b/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
@@ -8,9 +8,9 @@ SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix)
   _tempRaw.reserve(800);
 }
 
-SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std::vector<float>& analogSignal,
-                                                                      const SiStripGain* gain,
-                                                                      unsigned int detid) {
+SiDigitalConverter::DigitalVecType const& SiTrivialDigitalConverter::convert(const std::vector<float>& analogSignal,
+                                                                             const SiStripGain* gain,
+                                                                             unsigned int detid) {
   _temp.clear();
 
   if (PreMixing_) {
@@ -46,9 +46,8 @@ SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std:
   return _temp;
 }
 
-SiDigitalConverter::DigitalRawVecType SiTrivialDigitalConverter::convertRaw(const std::vector<float>& analogSignal,
-                                                                            const SiStripGain* gain,
-                                                                            unsigned int detid) {
+SiDigitalConverter::DigitalRawVecType const& SiTrivialDigitalConverter::convertRaw(
+    const std::vector<float>& analogSignal, const SiStripGain* gain, unsigned int detid) {
   _tempRaw.clear();
 
   if (gain) {

--- a/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
+++ b/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
@@ -2,7 +2,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix) : electronperADC(in), PreMixing_(PreMix) {
+SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix)
+    : ADCperElectron(1.f / in), PreMixing_(PreMix) {
   _temp.reserve(800);
   _tempRaw.reserve(800);
 }
@@ -18,7 +19,7 @@ SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std:
         continue;
       // convert analog amplitude to digital - special algorithm for PreMixing.
       // Need to keep all hits, including those at very low pulse heights.
-      int adc = truncate(sqrt(9.0 * analogSignal[i]));
+      int adc = truncate(std::sqrt(9.0f * analogSignal[i]));
       if (adc > 0)
         _temp.push_back(SiStripDigi(i, adc));
     }
@@ -77,7 +78,7 @@ SiDigitalConverter::DigitalRawVecType SiTrivialDigitalConverter::convertRaw(cons
 
 int SiTrivialDigitalConverter::truncate(float in_adc) const {
   //Rounding the ADC number instead of truncating it
-  int adc = int(in_adc + 0.5);
+  int adc = int(in_adc + 0.5f);
   /*
     254 ADC: 254  <= raw charge < 1023
     255 ADC: raw charge >= 1023
@@ -101,7 +102,7 @@ int SiTrivialDigitalConverter::truncate(float in_adc) const {
 
 int SiTrivialDigitalConverter::truncateRaw(float in_adc) const {
   //Rounding the ADC number
-  int adc = int(in_adc + 0.5);
+  int adc = int(in_adc + 0.5f);
   if (adc > 1023)
     return 1023;
   //Protection


### PR DESCRIPTION
Speed up of Strip digitization

a) 
ZeroSuppressor done in two loops: one compares adc with thresholds, the second performs the algo logic.
(it fixes also a defect in the previous implementation (fix done ONLY for the digitizer version))
speed up x2
b) remove maps and various copies in PreMixingSiStripWorker
c) optimize and make consistent math in single precision

igprof
original 
http://innocent.web.cern.ch/innocent/perfResults/igprof-navigator/digiDebug1T_ori_CMSSW_13_0_X_2023-01-24-1100_slc7_amd64_gcc11/24

this PR

http://innocent.web.cern.ch/innocent/perfResults/igprof-navigator/digiDebug1T_speedStrip5_CMSSW_13_0_X_2023-01-24-1100_slc7_amd64_gcc11/26




purely technical, regression expected due to the bug fix.

I'm under the impression that using a single-precision random number generator may speed up all those gaussian noise generators by a large amount.
I think that this would require a dedicated "project".