### PR TITLE
Removal of ofast-flag (AMD/Intel differences)

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaElectronAlgos/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="TrackingTools/MaterialEffects"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonAlgos/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/CaloGeometry"/>

--- a/RecoPixelVertexing/PixelTriplets/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/BuildFile.xml
@@ -27,5 +27,4 @@
 <export>
   <lib name="1"/>
 </export>
-<use name="ofast-flag"/>
 <flags CXXFLAGS="-fno-math-errno"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="CUDADataFormats/Track"/>
 <use name="CUDADataFormats/TrackingRecHit"/>
 <use name="CommonTools/RecoAlgos"/>

--- a/RecoTracker/FinalTrackSelectors/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/VertexReco"/>
 <use name="FWCore/Framework"/>

--- a/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
+++ b/RecoTracker/FinalTrackSelectors/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="CommonTools/Statistics"/>
 <use name="CommonTools/Utils"/>
 <use name="CondFormats/GBRForest"/>

--- a/RecoTracker/TkDetLayers/BuildFile.xml
+++ b/RecoTracker/TkDetLayers/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoTracker/TkHitPairs/BuildFile.xml
+++ b/RecoTracker/TkHitPairs/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="clhep"/>
 <use name="boost"/>
 <use name="root"/>

--- a/RecoVertex/PrimaryVertexProducer/BuildFile.xml
+++ b/RecoVertex/PrimaryVertexProducer/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/VertexReco"/>
 <use name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/BuildFile.xml
+++ b/TrackingTools/GsfTools/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="CLHEP"/>
 <export>
   <lib name="1"/>

--- a/TrackingTools/GsfTools/plugins/BuildFile.xml
+++ b/TrackingTools/GsfTools/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/GsfTools"/>
 <use name="FWCore/Framework"/>

--- a/TrackingTools/GsfTools/test/BuildFile.xml
+++ b/TrackingTools/GsfTools/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="TrackingTools/GsfTools"/>
 <use name="TrackingTools/AnalyticalJacobians"/>
 <use name="rootmath"/>

--- a/TrackingTools/GsfTracking/BuildFile.xml
+++ b/TrackingTools/GsfTracking/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="boost"/>
 <use name="CLHEP"/>
 <export>

--- a/TrackingTools/KalmanUpdators/BuildFile.xml
+++ b/TrackingTools/KalmanUpdators/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags CXXFLAGS="-funroll-all-loops"/>
-<use name="ofast-flag"/>
 <use name="clhep"/>
 <use name="RecoTracker/TransientTrackingRecHit"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>

--- a/TrackingTools/MaterialEffects/plugins/BuildFile.xml
+++ b/TrackingTools/MaterialEffects/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/MaterialEffects"/>
 <library file="*.cc" name="TrackingToolsMaterialEffectsPlugins">

--- a/TrackingTools/TrackFitters/BuildFile.xml
+++ b/TrackingTools/TrackFitters/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags CXXFLAGS="-ffp-contract=off"/>
-<use name="ofast-flag"/>
 <use name="boost"/>
 <use name="CLHEP"/>
 <export>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="ofast-flag"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/GeometryVector"/>


### PR DESCRIPTION
#### PR description:

About one year ago we discovered differences of few percents between AMD and Intel in few HLT paths when rerunning the HLT [1]. The situation got worse when we added the parking di-electron paths with dZ path, which gave a difference of ~8% [2].
Given that:
- we didn't manage yet to validate the impact on the offline reconstruction [3]
- we don't have yet a way to check if an event has been reconstructed by an AMD or Intel CPU [4]
- the parking di-electron paths with dZ will be used heavily in the 2023 menu (~500 Hz)

I propose to remove Ofast from all CMSSW package (except `DataFormat/Math/test`) since 13_0_0_pre4.

The impact on reco time is 1.1%-1.2% from @cms-sw/reconstruction-l2 measurement [5]. 
The impact on the HLT timing is negligible.

Caveat: there is an ongoing test by @gparida following @VinInn suggestion [6] about using `-Ofast  -fno-reciprocal-math -mno-recip`.

Warning to release managers: this PR changes many BuildFiles.xml and therefore the compilation takes a lot of time. This might be a problem for people who will need to rebase their PR including this PR.

[1] https://its.cern.ch/jira/browse/CMSHLT-2257
[2] https://docs.google.com/spreadsheets/d/1XRu1sfIYJUQ0e7Z_yJWdGrxTDA31zr33uWPFY54-APc
[3] https://its.cern.ch/jira/browse/PDMVRELVALS-159
[4] https://github.com/cms-sw/cmssw/issues/39982 and https://github.com/cms-sw/cmssw/issues/30044
[5] https://github.com/cms-sw/cmssw/issues/40089
[6] https://its.cern.ch/jira/browse/CMSHLT-2257?focusedCommentId=4686018&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4686018

cc: @dpiparo @gparida @cms-sw/hlt-l2 @sanuvarghese

#### PR validation:

Still ongoing