### PR TITLE
uGT fix for muon showers full emulation and for HMT mismatches in the DQM workflow

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -130,7 +130,7 @@ from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
 valGtStage2Digis = simGtStage2Digis.clone(
     ExtInputTag = "gtStage2Digis",
     MuonInputTag = "gtStage2Digis:Muon",
-    MuonShowerInputTag = "gmtStage2Digis:MuonShower",
+    MuonShowerInputTag = "gtStage2Digis:MuonShower",
     EGammaInputTag = "gtStage2Digis:EGamma",
     TauInputTag = "gtStage2Digis:Tau",
     JetInputTag = "gtStage2Digis:Jet",

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -130,6 +130,7 @@ from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
 valGtStage2Digis = simGtStage2Digis.clone(
     ExtInputTag = "gtStage2Digis",
     MuonInputTag = "gtStage2Digis:Muon",
+    MuonShowerInputTag = "gmtStage2Digis:MuonShower",
     EGammaInputTag = "gtStage2Digis:EGamma",
     TauInputTag = "gtStage2Digis:Tau",
     JetInputTag = "gtStage2Digis:Jet",

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -150,7 +150,7 @@ namespace l1t {
     inline const BXVector<const l1t::Muon*>* getCandL1Mu() const { return m_candL1Mu; }
 
     /// return global muon trigger candidate
-    inline const BXVector<const l1t::MuonShower*>* getCandL1MuShower() const { return m_candL1MuShower; }
+    inline const BXVector<std::shared_ptr<l1t::MuonShower>>* getCandL1MuShower() const { return m_candL1MuShower; }
 
     /// pointer to EG data list
     inline const BXVector<const l1t::L1Candidate*>* getCandL1EG() const { return m_candL1EG; }
@@ -221,7 +221,7 @@ namespace l1t {
 
   private:
     BXVector<const l1t::Muon*>* m_candL1Mu;
-    BXVector<const l1t::MuonShower*>* m_candL1MuShower;
+    BXVector<std::shared_ptr<l1t::MuonShower>>* m_candL1MuShower;
     BXVector<const l1t::L1Candidate*>* m_candL1EG;
     BXVector<const l1t::L1Candidate*>* m_candL1Tau;
     BXVector<const l1t::L1Candidate*>* m_candL1Jet;

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -7,11 +7,13 @@
  * Implementation:
  *    <TODO: enter implementation details>
  *
- * \author: M. Fierro            - HEPHY Vienna - ORCA version
- * \author: Vasile Mihai Ghete   - HEPHY Vienna - CMSSW version
- * \author: Vladimir Rekovic     - add correlation with overlap removal cases
- *                               - fractional prescales
- * \author: Elisa Fontanesi      - extended for three-body correlation conditions
+ * \author: M. Fierro                    - HEPHY Vienna - ORCA version
+ * \author: V. M. Ghete                  - HEPHY Vienna - CMSSW version
+ * \author: V. Rekovic                   - add correlation with overlap removal cases
+ *                                       - fractional prescales
+ * \author: E. Fontanesi                 - extended for three-body correlation conditions
+ *
+ * \author: E. Fontanesi, E. Yigitbasi   - fix for the muon showers (original implementation by S. Dildick, 2021)
  *
  * $Date$
  * $Revision$
@@ -25,7 +27,6 @@
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMap.h"
 #include "L1Trigger/L1TGlobal/interface/TriggerMenu.h"
 #include "L1Trigger/L1TGlobal/interface/GlobalAlgorithm.h"
-
 #include "L1Trigger/L1TGlobal/interface/MuonTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/CaloTemplate.h"
@@ -37,11 +38,10 @@
 #include "L1Trigger/L1TGlobal/interface/GlobalCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CorrCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CorrWithOverlapRemovalCondition.h"
-
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
 #include "L1Trigger/L1TGlobal/interface/AlgorithmEvaluation.h"
 
-// Conditions for uGt
+// Conditions for uGT
 #include "L1Trigger/L1TGlobal/interface/MuCondition.h"
 #include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
 #include "L1Trigger/L1TGlobal/interface/CaloCondition.h"
@@ -54,7 +54,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
-// constructor
+// Constructor
 l1t::GlobalBoard::GlobalBoard()
     : m_candL1Mu(new BXVector<const l1t::Muon*>),
       m_candL1MuShower(new BXVector<const l1t::MuonShower*>),
@@ -72,7 +72,7 @@ l1t::GlobalBoard::GlobalBoard()
 
   m_prescaleCounterAlgoTrig.clear();
 
-  // initialize cached IDs
+  // Initialize cached IDs
   m_l1GtMenuCacheID = 0ULL;
   m_l1CaloGeometryCacheID = 0ULL;
   m_l1MuTriggerScalesCacheID = 0ULL;
@@ -80,12 +80,12 @@ l1t::GlobalBoard::GlobalBoard()
   // Counter for number of events board sees
   m_boardEventCount = 0;
 
-  // Need to expand use with more than one uGt GlobalBoard for now assume 1
+  // A single uGT GlobalBoard is taken into account in the emulator
   m_uGtBoardNumber = 0;
   m_uGtFinalBoard = true;
 }
 
-// destructor
+// Destructor
 l1t::GlobalBoard::~GlobalBoard() {
   //reset();  //why would we need a reset?
   delete m_candL1Mu;
@@ -95,11 +95,9 @@ l1t::GlobalBoard::~GlobalBoard() {
   delete m_candL1Jet;
   delete m_candL1EtSum;
   delete m_candL1External;
-
-  //    delete m_gtEtaPhiConversions;
 }
 
-// operations
+// Operations
 void l1t::GlobalBoard::setBxFirst(int bx) { m_bxFirst_ = bx; }
 
 void l1t::GlobalBoard::setBxLast(int bx) { m_bxLast_ = bx; }
@@ -179,11 +177,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
 
           nObj++;
         }  //end loop over EG in bx
-      }    //end loop over bx
-
+      }  //end loop over bx
     }  //end if over valid EG data
-
-  }  //end if ReveiveEG data
+  }  //end if ReceiveEG data
 
   if (receiveTau) {
     edm::Handle<BXVector<l1t::Tau>> tauData;
@@ -216,11 +212,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
           nObj++;
 
         }  //end loop over tau in bx
-      }    //end loop over bx
-
+      }  //end loop over bx
     }  //end if over valid tau data
