### PR TITLE
PPS pixel track reco in bad pots

### DIFF
--- a/RecoPPS/Local/interface/RPixDetPatternFinder.h
+++ b/RecoPPS/Local/interface/RPixDetPatternFinder.h
@@ -38,7 +38,7 @@ public:
   typedef std::vector<PointInPlane> Road;
 
   void setHits(const edm::DetSetVector<CTPPSPixelRecHit> *hitVector) { hitVector_ = hitVector; }
-  virtual void findPattern(bool *isbadpot) = 0;
+  virtual void findPattern(bool *is2planepot) = 0;
   void clear() { patternVector_.clear(); }
   std::vector<Road> const &getPatterns() const { return patternVector_; }
   void setGeometry(const CTPPSGeometry *geometry) { geometry_ = geometry; }

--- a/RecoPPS/Local/interface/RPixDetPatternFinder.h
+++ b/RecoPPS/Local/interface/RPixDetPatternFinder.h
@@ -38,7 +38,7 @@ public:
   typedef std::vector<PointInPlane> Road;
 
   void setHits(const edm::DetSetVector<CTPPSPixelRecHit> *hitVector) { hitVector_ = hitVector; }
-  virtual void findPattern(bool isbadpot) = 0;
+  virtual void findPattern(bool *isbadpot) = 0;
   void clear() { patternVector_.clear(); }
   std::vector<Road> const &getPatterns() const { return patternVector_; }
   void setGeometry(const CTPPSGeometry *geometry) { geometry_ = geometry; }

--- a/RecoPPS/Local/interface/RPixRoadFinder.h
+++ b/RecoPPS/Local/interface/RPixRoadFinder.h
@@ -35,14 +35,14 @@ class RPixRoadFinder : public RPixDetPatternFinder {
 public:
   explicit RPixRoadFinder(const edm::ParameterSet &param);
   ~RPixRoadFinder() override;
-  void findPattern(bool *isbadpot) override;
+  void findPattern(bool *is2planepot) override;
 
 private:
   int verbosity_;
   double roadRadius_;
   unsigned int minRoadSize_;
   unsigned int maxRoadSize_;
-  double roadRadiusBadPot_;
+  double roadRadius2PlanePot_;
   void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry &geometry, std::vector<Road> &roads);
 };
 

--- a/RecoPPS/Local/interface/RPixRoadFinder.h
+++ b/RecoPPS/Local/interface/RPixRoadFinder.h
@@ -42,7 +42,7 @@ private:
   double roadRadius_;
   unsigned int minRoadSize_;
   unsigned int maxRoadSize_;
-  double roadRadius2PlanePot_;
+  double roadRadiusBadPot_;
   void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry &geometry, std::vector<Road> &roads);
 };
 

