### PR TITLE
Migrate consumesMany() to edm::GetterOfProducts() in GlobalHitsAnalyzer

### DIFF
--- a/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
+++ b/Validation/GlobalHits/interface/GlobalHitsAnalyzer.h
@@ -20,6 +20,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 // DQM services
@@ -150,6 +152,7 @@ private:
   edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> hcaldddRecToken_;
+  edm::GetterOfProducts<edm::HepMCProduct> getterOfProducts_;
 
   // Electromagnetic info
   // ECal info

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -14,6 +14,10 @@
 #include "Geometry/HcalCommonData/interface/HcalHitRelabeller.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
+
+edm::GetterOfProducts<edm::HepMCProduct> getterOfProducts_;
 
 GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
     : fName(""),
@@ -33,7 +37,9 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
       caloGeomToken_(esConsumes()),
       hcaldddRecToken_(esConsumes()),
       count(0) {
-  consumesMany<edm::HepMCProduct>();
+  getterOfProducts_ = edm::GetterOfProducts<edm::HepMCProduct>(edm::ProcessMatch("*"), this);
+  callWhenNewProductsRegistered(getterOfProducts_);
+
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_GlobalHitsAnalyzer";
 
   // get information from parameter set
@@ -753,8 +759,7 @@ void GlobalHitsAnalyzer::fillG4MC(const edm::Event &iEvent) {
   /////////////////////
   edm::Handle<edm::HepMCProduct> HepMCEvt;
   std::vector<edm::Handle<edm::HepMCProduct>> AllHepMCEvt;
-  iEvent.getManyByType(AllHepMCEvt);
-
+  getterOfProducts_.fillHandles(iEvent, AllHepMCEvt);
   // loop through products and extract VtxSmearing if available. Any of them
   // should have the information needed
   for (unsigned int i = 0; i < AllHepMCEvt.size(); ++i) {

--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -17,8 +17,6 @@
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 #include "FWCore/Framework/interface/ProcessMatch.h"
 
-edm::GetterOfProducts<edm::HepMCProduct> getterOfProducts_;
-
 GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet &iPSet)
     : fName(""),
       verbosity(0),


### PR DESCRIPTION
#### PR description:
Based on PR #40167 . 
Validation code :
Migrate GlobalHitsAnalyzer away from consumesMany() to use edm::GetterOfProducts().

#### PR validation:
Tested in CMSSW_13_0_0_pre4, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)