-
-  }  //end if ReveiveTau data
+  }  //end if ReceiveTau data
 
   if (receiveJet) {
     edm::Handle<BXVector<l1t::Jet>> jetData;
@@ -252,11 +246,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
                                 << "  Qual " << jet->hwQual() << "  Iso " << jet->hwIso();
           nObj++;
         }  //end loop over jet in bx
-      }    //end loop over bx
-
+      }  //end loop over bx
     }  //end if over valid jet data
-
-  }  //end if ReveiveJet data
+  }  //end if ReceiveJet data
 
   if (receiveEtSums) {
     edm::Handle<BXVector<l1t::EtSum>> etSumData;
@@ -365,11 +357,9 @@ void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
                                 << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
           nObj++;
         }  //end loop over muons in bx
-      }    //end loop over bx
-
+      }  //end loop over bx
     }  //end if over valid muon data
-
-  }  //end if ReveiveMuon data
+  }  //end if ReceiveMuon data
 }
 
 // receive muon shower data from Global Muon Trigger
@@ -388,35 +378,36 @@ void l1t::GlobalBoard::receiveMuonShowerObjectData(const edm::Event& iEvent,
                                      << "\nrequested in configuration, but not found in the event.\n";
       }
     } else {
-      //Loop over Muon Showers in this bx
+      // Loop over Muon Showers in this bx
       int nObj = 0;
       for (auto mu = muonData->begin(0); mu != muonData->end(0); ++mu) {
         if (nObj < nrL1MuShower) {
-          /* Important here to split up the single object into 4 separate MuonShower
-             bits for the global board. This is because the UTM library considers those bits separate as well
+          /* NOTE: here the single object is split up into 4 separate MuonShower objects 
+	     similarly to the description in the UTM library, where the conditions are four different objects.
            */
-          l1t::MuonShower mus0;
-          l1t::MuonShower mus1;
-          l1t::MuonShower musOutOfTime0;
-          l1t::MuonShower musOutOfTime1;
+	  l1t::MuonShower* musOneNominalInTime = new l1t::MuonShower(false, false, false, false, false, false);
+	  l1t::MuonShower* musOneTightInTime = new l1t::MuonShower(false, false, false, false, false, false);
+	  l1t::MuonShower* musOutOfTime0 = new l1t::MuonShower(false, false, false, false, false, false);
+	  l1t::MuonShower* musOutOfTime1 = new l1t::MuonShower(false, false, false, false, false, false);
 
-          mus0.setMus0(mu->mus0());
-          mus1.setMus1(mu->mus1());
-          musOutOfTime0.setMusOutOfTime0(mu->musOutOfTime0());
-          musOutOfTime1.setMusOutOfTime1(mu->musOutOfTime1());
+          musOneNominalInTime->setOneNominalInTime(mu->isOneNominalInTime());
+          musOneTightInTime->setOneTightInTime(mu->isOneTightInTime());
+          musOutOfTime0->setMusOutOfTime0(mu->musOutOfTime0());
+          musOutOfTime1->setMusOutOfTime1(mu->musOutOfTime1());
 
-          (*m_candL1MuShower).push_back(0, &mus0);
-          (*m_candL1MuShower).push_back(0, &mus1);
-          (*m_candL1MuShower).push_back(0, &musOutOfTime0);
-          (*m_candL1MuShower).push_back(0, &musOutOfTime1);
+          (*m_candL1MuShower).push_back(0, &(*musOneNominalInTime));
+          (*m_candL1MuShower).push_back(0, &(*musOneTightInTime));
+          (*m_candL1MuShower).push_back(0, &(*musOutOfTime0));
+          (*m_candL1MuShower).push_back(0, &(*musOutOfTime1));
+
         } else {
           edm::LogWarning("L1TGlobal") << " Too many Muon Showers (" << nObj
                                        << ") for uGT Configuration maxMuShower =" << nrL1MuShower;
         }
         nObj++;
       }  //end loop over muon showers in bx
-    }    //end if over valid muon shower data
-  }      //end if ReveiveMuonShower data
+    }  //end if over valid muon shower data
+  }  //end if ReceiveMuonShower data
 }
 
 // receive data from Global External Conditions
@@ -452,11 +443,9 @@ void l1t::GlobalBoard::receiveExternalData(const edm::Event& iEvent,
         for (std::vector<GlobalExtBlk>::const_iterator ext = extData->begin(i); ext != extData->end(i); ++ext) {
           (*m_candL1External).push_back(i, &(*ext));
         }  //end loop over ext in bx
-      }    //end loop over bx
-
+      }  //end loop over bx
     }  //end if over valid ext data
-
-  }  //end if ReveiveExt data
+  }  //end if ReceiveExt data
 }
 
 // run GTL
@@ -496,10 +485,11 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
   LogDebug("L1TGlobal") << "Size corrMuon " << corrMuon.size() << "\nSize corrCalo " << corrCalo.size()
                         << "\nSize corrSums " << corrEnergySum.size();
 
-  // loop over condition maps (one map per condition chip)
-  // then loop over conditions in the map
+  // -----------------------------------------------------
+  // Loop over condition maps (one map per condition chip),
+  // then loop over conditions in the map and
   // save the results in temporary maps
-
+  // -----------------------------------------------------
   // never happens in production but at first event...
   if (m_conditionResultMaps.size() != conditionMap.size()) {
     m_conditionResultMaps.clear();
@@ -832,9 +822,10 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
     }
   }
 
-  // loop over algorithm map
-  /// DMP Start debugging here
-  // empty vector for object maps - filled during loop
+  // -----------------------
+  // Loop over algorithm map
+  // -----------------------
+  // Empty vector for object maps - filled during loop
   std::vector<GlobalObjectMap> objMapVec;
   if (produceL1GtObjectMapRecord && (iBxInEvent == 0))
     objMapVec.reserve(numberPhysTriggers);
@@ -933,7 +924,9 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
   }
 }
 
-// run GTL
+// -------
+// Run GTL
+// -------
 void l1t::GlobalBoard::runFDL(const edm::Event& iEvent,
                               const int iBxInEvent,
                               const int totalBxInEvent,
@@ -1048,7 +1041,9 @@ void l1t::GlobalBoard::runFDL(const edm::Event& iEvent,
 
   }  ///if we are masking.
 
+  // --------------------------
   // Set FinalOR for this board
+  // --------------------------
   m_algFinalOr = (m_algIntermOr & !m_algFinalOrVeto);
 }
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -13,7 +13,8 @@
  *                                       - fractional prescales
  * \author: E. Fontanesi                 - extended for three-body correlation conditions
  *
