### PR TITLE
[12.6.X] Ensure that egamma picks up 2023 HB thresholds for 12_6_X MC production 

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -15,6 +15,6 @@ from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018]),
+Run3_2023 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018]),
                          run3_common, run3_egamma, run3_egamma_2023, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC)
 

--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
+from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
+from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018]),
+                         run3_common, run3_egamma, run3_egamma_2023, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC)
+

--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -1,20 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-from Configuration.Eras.Modifier_run3_HFSL_cff import run3_HFSL
-from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
-from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
-from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
-from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
-from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
-from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
 
-Run3_2023 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018]),
-                         run3_common, run3_egamma, run3_egamma_2023, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC)
-
+Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023)

--- a/Configuration/Eras/python/Modifier_run3_egamma_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_egamma_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_egamma_2023 =cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -34,6 +34,7 @@ class Eras (object):
                  'Run2_2018_highBetaStar',
                  'Run2_2018_noMkFit',
                  'Run3',
+                 'Run3_2023',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',
                  'Run3_pp_on_PbPb_approxSiStripClusters',

--- a/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1, _thresholdsHBphase1_2023
 
 egammaHBHERecHit = cms.PSet(
     hbheRecHits = cms.InputTag('hbhereco'),
@@ -8,3 +8,10 @@ egammaHBHERecHit = cms.PSet(
     recHitEThresholdHE = _thresholdsHEphase1,
     maxHcalRecHitSeverity = cms.int32(9),
 )
+
+egammaHBHERecHit_2023 = egammaHBHERecHit.clone(
+    recHitEThresholdHB = _thresholdsHBphase1_2023
+)
+
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+run3_egamma_2023.toReplaceWith(egammaHBHERecHit,egammaHBHERecHit_2023)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -4,6 +4,8 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+#updated HB RecHit threshold for 2023
+_thresholdsHBphase1_2023 = cms.vdouble(0.4, 0.3, 0.3, 0.3)
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(


### PR DESCRIPTION
#### PR description:
This is to ensure that egamma reco picks up updated HB recHit thresholds for 12_6_X MC production.

A new Era called `Run3_2023` is introduced: `Configuration/Eras/python/Era_Run3_2023_cff.py` .

At the time of opening this PR, `Era_Run3_2023_cff.py` and `Era_Run3_cff.py` are basically same, the only notable difference is that `run3_egamma_2023` is included in ModifierChain of `Run3_2023`. 

#### PR validation:
After doing this:
`cmsDriver.py step3 -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2023_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3_2023 --filein file:step2.root --fileout file:step3.root --customise RecoParticleFlow/PFClusterProducer/particleFlow_HB2023.customiseHB2023  --no_exec`

obtained `step3_RAW2DIGI_L1Reco_RECO_RECOSIM_PAT_NANO_VALIDATION_DQM.py`. 

Then, `edmConfigDump step3_RAW2DIGI_L1Reco_RECO_RECOSIM_PAT_NANO_VALIDATION_DQM.py > dump_1.py`;

Checked by doing `grep recHitEThresholdHB dump_1.py` that correct HB thresholds were picked up everywhere; i.e. 
`recHitEThresholdHB = cms.vdouble(0.4, 0.3, 0.3, 0.3),` in `dump_1.py`.

Checked that `step3_RAW2DIGI_L1Reco_RECO_RECOSIM_PAT_NANO_VALIDATION_DQM.py` runs fine on a proper input root file.

Note that `--customise RecoParticleFlow/PFClusterProducer/particleFlow_HB2023.customiseHB2023` is available 
 via https://github.com/cms-sw/cmssw/pull/40689

There is no corresponding PR for master branch, as discussed with PPD. For now, this change is needed only for 12_6_X MC production. Studies based on the upcoming 12_6_X MC would tell us if these changes need to be propagated to the 2023 data-taking release (13_X) or not.