### PR TITLE
Add VtxSmearing scenario for 2022 EOY MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -67,6 +67,7 @@ VtxSmeared = {
     'Run3FlatOpticsGaussSigmaZ5p3cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi',
     'Realistic25ns900GeV2021Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns900GeV2021Collision_cfi',
     'Realistic25ns13p6TeVEarly2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi',
+    'Realistic25ns13p6TeVEOY2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi',
     'Nominal2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2022PbPbCollision_cfi',
     'Realistic2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2022PbPbCollision_cfi',
 }

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -812,6 +812,37 @@ Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(1.298155)
 )
 
+# BS parameters extracted from run 360459, Fill 8274:
+# X0         =  0.1742 [cm]
+# Y0         = -0.1831 [cm]
+# Z0         = -0.2531 [cm]
+# sigmaZ0    =  3.4019  [cm]
+# BeamWidthX = 0.0007519 [cm]
+# BeamWidthY = 0.0008636 [cm]
+#
+# set SigmaZ0 = 3.4 [cm]
+# set BeamWidthX = BeamWidthY = 8.0 [um]
+# set beta* = 30 cm
+# energy = 13.6 TeV
+# From LHC calculator, emittance is 4.276-8 cm
+# https://lpc.web.cern.ch/lumiCalc.html
+#
+# BPIX absolute position:
+# X =  0.0714025 cm
+# Y = -0.166338  cm
+# Z = -0.354856  cm
+Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(30.0),
+    Emittance = cms.double(4.276e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(3.4),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.1027975),
+    Y0 = cms.double(-0.016762),
+    Z0 = cms.double(0.607956)
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:
This PR adds a new VtxSmearing scenario `Realistic25ns13p6TeVEOY2022Collision` which better represents the BeamSpot in 2022 (with respect to the previously used `Early2022` smearing) and will be used for the "EOY" 2022 MC campaigns, later this year:
 - The BeamSpot is extracted from run [360459](https://cmsoms.cern.ch/cms/runs/report?cms_run=360459) (Fill [8274](https://cmsoms.cern.ch/cms/fills/report?cms_fill=8274))
 - The BPIX barycenter is taken from the Prompt GT from the same run
 - The corresponding BS tag in CondDB is [BeamSpotObjects_Realistic25ns_13p6TeVCollisions_EOY2022_v0_mc](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/BeamSpotObjects_Realistic25ns_13p6TeVCollisions_EOY2022_v0_mc)

This set of VtxSmearing parameters has been discussed (and approved) at the [Joint Tracker DPG / Tracking POG meeting during CMS week](https://indico.cern.ch/event/1243349/?showDate=all&showSession=8#7-beamspot-for-2022-eoy-mc).

#### PR validation:
None
At the moment the new smearing is not used anywhere and we will have to go through the usual action-items
before actually deploying it:
 - this PR:
    - include the smearing in a pre-release
 - "offline":
    - generate relvals with the new smearing
    - fit the reco-BeamSpot
 - future PR
    - include the new reco-BeamSpot in the GTs and the workflows

#### Backport:
Not a backport, no backport needed