- * \author: E. Fontanesi, E. Yigitbasi   - fix for the muon showers (original implementation by S. Dildick, 2021)
+ * \author: E. Fontanesi, E. Yigitbasi, A. Loeliger (original implementation by S. Dildick, 2021)   
+ *                                       - fix for the muon shower triggers
  *
  * $Date$
  * $Revision$
@@ -57,7 +58,7 @@
 // Constructor
 l1t::GlobalBoard::GlobalBoard()
     : m_candL1Mu(new BXVector<const l1t::Muon*>),
-      m_candL1MuShower(new BXVector<const l1t::MuonShower*>),
+      m_candL1MuShower(new BXVector<std::shared_ptr<l1t::MuonShower>>),
       m_candL1EG(new BXVector<const l1t::L1Candidate*>),
       m_candL1Tau(new BXVector<const l1t::L1Candidate*>),
       m_candL1Jet(new BXVector<const l1t::L1Candidate*>),
@@ -385,20 +386,25 @@ void l1t::GlobalBoard::receiveMuonShowerObjectData(const edm::Event& iEvent,
           /* NOTE: here the single object is split up into 4 separate MuonShower objects 
 	     similarly to the description in the UTM library, where the conditions are four different objects.
            */
-          l1t::MuonShower* musOneNominalInTime = new l1t::MuonShower(false, false, false, false, false, false);
-          l1t::MuonShower* musOneTightInTime = new l1t::MuonShower(false, false, false, false, false, false);
-          l1t::MuonShower* musOutOfTime0 = new l1t::MuonShower(false, false, false, false, false, false);
-          l1t::MuonShower* musOutOfTime1 = new l1t::MuonShower(false, false, false, false, false, false);
+
+          std::shared_ptr<l1t::MuonShower> musOneNominalInTime =
+              std::make_shared<l1t::MuonShower>(false, false, false, false, false, false);
+          std::shared_ptr<l1t::MuonShower> musOneTightInTime =
+              std::make_shared<l1t::MuonShower>(false, false, false, false, false, false);
+          std::shared_ptr<l1t::MuonShower> musOutOfTime0 =
+              std::make_shared<l1t::MuonShower>(false, false, false, false, false, false);
+          std::shared_ptr<l1t::MuonShower> musOutOfTime1 =
+              std::make_shared<l1t::MuonShower>(false, false, false, false, false, false);
 
           musOneNominalInTime->setOneNominalInTime(mu->isOneNominalInTime());
           musOneTightInTime->setOneTightInTime(mu->isOneTightInTime());
           musOutOfTime0->setMusOutOfTime0(mu->musOutOfTime0());
           musOutOfTime1->setMusOutOfTime1(mu->musOutOfTime1());
 
-          (*m_candL1MuShower).push_back(0, &(*musOneNominalInTime));
-          (*m_candL1MuShower).push_back(0, &(*musOneTightInTime));
-          (*m_candL1MuShower).push_back(0, &(*musOutOfTime0));
-          (*m_candL1MuShower).push_back(0, &(*musOutOfTime1));
+          (*m_candL1MuShower).push_back(0, musOneNominalInTime);
+          (*m_candL1MuShower).push_back(0, musOneTightInTime);
+          (*m_candL1MuShower).push_back(0, musOutOfTime0);
+          (*m_candL1MuShower).push_back(0, musOutOfTime1);
 
         } else {
           edm::LogWarning("L1TGlobal") << " Too many Muon Showers (" << nObj

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -177,9 +177,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
 
           nObj++;
         }  //end loop over EG in bx
-      }  //end loop over bx
-    }  //end if over valid EG data
-  }  //end if ReceiveEG data
+      }    //end loop over bx
+    }      //end if over valid EG data
+  }        //end if ReceiveEG data
 
   if (receiveTau) {
     edm::Handle<BXVector<l1t::Tau>> tauData;
@@ -212,9 +212,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
           nObj++;
 
         }  //end loop over tau in bx
-      }  //end loop over bx
-    }  //end if over valid tau data
-  }  //end if ReceiveTau data
+      }    //end loop over bx
+    }      //end if over valid tau data
+  }        //end if ReceiveTau data
 
   if (receiveJet) {
     edm::Handle<BXVector<l1t::Jet>> jetData;
@@ -246,9 +246,9 @@ void l1t::GlobalBoard::receiveCaloObjectData(const edm::Event& iEvent,
                                 << "  Qual " << jet->hwQual() << "  Iso " << jet->hwIso();
           nObj++;
         }  //end loop over jet in bx
-      }  //end loop over bx
-    }  //end if over valid jet data
-  }  //end if ReceiveJet data
+      }    //end loop over bx
+    }      //end if over valid jet data
+  }        //end if ReceiveJet data
 
   if (receiveEtSums) {
     edm::Handle<BXVector<l1t::EtSum>> etSumData;
@@ -357,9 +357,9 @@ void l1t::GlobalBoard::receiveMuonObjectData(const edm::Event& iEvent,
                                 << mu->hwPhiAtVtx() << "  Qual " << mu->hwQual() << "  Iso " << mu->hwIso();
           nObj++;
         }  //end loop over muons in bx
-      }  //end loop over bx
-    }  //end if over valid muon data
-  }  //end if ReceiveMuon data
+      }    //end loop over bx
+    }      //end if over valid muon data
+  }        //end if ReceiveMuon data
 }
 
 // receive muon shower data from Global Muon Trigger