--- a/RecoPPS/Local/interface/RPixRoadFinder.h
+++ b/RecoPPS/Local/interface/RPixRoadFinder.h
@@ -35,7 +35,7 @@ class RPixRoadFinder : public RPixDetPatternFinder {
 public:
   explicit RPixRoadFinder(const edm::ParameterSet &param);
   ~RPixRoadFinder() override;
-  void findPattern(bool isbadpot) override;
+  void findPattern(bool *isbadpot) override;
 
 private:
   int verbosity_;

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -189,26 +189,26 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
       if (rocNum > 5 || detId.plane() > 5)
         throw cms::Exception("InvalidRocOrPlaneNumber") << "roc number from mask: " << rocNum;
 
-      if (detId.arm() == 0 && detId.rp() == 3) { 
-	if(detId.station() == 2){                        // pot 45-220-far
-	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-	    maskV[0][detId.plane()][rocNum] = true;
-	  }
-	}else if(detId.station() == 0){        // pot 45-210-far
-	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-	    maskV[1][detId.plane()][rocNum] = true;
-	  }
-	}
-      }else if(detId.arm() == 1 && detId.rp() == 3) { 
-	if(detId.station() == 0){                        // pot 56-210-far
-	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-	    maskV[2][detId.plane()][rocNum] = true;
-	  }
-	}else if(detId.station() == 2){        // pot 56-220-far
-	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-	    maskV[3][detId.plane()][rocNum] = true;
-	  }
-	}
+      if (detId.arm() == 0 && detId.rp() == 3) {
+        if (detId.station() == 2) {                                                                // pot 45-220-far
+          if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+            maskV[0][detId.plane()][rocNum] = true;
+          }
+        } else if (detId.station() == 0) {                                                         // pot 45-210-far
+          if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+            maskV[1][detId.plane()][rocNum] = true;
+          }
+        }
+      } else if (detId.arm() == 1 && detId.rp() == 3) {
+        if (detId.station() == 0) {                                                                // pot 56-210-far
+          if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+            maskV[2][detId.plane()][rocNum] = true;
+          }
+        } else if (detId.station() == 2) {                                                         // pot 56-220-far
+          if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+            maskV[3][detId.plane()][rocNum] = true;
+          }
+        }
       }
     }
     // search for specific pattern that requires special reconstruction (use of two plane tracks)

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -190,44 +190,44 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
       unsigned int rocNum = (det.first & rocMask) >> rocOffset;
       if (rocNum > 5 || detId.plane() > 5)
         throw cms::Exception("InvalidRocOrPlaneNumber") << "roc number from mask: " << rocNum;
- 
-      if (detId.arm() == 0 && detId.station() == 2 && detId.rp() == 3) {  // pot 45-220-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+
+      if (detId.arm() == 0 && detId.station() == 2 && detId.rp() == 3) {                         // pot 45-220-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
           maskV[0][detId.plane()][rocNum] = true;
         }
       }
-      if (detId.arm() == 0 && detId.station() == 0 && detId.rp() == 3) {  // pot 45-210-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+      if (detId.arm() == 0 && detId.station() == 0 && detId.rp() == 3) {                         // pot 45-210-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
           maskV[1][detId.plane()][rocNum] = true;
         }
       }
-      if (detId.arm() == 1 && detId.station() == 0 && detId.rp() == 3) {  // pot 56-210-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+      if (detId.arm() == 1 && detId.station() == 0 && detId.rp() == 3) {                         // pot 56-210-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
           maskV[2][detId.plane()][rocNum] = true;
         }
       }
-      if (detId.arm() == 1 && detId.station() == 2 && detId.rp() == 3) {  // pot 56-220-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+      if (detId.arm() == 1 && detId.station() == 2 && detId.rp() == 3) {                         // pot 56-220-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
           maskV[3][detId.plane()][rocNum] = true;
         }
       }
-
     }
 
     // search for specific pattern that requires special reconstruction (use of two plane tracks)
 
