### PR TITLE
MTD clusters and rechits in Fireworks

### DIFF
--- a/Fireworks/Core/interface/Context.h
+++ b/Fireworks/Core/interface/Context.h
@@ -98,6 +98,11 @@ namespace fireworks {
     static float caloTransAngle();
     static double caloMaxEta();
 
+    static float mtdEtlR1();
+    static float mtdEtlR2();
+    static float mtdEtlZ1(const unsigned int& disk_number = 1);
+    static float mtdEtlZ2(const unsigned int& disk_number = 1);
+
     Context(const Context&) = delete;                   // stop default
     const Context& operator=(const Context&) = delete;  // stop default
   private:
@@ -139,6 +144,13 @@ namespace fireworks {
     // proxy-builder offsets
     static const float s_caloOffR;
     static const float s_caloOffZ;
+
+    // mtd data
+    static const float s_mtdEtlR1;
+    static const float s_mtdEtlR2;
+    static const float s_mtdEtlZ1;
+    static const float s_mtdEtlZ2;
+    static const float s_mtdEtlOffZ;
   };
 }  // namespace fireworks
 

--- a/Fireworks/Core/interface/FW3DViewBase.h
+++ b/Fireworks/Core/interface/FW3DViewBase.h
@@ -85,6 +85,8 @@ private:
   FWBoolParameter m_showHGCalEE;
   FWBoolParameter m_showHGCalHSi;
   FWBoolParameter m_showHGCalHSc;
+  FWBoolParameter m_showMtdBarrel;
+  FWBoolParameter m_showMtdEndcap;
 
   TEveBoxSet* m_ecalBarrel;
   FWBoolParameter m_showEcalBarrel;

--- a/Fireworks/Core/interface/FW3DViewGeometry.h
+++ b/Fireworks/Core/interface/FW3DViewGeometry.h
@@ -50,6 +50,8 @@ public:
   TEveElementList const* const getHGCalHSi() { return m_HGCalHSiElements; }
   void showHGCalHSc(bool);
   TEveElementList const* const getHGCalHSc() { return m_HGCalHScElements; }
+  void showMtdBarrel(bool);
+  void showMtdEndcap(bool);
 
   FW3DViewGeometry(const FW3DViewGeometry&) = delete;  // stop default
 
@@ -69,6 +71,8 @@ private:
   TEveElementList* m_HGCalEEElements;
   TEveElementList* m_HGCalHSiElements;
   TEveElementList* m_HGCalHScElements;
+  TEveElementList* m_mtdBarrelElements;
+  TEveElementList* m_mtdEndcapElements;
 };
 
 #endif

--- a/Fireworks/Core/interface/FWColorManager.h
+++ b/Fireworks/Core/interface/FWColorManager.h
@@ -39,6 +39,8 @@ enum FWGeomColorIndex {
   kFwHGCalEEColorIndex,
   kFwHGCalHSiColorIndex,
   kFwHGCalHScColorIndex,
+  kFWMtdBarrelColorIndex,
+  kFWMtdEndcapColorIndex,
   kFWGeomColorSize
 };
 

--- a/Fireworks/Core/interface/FWGeometry.h
+++ b/Fireworks/Core/interface/FWGeometry.h
@@ -35,6 +35,7 @@ public:
     Ecal = 3,
     Hcal = 4,
     Calo = 5,
+    MTD = 6,
     HGCalEE = 8,
     HGCalHSi = 9,
     HGCalHSc = 10,

--- a/Fireworks/Core/interface/FWGeometry.h
+++ b/Fireworks/Core/interface/FWGeometry.h
@@ -35,7 +35,7 @@ public:
     Ecal = 3,
     Hcal = 4,
     Calo = 5,
-    MTD = 6,
+    Forward = 6,
     HGCalEE = 8,
     HGCalHSi = 9,
     HGCalHSc = 10,

--- a/Fireworks/Core/interface/FWRPZView.h
+++ b/Fireworks/Core/interface/FWRPZView.h
@@ -95,6 +95,8 @@ private:
   FWBoolParameter m_showRpcEndcap;
   FWBoolParameter m_showGEM;
   FWBoolParameter m_showME0;
+  FWBoolParameter m_showMtdBarrel;
+  FWBoolParameter m_showMtdEndcap;
 
   FWBoolParameter m_shiftOrigin;
   FWDoubleParameter m_fishEyeDistortion;

--- a/Fireworks/Core/interface/FWRPZViewGeometry.h
+++ b/Fireworks/Core/interface/FWRPZViewGeometry.h
@@ -48,6 +48,8 @@ public:
   void showRpcEndcap(bool);
   void showGEM(bool);
   void showME0(bool);
+  void showMtdBarrel(bool);
+  void showMtdEndcap(bool);
 
 private:
   FWRPZViewGeometry(const FWRPZViewGeometry&);                   // stop default
@@ -77,6 +79,8 @@ private:
   TEveElementList* m_rpcEndcapElements;
   TEveElementList* m_GEMElements;
   TEveElementList* m_ME0Elements;
+  TEveElementList* m_mtdBarrelElements;
+  TEveElementList* m_mtdEndcapElements;
 };
 
 #endif

--- a/Fireworks/Core/src/Context.cc
+++ b/Fireworks/Core/src/Context.cc
@@ -50,6 +50,13 @@ const float Context::s_caloR2 = s_caloZ2*tan(s_caloTransAngle);
 const float Context::s_caloOffR = 10;
 const float Context::s_caloOffZ = s_caloOffR / tan(s_caloTransAngle);
 
+// mtd data [cm]
+const float Context::s_mtdEtlR1 = 30.;
+const float Context::s_mtdEtlR2 = 119.;
+const float Context::s_mtdEtlZ1 = 298.9;
+const float Context::s_mtdEtlZ2 = 301.25;
+const float Context::s_mtdEtlOffZ = 2.5;
+
 //
 // constructors and destructor
 //
@@ -189,5 +196,14 @@ float Context::caloTransEta() { return s_caloTransEta; }
 float Context::caloTransAngle() { return s_caloTransAngle; }
 
 double Context::caloMaxEta() { return fw3dlego::xbins_hf[fw3dlego::xbins_hf_n - 1]; }
+
+float Context::mtdEtlR1() { return s_mtdEtlR1; }
+float Context::mtdEtlR2() { return s_mtdEtlR2; }
+float Context::mtdEtlZ1(const unsigned int& disk_number) {
+  return disk_number == 2 ? s_mtdEtlZ1 + s_mtdEtlOffZ : s_mtdEtlZ1;
+}
+float Context::mtdEtlZ2(const unsigned int& disk_number) {
+  return disk_number == 2 ? s_mtdEtlZ2 + s_mtdEtlOffZ : s_mtdEtlZ2;
+}
 
 Context* Context::getInstance() { return s_fwContext; }