@@ -385,10 +385,10 @@ void l1t::GlobalBoard::receiveMuonShowerObjectData(const edm::Event& iEvent,
           /* NOTE: here the single object is split up into 4 separate MuonShower objects 
 	     similarly to the description in the UTM library, where the conditions are four different objects.
            */
-	  l1t::MuonShower* musOneNominalInTime = new l1t::MuonShower(false, false, false, false, false, false);
-	  l1t::MuonShower* musOneTightInTime = new l1t::MuonShower(false, false, false, false, false, false);
-	  l1t::MuonShower* musOutOfTime0 = new l1t::MuonShower(false, false, false, false, false, false);
-	  l1t::MuonShower* musOutOfTime1 = new l1t::MuonShower(false, false, false, false, false, false);
+          l1t::MuonShower* musOneNominalInTime = new l1t::MuonShower(false, false, false, false, false, false);
+          l1t::MuonShower* musOneTightInTime = new l1t::MuonShower(false, false, false, false, false, false);
+          l1t::MuonShower* musOutOfTime0 = new l1t::MuonShower(false, false, false, false, false, false);
+          l1t::MuonShower* musOutOfTime1 = new l1t::MuonShower(false, false, false, false, false, false);
 
           musOneNominalInTime->setOneNominalInTime(mu->isOneNominalInTime());
           musOneTightInTime->setOneTightInTime(mu->isOneTightInTime());
@@ -406,8 +406,8 @@ void l1t::GlobalBoard::receiveMuonShowerObjectData(const edm::Event& iEvent,
         }
         nObj++;
       }  //end loop over muon showers in bx
-    }  //end if over valid muon shower data
-  }  //end if ReceiveMuonShower data
+    }    //end if over valid muon shower data
+  }      //end if ReceiveMuonShower data
 }
 
 // receive data from Global External Conditions
