### PR TITLE
Backport of new FxFx JetMatching plugin for Run3

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
@@ -26,3 +26,7 @@
 <library file="Suep*.cc" name="GeneratorInterfacePythia8SUEPHook">
 </library>
 
+<library file="JetMatchingEWK*.cc" name="GeneratorInterfacePythia8JetMatchingFxFxHook">
+</library>
+
+

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -1,0 +1,968 @@
+// Implementation of the new JetMatching plugin
+// author: Carlos Vico (U. Oviedo)
+// taken from: https://amcatnlo.web.cern.ch/amcatnlo/JetMatching.h
+
+#include "JetMatchingEWKFxFx.h"
+using namespace Pythia8;
+
+JetMatchingEWKFxFx::JetMatchingEWKFxFx(const edm::ParameterSet& iConfig){}
+
+bool JetMatchingEWKFxFx::initAfterBeams() {
+  // This method is automatically called by Pythia8::init
+  // and it can be used to change any of the parameter given
+  // in the fragment. 
+
+  // Initialise values for stored jet matching veto inputs.
+  pTfirstSave = -1.;
+  processSubsetSave.init("(eventProcess)", particleDataPtr);
+  workEventJetSave.init("(workEventJet)", particleDataPtr); 
+
+  // Read Madgraph specific configuration variables
+  bool setMad = settingsPtr->flag("JetMatching:setMad");
+
+  // Parse in MadgraphPar object
+  MadgraphPar par;
+  
+  string parStr = infoPtr->header("MGRunCard");
+  if (!parStr.empty()) {
+    par.parse(parStr);
+    par.printParams();
+  }
+
+  // Set Madgraph merging parameters from the file if requested
+  if (setMad) {
+    if ( par.haveParam("xqcut")    && par.haveParam("maxjetflavor")
+      && par.haveParam("alpsfact") && par.haveParam("ickkw") ) {
+      settingsPtr->flag("JetMatching:merge", par.getParam("ickkw"));
+      settingsPtr->parm("JetMatching:qCut", par.getParam("xqcut"));
+      settingsPtr->mode("JetMatching:nQmatch",
+        par.getParamAsInt("maxjetflavor"));
+      settingsPtr->parm("JetMatching:clFact",
+        clFact = par.getParam("alpsfact"));
+      if (par.getParamAsInt("ickkw") == 0)
+        errorMsg("Error in JetMatchingMadgraph:init: "
+          "Madgraph file parameters are not set for merging");
+
+    // Warn if setMad requested, but one or more parameters not present
+    } else {
+       errorMsg("Warning in JetMatchingMadgraph:init: "
+          "Madgraph merging parameters not found");
+       if (!par.haveParam("xqcut")) errorMsg("Warning in "
+          "JetMatchingMadgraph:init: No xqcut");
+       if (!par.haveParam("ickkw")) errorMsg("Warning in "
+          "JetMatchingMadgraph:init: No ickkw");
+       if (!par.haveParam("maxjetflavor")) errorMsg("Warning in "
+          "JetMatchingMadgraph:init: No maxjetflavor");
+       if (!par.haveParam("alpsfact")) errorMsg("Warning in "
+          "JetMatchingMadgraph:init: No alpsfact");
+    }
+  }
+ 
+  // Read in FxFx matching parameters
+  doFxFx       = settingsPtr->flag("JetMatching:doFxFx");
+  nPartonsNow  = settingsPtr->mode("JetMatching:nPartonsNow");
+  qCutME       = settingsPtr->parm("JetMatching:qCutME");
+  qCutMESq     = pow(qCutME,2);
+
+  // Read in Madgraph merging parameters
+  doMerge      = settingsPtr->flag("JetMatching:merge");
+  doShowerKt   = settingsPtr->flag("JetMatching:doShowerKt");
+  qCut         = settingsPtr->parm("JetMatching:qCut");
+  nQmatch      = settingsPtr->mode("JetMatching:nQmatch");
+  clFact       = settingsPtr->parm("JetMatching:clFact");
+
+  // Read in jet algorithm parameters
+  jetAlgorithm   = settingsPtr->mode("JetMatching:jetAlgorithm");
+  nJetMax        = settingsPtr->mode("JetMatching:nJetMax");
+  eTjetMin       = settingsPtr->parm("JetMatching:eTjetMin");
+  coneRadius     = settingsPtr->parm("JetMatching:coneRadius");
+  etaJetMax      = settingsPtr->parm("JetMatching:etaJetMax");
+  slowJetPower   = settingsPtr->mode("JetMatching:slowJetPower");
+
+  // Matching procedure
+  jetAllow       = settingsPtr->mode("JetMatching:jetAllow");
+  exclusiveMode  = settingsPtr->mode("JetMatching:exclusive");
+  qCutSq         = pow(qCut,2);
+  etaJetMaxAlgo  = etaJetMax;
+  //performVeto    = true;
+
+  // If not merging is applied, then we are done
+  if (!doMerge) return true;
+
+  // Exclusive mode; if set to 2, then set based on nJet/nJetMax
+  if (exclusiveMode == 2) {
+    // No nJet or nJetMax, so default to exclusive mode
+    if (nJetMax < 0) {
+      errorMsg("Warning in JetMatchingMadgraph:init: "
+        "missing jet multiplicity information; running in exclusive mode");
+      exclusiveMode = 1;
+    }
+  }
+
+  // Initialise chosen jet algorithm.
+  // Currently, this only supports the kT-algorithm in SlowJet.
+  // Use the QCD distance measure by default.
+  jetAlgorithm = 2;
+  slowJetPower = 1;
+
+  slowJet = new SlowJet(slowJetPower, coneRadius, eTjetMin,
+    etaJetMaxAlgo, 2, 2, NULL, false);
+
+  // For FxFx, also initialise jet algorithm to define matrix element jets.
+  slowJetHard = new SlowJet(slowJetPower, coneRadius, qCutME,
+    etaJetMaxAlgo, 2, 2, NULL, false);
+
+  // To access the DJR's
+  slowJetDJR = new SlowJet(slowJetPower, coneRadius, qCutME,
+    etaJetMaxAlgo, 2, 2, NULL, false);
+
+  // A special version of SlowJet to handle heavy and other partons
+  hjSlowJet = new HJSlowJet(slowJetPower, coneRadius, 0.0,
+    100.0, 1, 2, NULL, false, true);
+
+  // Setup local event records
+  eventProcessOrig.init("(eventProcessOrig)", particleDataPtr);
+  eventProcess.init("(eventProcess)", particleDataPtr);
+  workEventJet.init("(workEventJet)", particleDataPtr);
+
+  // Print information
+  string jetStr  = (jetAlgorithm ==  1) ? "CellJet" :
+                   (slowJetPower == -1) ? "anti-kT" :
+                   (slowJetPower ==  0) ? "C/A"     :
+                   (slowJetPower ==  1) ? "kT"      : "unknown";
+  string modeStr = (exclusiveMode)         ? "exclusive" : "inclusive";
+  cout << endl
+       << " *-----  Madgraph matching parameters  -----*" << endl
+       << " |  qCut                |  " << setw(14)
+       << qCut << "  |" << endl
+       << " |  nQmatch             |  " << setw(14)
+       << nQmatch << "  |" << endl
+       << " |  clFact              |  " << setw(14)
+       << clFact << "  |" << endl
+       << " |  Jet algorithm       |  " << setw(14)
+       << jetStr << "  |" << endl
+       << " |  eTjetMin            |  " << setw(14)
+       << eTjetMin << "  |" << endl
+       << " |  etaJetMax           |  " << setw(14)
+       << etaJetMax << "  |" << endl
+       << " |  jetAllow            |  " << setw(14)
+       << jetAllow << "  |" << endl
+       << " |  Mode                |  " << setw(14)
+       << modeStr << "  |" << endl
+       << " *-----------------------------------------*" << endl;
+
+  return true;
+}
+
+bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
+  // Sort event using the procedure required at parton level
+  sortIncomingProcess(event);
+
+  // For the shower-kT scheme, do not perform any veto here, as any vetoing
+  // will already have taken place in doVetoStep.
+  if ( doShowerKt ) return false;
+
+  // Debug printout.
+  if (MATCHINGDEBUG) {
+    // Begin
+    cout << endl << "-------- Begin Madgraph Debug --------" << endl;
+    // Original incoming process
+    cout << endl << "Original incoming process:";
+    eventProcessOrig.list();
+    // Final-state of original incoming process
+    cout << endl << "Final-state incoming process:";
+    eventProcess.list();
+    // List categories of sorted particles
+    for (size_t i = 0; i < typeIdx[0].size(); i++)
+      cout << ((i == 0) ? "Light jets: " : ", ")   << setw(3) << typeIdx[0][i];
+    if( typeIdx[0].size()== 0 )
+      cout << "Light jets: None";
+
+    for (size_t i = 0; i < typeIdx[1].size(); i++)
+      cout << ((i == 0) ? "\nHeavy jets: " : ", ") << setw(3) << typeIdx[1][i];
+    for (size_t i = 0; i < typeIdx[2].size(); i++)
+      cout << ((i == 0) ? "\nOther:      " : ", ") << setw(3) << typeIdx[2][i];
+    // Full event at this stage
+    cout << endl << endl << "Event:";
+    event.list();
+    // Work event (partons from hardest subsystem + ISR + FSR)
+    cout << endl << "Work event:";
+    workEvent.list();
+  }
+
+  // 2) Light/heavy jets: iType = 0 (light jets), 1 (heavy jets)
+  int iTypeEnd = (typeIdx[2].empty()) ? 2 : 3;
+  for (int iType = 0; iType < iTypeEnd; iType++) {
+
+    // 2a) Find particles which will be passed from the jet algorithm.
+    //     Input from 'workEvent' and output in 'workEventJet'.
+    jetAlgorithmInput(event, iType);
+
+    // Debug printout.
+    if (MATCHINGDEBUG) {
+      // Jet algorithm event
+      cout << endl << "Jet algorithm event (iType = " << iType << "):";
+      workEventJet.list();
+    }
+
+    // 2b) Run jet algorithm on 'workEventJet'.
+    //     Output is stored in jetMomenta.
+    runJetAlgorithm();
+
+    // 2c) Match partons to jets and decide if veto is necessary
+    if (matchPartonsToJets(iType) == true) {
+      // Debug printout.
+      if (MATCHINGDEBUG) {
+        cout << endl << "Event vetoed" << endl
+             << "----------  End MLM Debug  ----------" << endl;
+      }
+      return true;
+    }
+  }
+
+  // Debug printout.
+  if (MATCHINGDEBUG) {
+    cout << endl << "Event accepted" << endl
+         << "----------  End MLM Debug  ----------" << endl;
+  }
+  // If we reached here, then no veto
+  return false;
+}
+
+
+void JetMatchingEWKFxFx::sortIncomingProcess(const Event &event){
+  omitResonanceDecays(eventProcessOrig, true);
+  clearDJR();
+  clear_nMEpartons();  
+
+  // Step-FxFx-1: remove preclustering from FxFx
+  eventProcess = workEvent;
+
+  for (int i = 0; i < 3; i++) {
+    typeIdx[i].clear();
+    typeSet[i].clear();
+    origTypeIdx[i].clear();
+  }
+
+  for (int i = 0; i < eventProcess.size(); i++) {
+    // Ignore non-final state and default to 'other'
+    if (!eventProcess[i].isFinal()) continue;
+    int idx = -1;
+    int orig_idx = -1;
+
+    // Light jets: all gluons and quarks with id less than or equal to nQmatch
+    if (eventProcess[i].isGluon()
+      || (eventProcess[i].idAbs() <= nQmatch) ) {
+      orig_idx = 0;
+      if (doFxFx) {
+          // Crucial point FxFx: MG5 puts the scale of a not-to-be-matched quark 1 MeV lower than scalup. For
+          // such particles, we should keep the default "2"
+          idx = ( trunc(1000. * eventProcess[i].scale()) == trunc(1000. * infoPtr->scalup()) ) ? 0 : 2;
+
+      }
+      else {
+      // Crucial point: MG puts the scale of a non-QCD particle to eCM. For
+      // such particles, we should keep the default "2"
+      idx = ( eventProcess[i].scale() < 1.999 * sqrt(infoPtr->eA()
+        * infoPtr->eB()) ) ? 0 : 2;
+      }
+    }
+
+    // Heavy jets:  all quarks with id greater than nQmatch
+    else if (eventProcess[i].idAbs() > nQmatch
+      && eventProcess[i].idAbs() <= ID_TOP) {
+      idx = 1;
+      orig_idx = 1;
+    // Update to include non-SM colored particles
+    } else if (eventProcess[i].colType() != 0
+      && eventProcess[i].idAbs() > ID_TOP) {
+      idx = 1;
+      orig_idx = 1;
+    }
+    if( idx < 0 ) continue;
+    // Store
+    typeIdx[idx].push_back(i);
+    typeSet[idx].insert(eventProcess[i].daughter1());
+    origTypeIdx[orig_idx].push_back(i);
+  }
+  // Exclusive mode; if set to 2, then set based on nJet/nJetMax
+  if (exclusiveMode == 2) {
+
+    // Inclusive if nJet == nJetMax, exclusive otherwise
+    int nParton = origTypeIdx[0].size();
+    exclusive = (nParton == nJetMax) ? false : true;
+
+  // Otherwise, just set as given
+  } else {
+    exclusive = (exclusiveMode == 0) ? false : true;
+  }
+
+  // Extract partons from hardest subsystem + ISR + FSR only into
+  // workEvent. Note no resonance showers or MPIs.
+  subEvent(event);
+
+  // Store things that are necessary to perform the kT-MLM veto externally.
+  int nParton = typeIdx[0].size();
+  processSubsetSave.clear();
+  for ( int i = 0; i < nParton; ++i)
+    processSubsetSave.append( eventProcess[typeIdx[0][i]] );
+}
+
+bool JetMatchingEWKFxFx::doVetoProcessLevel(Event& process) {
+  eventProcessOrig = process;
+
+  // Setup for veto if hard ME has too many partons.
+  // This is done to achieve consistency with the Pythia6 implementation.
+
+  // Clear the event of MPI systems and resonace decay products. Store trimmed
+  // event in workEvent.
+  sortIncomingProcess(process);
+
+  // Veto in case the hard input matrix element already has too many partons.
+  if ( !doFxFx && int(typeIdx[0].size()) > nJetMax )
+    return true;
+  if ( doFxFx && npNLO() < nJetMax && int(typeIdx[0].size()) > nJetMax )
+    return true;
+
+  // Done
+  return false;
+}
+
+void JetMatchingEWKFxFx::jetAlgorithmInput(const Event &event, int iType){
+  // Take input from 'workEvent' and put output in  'workEventJet'
+  workEventJet = workEvent;
+
+  // Loop over particles and decide what to pass to the jet algorithm
+  for (int i = 0; i < workEventJet.size(); ++i) {
+    if (!workEventJet[i].isFinal()) continue;
+
+    // jetAllow option to disallow certain particle types
+    if (jetAllow == 1) {
+      // Remove all non-QCD partons from veto list
+      if( workEventJet[i].colType() == 0 ) {
+        workEventJet[i].statusNeg();
+        continue;
+      }
+    }
+    // Get the index of this particle in original event
+    int idx = workEventJet[i].daughter1();
+
+    // Start with particle idx, and afterwards track mothers
+    while (true) {
+      // Light jets
+      if (iType == 0) {
+
+        // Do not include if originates from heavy jet or 'other'
+        if (typeSet[1].find(idx) != typeSet[1].end() ||
+            typeSet[2].find(idx) != typeSet[2].end()) {
+          workEventJet[i].statusNeg();
+          break;
+        }
+
+        // Made it to start of event record so done
+        if (idx == 0) break;
+        // Otherwise next mother and continue
+        idx = event[idx].mother1();
+
+      // Heavy jets
+      } else if (iType == 1) {
+        // Only include if originates from heavy jet
+        if (typeSet[1].find(idx) != typeSet[1].end()) break;
+
+        // Made it to start of event record with no heavy jet mother,
+        // so DO NOT include particle
+        if (idx == 0) {
+          workEventJet[i].statusNeg();
+          break;
+        }
+
+        // Otherwise next mother and continue
+        idx = event[idx].mother1();
+
+      // Other jets
+      } else if (iType == 2) {
+
+        // Only include if originates from other jet
+        if (typeSet[2].find(idx) != typeSet[2].end()) break;
+
+        // Made it to start of event record with no heavy jet mother,
+        // so DO NOT include particle
+        if (idx == 0) {
+          workEventJet[i].statusNeg();
+          break;
+        }
+
+        // Otherwise next mother and continue
+        idx = event[idx].mother1();
+      }
+    }
+  }
+}
+
+void JetMatchingEWKFxFx::runJetAlgorithm(){; }
+
+bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& event){
+  // Do not perform any veto if not in the Shower-kT scheme.
+  if ( !doShowerKt ) return false;
+
+  // Do nothing for emissions after the first one.
+  if ( nISR + nFSR > 1 ) return false;
+
+  // Do nothing in resonance decay showers.
+  if (iPos == 5) return false;
+
+  // Clear the event of MPI systems and resonace decay products. Store trimmed
+  // event in workEvent.
+  sortIncomingProcess(event);
+
+  // Get (kinematical) pT of first emission
+  double pTfirst = 0.;
+
+  // Get weak bosons, for later checks if the emission is a "QCD emission".
+  vector<int> weakBosons;
+  for (int i = 0; i < event.size(); i++) {
+    if ( event[i].id() == 22
+      && event[i].id() == 23
+      && event[i].idAbs() == 24)
+      weakBosons.push_back(i);
+  }
+
+  for (int i =  workEvent.size()-1; i > 0; --i) {
+    if ( workEvent[i].isFinal() && workEvent[i].colType() != 0
+      && (workEvent[i].statusAbs() == 43 || workEvent[i].statusAbs() == 51)) {
+      // Check if any of the EW bosons are ancestors of this parton. This
+      // should never happen for the first non-resonance shower emission.
+      // Check just to be sure.
+      bool QCDemission = true;
+      // Get position of this parton in the actual event (workEvent does
+      // not contain right mother-daughter relations). Stored in daughters.
+      int iPosOld = workEvent[i].daughter1();
+      for (int j = 0; i < int(weakBosons.size()); ++i)
+        if ( event[iPosOld].isAncestor(j)) {
+          QCDemission = false;
+          break;
+        }
+      // Done for a QCD emission.
+      if (QCDemission){
+        pTfirst = workEvent[i].pT();
+        break;
+      }
+    }
+  }
+
+  // Store things that are necessary to perform the shower-kT veto externally.
+  pTfirstSave   = pTfirst;
+  // Done if only inputs for an external vetoing procedure should be stored.
+  //if (!performVeto) return false;
+
+  // Check veto.
+  if ( doShowerKtVeto(pTfirst) ) return true;
+
+  // No veto if come this far.
+  return false;
+}
+
+void JetMatchingEWKFxFx::setDJR( const Event& event) {
+
+ // Clear members.
+ clearDJR();
+ vector<double> result;
+
+  // Initialize SlowJetDJR jet algorithm with event
+  if (!slowJetDJR->setup(event) ) {
+    errorMsg("Warning in JetMatchingMadgraph:setDJR"
+      ": the SlowJet algorithm failed on setup");
+    return;
+  }
+
+  // Cluster in steps to find all hadronic jets
+  while ( slowJetDJR->sizeAll() - slowJetDJR->sizeJet() > 0 ) {
+    // Save the next clustering scale.
+    result.push_back(sqrt(slowJetDJR->dNext()));
+    // Perform step.
+    slowJetDJR->doStep();
+  }
+
+  // Save clustering scales in reserve order.
+  for (int i=int(result.size())-1; i >= 0; --i)
+    DJR.push_back(result[i]);
+
+}
+
+bool JetMatchingEWKFxFx::matchPartonsToJets(int iType){
+  // Use different routines for light/heavy/other jets as
+  // different veto conditions and for clarity
+  if (iType == 0) {
+    // Record the jet separations here, also if matchPartonsToJetsLight
+    // returns preemptively.
+    setDJR(workEventJet);
+    set_nMEpartons(origTypeIdx[0].size(), typeIdx[0].size());
+    // Perform jet matching.
+    return (matchPartonsToJetsLight() > 0);
+  } else if (iType == 1) {
+     return (matchPartonsToJetsHeavy() > 0);
+  } else {
+     return (matchPartonsToJetsOther() > 0);
+  }
+}
+
+int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
+  // Store things that are necessary to perform the kT-MLM veto externally.
+  workEventJetSave  = workEventJet;
+  // Done if only inputs for an external vetoing procedure should be stored.
+  //if (!performVeto) return false;
+
+  // Count the number of hard partons
+  int nParton = typeIdx[0].size();
+
+  // Initialize SlowJet with current working event
+  if (!slowJet->setup(workEventJet) ) {
+    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+      "Light: the SlowJet algorithm failed on setup");
+    return NONE;
+  }
+  double localQcutSq = qCutSq;
+  double dOld = 0.0;
+  // Cluster in steps to find all hadronic jets at the scale qCut
+  while ( slowJet->sizeAll() - slowJet->sizeJet() > 0 ) {
+    if( slowJet->dNext() > localQcutSq ) break;
+    dOld = slowJet->dNext();
+    slowJet->doStep();
+  }
+  int nJets = slowJet->sizeJet();
+  int nClus = slowJet->sizeAll();
+  
+  // Debug printout.
+  if (MATCHINGDEBUG) slowJet->list(true);
+
+  // Count of the number of hadronic jets in SlowJet accounting
+  int nCLjets = nClus - nJets;
+  // Get number of partons. Different for MLM and FxFx schemes.
+  //int nRequested = (doFxFx) ? npNLO() : nParton;
+  //Step-FxFx-3: Change nRequested subtracting the typeIdx[2] partons
+  //Exclude the highest multiplicity sample in the case of real emissions and all typeIdx[2]
+  //npNLO=multiplicity,nJetMax=njmax(shower_card),typeIdx[2]="Weak" jets
+  int nRequested = (doFxFx && !(npNLO()==nJetMax && npNLO()==(int)(typeIdx[2].size()-1) )) ? npNLO()-typeIdx[2].size() : nParton;
+
+  //Step-FxFx-4:For FxFx veto the real emissions that have only typeIdx=2 partons
+  //From Step-FxFx-3 they already have negative nRequested, so this step may not be necessary
+  //Exclude the highest multiplicity sample
+  if (doFxFx && npNLO()<nJetMax && typeIdx[2].size()>0 && npNLO()==(int)(typeIdx[2].size()-1)) {
+        return MORE_JETS;
+  }
+  //----------------
+  //Exclude all Weak Jets for matching
+  //if (doFxFx && typeIdx[2].size()>0) {
+  //      return MORE_JETS;
+  //} // 2A
+  //keep only Weak Jets for matching
+  //if (doFxFx && typeIdx[2].size()==0) {
+  //      return MORE_JETS;
+  //} // 2B
+  //keep only lowest multiplicity sample @0
+  //if (doFxFx && npNLO()==1) {
+  //      return MORE_JETS;
+  //} // 2C
+  //keep only highest multiplicity sample @1
+  //if (doFxFx && npNLO()==0) {
+  //      return MORE_JETS;
+  //} // 2D
+//--------------
+  // Veto event if too few hadronic jets
+  if ( nCLjets < nRequested ) return LESS_JETS;
+
+  // In exclusive mode, do not allow more hadronic jets than partons
+  if ( exclusive && !doFxFx ) {
+    if ( nCLjets > nRequested ) return MORE_JETS;
+  } else {
+
+    // For FxFx, in the non-highest multipicity, all jets need to matched to
+    // partons. For nCLjets > nRequested, this is not possible. Hence, we can
+    // veto here already.
+    // if ( doFxFx && nRequested < nJetMax && nCLjets > nRequested )
+    //Step-FxFx-5:Change the nRequested to npNLO() in the first condition
+    //Before in Step-FxFx-3 it was nRequested=npNLO() for FxFx
+    //This way we correctly select the non-highest multipicity regardless the nRequested
+     if ( doFxFx && npNLO() < nJetMax && nCLjets > nRequested )
+      return MORE_JETS;
+
+    // Now continue in inclusive mode.
+    // In inclusive mode, there can be more hadronic jets than partons,
+    // provided that all partons are properly matched to hadronic jets.
+    // Start by setting up the jet algorithm.
+    if (!slowJet->setup(workEventJet) ) {
+      errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+        "Light: the SlowJet algorithm failed on setup");
+      return NONE;
+    }
+ 
+    // For FxFx, continue clustering as long as the jet separation is above
+    // qCut.
+    if (doFxFx) {
+      while ( slowJet->sizeAll() - slowJet->sizeJet() > 0 ) {
+        if( slowJet->dNext() > localQcutSq ) break;
+        slowJet->doStep();
+      }
+    // For MLM, cluster into hadronic jets until there are the same number as
+    // partons.
+    } else {
+      while ( slowJet->sizeAll() - slowJet->sizeJet() > nParton )
+        slowJet->doStep();
+    }
+
+    // Sort partons in pT.  Update local qCut value.
+    //  Hadronic jets are already sorted in pT.
+    localQcutSq = dOld;
+    if ( clFact >= 0. && nParton > 0 ) {
+       vector<double> partonPt;
+       for (int i = 0; i < nParton; ++i)
+         partonPt.push_back( eventProcess[typeIdx[0][i]].pT2() );
+       sort( partonPt.begin(), partonPt.end());
+       localQcutSq = max( qCutSq, partonPt[0]);
+    }
+    nJets = slowJet->sizeJet();
+    nClus = slowJet->sizeAll();
+  }
+  // Update scale if clustering factor is non-zero
+  if ( clFact != 0. ) localQcutSq *= pow2(clFact);
+
+  Event tempEvent;
+  tempEvent.init( "(tempEvent)", particleDataPtr);
+  int nPass = 0;
+  double pTminEstimate = -1.;
+  // Construct a master copy of the event containing only the
+  // hardest nParton hadronic clusters. While constructing the event,
+  // the parton type (ID_GLUON) and status (98,99) are arbitrary.
+  for (int i = nJets; i < nClus; ++i) {
+    tempEvent.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0, slowJet->p(i).px(),
+      slowJet->p(i).py(), slowJet->p(i).pz(), slowJet->p(i).e() );
+    ++nPass;
+    pTminEstimate = max( pTminEstimate, slowJet->pT(i));
+    if(nPass == nRequested) break;
+  }
+
+  int tempSize = tempEvent.size();
+  // This keeps track of which hadronic jets are matched to parton
+  vector<bool> jetAssigned;
+  jetAssigned.assign( tempSize, false);
+
+  // This keeps track of which partons are matched to which hadronic
+  // jets.
+  vector< vector<bool> > partonMatchesJet;
+  for (int i=0; i < nParton; ++i )
+    partonMatchesJet.push_back( vector<bool>(tempEvent.size(),false) );
+
+  // Begin matching.
+  // Do jet matching for FxFx.
+  // Make sure that the nPartonsNow hardest hadronic jets are matched to any
+  // of the nPartonsNow (+1) partons. This matching is done by attaching a jet
+  // from the list of unmatched hadronic jets, and appending a jet from the
+  // list of partonic jets, one at a time. The partonic jet will be clustered
+  // with the hadronic jet or the beam if the distance measure is below the
+  // cut. The hadronic jet is matched once this happens. Otherwise, another
+  // partonic jet is tried. When a hadronic jet is matched to a partonic jet,
+  // it is removed from the list of unmatched hadronic jets. This process
+  // continues until the nPartonsNow hardest hadronic jets are matched to
+  // partonic jets, or it is not possible to make a match for a hadronic jet.
+  int iNow = 0;
+  int nMatched = 0;
+
+  while ( doFxFx && iNow < tempSize ) {
+
+    // Check if this shower jet matches any partonic jet.
+    Event tempEventJet;
+    tempEventJet.init("(tempEventJet)", particleDataPtr);
+    for (int i=0; i < nParton; ++i ) {
+
+      //// Only assign a parton once.
+      //for (int j=0; j < tempSize; ++j )
+      //  if ( partonMatchesJet[i][j]) continue;
+
+      // Attach a single hadronic jet.
+      tempEventJet.clear();
+      tempEventJet.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0,
+        tempEvent[iNow].px(), tempEvent[iNow].py(),
+        tempEvent[iNow].pz(), tempEvent[iNow].e() );
+      // Attach the current parton.
+      Vec4 pIn = eventProcess[typeIdx[0][i]].p();
+      tempEventJet.append( ID_GLUON, 99, 0, 0, 0, 0, 0, 0,
+        pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
+
+      // Setup jet algorithm.
+      if ( !slowJet->setup(tempEventJet) ) {
+        errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+          "Light: the SlowJet algorithm failed on setup");
+        return NONE;
+      }
+      // These are the conditions for the hadronic jet to match the parton
+      //  at the local qCut scale
+      if ( slowJet->iNext() == tempEventJet.size() - 1
+        && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq ) {
+        jetAssigned[iNow] = true;
+        partonMatchesJet[i][iNow] = true;
+      }
+
+    } // End loop over hard partons.
+
+    // Veto if the jet could not be assigned to any parton.
+    if ( jetAssigned[iNow] ) nMatched++;
+
+    // Continue;
+    ++iNow;
+  }
+  // Jet matching veto for FxFx
+  if (doFxFx) {
+//    if ( nRequested <  nJetMax && nMatched != nRequested )
+//      return UNMATCHED_PARTON;
+//    if ( nRequested == nJetMax && nMatched <  nRequested )
+//      return UNMATCHED_PARTON;
+      //Step-FxFx-6:Change the nRequested to npNLO() in the first condition (like in Step-FxFx-5)
+      //Before in Step-FxFx-3 it was nRequested=npNLO() for FxFx
+      //This way we correctly select the non-highest multipicity regardless the nRequested
+      if ( npNLO() <  nJetMax && nMatched != nRequested )
+        return UNMATCHED_PARTON;
+      if ( npNLO() == nJetMax && nMatched <  nRequested )
+        return UNMATCHED_PARTON;
+  }
+  // Do jet matching for MLM.
+  // Take the list of unmatched hadronic jets and append a parton, one at
+  // a time. The parton will be clustered with the "closest" hadronic jet
+  // or the beam if the distance measure is below the cut. When a hadronic
+  // jet is matched to a parton, it is removed from the list of unmatched
+  // hadronic jets. This process continues until all hadronic jets are
+  // matched to partons or it is not possible to make a match.
+  iNow = 0;
+  while (!doFxFx && iNow < nParton ) {
+    Event tempEventJet;
+    tempEventJet.init("(tempEventJet)", particleDataPtr);
+    for (int i = 0; i < tempSize; ++i) {
+      if (jetAssigned[i]) continue;
+      Vec4 pIn = tempEvent[i].p();
+      // Append unmatched hadronic jets
+      tempEventJet.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0,
+        pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
+    }
+
+    Vec4 pIn = eventProcess[typeIdx[0][iNow]].p();
+    // Append the current parton
+    tempEventJet.append( ID_GLUON, 99, 0, 0, 0, 0, 0, 0,
+      pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
+    if ( !slowJet->setup(tempEventJet) ) {
+      errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+        "Light: the SlowJet algorithm failed on setup");
+      return NONE;
+    }
+    // These are the conditions for the hadronic jet to match the parton
+    //  at the local qCut scale
+    if ( slowJet->iNext() == tempEventJet.size() - 1
+      && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq ) {
+      int iKnt = -1;
+      for (int i = 0; i != tempSize; ++i) {
+        if (jetAssigned[i]) continue;
+        ++iKnt;
+        // Identify the hadronic jet that matches the parton
+        if (iKnt == slowJet->jNext() ) jetAssigned[i] = true;
+      }
+    } else {
+      return UNMATCHED_PARTON;
+    }
+    ++iNow;
+  }
+  // Minimal eT/pT (CellJet/SlowJet) of matched light jets.
+  // Needed later for heavy jet vetos in inclusive mode.
+  // This information is not used currently.
+  if (nParton > 0 && pTminEstimate > 0) eTpTlightMin = pTminEstimate;
+  else eTpTlightMin = -1.;
+
+  // Record the jet separations.
+  setDJR(workEventJet);
+
+  // No veto
+  return NONE;
+}  
+
+int JetMatchingEWKFxFx::matchPartonsToJetsHeavy(){
+  // Currently, heavy jets are unmatched
+  // If there are no extra jets, then accept
+  // jetMomenta is NEVER used by MadGraph and is always empty.
+  //  This check does nothing.
+  //  Rather, if there is any heavy flavor that is harder than
+  //  what is present at the LHE level, then the event should
+  //  be vetoed.
+
+  // if (jetMomenta.empty()) return NONE;
+  // Count the number of hard partons
+  int nParton = typeIdx[1].size();
+
+  Event tempEventJet(workEventJet);
+
+  double scaleF(1.0);
+  // Rescale the heavy partons that are from the hard process to
+  //  have pT=collider energy.   Soft/collinear gluons will cluster
+  //  onto them, leaving a remnant of hard emissions.
+  for( int i=0; i<nParton; ++i) {
+    scaleF = eventProcessOrig[0].e()/workEventJet[typeIdx[1][i]].pT();
+    tempEventJet[typeIdx[1][i]].rescale5(scaleF);
+  }
+
+  if (!hjSlowJet->setup(tempEventJet) ) {
+    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+             "Heavy: the SlowJet algorithm failed on setup");
+    return NONE;
+  }
+
+
+  while ( hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0 ) {
+    if( hjSlowJet->dNext() > qCutSq ) break;
+    hjSlowJet->doStep();
+  }
+
+  int nCLjets(0);
+  // Count the number of clusters with pT>qCut.  This includes the
+  //  original hard partons plus any hard emissions.
+  for(int idx=0 ; idx< hjSlowJet->sizeAll(); ++idx) {
+    if( hjSlowJet->pT(idx) > sqrt(qCutSq) ) nCLjets++;
+  }
+
+  // Debug printout.
+  if (MATCHINGDEBUG) hjSlowJet->list(true);
+
+  // Count of the number of hadronic jets in SlowJet accounting
+  //  int nCLjets = nClus - nJets;
+  // Get number of partons. Different for MLM and FxFx schemes.
+  int nRequested = nParton;
+
+  // Veto event if too few hadronic jets
+  if ( nCLjets < nRequested ) {
+    if (MATCHINGDEBUG) cout << "veto : hvy  LESS_JETS " << endl;
+    if (MATCHINGDEBUG) cout << "nCLjets = " << nCLjets << "; nRequest = "
+      << nRequested << endl;
+    return LESS_JETS;
+  }
+
+  // In exclusive mode, do not allow more hadronic jets than partons
+  if ( exclusive ) {
+    if ( nCLjets > nRequested ) {
+      if (MATCHINGDEBUG) cout << "veto : excl hvy  MORE_JETS " << endl;
+      return MORE_JETS;
+    }
+  }
+
+  // No extra jets were present so no veto
+  return NONE;
+}
+
+int JetMatchingEWKFxFx::matchPartonsToJetsOther(){
+  // Currently, heavy jets are unmatched
+  // If there are no extra jets, then accept
+  // jetMomenta is NEVER used by MadGraph and is always empty.
+  //  This check does nothing.
+  //  Rather, if there is any heavy flavor that is harder than
+  //  what is present at the LHE level, then the event should
+  //  be vetoed.
+
+  // if (jetMomenta.empty()) return NONE;
+  // Count the number of hard partons
+  int nParton = typeIdx[2].size();
+
+  Event tempEventJet(workEventJet);
+
+  double scaleF(1.0);
+  // Rescale the heavy partons that are from the hard process to
+  //  have pT=collider energy.   Soft/collinear gluons will cluster
+  //  onto them, leaving a remnant of hard emissions.
+  for( int i=0; i<nParton; ++i) {
+    scaleF = eventProcessOrig[0].e()/workEventJet[typeIdx[2][i]].pT();
+    tempEventJet[typeIdx[2][i]].rescale5(scaleF);
+  }
+
+  if (!hjSlowJet->setup(tempEventJet) ) {
+    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
+             "Heavy: the SlowJet algorithm failed on setup");
+    return NONE;
+  }
+
+
+  while ( hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0 ) {
+    if( hjSlowJet->dNext() > qCutSq ) break;
+    hjSlowJet->doStep();
+  }
+
+  int nCLjets(0);
+  // Count the number of clusters with pT>qCut.  This includes the
+  //  original hard partons plus any hard emissions.
+  for(int idx=0 ; idx< hjSlowJet->sizeAll(); ++idx) {
+    if( hjSlowJet->pT(idx) > sqrt(qCutSq) ) nCLjets++;
+  }
+
+  // Debug printout.
+  if (MATCHINGDEBUG) hjSlowJet->list(true);
+
+  // Count of the number of hadronic jets in SlowJet accounting
+  //  int nCLjets = nClus - nJets;
+  // Get number of partons. Different for MLM and FxFx schemes.
+  int nRequested = nParton;
+
+  // Veto event if too few hadronic jets
+  if ( nCLjets < nRequested ) {
+    if (MATCHINGDEBUG) cout << "veto : other LESS_JETS " << endl;
+    if (MATCHINGDEBUG) cout << "nCLjets = " << nCLjets << "; nRequest = "
+      << nRequested << endl;
+    return LESS_JETS;
+  }
+
+  // In exclusive mode, do not allow more hadronic jets than partons
+  if ( exclusive ) {
+    if ( nCLjets > nRequested ) {
+      if (MATCHINGDEBUG) cout << "veto : excl other MORE_JETS" << endl;
+      return MORE_JETS;
+    }
+  }
+
+  // No extra jets were present so no veto
+  return NONE;
+}
+
+bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst){
+  // Only check veto in the shower-kT scheme.
+  if ( !doShowerKt ) return false;
+
+  // Reset veto code
+  bool doVeto = false;
+
+  // Find the (kinematical) pT of the softest (light) parton in the hard
+  // process.
+  int nParton = typeIdx[0].size();
+  double pTminME=1e10;
+  for ( int i = 0; i < nParton; ++i)
+    pTminME = min(pTminME,eventProcess[typeIdx[0][i]].pT());
+
+  // Veto if the softest hard process parton is below Qcut.
+  if ( nParton > 0 && pow(pTminME,2) < qCutSq ) doVeto = true;
+
+  // For non-highest multiplicity, veto if the hardest emission is harder
+  // than Qcut.
+  if ( exclusive && pow(pTfirst,2) > qCutSq ) {
+    doVeto = true;
+  // For highest multiplicity sample, veto if the hardest emission is harder
+  // than the hard process parton.
+  } else if ( !exclusive && nParton > 0 && pTfirst > pTminME ) {
+    doVeto = true;
+  }
+
+  // Return veto
+  return doVeto;
+}
+
+// Function to get the current number of partons in the Born state, as
+// read from LHE.
+
+int JetMatchingEWKFxFx::npNLO(){
+  string npIn = infoPtr->getEventAttribute("npNLO",true);
+  int np = (npIn != "") ? atoi((char*)npIn.c_str()) : -1;
+  if ( np < 0 ) { ; }
+  else return np;
+  return nPartonsNow;
+}
+
+

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -132,26 +132,25 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
 
   // Print information
   if (MATCHINGDEBUG) {
-  string jetStr = (jetAlgorithm == 1)    ? "CellJet"
-                  : (slowJetPower == -1) ? "anti-kT"
-                  : (slowJetPower == 0)  ? "C/A"
-                  : (slowJetPower == 1)  ? "kT"
-                                         : "unknown";
-  string modeStr = (exclusiveMode) ? "exclusive" : "inclusive";
-  cout << endl
-       << " *-----  Madgraph matching parameters  -----*" << endl
-       << " |  qCut                |  " << setw(14) << qCut << "  |" << endl
-       << " |  nQmatch             |  " << setw(14) << nQmatch << "  |" << endl
-       << " |  clFact              |  " << setw(14) << clFact << "  |" << endl
-       << " |  Jet algorithm       |  " << setw(14) << jetStr << "  |" << endl
-       << " |  eTjetMin            |  " << setw(14) << eTjetMin << "  |" << endl
-       << " |  etaJetMax           |  " << setw(14) << etaJetMax << "  |" << endl
-       << " |  jetAllow            |  " << setw(14) << jetAllow << "  |" << endl
-       << " |  Mode                |  " << setw(14) << modeStr << "  |" << endl
-       << " *-----------------------------------------*" << endl;
+    string jetStr = (jetAlgorithm == 1)    ? "CellJet"
+                    : (slowJetPower == -1) ? "anti-kT"
+                    : (slowJetPower == 0)  ? "C/A"
+                    : (slowJetPower == 1)  ? "kT"
+                                           : "unknown";
+    string modeStr = (exclusiveMode) ? "exclusive" : "inclusive";
+    cout << endl
+         << " *-----  Madgraph matching parameters  -----*" << endl
+         << " |  qCut                |  " << setw(14) << qCut << "  |" << endl
+         << " |  nQmatch             |  " << setw(14) << nQmatch << "  |" << endl
+         << " |  clFact              |  " << setw(14) << clFact << "  |" << endl
+         << " |  Jet algorithm       |  " << setw(14) << jetStr << "  |" << endl
+         << " |  eTjetMin            |  " << setw(14) << eTjetMin << "  |" << endl
+         << " |  etaJetMax           |  " << setw(14) << etaJetMax << "  |" << endl
+         << " |  jetAllow            |  " << setw(14) << jetAllow << "  |" << endl
+         << " |  Mode                |  " << setw(14) << modeStr << "  |" << endl
+         << " *-----------------------------------------*" << endl;
   }
   return true;
