### PR TITLE
[126X] Vertex smearing for PbPb MC based on 2022 PbPb data

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -68,6 +68,7 @@ VtxSmeared = {
     'Realistic25ns900GeV2021Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns900GeV2021Collision_cfi',
     'Realistic25ns13p6TeVEarly2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi',
     'Nominal2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2022PbPbCollision_cfi',
+    'Realistic2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2022PbPbCollision_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -983,6 +983,19 @@ Nominal2022PbPbCollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(1.298155)
 )
 
+# From 2022 PbPb test data 362294
+Realistic2022PbPbCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(50),
+    Emittance = cms.double(3.36e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.01265),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.1017599),
+    Y0 = cms.double(-0.015602),
+    Z0 = cms.double(0.131175)
+)
+
 # Parameters for HL-LHC operation at 13TeV
 HLLHCVtxSmearingParameters = cms.PSet(
     MeanXIncm = cms.double(0.),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2022PbPbCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic2022PbPbCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic2022PbPbCollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic2022PbPbCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:

This PR adds a vertex smearing for 2022 PbPb MC.
The vertex positions use the beamspot in 2022 PbPb data along with the BPIX barycentre provided by Tracker Alignment group. Details see [CMS-Talk](https://cms-talk.web.cern.ch/t/request-alca-input-to-update-vertex-in-mc-of-2022-pbpb-test-run/18799/15?u=wangj). The width parameters (sigmaZ) are taken from 2022 PbPb, which is quite close to what we got in 2018.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of #40496
