### PR TITLE
Add more `fillDescriptions` to `Alignment/OfflineValidation` plugins

### DIFF
--- a/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
@@ -332,40 +332,9 @@ void EopTreeWriter::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.setComment("Generate tree for Tracker Alignment E/p validation");
   desc.add<edm::InputTag>("src", edm::InputTag("generalTracks"));
 
-  // track association
+  // track association (take defaults)
   edm::ParameterSetDescription psd0;
-  psd0.add<bool>("accountForTrajectoryChangeCalo", false);
-  psd0.add<bool>("propagateAllDirections", true);
-  psd0.add<bool>("truthMatch", false);
-  psd0.add<bool>("useCalo", false);
-  psd0.add<bool>("useEcal", true);
-  psd0.add<bool>("useGEM", false);
-  psd0.add<bool>("useHO", false);
-  psd0.add<bool>("useHcal", true);
-  psd0.add<bool>("useME0", false);
-  psd0.add<bool>("useMuon", true);
-  psd0.add<bool>("usePreshower", false);
-  psd0.add<double>("dREcal", 9999.0);
-  psd0.add<double>("dREcalPreselection", 0.05);
-  psd0.add<double>("dRHcal", 9999.0);
-  psd0.add<double>("dRHcalPreselection", 0.2);
-  psd0.add<double>("dRMuon", 9999.0);
-  psd0.add<double>("dRMuonPreselection", 0.2);
-  psd0.add<double>("dRPreshowerPreselection", 0.2);
-  psd0.add<double>("muonMaxDistanceSigmaX", 0.0);
-  psd0.add<double>("muonMaxDistanceSigmaY", 0.0);
-  psd0.add<double>("muonMaxDistanceX", 5.0);
-  psd0.add<double>("muonMaxDistanceY", 5.0);
-  psd0.add<double>("trajectoryUncertaintyTolerance", -1.0);
-  psd0.add<edm::InputTag>("CSCSegmentCollectionLabel", edm::InputTag("cscSegments"));
-  psd0.add<edm::InputTag>("CaloTowerCollectionLabel", edm::InputTag("towerMaker"));
-  psd0.add<edm::InputTag>("DTRecSegment4DCollectionLabel", edm::InputTag("dt4DSegments"));
-  psd0.add<edm::InputTag>("EBRecHitCollectionLabel", edm::InputTag("IsoProd", "IsoTrackEcalRecHitCollection"));
-  psd0.add<edm::InputTag>("EERecHitCollectionLabel", edm::InputTag("IsoProd", "IsoTrackEcalRecHitCollection"));
-  psd0.add<edm::InputTag>("GEMSegmentCollectionLabel", edm::InputTag("gemSegments"));
-  psd0.add<edm::InputTag>("HBHERecHitCollectionLabel", edm::InputTag("IsoProd", "IsoTrackHBHERecHitCollection"));
-  psd0.add<edm::InputTag>("HORecHitCollectionLabel", edm::InputTag("IsoProd", "IsoTrackHORecHitCollection"));
-  psd0.add<edm::InputTag>("ME0SegmentCollectionLabel", edm::InputTag("me0Segments"));
+  TrackAssociatorParameters::fillPSetDescription(psd0);
   desc.add<edm::ParameterSetDescription>("TrackAssociatorParameters", psd0);
 
   descriptions.addWithDefaultLabel(desc);

--- a/Alignment/OfflineValidation/plugins/OverlapValidation.cc
+++ b/Alignment/OfflineValidation/plugins/OverlapValidation.cc
@@ -17,78 +17,73 @@
 
 // system include files
 #include <memory>
+#include <vector>
+#include <utility>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Utilities/interface/ESGetToken.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
-
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
-
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
+#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
-#include "RecoTracker/TransientTrackingRecHit/interface/TSiStripMatchedRecHit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TSiStripMatchedRecHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
-
-#include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
-#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCurvilinear.h"
-#include "TrackingTools/AnalyticalJacobians/interface/JacobianCurvilinearToLocal.h"
 #include "TrackingTools/AnalyticalJacobians/interface/AnalyticalCurvilinearJacobian.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianCurvilinearToLocal.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCurvilinear.h"
