### PR TITLE
Run3-gex151 Replace std::cout with messagelogger stareents in Geometry/EcalAlgo

### DIFF
--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -162,12 +162,14 @@ void EcalEndcapGeometry::initializeParms() {
   m_del += m_wref;
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("EcalGeom")<<"zeP="<<zeP<<", zeN="<<zeN<<", nP="<<nP<<", nN="<<nN;
+  edm::LogVerbatim("EcalGeom") << "zeP=" << zeP << ", zeN=" << zeN << ", nP=" << nP << ", nN=" << nN;
 
-  edm::LogVerbatim("EcalGeom")<<"xlo[0]="<<m_xlo[0]<<", xlo[1]="<<m_xlo[1]<<", xhi[0]="<<m_xhi[0]<<", xhi[1]="<<m_xhi[1]
-			      <<"\nylo[0]="<<m_ylo[0]<<", ylo[1]="<<m_ylo[1]<<", yhi[0]="<<m_yhi[0]<<", yhi[1]="<<m_yhi[1];
+  edm::LogVerbatim("EcalGeom") << "xlo[0]=" << m_xlo[0] << ", xlo[1]=" << m_xlo[1] << ", xhi[0]=" << m_xhi[0]
+                               << ", xhi[1]=" << m_xhi[1] << "\nylo[0]=" << m_ylo[0] << ", ylo[1]=" << m_ylo[1]
+                               << ", yhi[0]=" << m_yhi[0] << ", yhi[1]=" << m_yhi[1];
 
-  edm::LogVerbatim("EcalGeom")<<"xoff[0]="<<m_xoff[0]<<", xoff[1]"<<m_xoff[1]<<", yoff[0]="<<m_yoff[0]<<", yoff[1]"<<m_yoff[1];
+  edm::LogVerbatim("EcalGeom") << "xoff[0]=" << m_xoff[0] << ", xoff[1]" << m_xoff[1] << ", yoff[0]=" << m_yoff[0]
+                               << ", yoff[1]" << m_yoff[1];
 
   edm::LogVerbatim("EcalGeom") << "nref=" << m_nref << ", m_wref=" << m_wref;
 #endif

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -2,6 +2,7 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/CaloGeometry/interface/TruncatedPyramid.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include <CLHEP/Geometry/Point3D.h>
 #include <CLHEP/Geometry/Plane3D.h>
@@ -10,6 +11,8 @@ typedef CaloCellGeometry::CCGFloat CCGFloat;
 typedef CaloCellGeometry::Pt3D Pt3D;
 typedef CaloCellGeometry::Pt3DVec Pt3DVec;
 typedef HepGeom::Plane3D<CCGFloat> Pl3D;
+
+//#define EDM_ML_DEBUG
 
 EcalEndcapGeometry::EcalEndcapGeometry(void)
     : _nnmods(316),
@@ -157,16 +160,17 @@ void EcalEndcapGeometry::initializeParms() {
   m_yhi[1] += m_wref / 2;
 
   m_del += m_wref;
-  /*
-  std::cout<<"zeP="<<zeP<<", zeN="<<zeN<<", nP="<<nP<<", nN="<<nN<<std::endl ;
 
-  std::cout<<"xlo[0]="<<m_xlo[0]<<", xlo[1]="<<m_xlo[1]<<", xhi[0]="<<m_xhi[0]<<", xhi[1]="<<m_xhi[1]
-	   <<"\nylo[0]="<<m_ylo[0]<<", ylo[1]="<<m_ylo[1]<<", yhi[0]="<<m_yhi[0]<<", yhi[1]="<<m_yhi[1]<<std::endl ;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom")<<"zeP="<<zeP<<", zeN="<<zeN<<", nP="<<nP<<", nN="<<nN;
 
-  std::cout<<"xoff[0]="<<m_xoff[0]<<", xoff[1]"<<m_xoff[1]<<", yoff[0]="<<m_yoff[0]<<", yoff[1]"<<m_yoff[1]<<std::endl ;
+  edm::LogVerbatim("EcalGeom")<<"xlo[0]="<<m_xlo[0]<<", xlo[1]="<<m_xlo[1]<<", xhi[0]="<<m_xhi[0]<<", xhi[1]="<<m_xhi[1]
+			      <<"\nylo[0]="<<m_ylo[0]<<", ylo[1]="<<m_ylo[1]<<", yhi[0]="<<m_yhi[0]<<", yhi[1]="<<m_yhi[1];
 
-  std::cout<<"nref="<<m_nref<<", m_wref="<<m_wref<<std::endl ;
-*/
+  edm::LogVerbatim("EcalGeom")<<"xoff[0]="<<m_xoff[0]<<", xoff[1]"<<m_xoff[1]<<", yoff[0]="<<m_yoff[0]<<", yoff[1]"<<m_yoff[1];
+
+  edm::LogVerbatim("EcalGeom") << "nref=" << m_nref << ", m_wref=" << m_wref;
+#endif
 }
 
 unsigned int EcalEndcapGeometry::xindex(CCGFloat x, CCGFloat z) const {

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -164,8 +164,9 @@ DetId EcalPreshowerGeometry::getClosestCellInPlane(const GlobalPoint& point, int
 
   const int jz(0 > ze ? -1 : 1);
 
-  //   std::cout<<"** p="<<point<<", ("<<xe<<", "<<ye<<", "<<ze<<"), row="<<row<<", col="<<col<<std::endl;
-
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("EcalGeom")<<"** p="<<point<<", ("<<xe<<", "<<ye<<", "<<ze<<"), row="<<row<<", col="<<col;
+#endif
   for (int ix(-1); ix != 2; ++ix)  // search within +-1 in row and col
   {
     for (int iy(-1); iy != 2; ++iy) {

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -165,7 +165,8 @@ DetId EcalPreshowerGeometry::getClosestCellInPlane(const GlobalPoint& point, int
   const int jz(0 > ze ? -1 : 1);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("EcalGeom")<<"** p="<<point<<", ("<<xe<<", "<<ye<<", "<<ze<<"), row="<<row<<", col="<<col;
+  edm::LogVerbatim("EcalGeom") << "** p=" << point << ", (" << xe << ", " << ye << ", " << ze << "), row=" << row
+                               << ", col=" << col;
 #endif
   for (int ix(-1); ix != 2; ++ix)  // search within +-1 in row and col
   {

--- a/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -11,6 +12,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 typedef EZArrayFL<GlobalPoint> CornersVec;
 
@@ -34,8 +36,8 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
   const CaloSubdetectorGeometry* ecalGeom =
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
 
-  std::cout << "\n\nStudy Detector = Ecal SubDetector = EB"
-            << "\n======================================\n\n";
+  edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = EB"
+            << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalBarrel);
   int nall(0);
   for (auto id : ids) {
@@ -43,7 +45,8 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
     std::shared_ptr<const CaloCellGeometry> geom = ecalGeom->getGeometry(id);
     EBDetId ebid(id.rawId());
 
-    std::cout << "IEta = " << ebid.ieta() << ";  IPhi = " << ebid.iphi() << " geom->getPosition "
+    std::ostringstream st1;
+    st1 << "IEta = " << ebid.ieta() << ";  IPhi = " << ebid.iphi() << " geom->getPosition "
               << std::setprecision(4) << geom->getPosition() << " BackPoint " << geom->getBackPoint()
               << " [rho,eta:etaSpan,phi:phiSpan] (" << geom->rhoPos() << ", " << geom->etaPos() << ":"
               << geom->etaSpan() << ", " << geom->phiPos() << ":" << geom->phiSpan() << ")";
@@ -51,12 +54,12 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
     const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 
     for (unsigned int ci(0); ci != corners.size(); ci++) {
-      std::cout << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
+      st1 << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
     }
 
-    std::cout << std::endl;
+    edm::LogVerbatim("EcalGeom") << st1.str();
   }
-  std::cout << "\n\nDumps a total of : " << nall << " cells of the detector\n" << std::endl;
+  edm::LogVerbatim("EcalGeom") << "\n\nDumps a total of : " << nall << " cells of the detector\n";
 }
 
 DEFINE_FWK_MODULE(EcalBarrelCellParameterDump);

--- a/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalBarrelCellParameterDump.cc
@@ -37,7 +37,7 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
 
   edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = EB"
-            << "\n======================================\n";
+                               << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalBarrel);
   int nall(0);
   for (auto id : ids) {
@@ -46,10 +46,10 @@ void EcalBarrelCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
     EBDetId ebid(id.rawId());
 
     std::ostringstream st1;
-    st1 << "IEta = " << ebid.ieta() << ";  IPhi = " << ebid.iphi() << " geom->getPosition "
-              << std::setprecision(4) << geom->getPosition() << " BackPoint " << geom->getBackPoint()
-              << " [rho,eta:etaSpan,phi:phiSpan] (" << geom->rhoPos() << ", " << geom->etaPos() << ":"
-              << geom->etaSpan() << ", " << geom->phiPos() << ":" << geom->phiSpan() << ")";
+    st1 << "IEta = " << ebid.ieta() << ";  IPhi = " << ebid.iphi() << " geom->getPosition " << std::setprecision(4)
+        << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
+        << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
+        << geom->phiSpan() << ")";
 
     const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 

--- a/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
@@ -36,7 +36,7 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
 
   edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = EE"
-            << "\n======================================\n";
+                               << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalEndcap);
   int nall(0);
   for (auto id : ids) {
@@ -46,9 +46,9 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
 
     std::ostringstream st1;
     st1 << "IX = " << ebid.ix() << ";  IY = " << ebid.iy() << " geom->getPosition " << std::setprecision(4)
-              << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
-              << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
-              << geom->phiSpan() << ")";
+        << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
+        << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
+        << geom->phiSpan() << ")";
 
     const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 

--- a/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalEndcapCellParameterDump.cc
@@ -11,6 +11,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 typedef EZArrayFL<GlobalPoint> CornersVec;
 
@@ -34,8 +35,8 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
   const CaloSubdetectorGeometry* ecalGeom =
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
 
-  std::cout << "\n\nStudy Detector = Ecal SubDetector = EE"
-            << "\n======================================\n\n";
+  edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = EE"
+            << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalEndcap);
   int nall(0);
   for (auto id : ids) {
@@ -43,7 +44,8 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
     std::shared_ptr<const CaloCellGeometry> geom = ecalGeom->getGeometry(id);
     EEDetId ebid(id.rawId());
 
-    std::cout << "IX = " << ebid.ix() << ";  IY = " << ebid.iy() << " geom->getPosition " << std::setprecision(4)
+    std::ostringstream st1;
+    st1 << "IX = " << ebid.ix() << ";  IY = " << ebid.iy() << " geom->getPosition " << std::setprecision(4)
               << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
               << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
               << geom->phiSpan() << ")";
@@ -51,12 +53,12 @@ void EcalEndcapCellParameterDump::analyze(const edm::Event& /*iEvent*/, const ed
     const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 
     for (unsigned int ci(0); ci != corners.size(); ci++) {
-      std::cout << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
+      st1 << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
     }
 
-    std::cout << std::endl;
+    edm::LogVerbatim("EcalGeom") << st1.str();
   }
-  std::cout << "\n\nDumps a total of : " << nall << " cells of the detector\n" << std::endl;
+  edm::LogVerbatim("EcalGeom") << "\n\nDumps a total of : " << nall << " cells of the detector\n";
 }
 
 DEFINE_FWK_MODULE(EcalEndcapCellParameterDump);

--- a/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
@@ -69,7 +69,7 @@ void EcalPreshowerCellParameterDump::analyze(const edm::Event& /*iEvent*/, const
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
 
   edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = ES"
-            << "\n======================================\n";
+                               << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalPreshower);
   int nall(0);
   for (auto id : ids) {
@@ -84,10 +84,9 @@ void EcalPreshowerCellParameterDump::analyze(const edm::Event& /*iEvent*/, const
         hist_[hid]->Fill(geom->getPosition().x(), geom->getPosition().y());
     } else {
       std::ostringstream st1;
-      st1 << "Cell[" << nall << "] " << esid << " geom->getPosition " << std::setprecision(4)
-                << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
-                << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
-                << geom->phiSpan() << ")";
+      st1 << "Cell[" << nall << "] " << esid << " geom->getPosition " << std::setprecision(4) << geom->getPosition()
+          << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] (" << geom->rhoPos() << ", "
+          << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":" << geom->phiSpan() << ")";
 
       const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 

--- a/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
+++ b/Geometry/EcalAlgo/test/EcalPreshowerParameterDump.cc
@@ -68,8 +68,8 @@ void EcalPreshowerCellParameterDump::analyze(const edm::Event& /*iEvent*/, const
   const CaloSubdetectorGeometry* ecalGeom =
       static_cast<const CaloSubdetectorGeometry*>(geo->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
 
-  std::cout << "\n\nStudy Detector = Ecal SubDetector = ES"
-            << "\n======================================\n\n";
+  edm::LogVerbatim("EcalGeom") << "\n\nStudy Detector = Ecal SubDetector = ES"
+            << "\n======================================\n";
   const std::vector<DetId>& ids = ecalGeom->getValidDetIds(DetId::Ecal, EcalPreshower);
   int nall(0);
   for (auto id : ids) {
@@ -78,12 +78,13 @@ void EcalPreshowerCellParameterDump::analyze(const edm::Event& /*iEvent*/, const
     ESDetId esid(id);
 
     if (debug_) {
-      std::cout << nall << " " << esid.rawId() << " " << std::setprecision(6) << geom->getPosition() << std::endl;
+      edm::LogVerbatim("EcalGeom") << nall << " " << esid.rawId() << " " << std::setprecision(6) << geom->getPosition();
       unsigned int hid = ((esid.zside() + 1) + esid.plane() - 1);
       if (hid < hist_.size())
         hist_[hid]->Fill(geom->getPosition().x(), geom->getPosition().y());
     } else {
-      std::cout << "Cell[" << nall << "] " << esid << " geom->getPosition " << std::setprecision(4)
+      std::ostringstream st1;
+      st1 << "Cell[" << nall << "] " << esid << " geom->getPosition " << std::setprecision(4)
                 << geom->getPosition() << " BackPoint " << geom->getBackPoint() << " [rho,eta:etaSpan,phi:phiSpan] ("
                 << geom->rhoPos() << ", " << geom->etaPos() << ":" << geom->etaSpan() << ", " << geom->phiPos() << ":"
                 << geom->phiSpan() << ")";
@@ -91,13 +92,13 @@ void EcalPreshowerCellParameterDump::analyze(const edm::Event& /*iEvent*/, const
       const CaloCellGeometry::CornersVec& corners(geom->getCorners());
 
       for (unsigned int ci(0); ci != corners.size(); ci++) {
-        std::cout << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
+        st1 << " Corner: " << ci << "  Location" << corners[ci] << " ; ";
       }
 
-      std::cout << std::endl;
+      edm::LogVerbatim("EcalGeom") << st1.str();
     }
   }
-  std::cout << "\n\nDumps a total of : " << nall << " cells of the detector\n" << std::endl;
+  edm::LogVerbatim("EcalGeom") << "\n\nDumps a total of : " << nall << " cells of the detector\n";
 }
 
 DEFINE_FWK_MODULE(EcalPreshowerCellParameterDump);

--- a/Geometry/EcalAlgo/test/python/runESCellDump_cfg.py
+++ b/Geometry/EcalAlgo/test/python/runESCellDump_cfg.py
@@ -12,6 +12,10 @@ process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
 process.load("Geometry.EcalMapping.EcalMapping_cfi")
 process.load("Geometry.EcalMapping.EcalMappingRecord_cfi")
 process.load("Geometry.EcalAlgo.ecalPreshowerCellParameterDump_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.EcalGeom=dict()
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/EcalAlgo/test/python/runEcalCellDumpDD4hep_cfg.py
+++ b/Geometry/EcalAlgo/test/python/runEcalCellDumpDD4hep_cfg.py
@@ -5,6 +5,10 @@ process = cms.Process("EcalGeometryTest",Run3_dd4hep)
 
 process.load('Configuration.Geometry.GeometryDD4hepExtended2021_cff')
 process.load('Configuration.Geometry.GeometryDD4hepExtended2021Reco_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.EcalGeom=dict()
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/EcalAlgo/test/python/runEcalCellDumpDDD_cfg.py
+++ b/Geometry/EcalAlgo/test/python/runEcalCellDumpDDD_cfg.py
@@ -4,6 +4,10 @@ from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("EcalGeometryTest",Run3)
 
 process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.EcalGeom=dict()
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/EcalAlgo/test/python/testEcalGeometry.py
+++ b/Geometry/EcalAlgo/test/python/testEcalGeometry.py
@@ -11,6 +11,9 @@ process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
         enable = cms.untracked.bool(False)
     ),
+    EcalGeom = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
     cout = cms.untracked.PSet(
         enable = cms.untracked.bool(True),
         enableStatistics = cms.untracked.bool(True),


### PR DESCRIPTION
#### PR description:

Replace std::cout with messagelogger stareents in Geometry/EcalAlgo

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special