### PR TITLE
Remove trigger evaluation in ExoticaDQM module and related variables

### DIFF
--- a/DQM/Physics/python/ExoticaDQM_cfi.py
+++ b/DQM/Physics/python/ExoticaDQM_cfi.py
@@ -4,10 +4,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ExoticaDQM = DQMEDAnalyzer(
     "ExoticaDQM",
 
-    #Trigger Results
-    TriggerResults           = cms.InputTag('TriggerResults','','HLT'),
-    HltPaths                 = cms.vstring("HLT_Mu","HLT_Ele","HLT_Photon","HLT_PFHT","HLT_HT","HLT_PFMET","HLT_MET","HLT_"),
-
     #Physics objects
     vertexCollection         = cms.InputTag('offlinePrimaryVertices'),
     electronCollection       = cms.InputTag("gedGsfElectrons"),

--- a/DQM/Physics/src/ExoticaDQM.cc
+++ b/DQM/Physics/src/ExoticaDQM.cc
@@ -369,7 +369,6 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // JetCorrector
   bool ValidJetCorrector = iEvent.getByToken(JetCorrectorToken_, JetCorrector_);
 
-
   for (int i = 0; i < 2; i++) {
     //Jets
     PFJetPx[i] = 0.;

--- a/DQM/Physics/src/ExoticaDQM.cc
+++ b/DQM/Physics/src/ExoticaDQM.cc
@@ -3,7 +3,6 @@
 using namespace edm;
 using namespace std;
 using namespace reco;
-using namespace trigger;
 
 typedef vector<string> vstring;
 
@@ -17,9 +16,6 @@ ExoticaDQM::ExoticaDQM(const edm::ParameterSet& ps) {
   typedef std::vector<edm::InputTag> vtag;
 
   // Get parameters from configuration file
-  // Trigger
-  TriggerToken_ = consumes<TriggerResults>(ps.getParameter<edm::InputTag>("TriggerResults"));
-  HltPaths_ = ps.getParameter<vector<string> >("HltPaths");
   //
   VertexToken_ = consumes<reco::VertexCollection>(ps.getParameter<InputTag>("vertexCollection"));
   //
@@ -327,11 +323,6 @@ void ExoticaDQM::bookHistograms(DQMStore::IBooker& bei, edm::Run const&, edm::Ev
 void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // objects
 
-  //Trigger
-  bool ValidTriggers = iEvent.getByToken(TriggerToken_, TriggerResults_);
-  if (!ValidTriggers)
-    return;
-
   // Vertices
   bool ValidVertices = iEvent.getByToken(VertexToken_, VertexCollection_);
   if (!ValidVertices)
@@ -378,23 +369,6 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // JetCorrector
   bool ValidJetCorrector = iEvent.getByToken(JetCorrectorToken_, JetCorrector_);
 
-  //Trigger
-
-  int N_Triggers = TriggerResults_->size();
-  int N_GoodTriggerPaths = HltPaths_.size();
-  bool triggered_event = false;
-  const edm::TriggerNames& trigName = iEvent.triggerNames(*TriggerResults_);
-  for (int i_Trig = 0; i_Trig < N_Triggers; ++i_Trig) {
-    if (TriggerResults_.product()->accept(i_Trig)) {
-      for (int n = 0; n < N_GoodTriggerPaths; n++) {
-        if (trigName.triggerName(i_Trig).find(HltPaths_[n]) != std::string::npos) {
-          triggered_event = true;
-        }
-      }
-    }
-  }
-  if (triggered_event == false)
-    return;
 
   for (int i = 0; i < 2; i++) {
     //Jets

--- a/DQM/Physics/src/ExoticaDQM.h
+++ b/DQM/Physics/src/ExoticaDQM.h
@@ -22,11 +22,6 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-// Trigger
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include "FWCore/Common/interface/TriggerNames.h"
-
 // Candidate handling
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -128,13 +123,6 @@ private:
 
   int nLumiSecs_;
   int nEvents_, irun, ievt;
-
-  bool isValidHltConfig_;
-
-  //Trigger
-  std::vector<std::string> HltPaths_;
-  edm::EDGetTokenT<edm::TriggerResults> TriggerToken_;
-  edm::Handle<edm::TriggerResults> TriggerResults_;
 
   //Vertex
   edm::EDGetTokenT<reco::VertexCollection> VertexToken_;

--- a/DQM/Physics/test/ExoticaDQM_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_cfg.py
@@ -58,7 +58,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-'/store/relval/CMSSW_12_2_0_pre2/RelValZprimeToEE_M-6000_TuneCP5_14TeV-pythia8/GEN-SIM-RECO/122X_mcRun3_2021_realistic_v1_TkmkFitHighStat-v1/2580000/1e0694f9-fbf3-4bd0-8eef-3ec39232e5ad.root'
+'/store/relval/CMSSW_12_6_0_pre5/RelValZEE_14/GEN-SIM-RECO/125X_mcRun3_2022_realistic_v5-v1/2590000/30d197e2-5802-41da-9d2d-5c8e8bf7f1c0.root'
     )
 )
 

--- a/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
@@ -26,7 +26,7 @@ process.GlobalTag.globaltag = cms.string(options.globaltag)
 
 ## input file 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(options.inputFiles),
+    fileNames = cms.untracked.vstring('file:EXOTICA_DQM_TEST.root'),
     processingMode = cms.untracked.string('RunsAndLumis')
 )
 


### PR DESCRIPTION
#### PR description:

This PR removes the requirement of the Offline EXO PAG validation code for the events to pass the selected triggers. Currently a set of HLT paths was evaluated and the histograms were filled only if the events passed at least one of them.

Phase-2 HLT menu development (see https://github.com/cms-sw/cmssw/pull/40412) would reduce the statistics in the EXO DQM histograms as shown in [1]. To avoid this decrease and provided that trigger evaluation do not provide significant insight into the validation of offline objects, we have converged into removing the trigger requirement.

Impact in Phase-2 can be studied by testing together with https://github.com/cms-sw/cmssw/pull/40412 
@srimanob

[1] https://indico.cern.ch/event/1243344/

#### PR validation:

This PR passed all unit tests and the full standard battery of runTheMatrix workflows:
runTheMatrix.py -l limited -i all --ibeos

It was checked that the current HLT menu let all the events of the relval samples pass and fill the histograms. No changes are expected in the validation plots with respect to the previous EXO DQM configuration. The number of events that fired these triggers is shown in the attached plots for three different relval samples that are often used in EXO validation:

![trigger_triggeredEvents_QCD](https://user-images.githubusercontent.com/29282388/216104046-ba8c658e-297a-4731-9ede-660d88313707.png)
![trigger_triggeredEvents_SingleMu](https://user-images.githubusercontent.com/29282388/216104074-9b942560-0645-4e53-a644-c8bec428f804.png)
![trigger_triggeredEvents_ZEE](https://user-images.githubusercontent.com/29282388/216104090-17c6a939-9df3-44fb-a2d5-0153cee5fa1e.png)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It is not a backport