--- a/Fireworks/Core/src/FW3DViewBase.cc
+++ b/Fireworks/Core/src/FW3DViewBase.cc
@@ -110,6 +110,8 @@ FW3DViewBase::FW3DViewBase(TEveWindowSlot* iParent, FWViewType::EType typeId, un
       m_showHGCalEE(this, "Show HGCalEE", false),
       m_showHGCalHSi(this, "Show HGCalHSi", false),
       m_showHGCalHSc(this, "Show HGCalHSc", false),
+      m_showMtdBarrel(this, "Show MTD Barrel", false),
+      m_showMtdEndcap(this, "Show MTD Endcap", false),
       m_ecalBarrel(nullptr),
       m_showEcalBarrel(this, "Show Ecal Barrel", false),
       m_rnrStyle(this, "Render Style", 0l, 0l, 2l),
@@ -183,6 +185,8 @@ void FW3DViewBase::setContext(const fireworks::Context& context) {
   m_showHGCalHSi.changed_.connect(std::bind(&FW3DViewGeometry::showHGCalHSi, m_geometry, std::placeholders::_1));
   m_showHGCalHSc.changed_.connect(std::bind(&FW3DViewGeometry::showHGCalHSc, m_geometry, std::placeholders::_1));
   m_showMuonEndcap.changed_.connect(std::bind(&FW3DViewGeometry::showMuonEndcap, m_geometry, std::placeholders::_1));
+  m_showMtdBarrel.changed_.connect(std::bind(&FW3DViewGeometry::showMtdBarrel, m_geometry, std::placeholders::_1));
+  m_showMtdEndcap.changed_.connect(std::bind(&FW3DViewGeometry::showMtdEndcap, m_geometry, std::placeholders::_1));
   m_showEcalBarrel.changed_.connect(std::bind(&FW3DViewBase::showEcalBarrel, this, std::placeholders::_1));
 
   // don't clip event scene --  ideally, would have TGLClipNoClip in root
@@ -484,6 +488,8 @@ void FW3DViewBase::populateController(ViewerParameterGUI& gui) const {
       .addParam(&m_showPixelBarrel)
       .addParam(&m_showPixelEndcap)
       .addParam(&m_showEcalBarrel)
+      .addParam(&m_showMtdBarrel)
+      .addParam(&m_showMtdEndcap)
       .addParam(&m_rnrStyle)
       .addParam(&m_selectable);
 

--- a/Fireworks/Core/src/FW3DViewGeometry.cc
+++ b/Fireworks/Core/src/FW3DViewGeometry.cc
@@ -458,7 +458,7 @@ void FW3DViewGeometry::showMtdBarrel(bool showMtdBarrel) {
   if (showMtdBarrel && !m_mtdBarrelElements) {
     m_mtdBarrelElements = new TEveElementList("MtdBarrel");
 
-    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::Forward, FWGeometry::PixelBarrel);
     for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
       MTDDetId id(*mtdId);
       if (id.mtdSubDetector() != MTDDetId::MTDType::BTL)
@@ -484,7 +484,7 @@ void FW3DViewGeometry::showMtdEndcap(bool showMtdEndcap) {
   if (showMtdEndcap && !m_mtdEndcapElements) {
     m_mtdEndcapElements = new TEveElementList("MtdEndcap");
 
-    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::Forward, FWGeometry::PixelBarrel);
     for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
       MTDDetId id(*mtdId);
       if (id.mtdSubDetector() != MTDDetId::MTDType::ETL)

--- a/Fireworks/Core/src/FW3DViewGeometry.cc
+++ b/Fireworks/Core/src/FW3DViewGeometry.cc
@@ -32,6 +32,8 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+
 //
 // constants, enums and typedefs
 //
@@ -55,7 +57,9 @@ FW3DViewGeometry::FW3DViewGeometry(const fireworks::Context& context)
       m_trackerEndcapElements(nullptr),
       m_HGCalEEElements(nullptr),
       m_HGCalHSiElements(nullptr),
-      m_HGCalHScElements(nullptr) {
+      m_HGCalHScElements(nullptr),
+      m_mtdBarrelElements(nullptr),
+      m_mtdEndcapElements(nullptr) {
   SetElementName("3D Geometry");
 }
 
@@ -445,6 +449,58 @@ void FW3DViewGeometry::showHGCalHSc(bool showHGCalHSc) {
   }
   if (m_HGCalHScElements) {
     m_HGCalHScElements->SetRnrState(showHGCalHSc);
+    gEve->Redraw3D();
+  }
+}
+
+//______________________________________________________________________________
+void FW3DViewGeometry::showMtdBarrel(bool showMtdBarrel) {
+  if (showMtdBarrel && !m_mtdBarrelElements) {
+    m_mtdBarrelElements = new TEveElementList("MtdBarrel");
+
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
+      MTDDetId id(*mtdId);
+      if (id.mtdSubDetector() != MTDDetId::MTDType::BTL)
+        continue;
+
+      TEveGeoShape* shape = m_geom->getEveShape(id.rawId());
+      shape->SetTitle(Form("MTD barrel %d", id.rawId()));
+
+      addToCompound(shape, kFWMtdBarrelColorIndex);
+      m_mtdBarrelElements->AddElement(shape);
+    }
+    AddElement(m_mtdBarrelElements);
+  }
+
+  if (m_mtdBarrelElements) {
+    m_mtdBarrelElements->SetRnrState(showMtdBarrel);
+    gEve->Redraw3D();
+  }
+}
+
+//______________________________________________________________________________
+void FW3DViewGeometry::showMtdEndcap(bool showMtdEndcap) {
+  if (showMtdEndcap && !m_mtdEndcapElements) {
+    m_mtdEndcapElements = new TEveElementList("MtdEndcap");
+
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
+      MTDDetId id(*mtdId);
+      if (id.mtdSubDetector() != MTDDetId::MTDType::ETL)
+        continue;
+
+      TEveGeoShape* shape = m_geom->getEveShape(id.rawId());
+      shape->SetTitle(Form("MTD endcap %d", id.rawId()));
+
+      addToCompound(shape, kFWMtdEndcapColorIndex);
+      m_mtdEndcapElements->AddElement(shape);
+    }
+    AddElement(m_mtdEndcapElements);
+  }
+
+  if (m_mtdEndcapElements) {
+    m_mtdEndcapElements->SetRnrState(showMtdEndcap);
     gEve->Redraw3D();
   }
 }

--- a/Fireworks/Core/src/FWColorManager.cc
+++ b/Fireworks/Core/src/FWColorManager.cc
@@ -105,6 +105,9 @@ void FWColorManager::setDefaultGeomColors() {
   m_geomColor[kFwHGCalHSiColorIndex] = 1000;
   m_geomColor[kFwHGCalHScColorIndex] = 1012;
 
+  m_geomColor[kFWMtdBarrelColorIndex] = 1042;
+  m_geomColor[kFWMtdEndcapColorIndex] = 1043;
+
   switch (m_paletteId) {
     case (kArctic):
       // m_geomColor[kFWMuonBarrelLineColorIndex] = 1027;

--- a/Fireworks/Core/src/FWItemValueGetter.cc
+++ b/Fireworks/Core/src/FWItemValueGetter.cc
@@ -65,11 +65,16 @@ FWItemValueGetter::FWItemValueGetter(const edm::TypeWithDict& iType, const std::
     addEntry("chamberId().wheel()", 0, "wh");
     addEntry("chamberId().station()", 0, "st");
     addEntry("chamberId().sector()", 0, "sc");
-
   } else if (iPurpose == "CSC-segments") {
     addEntry("cscDetId().endcap()", 0, "ec");
     addEntry("cscDetId().station()", 0, "st");
     addEntry("cscDetId().ring()", 0, "rn");
+  } else if (iPurpose == "BTLclusters" || iPurpose == "BTLrechits") {
+    addEntry("energy()", 2, "E", "MeV");
+    addEntry("time()", 2, "T", "ns");
+  } else if (iPurpose == "ETLclusters" || iPurpose == "ETLrechits") {
+    addEntry("energy()", 3, "E", "MeV");
+    addEntry("time()", 2, "T", "ns");
   } else if (iPurpose == "HGCal Trigger Cell" || iPurpose == "HGCal Trigger Cluster") {
     addEntry("detId", 0);
   } else if (iPurpose == "CaloParticle") {

--- a/Fireworks/Core/src/FWRPZView.cc
+++ b/Fireworks/Core/src/FWRPZView.cc
@@ -59,6 +59,9 @@ FWRPZView::FWRPZView(TEveWindowSlot* iParent, FWViewType::EType id)
       m_showGEM(this, "Show GEM", false),
       m_showME0(this, "Show ME0", false),
 
+      m_showMtdBarrel(this, "Show MTD Barrel", false),
+      m_showMtdEndcap(this, "Show MTD Endcap", false),
+
       m_shiftOrigin(this, "Shift origin to beam-spot", false),
       m_fishEyeDistortion(this, "Distortion", 0., 0., 100.),
       m_fishEyeR(this, "FixedRadius", (double)fireworks::Context::caloR1(), 0.0, 150.0),
@@ -171,6 +174,8 @@ void FWRPZView::setContext(const fireworks::Context& ctx) {
   m_showRpcEndcap.changed_.connect(std::bind(&FWRPZViewGeometry::showRpcEndcap, m_geometryList, std::placeholders::_1));
   m_showGEM.changed_.connect(std::bind(&FWRPZViewGeometry::showGEM, m_geometryList, std::placeholders::_1));
   m_showME0.changed_.connect(std::bind(&FWRPZViewGeometry::showME0, m_geometryList, std::placeholders::_1));
+  m_showMtdBarrel.changed_.connect(std::bind(&FWRPZViewGeometry::showMtdBarrel, m_geometryList, std::placeholders::_1));
+  m_showMtdEndcap.changed_.connect(std::bind(&FWRPZViewGeometry::showMtdEndcap, m_geometryList, std::placeholders::_1));
 }
 
 void FWRPZView::eventBegin() {
@@ -383,6 +388,10 @@ void FWRPZView::populateController(ViewerParameterGUI& gui) const {
     if (showME0)
       det.addParam(&m_showME0);
   }
+
+  det.addParam(&m_showMtdBarrel);
+  if (typeId() == FWViewType::kRhoZ)
+    det.addParam(&m_showMtdEndcap);
 
 #ifdef TEVEPROJECTIONS_DISPLACE_ORIGIN_MODE
   gui.requestTab("Projection").addParam(&m_shiftOrigin);

--- a/Fireworks/Core/src/FWRPZViewGeometry.cc
+++ b/Fireworks/Core/src/FWRPZViewGeometry.cc
@@ -39,8 +39,8 @@
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 
-//
-//
+#include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+
 //
 // constants, enums and typedefs
 //
@@ -64,7 +64,9 @@ FWRPZViewGeometry::FWRPZViewGeometry(const fireworks::Context& context)
       m_trackerEndcapElements(nullptr),
       m_rpcEndcapElements(nullptr),
       m_GEMElements(nullptr),
-      m_ME0Elements(nullptr) {
+      m_ME0Elements(nullptr),
+      m_mtdBarrelElements(nullptr),
+      m_mtdEndcapElements(nullptr) {
   SetElementName("RPZGeomShared");
 }
 
@@ -593,6 +595,62 @@ void FWRPZViewGeometry::showME0(bool show) {
   }
   if (m_ME0Elements) {
     m_ME0Elements->SetRnrState(show);
+    gEve->Redraw3D();
+  }
+}
+
+//______________________________________________________________________________
+
+void FWRPZViewGeometry::showMtdBarrel(bool show) {
+  if (!m_mtdBarrelElements && show) {
+    m_mtdBarrelElements = new TEveElementList("MtdBarrel");
+
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
+      MTDDetId id(*mtdId);
+      if (id.mtdSubDetector() != MTDDetId::MTDType::BTL)
+        continue;
+
+      TEveGeoShape* shape = m_geom->getEveShape(id.rawId());
+      shape->SetTitle(Form("MTD barrel %d", id.rawId()));
+
+      addToCompound(shape, kFWMtdBarrelColorIndex);
+      m_mtdBarrelElements->AddElement(shape);
+    }
+
+    AddElement(m_mtdBarrelElements);
+    importNew(m_mtdBarrelElements);
+  }
+
+  if (m_mtdBarrelElements) {
+    m_mtdBarrelElements->SetRnrState(show);
+    gEve->Redraw3D();
+  }
+}
+
+void FWRPZViewGeometry::showMtdEndcap(bool show) {
+  if (!m_mtdEndcapElements && show) {
+    m_mtdEndcapElements = new TEveElementList("MtdEndcap");
+
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
+      MTDDetId id(*mtdId);
+      if (id.mtdSubDetector() != MTDDetId::MTDType::ETL)
+        continue;
+
+      TEveGeoShape* shape = m_geom->getEveShape(id.rawId());
+      shape->SetTitle(Form("MTD endcap %d", id.rawId()));
+
+      addToCompound(shape, kFWMtdEndcapColorIndex);
+      m_mtdEndcapElements->AddElement(shape);
+      //gEve->AddToListTree(shape, true);
+    }
+    AddElement(m_mtdEndcapElements);
+    importNew(m_mtdEndcapElements);
+  }
+
+  if (m_mtdEndcapElements) {
+    m_mtdEndcapElements->SetRnrState(show);
     gEve->Redraw3D();
   }
 }

--- a/Fireworks/Core/src/FWRPZViewGeometry.cc
+++ b/Fireworks/Core/src/FWRPZViewGeometry.cc
@@ -643,7 +643,6 @@ void FWRPZViewGeometry::showMtdEndcap(bool show) {
 
       addToCompound(shape, kFWMtdEndcapColorIndex);
       m_mtdEndcapElements->AddElement(shape);
-      //gEve->AddToListTree(shape, true);
     }
     AddElement(m_mtdEndcapElements);
     importNew(m_mtdEndcapElements);

--- a/Fireworks/Core/src/FWRPZViewGeometry.cc
+++ b/Fireworks/Core/src/FWRPZViewGeometry.cc
@@ -605,7 +605,7 @@ void FWRPZViewGeometry::showMtdBarrel(bool show) {
   if (!m_mtdBarrelElements && show) {
     m_mtdBarrelElements = new TEveElementList("MtdBarrel");
 
-    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
+    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::Forward, FWGeometry::PixelBarrel);
     for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
       MTDDetId id(*mtdId);
       if (id.mtdSubDetector() != MTDDetId::MTDType::BTL)

--- a/Fireworks/Core/src/FWRPZViewGeometry.cc
+++ b/Fireworks/Core/src/FWRPZViewGeometry.cc
@@ -632,18 +632,42 @@ void FWRPZViewGeometry::showMtdEndcap(bool show) {
   if (!m_mtdEndcapElements && show) {
     m_mtdEndcapElements = new TEveElementList("MtdEndcap");
 
-    std::vector<unsigned int> ids = m_geom->getMatchedIds(FWGeometry::MTD, FWGeometry::PixelBarrel);
-    for (std::vector<unsigned int>::const_iterator mtdId = ids.begin(); mtdId != ids.end(); ++mtdId) {
-      MTDDetId id(*mtdId);
-      if (id.mtdSubDetector() != MTDDetId::MTDType::ETL)
-        continue;
+    TEveElement* disk1ZposUp =
+        makeShape(m_context.mtdEtlR1(), m_context.mtdEtlR2(), m_context.mtdEtlZ1(1), m_context.mtdEtlZ2(1));
+    addToCompound(disk1ZposUp, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk1ZposUp);
+    TEveElement* disk1ZposDw =
+        makeShape(-m_context.mtdEtlR1(), -m_context.mtdEtlR2(), m_context.mtdEtlZ1(1), m_context.mtdEtlZ2(1));
+    addToCompound(disk1ZposDw, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk1ZposDw);
 
-      TEveGeoShape* shape = m_geom->getEveShape(id.rawId());
-      shape->SetTitle(Form("MTD endcap %d", id.rawId()));
+    TEveElement* disk2ZposUp =
+        makeShape(m_context.mtdEtlR1(), m_context.mtdEtlR2(), m_context.mtdEtlZ1(2), m_context.mtdEtlZ2(2));
+    addToCompound(disk2ZposUp, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk2ZposUp);
+    TEveElement* disk2ZposDw =
+        makeShape(-m_context.mtdEtlR1(), -m_context.mtdEtlR2(), m_context.mtdEtlZ1(2), m_context.mtdEtlZ2(2));
+    addToCompound(disk2ZposDw, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk2ZposDw);
 
-      addToCompound(shape, kFWMtdEndcapColorIndex);
-      m_mtdEndcapElements->AddElement(shape);
-    }
+    TEveElement* disk1ZnegUp =
+        makeShape(m_context.mtdEtlR1(), m_context.mtdEtlR2(), -m_context.mtdEtlZ1(1), -m_context.mtdEtlZ2(1));
+    addToCompound(disk1ZnegUp, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk1ZnegUp);
+    TEveElement* disk1ZnegDw =
+        makeShape(-m_context.mtdEtlR1(), -m_context.mtdEtlR2(), -m_context.mtdEtlZ1(1), -m_context.mtdEtlZ2(1));
+    addToCompound(disk1ZnegDw, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk1ZnegDw);
+
+    TEveElement* disk2ZnegUp =
+        makeShape(m_context.mtdEtlR1(), m_context.mtdEtlR2(), -m_context.mtdEtlZ1(2), -m_context.mtdEtlZ2(2));
+    addToCompound(disk2ZnegUp, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk2ZnegUp);
+    TEveElement* disk2ZnegDw =
+        makeShape(-m_context.mtdEtlR1(), -m_context.mtdEtlR2(), -m_context.mtdEtlZ1(2), -m_context.mtdEtlZ2(2));
+    addToCompound(disk2ZnegDw, kFWMtdEndcapColorIndex);
+    m_mtdEndcapElements->AddElement(disk2ZnegDw);
+
     AddElement(m_mtdEndcapElements);
     importNew(m_mtdEndcapElements);
   }

--- a/Fireworks/Geometry/BuildFile.xml
+++ b/Fireworks/Geometry/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="Geometry/RPCGeometry"/>
 <use name="Geometry/GEMGeometry"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
+<use name="Geometry/MTDGeometryBuilder"/>
 <use name="Geometry/Records"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/MuonDetId"/>

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -17,6 +17,8 @@ class GlobalTrackingGeometry;
 class GlobalTrackingGeometryRecord;
 class TrackerGeometry;
 class IdealGeometryRecord;
+class MTDGeometry;
+class MTDDigiGeometryRecord;
 class FWRecoGeometry;
 class FWRecoGeometryRecord;
 class GeomDet;
@@ -45,7 +47,7 @@ private:
   void addTECGeometry(FWRecoGeometry&);
   void addCaloGeometry(FWRecoGeometry&);
 
-  void addFTLGeometry(FWRecoGeometry&);
+  void addMTDGeometry(FWRecoGeometry&);
 
   void ADD_PIXEL_TOPOLOGY(unsigned int rawid, const GeomDet* detUnit, FWRecoGeometry&);
 
@@ -58,8 +60,10 @@ private:
   void writeTrackerParametersXML(FWRecoGeometry&);
 
   edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> m_trackingGeomToken;
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> m_mtdGeomToken;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_caloGeomToken;
   const GlobalTrackingGeometry* m_trackingGeom = nullptr;
+  const MTDGeometry* m_mtdGeom = nullptr;
   const CaloGeometry* m_caloGeom = nullptr;
   const TrackerGeometry* m_trackerGeom = nullptr;
 

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -51,6 +51,8 @@ private:
 
   void ADD_PIXEL_TOPOLOGY(unsigned int rawid, const GeomDet* detUnit, FWRecoGeometry&);
 
+  void ADD_MTD_TOPOLOGY(unsigned int rawid, const GeomDet* detUnit, FWRecoGeometry&);
+
   unsigned int insert_id(unsigned int id, FWRecoGeometry&);
   void fillPoints(unsigned int id,
                   std::vector<GlobalPoint>::const_iterator begin,

--- a/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
@@ -4,10 +4,11 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 
 class FWRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           FWRecoGeometryRecord,
-          edm::mpl::Vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, CaloGeometryRecord> > {};
+          edm::mpl::Vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, MTDDigiGeometryRecord, CaloGeometryRecord> > {};
 
 #endif  // GEOMETRY_FWRECO_GEOMETRY_RECORD_H

--- a/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryRecord.h
@@ -9,6 +9,7 @@
 class FWRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<
           FWRecoGeometryRecord,
-          edm::mpl::Vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, MTDDigiGeometryRecord, CaloGeometryRecord> > {};
+          edm::mpl::Vector<MuonGeometryRecord, GlobalTrackingGeometryRecord, MTDDigiGeometryRecord, CaloGeometryRecord> > {
+};
 
 #endif  // GEOMETRY_FWRECO_GEOMETRY_RECORD_H

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -113,7 +113,6 @@ void FWRecoGeometryESProducer::ADD_MTD_TOPOLOGY(unsigned int rawid,
 
     fwRecoGeometry.idToName[rawid].topology[2] = topo.xoffset();
     fwRecoGeometry.idToName[rawid].topology[3] = topo.yoffset();
-
   }
 }
 

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -635,8 +635,15 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
 }
 
 void FWRecoGeometryESProducer::addMTDGeometry(FWRecoGeometry& fwRecoGeometry) {
-  // do the barrel (do for BTL)
-  // do the endcap (do for ETL)
+  for (auto const& det : m_mtdGeom->detUnits()) {
+
+    if (det) {
+      DetId detid = det->geographicalId();
+      unsigned int rawid = detid.rawId();
+      unsigned int current = insert_id(rawid, fwRecoGeometry);
+      fillShapeAndPlacement(current, det, fwRecoGeometry);
+    }
+  }
 }
 
 unsigned int FWRecoGeometryESProducer::insert_id(unsigned int rawid, FWRecoGeometry& fwRecoGeometry) {

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -111,8 +111,9 @@ void FWRecoGeometryESProducer::ADD_MTD_TOPOLOGY(unsigned int rawid,
     fwRecoGeometry.idToName[rawid].topology[0] = pitch.first;
     fwRecoGeometry.idToName[rawid].topology[1] = pitch.second;
 
-    fwRecoGeometry.idToName[rawid].topology[2] = topo.localX(0.f);  // offsetX
-    fwRecoGeometry.idToName[rawid].topology[3] = topo.localY(0.f);  // offsetY
+    fwRecoGeometry.idToName[rawid].topology[2] = topo.xoffset();
+    fwRecoGeometry.idToName[rawid].topology[3] = topo.yoffset();
+
   }
 }
 

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -12,6 +12,7 @@
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -116,6 +117,9 @@ FWRecoGeometryESProducer::FWRecoGeometryESProducer(const edm::ParameterSet& pset
   if (m_calo) {
     m_caloGeomToken = cc.consumes();
   }
+  if (m_timing) {
+    m_mtdGeomToken = cc.consumes();
+  }
 }
 
 FWRecoGeometryESProducer::~FWRecoGeometryESProducer(void) {}
@@ -152,6 +156,10 @@ std::unique_ptr<FWRecoGeometry> FWRecoGeometryESProducer::produce(const FWRecoGe
   if (m_calo) {
     m_caloGeom = &record.get(m_caloGeomToken);
     addCaloGeometry(*fwRecoGeometry);
+  }
+  if (m_timing) {
+    m_mtdGeom  = &record.get(m_mtdGeomToken);
+    addMTDGeometry(*fwRecoGeometry);
   }
 
   fwRecoGeometry->idToName.resize(m_current + 1);
@@ -626,7 +634,7 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
   }
 }
 
-void FWRecoGeometryESProducer::addFTLGeometry(FWRecoGeometry& fwRecoGeometry) {
+void FWRecoGeometryESProducer::addMTDGeometry(FWRecoGeometry& fwRecoGeometry) {
   // do the barrel (do for BTL)
   // do the endcap (do for ETL)
 }

--- a/Fireworks/MTD/plugins/BuildFile.xml
+++ b/Fireworks/MTD/plugins/BuildFile.xml
@@ -1,0 +1,10 @@
+<library name="FireworksMtdPlugins" file="*.cc">
+  <use name="DataFormats/FTLRecHit"/>
+  <use name="Fireworks/Core"/>
+  <use name="rootinteractive"/>
+  <use name="rootphysics"/>
+  <use name="rooteve"/>
+  <use name="rootgeom"/>
+  <use name="rootrgl"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
@@ -41,28 +41,27 @@ void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
   iItem->get(clusters);
 
   if (!clusters) {
-    fwLog(fwlog::kWarning) << "failed to get the FTLClusterCollection" << std::endl;
+    fwLog(fwlog::kWarning) << "failed to get the BTL Cluster Collection" << std::endl;
     return;
   }
 
   const FWGeometry* geom = iItem->getGeom();
 
   TEvePointSet* pointSet = new TEvePointSet();
+  TEveElement* itemHolder = createCompound();
+  product->AddElement(itemHolder);
 
   for (const auto& detSet : *clusters) {
     unsigned int id = detSet.detId();
 
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get BTL geometry element with detid: " << id << std::endl;
+      continue;
+    }
+
     const float* pars = geom->getParameters(id);
 
     for (const auto& cluster : detSet) {
-      TEveElement* itemHolder = createCompound();
-      product->AddElement(itemHolder);
-
-      if (!geom->contains(id)) {
-        fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
-        continue;
-      }
-
       // --- Get the BTL cluster local position:
       float x_local =
           (cluster.getClusterErrorX() < 0. ? (cluster.x() + 0.5f) * pars[0] + pars[2] : cluster.getClusterPosX());
@@ -75,11 +74,11 @@ void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
 
       pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
 
-      setupAddElement(pointSet, itemHolder);
-
     }  // cluster loop
 
   }  // detSet loop
+
+  setupAddElement(pointSet, itemHolder);
 }
 
 REGISTER_FWPROXYBUILDER(FWBtlClusterProxyBuilder,

--- a/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
@@ -1,4 +1,3 @@
-
 // -*- C++ -*-
 //
 // Package:     MTD
@@ -11,7 +10,7 @@
 
 #include "TEvePointSet.h"
 #include "TEveCompound.h"
-#include "TEveBox.h"
+
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/Core/interface/FWGeometry.h"
@@ -37,7 +36,6 @@ private:
 };
 
 void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
-
   const FTLClusterCollection* clusters = nullptr;
 
   iItem->get(clusters);
@@ -47,31 +45,29 @@ void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
     return;
   }
 
-  for (const auto& detSet : *clusters) {
+  const FWGeometry* geom = iItem->getGeom();
 
+  TEvePointSet* pointSet = new TEvePointSet();
+
+  for (const auto& detSet : *clusters) {
     unsigned int id = detSet.detId();
 
-    const FWGeometry* geom = iItem->getGeom();
     const float* pars = geom->getParameters(id);
 
     for (const auto& cluster : detSet) {
-
       TEveElement* itemHolder = createCompound();
       product->AddElement(itemHolder);
 
-      TEvePointSet* pointSet = new TEvePointSet;
-
       if (!geom->contains(id)) {
-	fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
-	continue;
+        fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
+        continue;
       }
 
-      // --- Get the BTL cluster local position: 
-      float x_local = ( cluster.getClusterErrorX() < 0.          ?
-			(cluster.x() + 0.5f) * pars[0] + pars[2] :
-			cluster.getClusterPosX()                 );
-      float y_local =  (cluster.y() + 0.5f) * pars[1] + pars[3];
-     
+      // --- Get the BTL cluster local position:
+      float x_local =
+          (cluster.getClusterErrorX() < 0. ? (cluster.x() + 0.5f) * pars[0] + pars[2] : cluster.getClusterPosX());
+      float y_local = (cluster.y() + 0.5f) * pars[1] + pars[3];
+
       const float localPoint[3] = {x_local, y_local, 0.0};
 
       float globalPoint[3];
@@ -84,7 +80,6 @@ void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
     }  // cluster loop
 
   }  // detSet loop
-
 }
 
 REGISTER_FWPROXYBUILDER(FWBtlClusterProxyBuilder,

--- a/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlClusterProxyBuilder.cc
@@ -1,0 +1,93 @@
+
+// -*- C++ -*-
+//
+// Package:     MTD
+// Class  :     FWBtlClusterProxyBuilder
+//
+//
+// Original Author:
+//         Created:  Thu Nov 24 10:00:00 CET 2022
+//
+
+#include "TEvePointSet.h"
+#include "TEveCompound.h"
+#include "TEveBox.h"
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+
+class FWBtlClusterProxyBuilder : public FWProxyBuilderBase {
+public:
+  FWBtlClusterProxyBuilder(void) {}
+  ~FWBtlClusterProxyBuilder(void) override {}
+
+  REGISTER_PROXYBUILDER_METHODS();
+
+  // Disable default copy constructor
+  FWBtlClusterProxyBuilder(const FWBtlClusterProxyBuilder&) = delete;
+  // Disable default assignment operator
+  const FWBtlClusterProxyBuilder& operator=(const FWBtlClusterProxyBuilder&) = delete;
+
+private:
+  using FWProxyBuilderBase::build;
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+};
+
+void FWBtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
+
+  const FTLClusterCollection* clusters = nullptr;
+
+  iItem->get(clusters);
+
+  if (!clusters) {
+    fwLog(fwlog::kWarning) << "failed to get the FTLClusterCollection" << std::endl;
+    return;
+  }
+
+  for (const auto& detSet : *clusters) {
+
+    unsigned int id = detSet.detId();
+
+    const FWGeometry* geom = iItem->getGeom();
+    const float* pars = geom->getParameters(id);
+
+    for (const auto& cluster : detSet) {
+
+      TEveElement* itemHolder = createCompound();
+      product->AddElement(itemHolder);
+
+      TEvePointSet* pointSet = new TEvePointSet;
+
+      if (!geom->contains(id)) {
+	fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
+	continue;
+      }
+
+      // --- Get the BTL cluster local position: 
+      float x_local = ( cluster.getClusterErrorX() < 0.          ?
+			(cluster.x() + 0.5f) * pars[0] + pars[2] :
+			cluster.getClusterPosX()                 );
+      float y_local =  (cluster.y() + 0.5f) * pars[1] + pars[3];
+     
+      const float localPoint[3] = {x_local, y_local, 0.0};
+
+      float globalPoint[3];
+      geom->localToGlobal(id, localPoint, globalPoint);
+
+      pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
+
+      setupAddElement(pointSet, itemHolder);
+
+    }  // cluster loop
+
+  }  // detSet loop
+
+}
+
+REGISTER_FWPROXYBUILDER(FWBtlClusterProxyBuilder,
+                        FTLClusterCollection,
+                        "BTLclusters",
+                        FWViewType::kAll3DBits | FWViewType::kAllRPZBits);

--- a/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
@@ -1,0 +1,89 @@
+
+// -*- C++ -*-
+//
+// Package:     MTD
+// Class  :     FWBtlRecHitProxyBuilder
+//
+//
+// Original Author:
+//         Created:  Tue Dec 6 17:00:00 CET 2022
+//
+
+#include "TEvePointSet.h"
+#include "TEveCompound.h"
+#include "TEveBox.h"
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+class FWBtlRecHitProxyBuilder : public FWProxyBuilderBase {
+public:
+  FWBtlRecHitProxyBuilder(void) {}
+  ~FWBtlRecHitProxyBuilder(void) override {}
+
+  REGISTER_PROXYBUILDER_METHODS();
+
+  // Disable default copy constructor
+  FWBtlRecHitProxyBuilder(const FWBtlRecHitProxyBuilder&) = delete;
+  // Disable default assignment operator
+  const FWBtlRecHitProxyBuilder& operator=(const FWBtlRecHitProxyBuilder&) = delete;
+
+private:
+  using FWProxyBuilderBase::build;
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+};
+
+void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
+
+  const FTLRecHitCollection* recHits = nullptr;
+
+  iItem->get(recHits);
+
+  if (!recHits) {
+    fwLog(fwlog::kWarning) << "failed to get the FTLRecHitCollection" << std::endl;
+    return;
+  }
+
+  for (const auto& hit : *recHits) {
+
+    unsigned int id = hit.id().rawId();
+
+    const FWGeometry* geom = iItem->getGeom();
+    const float* pars = geom->getParameters(id);
+
+    TEveElement* itemHolder = createCompound();
+    product->AddElement(itemHolder);
+
+    TEvePointSet* pointSet = new TEvePointSet;
+
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
+      continue;
+    }
+
+    // --- Get the BTL RecHit local position: 
+    float x_local = ( hit.positionError() > 0.               ?
+		      hit.position()                         :
+		      (hit.row() + 0.5f) * pars[0] + pars[2] );
+    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3]; 
+
+    const float localPoint[3] = {x_local, y_local, 0.0};
+
+    float globalPoint[3];
+    geom->localToGlobal(id, localPoint, globalPoint);
+
+    pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
+
+    setupAddElement(pointSet, itemHolder);
+
+  }  // recHits loop
+
+}
+
+REGISTER_FWPROXYBUILDER(FWBtlRecHitProxyBuilder,
+                        FTLRecHitCollection,
+                        "BTLrechits",
+                        FWViewType::kAll3DBits | FWViewType::kAllRPZBits);

