### PR TITLE
`cmsDriver.py`: flush stdout buffer before call to `os.execvpe` [`12_6_X`]

### DIFF
--- a/Configuration/Applications/scripts/cmsDriver.py
+++ b/Configuration/Applications/scripts/cmsDriver.py
@@ -45,10 +45,8 @@ def run():
             commandString = options.prefix+" cmsRun "+options.suffix
             print("Starting "+commandString+' '+options.python_filename)
             commands = commandString.lstrip().split()
+            sys.stdout.flush()
             os.execvpe(commands[0],commands+[options.python_filename],os.environ)
             sys.exit()
 
 run()
-
-
-    


### PR DESCRIPTION
backport of #40635

#### PR description:

From the description of #40635:

>This PR updates the script `cmsDriver.py` adding a call to `sys.stdout.flush()` right before `os.execvpe` is used to execute `cmsRun`. As explained in the [documentation of `os.execvpe`](https://docs.python.org/3/library/os.html#os.execvpe), this ensures that the stdout buffer is flushed before the `os.execvpe` call replaces the current process.
>
>Currently (i.e. without this PR), redirecting the output of `cmsDriver.py` to a log file may result in the latter not containining all the printouts of `cmsDriver.py` (if the `--no_exec` option is not used). This means that this PR will increase the size of the logs of RelVal tests in PRs.
>
>For further details, see also https://github.com/cms-sw/cmssw/pull/40599#issuecomment-1407603855.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40635

Small bugfix to `cmsDriver.py`. The main reason to backport this fix is avoiding false reports about large reductions of logs in every future PR to this release cycle (see https://github.com/cms-sw/cmssw/pull/40650#issuecomment-1411586841 for an example). This fix alone does not warrant a new release, imho.