@@ -443,9 +443,9 @@ void l1t::GlobalBoard::receiveExternalData(const edm::Event& iEvent,
         for (std::vector<GlobalExtBlk>::const_iterator ext = extData->begin(i); ext != extData->end(i); ++ext) {
           (*m_candL1External).push_back(i, &(*ext));
         }  //end loop over ext in bx
-      }  //end loop over bx
-    }  //end if over valid ext data
-  }  //end if ReceiveExt data
+      }    //end loop over bx
+    }      //end if over valid ext data
+  }        //end if ReceiveExt data
 }
 
 // run GTL

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -66,8 +66,7 @@ void l1t::MuonShowerCondition::copy(const l1t::MuonShowerCondition& cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) 
-  : ConditionEvaluation() { copy(cp); }
+l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) : ConditionEvaluation() { copy(cp); }
 
 // destructor
 l1t::MuonShowerCondition::~MuonShowerCondition() {
@@ -88,16 +87,16 @@ void l1t::MuonShowerCondition::setGtMuonShowerTemplate(const MuonShowerTemplate*
 /// Set the pointer to GTL
 void l1t::MuonShowerCondition::setGtGTL(const GlobalBoard* ptrGTL) { m_gtGTL = ptrGTL; }
 
-// Try all object permutations 
+// Try all object permutations
 const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   bool condResult = false;
-  
+
   /* Number of trigger objects in the condition:
   // it is always 1 because at the uGT there is only one shower object per BX (that can be of several types).
   // See DN2020_033_v4 (sections 7.5 and 7.6) for reference
   */
   int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
-  
+
   const BXVector<const l1t::MuonShower*>* candVec = m_gtGTL->getCandL1MuShower();
 
   // Look at objects in BX = BX + relativeBX
@@ -122,7 +121,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   // If there is a muon shower trigger, the size of the candidates vector is always 4:
   // in fact, we have four muon shower objects created in the Global Board.
   */
-  int numberObjects = candVec->size(useBx); 
+  int numberObjects = candVec->size(useBx);
   if (numberObjects < 1) {
     return false;
   }
@@ -140,14 +139,13 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   for (int i = 0; i < numberObjects; i++) {
     passCondition = checkObjectParameter(0, *(candVec->at(useBx, index[i])), index[i]);  //BLW Change for BXVector
     condResult |= passCondition;
-    if (passCondition){
-      LogDebug("MuonShowerCondition") << "===> MuShowerCondition::evaluateCondition, PASS! This muon shower passed the condition."
-				      << std::endl;
+    if (passCondition) {
+      LogDebug("MuonShowerCondition")
+          << "===> MuShowerCondition::evaluateCondition, PASS! This muon shower passed the condition." << std::endl;
       objectsInComb.push_back(indexObj);
-    }
-    else
-      LogDebug("MuonShowerCondition") << "===> MuShowerCondition::evaluateCondition, FAIL! This muon shower failed the condition."
-				      << std::endl;
+    } else
+      LogDebug("MuonShowerCondition")
+          << "===> MuShowerCondition::evaluateCondition, FAIL! This muon shower failed the condition." << std::endl;
   }
 
   // if we get here all checks were successfull for this combination
@@ -156,7 +154,6 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
 
   return condResult;
 }
-
 
 /**
  * checkObjectParameter - Check if the bit associated to the type of shower is set to 1
@@ -168,7 +165,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
 
 const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
                                                           const l1t::MuonShower& cand,
-                                                          const unsigned int index) const{
+                                                          const unsigned int index) const {
   // number of objects in condition
   int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
 
@@ -179,18 +176,15 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
   const MuonShowerTemplate::ObjectParameter objPar = (*(m_gtMuonShowerTemplate->objectParameter()))[iCondition];
 
   LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter (utm objects, checking which condition is parsed): "
-	    << std::hex << "\n\t MuonShower0 = 0x " << objPar.MuonShower0 
-	                << "\n\t MuonShower1 = 0x " << objPar.MuonShower1
-                        << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
-                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 
-	    << std::endl;
+                        << std::hex << "\n\t MuonShower0 = 0x " << objPar.MuonShower0 << "\n\t MuonShower1 = 0x "
+                        << objPar.MuonShower1 << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 << std::endl;
 
   LogDebug("L1TGlobal") << "\n l1t::MuonShower (uGT emulator bits): "
-	    << "\n\t MuonShower0: isOneNominalInTime() = " << cand.isOneNominalInTime() 
-	    << "\n\t MuonShower1: isOneTightInTime() = " << cand.isOneTightInTime()
-	    << "\n\t MuonShowerOutOfTime0: musOutOfTime0() = " << cand.musOutOfTime0()
-	    << "\n\t MuonShowerOutOfTime1: musOutOfTime1() = " << cand.musOutOfTime1() 
-	    << std::endl;
+                        << "\n\t MuonShower0: isOneNominalInTime() = " << cand.isOneNominalInTime()
+                        << "\n\t MuonShower1: isOneTightInTime() = " << cand.isOneTightInTime()
+                        << "\n\t MuonShowerOutOfTime0: musOutOfTime0() = " << cand.musOutOfTime0()
+                        << "\n\t MuonShowerOutOfTime1: musOutOfTime1() = " << cand.musOutOfTime1() << std::endl;
 
   // Check oneNominalInTime
   if (cand.isOneNominalInTime() != objPar.MuonShower0) {
@@ -209,8 +203,8 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
   if (cand.musOutOfTime1() != objPar.MuonShowerOutOfTime1) {
     LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime1 requirement" << std::endl;
     return false;
-  } 
-  
+  }
+
   return true;
 }
 

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -14,7 +14,7 @@
  *  
  * \author: S. Dildick (2021) - Rice University                                                    
  *         
- * \fixes by: E. Fontanesi, E. Yigitbasi (2023)                                                                                                
+ * \fixes by: E. Fontanesi, E. Yigitbasi, A. Loeliger (2023)                                                                                                
  *         
  */
 
@@ -97,7 +97,7 @@ const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
   */
   int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
 
-  const BXVector<const l1t::MuonShower*>* candVec = m_gtGTL->getCandL1MuShower();
+  const BXVector<std::shared_ptr<l1t::MuonShower>>* candVec = m_gtGTL->getCandL1MuShower();
 
   // Look at objects in BX = BX + relativeBX
   int useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -1,3 +1,23 @@
+/**                                                                                                             
+ * \class MuonShowerCondition                                                                                
+ *                                                                                                               
+ *                                                                                                                  
+ * Description: evaluation of High Multiplicity Triggers (HMTs) based on the presence and type of a muon shower.                             
+ *                                                                                                                      
+ * Implementation:                                                                                                     
+ *    This condition class checks for the presente of a valid muon shower in the event.                                                                  
+ *    If present, according to the condition parsed by the xml menu 
+ *    (four possibilities for the first Run 3 implementation: MuonShower0, MuonShower1, MuonShowerOutOfTime0, MuonShowerOutOfTime1)
+ *    the corresponding boolean flag is checked (isOneNominalInTime, isOneTightInTime, musOutOfTime0, musOutOfTime1).   
+ *    If it is set to 1, the condition is satisfied and the object  is saved.
+ *    Note that for the start of Run 3 only two cases are considered in the menu: Nominal and Tight muon showers.  
+ *  
+ * \author: S. Dildick (2021) - Rice University                                                    
+ *         
+ * \fixes by: E. Fontanesi, E. Yigitbasi (2023)                                                                                                
+ *         
+ */
+
 // this class header
 #include "L1Trigger/L1TGlobal/interface/MuonShowerCondition.h"
 
@@ -13,11 +33,8 @@
 //   base classes
 #include "L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h"
 #include "L1Trigger/L1TGlobal/interface/ConditionEvaluation.h"
-
 #include "DataFormats/L1Trigger/interface/MuonShower.h"
-
 #include "L1Trigger/L1TGlobal/interface/GlobalBoard.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
@@ -49,7 +66,8 @@ void l1t::MuonShowerCondition::copy(const l1t::MuonShowerCondition& cp) {
   m_verbosity = cp.m_verbosity;
 }
 
-l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) : ConditionEvaluation() { copy(cp); }
+l1t::MuonShowerCondition::MuonShowerCondition(const l1t::MuonShowerCondition& cp) 
+  : ConditionEvaluation() { copy(cp); }
 
 // destructor
 l1t::MuonShowerCondition::~MuonShowerCondition() {
@@ -67,80 +85,90 @@ void l1t::MuonShowerCondition::setGtMuonShowerTemplate(const MuonShowerTemplate*
   m_gtMuonShowerTemplate = muonTempl;
 }
 
-///   set the pointer to GTL
+/// Set the pointer to GTL
 void l1t::MuonShowerCondition::setGtGTL(const GlobalBoard* ptrGTL) { m_gtGTL = ptrGTL; }
 
-// try all object permutations and check spatial correlations, if required
+// Try all object permutations 
 const bool l1t::MuonShowerCondition::evaluateCondition(const int bxEval) const {
-  // number of trigger objects in the condition
+  bool condResult = false;
+  
+  /* Number of trigger objects in the condition:
+  // it is always 1 because at the uGT there is only one shower object per BX (that can be of several types).
+  // See DN2020_033_v4 (sections 7.5 and 7.6) for reference
+  */
   int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
-
-  // the candidates
+  
   const BXVector<const l1t::MuonShower*>* candVec = m_gtGTL->getCandL1MuShower();
 
-  // Look at objects in bx = bx + relativeBx
+  // Look at objects in BX = BX + relativeBX
   int useBx = bxEval + m_gtMuonShowerTemplate->condRelativeBx();
+  LogDebug("MuonShowerCondition") << "Considering BX " << useBx << std::endl;
 
-  // Fail condition if attempting to get Bx outside of range
+  // Fail condition if attempting to get BX outside of range
   if ((useBx < candVec->getFirstBX()) || (useBx > candVec->getLastBX())) {
     return false;
   }
 
-  // store the indices of the shower objects
-  // from the combination evaluated in the condition
+  // Store the indices of the shower objects from the combination evaluated in the condition
   SingleCombInCond objectsInComb;
   objectsInComb.reserve(nObjInCond);
 
-  // clear the m_combinationsInCond vector
-  (combinationsInCond()).clear();
-
-  // clear the indices in the combination
+  // Clear the m_combinationsInCond vector
+  combinationsInCond().clear();
+  // Clear the indices in the combination
   objectsInComb.clear();
 
-  // If no candidates, no use looking any further.
-  int numberObjects = candVec->size(useBx);
+  /* If no candidates, no need to check further.
+  // If there is a muon shower trigger, the size of the candidates vector is always 4:
+  // in fact, we have four muon shower objects created in the Global Board.
+  */
+  int numberObjects = candVec->size(useBx); 
   if (numberObjects < 1) {
     return false;
   }
 
   std::vector<int> index(numberObjects);
-
   for (int i = 0; i < numberObjects; ++i) {
     index[i] = i;
   }
 
-  bool condResult = false;
-
   // index is always zero, as they are global quantities (there is only one object)
   int indexObj = 0;
 
-  objectsInComb.push_back(indexObj);
-  (combinationsInCond()).push_back(objectsInComb);
+  bool passCondition = false;
+
+  for (int i = 0; i < numberObjects; i++) {
+    passCondition = checkObjectParameter(0, *(candVec->at(useBx, index[i])), index[i]);  //BLW Change for BXVector
+    condResult |= passCondition;
+    if (passCondition){
+      LogDebug("MuonShowerCondition") << "===> MuShowerCondition::evaluateCondition, PASS! This muon shower passed the condition."
+				      << std::endl;
+      objectsInComb.push_back(indexObj);
+    }
+    else
+      LogDebug("MuonShowerCondition") << "===> MuShowerCondition::evaluateCondition, FAIL! This muon shower failed the condition."
+				      << std::endl;
+  }
 
   // if we get here all checks were successfull for this combination
   // set the general result for evaluateCondition to "true"
+  (combinationsInCond()).push_back(objectsInComb);
 
-  condResult = true;
   return condResult;
 }
 
-// load muon candidates
-const l1t::MuonShower* l1t::MuonShowerCondition::getCandidate(const int bx, const int indexCand) const {
-  return (m_gtGTL->getCandL1MuShower())->at(bx, indexCand);  //BLW Change for BXVector
-}
 
 /**
- * checkObjectParameter - Compare a single particle with a numbered condition.
+ * checkObjectParameter - Check if the bit associated to the type of shower is set to 1
  *
  * @param iCondition The number of the condition.
  * @param cand The candidate to compare.
- *
- * @return The result of the comparison (false if a condition does not exist).
+ * @return The result of the check on the condition (false if a condition does not exist)
  */
 
 const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
                                                           const l1t::MuonShower& cand,
-                                                          const unsigned int index) const {
+                                                          const unsigned int index) const{
   // number of objects in condition
   int nObjInCond = m_gtMuonShowerTemplate->nrObjects();
 
@@ -150,22 +178,27 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
 
   const MuonShowerTemplate::ObjectParameter objPar = (*(m_gtMuonShowerTemplate->objectParameter()))[iCondition];
 
-  LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter : " << std::hex << "\n\t MuonShower0 = 0x "
-                        << objPar.MuonShower0 << "\n\t MuonShower1 = 0x " << objPar.MuonShower1
+  LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter (utm objects, checking which condition is parsed): "
+	    << std::hex << "\n\t MuonShower0 = 0x " << objPar.MuonShower0 
+	                << "\n\t MuonShower1 = 0x " << objPar.MuonShower1
                         << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
-                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 << std::endl;
+                        << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 
+	    << std::endl;
 
-  LogDebug("L1TGlobal") << "\n l1t::MuonShower : "
-                        << "\n\t MuonShower0 = 0x " << cand.mus0() << "\n\t MuonShower1 = 0x " << cand.mus1()
-                        << "\n\t MuonShowerOutOfTime0 = 0x " << cand.musOutOfTime0()
-                        << "\n\t MuonShowerOutOfTime1 = 0x " << cand.musOutOfTime1() << std::dec << std::endl;
+  LogDebug("L1TGlobal") << "\n l1t::MuonShower (uGT emulator bits): "
+	    << "\n\t MuonShower0: isOneNominalInTime() = " << cand.isOneNominalInTime() 
+	    << "\n\t MuonShower1: isOneTightInTime() = " << cand.isOneTightInTime()
+	    << "\n\t MuonShowerOutOfTime0: musOutOfTime0() = " << cand.musOutOfTime0()
+	    << "\n\t MuonShowerOutOfTime1: musOutOfTime1() = " << cand.musOutOfTime1() 
+	    << std::endl;
 
-  // check oneNominalInTime
-  if (cand.mus0() != objPar.MuonShower0) {
+  // Check oneNominalInTime
+  if (cand.isOneNominalInTime() != objPar.MuonShower0) {
     LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower0 requirement" << std::endl;
     return false;
   }
-  if (cand.mus1() != objPar.MuonShower1) {
+  // Check oneTightInTime
+  if (cand.isOneTightInTime() != objPar.MuonShower1) {
     LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower1 requirement" << std::endl;
     return false;
   }
@@ -176,13 +209,12 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
   if (cand.musOutOfTime1() != objPar.MuonShowerOutOfTime1) {
     LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShowerOutOfTime1 requirement" << std::endl;
     return false;
-  }
-
+  } 
+  
   return true;
 }
 
 void l1t::MuonShowerCondition::print(std::ostream& myCout) const {
   m_gtMuonShowerTemplate->print(myCout);
-
   ConditionEvaluation::print(myCout);
 }

--- a/L1Trigger/L1TGlobal/test/testVectorCode_data.py
+++ b/L1Trigger/L1TGlobal/test/testVectorCode_data.py
@@ -155,7 +155,7 @@ process.load('L1Trigger.L1TGlobal.simGtStage2Digis_cfi')
 process.simGtStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
 process.simGtStage2Digis.MuonInputTag = cms.InputTag("gtStage2Digis", "Muon")
-process.simGtStage2Digis.MuonShowerInputTag = cms.InputTag("gmtStage2Digis", "MuonShower")
+process.simGtStage2Digis.MuonShowerInputTag = cms.InputTag("gtStage2Digis", "MuonShower")
 process.simGtStage2Digis.EGammaInputTag = cms.InputTag("gtStage2Digis", "EGamma")
 process.simGtStage2Digis.TauInputTag = cms.InputTag("gtStage2Digis", "Tau")
 process.simGtStage2Digis.JetInputTag = cms.InputTag("gtStage2Digis", "Jet")
@@ -192,8 +192,7 @@ process.dumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
 
 process.load("L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi")
 process.l1GtTrigReport.L1GtRecordInputTag = "simGtStage2Digis"
-process.l1GtTrigReport.PrintVerbosity = 0 #EF DEBUG
-#process.l1GtTrigReport.PrintVerbosity = 2 #EF DEBUG
+process.l1GtTrigReport.PrintVerbosity = 0 
 process.report = cms.Path(process.l1GtTrigReport)
 
 process.MessageLogger.categories.append("MuConditon")
@@ -260,7 +259,7 @@ process.l1tGlobalAnalyzer = cms.EDAnalyzer('L1TGlobalAnalyzer',
                                            dmxJetToken = cms.InputTag("None"),
                                            dmxEtSumToken = cms.InputTag("None"),
                                            muToken = cms.InputTag("gtStage2Digis", "Muon"),
-                                           muShowerToken = cms.InputTag("gmtStage2Digis", "MuonShower"),
+                                           muShowerToken = cms.InputTag("gtStage2Digis", "MuonShower"),
                                            egToken = cms.InputTag("gtStage2Digis", "EGamma"),
                                            tauToken = cms.InputTag("gtStage2Digis", "Tau"),
                                            jetToken = cms.InputTag("gtStage2Digis", "Jet"),

--- a/L1Trigger/L1TGlobal/test/testVectorCode_data.py
+++ b/L1Trigger/L1TGlobal/test/testVectorCode_data.py
@@ -58,14 +58,11 @@ process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 # Message Logger output
 # ---------------------
 process.load('FWCore.MessageService.MessageLogger_cfi')
-#process.load('L1Trigger/L1TYellow/l1t_debug_messages_cfi')
-#process.load('L1Trigger/L1TYellow/l1t_info_messages_cfi')
 
+# DEBUG
 process.load('L1Trigger/L1TGlobal/debug_messages_cfi')
 process.MessageLogger.l1t_debug.l1t.limit = cms.untracked.int32(100000)
-
 process.MessageLogger.categories.append('l1t|Global')
-
 # DEBUG
 #process.MessageLogger.debugModules = cms.untracked.vstring('simGtStage2Digis') 
 #process.MessageLogger.cerr.threshold = cms.untracked.string('DEBUG') 
@@ -82,7 +79,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        "/store/data/Run2022E/EphemeralHLTPhysics0/RAW/v1/000/359/661/00000/355c33ec-6253-4590-bc11-94e0ce1b45be.root"
+        "/store/data/Run2022G/EphemeralHLTPhysics0/RAW/v1/000/362/720/00000/36f350d4-8e8a-4e38-b399-77ad9bf351dc.root"
 	),
     skipEvents = cms.untracked.uint32(skip)
     )