--- a/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
@@ -41,7 +41,7 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
   iItem->get(recHits);
 
   if (!recHits) {
-    fwLog(fwlog::kWarning) << "failed to get the FTLRecHitCollection" << std::endl;
+    fwLog(fwlog::kWarning) << "failed to get the BTL RecHit Collection" << std::endl;
     return;
   }
 
@@ -52,15 +52,15 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
   for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
-    const float* pars = geom->getParameters(id);
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get BTL geometry element with detid: " << id << std::endl;
+      continue;
+    }
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);
 
-    if (!geom->contains(id)) {
-      fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
-      continue;
-    }
+    const float* pars = geom->getParameters(id);
 
     // --- Get the BTL RecHit local position:
     float x_local = (hit.positionError() > 0. ? hit.position() : (hit.row() + 0.5f) * pars[0] + pars[2]);

--- a/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
@@ -1,4 +1,3 @@
-
 // -*- C++ -*-
 //
 // Package:     MTD
@@ -11,7 +10,7 @@
 
 #include "TEvePointSet.h"
 #include "TEveCompound.h"
-#include "TEveBox.h"
+
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/Core/interface/FWGeometry.h"
@@ -37,7 +36,6 @@ private:
 };
 
 void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
-
   const FTLRecHitCollection* recHits = nullptr;
 
   iItem->get(recHits);
