### PR TITLE
Fix `JetHTAnalyzer::fillDescriptions`

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -1395,8 +1395,8 @@ private:
     edm::LogPrint("DMRChecker") << "n. tracks: " << itrks << std::endl;
     edm::LogPrint("DMRChecker") << "*******************************" << std::endl;
 
-    int nFiringTriggers = triggerMap_.size();
-    edm::LogPrint("DMRChecker") << "firing triggers: " << nFiringTriggers << std::endl;
+    int nFiringTriggers = !triggerMap_.empty() ? triggerMap_.size() : 1;
+    edm::LogPrint("DMRChecker") << "firing triggers: " << triggerMap_.size() << std::endl;
     edm::LogPrint("DMRChecker") << "*******************************" << std::endl;
 
     tksByTrigger_ =

--- a/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc
@@ -47,12 +47,6 @@
 #include "DataFormats/Common/interface/TriggerResults.h"  // Classes needed to print trigger results
 #include "FWCore/Common/interface/TriggerNames.h"
 
-// ROOT includes
-#include "TRandom.h"
-#include "TTree.h"
-#include "TString.h"
-#include "TMath.h"
-
 //
 // class declaration
 //
@@ -307,9 +301,8 @@ void JetHTAnalyzer::beginJob() {
   mon.addHistogram(new TH1F("dzerr", ";d_{z} error;tracks", 100, 0., 200));
   mon.addHistogram(new TProfile("dxyErrVsPt", ";track p_{T};d_{xy} error", 100, 0., 200, 0., 100.));
   mon.addHistogram(new TProfile("dzErrVsPt", ";track p_{T};d_{z} error", 100, 0., 200, 0., 100.));
-  mon.addHistogram(
-      new TProfile("dxyErrVsPhi", ";track #varphi;d_{xy} error", 100, -TMath::Pi(), TMath::Pi(), 0., 100.));
-  mon.addHistogram(new TProfile("dzErrVsPhi", ";track #varphi;d_{z} error", 100, -TMath::Pi(), TMath::Pi(), 0., 100.));
+  mon.addHistogram(new TProfile("dxyErrVsPhi", ";track #varphi;d_{xy} error", 100, -M_PI, M_PI, 0., 100.));
+  mon.addHistogram(new TProfile("dzErrVsPhi", ";track #varphi;d_{z} error", 100, -M_PI, M_PI, 0., 100.));
   mon.addHistogram(new TProfile("dxyErrVsEta", ";track #eta;d_{xy} error", 100, -2.5, 2.5, 0., 100.));
   mon.addHistogram(new TProfile("dzErrVsEta", ";track #eta;d_{z} error", 100, -2.5, 2.5, 0., 100.));
 
@@ -331,11 +324,11 @@ void JetHTAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<edm::InputTag>("vtxCollection", edm::InputTag("offlinePrimaryVerticesFromRefittedTrks"));
   desc.add<edm::InputTag>("triggerResults", edm::InputTag("TriggerResults", "", "HLT"));
   desc.add<edm::InputTag>("trackCollection", edm::InputTag("TrackRefitter"));
-  desc.add<int>("printTriggerTable", false);
-  desc.add<double>("minVertexNdf", 10.);
-  desc.add<double>("minVertexMeanWeight", 0.5);
-  desc.add<std::vector<double>>("profilePtBorders", {3, 5, 10, 20, 50, 100});
-  desc.add<std::vector<double>>("iovList", {0, 500000});
+  desc.addUntracked<int>("printTriggerTable", false);
+  desc.addUntracked<double>("minVertexNdf", 10.);
+  desc.addUntracked<double>("minVertexMeanWeight", 0.5);
+  desc.addUntracked<std::vector<double>>("profilePtBorders", {3, 5, 10, 20, 50, 100});
+  desc.addUntracked<std::vector<int>>("iovList", {0, 500000});
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
+++ b/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
@@ -1,5 +1,6 @@
 #include "FWCore/TestProcessor/interface/TestProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #define CATCH_CONFIG_MAIN
@@ -14,6 +15,7 @@ process = TestProcess()
 process.trackAnalyzer = generalPurposeTrackAnalyzer
 process.moduleToTest(process.trackAnalyzer)
 process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
 process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer1.root')))
 )_"};
 
@@ -50,6 +52,7 @@ process = TestProcess()
 process.dmrAnalyzer = dmrChecker
 process.moduleToTest(process.dmrAnalyzer)
 process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
 process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer2.root')))
 )_"};
 
@@ -61,10 +64,10 @@ process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer2.r
   //   REQUIRE_NOTHROW(tester.test());
   // }
 
-  // SECTION("beginJob and endJob only") {
-  //   edm::test::TestProcessor tester(config);
-  //   REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
-  // }
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
 
   // SECTION("Run with no LuminosityBlocks") {
   //   edm::test::TestProcessor tester(config);
@@ -75,4 +78,30 @@ process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer2.r
   //   edm::test::TestProcessor tester(config);
   //   REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
   // }
+}
+
+TEST_CASE("JetHTAnalyzer tests", "[JetHTAnalyzer]") {
+  //The python configuration
+  edm::test::TestProcessor::Config config{
+      R"_(import FWCore.ParameterSet.Config as cms
+from FWCore.TestProcessor.TestProcess import *
+from Alignment.OfflineValidation.jetHTAnalyzer_cfi import jetHTAnalyzer
+process = TestProcess()
+process.JetHTAnalyzer = jetHTAnalyzer
+process.moduleToTest(process.JetHTAnalyzer)
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer3.root')))
+)_"};
+
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  // SECTION("No event data") {
+  //  edm::test::TestProcessor tester(config);
+  //  REQUIRE_NOTHROW(tester.test());
+  //}
 }


### PR DESCRIPTION
#### PR description:

It was reported by @jusaviin that the declaration of the configuration parameters in the  `fillDescriptions` method of the `JetHTAnalyzer`

https://github.com/cms-sw/cmssw/blob/4dd963864653b12bd06cc29da5fa9dc744ec1901/Alignment/OfflineValidation/plugins/JetHTAnalyzer.cc#L334-L339

plugins doesn't agree with their usage in the all-in-one configuration:

https://github.com/cms-sw/cmssw/blob/4dd963864653b12bd06cc29da5fa9dc744ec1901/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py#L272-L276

This results in runtime failures. 
This PR fixes the issue in commit 7cc01f89fe2d5af061bc032856bf3295e206ed77
I profit of this to update the unit tests `testTrackAnalyzers` in order to test that the two do not go out of synch again.

#### PR validation:

Relies on the existing unit tests (`scram b runtests_testTrackAnalysis`)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