-    for(unsigned int i = 0; i<4; i++){
+    for (unsigned int i = 0; i < 4; i++) {
       unsigned int numberOfMaskedPlanes = 0;
-      for(unsigned int j = 0; j<6; j++){
-	if(maskV[i][j][0] && maskV[i][j][1] && maskV[i][j][4] && maskV[i][j][5]) numberOfMaskedPlanes++;
+      for (unsigned int j = 0; j < 6; j++) {
+        if (maskV[i][j][0] && maskV[i][j][1] && maskV[i][j][4] && maskV[i][j][5])
+          numberOfMaskedPlanes++;
       }
-      if(numberOfMaskedPlanes == 4)isBadPotV[i] = true;  // search for exactly 4 planes fully masked
-      edm::LogInfo("CTPPSPixelLocalTrackProducer") << " Masked planes in Pot #" 
-						   << i << " = " << numberOfMaskedPlanes;
-      if(isBadPotV[i]) edm::LogInfo("CTPPSPixelLocalTrackProducer") << " Enabling 2 plane track reconstruction for pot #" 
-								    << i << " (0=45-220, 1=45-210, 2=56-210, 3=56-220) ";
+      if (numberOfMaskedPlanes == 4)
+        isBadPotV[i] = true;  // search for exactly 4 planes fully masked
+      edm::LogInfo("CTPPSPixelLocalTrackProducer") << " Masked planes in Pot #" << i << " = " << numberOfMaskedPlanes;
+      if (isBadPotV[i])
+        edm::LogInfo("CTPPSPixelLocalTrackProducer")
+            << " Enabling 2 plane track reconstruction for pot #" << i << " (0=45-220, 1=45-210, 2=56-210, 3=56-220) ";
     }
-
   }
   std::vector<CTPPSPixelDetId> listOfPotWithHighOccupancyPlanes;
   std::map<CTPPSPixelDetId, uint32_t> mapHitPerPot;

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -150,7 +150,7 @@ void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<int>("minRoadSize", 3)->setComment("minimum number of points in a pattern");
   desc.add<int>("maxRoadSize", 20)->setComment("maximum number of points in a pattern");
   //parameter for 2-plane-pot reconstruction patch in run 3
-  desc.add<double>("roadRadius2PlanePot", 0.5)->setComment("radius of pattern search window for 2 plane pot");
+  desc.add<double>("roadRadiusBadPot", 0.5)->setComment("radius of pattern search window for 2 plane pot");
 
   descriptions.add("ctppsPixelLocalTracks", desc);
 }

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -180,8 +180,6 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
     // Read Mask checking if 45-220-far is masked as bad and needs special treatment
     std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &maschera = mask.analysisMask;
 
-    //bool mask_45_220[6][6] = {{false}};
-
     // vector of masked rocs
     bool maskV[4][6][6] = {{{false}}};
 
@@ -191,28 +189,28 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
       if (rocNum > 5 || detId.plane() > 5)
         throw cms::Exception("InvalidRocOrPlaneNumber") << "roc number from mask: " << rocNum;
 
-      if (detId.arm() == 0 && detId.station() == 2 && detId.rp() == 3) {                         // pot 45-220-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-          maskV[0][detId.plane()][rocNum] = true;
-        }
-      }
-      if (detId.arm() == 0 && detId.station() == 0 && detId.rp() == 3) {                         // pot 45-210-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-          maskV[1][detId.plane()][rocNum] = true;
-        }
-      }
-      if (detId.arm() == 1 && detId.station() == 0 && detId.rp() == 3) {                         // pot 56-210-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-          maskV[2][detId.plane()][rocNum] = true;
-        }
-      }
-      if (detId.arm() == 1 && detId.station() == 2 && detId.rp() == 3) {                         // pot 56-220-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
-          maskV[3][detId.plane()][rocNum] = true;
-        }
+      if (detId.arm() == 0 && detId.rp() == 3) { 
+	if(detId.station() == 2){                        // pot 45-220-far
+	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+	    maskV[0][detId.plane()][rocNum] = true;
+	  }
+	}else if(detId.station() == 0){        // pot 45-210-far
+	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+	    maskV[1][detId.plane()][rocNum] = true;
+	  }
+	}
+      }else if(detId.arm() == 1 && detId.rp() == 3) { 
+	if(detId.station() == 0){                        // pot 56-210-far
+	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+	    maskV[2][detId.plane()][rocNum] = true;
+	  }
+	}else if(detId.station() == 2){        // pot 56-220-far
+	  if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {  // roc fully masked
+	    maskV[3][detId.plane()][rocNum] = true;
+	  }
+	}
       }
     }
