### PR TITLE
improve check on size of L1-uGT digis in `HLTL1TSeed` plugin

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -476,10 +476,9 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
   }
 
   // check size
-  if (uGtAlgoBlocks->size() == 0) {
+  if (uGtAlgoBlocks->isEmpty(0)) {
     edm::LogWarning("HLTL1TSeed") << " Warning: GlobalAlgBlkBxCollection with input tag " << m_l1GlobalTag
-                                  << " is empty." << std::endl;
-
+                                  << " is empty for BX=0.";
     return false;
   }
 


### PR DESCRIPTION
#### PR description:

This PR improves a check on the size of the L1-uGT digis accessed in the `HLTL1TSeed` plugin.

Since the plugin accesses the digis associated to BX=0 (e.g. [here](https://github.com/cms-sw/cmssw/blob/3fa9bc2b0cc042ccc096cb794d35a25f227c3529/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc#L577)), the check now considers the number of digis in BX=0, rather than just the total size for all BXs.

Was discussed in https://github.com/cms-sw/cmssw/pull/40528#discussion_r1071129276.

Merely technical. No changes expected.

(I suspect that something makes 'old' and 'new' check equivalent for virtually all use cases; otherwise, I would not know how this did not cause crashes in the past.)

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A