### PR TITLE
Migrate consumesMany() to edm::GetterOfProducts() in EgammaHLTExtraProducer

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
@@ -186,7 +186,6 @@ private:
   bool saveHitsPlusHalfPi_;
   std::vector<double> recHitCountThresholds_;
   edm::GetterOfProducts<reco::RecoEcalCandidateIsolationMap> getterOfProducts_;
-
 };
 
 EgammaHLTExtraProducer::Tokens::Tokens(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc) {
@@ -204,32 +203,30 @@ EgammaHLTExtraProducer::EgammaHLTExtraProducer(const edm::ParameterSet& pset)
       saveHitsPlusPi_(pset.getParameter<bool>("saveHitsPlusPi")),
       saveHitsPlusHalfPi_(pset.getParameter<bool>("saveHitsPlusHalfPi")),
       recHitCountThresholds_(pset.getParameter<std::vector<double>>("recHitCountThresholds")) {
-        getterOfProducts_ = edm::GetterOfProducts<reco::RecoEcalCandidateIsolationMap>(edm::ProcessMatch("*"), this); 
-        callWhenNewProductsRegistered(getterOfProducts_);
-
-        for (auto& tokenLabel : tokens_.egCands) {
-          produces<trigger::EgammaObjectCollection>(tokenLabel.second);
-        }
-        for (auto& tokenLabel : tokens_.ecal) {
-          produces<EcalRecHitCollection>(tokenLabel.second);
-          for (const auto& thres : recHitCountThresholds_) {
-            produces<int>("countEcalRecHits" + tokenLabel.second + "Thres" + convertToProdNameStr(thres) + "GeV");
-          }
-        }
-        for (auto& tokenLabel : tokens_.hcal) {
-          produces<HBHERecHitCollection>(tokenLabel.second);
-          for (const auto& thres : recHitCountThresholds_) {
-            produces<int>("countHcalRecHits" + tokenLabel.second + "Thres" + convertToProdNameStr(thres) + "GeV");
-          }
-        }
-        for (auto& tokenLabel : tokens_.trks) {
-          produces<reco::TrackCollection>(tokenLabel.second);
-        }
-        for (auto& tokenLabel : tokens_.pfClusIso) {
-          produces<reco::PFClusterCollection>(tokenLabel.second);
-        }
+  getterOfProducts_ = edm::GetterOfProducts<reco::RecoEcalCandidateIsolationMap>(edm::ProcessMatch("*"), this);
+  callWhenNewProductsRegistered(getterOfProducts_);
+  for (auto& tokenLabel : tokens_.egCands) {
+    produces<trigger::EgammaObjectCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.ecal) {
+    produces<EcalRecHitCollection>(tokenLabel.second);
+    for (const auto& thres : recHitCountThresholds_) {
+      produces<int>("countEcalRecHits" + tokenLabel.second + "Thres" + convertToProdNameStr(thres) + "GeV");
+    }
+  }
+  for (auto& tokenLabel : tokens_.hcal) {
+    produces<HBHERecHitCollection>(tokenLabel.second);
+    for (const auto& thres : recHitCountThresholds_) {
+      produces<int>("countHcalRecHits" + tokenLabel.second + "Thres" + convertToProdNameStr(thres) + "GeV");
+    }
+  }
+  for (auto& tokenLabel : tokens_.trks) {
+    produces<reco::TrackCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.pfClusIso) {
+    produces<reco::PFClusterCollection>(tokenLabel.second);
+  }
 }
-
 
 void EgammaHLTExtraProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;


### PR DESCRIPTION
#### PR description:
Based on PR #40167 .
Migrate EgammaHLTExtraProducer away from consumesMany() to use edm::GetterOfProducts().

#### PR validation:
Tested in CMSSW_13_0_0_pre3, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)