### PR TITLE
[12_4_X] add DT and CSC rechits to AOD content

### DIFF
--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py
@@ -8,7 +8,9 @@ RecoLocalMuonAOD = cms.PSet(
         'keep *_dt4DSegments_*_*', 
         'keep *_dt4DCosmicSegments_*_*',
         'keep *_cscSegments_*_*',
-        'keep *_rpcRecHits_*_*')
+        'keep *_rpcRecHits_*_*',
+        'keep *_dt1DRecHits_*_*',
+        'keep *_csc2DRecHits_*_*')
 )
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM


### PR DESCRIPTION
#### PR description:

Backport of #40251 for 2022 data re-processing and signal MC production.

This PR adds CSC/DT rechits to the AOD datatier, which are the essential inputs for multiple searches of LLP decaying in the muon system and evaluating related trigger performances

#### PR validation:

Backport of #40251
