### PR TITLE
demote `LogError` about "L1GlobalDecision" in `HLTPrescaleProvider`

### DIFF
--- a/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
@@ -101,6 +101,8 @@ public:
                                   bool readPrescalesFromFile);
 
 private:
+  static constexpr const char* l1tGlobalDecisionKeyword_ = "L1GlobalDecision";
+
   void checkL1GtUtils() const;
   void checkL1TGlobalUtil() const;
 


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #40481. It demotes the `LogError` issued by the class `HLTPrescaleProvider` about "L1GlobalDecision" to a `LogDebug` message.

This error message, which laments a failure in determining the prescales of the L1T algorithm "L1GlobalDecision", can be seen in the logs of several Run-3 workflows (see https://github.com/cms-sw/cmssw/pull/40481#issuecomment-1381786806) [1]. This 'failure' is expected, because "L1GlobalDecision" is not a valid L1T algorithm, but a keyword used mainly by HLT to identify the global decision of the L1T trigger (Final OR, after vetos). For this reason, the `LogError` call is demoted to `LogDebug`.

Merely technical. No changes expected. Outputs are unchanged (except for the warning message).

[1] From [step 3 of wf `11634.0` in a recent IB](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-baseline-tests/CMSSW_13_0_X_2023-01-31-1100/el8_amd64_gcc11/-GenuineIntel/matrix-results/11634.0_TTbar_14TeV+2021/step3_TTbar_14TeV+2021.log):
```
%MSG-e HLTPrescaleProvider:  PATTriggerProducer:patTrigger  31-Jan-2023 17:18:08 CET Run: 1 Event: 1
 Error in determining L1T prescales for HLT path: 'MC_Run3_PFScoutingPixelTracking_v18' with complex L1T seed: 'L1GlobalDecision' using L1TGlobalUtil: 
 isValid=1 l1tname/error/prescale 1
 0:L1GlobalDecision/0/-1.
%MSG
```

#### PR validation:

Checked that the error message disappears as expected in one of the relevant wfs (i.e. wf `11634.0`).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A