### PR TITLE
Fix unit conversion in PPS Reco LUT shift

### DIFF
--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -73,7 +73,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
           (t_lead != 0) ? (t_lead - ch_t_offset / ts_to_ns_) / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       // calibrated time of arrival
-      const double t0 = (t_lead % 1024) * ts_to_ns_ + lut[t_lead % 1024] - ch_t_twc;
+      const double t0 = (t_lead % 1024) * ts_to_ns_ + lut[t_lead % 1024] * ts_to_ns_ - ch_t_twc;
       rec_hits.emplace_back(
           // spatial information
           x_pos,


### PR DESCRIPTION
#### PR description:
Fix units for LUT shift in PPS Reco - LUT shift is currently 0 for run3 data but the new payload will be uploaded in the future.

#### PR validation:

standard validation

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

not a backport