### PR TITLE
replace singularity with apptainer in SonicTriton

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -113,7 +113,7 @@ A script [`cmsTriton`](./scripts/cmsTriton) is provided to launch and manage loc
 The script has two operations (`start` and `stop`) and the following options:
 * `-c`: don't cleanup temporary dir (for debugging)
 * `-D`: dry run: print container commands rather than executing them
-* `-d`: use Docker instead of Singularity
+* `-d`: use Docker instead of Apptainer
 * `-f`: force reuse of (possibly) existing container instance
 * `-g`: use GPU instead of CPU
 * `-i` [name]`: server image name (default: fastml/triton-torchgeo:20.09-py3-geometric)
@@ -123,7 +123,7 @@ The script has two operations (`start` and `stop`) and the following options:
 * `-P [port]`: base port number for services (-1: automatically find an unused port range) (default: 8000)
 * `-p [pid]`: automatically shut down server when process w/ specified PID ends (-1: use parent process PID)
 * `-r [num]`: number of retries when starting container (default: 3)
-* `-s [dir]`: Singularity sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.09-py3-geometric)
+* `-s [dir]`: Apptainer sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.09-py3-geometric)
 * `-t [dir]`: non-default hidden temporary dir
 * `-v`: (verbose) start: activate server debugging info; stop: keep server logs
 * `-w [time]`: maximum time to wait for server to start (default: 300 seconds)
@@ -137,7 +137,7 @@ in order to ensure that everything is properly cleaned up.
 (In the example below, `$CMSSW_BASE/src/HeterogeneousCore/SonicTriton/data/models` is a model repository,
 while `$CMSSW_BASE/src/HeterogeneousCore/SonicTriton/data/models/resnet50_netdef` is a model directory.)
 If a model repository is provided, all of the models it contains will be provided to the server.
-* Older versions of Singularity have a short timeout that may cause launching the server to fail the first time the command is executed.
+* Older versions of Apptainer (Singularity) have a short timeout that may cause launching the server to fail the first time the command is executed.
 The `-r` (retry) flag exists to work around this issue.
 
 A central `TritonService` is provided to keep track of all available servers and which models they can serve.
@@ -160,7 +160,7 @@ The fallback server has a separate set of options, mostly related to the invocat
 * `enable`: enable the fallback server
 * `debug`: enable debugging (equivalent to `-c` in `cmsTriton`)
 * `verbose`: enable verbose output in logs (equivalent to `-v` in `cmsTriton`)
-* `useDocker`: use Docker instead of Singularity (equivalent to `-d` in `cmsTriton`)
+* `useDocker`: use Docker instead of Apptainer (equivalent to `-d` in `cmsTriton`)
 * `useGPU`: run on local GPU (equivalent to `-g` in `cmsTriton`)
 * `retries`: number of retries when starting container (passed to `-r [num]` in `cmsTriton` if >= 0; default: -1)
 * `wait`: maximum time to wait for server to start (passed to `-w time` in `cmsTriton` if >= 0; default: -1)
@@ -168,7 +168,7 @@ The fallback server has a separate set of options, mostly related to the invocat
 * `instanceName`: specific name for server instance as alternative to random name (passed to `-n [name]` in `cmsTriton` if non-empty)
 * `tempDir`: specific name for server temporary directory (passed to `-t [dir]` in `cmsTriton` if non-empty; if `"."`, uses `cmsTriton` default)
 * `imageName`: server image name (passed to `-i [name]` in `cmsTriton` if non-empty)
-* `sandboxName`: Singularity sandbox directory (passed to `-s [dir]` in `cmsTriton` if non-empty)
+* `sandboxName`: Apptainer sandbox directory (passed to `-s [dir]` in `cmsTriton` if non-empty)
 
 ## Examples
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -38,7 +38,7 @@ usage() {
 	$ECHO "-c          \t don't cleanup temporary dir (for debugging)"
 	$ECHO "-C [dir]    \t directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)"
 	$ECHO "-D          \t dry run: print container commands rather than executing them"
-	$ECHO "-d          \t use Docker instead of Singularity"
+	$ECHO "-d          \t use Docker instead of Apptainer"
 	$ECHO "-f          \t force reuse of (possibly) existing container instance"
 	$ECHO "-g          \t use GPU instead of CPU"
 	$ECHO "-i [name]   \t server image name (default: ${IMAGE})"
@@ -48,7 +48,7 @@ usage() {
 	$ECHO "-P [port]   \t base port number for services (-1: automatically find an unused port range) (default: ${BASEPORT})"
 	$ECHO "-p [pid]    \t automatically shut down server when process w/ specified PID ends (-1: use parent process PID)"
 	$ECHO "-r [num]    \t number of retries when starting container (default: ${RETRIES})"
-	$ECHO "-s [dir]    \t Singularity sandbox directory (default: $(get_sandbox))"
+	$ECHO "-s [dir]    \t Apptainer sandbox directory (default: $(get_sandbox))"
 	$ECHO "-t [dir]    \t non-default hidden temporary dir"
 	$ECHO "-v          \t (verbose) start: activate server debugging info; stop: keep server logs"
 	$ECHO "-w [time]   \t maximum time to wait for server to start (default: ${WTIME} seconds)"
@@ -126,9 +126,27 @@ else
 	TMPDIR=$(readlink -f $TMPDIR)
 fi
 
+# find executables
+if [ -n "$USEDOCKER" ]; then
+	if [ -z "$DOCKER" ]; then
+		DOCKER="sudo docker"
+	fi
+else
+	if [ -z "$APPTAINER" ]; then
+		if type apptainer >& /dev/null; then
+			APPTAINER=apptainer
+		elif type singularity >& /dev/null; then
+			APPTAINER=singularity
+		else
+			echo "Missing apptainer and singularity"
+			exit 1
+		fi
+	fi
+fi
+
+
 SANDBOX=$(get_sandbox)
 SANDBOX=$(readlink -f ${SANDBOX})
-DOCKER="sudo docker"
 LOG="log_${SERVER}.log"
 STOPLOG="log_stop_${SERVER}.log"
 LIB=lib
@@ -204,7 +222,7 @@ start_docker(){
 		${IMAGE} tritonserver $PORTARGS $REPOARGS $VERBOSE
 }
 
-start_singularity(){
+start_apptainer(){
 	# triton server image may need to modify contents of opt/tritonserver/lib/
 	# but cvmfs is read-only
 	# -> make a writable local directory with the same contents
@@ -241,7 +259,7 @@ start_singularity(){
 
 	# start instance
 	# need to bind /cvmfs for above symlinks to work inside container
-	$DRYRUN singularity instance start \
+	$DRYRUN $APPTAINER instance start \
 		-B ${SHM}:/run/shm -B ${LIB}:/opt/tritonserver/lib -B ${SANDBOX} $MOUNTARGS $EXTRA \
 		${SANDBOX} ${SERVER}
 
@@ -257,7 +275,7 @@ start_singularity(){
 	else
 		REDIR=/dev/stdout
 	fi
-	$DRYRUN singularity run instance://${SERVER} \
+	$DRYRUN $APPTAINER run instance://${SERVER} \
 		tritonserver $PORTARGS $REPOARGS $VERBOSE >& ${REDIR} &
 	[ -z "$DRYRUN" ] || wait
 }
@@ -272,8 +290,8 @@ stop_docker(){
 	$DRYRUN $DOCKER rm ${SERVER}
 }
 
-stop_singularity(){
-	$DRYRUN singularity instance stop ${SERVER}
+stop_apptainer(){
+	$DRYRUN $APPTAINER instance stop ${SERVER}
 }
 
 test_docker(){
@@ -281,7 +299,7 @@ test_docker(){
 	${DOCKER} logs ${SERVER} |& grep "$1"
 }
 
-test_singularity(){
+test_apptainer(){
 	grep "$1" $LOG
 }
 
@@ -401,18 +419,18 @@ scram_tag(){
 }
 
 driver_docker(){
-	docker run --rm --entrypoint env ${IMAGE} | grep "CUDA_DRIVER_VERSION="
+	$DOCKER run --rm --entrypoint env ${IMAGE} | grep "CUDA_DRIVER_VERSION="
 }
 
-driver_singularity(){
+driver_apptainer(){
 	source ${SANDBOX}/.singularity.d/env/10-docker2singularity.sh && echo $CUDA_DRIVER_VERSION
 }
 
 compat_docker(){
-	docker cp $(docker create --rm ${IMAGE}):${COMPAT_SCRIPT} .
+	$DOCKER cp $($DOCKER create --rm ${IMAGE}):${COMPAT_SCRIPT} .
 }
 
-compat_singularity(){
+compat_apptainer(){
 	cp ${SANDBOX}/${COMPAT_SCRIPT} .
 }
 
@@ -480,12 +498,12 @@ else
 	if [ -n "$GPU" ]; then
 		EXTRA="--nv"
 	fi
-	START_FN=start_singularity
-	TEST_FN=test_singularity
-	STOP_FN=stop_singularity
-	DRIVER_FN=driver_singularity
-	COMPAT_FN=compat_singularity
-	PROG_NAME=Singularity
+	START_FN=start_apptainer
+	TEST_FN=test_apptainer
+	STOP_FN=stop_apptainer
+	DRIVER_FN=driver_apptainer
+	COMPAT_FN=compat_apptainer
+	PROG_NAME=Apptainer
 fi
 
 if [ "$OP" == check ]; then

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -9,7 +9,7 @@ First, the relevant data for the image classification networks should be downloa
 ```
 
 A local Triton server will be launched automatically when the tests run.
-The local server will use Singularity with CPU by default; if a local Nvidia GPU is available, it will be used instead.
+The local server will use Apptainer with CPU by default; if a local Nvidia GPU is available, it will be used instead.
 (This behavior can also be controlled manually using the "device" argument to [tritonTest_cfg.py](./tritonTest_cfg.py).)
 
 ## Test commands


### PR DESCRIPTION
#### PR description:

Followup to #40329 for consistency: try to use Apptainer first, then fall back to Singularity. (Also fix some inconsistencies with the `DOCKER` executable variable.) Change propagated to documentation.

#### PR validation:

Ran `cmsTriton` and it still works.