### PR TITLE
[MkFit] Format change for windows in json files

### DIFF
--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -55,22 +55,22 @@ namespace mkfit {
     float min_dq() const { return m_select_min_dq; }
     float max_dq() const { return m_select_max_dq; }
 
-    //Hit selection windows: 2D fit/layer (72 in phase-1 CMS geometry)
-    //cut = [0]*1/pT + [1]*std::fabs(theta-pi/2) + [2])
-    float c_dp_sf = 1.1;
-    float c_dp_0 = 0.0;
-    float c_dp_1 = 0.0;
-    float c_dp_2 = 0.0;
-    //
-    float c_dq_sf = 1.1;
-    float c_dq_0 = 0.0;
-    float c_dq_1 = 0.0;
-    float c_dq_2 = 0.0;
-    //
-    float c_c2_sf = 1.1;
-    float c_c2_0 = 0.0;
-    float c_c2_1 = 0.0;
-    float c_c2_2 = 0.0;
+    const std::vector<float> &get_window_params(bool forward, bool fallback_to_other) const {
+      if (fallback_to_other) {
+        // Empty vector is a valid result, we do not need to check both.
+        if (forward)
+          return m_winpars_fwd.empty() ? m_winpars_bkw : m_winpars_fwd;
+        else
+          return m_winpars_bkw.empty() ? m_winpars_fwd : m_winpars_bkw;
+      } else {
+        return forward ? m_winpars_fwd : m_winpars_bkw;
+      }
+    }
+
+    //Hit selection window parameters: 2D fit/layer (72 in phase-1 CMS geometry).
+    //Used in MkFinder::selectHitIndices().
+    std::vector<float> m_winpars_fwd;
+    std::vector<float> m_winpars_bkw;
 
     //----------------------------------------------------------------------------
 

--- a/RecoTracker/MkFitCore/src/IterationConfig.cc
+++ b/RecoTracker/MkFitCore/src/IterationConfig.cc
@@ -42,9 +42,7 @@ namespace mkfit {
                                    /* int */ m_region,
                                    /* int */ m_fwd_search_pickup,
                                    /* int */ m_bkw_fit_last,
-                                   /* int */ m_bkw_search_pickup
-
-  )
+                                   /* int */ m_bkw_search_pickup)
 
   ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationLayerConfig,
                                    /* int */ m_layer,
@@ -52,18 +50,8 @@ namespace mkfit {
                                    /* float */ m_select_max_dphi,
                                    /* float */ m_select_min_dq,
                                    /* float */ m_select_max_dq,
-                                   /* float */ c_dp_sf,
-                                   /* float */ c_dp_0,
-                                   /* float */ c_dp_1,
-                                   /* float */ c_dp_2,
-                                   /* float */ c_dq_sf,
-                                   /* float */ c_dq_0,
-                                   /* float */ c_dq_1,
-                                   /* float */ c_dq_2,
-                                   /* float */ c_c2_sf,
-                                   /* float */ c_c2_0,
-                                   /* float */ c_c2_1,
-                                   /* float */ c_c2_2)
+                                   /* std::vector<float> */ m_winpars_fwd,
+                                   /* std::vector<float> */ m_winpars_bkw)
 
   ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationParams,
                                    /* int */ nlayers_per_seed,

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -528,7 +528,8 @@ namespace mkfit {
                           m_job->m_iter_config.m_params,
                           m_job->m_iter_config.m_layer_configs[curr_layer],
                           st_par,
-                          m_job->get_mask_for_layer(curr_layer));
+                          m_job->get_mask_for_layer(curr_layer),
+                          m_job->m_in_fwd);
 
             const LayerOfHits &layer_of_hits = m_job->m_event_of_hits[curr_layer];
             const LayerInfo &layer_info = trk_info.layer(curr_layer);
@@ -812,7 +813,8 @@ namespace mkfit {
                         iter_params,
                         m_job->m_iter_config.m_layer_configs[curr_layer],
                         st_par,
-                        m_job->get_mask_for_layer(curr_layer));
+                        m_job->get_mask_for_layer(curr_layer),
+                        m_job->m_in_fwd);
 
           dprintf("\n* Processing layer %d\n", curr_layer);
 
