### PR TITLE
remove duplicate plugins left by #38761 and #40264

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVertexSoA.cc
@@ -182,7 +182,5 @@ void SiPixelCompareVertexSoA::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<double>("dzCut", 1.);
   descriptions.addWithDefaultLabel(desc);
 }
-DEFINE_FWK_MODULE(SiPixelCompareVertexSoA);
 
-using SiPixelPhase1CompareVertexSoA = SiPixelCompareVertexSoA;
-DEFINE_FWK_MODULE(SiPixelPhase1CompareVertexSoA);
+DEFINE_FWK_MODULE(SiPixelCompareVertexSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorVertexSoA.cc
@@ -128,7 +128,5 @@ void SiPixelMonitorVertexSoA::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelVertexSoA");
   descriptions.addWithDefaultLabel(desc);
 }
-DEFINE_FWK_MODULE(SiPixelMonitorVertexSoA);
 
-using SiPixelPhase1MonitorVertexSoA = SiPixelMonitorVertexSoA;
-DEFINE_FWK_MODULE(SiPixelPhase1MonitorVertexSoA);
+DEFINE_FWK_MODULE(SiPixelMonitorVertexSoA);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -205,8 +205,6 @@ void SiPixelDigisClustersFromSoAT<TrackerTraits>::produce(edm::StreamID,
   iEvent.put(clusterPutToken_, std::move(outputClusters));
 }
 
-using SiPixelDigisClustersFromSoA = SiPixelDigisClustersFromSoAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelDigisClustersFromSoA);
 using SiPixelDigisClustersFromSoAPhase1 = SiPixelDigisClustersFromSoAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelDigisClustersFromSoAPhase1);
 using SiPixelDigisClustersFromSoAPhase2 = SiPixelDigisClustersFromSoAT<pixelTopology::Phase2>;

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
@@ -24,10 +24,10 @@ run3_common.toModify(siPixelClustersPreSplittingCUDA,
                      clusterThreshold_layer1 = 4000)
 
 # convert the pixel digis (except errors) and clusters to the legacy format
-from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoA_cfi import siPixelDigisClustersFromSoA as _siPixelDigisClustersFromSoA
+from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoAPhase1_cfi import siPixelDigisClustersFromSoAPhase1 as _siPixelDigisClustersFromSoAPhase1
 from RecoLocalTracker.SiPixelClusterizer.siPixelDigisClustersFromSoAPhase2_cfi import siPixelDigisClustersFromSoAPhase2 as _siPixelDigisClustersFromSoAPhase2
 
-siPixelDigisClustersPreSplitting = _siPixelDigisClustersFromSoA.clone()
+siPixelDigisClustersPreSplitting = _siPixelDigisClustersFromSoAPhase1.clone()
 
 run3_common.toModify(siPixelDigisClustersPreSplitting,
                      clusterThreshold_layer1 = 4000)

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEFastESProducer.cc
@@ -102,8 +102,6 @@ void PixelCPEFastESProducerT<TrackerTraits>::fillDescriptions(edm::Configuration
   descriptions.addWithDefaultLabel(desc);
 }
 
-using PixelCPEFastESProducer = PixelCPEFastESProducerT<pixelTopology::Phase1>;
-DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEFastESProducer);
 using PixelCPEFastESProducerPhase1 = PixelCPEFastESProducerT<pixelTopology::Phase1>;
 DEFINE_FWK_EVENTSETUP_MODULE(PixelCPEFastESProducerPhase1);
 using PixelCPEFastESProducerPhase2 = PixelCPEFastESProducerT<pixelTopology::Phase2>;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitCUDA.cc
@@ -94,9 +94,6 @@ void SiPixelRecHitCUDAT<TrackerTraits>::produce(edm::StreamID streamID,
               gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe->getGPUProductAsync(ctx.stream()), ctx.stream()));
 }
 
-using SiPixelRecHitCUDA = SiPixelRecHitCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelRecHitCUDA);
-
 using SiPixelRecHitCUDAPhase1 = SiPixelRecHitCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelRecHitCUDAPhase1);
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromCUDA.cc
@@ -193,9 +193,6 @@ void SiPixelRecHitFromCUDAT<TrackerTraits>::produce(edm::Event& iEvent, edm::Eve
   iEvent.emplace(rechitsPutToken_, std::move(output));
 }
 
-using SiPixelRecHitFromCUDA = SiPixelRecHitFromCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelRecHitFromCUDA);
-
 using SiPixelRecHitFromCUDAPhase1 = SiPixelRecHitFromCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelRecHitFromCUDAPhase1);
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromCUDA.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromCUDA.cc
@@ -93,9 +93,6 @@ void SiPixelRecHitSoAFromCUDAT<TrackerTraits>::produce(edm::Event& iEvent, edm::
   iEvent.emplace(hitsPutTokenCPU_, std::move(hits_h_));
 }
 
-using SiPixelRecHitSoAFromCUDA = SiPixelRecHitSoAFromCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelRecHitSoAFromCUDA);
-
 using SiPixelRecHitSoAFromCUDAPhase1 = SiPixelRecHitSoAFromCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelRecHitSoAFromCUDAPhase1);
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
@@ -286,9 +286,6 @@ void SiPixelRecHitSoAFromLegacyT<TrackerTraits>::produce(edm::StreamID streamID,
     iEvent.put(std::move(legacyOutput));
 }
 
