### PR TITLE
[TkAl] Further fixes to JetHT Validation

### DIFF
--- a/Alignment/OfflineValidation/bin/jetHtPlotter.cc
+++ b/Alignment/OfflineValidation/bin/jetHtPlotter.cc
@@ -1,3 +1,6 @@
+// framework includes
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
 // C++ includes
 #include <iostream>  // Input/output stream. Needed for cout.
 #include <vector>
@@ -256,7 +259,7 @@ std::tuple<std::vector<int>, std::vector<double>, std::vector<TString>, std::vec
   double thisLumi;
 
   // Load the iovList
-  std::ifstream iovList(inputFile);
+  std::ifstream iovList(edm::FileInPath(inputFile).fullPath().c_str());
 
   // Go through the file line by line. Each line has an IOV boundary and luminosity for this IOV.
   while (std::getline(iovList, lineInFile)) {

--- a/Alignment/OfflineValidation/bin/jetHtPlotter.cc
+++ b/Alignment/OfflineValidation/bin/jetHtPlotter.cc
@@ -46,7 +46,7 @@ void drawSingleHistogram(TH1D *histogram[kMaxFiles],
                          bool logScale,
                          int color[kMaxFiles]) {
   // Create and setup the histogram drawer
-  const auto &drawer = std::make_unique<JDrawer>();
+  JDrawer *drawer = new JDrawer();
   drawer->SetLogY(logScale);
   drawer->SetTopMargin(0.08);
 
@@ -812,7 +812,7 @@ void jetHtPlotter(std::string configurationFileName) {
   //                  Draw the plots
   // ===============================================
 
-  const auto &drawer = std::make_unique<JDrawer>();
+  JDrawer *drawer = new JDrawer();
   TLegend *legend[nMaxLegendColumns];
   int columnOrder[nMaxLegendColumns];
   bool noIovFound = true;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -5,6 +5,7 @@ here doing refit of tracks and vertices using latest alignment
 
 # Define the process
 import FWCore.ParameterSet.Config as cms
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_JetHTRun2018D
 process = cms.Process("JetHTAnalyzer")
 
 # Choose whether to run with Monte Carlo or data settings based on command line argument
@@ -169,9 +170,7 @@ else:
     else:
         print(">>>>>>>>>> JetHT_cfg.py: msg%-i: Default file read from 2018D JetHT dataset.")
         process.source = cms.Source("PoolSource",
-                              fileNames = cms.untracked.vstring('root://xrootd-cms.infn.it//store/data/Run2018D/JetHT/ALCARECO/TkAlMinBias-12Nov2019_UL2018-v4/00000/009085FF-603B-044D-8879-0599B156831D.root') # A file from 2018 JetHT file in DESY
-
-                              )
+                                    fileNames = filesDefaultData_JetHTRun2018D)
 
 ####################################################################
 # Global tag

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -264,7 +264,7 @@ if not (triggerFilter == "nothing" or triggerFilter == ""):
 ###################################################################
 # The analysis module
 ###################################################################
-from Alignment.OfflineValidation.jetHTAnalyzer_cfi.py import jetHTAnalyzer as _jetHTAnalyzer
+from Alignment.OfflineValidation.jetHTAnalyzer_cfi import jetHTAnalyzer as _jetHTAnalyzer
 process.jetHTAnalyzer = _jetHTAnalyzer.clone(
                                        vtxCollection       = "offlinePrimaryVerticesFromRefittedTrks",
                                        trackCollection	   = "TrackRefitter",

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -18,6 +18,11 @@
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testingScripts/test_unitSplitV.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
+  <bin file="testAlignmentOfflineValidation.cpp" name="JetHTall">
+    <flags PRE_TEST="validateAlignments"/>
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testingScripts/test_unitJetHT.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
   <bin file="testAlignmentOfflineValidation.cpp" name="GCPall">
     <flags PRE_TEST="validateAlignments"/>
     <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testingScripts/test_unitGCP.sh"/>

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
@@ -16,3 +16,7 @@ cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_yaml/JetHT/merge/testJo
 echo "TESTING JetHT plotting"
 cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_yaml/JetHT/plot/testJob/
 ./run.sh || die "Failure running JetHT plotting" $?
+
+echo "TESTING JetHT multi-IOV plotting"
+cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/examples
+jetHtPlotter jetHt_multiYearTrendPlot.json || die "Failure running multi-IOV JetHT plotting" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitJetHT.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Alignment/JetHT single configuration with json..."
+cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_yaml/JetHT/single/testJob/unitTestJetHT
+./cmsRun validation_cfg.py config=validation.json || die "Failure running JetHT single configuration with json" $?
+
+echo "TESTING Alignment/JetHT single configuration standalone..."
+./cmsRun validation_cfg.py || die "Failure running JetHT single configuration standalone" $?
+
+echo "TESTING JetHT merge step"
+cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_yaml/JetHT/merge/testJob/unitTestJetHT
+./run.sh || die "Failure running JetHT merge step" $?
+
+echo "TESTING JetHT plotting"
+cd $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_yaml/JetHT/plot/testJob/
+./run.sh || die "Failure running JetHT plotting" $?


### PR DESCRIPTION
#### PR description:

This PR fixes another couple of bugs reported by @jusaviin in the context of running the JetHT validation (see report at the Tracker Alignment meeting of [7th of Feb 2023](https://indico.cern.ch/event/1243355/contributions/5249350/attachments/2589130/4467472/jussi_jetHtStatus_2023-02-07.pdf)).
These were mostly related to plotting:
   * afa5f3390e1a322395ff990d7a4c846fd006f528 undoes a part of https://github.com/cms-sw/cmssw/commit/1d2058c0829242fd5388aa490103ab79d069b166 which cause the destructor of `JDrawer` to segfault. 
   * 92f63b8527c09e67c653e6e7a5ce3334caf53d3f complies with the fact that now the input luminosity files are taken from `cms-data` (following https://github.com/cms-data/Alignment-OfflineValidation/pull/3)
   * 33b6fc0c2cf91dc2cb813d40eab1b36c86297735 fixes a mistake unintentionally introduced in PR https://github.com/cms-sw/cmssw/pull/40695 when including the auto-generated cfi 
   * eb133b4ea3422f629d1f831e6d14e6c3978885cb adds a complete set of unit tests, to avoid similar mistakes arising again in the future.

#### PR validation:

Relies on the existing (and augmented) unit tests: `scram b runtests_JetHTall`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A