@@ -47,28 +45,26 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
     return;
   }
 
-  for (const auto& hit : *recHits) {
+  const FWGeometry* geom = iItem->getGeom();
 
+  TEvePointSet* pointSet = new TEvePointSet();
+
+  for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
-    const FWGeometry* geom = iItem->getGeom();
     const float* pars = geom->getParameters(id);
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);
-
-    TEvePointSet* pointSet = new TEvePointSet;
 
     if (!geom->contains(id)) {
       fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
       continue;
     }
 
-    // --- Get the BTL RecHit local position: 
-    float x_local = ( hit.positionError() > 0.               ?
-		      hit.position()                         :
-		      (hit.row() + 0.5f) * pars[0] + pars[2] );
-    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3]; 
+    // --- Get the BTL RecHit local position:
+    float x_local = (hit.positionError() > 0. ? hit.position() : (hit.row() + 0.5f) * pars[0] + pars[2]);
+    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3];
 
     const float localPoint[3] = {x_local, y_local, 0.0};
 
@@ -80,7 +76,6 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
     setupAddElement(pointSet, itemHolder);
 
   }  // recHits loop
-
 }
 
 REGISTER_FWPROXYBUILDER(FWBtlRecHitProxyBuilder,

--- a/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWBtlRecHitsProxyBuilder.cc
@@ -47,8 +47,6 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
 
   const FWGeometry* geom = iItem->getGeom();
 
-  TEvePointSet* pointSet = new TEvePointSet();
-
   for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
@@ -56,6 +54,8 @@ void FWBtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
       fwLog(fwlog::kWarning) << "failed to get BTL geometry element with detid: " << id << std::endl;
       continue;
     }