@@ -113,7 +110,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, '124X_dataRun3_Prompt_v4', '')
 # ----------------
 process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
-xmlMenu="L1Menu_Collisions2022_v1_3_0.xml"
+xmlMenu="L1Menu_Collisions2022_v1_4_0.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 
@@ -128,13 +125,14 @@ process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.raw2digi_step = cms.Path(process.RawToDigi)
 
 process.dumpGT = cms.EDAnalyzer("l1t::GtInputDump",
-                egInputTag    = cms.InputTag("gtInput"),
-		muInputTag    = cms.InputTag("gtInput"),
-		tauInputTag   = cms.InputTag("gtInput"),
-		jetInputTag   = cms.InputTag("gtInput"),
-		etsumInputTag = cms.InputTag("gtInput"),
-		minBx         = cms.int32(0),
-		maxBx         = cms.int32(0)
+                egInputTag       = cms.InputTag("gtInput"),
+		muInputTag       = cms.InputTag("gtInput"),
+		muShowerInputTag = cms.InputTag("gtInput"),
+		tauInputTag      = cms.InputTag("gtInput"),
+		jetInputTag      = cms.InputTag("gtInput"),
+		etsumInputTag    = cms.InputTag("gtInput"),
+		minBx            = cms.int32(0),
+		maxBx            = cms.int32(0)
 		 )
 process.dumpED = cms.EDAnalyzer("EventContentAnalyzer")
 process.dumpES = cms.EDAnalyzer("PrintEventSetupContent")
