### PR TITLE
[12_6_X] Switch file catalog back to TFC on the request of T0

### DIFF
--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -37,8 +37,8 @@ namespace edm {
                      std::string const& override,
                      bool useLFNasPFNifLFNnotFound = false,
                      //switching between two catalog types
-                     //edm::CatalogType catType = edm::CatalogType::TrivialCatalog);
-                     edm::CatalogType catType = edm::CatalogType::RucioCatalog);
+                     edm::CatalogType catType = edm::CatalogType::TrivialCatalog);
+    //edm::CatalogType catType = edm::CatalogType::RucioCatalog);
 
     ~InputFileCatalog();
     std::vector<FileCatalogItem> const& fileCatalogItems() const { return fileCatalogItems_; }


### PR DESCRIPTION
#### PR description:

This PR switches the file catalog back to TFC from the Rucio catalog (introduced in https://github.com/cms-sw/cmssw/pull/37278). The use of Rucio catalog turned out to be problematic for Tier 0 (for now), so on Tier 0 request  (https://cms-talk.web.cern.ch/t/request-for-recompilation-of-cmssw-12-6-2-to-be-used-in-mwgr1/19957/1) this PR changes the file catalog back to TFC for 12_6_X.

FYI @germanfgv @stlammel @nhduongvn

#### PR validation:

Unit tests in `FWCore/Catalog` and `FWCore/Services` pass.