-using SiPixelRecHitSoAFromLegacy = SiPixelRecHitSoAFromLegacyT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelRecHitSoAFromLegacy);
-
 using SiPixelRecHitSoAFromLegacyPhase1 = SiPixelRecHitSoAFromLegacyT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelRecHitSoAFromLegacyPhase1);
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -10,7 +10,7 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 # 2. Pixel Generic CPE
 #
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
-from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import *
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase1_cfi import *
 from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase2_cfi import *
 #
 # 3. ESProducer for the Magnetic-field dependent template records

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -43,9 +43,9 @@ siPixelRecHitsPreSplittingTask = cms.Task(
 )
 
 # reconstruct the pixel rechits on the gpu
-from RecoLocalTracker.SiPixelRecHits.siPixelRecHitCUDA_cfi import siPixelRecHitCUDA as _siPixelRecHitCUDA
+from RecoLocalTracker.SiPixelRecHits.siPixelRecHitCUDAPhase1_cfi import siPixelRecHitCUDAPhase1 as _siPixelRecHitCUDAPhase1
 from RecoLocalTracker.SiPixelRecHits.siPixelRecHitCUDAPhase2_cfi import siPixelRecHitCUDAPhase2 as _siPixelRecHitCUDAPhase2
-siPixelRecHitsPreSplittingCUDA = _siPixelRecHitCUDA.clone(
+siPixelRecHitsPreSplittingCUDA = _siPixelRecHitCUDAPhase1.clone(
     beamSpot = "offlineBeamSpotToCUDA"
 )
 phase2_tracker.toReplaceWith(siPixelRecHitsPreSplittingCUDA,_siPixelRecHitCUDAPhase2.clone(

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackDumpCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackDumpCUDA.cc
@@ -94,9 +94,6 @@ void PixelTrackDumpCUDAT<TrackerTraits>::analyze(edm::StreamID streamID,
   }
 }
 
-using PixelTrackDumpCUDA = PixelTrackDumpCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(PixelTrackDumpCUDA);
-
 using PixelTrackDumpCUDAPhase1 = PixelTrackDumpCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(PixelTrackDumpCUDAPhase1);
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -256,9 +256,6 @@ void PixelTrackProducerFromSoAT<TrackerTraits>::produce(edm::StreamID streamID,
   iEvent.put(std::move(indToEdmP));
 }
 
-using PixelTrackProducerFromSoA = PixelTrackProducerFromSoAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(PixelTrackProducerFromSoA);
-
 using PixelTrackProducerFromSoAPhase1 = PixelTrackProducerFromSoAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(PixelTrackProducerFromSoAPhase1);
 

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
@@ -103,9 +103,6 @@ void PixelTrackSoAFromCUDAT<TrackerTraits>::produce(edm::Event& iEvent, edm::Eve
   assert(!tracks_h_.buffer());
 }
 
-using PixelTrackSoAFromCUDA = PixelTrackSoAFromCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(PixelTrackSoAFromCUDA);
-
 using PixelTrackSoAFromCUDAPhase1 = PixelTrackSoAFromCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(PixelTrackSoAFromCUDAPhase1);
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletCUDA.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletCUDA.cc
@@ -108,9 +108,6 @@ void CAHitNtupletCUDAT<TrackerTraits>::produce(edm::StreamID streamID,
   }
 }
 
-using CAHitNtupletCUDA = CAHitNtupletCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(CAHitNtupletCUDA);
-
 using CAHitNtupletCUDAPhase1 = CAHitNtupletCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(CAHitNtupletCUDAPhase1);
 

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
@@ -154,9 +154,6 @@ void PixelVertexProducerCUDAT<TrackerTraits>::produce(edm::StreamID streamID,
   }
 }
 
-using PixelVertexProducerCUDA = PixelVertexProducerCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(PixelVertexProducerCUDA);
-
 using PixelVertexProducerCUDAPhase1 = PixelVertexProducerCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(PixelVertexProducerCUDAPhase1);
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromSoA.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedProducerFromSoA.cc
@@ -174,9 +174,6 @@ void SeedProducerFromSoAT<TrackerTraits>::produce(edm::StreamID streamID,
   iEvent.put(std::move(result));
 }
 
-using SeedProducerFromSoA = SeedProducerFromSoAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SeedProducerFromSoA);
-
 using SeedProducerFromSoAPhase1 = SeedProducerFromSoAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SeedProducerFromSoAPhase1);
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -7,7 +7,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4MixedTriplets_cfi impor
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
-from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducer_cfi import *
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase1_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -8,6 +8,7 @@ from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelPairs_cfi import *
 from RecoTracker.TkSeedingLayers.TTRHBuilderWithoutAngle4PixelTriplets_cfi import *
 #TransientTRH builder with template
 from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase1_cfi import *
+from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerPhase2_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPETemplateReco_cfi import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *


### PR DESCRIPTION
#### PR description:

#38761 and #40264 led to the renaming of a few plugin types. The old plugin types were kept in place as duplicates at the request of HLT, to ease the renaming of these plugins in the HLT menus. After the HLT-menu updates integrated in #40641, these duplicate plugins can be removed.

Merely technical. No changes expected.

#### PR validation:

Tested a small number of workflows with `runTheMatrix.py`.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A