+#include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
-#include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+
+// ROOT includes
 #include "TFile.h"
 #include "TTree.h"
-
-#include <vector>
-#include <utility>
 
 using namespace std;
 //
 // class decleration
 //
 
-class OverlapValidation : public edm::one::EDAnalyzer<> {
+class OverlapValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit OverlapValidation(const edm::ParameterSet&);
   ~OverlapValidation() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   typedef vector<Trajectory> TrajectoryCollection;
@@ -200,6 +195,7 @@ OverlapValidation::OverlapValidation(const edm::ParameterSet& iConfig)
       addExtraBranches_(false),
       minHitsCut_(6),
       chi2ProbCut_(0.001) {
+  usesResource(TFileService::kSharedResource);
   edm::ConsumesCollector&& iC = consumesCollector();
   //now do what ever initialization is needed
   trajectoryTag_ = iConfig.getParameter<edm::InputTag>("trajectories");
@@ -274,11 +270,28 @@ OverlapValidation::OverlapValidation(const edm::ParameterSet& iConfig)
   rootTree_->Branch("localydotglobaly", localydotglobaly_, "localydotglobaly[2]/F");
 }
 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void OverlapValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Overlap Validation analyzer plugin.");
+  TrackerHitAssociator::fillPSetDescription(desc);
+  //desc.add<bool>("associateStrip",false);  // NB this comes from the fillPSetDescription
+  desc.addUntracked<int>("compressionSettings", -1);
+  desc.add<edm::InputTag>("trajectories", edm::InputTag("FinalTrackRefitter"));
+  desc.add<bool>("barrelOnly", false);
+  desc.add<bool>("usePXB", true);
+  desc.add<bool>("usePXF", true);
+  desc.add<bool>("useTIB", true);
+  desc.add<bool>("useTOB", true);
+  desc.add<bool>("useTID", true);
+  desc.add<bool>("useTEC", true);
+  descriptions.addWithDefaultLabel(desc);
+}
+
 OverlapValidation::~OverlapValidation() {
   edm::LogWarning w("Overlaps");
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
   w << "Counters =";
   w << " Number of tracks: " << overlapCounts_[0];
   w << " Number of valid hits: " << overlapCounts_[1];

--- a/Alignment/OfflineValidation/python/eopTreeWriter_cfi.py
+++ b/Alignment/OfflineValidation/python/eopTreeWriter_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-energyOverMomentumTree = cms.EDAnalyzer('EOP',
-             src = cms.InputTag('TrackRefitter')
+from Alignment.OfflineValidation.eopTreeWriter_cfi import eopTreeWriter as _eopTreeWriter
+energyOverMomentumTree = _eopTreeWriter.clone(
+    src = 'TrackRefitter'
 )

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -124,6 +124,13 @@ process.TrackRefitter.NavigationSchool = ''
 ####################################################################
 # configure tree writer
 ####################################################################
+
+# uncomment following block in case it is run over the HcalCalIsoTrk AlCaReco
+# TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("IsoProd", "IsoTrackEcalRecHitCollection")
+# TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("IsoProd", "IsoTrackEcalRecHitCollection")
+# TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("IsoProd", "IsoTrackHBHERecHitCollection")
+# TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("IsoProd", "IsoTrackHORecHitCollection")
+
 TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
 TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
 TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("hbhereco")

--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -69,6 +69,8 @@ public:
   // Destructor
   virtual ~TrackerHitAssociator() {}
 
+  static void fillPSetDescription(edm::ParameterSetDescription& descriptions);
+
   typedef std::pair<unsigned int, unsigned int> simhitAddr, subDetTofBin;
   typedef unsigned int simHitCollectionID;
 

--- a/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
+++ b/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
@@ -40,11 +40,17 @@ class GlobalTrackingGeometryRecord;
 class MagneticField;
 class IdealMagneticFieldRecord;
 
+namespace edm {
+  class ParameterSetDescription;
+}
+
 class TrackAssociatorParameters {
 public:
   TrackAssociatorParameters() {}
   TrackAssociatorParameters(const edm::ParameterSet&, edm::ConsumesCollector&&);
   void loadParameters(const edm::ParameterSet&, edm::ConsumesCollector&);
+
+  static void fillPSetDescription(edm::ParameterSetDescription& descriptions);
 
   double dREcal;
   double dRHcal;

--- a/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
+++ b/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
@@ -12,7 +12,7 @@
 // Original Author:  Dmytro Kovalskyi
 //
 //
-
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
 
 void TrackAssociatorParameters::loadParameters(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) {
@@ -94,4 +94,41 @@ void TrackAssociatorParameters::loadParameters(const edm::ParameterSet& iConfig,
 
 TrackAssociatorParameters::TrackAssociatorParameters(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
   loadParameters(iConfig, iC);
+}
+
+void TrackAssociatorParameters::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.setComment("Auxilliary class to store parameters for track association");
+  // the following setup is the one from TrackingTools/TrackAssociator/python/default_cfi.py
+  desc.add<bool>("accountForTrajectoryChangeCalo", false);
+  desc.add<bool>("propagateAllDirections", true);
+  desc.add<bool>("truthMatch", false);
+  desc.add<bool>("useCalo", false);
+  desc.add<bool>("useEcal", true);
+  desc.add<bool>("useGEM", false);
+  desc.add<bool>("useHO", true);
+  desc.add<bool>("useHcal", true);
+  desc.add<bool>("useME0", false);
+  desc.add<bool>("useMuon", true);
+  desc.add<bool>("usePreshower", false);
+  desc.add<double>("dREcal", 9999.0);
+  desc.add<double>("dREcalPreselection", 0.05);
+  desc.add<double>("dRHcal", 9999.0);
+  desc.add<double>("dRHcalPreselection", 0.2);
+  desc.add<double>("dRMuon", 9999.0);
+  desc.add<double>("dRMuonPreselection", 0.2);
+  desc.add<double>("dRPreshowerPreselection", 0.2);
+  desc.add<double>("muonMaxDistanceSigmaX", 0.0);
+  desc.add<double>("muonMaxDistanceSigmaY", 0.0);
+  desc.add<double>("muonMaxDistanceX", 5.0);
+  desc.add<double>("muonMaxDistanceY", 5.0);
+  desc.add<double>("trajectoryUncertaintyTolerance", -1.0);
+  desc.add<edm::InputTag>("CSCSegmentCollectionLabel", edm::InputTag("cscSegments"));
+  desc.add<edm::InputTag>("CaloTowerCollectionLabel", edm::InputTag("towerMaker"));
+  desc.add<edm::InputTag>("DTRecSegment4DCollectionLabel", edm::InputTag("dt4DSegments"));
+  desc.add<edm::InputTag>("EBRecHitCollectionLabel", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("EERecHitCollectionLabel", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+  desc.add<edm::InputTag>("GEMSegmentCollectionLabel", edm::InputTag("gemSegments"));
+  desc.add<edm::InputTag>("HBHERecHitCollectionLabel", edm::InputTag("hbreco"));
+  desc.add<edm::InputTag>("HORecHitCollectionLabel", edm::InputTag("horeco"));
+  desc.add<edm::InputTag>("ME0SegmentCollectionLabel", edm::InputTag("me0Segments"));
 }


### PR DESCRIPTION
#### PR description:

This PR is a companion of https://github.com/cms-sw/cmssw/pull/40695, in which a `fillDescptions` method is added to few other plugins. These changes are proposed separately because in order to profit of `fillPSetDescription` methods used in auxiliary classes in other subsystems, this PR will trigger reconstruction and simulation signatures.

#### PR validation:

Relies on the existing unit tests:

 `scram b runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A