### PR TITLE
Run3JetID

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_cff.py
@@ -18,9 +18,10 @@ from Configuration.Eras.Modifier_run2_L1prefiring_cff import run2_L1prefiring
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
+from Configuration.Eras.Modifier_run2_jme_2018_cff import run2_jme_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
 
 Run2_2018 = cms.ModifierChain(Run2_2017.copyAndExclude([run2_HEPlan1_2017, run2_muon_2017, run2_L1prefiring, run2_HLTconditions_2017, run2_egamma_2017, ctpps_2017, run2_jme_2017]),
 run2_CSC_2018, run2_HCAL_2018, run2_HB_2018, run2_HE_2018,run2_DT_2018, run2_SiPixel_2018, 
-run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, stage2L1Trigger_2018
+run2_HLTconditions_2018, run2_muon_2018, run2_egamma_2018, ctpps_2018, stage2L1Trigger_2018, run2_jme_2018
 )

--- a/Configuration/Eras/python/Modifier_run2_jme_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_jme_2018_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_jme_2018 =cms.Modifier()

--- a/Configuration/Eras/python/Modifier_run3_jme_Winter22runsBCDEprompt_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_jme_Winter22runsBCDEprompt_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_jme_Winter22runsBCDEprompt =cms.Modifier()

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -36,14 +36,14 @@ looseJetId = cms.EDProducer("PatJetIDValueMapProducer",
 )
 tightJetId = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULCHS'),
+        version = cms.string('RUN3WINTER22CHS'),
         quality = cms.string('TIGHT'),
     ),
     src = cms.InputTag("updatedJets")
 )
 tightJetIdLepVeto = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULCHS'),
+        version = cms.string('RUN3WINTER22CHS'),
         quality = cms.string('TIGHTLEPVETO'),
     ),
     src = cms.InputTag("updatedJets")
@@ -52,6 +52,18 @@ run2_jme_2016.toModify(
     tightJetId.filterParams, version = "RUN2UL16CHS"
 ).toModify(
     tightJetIdLepVeto.filterParams, version = "RUN2UL16CHS"
+)
+
+(run2_jme_2017 | run2_jme_2018).toModify(
+    tightJetId.filterParams, version = "RUN2ULCHS"
+).toModify(
+    tightJetIdLepVeto.filterParams, version = "RUN2ULCHS"
+)
+
+run3_jme_Winter22runsBCDEprompt.toModify(
+    tightJetId.filterParams, version = "RUN3WINTER22CHSrunsBCDEprompt"
+).toModify(
+    tightJetIdLepVeto.filterParams, version = "RUN3WINTER22CHSrunsBCDEprompt"
 )
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -27,14 +27,14 @@ updatedJetsPuppi = updatedPatJets.clone(
 
 tightJetPuppiId = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULPUPPI'),
+        version = cms.string('RUN3WINTER22PUPPI'),
         quality = cms.string('TIGHT'),
     ),
     src = cms.InputTag("updatedJetsPuppi")
 )
 tightJetPuppiIdLepVeto = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULPUPPI'),
+        version = cms.string('RUN3WINTER22PUPPI'),
         quality = cms.string('TIGHTLEPVETO'),
     ),
     src = cms.InputTag("updatedJetsPuppi")

--- a/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
@@ -35,14 +35,14 @@ looseJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
 )
 tightJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULPUPPI'),
+        version = cms.string('RUN3WINTER22PUPPI'),
         quality = cms.string('TIGHT'),
     ),
     src = cms.InputTag("updatedJetsAK8")
 )
 tightJetIdLepVetoAK8 = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN2ULPUPPI'),
+        version = cms.string('RUN3WINTER22PUPPI'),
         quality = cms.string('TIGHTLEPVETO'),
     ),
     src = cms.InputTag("updatedJetsAK8")