+
+    TEvePointSet* pointSet = new TEvePointSet();
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);

--- a/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
@@ -1,4 +1,3 @@
-
 // -*- C++ -*-
 //
 // Package:     MTD
@@ -11,7 +10,7 @@
 
 #include "TEvePointSet.h"
 #include "TEveCompound.h"
-#include "TEveBox.h"
+
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/Core/interface/FWGeometry.h"
@@ -37,7 +36,6 @@ private:
 };
 
 void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
-
   const FTLClusterCollection* clusters = nullptr;
 
   iItem->get(clusters);
@@ -47,26 +45,25 @@ void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
     return;
   }
 
-  for (const auto& detSet : *clusters) {
+  const FWGeometry* geom = iItem->getGeom();
 
+  TEvePointSet* pointSet = new TEvePointSet();
+
+  for (const auto& detSet : *clusters) {
     unsigned int id = detSet.detId();
 
-    const FWGeometry* geom = iItem->getGeom();
     const float* pars = geom->getParameters(id);
 
     for (const auto& cluster : detSet) {
-
       TEveElement* itemHolder = createCompound();
       product->AddElement(itemHolder);
 
-      TEvePointSet* pointSet = new TEvePointSet;
-
       if (!geom->contains(id)) {
-	fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
-	continue;
+        fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
+        continue;
       }
 
-      // --- Get the ETL cluster local position: 
+      // --- Get the ETL cluster local position:
       float x_local = (cluster.x() + 0.5f) * pars[0] + pars[2];
       float y_local = (cluster.y() + 0.5f) * pars[1] + pars[3];
 
@@ -82,7 +79,6 @@ void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
     }  // cluster loop
 
   }  // detSet loop
-
 }
 
 REGISTER_FWPROXYBUILDER(FWEtlClusterProxyBuilder,

--- a/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
@@ -41,28 +41,27 @@ void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
   iItem->get(clusters);
 
   if (!clusters) {
-    fwLog(fwlog::kWarning) << "failed to get the FTLClusterCollection" << std::endl;
+    fwLog(fwlog::kWarning) << "failed to get the ETL Cluster Collection" << std::endl;
     return;
   }
 
   const FWGeometry* geom = iItem->getGeom();
 
   TEvePointSet* pointSet = new TEvePointSet();
+  TEveElement* itemHolder = createCompound();
+  product->AddElement(itemHolder);
 
   for (const auto& detSet : *clusters) {
     unsigned int id = detSet.detId();
 
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get ETL geometry element with detid: " << id << std::endl;
+      continue;
+    }
+
     const float* pars = geom->getParameters(id);
 
     for (const auto& cluster : detSet) {
-      TEveElement* itemHolder = createCompound();
-      product->AddElement(itemHolder);
-
-      if (!geom->contains(id)) {
-        fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
-        continue;
-      }
-
       // --- Get the ETL cluster local position:
       float x_local = (cluster.x() + 0.5f) * pars[0] + pars[2];
       float y_local = (cluster.y() + 0.5f) * pars[1] + pars[3];
@@ -74,11 +73,11 @@ void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
 
       pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
 
-      setupAddElement(pointSet, itemHolder);
-
     }  // cluster loop
 
   }  // detSet loop
