### PR TITLE
Make WriteBuffer delete all its temp files in /dev/shm

### DIFF
--- a/FWCore/SharedMemory/interface/WriteBuffer.h
+++ b/FWCore/SharedMemory/interface/WriteBuffer.h
@@ -73,7 +73,7 @@ namespace edm::shared_memory {
       SMOwner() = default;
       SMOwner(std::string const& iName, std::size_t iLength);
       ~SMOwner();
-      SMOwner& operator=(SMOwner&&) = default;
+      SMOwner& operator=(SMOwner&&);
       boost::interprocess::managed_shared_memory* operator->() { return sm_.get(); }
       boost::interprocess::managed_shared_memory* get() { return sm_.get(); }
       operator bool() const { return bool(sm_); }

--- a/FWCore/SharedMemory/src/WriteBuffer.cc
+++ b/FWCore/SharedMemory/src/WriteBuffer.cc
@@ -41,6 +41,15 @@ WriteBuffer::SMOwner::~SMOwner() {
   }
 }
 
+WriteBuffer::SMOwner& WriteBuffer::SMOwner::operator=(WriteBuffer::SMOwner&& other) {
+  if (sm_) {
+    boost::interprocess::shared_memory_object::remove(name_.c_str());
+  }
+  name_ = std::move(other.name_);
+  sm_ = std::move(other.sm_);
+  return *this;
+}
+
 void WriteBuffer::SMOwner::reset() { *this = SMOwner(); }
 
 WriteBuffer::~WriteBuffer() {
@@ -48,6 +57,7 @@ WriteBuffer::~WriteBuffer() {
     sm_->destroy<char>(buffer_names::kBuffer);
   }
 }
+
 //
 // member functions
 //


### PR DESCRIPTION
#### PR description:

Make WriteBuffer delete all its temp files in /dev/shm.

Each time the unit tests run the bug fixed here leaves behind 4 files with names similar to the following.

```
-rw-r--r--. 1 wdd    zh 1842 Jan 31 20:44 testProd23885_2buffer1
-rw-r--r--. 1 wdd    zh 1842 Jan 31 20:44 testProd23885_3buffer1
-rw-r--r--. 1 wdd    zh 1842 Jan 31 20:44 testProd23885_1buffer1
-rw-r--r--. 1 wdd    zh 5842 Jan 31 20:44 testProd23885_0buffer1
```

The 5 digit number is the PID. There is a possibility of a name clash if a later unit test both has the same PID AND is run by a different user. I noticed this while testing an unrelated PR and probably unluckily hit such a name clash.

This is related to #40484. Note that on cmsdev32 there are a few thousand old files in /dev/shm related to this problem  cluttering up that directory. Some are there from problems fixed in #40484 and some from problems fixed by this PR. There could be some on other machines as well. I'm not sure how the machines are configured, but I would guess these will cleaned up next time each machine is rebooted. Until then, there is a possibility of name clashes in these unit tests (probably rarely). We believe the IBs avoid the problem because the code does try to delete the clashing file if it can. That does not work if a different user owns the file though, so for users running the unit tests outside the IBs there is a potential for problems.

#### PR validation:

Existing unit tests pass. I manually ran them and manually examined the contents of /dev/shm and new files are not left there anymore when the unit tests run. They appear to be getting cleaned up when the test ends as intended.