@@ -52,6 +52,18 @@ run2_jme_2016.toModify(
     tightJetIdAK8.filterParams, version = "RUN2UL16PUPPI"
 ).toModify(
     tightJetIdLepVetoAK8.filterParams, version = "RUN2UL16PUPPI"
+)
+
+(run2_jme_2017 | run2_jme_2018).toModify(
+    tightJetIdAK8.filterParams, version = "RUN2ULPUPPI"
+).toModify(
+    tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI"
+)
+
+run3_jme_Winter22runsBCDEprompt.toModify(
+    tightJetIdAK8.filterParams, version = "RUN3WINTER22PUPPIrunsBCDEprompt"
+).toModify(
+    tightJetIdLepVetoAK8.filterParams, version = "RUN3WINTER22PUPPIrunsBCDEprompt"
 )
 
 updatedJetsAK8WithUserData = cms.EDProducer("PATJetUserDataEmbedder",

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -3,6 +3,7 @@ from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
+from Configuration.Eras.Modifier_run2_jme_2018_cff import run2_jme_2018
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 from Configuration.Eras.Modifier_run2_muon_2018_cff import run2_muon_2018
 
@@ -15,6 +16,7 @@ from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_v
 
 from Configuration.Eras.Modifier_run3_nanoAOD_122_cff import run3_nanoAOD_122
 from Configuration.Eras.Modifier_run3_nanoAOD_124_cff import run3_nanoAOD_124
+from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3_jme_Winter22runsBCDEprompt
 
 run2_nanoAOD_ANY = (
     run2_nanoAOD_106Xv2

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -37,6 +37,10 @@ public:  // interface
     SUMMER18PUPPI,
     RUN2UL16CHS,
     RUN2UL16PUPPI,
+    RUN3WINTER22CHSrunsBCDEprompt,
+    RUN3WINTER22PUPPIrunsBCDEprompt,
+    RUN3WINTER22CHS,
+    RUN3WINTER22PUPPI,
     RUN2ULCHS,
     RUN2ULPUPPI,
     N_VERSIONS
@@ -76,8 +80,16 @@ public:  // interface
       version_ = RUN2ULCHS;
     else if (versionStr == "RUN2ULPUPPI")
       version_ = RUN2ULPUPPI;
+    else if (versionStr == "RUN3WINTER22CHSrunsBCDEprompt")
+      version_ = RUN3WINTER22CHSrunsBCDEprompt;
+    else if (versionStr == "RUN3WINTER22PUPPIrunsBCDEprompt")
+      version_ = RUN3WINTER22PUPPIrunsBCDEprompt;
+    else if (versionStr == "RUN3WINTER22CHS")
+      version_ = RUN3WINTER22CHS;
+    else if (versionStr == "RUN3WINTER22PUPPI")
+      version_ = RUN3WINTER22PUPPI;
     else
-      version_ = RUN2ULCHS;  //set RUN2ULCHS as default //this is extremely unsafe
+      version_ = RUN3WINTER22PUPPI;  //set RUN3WINTER22PUPPI as default //this is extremely unsafe
 
     if (qualityStr == "LOOSE")
       quality_ = LOOSE;
@@ -119,7 +131,7 @@ public:  // interface
   static edm::ParameterSetDescription getDescription() {
     edm::ParameterSetDescription desc;
 
-    desc.ifValue(edm::ParameterDescription<std::string>("version", "RUN2ULCHS", true, edm::Comment("")),
+    desc.ifValue(edm::ParameterDescription<std::string>("version", "RUN3WINTER22PUPPI", true, edm::Comment("")),
                  edm::allowedValues<std::string>("FIRSTDATA",
                                                  "RUNIISTARTUP",
                                                  "WINTER16",
@@ -130,7 +142,11 @@ public:  // interface
                                                  "RUN2UL16CHS",
                                                  "RUN2UL16PUPPI",
                                                  "RUN2ULCHS",
-                                                 "RUN2ULPUPPI"));
+                                                 "RUN2ULPUPPI",
+                                                 "RUN3WINTER22CHSrunsBCDEprompt",
+                                                 "RUN3WINTER22PUPPIrunsBCDEprompt",
+                                                 "RUN3WINTER22CHS",
+                                                 "RUN3WINTER22PUPPI"));
     desc.ifValue(edm::ParameterDescription<std::string>("quality", "TIGHT", true, edm::Comment("")),
                  edm::allowedValues<std::string>("LOOSE", "TIGHT", "TIGHTLEPVETO"));
     desc.addOptional<std::vector<std::string>>("cutsToIgnore")->setComment("");
@@ -195,7 +211,9 @@ public:  // interface
   bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
         version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
-        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
+        version_ == RUN2UL16PUPPI || version_ == RUN3WINTER22CHSrunsBCDEprompt ||
+        version_ == RUN3WINTER22PUPPIrunsBCDEprompt || version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI ||
+        version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
         return firstDataCuts(jet, ret, version_);
       else
@@ -213,7 +231,9 @@ public:  // interface
   bool operator()(const reco::PFJet &jet, pat::strbitset &ret) {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
         version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
-        version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
+        version_ == RUN2UL16PUPPI || version_ == RUN3WINTER22CHSrunsBCDEprompt ||
+        version_ == RUN3WINTER22PUPPIrunsBCDEprompt || version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI ||
+        version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
       return firstDataCuts(jet, ret, version_);
     } else {
       return false;
@@ -359,10 +379,14 @@ public:  // interface
 
     float etaB = 2.4;
     // Cuts for |eta| < 2.6 for Summer18
-    if (version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI)
+    if (version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI ||
+        version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
+        version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
       etaB = 2.6;
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN3WINTER22CHSrunsBCDEprompt &&
+         version_ != RUN3WINTER22PUPPIrunsBCDEprompt && version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI &&
+         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > etaB))
         passCut(ret, indexCEF_);
@@ -569,7 +593,8 @@ public:  // interface
           (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
         passCut(ret, indexNNeutrals_FW_U_);
 
-    } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
+    } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
+               (version_ == RUN3WINTER22CHS)) {
       // Cuts for |eta| <= 2.6 for SUMMER18 scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.6))
@@ -622,7 +647,8 @@ public:  // interface
         passCut(ret, indexNNeutrals_FW_);
     }
 
