### PR TITLE
Fix testCUDAService unit test

### DIFF
--- a/HeterogeneousCore/CUDAServices/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/test/BuildFile.xml
@@ -2,7 +2,11 @@
   <bin file="testCUDAService.cpp test_main.cpp" name="testCUDAService">
     <use name="catch2"/>
     <use name="cuda"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ParameterSetReader"/>
+    <use name="FWCore/PluginManager"/>
     <use name="FWCore/ServiceRegistry"/>
+    <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
   </bin>
 </iftool>

--- a/HeterogeneousCore/CUDAServices/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/test/BuildFile.xml
@@ -2,6 +2,7 @@
   <bin file="testCUDAService.cpp test_main.cpp" name="testCUDAService">
     <use name="catch2"/>
     <use name="cuda"/>
+    <use name="FWCore/ServiceRegistry"/>
     <use name="HeterogeneousCore/CUDAServices"/>
   </bin>
 </iftool>

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -10,9 +10,14 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 
 namespace {
@@ -59,19 +64,18 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
     }
 
     auto cs = makeCUDAService(ps);
+    int driverVersion = 0, runtimeVersion = 0;
+    ret = cudaDriverGetVersion(&driverVersion);
+    if (ret != cudaSuccess) {
+      FAIL("Unable to query the CUDA driver version from the CUDA runtime API: (" << ret << ") "
+                                                                                  << cudaGetErrorString(ret));
+    }
+    ret = cudaRuntimeGetVersion(&runtimeVersion);
+    if (ret != cudaSuccess) {
+      FAIL("Unable to query the CUDA runtime API version: (" << ret << ") " << cudaGetErrorString(ret));
+    }
 
     SECTION("CUDA Queries") {
-      int driverVersion = 0, runtimeVersion = 0;
-      ret = cudaDriverGetVersion(&driverVersion);
-      if (ret != cudaSuccess) {
-        FAIL("Unable to query the CUDA driver version from the CUDA runtime API: (" << ret << ") "
-                                                                                    << cudaGetErrorString(ret));
-      }
-      ret = cudaRuntimeGetVersion(&runtimeVersion);
-      if (ret != cudaSuccess) {
-        FAIL("Unable to query the CUDA runtime API version: (" << ret << ") " << cudaGetErrorString(ret));
-      }
-
       WARN("CUDA Driver Version / Runtime Version: " << driverVersion / 1000 << "." << (driverVersion % 100) / 10
                                                      << " / " << runtimeVersion / 1000 << "."
                                                      << (runtimeVersion % 100) / 10);
@@ -113,6 +117,27 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
       }
       WARN("Device with most free memory " << dev << "\n"
                                            << "     as given by CUDAService " << cs.deviceWithMostFreeMemory());
+    }
+
+    SECTION("With ResourceInformationService available") {
+      edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+      std::string const config = R"_(import FWCore.ParameterSet.Config as cms
+process = cms.Process('Test')
+process.add_(cms.Service('ResourceInformationService'))
+)_";
+      std::unique_ptr<edm::ParameterSet> params;
+      edm::makeParameterSets(config, params);
+      edm::ServiceToken tempToken(edm::ServiceRegistry::createServicesFromConfig(std::move(params)));
+      edm::ServiceRegistry::Operate operate2(tempToken);
+
+      auto cs = makeCUDAService(edm::ParameterSet{});
+      REQUIRE(cs.enabled());
+      edm::Service<edm::ResourceInformation> ri;
+      REQUIRE(ri->gpuModels().size() > 0);
+      REQUIRE(ri->nvidiaDriverVersion().size() > 0);
+      REQUIRE(ri->cudaDriverVersion() == driverVersion);
+      REQUIRE(ri->cudaRuntimeVersion() == runtimeVersion);
     }
   }
 

--- a/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
+++ b/HeterogeneousCore/CUDAServices/test/testCUDAService.cpp
@@ -10,6 +10,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 
@@ -32,6 +34,11 @@ TEST_CASE("Tests of CUDAService", "[CUDAService]") {
     WARN("Unable to query the CUDA capable devices from the CUDA runtime API: ("
          << ret << ") " << cudaGetErrorString(ret) << ". Running only tests not requiring devices.");
   }
+
+  // Make Service system available as CUDAService depends on ResourceInformationService
+  std::vector<edm::ParameterSet> psets;
+  edm::ServiceToken serviceToken = edm::ServiceRegistry::createSet(psets);
+  edm::ServiceRegistry::Operate operate(serviceToken);
 
   SECTION("CUDAService enabled") {
     edm::ParameterSet ps;


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/40616. I also added some tests that the `ResourceInformation` service gets filled by `CUDAService`.

#### PR validation:

Tested both with and without a GPU (on `amd64`) that the unit test runs.