### PR TITLE
guard against no L1T uGT digis in `L1TriggerResultsConverter` [`12_4_X`]

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
+++ b/PhysicsTools/NanoAOD/plugins/L1TriggerResultsConverter.cc
@@ -125,18 +125,17 @@ void L1TriggerResultsConverter::beginRun(edm::Run const&, edm::EventSetup const&
 // ------------ method called to produce the data  ------------
 
 void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace edm;
   const std::vector<bool>* wordp = nullptr;
   bool unprefireable_bit = false;
   if (!legacyL1_) {
-    edm::Handle<GlobalAlgBlkBxCollection> handleResults;
-    iEvent.getByToken(token_, handleResults);
-    wordp = &handleResults->at(0, 0).getAlgoDecisionFinal();
+    const auto& resultsProd = iEvent.get(token_);
+    if (not resultsProd.isEmpty(0)) {
+      wordp = &resultsProd.at(0, 0).getAlgoDecisionFinal();
+    }
     if (store_unprefireable_bit_) {
-      edm::Handle<GlobalExtBlkBxCollection> handleExtResults;
-      iEvent.getByToken(token_ext_, handleExtResults);
+      auto handleExtResults = iEvent.getHandle(token_ext_);
       if (handleExtResults.isValid()) {
-        if (handleExtResults->size() != 0) {
+        if (not handleExtResults->isEmpty(0)) {
           unprefireable_bit = handleExtResults->at(0, 0).getExternalDecision(GlobalExtBlk::maxExternalConditions - 1);
         }
       } else {
@@ -149,18 +148,17 @@ void L1TriggerResultsConverter::produce(edm::Event& iEvent, const edm::EventSetu
     iEvent.getByToken(tokenLegacy_, handleResults);
     wordp = &handleResults->decisionWord();
   }
-  auto const& word = *wordp;
-  HLTGlobalStatus l1bitsAsHLTStatus(names_.size());
+  edm::HLTGlobalStatus l1bitsAsHLTStatus(names_.size());
   unsigned indices_size = indices_.size();
   for (size_t nidx = 0; nidx < indices_size; nidx++) {
-    unsigned int index = indices_[nidx];
-    bool result = word[index];
-    if (!mask_.empty())
-      result &= (mask_[index] != 0);
-    l1bitsAsHLTStatus[nidx] = HLTPathStatus(result ? edm::hlt::Pass : edm::hlt::Fail);
+    unsigned int const index = indices_[nidx];
+    bool result = wordp ? wordp->at(index) : false;
+    if (not mask_.empty())
+      result &= (mask_.at(index) != 0);
+    l1bitsAsHLTStatus[nidx] = edm::HLTPathStatus(result ? edm::hlt::Pass : edm::hlt::Fail);
   }
   if (store_unprefireable_bit_)
-    l1bitsAsHLTStatus[indices_size] = HLTPathStatus(unprefireable_bit ? edm::hlt::Pass : edm::hlt::Fail);
+    l1bitsAsHLTStatus[indices_size] = edm::HLTPathStatus(unprefireable_bit ? edm::hlt::Pass : edm::hlt::Fail);
   //mimic HLT trigger bits for L1
   auto out = std::make_unique<edm::TriggerResults>(l1bitsAsHLTStatus, names_);
   iEvent.put(std::move(out));


### PR DESCRIPTION
backport of #40528

#### PR description:

This PR fixes the edge case reported in #40494. It adds a check on the size of the L1T uGT digis, returning `false` for all L1T algorithms when said input collection has `0` elements for the relevant BX (see https://github.com/cms-sw/cmssw/pull/40528#discussion_r1081662085 for details).

#### PR validation:

None beyond the checks done for #40528.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40528

Bugfix to NanoAOD.