+
+  setupAddElement(pointSet, itemHolder);
 }
 
 REGISTER_FWPROXYBUILDER(FWEtlClusterProxyBuilder,

--- a/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlClusterProxyBuilder.cc
@@ -1,0 +1,91 @@
+
+// -*- C++ -*-
+//
+// Package:     MTD
+// Class  :     FWEtlClusterProxyBuilder
+//
+//
+// Original Author:
+//         Created:  Thu Nov 28 10:00:00 CET 2022
+//
+
+#include "TEvePointSet.h"
+#include "TEveCompound.h"
+#include "TEveBox.h"
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+
+class FWEtlClusterProxyBuilder : public FWProxyBuilderBase {
+public:
+  FWEtlClusterProxyBuilder(void) {}
+  ~FWEtlClusterProxyBuilder(void) override {}
+
+  REGISTER_PROXYBUILDER_METHODS();
+
+  // Disable default copy constructor
+  FWEtlClusterProxyBuilder(const FWEtlClusterProxyBuilder&) = delete;
+  // Disable default assignment operator
+  const FWEtlClusterProxyBuilder& operator=(const FWEtlClusterProxyBuilder&) = delete;
+
+private:
+  using FWProxyBuilderBase::build;
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+};
+
+void FWEtlClusterProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
+
+  const FTLClusterCollection* clusters = nullptr;
+
+  iItem->get(clusters);
+
+  if (!clusters) {
+    fwLog(fwlog::kWarning) << "failed to get the FTLClusterCollection" << std::endl;
+    return;
+  }
+
+  for (const auto& detSet : *clusters) {
+
+    unsigned int id = detSet.detId();
+
+    const FWGeometry* geom = iItem->getGeom();
+    const float* pars = geom->getParameters(id);
+
+    for (const auto& cluster : detSet) {
+
+      TEveElement* itemHolder = createCompound();
+      product->AddElement(itemHolder);
+
+      TEvePointSet* pointSet = new TEvePointSet;
+
+      if (!geom->contains(id)) {
+	fwLog(fwlog::kWarning) << "failed to get geometry of FTLCluster with detid: " << id << std::endl;
+	continue;
+      }
+
+      // --- Get the ETL cluster local position: 
+      float x_local = (cluster.x() + 0.5f) * pars[0] + pars[2];
+      float y_local = (cluster.y() + 0.5f) * pars[1] + pars[3];
+
+      const float localPoint[3] = {x_local, y_local, 0.0};
+
+      float globalPoint[3];
+      geom->localToGlobal(id, localPoint, globalPoint);
+
+      pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
+
+      setupAddElement(pointSet, itemHolder);
+
+    }  // cluster loop
+
+  }  // detSet loop
+
+}
+
+REGISTER_FWPROXYBUILDER(FWEtlClusterProxyBuilder,
+                        FTLClusterCollection,
+                        "ETLclusters",
+                        FWViewType::kAll3DBits | FWViewType::kAllRPZBits);