@@ -157,6 +155,7 @@ process.load('L1Trigger.L1TGlobal.simGtStage2Digis_cfi')
 process.simGtStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
 process.simGtStage2Digis.MuonInputTag = cms.InputTag("gtStage2Digis", "Muon")
+process.simGtStage2Digis.MuonShowerInputTag = cms.InputTag("gmtStage2Digis", "MuonShower")
 process.simGtStage2Digis.EGammaInputTag = cms.InputTag("gtStage2Digis", "EGamma")
 process.simGtStage2Digis.TauInputTag = cms.InputTag("gtStage2Digis", "Tau")
 process.simGtStage2Digis.JetInputTag = cms.InputTag("gtStage2Digis", "Jet")
@@ -164,13 +163,14 @@ process.simGtStage2Digis.EtSumInputTag = cms.InputTag("gtStage2Digis", "ETSum")
 process.simGtStage2Digis.EmulateBxInEvent = cms.int32(1)
 
 process.dumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
-                                      egInputTag    = cms.InputTag("gtStage2Digis", "EGamma"),
-		                      muInputTag    = cms.InputTag("gtStage2Digis", "Muon"),
-		                      tauInputTag   = cms.InputTag("gtStage2Digis", "Tau"),
-                                      jetInputTag   = cms.InputTag("gtStage2Digis", "Jet"),
-                                      etsumInputTag = cms.InputTag("gtStage2Digis", "ETSum"),
-                                      uGtAlgInputTag = cms.InputTag("simGtStage2Digis"),
-                                      uGtExtInputTag = cms.InputTag("simGtExtFakeProd"),
+                                      egInputTag       = cms.InputTag("gtStage2Digis", "EGamma"),
+		                      muInputTag       = cms.InputTag("gtStage2Digis", "Muon"),
+		                      muShowerInputTag = cms.InputTag("gtStage2Digis", "MuonShower"),
+		                      tauInputTag      = cms.InputTag("gtStage2Digis", "Tau"),
+                                      jetInputTag      = cms.InputTag("gtStage2Digis", "Jet"),
+                                      etsumInputTag    = cms.InputTag("gtStage2Digis", "ETSum"),
+                                      uGtAlgInputTag   = cms.InputTag("simGtStage2Digis"),
+                                      uGtExtInputTag   = cms.InputTag("simGtExtFakeProd"),
                                       uGtObjectMapInputTag = cms.InputTag("simGtStage2Digis"),
                                       bxOffset       = cms.int32(skip),
                                       minBx          = cms.int32(-2),
@@ -192,7 +192,8 @@ process.dumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
 
 process.load("L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi")
 process.l1GtTrigReport.L1GtRecordInputTag = "simGtStage2Digis"
-process.l1GtTrigReport.PrintVerbosity = 2
+process.l1GtTrigReport.PrintVerbosity = 0 #EF DEBUG
+#process.l1GtTrigReport.PrintVerbosity = 2 #EF DEBUG
 process.report = cms.Path(process.l1GtTrigReport)
 
 process.MessageLogger.categories.append("MuConditon")
@@ -208,6 +209,7 @@ process.gtStage2Raw.TauInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.JetInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.EtSumInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.MuonInputTag = cms.InputTag("gtInput")
+process.gtStage2Raw.MuonShowerInputTag = cms.InputTag("gtInput")
 
 process.load('EventFilter.L1TRawToDigi.gtStage2Digis_cfi')
 process.newGtStage2Digis = process.gtStage2Digis.clone()
