### PR TITLE
fix mg_reweighting

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -841,7 +841,7 @@ public:
             }
           } else if (std::regex_search(lines[iLine], groups, weightgroupRwgt)) {
             std::string groupname = groups.str(1);
-            if (groupname == "mg_reweighting") {
+            if (groupname.find("mg_reweighting") != std::string::npos) {
               if (lheDebug)
                 std::cout << ">>> Looks like a LHE weights for reweighting" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {


### PR DESCRIPTION
#### PR description:

Solve the problem that NanoAOD cannot store the ReweightingWeight of MC samples generated with MG5.

#### PR validation:

Validated in this [link](https://cms-talk.web.cern.ch/t/problems-with-lhereweightingweight-in-new-ul-aqgc-samples/8861) and the private UL samples.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

The original PR is [#37508](https://github.com/cms-sw/cmssw/pull/37508), which aims to make NanoAOD able to store ReweightingWeight.