-    else if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
+    else if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) ||
+             (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) || (version_ == RUN3WINTER22PUPPI)) {
       // Cuts for |eta| <= 2.6 for SUMMER18PUPPI scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.6))
@@ -682,7 +708,9 @@ private:  // member variables
     push_back("CHF");
     push_back("NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
+         version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
+         version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI) ||
         quality_ != TIGHT)
       push_back("CEF");
     push_back("NEF");
@@ -747,7 +775,8 @@ private:  // member variables
         push_back("MUF");
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
+        (version_ == RUN3WINTER22CHS)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");
@@ -764,7 +793,8 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) ||
+        (version_ == RUN3WINTER22PUPPI)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NHF_EC");
@@ -781,7 +811,9 @@ private:  // member variables
     }
 
     if ((version_ == WINTER17 || version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI ||
-         version_ == RUN2UL16CHS || version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) &&
+         version_ == RUN2UL16CHS || version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI ||
+         version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
+         version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) &&
         quality_ == LOOSE) {
       edm::LogWarning("BadJetIDVersion")
           << "The LOOSE operating point is only supported for the WINTER16 JetID version -- defaulting to TIGHT";
@@ -810,8 +842,15 @@ private:  // member variables
       set("CHF", 0.0);
       set("NHF", 0.9);
       if (version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI)
+          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
+          version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
+          version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI)
         set("CEF", 0.99);
