### PR TITLE
Fixes for newer Eigen: Use Eigen::placeholders::all

### DIFF
--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -94,7 +94,7 @@ public:
           << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size())
           << ",\n"
           << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n'
-          << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::all)
+          << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::placeholders::all)
           << " } ... } \n";
       msg << std::hex << "  [y - x] = 0x"
           << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -

--- a/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
@@ -71,7 +71,7 @@ public:
         << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
         << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
         << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n'
-        << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::all) << " } ... } \n";
+        << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::placeholders::all) << " } ... } \n";
     msg << std::hex << "  [y - x] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                reinterpret_cast<intptr_t>(view.metadata().addressOf_x())

--- a/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
+++ b/HeterogeneousCore/CUDATest/plugins/TestPortableAnalyzer.cc
@@ -71,7 +71,8 @@ public:
         << "  z    @ " << view.metadata().addressOf_z() << " = " << Column(view.z(), view.metadata().size()) << ",\n"
         << "  id   @ " << view.metadata().addressOf_id() << " = " << Column(view.id(), view.metadata().size()) << ",\n"
         << "  r    @ " << view.metadata().addressOf_r() << " = " << view.r() << '\n'
-        << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::placeholders::all) << " } ... } \n";
+        << "  m    @ " << view.metadata().addressOf_m() << " = { ... {" << view[1].m()(1, Eigen::placeholders::all)
+        << " } ... } \n";
     msg << std::hex << "  [y - x] = 0x"
         << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
                reinterpret_cast<intptr_t>(view.metadata().addressOf_x())


### PR DESCRIPTION
Use  `Eigen::placeholders::all` instead of `Eigen::all` which has been [removed in newer Eigen](https://gitlab.com/libeigen/eigen/-/commit/5dac0b53c94a7b36b5aef609df73453c09ee66bb ). Although `Eigen::placeholders::all` was marked as deprecated for current version of Eigen but in newer version it has been un-deprecated.

This is needed for newer [Tensorflow 2.11.0](https://github.com/cms-sw/cmsdist/pull/8258) ( which requires newer Eigen)

FYI @fwyzard 