-
     // search for specific pattern that requires special reconstruction (use of two plane tracks)
 
     for (unsigned int i = 0; i < 4; i++) {

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -170,30 +170,64 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
   geometryWatcher_.check(iSetup);
 
   // get mask
-  bool isBadPot_45_220 = false;
+
+  // bad pot flag vector 0=45-220, 1=45-210, 2=56-210, 3=56-220
+  bool isBadPotV[4] = {false};
+
   if (!recHits->empty()) {
     const auto &mask = iSetup.getData(tokenCTPPSPixelAnalysisMask_);
 
     // Read Mask checking if 45-220-far is masked as bad and needs special treatment
     std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &maschera = mask.analysisMask;
 
-    bool mask_45_220[6][6] = {{false}};
+    //bool mask_45_220[6][6] = {{false}};
+
+    // vector of masked rocs
+    bool maskV[4][6][6] = {{{false}}};
+
     for (auto const &det : maschera) {
       CTPPSPixelDetId detId(det.first);
       unsigned int rocNum = (det.first & rocMask) >> rocOffset;
       if (rocNum > 5 || detId.plane() > 5)
         throw cms::Exception("InvalidRocOrPlaneNumber") << "roc number from mask: " << rocNum;
-
+ 
       if (detId.arm() == 0 && detId.station() == 2 && detId.rp() == 3) {  // pot 45-220-far
-        if (det.second.maskedPixels.size() == rocSizeInPixels) {          // roc fully masked
-          mask_45_220[detId.plane()][rocNum] = true;
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+          maskV[0][detId.plane()][rocNum] = true;
         }
       }
+      if (detId.arm() == 0 && detId.station() == 0 && detId.rp() == 3) {  // pot 45-210-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+          maskV[1][detId.plane()][rocNum] = true;
+        }
+      }
+      if (detId.arm() == 1 && detId.station() == 0 && detId.rp() == 3) {  // pot 56-210-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+          maskV[2][detId.plane()][rocNum] = true;
+        }
+      }
+      if (detId.arm() == 1 && detId.station() == 2 && detId.rp() == 3) {  // pot 56-220-far
+        if (det.second.maskedPixels.size() == rocSizeInPixels || det.second.fullMask == true) {          // roc fully masked
+          maskV[3][detId.plane()][rocNum] = true;
+        }
+      }
+
     }
 
-    // search for specific pattern that requires special reconstruction (isBadPot)
-    isBadPot_45_220 = mask_45_220[1][4] && mask_45_220[1][5] && mask_45_220[2][4] && mask_45_220[2][5] &&
-                      mask_45_220[3][4] && mask_45_220[3][5] && mask_45_220[4][4] && mask_45_220[4][5];
+    // search for specific pattern that requires special reconstruction (use of two plane tracks)
+
+    for(unsigned int i = 0; i<4; i++){
+      unsigned int numberOfMaskedPlanes = 0;
+      for(unsigned int j = 0; j<6; j++){
+	if(maskV[i][j][0] && maskV[i][j][1] && maskV[i][j][4] && maskV[i][j][5]) numberOfMaskedPlanes++;
+      }
+      if(numberOfMaskedPlanes == 4)isBadPotV[i] = true;  // search for exactly 4 planes fully masked
+      edm::LogInfo("CTPPSPixelLocalTrackProducer") << " Masked planes in Pot #" 
+						   << i << " = " << numberOfMaskedPlanes;
+      if(isBadPotV[i]) edm::LogInfo("CTPPSPixelLocalTrackProducer") << " Enabling 2 plane track reconstruction for pot #" 
+								    << i << " (0=45-220, 1=45-210, 2=56-210, 3=56-220) ";
+    }
+
   }
   std::vector<CTPPSPixelDetId> listOfPotWithHighOccupancyPlanes;
   std::map<CTPPSPixelDetId, uint32_t> mapHitPerPot;
@@ -215,7 +249,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
     if (maxHitPerPlane_ >= 0 && hitOnPlane > (uint32_t)maxHitPerPlane_) {
       if (verbosity_ > 2)
         edm::LogInfo("CTPPSPixelLocalTrackProducer")
-            << " ---> To many hits in the plane, pot will be excluded from tracking cleared";
+            << " ---> Too many hits in the plane, pot will be excluded from tracking cleared";
       listOfPotWithHighOccupancyPlanes.push_back(tmpRomanPotId);
     }
   }