+      if (version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
+          version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
+        set("CHF", 0.01);
+      if (version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
+        set("NHF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
@@ -872,7 +911,7 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN2ULCHS) {
+      } else if (version_ == RUN2ULCHS || version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22CHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NCH_TR", 0);
@@ -882,7 +921,7 @@ private:  // member variables
         set("NHF_FW", 0.2);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
-      } else if (version_ == RUN2ULPUPPI) {
+      } else if (version_ == RUN2ULPUPPI || version_ == RUN3WINTER22PUPPIrunsBCDEprompt) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NHF_EC", 0.9999);
@@ -890,30 +929,42 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
+      } else if (version_ == RUN3WINTER22PUPPI) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.9999);
+        set("NHF_FW", -1.0);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 1);
+        set("nNeutrals_FW_U", 999999);
       }
     } else if (quality_ == TIGHTLEPVETO) {
       set("CHF", 0.0);
       set("NHF", 0.9);
+      set("CEF", 0.8);
       set("NEF", 0.9);
       set("NCH", 0);
       set("nConstituents", 1);
+      set("MUF", 0.8);
       if (version_ == WINTER17) {
-        set("CEF", 0.8);
         set("NEF_EC_L", 0.02);
         set("NEF_EC_U", 0.99);
         set("nNeutrals_EC", 2);
         set("NHF_FW", 0.02);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
-        set("MUF", 0.8);
+      }
+      if (version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
+          version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) {
+        set("CHF", 0.01);
+      } else if (version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) {
+        set("NHF", 0.99);
       } else if (version_ == WINTER17PUPPI) {
-        set("CEF", 0.8);
         set("NHF_EC", 0.99);
         set("NHF_FW", 0.02);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
-        set("MUF", 0.8);
       } else if (version_ == WINTER16) {
         set("CEF", 0.9);
         set("NEF_EC", 0.01);
@@ -921,15 +972,12 @@ private:  // member variables
         set("nNeutrals_EC", 2);
         set("nNeutrals_FW", 10);
         set("NEF_FW", 0.90);
-        set("MUF", 0.8);
       } else if (version_ == WINTER17PUPPI) {
-        set("CEF", 0.8);
         set("NHF_EC", 0.99);
         set("NHF_FW", 0.02);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
-        set("MUF", 0.8);
       } else if (version_ == WINTER16) {
         set("CEF", 0.9);
         set("NEF_EC", 0.01);
@@ -937,10 +985,7 @@ private:  // member variables
         set("nNeutrals_EC", 2);
         set("nNeutrals_FW", 10);
         set("NEF_FW", 0.90);
-        set("MUF", 0.8);
       } else if (version_ == SUMMER18) {
-        set("CEF", 0.8);
-        set("MUF", 0.8);
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -953,8 +998,6 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
       } else if (version_ == SUMMER18PUPPI) {
-        set("CEF", 0.8);
-        set("MUF", 0.8);
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -965,8 +1008,6 @@ private:  // member variables
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 15);
       } else if (version_ == RUN2UL16CHS) {
-        set("MUF", 0.8);
-        set("CEF", 0.8);
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NHF_EC", 0.9);
@@ -977,17 +1018,13 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
       } else if (version_ == RUN2UL16PUPPI) {
-        set("MUF", 0.8);
-        set("CEF", 0.8);
         set("NHF_TR", 0.98);
         set("NEF_TR", 0.99);
         set("nNeutrals_EC", 1);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN2ULCHS) {
-        set("CEF", 0.8);
-        set("MUF", 0.8);
+      } else if (version_ == RUN2ULCHS || version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22CHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -999,9 +1036,7 @@ private:  // member variables
         set("NHF_FW", 0.2);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
-      } else if (version_ == RUN2ULPUPPI) {
-        set("CEF", 0.8);
-        set("MUF", 0.8);
+      } else if (version_ == RUN2ULPUPPI || version_ == RUN3WINTER22PUPPIrunsBCDEprompt) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -1010,6 +1045,16 @@ private:  // member variables
         set("NHF_FW", -1.0);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
+        set("nNeutrals_FW_U", 999999);
+      } else if (version_ == RUN3WINTER22PUPPI) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("MUF_TR", 0.8);
+        set("CEF_TR", 0.8);
+        set("NHF_EC", 0.9999);
+        set("NHF_FW", -1.0);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 1);
         set("nNeutrals_FW_U", 999999);
       }
     }
@@ -1020,7 +1065,9 @@ private:  // member variables
     indexNEF_ = index_type(&bits_, "NEF");
     indexNHF_ = index_type(&bits_, "NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
+         version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
+         version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI) ||
         quality_ != TIGHT)
       indexCEF_ = index_type(&bits_, "CEF");
 
@@ -1061,7 +1108,8 @@ private:  // member variables
         indexMUF_ = index_type(&bits_, "MUF");
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
+        (version_ == RUN3WINTER22CHS)) {
       indexNHF_TR_ = index_type(&bits_, "NHF_TR");
       indexNEF_TR_ = index_type(&bits_, "NEF_TR");
       indexNCH_TR_ = index_type(&bits_, "NCH_TR");
@@ -1077,7 +1125,8 @@ private:  // member variables
         indexCEF_TR_ = index_type(&bits_, "CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) ||
+        (version_ == RUN3WINTER22PUPPI)) {
       indexNHF_TR_ = index_type(&bits_, "NHF_TR");
       indexNEF_TR_ = index_type(&bits_, "NEF_TR");
       indexNHF_EC_ = index_type(&bits_, "NHF_EC");


### PR DESCRIPTION
#### PR description:
This PR implements the new Run3 JetID criteria and makes them the default. It also creates a new modifier for general Run2 and for the Run3 BCDEprompt.

Relevant presentations and twiki's:

https://indico.cern.ch/event/1212177/contributions/5119544/attachments/2538364/4371070/JetIDrecommendations_Run3_01112022.pdf
https://indico.cern.ch/event/1223865/contributions/5171746/attachments/2561170/4424192/RunF_JetID_jmar_13_December_2022.pdf
https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV


#### PR validation:

Tested a subset of workflows (136.88811 and jetmc) and they ran successfully.

@etzia @nurfikri89 
