### PR TITLE
Phase2-gex146 Rename name of a Phase2 Era to match calorimeter scenario name

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C20I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C20I13M9_cff.py
@@ -3,4 +3,4 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 
-Phase2C18I13M9 = cms.ModifierChain(Phase2C17I13M9, phase2_hfnose)
+Phase2C20I13M9 = cms.ModifierChain(Phase2C17I13M9, phase2_hfnose)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2363,7 +2363,7 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D94',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C18I13M9',
+        'Era' : 'Phase2C20I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
     },
     '2026D95' : {

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -55,7 +55,7 @@ class Eras (object):
                  'Phase2C11I13T25M9',
                  'Phase2C11I13T26M9',
                  'Phase2C17I13M9',
-                 'Phase2C18I13M9'
+                 'Phase2C20I13M9'
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',

--- a/Validation/HGCalValidation/test/python/runHFNoseDigiStudy_cfg.py
+++ b/Validation/HGCalValidation/test/python/runHFNoseDigiStudy_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C18I13M9_cff import Phase2C18I13M9
-process = cms.Process('PROD',Phase2C18I13M9)
+from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
+process = cms.Process('PROD',Phase2C20I13M9)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load('Configuration.Geometry.GeometryExtended2026D94Reco_cff')

--- a/Validation/HGCalValidation/test/python/runHFNoseRecHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/python/runHFNoseRecHitStudy_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import FWCore.Utilities.FileUtils as FileUtils
 
-from Configuration.Eras.Era_Phase2C18I13M9_cff import Phase2C18I13M9
-process = cms.Process('PROD',Phase2C18I13M9)
+from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
+process = cms.Process('PROD',Phase2C20I13M9)
 
 process.load('Configuration.Geometry.GeometryExtended2026D94Reco_cff')
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/Validation/HGCalValidation/test/python/runHFNoseSimHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/python/runHFNoseSimHitStudy_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C18I13M9_cff import Phase2C18I13M9
-process = cms.Process('PROD',Phase2C18I13M9)
+from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
+process = cms.Process('PROD',Phase2C20I13M9)
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")

--- a/Validation/HGCalValidation/test/python/testHFNoseSimHitStudy_cfg.py
+++ b/Validation/HGCalValidation/test/python/testHFNoseSimHitStudy_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C18I13M9_cff import Phase2C18I13M9
+from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
 
-process = cms.Process('SIM',Phase2C18I13M9)
+process = cms.Process('SIM',Phase2C20I13M9)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
#### PR description:

Rename name of a Phase2 Era to match calorimeter scenario name

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special