### PR TITLE
Adding a check on the BS transverse widths in OnlineBeamSpotESProducer

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -30,6 +30,7 @@ public:
 private:
   const BeamSpotOnlineObjects* compareBS(const BeamSpotOnlineObjects* bs1, const BeamSpotOnlineObjects* bs2);
   const BeamSpotOnlineObjects* checkSingleBS(const BeamSpotOnlineObjects* bs1);
+  bool isGoodBS(const BeamSpotOnlineObjects* bs1) const;
 
   edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> const bsToken_;
   edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
@@ -38,12 +39,14 @@ private:
   BeamSpotObjects fakeBS_;
   const int timeThreshold_;
   const double sigmaZThreshold_;
+  const double sigmaXYThreshold_;
 };
 
 OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p)
     // get parameters
     : timeThreshold_(p.getParameter<int>("timeThreshold")),
-      sigmaZThreshold_(p.getParameter<double>("sigmaZThreshold")) {
+      sigmaZThreshold_(p.getParameter<double>("sigmaZThreshold")),
+      sigmaXYThreshold_(p.getParameter<double>("sigmaXYThreshold") * 1E-4) {
   auto cc = setWhatProduced(this);
 
   fakeBS_.setBeamWidthX(0.1);
@@ -60,6 +63,7 @@ void OnlineBeamSpotESProducer::fillDescriptions(edm::ConfigurationDescriptions& 
   edm::ParameterSetDescription dsc;
   dsc.add<int>("timeThreshold", 48)->setComment("hours");
   dsc.add<double>("sigmaZThreshold", 2.)->setComment("cm");
+  dsc.add<double>("sigmaXYThreshold", 4.)->setComment("um");
   desc.addWithDefaultLabel(dsc);
 }
 
@@ -80,15 +84,15 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
 
   // Logic to choose between the two BeamSpots:
   // 1. If both BS are older than limitTime retun fake BS
-  // 2. If only one BS is newer than limitTime return it only if it has
-  //    sigmaZ larger than sigmaZthreshold_ and the fit converged (BeamType 2)
-  // 3. If both are newer than the limit threshold return
-  //    the BS that converged and has larger sigmaZ
+  // 2. If only one BS is newer than limitTime return it only if
+  //     it passes isGoodBS (checks on sigmaZ, sigmaXY and fit convergence)
+  // 3. If both are newer than the limit threshold return the BS that
+  //     passes isGoodBS and has larger sigmaZ
   if (diffBStime1 > limitTime && diffBStime2 > limitTime) {
     edm::LogInfo("OnlineBeamSpotESProducer") << "Defaulting to fake because both payloads are too old.";
     return nullptr;
   } else if (diffBStime2 > limitTime) {
-    if (bs1->sigmaZ() > sigmaZThreshold_ && bs1->beamType() == 2) {
+    if (isGoodBS(bs1)) {
       return bs1;
     } else {
       edm::LogInfo("OnlineBeamSpotESProducer")
@@ -96,7 +100,7 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
       return nullptr;
     }
   } else if (diffBStime1 > limitTime) {
-    if (bs2->sigmaZ() > sigmaZThreshold_ && bs2->beamType() == 2) {
+    if (isGoodBS(bs2)) {
       return bs2;
     } else {
       edm::LogInfo("OnlineBeamSpotESProducer")
@@ -104,13 +108,13 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
       return nullptr;
     }
   } else {
-    if (bs1->sigmaZ() > bs2->sigmaZ() && bs1->beamType() == 2) {
+    if (bs1->sigmaZ() > bs2->sigmaZ() && isGoodBS(bs1)) {
       return bs1;
-    } else if (bs2->sigmaZ() >= bs1->sigmaZ() && bs2->beamType() == 2) {
+    } else if (bs2->sigmaZ() >= bs1->sigmaZ() && isGoodBS(bs2)) {
       return bs2;
     } else {
       edm::LogInfo("OnlineBeamSpotESProducer")
-          << "Defaulting to fake because despite both payloads are young enough, none has the right BeamType.";
+          << "Defaulting to fake because despite both payloads are young enough, none has passed the fit sanity checks";
       return nullptr;
     }
   }
@@ -129,11 +133,20 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::checkSingleBS(const BeamS
   auto limitTime = std::chrono::microseconds((std::chrono::hours)timeThreshold_).count();
 
   // Check that the BS is within the timeThreshold, converges and passes the sigmaZthreshold
-  if (diffBStime1 < limitTime && bs1->sigmaZ() > sigmaZThreshold_ && bs1->beamType() == 2) {
+  if (diffBStime1 < limitTime && isGoodBS(bs1)) {
     return bs1;
   } else {
     return nullptr;
   }
+}
+
+// This method is used to check the quality of the beamspot fit
+bool OnlineBeamSpotESProducer::isGoodBS(const BeamSpotOnlineObjects* bs1) const {
+  if (bs1->sigmaZ() > sigmaZThreshold_ && bs1->beamType() == reco::BeamSpot::Tracker &&
+      bs1->beamWidthX() > sigmaXYThreshold_ && bs1->beamWidthY() > sigmaXYThreshold_)
+    return true;
+  else
+    return false;
 }
 
 std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const BeamSpotTransientObjectsRcd& iRecord) {


### PR DESCRIPTION
#### PR description:

This PR adds a check on the BeamSpot transverse widths in OnlineBeamSpotESProducer. The producer checks the BS Fit produced by the two DQM clients and performs an arbitration. We are now adding a new condition (transverse widths larger than a certain threshold) to prevent the upload of payloads containing the results of fit that converged with unphysical values.

#### PR validation:

Code compiles.
The following commands have been run
scram b code-format
scram b code-checks

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Since the code runs online we propose not to have backports.