### PR TITLE
pixelLess efficiency recovery: maxhits 32, prune first hit

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -325,6 +325,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     seeds = 'pixelLessStepSeeds',
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
+    matchFirstLayerHitToCandStateRZ = true,
     candMVASel = False,
     candWP = -0.7,
 ))

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -200,7 +200,7 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("qualityMaxPosErr", 100)->setComment("max position error for converted tracks");
   desc.add<bool>("qualitySignPt", true)->setComment("check sign of 1/pt for converted tracks");
 
-  desc.add<bool>("matchFirstLayerHitToCandStateRZ", true)->setComment("match first hit to the candidate state in R/Z");
+  desc.add<bool>("matchFirstLayerHitToCandStateRZ", false)->setComment("match first hit to the candidate state in R/Z");
   desc.add<bool>("doErrorRescale", true)->setComment("rescale candidate error before final fit");
 
   desc.add<std::string>("tfDnnLabel", "trackSelectionTf");

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -40,7 +40,7 @@ namespace mkfit {
     friend class MkBuilder;
 
   public:
-    static constexpr int MPlexHitIdxMax = 16;
+    static constexpr int MPlexHitIdxMax = 32;
 
     using MPlexHitIdx = Matriplex::Matriplex<int, MPlexHitIdxMax, 1, NN>;
     using MPlexQHoT = Matriplex::Matriplex<HitOnTrack, 1, 1, NN>;


### PR DESCRIPTION
- increase the number of preselected hits from 16 to 32: this helps in the [pixelLess](http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/CMSSW_12_6_0_pre5-pixmkf/RelValTTbar_14TeV-PU_2022_realistic/mtv-ckf-pmkf-orig-max32-prune1st-3366d02/plots_pixelLessStep.html) and gives almost no effect in [default mkfit-5](http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/CMSSW_12_6_0_pre5-pixmkf/RelValTTbar_14TeV-PU_2022_realistic/mtv-ckf-mkf5-orig-max32-prune1st-b778e2f/plots_ootb.html)
- prune the first layer hits to contain only one hit that matches with the track candidate state (enabled only in the pixelLess)

in pixelLess-only ckf.vs.mkfit:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/4676718/218203167-9167a4e8-317e-4f54-8b51-ee8fc19d8b72.png">
<img width="800" alt="image" src="https://user-images.githubusercontent.com/4676718/218203244-6ee53f97-9e23-4dfd-bbf2-8008fafc773d.png">

in mkfit-5 (current default) compared to all ckf: red (default) and black (this PR) are essentially the same
<img width="800" alt="image" src="https://user-images.githubusercontent.com/4676718/218203490-22896f86-f938-4121-9096-ba74a7d85610.png">


I will keep this as a draft for now.