@@ -1021,7 +1023,8 @@ namespace mkfit {
                     iter_params,
                     m_job->m_iter_config.m_layer_configs[curr_layer],
                     st_par,
-                    m_job->get_mask_for_layer(curr_layer));
+                    m_job->get_mask_for_layer(curr_layer),
+                    m_job->m_in_fwd);
 
       const bool pickup_only = layer_plan_it.is_pickup_only();
 

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -37,12 +37,14 @@ namespace mkfit {
                        const IterationParams &ip,
                        const IterationLayerConfig &ilc,
                        const SteeringParams &sp,
-                       const std::vector<bool> *ihm) {
+                       const std::vector<bool> *ihm,
+                       bool infwd) {
     m_prop_config = &pc;
     m_iteration_params = &ip;
     m_iteration_layer_config = &ilc;
     m_steering_params = &sp;
     m_iteration_hit_mask = ihm;
+    m_in_fwd = infwd;
   }
 
   void MkFinder::setup_bkfit(const PropagationConfig &pc, const SteeringParams &sp) {
@@ -56,6 +58,7 @@ namespace mkfit {
     m_iteration_layer_config = nullptr;
     m_steering_params = nullptr;
     m_iteration_hit_mask = nullptr;
+    m_in_fwd = true;
   }
 
   //==============================================================================
@@ -205,34 +208,31 @@ namespace mkfit {
 
   void MkFinder::getHitSelDynamicWindows(
       const float invpt, const float theta, float &min_dq, float &max_dq, float &min_dphi, float &max_dphi) {
-    const IterationLayerConfig &ILC = *m_iteration_layer_config;
+    float max_invpt = std::min(invpt, 10.0f);  // => pT>0.1 GeV
 
-    float max_invpt = invpt;
-    if (invpt > 10.0)
-      max_invpt = 10.0;  // => pT>0.1 GeV
+    enum SelWinParameters_e { dp_sf = 0, dp_0, dp_1, dp_2, dq_sf, dq_0, dq_1, dq_2 };
+    auto &v = m_iteration_layer_config->get_window_params(m_in_fwd, true);
 
-    // dq hit selection window
-    float this_dq = (ILC.c_dq_0) * max_invpt + (ILC.c_dq_1) * theta + (ILC.c_dq_2);
-    // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-    if ((ILC.c_dq_sf) * this_dq > 0.f) {
-      min_dq = (ILC.c_dq_sf) * this_dq;
-      max_dq = 2.0f * min_dq;
+    if (!v.empty()) {
+      // dq hit selection window
+      float this_dq = v[dq_sf] * (v[dq_0] * max_invpt + v[dq_1] * theta + v[dq_2]);
+      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
+      // XXX-MT Do we still need this check or is vector.empty() enough?
+      // We can assign straight into min_dq otherwise.
+      if (this_dq > 0.f) {
+        min_dq = this_dq;
+        max_dq = 2.0f * min_dq;
+      }
+
+      // dphi hit selection window
+      float this_dphi = v[dp_sf] * (v[dp_0] * max_invpt + v[dp_1] * theta + v[dp_2]);
+      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
+      // XXX-MT Do we still need this check or is vector.empty() enough?
+      if (this_dphi > min_dphi) {
+        min_dphi = this_dphi;
+        max_dphi = 2.0f * min_dphi;
+      }
     }
-
-    // dphi hit selection window
-    float this_dphi = (ILC.c_dp_0) * max_invpt + (ILC.c_dp_1) * theta + (ILC.c_dp_2);
-    // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-    if ((ILC.c_dp_sf) * this_dphi > min_dphi) {
-      min_dphi = (ILC.c_dp_sf) * this_dphi;
-      max_dphi = 2.0f * min_dphi;
-    }
-
-    //// For future optimization: for layer & iteration dependend hit chi2 cut
-    //float this_c2 = (ILC.c_c2_0)*invpt+(ILC.c_c2_1)*theta+(ILC.c_c2_2);
-    //// In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-    //if(this_c2>0.f){
-    //  max_c2 = (ILC.c_c2_sf)*this_c2;
-    //}
   }
 
   //==============================================================================
@@ -241,22 +241,24 @@ namespace mkfit {
   // From HitSelectionWindows.h: track-related config on hit selection windows
 
   inline float MkFinder::getHitSelDynamicChi2Cut(const int itrk, const int ipar) {
-    const IterationLayerConfig &ILC = *m_iteration_layer_config;
-
     const float minChi2Cut = m_iteration_params->chi2Cut_min;
     const float invpt = m_Par[ipar].At(itrk, 3, 0);
     const float theta = std::abs(m_Par[ipar].At(itrk, 5, 0) - Const::PIOver2);
 
-    float max_invpt = invpt;
-    if (invpt > 10.0)
-      max_invpt = 10.0;
+    float max_invpt = std::min(invpt, 10.0f);  // => pT>0.1 GeV
 
-    float this_c2 = ILC.c_c2_0 * max_invpt + ILC.c_c2_1 * theta + ILC.c_c2_2;
-    // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-    if ((ILC.c_c2_sf) * this_c2 > minChi2Cut)
-      return ILC.c_c2_sf * this_c2;
-    else
-      return minChi2Cut;
+    enum SelWinParameters_e { c2_sf = 8, c2_0, c2_1, c2_2 };
+    auto &v = m_iteration_layer_config->get_window_params(m_in_fwd, true);
+
+    if (!v.empty()) {
+      float this_c2 = v[c2_sf] * (v[c2_0] * max_invpt + v[c2_1] * theta + v[c2_2]);
+      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
+      // XXX-MT Do we still need this check or is vector.empty() enough?
+      // XXX-MT Note, this seems different than above.
+      if (this_c2 > minChi2Cut)
+        return this_c2;
+    }
+    return minChi2Cut;
   }
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -216,9 +216,7 @@ namespace mkfit {
     if (!v.empty()) {
       // dq hit selection window
       float this_dq = v[dq_sf] * (v[dq_0] * max_invpt + v[dq_1] * theta + v[dq_2]);
-      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-      // XXX-MT Do we still need this check or is vector.empty() enough?
-      // We can assign straight into min_dq otherwise.
+      // In case value is below 0 (bad window derivation or other reasons), leave original limits
       if (this_dq > 0.f) {
         min_dq = this_dq;
         max_dq = 2.0f * min_dq;
@@ -226,8 +224,7 @@ namespace mkfit {
 
       // dphi hit selection window
       float this_dphi = v[dp_sf] * (v[dp_0] * max_invpt + v[dp_1] * theta + v[dp_2]);
-      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-      // XXX-MT Do we still need this check or is vector.empty() enough?
+      // In case value is too low (bad window derivation or other reasons), leave original limits
       if (this_dphi > min_dphi) {
         min_dphi = this_dphi;
         max_dphi = 2.0f * min_dphi;
@@ -252,9 +249,7 @@ namespace mkfit {
 
     if (!v.empty()) {
       float this_c2 = v[c2_sf] * (v[c2_0] * max_invpt + v[c2_1] * theta + v[c2_2]);
-      // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-      // XXX-MT Do we still need this check or is vector.empty() enough?
-      // XXX-MT Note, this seems different than above.
+      // In case value is too low (bad window derivation or other reasons), leave original limits
       if (this_c2 > minChi2Cut)
         return this_c2;
     }

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -53,7 +53,8 @@ namespace mkfit {
                const IterationParams &ip,
                const IterationLayerConfig &ilc,
                const SteeringParams &sp,
-               const std::vector<bool> *ihm);
+               const std::vector<bool> *ihm,
+               bool infwd);
     void setup_bkfit(const PropagationConfig &pc, const SteeringParams &sp);
     void release();
 
@@ -329,6 +330,7 @@ namespace mkfit {
     const IterationLayerConfig *m_iteration_layer_config = nullptr;
     const SteeringParams *m_steering_params = nullptr;
     const std::vector<bool> *m_iteration_hit_mask = nullptr;
+    bool m_in_fwd = true;
 
     // Backward fit
     int m_CurHit[NN];


### PR DESCRIPTION
#### PR description:

This PR enables having different values for hit selection windows in the backward and forward propagation.

It should be tested with using the new jsons: https://github.com/cms-data/RecoTracker-MkFit/pull/12

At this stage this is a purely technical PR, but new windows will be derived separately for layers where hits can be picked up both in the backward and forward propagation.

#### PR validation:

no differences are found in the MTV validation, as expected

http://uaf-10.t2.ucsd.edu/~legianni/TechnicalPRNewWindows/plots-new-windows/

** minimal differences are expected when mkFit is used for HLT (not a default configuration)
see note https://github.com/cms-sw/cmssw/pull/40679#issuecomment-1419273999