@@ -240,7 +274,7 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
   patternFinder_->clear();
   patternFinder_->setHits(&recHitVector);
   patternFinder_->setGeometry(&geometry);
-  patternFinder_->findPattern(isBadPot_45_220);
+  patternFinder_->findPattern(isBadPotV);
   std::vector<RPixDetPatternFinder::Road> patternVector = patternFinder_->getPatterns();
 
   //loop on all the patterns

--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -7,6 +7,8 @@
 namespace {
   constexpr int maxCol = CTPPSPixelCluster::MAXCOL;
   constexpr int maxRow = CTPPSPixelCluster::MAXROW;
+  constexpr int maxColRoc = rpixValues::ROCSizeInX;
+  constexpr int maxRowRoc = rpixValues::ROCSizeInY;
   constexpr double highRangeCal = 1800.;
   constexpr double lowRangeCal = 260.;
   constexpr int rocMask = 0xE000;
@@ -33,6 +35,9 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
   std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &mask = maskera->analysisMask;
   std::set<std::pair<unsigned char, unsigned char> > maskedPixels;
 
+  bool fullyMaskedRoc[6][6] = {{false}};
+  CTPPSPixelDetId currentId(detId);
+
   // read and store masked pixels after converting ROC numbering into module numbering
   CTPPSPixelIndices pI;
   for (auto const &det : mask) {
@@ -42,6 +47,7 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
       unsigned int rocNum = (det.first & rocMask) >> rocOffset;
       if (rocNum > 5)
         throw cms::Exception("InvalidRocNumber") << "roc number from mask: " << rocNum;
+      if(det.second.fullMask) fullyMaskedRoc[currentId.plane()][rocNum] = true;
       for (auto const &paio : det.second.maskedPixels) {
         std::pair<unsigned char, unsigned char> pa = paio;
         int modCol, modRow;
@@ -76,7 +82,12 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
 
     // check if pixel is noisy or dead (i.e. in the mask)
     const bool is_in = maskedPixels.find(pixel) != maskedPixels.end();
-    if (!is_in) {
+
+    // check if pixel inside a fully masked roc
+    int piano = currentId.plane();
+    int rocId = pI.getROCId(column,row);
+
+    if (!is_in && !fullyMaskedRoc[piano][rocId]) {
       //calibrate digi and store the new ones
       electrons = calibrate(detId, adc, row, column, pcalibrations);
       if (electrons < SeedADCThreshold_ * ElectronADCGain_)

--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -7,8 +7,6 @@
 namespace {
   constexpr int maxCol = CTPPSPixelCluster::MAXCOL;
   constexpr int maxRow = CTPPSPixelCluster::MAXROW;
-  constexpr int maxColRoc = rpixValues::ROCSizeInX;
-  constexpr int maxRowRoc = rpixValues::ROCSizeInY;
   constexpr double highRangeCal = 1800.;
   constexpr double lowRangeCal = 260.;
   constexpr int rocMask = 0xE000;

--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -47,7 +47,8 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
       unsigned int rocNum = (det.first & rocMask) >> rocOffset;
       if (rocNum > 5)
         throw cms::Exception("InvalidRocNumber") << "roc number from mask: " << rocNum;
-      if(det.second.fullMask) fullyMaskedRoc[currentId.plane()][rocNum] = true;
+      if (det.second.fullMask)
+        fullyMaskedRoc[currentId.plane()][rocNum] = true;
       for (auto const &paio : det.second.maskedPixels) {
         std::pair<unsigned char, unsigned char> pa = paio;
         int modCol, modRow;
@@ -85,7 +86,7 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
 
     // check if pixel inside a fully masked roc
     int piano = currentId.plane();
-    int rocId = pI.getROCId(column,row);
+    int rocId = pI.getROCId(column, row);
 
     if (!is_in && !fullyMaskedRoc[piano][rocId]) {
       //calibrate digi and store the new ones

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -163,7 +163,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
   //The loop stops when the number of planes with recorded hits is less than the minimum number of planes required
   //or if the track with minimum chiSquare found has a chiSquare higher than the maximum required
 
-  // bad Pot patch 45-220-fr 2022 -- beginning
+  // bad Pot patch -- beginning
   // check number of hits in road
   unsigned int hitNum = 0;
   for (const auto &plane : *hitMap_) {
@@ -213,7 +213,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     // save track in collection
     localTrackVector_.push_back(track);
   }
-  // bad Pot patch 45-220-fr 2022 -- end
+  // bad Pot patch -- end
 
   while (hitMap_->size() >= trackMinNumberOfPoints_) {
     if (verbosity_ >= 1)

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -29,12 +29,13 @@ RPixRoadFinder::~RPixRoadFinder() {}
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixRoadFinder::findPattern(bool *isBadPot) {
+void RPixRoadFinder::findPattern(bool* isBadPot) {
   Road temp_all_hits;
   temp_all_hits.clear();
 
   Road temp_all_hits_badPot[4];
-  for(unsigned int i = 0; i < 4; i++) temp_all_hits_badPot[i].clear();
+  for (unsigned int i = 0; i < 4; i++)
+    temp_all_hits_badPot[i].clear();
 
   // convert local hit sto global and push them to a vector
   for (const auto& ds_rh2 : *hitVector_) {
@@ -73,14 +74,14 @@ void RPixRoadFinder::findPattern(bool *isBadPot) {
 
       if (isBadPot[0] == true && myid.arm() == 0 && myid.station() == 2) {  // 45-220
         temp_all_hits_badPot[0].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      }else if (isBadPot[1] == true && myid.arm() == 0 && myid.station() == 0) {  // 45-210
-	temp_all_hits_badPot[1].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      }else if (isBadPot[2] == true && myid.arm() == 1 && myid.station() == 0) {  // 56-210
-	temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      }else if (isBadPot[3] == true && myid.arm() == 1 && myid.station() == 2) {  // 56-220
-	temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      }else{
-	temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (isBadPot[1] == true && myid.arm() == 0 && myid.station() == 0) {  // 45-210
+        temp_all_hits_badPot[1].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (isBadPot[2] == true && myid.arm() == 1 && myid.station() == 0) {  // 56-210
+        temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (isBadPot[3] == true && myid.arm() == 1 && myid.station() == 2) {  // 56-220
+        temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else {
+        temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       }
     }
   }
@@ -122,32 +123,32 @@ void RPixRoadFinder::findPattern(bool *isBadPot) {
 
   // badPot algorithm
 
-  for(unsigned int i = 0; i < 4; i++){
-    if(isBadPot[i]){
+  for (unsigned int i = 0; i < 4; i++) {
+    if (isBadPot[i]) {
       Road::iterator it_gh1_bP = temp_all_hits_badPot[i].begin();
       Road::iterator it_gh2_bP;
 
       while (it_gh1_bP != temp_all_hits_badPot[i].end() && temp_all_hits_badPot[i].size() >= 2) {
-	Road temp_road;
+        Road temp_road;
 
-	it_gh2_bP = it_gh1_bP;
+        it_gh2_bP = it_gh1_bP;
 
-	const auto currPoint = it_gh1_bP->globalPoint;
+        const auto currPoint = it_gh1_bP->globalPoint;
 
-	while (it_gh2_bP != temp_all_hits_badPot[i].end()) {
-	  const auto subtraction = currPoint - it_gh2_bP->globalPoint;
+        while (it_gh2_bP != temp_all_hits_badPot[i].end()) {
+          const auto subtraction = currPoint - it_gh2_bP->globalPoint;
 
-	  if (subtraction.Rho() < roadRadiusBadPot_) {
-	    temp_road.push_back(*it_gh2_bP);
-	    temp_all_hits_badPot[i].erase(it_gh2_bP);
-	  } else {
-	    ++it_gh2_bP;
-	  }
-	}
+          if (subtraction.Rho() < roadRadiusBadPot_) {
+            temp_road.push_back(*it_gh2_bP);
+            temp_all_hits_badPot[i].erase(it_gh2_bP);
+          } else {
+            ++it_gh2_bP;
+          }
+        }
 
-	if (temp_road.size() == 2) {  // look for isolated tracks
-	  patternVector_.push_back(temp_road);
-	}
+        if (temp_road.size() == 2) {  // look for isolated tracks
+          patternVector_.push_back(temp_road);
+        }
       }
     }
   }

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -75,7 +75,7 @@ void RPixRoadFinder::findPattern(bool* isBadPot) {
       } else if (isBadPot[2] == true && myid.arm() == 1 && myid.station() == 0) {  // 56-210
         temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       } else if (isBadPot[3] == true && myid.arm() == 1 && myid.station() == 2) {  // 56-220
-        temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+        temp_all_hits_badPot[3].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       } else {
         temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       }

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -20,7 +20,7 @@ RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : RPixDetP
   roadRadius_ = parameterSet.getParameter<double>("roadRadius");
   minRoadSize_ = parameterSet.getParameter<int>("minRoadSize");
   maxRoadSize_ = parameterSet.getParameter<int>("maxRoadSize");
-  roadRadius2PlanePot_ = parameterSet.getParameter<double>("roadRadius2PlanePot");
+  roadRadiusBadPot_ = parameterSet.getParameter<double>("roadRadiusBadPot");
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -134,7 +134,7 @@ void RPixRoadFinder::findPattern(bool* is2PlanePot) {
         while (it_gh2_bP != temp_all_hits_2PlanePot[i].end()) {
           const auto subtraction = currPoint - it_gh2_bP->globalPoint;
 
-          if (subtraction.Rho() < roadRadius2PlanePot_) {
+          if (subtraction.Rho() < roadRadiusBadPot_) {
             temp_road.push_back(*it_gh2_bP);
             temp_all_hits_2PlanePot[i].erase(it_gh2_bP);
           } else {

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -20,7 +20,7 @@ RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : RPixDetP
   roadRadius_ = parameterSet.getParameter<double>("roadRadius");
   minRoadSize_ = parameterSet.getParameter<int>("minRoadSize");
   maxRoadSize_ = parameterSet.getParameter<int>("maxRoadSize");
-  roadRadiusBadPot_ = parameterSet.getParameter<double>("roadRadiusBadPot");
+  roadRadius2PlanePot_ = parameterSet.getParameter<double>("roadRadius2PlanePot");
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -29,9 +29,9 @@ RPixRoadFinder::~RPixRoadFinder() {}
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixRoadFinder::findPattern(bool* isBadPot) {
+void RPixRoadFinder::findPattern(bool* is2PlanePot) {
   Road temp_all_hits;
-  Road temp_all_hits_badPot[4];
+  Road temp_all_hits_2PlanePot[4];
 
   // convert local hit sto global and push them to a vector
   for (const auto& ds_rh2 : *hitVector_) {
@@ -66,16 +66,16 @@ void RPixRoadFinder::findPattern(bool* isBadPot) {
 
       math::Error<3>::type globalError = ROOT::Math::SimilarityT(theRotationTMatrix, localError);
 
-      // create new collections for bad and good pots
+      // create new collections for bad (2 planes) and good pots
 
-      if (isBadPot[0] == true && myid.arm() == 0 && myid.station() == 2) {  // 45-220
-        temp_all_hits_badPot[0].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      } else if (isBadPot[1] == true && myid.arm() == 0 && myid.station() == 0) {  // 45-210
-        temp_all_hits_badPot[1].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      } else if (isBadPot[2] == true && myid.arm() == 1 && myid.station() == 0) {  // 56-210
-        temp_all_hits_badPot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      } else if (isBadPot[3] == true && myid.arm() == 1 && myid.station() == 2) {  // 56-220
-        temp_all_hits_badPot[3].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      if (is2PlanePot[0] == true && myid.arm() == 0 && myid.station() == 2) {  // 45-220
+        temp_all_hits_2PlanePot[0].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (is2PlanePot[1] == true && myid.arm() == 0 && myid.station() == 0) {  // 45-210
+        temp_all_hits_2PlanePot[1].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (is2PlanePot[2] == true && myid.arm() == 1 && myid.station() == 0) {  // 56-210
+        temp_all_hits_2PlanePot[2].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      } else if (is2PlanePot[3] == true && myid.arm() == 1 && myid.station() == 2) {  // 56-220
+        temp_all_hits_2PlanePot[3].emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       } else {
         temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
       }
@@ -117,26 +117,26 @@ void RPixRoadFinder::findPattern(bool* isBadPot) {
   }
   // end of algorithm
 
-  // badPot algorithm
+  // 2PlanePot algorithm
 
   for (unsigned int i = 0; i < 4; i++) {
-    if (isBadPot[i]) {
-      Road::iterator it_gh1_bP = temp_all_hits_badPot[i].begin();
+    if (is2PlanePot[i]) {
+      Road::iterator it_gh1_bP = temp_all_hits_2PlanePot[i].begin();
       Road::iterator it_gh2_bP;
 
-      while (it_gh1_bP != temp_all_hits_badPot[i].end() && temp_all_hits_badPot[i].size() >= 2) {
+      while (it_gh1_bP != temp_all_hits_2PlanePot[i].end() && temp_all_hits_2PlanePot[i].size() >= 2) {
         Road temp_road;
 
         it_gh2_bP = it_gh1_bP;
 
         const auto currPoint = it_gh1_bP->globalPoint;
 
-        while (it_gh2_bP != temp_all_hits_badPot[i].end()) {
+        while (it_gh2_bP != temp_all_hits_2PlanePot[i].end()) {
           const auto subtraction = currPoint - it_gh2_bP->globalPoint;
 
-          if (subtraction.Rho() < roadRadiusBadPot_) {
+          if (subtraction.Rho() < roadRadius2PlanePot_) {
             temp_road.push_back(*it_gh2_bP);
-            temp_all_hits_badPot[i].erase(it_gh2_bP);
+            temp_all_hits_2PlanePot[i].erase(it_gh2_bP);
           } else {
             ++it_gh2_bP;
           }

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -31,11 +31,7 @@ RPixRoadFinder::~RPixRoadFinder() {}
 
 void RPixRoadFinder::findPattern(bool* isBadPot) {
   Road temp_all_hits;
-  temp_all_hits.clear();
-
   Road temp_all_hits_badPot[4];
-  for (unsigned int i = 0; i < 4; i++)
-    temp_all_hits_badPot[i].clear();
 
   // convert local hit sto global and push them to a vector
   for (const auto& ds_rh2 : *hitVector_) {


### PR DESCRIPTION
#### PR description:
This PR generalizes what reported in:
https://indico.cern.ch/event/1176711/contributions/4945189/attachments/2474024/4244960/pps-badpot-studies_3.pdf

The generalization is that the 2-plane-track reconstruction can be activated using the channel mask in the DB.
Normally the track reconstruction is done using at least 3 planes out of 6. In the unlikely case 4/6 planes are damaged no track is normally recostructed. 
With this PR, a special 2 plane reconstruction is introduced to recover tracks also in these pathologic situations.
The dedicated 2-plane-track reconstruction is activated if 4/6 planes are fully masked in the channel mask inside DB.
This strategy recovers tracks, is double counting safe, is triggered by DB objects (channel mask).  

#### PR validation:

Private tests on Run3 and Run2 data show that the special reco is triggered if and only if 4/6 plane in a detector package are masked.
136 WFs with GT conditions show no changes, as expected (no 4 masked planes condition in any current GT).

No backport currently expected.