-
 }
 
 bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -549,7 +549,7 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight() {
   //Step-FxFx-4:For FxFx veto the real emissions that have only typeIdx=2 partons
   //From Step-FxFx-3 they already have negative nRequested, so this step may not be necessary
   //Exclude the highest multiplicity sample
-  if (doFxFx && npNLO() < nJetMax && typeIdx[2].empty() && npNLO() == (int)(typeIdx[2].size() - 1)) {
+  if (doFxFx && npNLO() < nJetMax && !typeIdx[2].empty() && npNLO() == (int)(typeIdx[2].size() - 1)) {
     return MORE_JETS;
   }
   //----------------
@@ -916,7 +916,7 @@ int JetMatchingEWKFxFx::matchPartonsToJetsOther() {
   // Count the number of clusters with pT>qCut.  This includes the
   //  original hard partons plus any hard emissions.
   for (int idx = 0; idx < hjSlowJet->sizeAll(); ++idx) {
-    if (hjSlowJet->pT(idx) > sqrt(qCutSq))
+    if (hjSlowJet->pT(idx) > qCut)
       nCLjets++;
   }
 
@@ -989,7 +989,7 @@ bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst) {
 
 int JetMatchingEWKFxFx::npNLO() {
   string npIn = infoPtr->getEventAttribute("npNLO", true);
-  int np = (npIn.empty()) ? atoi((char*)npIn.c_str()) : -1;
+  int np = !npIn.empty() ? std::atoi(npIn.c_str()) : -1;
   if (np < 0) {
     ;
   } else

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -131,6 +131,7 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
   workEventJet.init("(workEventJet)", particleDataPtr);
 
   // Print information
+  if (MATCHINGDEBUG) {
   string jetStr = (jetAlgorithm == 1)    ? "CellJet"
                   : (slowJetPower == -1) ? "anti-kT"
                   : (slowJetPower == 0)  ? "C/A"
@@ -148,8 +149,9 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
        << " |  jetAllow            |  " << setw(14) << jetAllow << "  |" << endl
        << " |  Mode                |  " << setw(14) << modeStr << "  |" << endl
        << " *-----------------------------------------*" << endl;
-
+  }
   return true;
+
 }
 
 bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -5,24 +5,24 @@
 #include "JetMatchingEWKFxFx.h"
 using namespace Pythia8;
 
-JetMatchingEWKFxFx::JetMatchingEWKFxFx(const edm::ParameterSet& iConfig){}
+JetMatchingEWKFxFx::JetMatchingEWKFxFx(const edm::ParameterSet& iConfig) {}
 
 bool JetMatchingEWKFxFx::initAfterBeams() {
   // This method is automatically called by Pythia8::init
   // and it can be used to change any of the parameter given
-  // in the fragment. 
+  // in the fragment.
 
   // Initialise values for stored jet matching veto inputs.
   pTfirstSave = -1.;
   processSubsetSave.init("(eventProcess)", particleDataPtr);
-  workEventJetSave.init("(workEventJet)", particleDataPtr); 
+  workEventJetSave.init("(workEventJet)", particleDataPtr);
 
   // Read Madgraph specific configuration variables
   bool setMad = settingsPtr->flag("JetMatching:setMad");
 
   // Parse in MadgraphPar object
   MadgraphPar par;
-  
+
   string parStr = infoPtr->header("MGRunCard");
   if (!parStr.empty()) {
     par.parse(parStr);
@@ -31,70 +31,80 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
 
   // Set Madgraph merging parameters from the file if requested
   if (setMad) {
-    if ( par.haveParam("xqcut")    && par.haveParam("maxjetflavor")
-      && par.haveParam("alpsfact") && par.haveParam("ickkw") ) {
+    if (par.haveParam("xqcut") && par.haveParam("maxjetflavor") && par.haveParam("alpsfact") &&
+        par.haveParam("ickkw")) {
       settingsPtr->flag("JetMatching:merge", par.getParam("ickkw"));
       settingsPtr->parm("JetMatching:qCut", par.getParam("xqcut"));
-      settingsPtr->mode("JetMatching:nQmatch",
-        par.getParamAsInt("maxjetflavor"));
-      settingsPtr->parm("JetMatching:clFact",
-        clFact = par.getParam("alpsfact"));
+      settingsPtr->mode("JetMatching:nQmatch", par.getParamAsInt("maxjetflavor"));
+      settingsPtr->parm("JetMatching:clFact", clFact = par.getParam("alpsfact"));
       if (par.getParamAsInt("ickkw") == 0)
-        errorMsg("Error in JetMatchingMadgraph:init: "
-          "Madgraph file parameters are not set for merging");
+        errorMsg(
+            "Error in JetMatchingMadgraph:init: "
+            "Madgraph file parameters are not set for merging");
 
-    // Warn if setMad requested, but one or more parameters not present
+      // Warn if setMad requested, but one or more parameters not present
     } else {
-       errorMsg("Warning in JetMatchingMadgraph:init: "
+      errorMsg(
+          "Warning in JetMatchingMadgraph:init: "
           "Madgraph merging parameters not found");
-       if (!par.haveParam("xqcut")) errorMsg("Warning in "
-          "JetMatchingMadgraph:init: No xqcut");
-       if (!par.haveParam("ickkw")) errorMsg("Warning in "
-          "JetMatchingMadgraph:init: No ickkw");
-       if (!par.haveParam("maxjetflavor")) errorMsg("Warning in "
-          "JetMatchingMadgraph:init: No maxjetflavor");
-       if (!par.haveParam("alpsfact")) errorMsg("Warning in "
-          "JetMatchingMadgraph:init: No alpsfact");
+      if (!par.haveParam("xqcut"))
+        errorMsg(
+            "Warning in "
+            "JetMatchingMadgraph:init: No xqcut");
+      if (!par.haveParam("ickkw"))
+        errorMsg(
+            "Warning in "
+            "JetMatchingMadgraph:init: No ickkw");
+      if (!par.haveParam("maxjetflavor"))
+        errorMsg(
+            "Warning in "
+            "JetMatchingMadgraph:init: No maxjetflavor");
+      if (!par.haveParam("alpsfact"))
+        errorMsg(
+            "Warning in "
+            "JetMatchingMadgraph:init: No alpsfact");
     }
   }
- 
+
   // Read in FxFx matching parameters
-  doFxFx       = settingsPtr->flag("JetMatching:doFxFx");
-  nPartonsNow  = settingsPtr->mode("JetMatching:nPartonsNow");
-  qCutME       = settingsPtr->parm("JetMatching:qCutME");
-  qCutMESq     = pow(qCutME,2);
+  doFxFx = settingsPtr->flag("JetMatching:doFxFx");
+  nPartonsNow = settingsPtr->mode("JetMatching:nPartonsNow");
+  qCutME = settingsPtr->parm("JetMatching:qCutME");
+  qCutMESq = pow(qCutME, 2);
 
   // Read in Madgraph merging parameters
-  doMerge      = settingsPtr->flag("JetMatching:merge");
-  doShowerKt   = settingsPtr->flag("JetMatching:doShowerKt");
-  qCut         = settingsPtr->parm("JetMatching:qCut");
-  nQmatch      = settingsPtr->mode("JetMatching:nQmatch");
-  clFact       = settingsPtr->parm("JetMatching:clFact");
+  doMerge = settingsPtr->flag("JetMatching:merge");
+  doShowerKt = settingsPtr->flag("JetMatching:doShowerKt");
+  qCut = settingsPtr->parm("JetMatching:qCut");
+  nQmatch = settingsPtr->mode("JetMatching:nQmatch");
+  clFact = settingsPtr->parm("JetMatching:clFact");
 
   // Read in jet algorithm parameters
-  jetAlgorithm   = settingsPtr->mode("JetMatching:jetAlgorithm");
-  nJetMax        = settingsPtr->mode("JetMatching:nJetMax");
-  eTjetMin       = settingsPtr->parm("JetMatching:eTjetMin");
-  coneRadius     = settingsPtr->parm("JetMatching:coneRadius");
-  etaJetMax      = settingsPtr->parm("JetMatching:etaJetMax");
-  slowJetPower   = settingsPtr->mode("JetMatching:slowJetPower");
+  jetAlgorithm = settingsPtr->mode("JetMatching:jetAlgorithm");
+  nJetMax = settingsPtr->mode("JetMatching:nJetMax");
+  eTjetMin = settingsPtr->parm("JetMatching:eTjetMin");
+  coneRadius = settingsPtr->parm("JetMatching:coneRadius");
+  etaJetMax = settingsPtr->parm("JetMatching:etaJetMax");
+  slowJetPower = settingsPtr->mode("JetMatching:slowJetPower");
 
   // Matching procedure
-  jetAllow       = settingsPtr->mode("JetMatching:jetAllow");
-  exclusiveMode  = settingsPtr->mode("JetMatching:exclusive");
-  qCutSq         = pow(qCut,2);
-  etaJetMaxAlgo  = etaJetMax;
+  jetAllow = settingsPtr->mode("JetMatching:jetAllow");
+  exclusiveMode = settingsPtr->mode("JetMatching:exclusive");
+  qCutSq = pow(qCut, 2);
+  etaJetMaxAlgo = etaJetMax;
   //performVeto    = true;
 
   // If not merging is applied, then we are done
-  if (!doMerge) return true;
+  if (!doMerge)
+    return true;
 
   // Exclusive mode; if set to 2, then set based on nJet/nJetMax
   if (exclusiveMode == 2) {
     // No nJet or nJetMax, so default to exclusive mode
     if (nJetMax < 0) {
-      errorMsg("Warning in JetMatchingMadgraph:init: "
-        "missing jet multiplicity information; running in exclusive mode");
+      errorMsg(
+          "Warning in JetMatchingMadgraph:init: "
+          "missing jet multiplicity information; running in exclusive mode");
       exclusiveMode = 1;
     }
   }
@@ -103,22 +113,17 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
   // Currently, this only supports the kT-algorithm in SlowJet.
   // Use the QCD distance measure by default.
   jetAlgorithm = 2;
-  slowJetPower = 1;
 
-  slowJet = new SlowJet(slowJetPower, coneRadius, eTjetMin,
-    etaJetMaxAlgo, 2, 2, NULL, false);
+  slowJet = new SlowJet(slowJetPower, coneRadius, eTjetMin, etaJetMaxAlgo, 2, 2, nullptr, false);
 
   // For FxFx, also initialise jet algorithm to define matrix element jets.
-  slowJetHard = new SlowJet(slowJetPower, coneRadius, qCutME,
-    etaJetMaxAlgo, 2, 2, NULL, false);
+  slowJetHard = new SlowJet(slowJetPower, coneRadius, qCutME, etaJetMaxAlgo, 2, 2, nullptr, false);
 
   // To access the DJR's
-  slowJetDJR = new SlowJet(slowJetPower, coneRadius, qCutME,
-    etaJetMaxAlgo, 2, 2, NULL, false);
+  slowJetDJR = new SlowJet(slowJetPower, coneRadius, qCutME, etaJetMaxAlgo, 2, 2, nullptr, false);
 
   // A special version of SlowJet to handle heavy and other partons
-  hjSlowJet = new HJSlowJet(slowJetPower, coneRadius, 0.0,
-    100.0, 1, 2, NULL, false, true);
+  hjSlowJet = new HJSlowJet(slowJetPower, coneRadius, 0.0, 100.0, 1, 2, nullptr, false, true);
 
   // Setup local event records
   eventProcessOrig.init("(eventProcessOrig)", particleDataPtr);
@@ -126,29 +131,22 @@ bool JetMatchingEWKFxFx::initAfterBeams() {
   workEventJet.init("(workEventJet)", particleDataPtr);
 
   // Print information
-  string jetStr  = (jetAlgorithm ==  1) ? "CellJet" :
-                   (slowJetPower == -1) ? "anti-kT" :
-                   (slowJetPower ==  0) ? "C/A"     :
-                   (slowJetPower ==  1) ? "kT"      : "unknown";
-  string modeStr = (exclusiveMode)         ? "exclusive" : "inclusive";
+  string jetStr = (jetAlgorithm == 1)    ? "CellJet"
+                  : (slowJetPower == -1) ? "anti-kT"
+                  : (slowJetPower == 0)  ? "C/A"
+                  : (slowJetPower == 1)  ? "kT"
+                                         : "unknown";
+  string modeStr = (exclusiveMode) ? "exclusive" : "inclusive";
   cout << endl
        << " *-----  Madgraph matching parameters  -----*" << endl
-       << " |  qCut                |  " << setw(14)
-       << qCut << "  |" << endl
-       << " |  nQmatch             |  " << setw(14)
-       << nQmatch << "  |" << endl
-       << " |  clFact              |  " << setw(14)
-       << clFact << "  |" << endl
-       << " |  Jet algorithm       |  " << setw(14)
-       << jetStr << "  |" << endl
-       << " |  eTjetMin            |  " << setw(14)
-       << eTjetMin << "  |" << endl
-       << " |  etaJetMax           |  " << setw(14)
-       << etaJetMax << "  |" << endl
-       << " |  jetAllow            |  " << setw(14)
-       << jetAllow << "  |" << endl
-       << " |  Mode                |  " << setw(14)
-       << modeStr << "  |" << endl
+       << " |  qCut                |  " << setw(14) << qCut << "  |" << endl
+       << " |  nQmatch             |  " << setw(14) << nQmatch << "  |" << endl
+       << " |  clFact              |  " << setw(14) << clFact << "  |" << endl
+       << " |  Jet algorithm       |  " << setw(14) << jetStr << "  |" << endl
+       << " |  eTjetMin            |  " << setw(14) << eTjetMin << "  |" << endl
+       << " |  etaJetMax           |  " << setw(14) << etaJetMax << "  |" << endl
+       << " |  jetAllow            |  " << setw(14) << jetAllow << "  |" << endl
+       << " |  Mode                |  " << setw(14) << modeStr << "  |" << endl
        << " *-----------------------------------------*" << endl;
 
   return true;
@@ -160,7 +158,8 @@ bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
 
   // For the shower-kT scheme, do not perform any veto here, as any vetoing
   // will already have taken place in doVetoStep.
-  if ( doShowerKt ) return false;
+  if (doShowerKt)
+    return false;
 
   // Debug printout.
   if (MATCHINGDEBUG) {
@@ -174,8 +173,8 @@ bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
     eventProcess.list();
     // List categories of sorted particles
     for (size_t i = 0; i < typeIdx[0].size(); i++)
-      cout << ((i == 0) ? "Light jets: " : ", ")   << setw(3) << typeIdx[0][i];
-    if( typeIdx[0].size()== 0 )
+      cout << ((i == 0) ? "Light jets: " : ", ") << setw(3) << typeIdx[0][i];
+    if (typeIdx[0].empty())
       cout << "Light jets: None";
 
     for (size_t i = 0; i < typeIdx[1].size(); i++)
@@ -193,7 +192,6 @@ bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
   // 2) Light/heavy jets: iType = 0 (light jets), 1 (heavy jets)
   int iTypeEnd = (typeIdx[2].empty()) ? 2 : 3;
   for (int iType = 0; iType < iTypeEnd; iType++) {
-
     // 2a) Find particles which will be passed from the jet algorithm.
     //     Input from 'workEvent' and output in 'workEventJet'.
     jetAlgorithmInput(event, iType);
@@ -213,7 +211,8 @@ bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
     if (matchPartonsToJets(iType) == true) {
       // Debug printout.
       if (MATCHINGDEBUG) {
-        cout << endl << "Event vetoed" << endl
+        cout << endl
+             << "Event vetoed"
              << "----------  End MLM Debug  ----------" << endl;
       }
       return true;
@@ -222,18 +221,18 @@ bool JetMatchingEWKFxFx::doVetoPartonLevelEarly(const Event& event) {
 
   // Debug printout.
   if (MATCHINGDEBUG) {
-    cout << endl << "Event accepted" << endl
+    cout << endl
+         << "Event accepted"
          << "----------  End MLM Debug  ----------" << endl;
   }
   // If we reached here, then no veto
   return false;
 }
 
-
-void JetMatchingEWKFxFx::sortIncomingProcess(const Event &event){
+void JetMatchingEWKFxFx::sortIncomingProcess(const Event& event) {
   omitResonanceDecays(eventProcessOrig, true);
   clearDJR();
-  clear_nMEpartons();  
+  clear_nMEpartons();
 
   // Step-FxFx-1: remove preclustering from FxFx
   eventProcess = workEvent;
@@ -246,40 +245,36 @@ void JetMatchingEWKFxFx::sortIncomingProcess(const Event &event){
 
   for (int i = 0; i < eventProcess.size(); i++) {
     // Ignore non-final state and default to 'other'
-    if (!eventProcess[i].isFinal()) continue;
+    if (!eventProcess[i].isFinal())
+      continue;
     int idx = -1;
     int orig_idx = -1;
 
     // Light jets: all gluons and quarks with id less than or equal to nQmatch
-    if (eventProcess[i].isGluon()
-      || (eventProcess[i].idAbs() <= nQmatch) ) {
+    if (eventProcess[i].isGluon() || (eventProcess[i].idAbs() <= nQmatch)) {
       orig_idx = 0;
       if (doFxFx) {
-          // Crucial point FxFx: MG5 puts the scale of a not-to-be-matched quark 1 MeV lower than scalup. For
-          // such particles, we should keep the default "2"
-          idx = ( trunc(1000. * eventProcess[i].scale()) == trunc(1000. * infoPtr->scalup()) ) ? 0 : 2;
-
-      }
-      else {
-      // Crucial point: MG puts the scale of a non-QCD particle to eCM. For
-      // such particles, we should keep the default "2"
-      idx = ( eventProcess[i].scale() < 1.999 * sqrt(infoPtr->eA()
-        * infoPtr->eB()) ) ? 0 : 2;
+        // Crucial point FxFx: MG5 puts the scale of a not-to-be-matched quark 1 MeV lower than scalup. For
+        // such particles, we should keep the default "2"
+        idx = (trunc(1000. * eventProcess[i].scale()) == trunc(1000. * infoPtr->scalup())) ? 0 : 2;
+      } else {
+        // Crucial point: MG puts the scale of a non-QCD particle to eCM. For
+        // such particles, we should keep the default "2"
+        idx = (eventProcess[i].scale() < 1.999 * sqrt(infoPtr->eA() * infoPtr->eB())) ? 0 : 2;
       }
     }
 
     // Heavy jets:  all quarks with id greater than nQmatch
-    else if (eventProcess[i].idAbs() > nQmatch
-      && eventProcess[i].idAbs() <= ID_TOP) {
+    else if (eventProcess[i].idAbs() > nQmatch && eventProcess[i].idAbs() <= ID_TOP) {
       idx = 1;
       orig_idx = 1;
-    // Update to include non-SM colored particles
-    } else if (eventProcess[i].colType() != 0
-      && eventProcess[i].idAbs() > ID_TOP) {
+      // Update to include non-SM colored particles
+    } else if (eventProcess[i].colType() != 0 && eventProcess[i].idAbs() > ID_TOP) {
       idx = 1;
       orig_idx = 1;
     }
-    if( idx < 0 ) continue;
+    if (idx < 0)
+      continue;
     // Store
     typeIdx[idx].push_back(i);
     typeSet[idx].insert(eventProcess[i].daughter1());
@@ -287,12 +282,11 @@ void JetMatchingEWKFxFx::sortIncomingProcess(const Event &event){
   }
   // Exclusive mode; if set to 2, then set based on nJet/nJetMax
   if (exclusiveMode == 2) {
-
     // Inclusive if nJet == nJetMax, exclusive otherwise
     int nParton = origTypeIdx[0].size();
     exclusive = (nParton == nJetMax) ? false : true;
 
-  // Otherwise, just set as given
+    // Otherwise, just set as given
   } else {
     exclusive = (exclusiveMode == 0) ? false : true;
   }
@@ -304,8 +298,8 @@ void JetMatchingEWKFxFx::sortIncomingProcess(const Event &event){
   // Store things that are necessary to perform the kT-MLM veto externally.
   int nParton = typeIdx[0].size();
   processSubsetSave.clear();
-  for ( int i = 0; i < nParton; ++i)
-    processSubsetSave.append( eventProcess[typeIdx[0][i]] );
+  for (int i = 0; i < nParton; ++i)
+    processSubsetSave.append(eventProcess[typeIdx[0][i]]);
 }
 
 bool JetMatchingEWKFxFx::doVetoProcessLevel(Event& process) {
@@ -319,27 +313,28 @@ bool JetMatchingEWKFxFx::doVetoProcessLevel(Event& process) {
   sortIncomingProcess(process);
 
   // Veto in case the hard input matrix element already has too many partons.
-  if ( !doFxFx && int(typeIdx[0].size()) > nJetMax )
+  if (!doFxFx && int(typeIdx[0].size()) > nJetMax)
     return true;
-  if ( doFxFx && npNLO() < nJetMax && int(typeIdx[0].size()) > nJetMax )
+  if (doFxFx && npNLO() < nJetMax && int(typeIdx[0].size()) > nJetMax)
     return true;
 
   // Done
   return false;
 }
 
-void JetMatchingEWKFxFx::jetAlgorithmInput(const Event &event, int iType){
+void JetMatchingEWKFxFx::jetAlgorithmInput(const Event& event, int iType) {
   // Take input from 'workEvent' and put output in  'workEventJet'
   workEventJet = workEvent;
 
   // Loop over particles and decide what to pass to the jet algorithm
   for (int i = 0; i < workEventJet.size(); ++i) {
-    if (!workEventJet[i].isFinal()) continue;
+    if (!workEventJet[i].isFinal())
+      continue;
 
     // jetAllow option to disallow certain particle types
     if (jetAllow == 1) {
       // Remove all non-QCD partons from veto list
-      if( workEventJet[i].colType() == 0 ) {
+      if (workEventJet[i].colType() == 0) {
         workEventJet[i].statusNeg();
         continue;
       }
@@ -351,23 +346,23 @@ void JetMatchingEWKFxFx::jetAlgorithmInput(const Event &event, int iType){
     while (true) {
       // Light jets
       if (iType == 0) {
-
         // Do not include if originates from heavy jet or 'other'
-        if (typeSet[1].find(idx) != typeSet[1].end() ||
-            typeSet[2].find(idx) != typeSet[2].end()) {
+        if (typeSet[1].find(idx) != typeSet[1].end() || typeSet[2].find(idx) != typeSet[2].end()) {
           workEventJet[i].statusNeg();
           break;
         }
 
         // Made it to start of event record so done
-        if (idx == 0) break;
+        if (idx == 0)
+          break;
         // Otherwise next mother and continue
         idx = event[idx].mother1();
 
-      // Heavy jets
+        // Heavy jets
       } else if (iType == 1) {
         // Only include if originates from heavy jet
-        if (typeSet[1].find(idx) != typeSet[1].end()) break;
+        if (typeSet[1].find(idx) != typeSet[1].end())
+          break;
 
         // Made it to start of event record with no heavy jet mother,
         // so DO NOT include particle
@@ -379,11 +374,11 @@ void JetMatchingEWKFxFx::jetAlgorithmInput(const Event &event, int iType){
         // Otherwise next mother and continue
         idx = event[idx].mother1();
 
-      // Other jets
+        // Other jets
       } else if (iType == 2) {
-
         // Only include if originates from other jet
-        if (typeSet[2].find(idx) != typeSet[2].end()) break;
+        if (typeSet[2].find(idx) != typeSet[2].end())
+          break;
 
         // Made it to start of event record with no heavy jet mother,
         // so DO NOT include particle
@@ -399,17 +394,20 @@ void JetMatchingEWKFxFx::jetAlgorithmInput(const Event &event, int iType){
   }
 }
 
-void JetMatchingEWKFxFx::runJetAlgorithm(){; }
+void JetMatchingEWKFxFx::runJetAlgorithm() { ; }
 
-bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& event){
+bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& event) {
   // Do not perform any veto if not in the Shower-kT scheme.
-  if ( !doShowerKt ) return false;
+  if (!doShowerKt)
+    return false;
 
   // Do nothing for emissions after the first one.
-  if ( nISR + nFSR > 1 ) return false;
+  if (nISR + nFSR > 1)
+    return false;
 
   // Do nothing in resonance decay showers.
-  if (iPos == 5) return false;
+  if (iPos == 5)
+    return false;
 
   // Clear the event of MPI systems and resonace decay products. Store trimmed
   // event in workEvent.
@@ -421,15 +419,13 @@ bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& e
   // Get weak bosons, for later checks if the emission is a "QCD emission".
   vector<int> weakBosons;
   for (int i = 0; i < event.size(); i++) {
-    if ( event[i].id() == 22
-      && event[i].id() == 23
-      && event[i].idAbs() == 24)
+    if (event[i].id() == 22 && event[i].id() == 23 && event[i].idAbs() == 24)
       weakBosons.push_back(i);
   }
 
-  for (int i =  workEvent.size()-1; i > 0; --i) {
-    if ( workEvent[i].isFinal() && workEvent[i].colType() != 0
-      && (workEvent[i].statusAbs() == 43 || workEvent[i].statusAbs() == 51)) {
+  for (int i = workEvent.size() - 1; i > 0; --i) {
+    if (workEvent[i].isFinal() && workEvent[i].colType() != 0 &&
+        (workEvent[i].statusAbs() == 43 || workEvent[i].statusAbs() == 51)) {
       // Check if any of the EW bosons are ancestors of this parton. This
       // should never happen for the first non-resonance shower emission.
       // Check just to be sure.
@@ -438,12 +434,12 @@ bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& e
       // not contain right mother-daughter relations). Stored in daughters.
       int iPosOld = workEvent[i].daughter1();
       for (int j = 0; i < int(weakBosons.size()); ++i)
-        if ( event[iPosOld].isAncestor(j)) {
+        if (event[iPosOld].isAncestor(j)) {
           QCDemission = false;
           break;
         }
       // Done for a QCD emission.
-      if (QCDemission){
+      if (QCDemission) {
         pTfirst = workEvent[i].pT();
         break;
       }
@@ -451,32 +447,33 @@ bool JetMatchingEWKFxFx::doVetoStep(int iPos, int nISR, int nFSR, const Event& e
   }
 
   // Store things that are necessary to perform the shower-kT veto externally.
-  pTfirstSave   = pTfirst;
+  pTfirstSave = pTfirst;
   // Done if only inputs for an external vetoing procedure should be stored.
   //if (!performVeto) return false;
 
   // Check veto.
-  if ( doShowerKtVeto(pTfirst) ) return true;
+  if (doShowerKtVeto(pTfirst))
+    return true;
 
   // No veto if come this far.
   return false;
 }
 
-void JetMatchingEWKFxFx::setDJR( const Event& event) {
-
- // Clear members.
- clearDJR();
- vector<double> result;
+void JetMatchingEWKFxFx::setDJR(const Event& event) {
+  // Clear members.
+  clearDJR();
+  vector<double> result;
 
   // Initialize SlowJetDJR jet algorithm with event
-  if (!slowJetDJR->setup(event) ) {
-    errorMsg("Warning in JetMatchingMadgraph:setDJR"
-      ": the SlowJet algorithm failed on setup");
+  if (!slowJetDJR->setup(event)) {
+    errorMsg(
+        "Warning in JetMatchingMadgraph:setDJR"
+        ": the SlowJet algorithm failed on setup");
     return;
   }
 
   // Cluster in steps to find all hadronic jets
-  while ( slowJetDJR->sizeAll() - slowJetDJR->sizeJet() > 0 ) {
+  while (slowJetDJR->sizeAll() - slowJetDJR->sizeJet() > 0) {
     // Save the next clustering scale.
     result.push_back(sqrt(slowJetDJR->dNext()));
     // Perform step.
@@ -484,12 +481,11 @@ void JetMatchingEWKFxFx::setDJR( const Event& event) {
   }
 
   // Save clustering scales in reserve order.
-  for (int i=int(result.size())-1; i >= 0; --i)
+  for (int i = int(result.size()) - 1; i >= 0; --i)
     DJR.push_back(result[i]);
-
 }
 
-bool JetMatchingEWKFxFx::matchPartonsToJets(int iType){
+bool JetMatchingEWKFxFx::matchPartonsToJets(int iType) {
   // Use different routines for light/heavy/other jets as
   // different veto conditions and for clarity
   if (iType == 0) {
@@ -500,15 +496,15 @@ bool JetMatchingEWKFxFx::matchPartonsToJets(int iType){
     // Perform jet matching.
     return (matchPartonsToJetsLight() > 0);
   } else if (iType == 1) {
-     return (matchPartonsToJetsHeavy() > 0);
+    return (matchPartonsToJetsHeavy() > 0);
   } else {
-     return (matchPartonsToJetsOther() > 0);
+    return (matchPartonsToJetsOther() > 0);
   }
 }
 
-int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
+int JetMatchingEWKFxFx::matchPartonsToJetsLight() {
   // Store things that are necessary to perform the kT-MLM veto externally.
-  workEventJetSave  = workEventJet;
+  workEventJetSave = workEventJet;
   // Done if only inputs for an external vetoing procedure should be stored.
   //if (!performVeto) return false;
 
@@ -516,24 +512,27 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   int nParton = typeIdx[0].size();
 
   // Initialize SlowJet with current working event
-  if (!slowJet->setup(workEventJet) ) {
-    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-      "Light: the SlowJet algorithm failed on setup");
+  if (!slowJet->setup(workEventJet)) {
+    errorMsg(
+        "Warning in JetMatchingMadgraph:matchPartonsToJets"
+        "Light: the SlowJet algorithm failed on setup");
     return NONE;
   }
   double localQcutSq = qCutSq;
   double dOld = 0.0;
   // Cluster in steps to find all hadronic jets at the scale qCut
-  while ( slowJet->sizeAll() - slowJet->sizeJet() > 0 ) {
-    if( slowJet->dNext() > localQcutSq ) break;
+  while (slowJet->sizeAll() - slowJet->sizeJet() > 0) {
+    if (slowJet->dNext() > localQcutSq)
+      break;
     dOld = slowJet->dNext();
     slowJet->doStep();
   }
   int nJets = slowJet->sizeJet();
   int nClus = slowJet->sizeAll();
-  
+
   // Debug printout.
-  if (MATCHINGDEBUG) slowJet->list(true);
+  if (MATCHINGDEBUG)
+    slowJet->list(true);
 
   // Count of the number of hadronic jets in SlowJet accounting
   int nCLjets = nClus - nJets;
@@ -542,13 +541,15 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   //Step-FxFx-3: Change nRequested subtracting the typeIdx[2] partons
   //Exclude the highest multiplicity sample in the case of real emissions and all typeIdx[2]
   //npNLO=multiplicity,nJetMax=njmax(shower_card),typeIdx[2]="Weak" jets
-  int nRequested = (doFxFx && !(npNLO()==nJetMax && npNLO()==(int)(typeIdx[2].size()-1) )) ? npNLO()-typeIdx[2].size() : nParton;
+  int nRequested = (doFxFx && !(npNLO() == nJetMax && npNLO() == (int)(typeIdx[2].size() - 1)))
+                       ? npNLO() - typeIdx[2].size()
+                       : nParton;
 
   //Step-FxFx-4:For FxFx veto the real emissions that have only typeIdx=2 partons
   //From Step-FxFx-3 they already have negative nRequested, so this step may not be necessary
   //Exclude the highest multiplicity sample
-  if (doFxFx && npNLO()<nJetMax && typeIdx[2].size()>0 && npNLO()==(int)(typeIdx[2].size()-1)) {
-        return MORE_JETS;
+  if (doFxFx && npNLO() < nJetMax && typeIdx[2].empty() && npNLO() == (int)(typeIdx[2].size() - 1)) {
+    return MORE_JETS;
   }
   //----------------
   //Exclude all Weak Jets for matching
@@ -567,15 +568,16 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   //if (doFxFx && npNLO()==0) {
   //      return MORE_JETS;
   //} // 2D
-//--------------
+  //--------------
   // Veto event if too few hadronic jets
-  if ( nCLjets < nRequested ) return LESS_JETS;
+  if (nCLjets < nRequested)
+    return LESS_JETS;
 
   // In exclusive mode, do not allow more hadronic jets than partons
-  if ( exclusive && !doFxFx ) {
-    if ( nCLjets > nRequested ) return MORE_JETS;
+  if (exclusive && !doFxFx) {
+    if (nCLjets > nRequested)
+      return MORE_JETS;
   } else {
-
     // For FxFx, in the non-highest multipicity, all jets need to matched to
     // partons. For nCLjets > nRequested, this is not possible. Hence, we can
     // veto here already.
@@ -583,74 +585,80 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
     //Step-FxFx-5:Change the nRequested to npNLO() in the first condition
     //Before in Step-FxFx-3 it was nRequested=npNLO() for FxFx
     //This way we correctly select the non-highest multipicity regardless the nRequested
-     if ( doFxFx && npNLO() < nJetMax && nCLjets > nRequested )
+    if (doFxFx && npNLO() < nJetMax && nCLjets > nRequested)
       return MORE_JETS;
 
     // Now continue in inclusive mode.
     // In inclusive mode, there can be more hadronic jets than partons,
     // provided that all partons are properly matched to hadronic jets.
     // Start by setting up the jet algorithm.
-    if (!slowJet->setup(workEventJet) ) {
-      errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-        "Light: the SlowJet algorithm failed on setup");
+    if (!slowJet->setup(workEventJet)) {
+      errorMsg(
+          "Warning in JetMatchingMadgraph:matchPartonsToJets"
+          "Light: the SlowJet algorithm failed on setup");
       return NONE;
     }
- 
+
     // For FxFx, continue clustering as long as the jet separation is above
     // qCut.
     if (doFxFx) {
-      while ( slowJet->sizeAll() - slowJet->sizeJet() > 0 ) {
-        if( slowJet->dNext() > localQcutSq ) break;
+      while (slowJet->sizeAll() - slowJet->sizeJet() > 0) {
+        if (slowJet->dNext() > localQcutSq)
+          break;
         slowJet->doStep();
       }
-    // For MLM, cluster into hadronic jets until there are the same number as
-    // partons.
+      // For MLM, cluster into hadronic jets until there are the same number as
+      // partons.
     } else {
-      while ( slowJet->sizeAll() - slowJet->sizeJet() > nParton )
+      while (slowJet->sizeAll() - slowJet->sizeJet() > nParton)
         slowJet->doStep();
     }
 
     // Sort partons in pT.  Update local qCut value.
     //  Hadronic jets are already sorted in pT.
     localQcutSq = dOld;
-    if ( clFact >= 0. && nParton > 0 ) {
-       vector<double> partonPt;
-       for (int i = 0; i < nParton; ++i)
-         partonPt.push_back( eventProcess[typeIdx[0][i]].pT2() );
-       sort( partonPt.begin(), partonPt.end());
-       localQcutSq = max( qCutSq, partonPt[0]);
+    if (clFact >= 0. && nParton > 0) {
+      vector<double> partonPt;
+      partonPt.reserve(nParton);
+      for (int i = 0; i < nParton; ++i)
+        partonPt.push_back(eventProcess[typeIdx[0][i]].pT2());
+      sort(partonPt.begin(), partonPt.end());
+      localQcutSq = max(qCutSq, partonPt[0]);
     }
     nJets = slowJet->sizeJet();
     nClus = slowJet->sizeAll();
   }
   // Update scale if clustering factor is non-zero
-  if ( clFact != 0. ) localQcutSq *= pow2(clFact);
+  if (clFact != 0.)
+    localQcutSq *= pow2(clFact);
 
   Event tempEvent;
-  tempEvent.init( "(tempEvent)", particleDataPtr);
+  tempEvent.init("(tempEvent)", particleDataPtr);
   int nPass = 0;
   double pTminEstimate = -1.;
   // Construct a master copy of the event containing only the
   // hardest nParton hadronic clusters. While constructing the event,
   // the parton type (ID_GLUON) and status (98,99) are arbitrary.
   for (int i = nJets; i < nClus; ++i) {
-    tempEvent.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0, slowJet->p(i).px(),
-      slowJet->p(i).py(), slowJet->p(i).pz(), slowJet->p(i).e() );
+    tempEvent.append(
+        ID_GLUON, 98, 0, 0, 0, 0, 0, 0, slowJet->p(i).px(), slowJet->p(i).py(), slowJet->p(i).pz(), slowJet->p(i).e());
     ++nPass;
-    pTminEstimate = max( pTminEstimate, slowJet->pT(i));
-    if(nPass == nRequested) break;
+    pTminEstimate = max(pTminEstimate, slowJet->pT(i));
+    if (nPass == nRequested)
+      break;
   }
 
   int tempSize = tempEvent.size();
   // This keeps track of which hadronic jets are matched to parton
   vector<bool> jetAssigned;
-  jetAssigned.assign( tempSize, false);
+  jetAssigned.assign(tempSize, false);
 
   // This keeps track of which partons are matched to which hadronic
   // jets.
-  vector< vector<bool> > partonMatchesJet;
-  for (int i=0; i < nParton; ++i )
-    partonMatchesJet.push_back( vector<bool>(tempEvent.size(),false) );
+  vector<vector<bool> > partonMatchesJet;
+  partonMatchesJet.reserve(nParton);
+  for (int i = 0; i < nParton; ++i)
+    partonMatchesJet.push_back(vector<bool>(tempEvent.size(), false));
 
   // Begin matching.
   // Do jet matching for FxFx.
@@ -667,62 +675,68 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   int iNow = 0;
   int nMatched = 0;
 
-  while ( doFxFx && iNow < tempSize ) {
-
+  while (doFxFx && iNow < tempSize) {
     // Check if this shower jet matches any partonic jet.
     Event tempEventJet;
     tempEventJet.init("(tempEventJet)", particleDataPtr);
-    for (int i=0; i < nParton; ++i ) {
-
+    for (int i = 0; i < nParton; ++i) {
       //// Only assign a parton once.
       //for (int j=0; j < tempSize; ++j )
       //  if ( partonMatchesJet[i][j]) continue;
 
       // Attach a single hadronic jet.
       tempEventJet.clear();
-      tempEventJet.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0,
-        tempEvent[iNow].px(), tempEvent[iNow].py(),
-        tempEvent[iNow].pz(), tempEvent[iNow].e() );
+      tempEventJet.append(ID_GLUON,
+                          98,
+                          0,
+                          0,
+                          0,
+                          0,
+                          0,
+                          0,
+                          tempEvent[iNow].px(),
+                          tempEvent[iNow].py(),
+                          tempEvent[iNow].pz(),
+                          tempEvent[iNow].e());
       // Attach the current parton.
       Vec4 pIn = eventProcess[typeIdx[0][i]].p();
-      tempEventJet.append( ID_GLUON, 99, 0, 0, 0, 0, 0, 0,
-        pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
+      tempEventJet.append(ID_GLUON, 99, 0, 0, 0, 0, 0, 0, pIn.px(), pIn.py(), pIn.pz(), pIn.e());
 
       // Setup jet algorithm.
-      if ( !slowJet->setup(tempEventJet) ) {
-        errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-          "Light: the SlowJet algorithm failed on setup");
+      if (!slowJet->setup(tempEventJet)) {
+        errorMsg(
+            "Warning in JetMatchingMadgraph:matchPartonsToJets"
+            "Light: the SlowJet algorithm failed on setup");
         return NONE;
       }
       // These are the conditions for the hadronic jet to match the parton
       //  at the local qCut scale
-      if ( slowJet->iNext() == tempEventJet.size() - 1
-        && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq ) {
+      if (slowJet->iNext() == tempEventJet.size() - 1 && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq) {
         jetAssigned[iNow] = true;
         partonMatchesJet[i][iNow] = true;
       }
-
-    } // End loop over hard partons.
+    }  // End loop over hard partons.
 
     // Veto if the jet could not be assigned to any parton.
-    if ( jetAssigned[iNow] ) nMatched++;
+    if (jetAssigned[iNow])
+      nMatched++;
 
     // Continue;
     ++iNow;
   }
   // Jet matching veto for FxFx
   if (doFxFx) {
-//    if ( nRequested <  nJetMax && nMatched != nRequested )
-//      return UNMATCHED_PARTON;
-//    if ( nRequested == nJetMax && nMatched <  nRequested )
-//      return UNMATCHED_PARTON;
-      //Step-FxFx-6:Change the nRequested to npNLO() in the first condition (like in Step-FxFx-5)
-      //Before in Step-FxFx-3 it was nRequested=npNLO() for FxFx
-      //This way we correctly select the non-highest multipicity regardless the nRequested
-      if ( npNLO() <  nJetMax && nMatched != nRequested )
-        return UNMATCHED_PARTON;
-      if ( npNLO() == nJetMax && nMatched <  nRequested )
-        return UNMATCHED_PARTON;
+    // if ( nRequested <  nJetMax && nMatched != nRequested )
+    //   return UNMATCHED_PARTON;
+    // if ( nRequested == nJetMax && nMatched <  nRequested )
+    //   return UNMATCHED_PARTON;
+    //Step-FxFx-6:Change the nRequested to npNLO() in the first condition (like in Step-FxFx-5)
+    //Before in Step-FxFx-3 it was nRequested=npNLO() for FxFx
+    //This way we correctly select the non-highest multipicity regardless the nRequested
+    if (npNLO() < nJetMax && nMatched != nRequested)
+      return UNMATCHED_PARTON;
+    if (npNLO() == nJetMax && nMatched < nRequested)
+      return UNMATCHED_PARTON;
   }
   // Do jet matching for MLM.
   // Take the list of unmatched hadronic jets and append a parton, one at
@@ -732,36 +746,37 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   // hadronic jets. This process continues until all hadronic jets are
   // matched to partons or it is not possible to make a match.
   iNow = 0;
-  while (!doFxFx && iNow < nParton ) {
+  while (!doFxFx && iNow < nParton) {
     Event tempEventJet;
     tempEventJet.init("(tempEventJet)", particleDataPtr);
     for (int i = 0; i < tempSize; ++i) {
-      if (jetAssigned[i]) continue;
+      if (jetAssigned[i])
+        continue;
       Vec4 pIn = tempEvent[i].p();
       // Append unmatched hadronic jets
-      tempEventJet.append( ID_GLUON, 98, 0, 0, 0, 0, 0, 0,
-        pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
+      tempEventJet.append(ID_GLUON, 98, 0, 0, 0, 0, 0, 0, pIn.px(), pIn.py(), pIn.pz(), pIn.e());
     }
 
     Vec4 pIn = eventProcess[typeIdx[0][iNow]].p();
     // Append the current parton
-    tempEventJet.append( ID_GLUON, 99, 0, 0, 0, 0, 0, 0,
-      pIn.px(), pIn.py(), pIn.pz(), pIn.e() );
-    if ( !slowJet->setup(tempEventJet) ) {
-      errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-        "Light: the SlowJet algorithm failed on setup");
+    tempEventJet.append(ID_GLUON, 99, 0, 0, 0, 0, 0, 0, pIn.px(), pIn.py(), pIn.pz(), pIn.e());
+    if (!slowJet->setup(tempEventJet)) {
+      errorMsg(
+          "Warning in JetMatchingMadgraph:matchPartonsToJets"
+          "Light: the SlowJet algorithm failed on setup");
       return NONE;
     }
     // These are the conditions for the hadronic jet to match the parton
     //  at the local qCut scale
-    if ( slowJet->iNext() == tempEventJet.size() - 1
-      && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq ) {
+    if (slowJet->iNext() == tempEventJet.size() - 1 && slowJet->jNext() > -1 && slowJet->dNext() < localQcutSq) {
       int iKnt = -1;
       for (int i = 0; i != tempSize; ++i) {
-        if (jetAssigned[i]) continue;
+        if (jetAssigned[i])
+          continue;
         ++iKnt;
         // Identify the hadronic jet that matches the parton
-        if (iKnt == slowJet->jNext() ) jetAssigned[i] = true;
+        if (iKnt == slowJet->jNext())
+          jetAssigned[i] = true;
       }
     } else {
       return UNMATCHED_PARTON;
@@ -771,17 +786,19 @@ int JetMatchingEWKFxFx::matchPartonsToJetsLight(){
   // Minimal eT/pT (CellJet/SlowJet) of matched light jets.
   // Needed later for heavy jet vetos in inclusive mode.
   // This information is not used currently.
-  if (nParton > 0 && pTminEstimate > 0) eTpTlightMin = pTminEstimate;
-  else eTpTlightMin = -1.;
+  if (nParton > 0 && pTminEstimate > 0)
+    eTpTlightMin = pTminEstimate;
+  else
+    eTpTlightMin = -1.;
 
   // Record the jet separations.
   setDJR(workEventJet);
 
   // No veto
   return NONE;
-}  
+}
 
-int JetMatchingEWKFxFx::matchPartonsToJetsHeavy(){
+int JetMatchingEWKFxFx::matchPartonsToJetsHeavy() {
   // Currently, heavy jets are unmatched
   // If there are no extra jets, then accept
   // jetMomenta is NEVER used by MadGraph and is always empty.
@@ -800,32 +817,35 @@ int JetMatchingEWKFxFx::matchPartonsToJetsHeavy(){
   // Rescale the heavy partons that are from the hard process to
   //  have pT=collider energy.   Soft/collinear gluons will cluster
   //  onto them, leaving a remnant of hard emissions.
-  for( int i=0; i<nParton; ++i) {
-    scaleF = eventProcessOrig[0].e()/workEventJet[typeIdx[1][i]].pT();
+  for (int i = 0; i < nParton; ++i) {
+    scaleF = eventProcessOrig[0].e() / workEventJet[typeIdx[1][i]].pT();
     tempEventJet[typeIdx[1][i]].rescale5(scaleF);
   }
 
-  if (!hjSlowJet->setup(tempEventJet) ) {
-    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-             "Heavy: the SlowJet algorithm failed on setup");
+  if (!hjSlowJet->setup(tempEventJet)) {
+    errorMsg(
+        "Warning in JetMatchingMadgraph:matchPartonsToJets"
+        "Heavy: the SlowJet algorithm failed on setup");
     return NONE;
   }
 
-
-  while ( hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0 ) {
-    if( hjSlowJet->dNext() > qCutSq ) break;
+  while (hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0) {
+    if (hjSlowJet->dNext() > qCutSq)
+      break;
     hjSlowJet->doStep();
   }
 
   int nCLjets(0);
   // Count the number of clusters with pT>qCut.  This includes the
   //  original hard partons plus any hard emissions.
-  for(int idx=0 ; idx< hjSlowJet->sizeAll(); ++idx) {
-    if( hjSlowJet->pT(idx) > sqrt(qCutSq) ) nCLjets++;
+  for (int idx = 0; idx < hjSlowJet->sizeAll(); ++idx) {
+    if (hjSlowJet->pT(idx) > sqrt(qCutSq))
+      nCLjets++;
   }
 
   // Debug printout.
-  if (MATCHINGDEBUG) hjSlowJet->list(true);
+  if (MATCHINGDEBUG)
+    hjSlowJet->list(true);
 
   // Count of the number of hadronic jets in SlowJet accounting
   //  int nCLjets = nClus - nJets;
@@ -833,17 +853,19 @@ int JetMatchingEWKFxFx::matchPartonsToJetsHeavy(){
   int nRequested = nParton;
 
   // Veto event if too few hadronic jets
-  if ( nCLjets < nRequested ) {
-    if (MATCHINGDEBUG) cout << "veto : hvy  LESS_JETS " << endl;
-    if (MATCHINGDEBUG) cout << "nCLjets = " << nCLjets << "; nRequest = "
-      << nRequested << endl;
+  if (nCLjets < nRequested) {
+    if (MATCHINGDEBUG)
+      cout << "veto : hvy  LESS_JETS " << endl;
+    if (MATCHINGDEBUG)
+      cout << "nCLjets = " << nCLjets << "; nRequest = " << nRequested << endl;
     return LESS_JETS;
   }
 
   // In exclusive mode, do not allow more hadronic jets than partons
-  if ( exclusive ) {
-    if ( nCLjets > nRequested ) {
-      if (MATCHINGDEBUG) cout << "veto : excl hvy  MORE_JETS " << endl;
+  if (exclusive) {
+    if (nCLjets > nRequested) {
+      if (MATCHINGDEBUG)
+        cout << "veto : excl hvy  MORE_JETS " << endl;
       return MORE_JETS;
     }
   }
@@ -852,7 +874,7 @@ int JetMatchingEWKFxFx::matchPartonsToJetsHeavy(){
   return NONE;
 }
 
-int JetMatchingEWKFxFx::matchPartonsToJetsOther(){
+int JetMatchingEWKFxFx::matchPartonsToJetsOther() {
   // Currently, heavy jets are unmatched
   // If there are no extra jets, then accept
   // jetMomenta is NEVER used by MadGraph and is always empty.
@@ -871,32 +893,35 @@ int JetMatchingEWKFxFx::matchPartonsToJetsOther(){
   // Rescale the heavy partons that are from the hard process to
   //  have pT=collider energy.   Soft/collinear gluons will cluster
   //  onto them, leaving a remnant of hard emissions.
-  for( int i=0; i<nParton; ++i) {
-    scaleF = eventProcessOrig[0].e()/workEventJet[typeIdx[2][i]].pT();
+  for (int i = 0; i < nParton; ++i) {
+    scaleF = eventProcessOrig[0].e() / workEventJet[typeIdx[2][i]].pT();
     tempEventJet[typeIdx[2][i]].rescale5(scaleF);
   }
 
-  if (!hjSlowJet->setup(tempEventJet) ) {
-    errorMsg("Warning in JetMatchingMadgraph:matchPartonsToJets"
-             "Heavy: the SlowJet algorithm failed on setup");
+  if (!hjSlowJet->setup(tempEventJet)) {
+    errorMsg(
+        "Warning in JetMatchingMadgraph:matchPartonsToJets"
+        "Heavy: the SlowJet algorithm failed on setup");
     return NONE;
   }
 
-
-  while ( hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0 ) {
-    if( hjSlowJet->dNext() > qCutSq ) break;
+  while (hjSlowJet->sizeAll() - hjSlowJet->sizeJet() > 0) {
+    if (hjSlowJet->dNext() > qCutSq)
+      break;
     hjSlowJet->doStep();
   }
 
   int nCLjets(0);
   // Count the number of clusters with pT>qCut.  This includes the
   //  original hard partons plus any hard emissions.
-  for(int idx=0 ; idx< hjSlowJet->sizeAll(); ++idx) {
-    if( hjSlowJet->pT(idx) > sqrt(qCutSq) ) nCLjets++;
+  for (int idx = 0; idx < hjSlowJet->sizeAll(); ++idx) {
+    if (hjSlowJet->pT(idx) > sqrt(qCutSq))
+      nCLjets++;
   }
 
   // Debug printout.
-  if (MATCHINGDEBUG) hjSlowJet->list(true);
+  if (MATCHINGDEBUG)
+    hjSlowJet->list(true);
 
   // Count of the number of hadronic jets in SlowJet accounting
   //  int nCLjets = nClus - nJets;
@@ -904,17 +929,19 @@ int JetMatchingEWKFxFx::matchPartonsToJetsOther(){
   int nRequested = nParton;
 
   // Veto event if too few hadronic jets
-  if ( nCLjets < nRequested ) {
-    if (MATCHINGDEBUG) cout << "veto : other LESS_JETS " << endl;
-    if (MATCHINGDEBUG) cout << "nCLjets = " << nCLjets << "; nRequest = "
-      << nRequested << endl;
+  if (nCLjets < nRequested) {
+    if (MATCHINGDEBUG)
+      cout << "veto : other LESS_JETS " << endl;
+    if (MATCHINGDEBUG)
+      cout << "nCLjets = " << nCLjets << "; nRequest = " << nRequested << endl;
     return LESS_JETS;
   }
 
   // In exclusive mode, do not allow more hadronic jets than partons
-  if ( exclusive ) {
-    if ( nCLjets > nRequested ) {
-      if (MATCHINGDEBUG) cout << "veto : excl other MORE_JETS" << endl;
+  if (exclusive) {
+    if (nCLjets > nRequested) {
+      if (MATCHINGDEBUG)
+        cout << "veto : excl other MORE_JETS" << endl;
       return MORE_JETS;
     }
   }
@@ -923,9 +950,10 @@ int JetMatchingEWKFxFx::matchPartonsToJetsOther(){
   return NONE;
 }
 
-bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst){
+bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst) {
   // Only check veto in the shower-kT scheme.
-  if ( !doShowerKt ) return false;
+  if (!doShowerKt)
+    return false;
 
   // Reset veto code
   bool doVeto = false;
@@ -933,20 +961,21 @@ bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst){
   // Find the (kinematical) pT of the softest (light) parton in the hard
   // process.
   int nParton = typeIdx[0].size();
-  double pTminME=1e10;
-  for ( int i = 0; i < nParton; ++i)
-    pTminME = min(pTminME,eventProcess[typeIdx[0][i]].pT());
+  double pTminME = 1e10;
+  for (int i = 0; i < nParton; ++i)
+    pTminME = min(pTminME, eventProcess[typeIdx[0][i]].pT());
 
   // Veto if the softest hard process parton is below Qcut.
-  if ( nParton > 0 && pow(pTminME,2) < qCutSq ) doVeto = true;
+  if (nParton > 0 && pow(pTminME, 2) < qCutSq)
+    doVeto = true;
 
   // For non-highest multiplicity, veto if the hardest emission is harder
   // than Qcut.
-  if ( exclusive && pow(pTfirst,2) > qCutSq ) {
+  if (exclusive && pow(pTfirst, 2) > qCutSq) {
     doVeto = true;
-  // For highest multiplicity sample, veto if the hardest emission is harder
-  // than the hard process parton.
-  } else if ( !exclusive && nParton > 0 && pTfirst > pTminME ) {
+    // For highest multiplicity sample, veto if the hardest emission is harder
+    // than the hard process parton.
+  } else if (!exclusive && nParton > 0 && pTfirst > pTminME) {
     doVeto = true;
   }
 
@@ -957,12 +986,12 @@ bool JetMatchingEWKFxFx::doShowerKtVeto(double pTfirst){
 // Function to get the current number of partons in the Born state, as
 // read from LHE.
 
-int JetMatchingEWKFxFx::npNLO(){
-  string npIn = infoPtr->getEventAttribute("npNLO",true);
-  int np = (npIn != "") ? atoi((char*)npIn.c_str()) : -1;
-  if ( np < 0 ) { ; }
-  else return np;
+int JetMatchingEWKFxFx::npNLO() {
+  string npIn = infoPtr->getEventAttribute("npNLO", true);
+  int np = (npIn.empty()) ? atoi((char*)npIn.c_str()) : -1;
+  if (np < 0) {
+    ;
+  } else
+    return np;
   return nPartonsNow;
 }
-
-

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.cc
@@ -840,7 +840,7 @@ int JetMatchingEWKFxFx::matchPartonsToJetsHeavy() {
   // Count the number of clusters with pT>qCut.  This includes the
   //  original hard partons plus any hard emissions.
   for (int idx = 0; idx < hjSlowJet->sizeAll(); ++idx) {
-    if (hjSlowJet->pT(idx) > sqrt(qCutSq))
+    if (hjSlowJet->pT(idx) > qCut)
       nCLjets++;
   }
 

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.h
@@ -18,68 +18,66 @@
 // class
 
 class JetMatchingEWKFxFx : public Pythia8::JetMatching {
-
-public: 
+public:
   // Constructor and destructor
   JetMatchingEWKFxFx(const edm::ParameterSet& iConfig);
-  ~JetMatchingEWKFxFx(){}
-  
-  // Method declaration
-  bool initAfterBeams();
-  
-  bool canVetoPartonLevelEarly(){return true;}
-  bool doVetoPartonLevelEarly(const Pythia8::Event& event);
+  ~JetMatchingEWKFxFx() override {}
 
-  bool canVetoProcessLevel(){return true;}
-  bool doVetoProcessLevel(Pythia8::Event& event);
-   
+  // Method declaration
+  bool initAfterBeams() override;
+
+  bool canVetoPartonLevelEarly() override { return true; }
+  bool doVetoPartonLevelEarly(const Pythia8::Event& event) override;
+
+  bool canVetoProcessLevel() override { return true; }
+  bool doVetoProcessLevel(Pythia8::Event& event) override;
+
   // Shower step vetoes (after the first emission, for Shower-kT scheme)
-  int  numberVetoStep() {return 1;}
-  bool canVetoStep() { return doShowerKt; }
-  bool doVetoStep(int,  int, int, const Pythia8::Event& );
+  int numberVetoStep() override { return 1; }
+  bool canVetoStep() override { return doShowerKt; }
+  bool doVetoStep(int, int, int, const Pythia8::Event&) override;
 
   Pythia8::SlowJet* slowJetDJR;
 
-  Pythia8::vector<double> getDJR() { return DJR;}
-  Pythia8::pair<int,int> nMEpartons() { return nMEpartonsSave;}
+  Pythia8::vector<double> getDJR() { return DJR; }
+  Pythia8::pair<int, int> nMEpartons() { return nMEpartonsSave; }
 
   Pythia8::Event getWorkEventJet() { return workEventJetSave; }
   Pythia8::Event getProcessSubset() { return processSubsetSave; }
-  bool  getExclusive() { return exclusive; }
+  bool getExclusive() { return exclusive; }
   double getPTfirst() { return pTfirstSave; }
 
-
   // Different steps of the matching algorithm.
-  void sortIncomingProcess(const Pythia8::Event &);
+  void sortIncomingProcess(const Pythia8::Event&) override;
 
-  void jetAlgorithmInput(const Pythia8::Event &, int);
-  void runJetAlgorithm();
-  bool matchPartonsToJets(int);
-  int  matchPartonsToJetsLight();
-  int  matchPartonsToJetsHeavy();
-  int  matchPartonsToJetsOther();
+  void jetAlgorithmInput(const Pythia8::Event&, int) override;
+  void runJetAlgorithm() override;
+  bool matchPartonsToJets(int) override;
+  int matchPartonsToJetsLight() override;
+  int matchPartonsToJetsHeavy() override;
+  int matchPartonsToJetsOther();
   bool doShowerKtVeto(double pTfirst);
 
   // Functions to clear and set the jet clustering scales.
-  void clearDJR() { DJR.resize(0);}
-  void setDJR( const Pythia8::Event& event);
+  void clearDJR() { DJR.resize(0); }
+  void setDJR(const Pythia8::Event& event);
   // Functions to clear and set the jet clustering scales.
-  void clear_nMEpartons() { nMEpartonsSave.first = nMEpartonsSave.second =-1;}
-  void set_nMEpartons( const int nOrig, const int nMatch) {
+  void clear_nMEpartons() { nMEpartonsSave.first = nMEpartonsSave.second = -1; }
+  void set_nMEpartons(const int nOrig, const int nMatch) {
     clear_nMEpartons();
-    nMEpartonsSave.first  = nOrig;
+    nMEpartonsSave.first = nOrig;
     nMEpartonsSave.second = nMatch;
   };
 
   // Function to get the current number of partons in the Born state, as
   // read from LHE.
   int npNLO();
-  
+
 private:
   Pythia8::Event processSubsetSave;
   Pythia8::Event workEventJetSave;
   double pTfirstSave;
-  
+
   bool performVeto;
 
   Pythia8::vector<int> origTypeIdx[3];
@@ -92,7 +90,6 @@ private:
   Pythia8::vector<double> DJR;
 
   Pythia8::pair<int, int> nMEpartonsSave;
-
 };
 
 // Register in the UserHook factory

--- a/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/JetMatchingEWKFxFx.h
@@ -1,0 +1,100 @@
+#ifndef GeneratorInterface_Pythia8Interface_JetMatchingEWKFxFx_h
+#define GeneratorInterface_Pythia8Interface_JetMatchingEWKFxFx_h
+
+// Class declaration for the new JetMatching plugin
+// Author: Carlos Vico (U. Oviedo)
+// taken from: https://amcatnlo.web.cern.ch/amcatnlo/JetMatching.h
+
+// Includes
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "Pythia8/Pythia.h"
+#include "Pythia8Plugins/JetMatching.h"
+#include "Pythia8Plugins/GeneratorInput.h"
+#include <memory>
+#include "GeneratorInterface/Pythia8Interface/interface/CustomHook.h"
+
+// The plugin must inherit from the original Pythia8::JetMatching
+// class
+
+class JetMatchingEWKFxFx : public Pythia8::JetMatching {
+
+public: 
+  // Constructor and destructor
+  JetMatchingEWKFxFx(const edm::ParameterSet& iConfig);
+  ~JetMatchingEWKFxFx(){}
+  
+  // Method declaration
+  bool initAfterBeams();
+  
+  bool canVetoPartonLevelEarly(){return true;}
+  bool doVetoPartonLevelEarly(const Pythia8::Event& event);
+
+  bool canVetoProcessLevel(){return true;}
+  bool doVetoProcessLevel(Pythia8::Event& event);
+   
+  // Shower step vetoes (after the first emission, for Shower-kT scheme)
+  int  numberVetoStep() {return 1;}
+  bool canVetoStep() { return doShowerKt; }
+  bool doVetoStep(int,  int, int, const Pythia8::Event& );
+
+  Pythia8::SlowJet* slowJetDJR;
+
+  Pythia8::vector<double> getDJR() { return DJR;}
+  Pythia8::pair<int,int> nMEpartons() { return nMEpartonsSave;}
+
+  Pythia8::Event getWorkEventJet() { return workEventJetSave; }
+  Pythia8::Event getProcessSubset() { return processSubsetSave; }
+  bool  getExclusive() { return exclusive; }
+  double getPTfirst() { return pTfirstSave; }
+
+
+  // Different steps of the matching algorithm.
+  void sortIncomingProcess(const Pythia8::Event &);
+
+  void jetAlgorithmInput(const Pythia8::Event &, int);
+  void runJetAlgorithm();
+  bool matchPartonsToJets(int);
+  int  matchPartonsToJetsLight();
+  int  matchPartonsToJetsHeavy();
+  int  matchPartonsToJetsOther();
+  bool doShowerKtVeto(double pTfirst);
+
+  // Functions to clear and set the jet clustering scales.
+  void clearDJR() { DJR.resize(0);}
+  void setDJR( const Pythia8::Event& event);
+  // Functions to clear and set the jet clustering scales.
+  void clear_nMEpartons() { nMEpartonsSave.first = nMEpartonsSave.second =-1;}
+  void set_nMEpartons( const int nOrig, const int nMatch) {
+    clear_nMEpartons();
+    nMEpartonsSave.first  = nOrig;
+    nMEpartonsSave.second = nMatch;
+  };
+
+  // Function to get the current number of partons in the Born state, as
+  // read from LHE.
+  int npNLO();
+  
+private:
+  Pythia8::Event processSubsetSave;
+  Pythia8::Event workEventJetSave;
+  double pTfirstSave;
+  
+  bool performVeto;
+
+  Pythia8::vector<int> origTypeIdx[3];
+  int nQmatch;
+  double qCut, qCutSq, clFact;
+  bool doFxFx;
+  int nPartonsNow;
+  double qCutME, qCutMESq;
+
+  Pythia8::vector<double> DJR;
+
+  Pythia8::pair<int, int> nMEpartonsSave;
+
+};
+
+// Register in the UserHook factory
+REGISTER_USERHOOK(JetMatchingEWKFxFx);
+#endif

--- a/GeneratorInterface/Pythia8Interface/python/FxFxEWK.py
+++ b/GeneratorInterface/Pythia8Interface/python/FxFxEWK.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/afs/cern.ch/user/c/cvicovil/public/TTWJetsToLNu_5f_NLO_FXFX_slc7_amd64_gcc900_CMSSW_12_0_2_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+# Link to datacards:
+# https://github.com/cms-sw/genproductions/tree/5fb3762c8be13dabb89a8580863856201d56f49c/bin/MadGraph5_aMCatNLO/cards/production/2017/13TeV/TTWJets/TTWJetsToLNu_5f_NLO_FXFX
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+from Configuration.Generator.PSweightsPythia.PythiaPSweightsSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        pythia8PSweightsSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:doVeto = off',  # Turn OFF Pythia JetMatching
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 1000',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 42.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 1', #number of partons in born matrix element for highest multiplicity
+        
+        ), 
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'pythia8PSweightsSettings',
+                                    'processParameters',
+                                    )
+    ),
+    UserCustomization = cms.VPSet(
+           cms.PSet(
+             pluginName = cms.string("JetMatchingEWKFxFx"), # Call the new JetMatching plugin
+           )
+        ), 
+)
+

--- a/GeneratorInterface/Pythia8Interface/test/FXFXewk_test.py
+++ b/GeneratorInterface/Pythia8Interface/test/FXFXewk_test.py
@@ -1,0 +1,241 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: GeneratorInterface/Pythia8Interface/python/fxfxEWK.py --python_filename cfg_newLHE_newMatching.py --eventcontent NANOAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAOD --fileout file:NanoGen_newLHE_newMatching.root --conditions 106X_upgrade2018_realistic_v4 --beamspot Realistic25ns13TeVEarly2018Collision --customise_commands process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(161) --step LHE,GEN,NANOGEN --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 1000
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+
+process = cms.Process('NANOGEN',Run2_2018)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('PhysicsTools.NanoAOD.nanogen_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('GeneratorInterface/Pythia8Interface/python/fxfxEWK.py nevts:1000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODSIMoutput = cms.OutputModule("NanoAODOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAOD'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:NanoGen_newLHE_newMatching.root'),
+    outputCommands = process.NANOAODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v4', '')
+
+process.generator = cms.EDFilter("Pythia8HadronizerFilter",
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CP5Settings',
+            'pythia8aMCatNLOSettings',
+            'pythia8PSweightsSettings',
+            'processParameters'
+        ),
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:doVeto = off',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 1000',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 42.',
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 20.',
+            'JetMatching:nQmatch = 5',
+            'JetMatching:nJetMax = 1'
+        ),
+        pythia8CP5Settings = cms.vstring(
+            'Tune:pp 14',
+            'Tune:ee 7',
+            'MultipartonInteractions:ecmPow=0.03344',
+            'MultipartonInteractions:bProfile=2',
+            'MultipartonInteractions:pT0Ref=1.41',
+            'MultipartonInteractions:coreRadius=0.7634',
+            'MultipartonInteractions:coreFraction=0.63',
+            'ColourReconnection:range=5.176',
+            'SigmaTotal:zeroAXB=off',
+            'SpaceShower:alphaSorder=2',
+            'SpaceShower:alphaSvalue=0.118',
+            'SigmaProcess:alphaSvalue=0.118',
+            'SigmaProcess:alphaSorder=2',
+            'MultipartonInteractions:alphaSvalue=0.118',
+            'MultipartonInteractions:alphaSorder=2',
+            'TimeShower:alphaSorder=2',
+            'TimeShower:alphaSvalue=0.118',
+            'SigmaTotal:mode = 0',
+            'SigmaTotal:sigmaEl = 21.89',
+            'SigmaTotal:sigmaTot = 100.309',
+            'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118'
+        ),
+        pythia8CommonSettings = cms.vstring(
+            'Tune:preferLHAPDF = 2',
+            'Main:timesAllowErrors = 10000',
+            'Check:epTolErr = 0.01',
+            'Beams:setProductionScalesFromLHEF = off',
+            'SLHA:minMassSM = 1000.',
+            'ParticleDecays:limitTau0 = on',
+            'ParticleDecays:tau0Max = 10',
+            'ParticleDecays:allowPhotonRadiation = on'
+        ),
+        pythia8PSweightsSettings = cms.vstring(
+            'UncertaintyBands:doVariations = on',
+            'UncertaintyBands:List = {isrRedHi isr:muRfac=0.707,fsrRedHi fsr:muRfac=0.707,isrRedLo isr:muRfac=1.414,fsrRedLo fsr:muRfac=1.414,isrDefHi isr:muRfac=0.5,fsrDefHi fsr:muRfac=0.5,isrDefLo isr:muRfac=2.0,fsrDefLo fsr:muRfac=2.0,isrConHi isr:muRfac=0.25,fsrConHi fsr:muRfac=0.25,isrConLo isr:muRfac=4.0,fsrConLo fsr:muRfac=4.0,fsr_G2GG_muR_dn fsr:G2GG:muRfac=0.5,fsr_G2GG_muR_up fsr:G2GG:muRfac=2.0,fsr_G2QQ_muR_dn fsr:G2QQ:muRfac=0.5,fsr_G2QQ_muR_up fsr:G2QQ:muRfac=2.0,fsr_Q2QG_muR_dn fsr:Q2QG:muRfac=0.5,fsr_Q2QG_muR_up fsr:Q2QG:muRfac=2.0,fsr_X2XG_muR_dn fsr:X2XG:muRfac=0.5,fsr_X2XG_muR_up fsr:X2XG:muRfac=2.0,fsr_G2GG_cNS_dn fsr:G2GG:cNS=-2.0,fsr_G2GG_cNS_up fsr:G2GG:cNS=2.0,fsr_G2QQ_cNS_dn fsr:G2QQ:cNS=-2.0,fsr_G2QQ_cNS_up fsr:G2QQ:cNS=2.0,fsr_Q2QG_cNS_dn fsr:Q2QG:cNS=-2.0,fsr_Q2QG_cNS_up fsr:Q2QG:cNS=2.0,fsr_X2XG_cNS_dn fsr:X2XG:cNS=-2.0,fsr_X2XG_cNS_up fsr:X2XG:cNS=2.0,isr_G2GG_muR_dn isr:G2GG:muRfac=0.5,isr_G2GG_muR_up isr:G2GG:muRfac=2.0,isr_G2QQ_muR_dn isr:G2QQ:muRfac=0.5,isr_G2QQ_muR_up isr:G2QQ:muRfac=2.0,isr_Q2QG_muR_dn isr:Q2QG:muRfac=0.5,isr_Q2QG_muR_up isr:Q2QG:muRfac=2.0,isr_X2XG_muR_dn isr:X2XG:muRfac=0.5,isr_X2XG_muR_up isr:X2XG:muRfac=2.0,isr_G2GG_cNS_dn isr:G2GG:cNS=-2.0,isr_G2GG_cNS_up isr:G2GG:cNS=2.0,isr_G2QQ_cNS_dn isr:G2QQ:cNS=-2.0,isr_G2QQ_cNS_up isr:G2QQ:cNS=2.0,isr_Q2QG_cNS_dn isr:Q2QG:cNS=-2.0,isr_Q2QG_cNS_up isr:Q2QG:cNS=2.0,isr_X2XG_cNS_dn isr:X2XG:cNS=-2.0,isr_X2XG_cNS_up isr:X2XG:cNS=2.0}',
+            'UncertaintyBands:nFlavQ = 4',
+            'UncertaintyBands:MPIshowers = on',
+            'UncertaintyBands:overSampleFSR = 10.0',
+            'UncertaintyBands:overSampleISR = 10.0',
+            'UncertaintyBands:FSRpTmin2Fac = 20',
+            'UncertaintyBands:ISRpTmin2Fac = 1'
+        ),
+        pythia8aMCatNLOSettings = cms.vstring(
+            'SpaceShower:pTmaxMatch = 1',
+            'SpaceShower:pTmaxFudge = 1',
+            'SpaceShower:MEcorrections = off',
+            'TimeShower:pTmaxMatch = 1',
+            'TimeShower:pTmaxFudge = 1',
+            'TimeShower:MEcorrections = off',
+            'TimeShower:globalRecoil = on',
+            'TimeShower:limitPTmaxGlobal = on',
+            'TimeShower:nMaxGlobalRecoil = 1',
+            'TimeShower:globalRecoilMode = 2',
+            'TimeShower:nMaxGlobalBranch = 1',
+            'TimeShower:weightGluonToQuark = 1'
+        )
+    ),
+    UserCustomization = cms.VPSet(cms.PSet(
+        pluginName = cms.string('JetMatchingEWKFxFx')
+    )),
+    comEnergy = cms.double(13000.0),
+    filterEfficiency = cms.untracked.double(1.0),
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    pythiaPylistVerbosity = cms.untracked.int32(1)
+)
+
+
+process.externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/afs/cern.ch/user/c/cvicovil/public/TTWJetsToLNu_5f_NLO_FXFX_slc7_amd64_gcc900_CMSSW_12_0_2_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+
+# Path and EndPath definitions
+process.lhe_step = cms.Path(process.externalLHEProducer)
+process.generation_step = cms.Path(process.pgen)
+process.nanoAOD_step = cms.Path(process.nanogenSequence)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODSIMoutput_step = cms.EndPath(process.NANOAODSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.lhe_step,process.generation_step,process.genfiltersummary_step,process.nanoAOD_step,process.endjob_step,process.NANOAODSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfConcurrentLuminosityBlocks = 1
+process.options.eventSetup.numberOfConcurrentIOVs = 1
+# filter all path with the production filter sequence
+for path in process.paths:
+	if path in ['lhe_step']: continue
+	getattr(process,path).insert(0, process.generator)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.NanoAOD.nanogen_cff
+from PhysicsTools.NanoAOD.nanogen_cff import customizeNanoGEN 
+
+#call to customisation function customizeNanoGEN imported from PhysicsTools.NanoAOD.nanogen_cff
+process = customizeNanoGEN(process)
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.Utils
+from Configuration.DataProcessing.Utils import addMonitoring 
+
+#call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
+process = addMonitoring(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(161)
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/39996, intended for Run3 MC production. I've checked with the GEN conveners and since I'm interested in 2022 production, I would need the plugin in CMSSW_12_4_X. 

**PR description**:

This PR includes a plugin that allows to run an alternative Pythia8 FxFx jet matching prescription. The plugin has been implemented using the PluginFactory and the code has been directly taken from the new JetMaching.h file that can be found [here](http://amcatnlo.web.cern.ch/amcatnlo/FxFx_merging.htm). As stated in the link, this new jet matching algorithm only works in Pythia8.3 and beyond.

New versions of Madgraph5_aMC@NLO (v3.3.0 and beyond) introduce a new clustering procedure that distinguishes between jets that have been generated in a QCD or EWK vertex. This new jet matching prescription is required so the proper treatment of jets is also accounted for in the parton shower (PS) and matrix element matching step.

An example of its usage can be found in [this fragment example](https://github.com/Cvico/cmssw/blob/JetMatchingEWKFxFx/GeneratorInterface/Pythia8Interface/python/FxFxEWK.py). Basically, the user needs to apply two modifications to the common fragments used for FxFx merging:

1) Turn off Pythia8 default matching so new matchings can be add applied UserHooks. This can be done by adding the following line into the process parameters of the fragment:
```
    'JetMatching:doVeto = off',  # Turn OFF Pythia JetMatching
```

2) Include the new matching as a UserHook via the UserCustmization method.
```
    UserCustomization = cms.VPSet(
           cms.PSet(pluginName = cms.string("JetMatchingEWKFxFx"))
           ),
```

**PR validation**:

Tests using the [local config file](https://github.com/Cvico/cmssw/blob/JetMatchingEWKFxFx/GeneratorInterface/Pythia8Interface/python/FxFxEWK.py) show that the JetMatchingEWKFxFx plugin properly matches between Pythia8.3 and MG33X gridpacks.
        A set of preliminary results for ttW production can be found [here](https://indico.cern.ch/event/1192555/contributions/5086026/attachments/2525008/4342613/ttWnewFxFxSample_CarlosVico_TMG10oct.pdf).
