### PR TITLE
BTL geometry: fixed overlaps

### DIFF
--- a/Geometry/MTDCommonData/data/btl/v2/btl.xml
+++ b/Geometry/MTDCommonData/data/btl/v2/btl.xml
@@ -1480,8 +1480,8 @@
       <Numeric name="Tilt" value="0*deg"/>
       <Numeric name="StartAngle" value="4.7368421*deg"/>
       <Numeric name="RangeAngle" value="350.52632*deg"/>
-      <Numeric name="RadiusIn" value="1176.15*mm"/>
-      <Numeric name="RadiusOut" value="1176.15*mm"/>
+      <Numeric name="RadiusIn" value="1176.25*mm"/>
+      <Numeric name="RadiusOut" value="1176.25*mm"/>
       <Numeric name="ZPosition" value="1286*mm"/>
       <Numeric name="Number" value="38"/>
       <Numeric name="StartCopyNo" value="1"/>
@@ -1493,8 +1493,8 @@
       <Numeric name="Tilt" value="0*deg"/>
       <Numeric name="StartAngle" value="4.7368421*deg"/>
       <Numeric name="RangeAngle" value="350.52632*deg"/>
-      <Numeric name="RadiusIn" value="1176.15*mm"/>
-      <Numeric name="RadiusOut" value="1176.15*mm"/>
+      <Numeric name="RadiusIn" value="1176.25*mm"/>
+      <Numeric name="RadiusOut" value="1176.25*mm"/>
       <Numeric name="ZPosition" value="-1286*mm"/>
       <Numeric name="Number" value="38"/>
       <Numeric name="StartCopyNo" value="39"/>


### PR DESCRIPTION
This PR introduces a minor fix to the BTL geometry to pass the overlapping test with a tolerance of 10 µm. Previous checks had been done at 100-µm tolerance. 
(@fabiocos @bsunanda @civanch) 

During checks for PR #40704, a small overlap between the top bar of the BTL rails and the tray volumes was found. To avoid the overlaps, the Rail3 volumes have been moved out radially by 100 µm.

The updated geometry has been tested with:
g4OverlapCheck2026DD4hep_cfg.py geometry=D96 tol=0.01
No overlaps have been detected.