### PR TITLE
Alpaka-related updates

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1538,10 +1538,10 @@ class Process(object):
                    resolved.update(acc)
             # Sanity check
             if len(invalid) != 0:
-                raise ValueError("Invalid pattern{} of {} in process.options.accelerators, valid values are {} or a pattern matching to some of them.".format(
+                raise ValueError("Invalid pattern{} of '{}' in process.options.accelerators, valid values are '{}' or a pattern matching some of them.".format(
                     "s" if len(invalid) > 2 else "",
-                    ",".join(invalid),
-                    ",".join(sorted(list(allAccelerators)))))
+                    "', '".join(invalid),
+                    "', '".join(sorted(list(allAccelerators)))))
             selectedAccelerators = sorted(list(resolved))
         parameterSet.addVString(False, "@selected_accelerators", selectedAccelerators)
 

--- a/HeterogeneousCore/AlpakaCore/interface/EventCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/EventCache.h
@@ -21,7 +21,7 @@ namespace cms::alpakatools {
     friend class alpaka_cuda_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-    friend class alpaka_hip_async::AlpakaService;
+    friend class alpaka_rocm_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
     friend class alpaka_serial_sync::AlpakaService;

--- a/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
+++ b/HeterogeneousCore/AlpakaCore/interface/QueueCache.h
@@ -19,7 +19,7 @@ namespace cms::alpakatools {
     friend class alpaka_cuda_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-    friend class alpaka_hip_async::AlpakaService;
+    friend class alpaka_rocm_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
     friend class alpaka_serial_sync::AlpakaService;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h
@@ -1,5 +1,5 @@
-#ifndef HeterogeneousCore_AlpakaCore_interface_MakerMacros_h
-#define HeterogeneousCore_AlpakaCore_interface_MakerMacros_h
+#ifndef HeterogeneousCore_AlpakaCore_interface_alpaka_MakerMacros_h
+#define HeterogeneousCore_AlpakaCore_interface_alpaka_MakerMacros_h
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -16,4 +16,4 @@
 #define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name)
 #endif
 
-#endif  // HeterogeneousCore_AlpakaCore_interface_MakerMacros_h
+#endif  // HeterogeneousCore_AlpakaCore_interface_alpaka_MakerMacros_h

--- a/HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AlpakaServiceFwd.h
@@ -13,9 +13,9 @@ namespace alpaka_cuda_async {
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-namespace alpaka_hip_async {
+namespace alpaka_rocm_async {
   class AlpakaService;
-}  // namespace alpaka_hip_async
+}  // namespace alpaka_rocm_async
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -91,7 +91,7 @@ namespace cms::alpakatools {
     friend class alpaka_cuda_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-    friend class alpaka_hip_async::AlpakaService;
+    friend class alpaka_rocm_async::AlpakaService;
 #endif
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
     friend class alpaka_serial_sync::AlpakaService;

--- a/HeterogeneousCore/AlpakaInterface/interface/config.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/config.h
@@ -65,7 +65,7 @@ namespace alpaka_cuda_async {
 #endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-namespace alpaka_hip_async {
+namespace alpaka_rocm_async {
   using namespace alpaka_common;
 
   using Platform = alpaka::PltfHipRt;
@@ -79,13 +79,13 @@ namespace alpaka_hip_async {
   using Acc2D = Acc<Dim2D>;
   using Acc3D = Acc<Dim3D>;
 
-}  // namespace alpaka_hip_async
+}  // namespace alpaka_rocm_async
 
 #ifdef ALPAKA_ACCELERATOR_NAMESPACE
 #define ALPAKA_DUPLICATE_NAMESPACE
 #else
-#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_hip_async
-#define ALPAKA_TYPE_SUFFIX HipAsync
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_rocm_async
+#define ALPAKA_TYPE_SUFFIX ROCmAsync
 #endif
 
 #endif  // ALPAKA_ACC_GPU_HIP_ENABLED

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -59,5 +59,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
@@ -63,5 +63,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducerOffset);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -46,5 +46,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaProducer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -66,5 +66,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaStreamProducer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducer.cc
@@ -48,5 +48,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(TestAlpakaStreamSynchronizingProducer);


### PR DESCRIPTION
#### PR description:

Various Alpaka-related updates:
  - move `HeterogeneousCore/AlpakaCore/interface/MakerMacros.h` under `alpaka/`
  - rename `alpaka_hip_async` to `alpaka_rocm_async`
  - adopt the "alternative module loading" approach in the Alpaka test

#### PR validation:

All unit tests should pass.

#### PR backport:

To be backported to `CMSSW_13_0_X` for 2023 data taking.