### PR TITLE
Moved PFClusterProducer from beginLuminosityBlock to beginRun

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -25,7 +25,7 @@ public:
       : PFRecHitNavigatorBase(iConfig, cc),
         neighbourmapcalculated_(false),
         crossBarrelEndcapBorder_(iConfig.getParameter<bool>("crossBarrelEndcapBorder")),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -32,7 +32,7 @@ public:
         recHitToken_(cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
         triggerTowerMap_(nullptr),
         geomToken_(cc.esConsumes()),
-        towerToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+        towerToken_(cc.esConsumes<edm::Transition::BeginRun>()) {
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
       srFlagToken_ = cc.consumes<EBSrFlagCollection>(srF);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -34,7 +34,7 @@ public:
         recHitToken_(cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"))),
         elecMap_(nullptr),
         geomToken_(cc.esConsumes()),
-        mappingToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+        mappingToken_(cc.esConsumes<edm::Transition::BeginRun>()) {
     auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
     if (not srF.label().empty())
       srFlagToken_ = cc.consumes<EESrFlagCollection>(srF);

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -33,8 +33,8 @@ public:
 
   PFHCALDenseIdNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : vhcalEnum_(iConfig.getParameter<std::vector<int>>("hcalEnums")),
-        hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()),
+        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     bool check = theRecNumberWatcher_.check(iSetup);

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
@@ -36,7 +36,7 @@ public:
         _esGeom(nullptr),
         _esPlus(false),
         _esMinus(false),
-        _geomToken(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+        _geomToken(cc.esConsumes<edm::Transition::BeginRun>()) {
     _timeResolutionCalc.reset(nullptr);
     if (conf.exists("timeResolutionCalc")) {
       const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalc");

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -20,7 +20,7 @@ private:
 DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, ECALPFSeedCleaner, "ECALPFSeedCleaner");
 
 ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf, edm::ConsumesCollector& cc)
-    : RecHitTopologicalCleanerBase(conf, cc), thsToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+    : RecHitTopologicalCleanerBase(conf, cc), thsToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
 void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) { ths_ = iSetup.getHandle(thsToken_); }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -15,7 +15,7 @@ class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
 public:
   PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -30,7 +30,7 @@ class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
 public:
   PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -44,7 +44,7 @@ private:
 class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId, EcalBarrelTopology> {
 public:
   PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -58,7 +58,7 @@ private:
 class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId, EcalEndcapTopology> {
 public:
   PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -85,7 +85,7 @@ public:
 class PFRecHitHCALNavigator : public PFRecHitCaloNavigator<HcalDetId, HcalTopology, false> {
 public:
   PFRecHitHCALNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
@@ -101,7 +101,7 @@ class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalD
 public:
   PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
       : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        hcalToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);
@@ -116,7 +116,7 @@ private:
 class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId, CaloTowerTopology> {
 public:
   PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : caloToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+      : caloToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloTowerTopology> caloTowerTopology = iSetup.getHandle(caloToken_);

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -14,8 +14,7 @@
 class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId, EcalBarrelTopology> {
 public:
   PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc), geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -29,8 +28,7 @@ private:
 class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId, EcalEndcapTopology> {
 public:
   PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc), geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle = iSetup.getHandle(geomToken_);
@@ -100,8 +98,7 @@ private:
 class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId, HcalTopology, false> {
 public:
   PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitCaloNavigatorWithTime(iConfig, cc),
-        hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
+      : PFRecHitCaloNavigatorWithTime(iConfig, cc), hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   void init(const edm::EventSetup& iSetup) override {
     edm::ESHandle<HcalTopology> hcalTopology = iSetup.getHandle(hcalToken_);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -19,7 +19,7 @@ public:
   PFClusterProducer(const edm::ParameterSet&);
   ~PFClusterProducer() override = default;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -106,7 +106,7 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
   produces<reco::PFClusterCollection>();
 }
 
-void PFClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
+void PFClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   _initialClustering->update(es);
   if (_pfClusterBuilder)
     _pfClusterBuilder->update(es);

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -21,7 +21,7 @@ public:
   PFMultiDepthClusterProducer(const edm::ParameterSet&);
   ~PFMultiDepthClusterProducer() override = default;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -66,7 +66,7 @@ PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet
   produces<reco::PFClusterCollection>();
 }
 
-void PFMultiDepthClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
+void PFMultiDepthClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   _pfClusterBuilder->update(es);
 }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -22,8 +22,7 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
-  void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
+  void beginRun(edm::Run const&, const edm::EventSetup&) override;
   std::vector<std::unique_ptr<PFRecHitCreatorBase> > creators_;
   std::unique_ptr<PFRecHitNavigatorBase> navigator_;
   bool init_;
@@ -61,14 +60,12 @@ PFRecHitProducer::~PFRecHitProducer() = default;
 // member functions
 //
 
-void PFRecHitProducer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup& iSetup) {
+void PFRecHitProducer::beginRun(edm::Run const& iRun, const edm::EventSetup& iSetup) {
   for (const auto& creator : creators_) {
     creator->init(iSetup);
   }
   navigator_->init(iSetup);
 }
-
-void PFRecHitProducer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup&) {}
 
 // ------------ method called to produce the data  ------------
 void PFRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -36,7 +36,7 @@ public:
         hadronCalib_(conf.getParameter<std::vector<double> >("hadronCalib")),
         egammaCalib_(conf.getParameter<std::vector<double> >("egammaCalib")),
         simClusterToken_(cc.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"))),
-        geomToken_(cc.esConsumes<edm::Transition::BeginLuminosityBlock>()) {}
+        geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
   ~RealisticSimClusterMapper() override {}
   RealisticSimClusterMapper(const RealisticSimClusterMapper&) = delete;


### PR DESCRIPTION
#### PR description:

This is a follow-up to #33652. Functions in PFClusterProducer were sectioned by luminosity block, but this was unnecessary so a change was made to section by run.

#### PR validation:

`runTheMatrix.py -l limited -i all --ibeos` performed and passed

Additionally performed PF specific [validation](https://hep.baylor.edu/jsamudio/beginRunPFVal/plots/)

@hatakeyamak @juska @kdlong 
