### PR TITLE
remove the hook for MC/Data specific configuration

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1723,7 +1723,7 @@ class ConfigBuilder(object):
         ''' Enrich the schedule with NANO '''
         _,_nanoSeq,_nanoCff = self.loadDefaultOrSpecifiedCFF(stepSpec,self.NANODefaultCFF,self.NANODefaultSeq)
         self.scheduleSequence(_nanoSeq,'nanoAOD_step')
-        custom = "nanoAOD_customizeData" if self._options.isData else "nanoAOD_customizeMC"
+        custom = "nanoAOD_customizeCommon"
         self._options.customisation_file.insert(0,'.'.join([_nanoCff,custom]))
         if self._options.hltProcess:
             if len(self._options.customise_commands) > 1:

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -191,14 +191,6 @@ def nanoAOD_customizeCommon(process):
 
     return process
 
-def nanoAOD_customizeData(process):
-    process = nanoAOD_customizeCommon(process)
-    return process
-
-def nanoAOD_customizeMC(process):
-    process = nanoAOD_customizeCommon(process)
-    return process
-
 ###increasing the precision of selected GenParticles.
 def nanoWmassGenCustomize(process):
     pdgSelection="?(abs(pdgId) == 11|| abs(pdgId)==13 || abs(pdgId)==15 ||abs(pdgId)== 12 || abs(pdgId)== 14 || abs(pdgId)== 16|| abs(pdgId)== 24|| pdgId== 23)"


### PR DESCRIPTION
#### PR description:

there should be no need for a specific configuration for data or MC for NANO. This removes the call for two different customize function (hopefully we can come up with an update to remove the need for that customize all together)

#### PR validation:

the nano matrix ran through.