--- a/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
@@ -47,8 +47,6 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
 
   const FWGeometry* geom = iItem->getGeom();
 
-  TEvePointSet* pointSet = new TEvePointSet();
-
   for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
@@ -56,6 +54,8 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
       fwLog(fwlog::kWarning) << "failed to get ETL geometry element with detid: " << id << std::endl;
       continue;
     }
+
+    TEvePointSet* pointSet = new TEvePointSet();
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);

--- a/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
@@ -41,7 +41,7 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
   iItem->get(recHits);
 
   if (!recHits) {
-    fwLog(fwlog::kWarning) << "failed to get the FTLRecHitCollection" << std::endl;
+    fwLog(fwlog::kWarning) << "failed to get the ETL RecHit Collection" << std::endl;
     return;
   }
 
@@ -52,15 +52,15 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
   for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
-    const float* pars = geom->getParameters(id);
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get ETL geometry element with detid: " << id << std::endl;
+      continue;
+    }
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);
 
-    if (!geom->contains(id)) {
-      fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
-      continue;
-    }
+    const float* pars = geom->getParameters(id);
 
     // --- Get the ETL RecHit local position:
     float x_local = (hit.row() + 0.5f) * pars[0] + pars[2];

--- a/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
@@ -1,0 +1,88 @@
+
+// -*- C++ -*-
+//
+// Package:     MTD
+// Class  :     FWEtlRecHitProxyBuilder
+//
+//
+// Original Author:
+//         Created:  Tue Dec 6 17:00:00 CET 2022
+//
+
+#include "TEvePointSet.h"
+#include "TEveCompound.h"
+
+#include "TEveBox.h"
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/fwLog.h"
+
+#include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+class FWEtlRecHitProxyBuilder : public FWProxyBuilderBase {
+public:
+  FWEtlRecHitProxyBuilder(void) {}
+  ~FWEtlRecHitProxyBuilder(void) override {}
+
+  REGISTER_PROXYBUILDER_METHODS();
+
+  // Disable default copy constructor
+  FWEtlRecHitProxyBuilder(const FWEtlRecHitProxyBuilder&) = delete;
+  // Disable default assignment operator
+  const FWEtlRecHitProxyBuilder& operator=(const FWEtlRecHitProxyBuilder&) = delete;
+
+private:
+  using FWProxyBuilderBase::build;
+  void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+};
+
+void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
+
+  const FTLRecHitCollection* recHits = nullptr;
+
+  iItem->get(recHits);
+
+  if (!recHits) {
+    fwLog(fwlog::kWarning) << "failed to get the FTLRecHitCollection" << std::endl;
+    return;
+  }
+
+  for (const auto& hit : *recHits) {
+
+    unsigned int id = hit.id().rawId();
+
+    const FWGeometry* geom = iItem->getGeom();
+    const float* pars = geom->getParameters(id);
+
+    TEveElement* itemHolder = createCompound();
+    product->AddElement(itemHolder);
+
+    TEvePointSet* pointSet = new TEvePointSet;
+
+    if (!geom->contains(id)) {
+      fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
+      continue;
+    }
+
+    // --- Get the ETL RecHit local position:
+    float x_local = (hit.row() + 0.5f) * pars[0] + pars[2];
+    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3]; 
+
+    const float localPoint[3] = {x_local, y_local, 0.0};
+
+    float globalPoint[3];
+    geom->localToGlobal(id, localPoint, globalPoint);
+
+    pointSet->SetNextPoint(globalPoint[0], globalPoint[1], globalPoint[2]);
+
+    setupAddElement(pointSet, itemHolder);
+
+  }  // recHits loop
+
+}
+
+REGISTER_FWPROXYBUILDER(FWEtlRecHitProxyBuilder,
+                        FTLRecHitCollection,
+                        "ETLrechits",
+                        FWViewType::kAll3DBits | FWViewType::kAllRPZBits);

