### PR TITLE
[13_0_X] Only compare geometry in Geometry/TrackerGoeometryBuilder test

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDD4hep_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDD4hep_cfg.py
@@ -54,7 +54,4 @@ process.maxEvents = cms.untracked.PSet(
 
 process.test = cms.EDAnalyzer("TrackerParametersAnalyzer")
 
-process.Timing = cms.Service("Timing")
-process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
- 
 process.p1 = cms.Path(process.test)

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDDD_cfg.py
@@ -56,9 +56,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.test = cms.EDAnalyzer("TrackerParametersAnalyzer")
 
-process.Timing = cms.Service("Timing")
-process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
-
 process.p1 = cms.Path(process.test)
 
 


### PR DESCRIPTION
Removed inclusion of SimpleMemoryCheck and Timing service in the test to avoid those causing non-geometry related failures.

The test was previously failing because of a change to the output of SimpleMemoryCheck.

Backport of #40757