@@ -225,6 +227,7 @@ process.dumpRaw = cms.EDAnalyzer(
 process.newDumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
                 egInputTag    = cms.InputTag("newGtStage2Digis","EGamma"),
 		muInputTag    = cms.InputTag("newGtStage2Digis","Muon"),
+		muShowerInputTag    = cms.InputTag("newGtStage2Digis","MuonShower"),
 		tauInputTag   = cms.InputTag("newGtStage2Digis","Tau"),
 		jetInputTag   = cms.InputTag("newGtStage2Digis","Jet"),
 		etsumInputTag = cms.InputTag("newGtStage2Digis","EtSum"),
@@ -257,6 +260,7 @@ process.l1tGlobalAnalyzer = cms.EDAnalyzer('L1TGlobalAnalyzer',
                                            dmxJetToken = cms.InputTag("None"),
                                            dmxEtSumToken = cms.InputTag("None"),
                                            muToken = cms.InputTag("gtStage2Digis", "Muon"),
+                                           muShowerToken = cms.InputTag("gmtStage2Digis", "MuonShower"),
                                            egToken = cms.InputTag("gtStage2Digis", "EGamma"),
                                            tauToken = cms.InputTag("gtStage2Digis", "Tau"),
                                            jetToken = cms.InputTag("gtStage2Digis", "Jet"),
@@ -272,7 +276,7 @@ process.l1tGlobalAnalyzer = cms.EDAnalyzer('L1TGlobalAnalyzer',
 process.p1 = cms.Path(
     ## Input, emulation, dump of the results
     process.dumpMenu
-    *process.RawToDigi
+    *process.RawToDigi 
     #*process.gtInput
     #*process.dumpGT
     *process.simGtExtFakeProd


### PR DESCRIPTION
#### PR description:
The purpose of this PR is to address multiple issues at the GT level related to the muon shower emulation. Here two main items are discussed:
1) **uGT emulation of HMT**
2) **DQM mismatches** 

Thanks @eyigitba and @aloeliger for the work and the discussion. 


1) **uGT emulation of HMT**
The MuonShowerCondition class was broken and was not evaluating at all the condition: this PR contains a first iteration of updates to get reasonable results (with a proper check of the condition for all HMT cases, able to distinguish between Nominal and Tight showers). 

Summary of the main issues:
- The checkObjectParameter function responsible for the check of the muon shower bit for each condition was never called in the class.
- The vector of candidates in MuonShowerCondition (_int numberObjects = candVec->size(useBx)_) was returning four objects (as supposed to be given the splitting in four separate muon shower objects in the Global Board), but we never compare them one by one to the MuonShowerTemplate. For each condition, we should compare each object to the template to make sure one of them passes. All four objects are exclusive in which bits are set to true.
- The declaration of the four muon shower objects in the GlobalBoard was wrong: without having them declared as pointers, they were not passed correctly to the MuonShowerCondition (that was receiving random objects).

Open items:
- At the moment, the class is checking only the central BX: _ReceiveMuonShowerObjectData_ is only looking at BX0. However, we can have showers in other BXs, too (as we saw last year with muon showers before fixing the timing). This has to be included.
- Github issue in the OSW IB: https://github.com/cms-l1t-offline/cmssw/issues/1071.
- In the L1Ntuple workflow running on 1000 events using run 362720 (find the cmsDriver command below), two additional events with a nominal shower were found, and five of those events fire for a tight shower (when we would expect a nominal shower only). No mismatch when running the DQM with the below fix. 
**Note** that L1Ntuple workflow runs the full L1 emulation starting from muonCSCDigis, so the steps in the middle that might be responsible for the discrepancy are: CSC digi unpacker, CSC shower re-emulation, EMTF shower re-emulation. 
After a follow up with @kakwok, we realised that the new CSC thresholds for the HMT shower thresholds had not been updated after the deployment online: fix in https://github.com/cms-sw/cmssw/pull/40829. Including this fix, a single event with a mismatch is found (having both a Nominal and Tight shower): 362720:105:115847543. 
Further checks with @eyigitba for EMTF and @kakwok for CSC needed.
Github issue in the OSW IB: https://github.com/cms-l1t-offline/cmssw/issues/1070.

Validation: 
- L1 emulation run using the L1Ntuples worflow and checking the number of events triggered by HMT. Expected number of events in data: 12 L1_SingleMuShower_Nominal and 5 L1_SingleMuShower_Tight; current emulator counts: 13 L1_SingleMuShower_Nominal and 6 L1_SingleMuShower_Tight. 
- The testing cmsDriver command is:
`cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=data.py -n 1000  --era=Run3 --data --conditions=126X_dataRun3_Prompt_v2 --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --filein=/store/data/Run2022G/EphemeralHLTPhysics0/RAW/v1/000/362/720/00000/36f350d4-8e8a-4e38-b399-77ad9bf351dc.root --nThreads 8`


2) **DQM mismatches** (countings in data, zero countings in the emulator)
- Strategy: Running the emulator with the DQM workflow (see [instructions](https://docs.google.com/document/d/17JQu9lvu93kbkyk0PXQmC_jo8YdXIdQ1g5dV2hWhM7k/edit)) for a specific run containing showers (run 362720).
- Missing input for the hadronic showers in valGtStage2Digis: to be added [here](https://github.com/cms-sw/cmssw/blob/master/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py#L130-L143). 
- At the beginning, providing the uGT input coming from the unpacker, MuonInputTag = "gtStage2Digis:MuonShower", we still observed zero countings; switching to the GMT output MuonInputTag = "gmtStage2Digis:MuonShower", the mismatches disappeared. A fix of the GT unpacker for showers was needed: follow up with @dinyar in https://github.com/cms-sw/cmssw/pull/40822. Everything was tested again with this update and worked successfully (no dataVSemu mismatches in the DQM).

NOTE: An update of the script to produce test vectors for the uGT firmware-emulator comparison is also provided to rely on the unpacked uGT information as input for the muon shower objects.

#### PR validation:
Basic tests performed successfully starting from CMSSW_13_0_0_pre4
> cmsrel CMSSW_13_0_0_pre4
> cd CMSSW_13_0_0_pre4/src
> cmsenv
> git cms-addpkg L1Trigger/L1TGlobal 
> git cms-addpkg DQM/L1TMonitor 
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests 
> scram build code-checks
> scram build code-format