--- a/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
+++ b/Fireworks/MTD/plugins/FWEtlRecHitsProxyBuilder.cc
@@ -1,4 +1,3 @@
-
 // -*- C++ -*-
 //
 // Package:     MTD
@@ -12,7 +11,6 @@
 #include "TEvePointSet.h"
 #include "TEveCompound.h"
 
-#include "TEveBox.h"
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
 #include "Fireworks/Core/interface/FWGeometry.h"
@@ -38,7 +36,6 @@ private:
 };
 
 void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) {
-
   const FTLRecHitCollection* recHits = nullptr;
 
   iItem->get(recHits);
@@ -48,17 +45,17 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
     return;
   }
 
-  for (const auto& hit : *recHits) {
+  const FWGeometry* geom = iItem->getGeom();
 
+  TEvePointSet* pointSet = new TEvePointSet();
+
+  for (const auto& hit : *recHits) {
     unsigned int id = hit.id().rawId();
 
-    const FWGeometry* geom = iItem->getGeom();
     const float* pars = geom->getParameters(id);
 
     TEveElement* itemHolder = createCompound();
     product->AddElement(itemHolder);
-
-    TEvePointSet* pointSet = new TEvePointSet;
 
     if (!geom->contains(id)) {
       fwLog(fwlog::kWarning) << "failed to get geometry of FTLRecHit with detid: " << id << std::endl;
@@ -67,7 +64,7 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
 
     // --- Get the ETL RecHit local position:
     float x_local = (hit.row() + 0.5f) * pars[0] + pars[2];
-    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3]; 
+    float y_local = (hit.column() + 0.5f) * pars[1] + pars[3];
 
     const float localPoint[3] = {x_local, y_local, 0.0};
 
@@ -79,7 +76,6 @@ void FWEtlRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
     setupAddElement(pointSet, itemHolder);
 
   }  // recHits loop
-
 }
 
 REGISTER_FWPROXYBUILDER(FWEtlRecHitProxyBuilder,


### PR DESCRIPTION
This PR introduces the following changes to the Fireworks package:
- addition of the MTD geometry (by @fabiocos) and topology;
- visualization of the BTL and ETL detectors in the 3D, Rho-Phi, and Rho-Z views;
- implementation of the ProxyBuilder plugins to display the MTD rechits and clusters. 

The new code has been tested with TTbar and SingleMuPt10 events simulated in the scenario 2026D96. Two examples:

![mtd_display_1](https://user-images.githubusercontent.com/5435977/216377444-1f308bf7-dba7-4b49-a715-70aa24f94fdf.jpg)

![mtd_display_2](https://user-images.githubusercontent.com/5435977/216377608-6e65213f-acd1-4ada-8bd1-88b77ce5ae74.jpg)




 