### PR TITLE
[12_6_X] Switch file catalog back to Rucio catalog

### DIFF
--- a/FWCore/Catalog/interface/InputFileCatalog.h
+++ b/FWCore/Catalog/interface/InputFileCatalog.h
@@ -37,8 +37,8 @@ namespace edm {
                      std::string const& override,
                      bool useLFNasPFNifLFNnotFound = false,
                      //switching between two catalog types
-                     edm::CatalogType catType = edm::CatalogType::TrivialCatalog);
-    //edm::CatalogType catType = edm::CatalogType::RucioCatalog);
+                     //edm::CatalogType catType = edm::CatalogType::TrivialCatalog);
+                     edm::CatalogType catType = edm::CatalogType::RucioCatalog);
 
     ~InputFileCatalog();
     std::vector<FileCatalogItem> const& fileCatalogItems() const { return fileCatalogItems_; }


### PR DESCRIPTION
#### PR description:

Following Tier0 being now able to use both Trivial File Catalog and Rucio Catalog (https://github.com/dmwm/WMCore/pull/11481#issuecomment-1425449864), this PR changes the file catalog back to Rucio catalog by reverting cms-sw/cmssw#40685.

#### PR validation:

None