### PR TITLE
RUn3-gex152 Use edm::LogVerbatim instead of std::cout in Geometry/CaloEventSetup

### DIFF
--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -187,7 +187,9 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
   DetSet over = geom->getCells(gp, dR);
   if (over == base) {
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": base and over are equal!\n ***************************\n ";
+    edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta()
+                                 << ", gp.phi=" << gp.phi()
+                                 << ": base and over are equal!\n ***************************\n ";
 #endif
   } else {
     if (2 < std::abs((int)(base.size()) - (int)(over.size()))) {
@@ -197,14 +199,15 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
           base.begin(), base.end(), over.begin(), over.end(), std::inserter(inBaseNotOver, inBaseNotOver.begin()));
 
       if (inBaseNotOver.empty()) {
-        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": No elements in base but not overload ";
+        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta()
+                                     << ", gp.phi=" << gp.phi() << ": No elements in base but not overload ";
       } else {
         edm::LogVerbatim("CaloGeom") << "Length of Base is " << base.size();
         edm::LogVerbatim("CaloGeom") << "Length of Over is " << over.size();
         edm::LogVerbatim("CaloGeom") << "There are " << inBaseNotOver.size() << " items in Base but not in Overload";
 
         for (const auto& iS : inBaseNotOver) {
-	  std::ostringstream st1;
+          std::ostringstream st1;
           st1 << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in base but not overload = ";
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
             st1 << EBDetId(iS);
@@ -220,14 +223,15 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
           over.begin(), over.end(), base.begin(), base.end(), std::inserter(inOverNotBase, inOverNotBase.begin()));
 
       if (inOverNotBase.empty()) {
-        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": No elements in overload but not base ";
+        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta()
+                                     << ", gp.phi=" << gp.phi() << ": No elements in overload but not base ";
       } else {
         edm::LogVerbatim("CaloGeom") << "Length of Base is " << base.size();
         edm::LogVerbatim("CaloGeom") << "Length of Over is " << over.size();
         edm::LogVerbatim("CaloGeom") << "There are " << inOverNotBase.size() << " items in Overload but not in Base";
 
         for (const auto& iS : inOverNotBase) {
-	  std::ostringstream st1;
+          std::ostringstream st1;
           st1 << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in overload but not base = ";
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
             st1 << EBDetId(iS);
@@ -324,8 +328,8 @@ void CaloGeometryAnalyzer::ovrTst(const CaloGeometry* cg,
 void CaloGeometryAnalyzer::checkDiff(int i1, int i2, int i3, CenterOrCorner iCtrCor, XorYorZ iXYZ, double diff) {
   if (3.5 < fabs(diff)) {
     edm::LogVerbatim("CaloGeom") << "For a volume " << (kCenter == iCtrCor ? "CENTER" : "CORNER") << ", & "
-              << "i1=" << i1 << " & i2=" << i2 << " & i3=" << i3 << ", ***BIG DISAGREEMENT FOUND. D"
-              << (kX == iXYZ ? "X" : (kY == iXYZ ? "Y" : "Z")) << "=" << diff << " microns";
+                                 << "i1=" << i1 << " & i2=" << i2 << " & i3=" << i3 << ", ***BIG DISAGREEMENT FOUND. D"
+                                 << (kX == iXYZ ? "X" : (kY == iXYZ ? "Y" : "Z")) << "=" << diff << " microns";
     m_allOK = false;
   }
 }
@@ -491,7 +495,8 @@ void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
   const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
 
   if (ids != ids2) {
-    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size();
+    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size "
+                                 << ids2.size();
   }
   assert(ids == ids2);
 
@@ -622,7 +627,8 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
   const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
 
   if (ids != ids2) {
-    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size();
+    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size "
+                                 << ids2.size();
   }
 
   assert(ids == ids2);
@@ -896,7 +902,8 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                        geom->getGeometry(closestCell)->getPosition().eta(),
                                        geom->getGeometry(closestCell)->getPosition().phi()));
           if (rr > 1.e-5)
-            edm::LogVerbatim("CaloGeom") << "For " << HcalCastorDetId(i) << " closest is " << HcalCastorDetId(closestCell) << " dR=" << rr;
+            edm::LogVerbatim("CaloGeom") << "For " << HcalCastorDetId(i) << " closest is "
+                                         << HcalCastorDetId(closestCell) << " dR=" << rr;
         }
       }
       // test getCells against base class version every so often
@@ -925,7 +932,8 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                        geom->getGeometry(closestCell)->getPosition().eta(),
                                        geom->getGeometry(closestCell)->getPosition().phi()));
           if (rr > 1.e-5)
-            edm::LogVerbatim("CaloGeom") << "For " << HcalZDCDetId(i) << " closest is " << HcalZDCDetId(closestCell) << " dR=" << rr;
+            edm::LogVerbatim("CaloGeom") << "For " << HcalZDCDetId(i) << " closest is " << HcalZDCDetId(closestCell)
+                                         << " dR=" << rr;
         }
       }
       // test getCells against base class version every so often
@@ -991,10 +999,14 @@ void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Even
   //
   if (pass_ == 0) {
     edm::LogVerbatim("CaloGeom") << "**Ecal Barrel avg Radius = "
-				 << dynamic_cast<const EcalBarrelGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))->avgRadiusXYFrontFaceCenter();
+                                 << dynamic_cast<const EcalBarrelGeometry*>(
+                                        pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))
+                                        ->avgRadiusXYFrontFaceCenter();
 
     edm::LogVerbatim("CaloGeom") << "**Ecal Endcap avg Zabs = "
-				 << dynamic_cast<const EcalEndcapGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))->avgAbsZFrontFaceCenter();
+                                 << dynamic_cast<const EcalEndcapGeometry*>(
+                                        pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))
+                                        ->avgAbsZFrontFaceCenter();
 
     m_allOK = true;
 
@@ -1010,7 +1022,8 @@ void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Even
     // Castor has been removed from CMS
     build(cG, pT, DetId::Calo, HcalZDCDetId::SubdetectorId, "zd", 9);
 
-    edm::LogVerbatim("CaloGeom") << "\n\n*********** Validation of cell centers and corners " << (m_allOK ? "SUCCEEDS!! " : "FAILS!! ") << "**********************\n\n\n";
+    edm::LogVerbatim("CaloGeom") << "\n\n*********** Validation of cell centers and corners "
+                                 << (m_allOK ? "SUCCEEDS!! " : "FAILS!! ") << "**********************\n\n\n";
   }
 
   pass_++;

--- a/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
+++ b/Geometry/CaloEventSetup/test/CaloGeometryAnalyzer.cc
@@ -25,12 +25,14 @@
 
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include <fstream>
 #include <iomanip>
 #include <iterator>
+#include <sstream>
 #include "TH1.h"
 #include "TH1D.h"
 #include "TProfile.h"
@@ -184,15 +186,9 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
   DetSet base = geom->CaloSubdetectorGeometry::getCells(gp, dR);
   DetSet over = geom->getCells(gp, dR);
   if (over == base) {
-    /*
-      std::cout << "getCells Test dR="
-		<< dR
-		<< ", gp=" << gp 
-		<< ", gp.eta=" << gp.eta() 
-		<< ", gp.phi=" << gp.phi() 
-		<< ": base and over are equal!\n ***************************\n " 
-		<< std::endl ;
-*/
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": base and over are equal!\n ***************************\n ";
+#endif
   } else {
     if (2 < std::abs((int)(base.size()) - (int)(over.size()))) {
       DetSet inBaseNotOver;
@@ -201,22 +197,22 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
           base.begin(), base.end(), over.begin(), over.end(), std::inserter(inBaseNotOver, inBaseNotOver.begin()));
 
       if (inBaseNotOver.empty()) {
-        std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi()
-                  << ": No elements in base but not overload " << std::endl;
+        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": No elements in base but not overload ";
       } else {
-        std::cout << "Length of Base is " << base.size() << std::endl;
-        std::cout << "Length of Over is " << over.size() << std::endl;
-        std::cout << "There are " << inBaseNotOver.size() << " items in Base but not in Overload" << std::endl;
+        edm::LogVerbatim("CaloGeom") << "Length of Base is " << base.size();
+        edm::LogVerbatim("CaloGeom") << "Length of Over is " << over.size();
+        edm::LogVerbatim("CaloGeom") << "There are " << inBaseNotOver.size() << " items in Base but not in Overload";
 
         for (const auto& iS : inBaseNotOver) {
-          std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in base but not overload = ";
+	  std::ostringstream st1;
+          st1 << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in base but not overload = ";
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
-            std::cout << EBDetId(iS);
+            st1 << EBDetId(iS);
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalEndcap)
-            std::cout << EEDetId(iS);
+            st1 << EEDetId(iS);
           if (iS.det() == DetId::Hcal)
-            std::cout << HcalDetId(iS);
-          std::cout << std::endl;
+            st1 << HcalDetId(iS);
+          edm::LogVerbatim("CaloGeom") << st1.str();
         }
       }
 
@@ -224,25 +220,25 @@ void CaloGeometryAnalyzer::cmpset(const CaloSubdetectorGeometry* geom, const Glo
           over.begin(), over.end(), base.begin(), base.end(), std::inserter(inOverNotBase, inOverNotBase.begin()));
 
       if (inOverNotBase.empty()) {
-        std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi()
-                  << ": No elements in overload but not base " << std::endl;
+        edm::LogVerbatim("CaloGeom") << "getCells Test dR=" << dR << ", gp=" << gp << ", gp.eta=" << gp.eta() << ", gp.phi=" << gp.phi() << ": No elements in overload but not base ";
       } else {
-        std::cout << "Length of Base is " << base.size() << std::endl;
-        std::cout << "Length of Over is " << over.size() << std::endl;
-        std::cout << "There are " << inOverNotBase.size() << " items in Overload but not in Base" << std::endl;
+        edm::LogVerbatim("CaloGeom") << "Length of Base is " << base.size();
+        edm::LogVerbatim("CaloGeom") << "Length of Over is " << over.size();
+        edm::LogVerbatim("CaloGeom") << "There are " << inOverNotBase.size() << " items in Overload but not in Base";
 
         for (const auto& iS : inOverNotBase) {
-          std::cout << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in overload but not base = ";
+	  std::ostringstream st1;
+          st1 << "getCells Test dR=" << dR << ", gp=" << gp << ": cell in overload but not base = ";
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalBarrel)
-            std::cout << EBDetId(iS);
+            st1 << EBDetId(iS);
           if (iS.det() == DetId::Ecal && iS.subdetId() == EcalEndcap)
-            std::cout << EEDetId(iS);
+            st1 << EEDetId(iS);
           if (iS.det() == DetId::Hcal)
-            std::cout << HcalDetId(iS);
-          std::cout << std::endl;
+            st1 << HcalDetId(iS);
+          edm::LogVerbatim("CaloGeom") << st1.str();
         }
       }
-      std::cout << "------------- done with mismatch printout ---------------" << std::endl;
+      edm::LogVerbatim("CaloGeom") << "------------- done with mismatch printout ---------------";
     }
   }
 }
@@ -327,9 +323,9 @@ void CaloGeometryAnalyzer::ovrTst(const CaloGeometry* cg,
 
 void CaloGeometryAnalyzer::checkDiff(int i1, int i2, int i3, CenterOrCorner iCtrCor, XorYorZ iXYZ, double diff) {
   if (3.5 < fabs(diff)) {
-    std::cout << "For a volume " << (kCenter == iCtrCor ? "CENTER" : "CORNER") << ", & "
+    edm::LogVerbatim("CaloGeom") << "For a volume " << (kCenter == iCtrCor ? "CENTER" : "CORNER") << ", & "
               << "i1=" << i1 << " & i2=" << i2 << " & i3=" << i3 << ", ***BIG DISAGREEMENT FOUND. D"
-              << (kX == iXYZ ? "X" : (kY == iXYZ ? "Y" : "Z")) << "=" << diff << " microns" << std::endl;
+              << (kX == iXYZ ? "X" : (kY == iXYZ ? "Y" : "Z")) << "=" << diff << " microns";
     m_allOK = false;
   }
 }
@@ -466,7 +462,7 @@ void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
                                      int subdetn,
                                      const char* name,
                                      unsigned int histi) {
-  std::cout << "Now checking detector " << name << std::endl;
+  edm::LogVerbatim("CaloGeom") << "Now checking detector " << name;
   const std::string oldnameCtr("old" + std::string(name) + ".ctr");
   const std::string oldnameCor("old" + std::string(name) + ".cor");
   const std::string fnameCtr(std::string(name) + ".ctr");
@@ -495,8 +491,7 @@ void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
   const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
 
   if (ids != ids2) {
-    std::cout << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size()
-              << std::endl;
+    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size();
   }
   assert(ids == ids2);
 
@@ -523,7 +518,7 @@ void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
         pos.x() - 0.1 * pos.x() / posmag, pos.y() - 0.1 * pos.y() / posmag, pos.z() - 0.1 * pos.z() / posmag);
 
     if (cell->inside(pointFr))
-      std::cout << "Bad outside: " << pointIn << ", " << pointFr << std::endl;
+      edm::LogVerbatim("CaloGeom") << "Bad outside: " << pointIn << ", " << pointFr;
     assert(cell->inside(pointIn));
     assert(!cell->inside(pointFr));
 
@@ -562,7 +557,7 @@ void CaloGeometryAnalyzer::buildHcal(const CaloGeometry* cg,
                                    geom->getGeometry(closestCell)->getPosition().eta(),
                                    geom->getGeometry(closestCell)->getPosition().phi()));
       if (rr > 1.e-5)
-        std::cout << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr << std::endl;
+        edm::LogVerbatim("CaloGeom") << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr;
     }
     // test getCells against base class version every so often
     if (0 == ht.detId2denseId(closestCell) % 30) {
@@ -597,7 +592,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                  int subdetn,
                                  const char* name,
                                  unsigned int histi) {
-  std::cout << "Now checking detector " << name << std::endl;
+  edm::LogVerbatim("CaloGeom") << "Now checking detector " << name;
 
   const std::string oldnameCtr("old" + std::string(name) + ".ctr");
   const std::string oldnameCor("old" + std::string(name) + ".cor");
@@ -627,8 +622,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
   const std::vector<DetId>& ids2(cg->getValidDetIds(det, subdetn));
 
   if (ids != ids2) {
-    std::cout << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size()
-              << std::endl;
+    edm::LogVerbatim("CaloGeom") << "Methods differ! One gives size " << ids.size() << " and the other gives size " << ids2.size();
   }
 
   assert(ids == ids2);
@@ -662,7 +656,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
         pos.x() - 0.1 * pos.x() / posmag, pos.y() - 0.1 * pos.y() / posmag, pos.z() - 0.1 * pos.z() / posmag);
 
     if (cell->inside(pointFr))
-      std::cout << "Bad outside: " << pointIn << ", " << pointFr << std::endl;
+      edm::LogVerbatim("CaloGeom") << "Bad outside: " << pointIn << ", " << pointFr;
     assert(cell->inside(pointIn));
     assert(!cell->inside(pointFr));
 
@@ -839,7 +833,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
         assert((o_zside < 0 && cell->getPosition().z() < 0.) || (o_zside > 0 && cell->getPosition().z() > 0.));
 
         if (closestCell != esid)
-          std::cout << "** esid=" << esid << ", closest=" << closestCell << std::endl;
+          edm::LogVerbatim("CaloGeom") << "** esid=" << esid << ", closest=" << closestCell;
 
         const unsigned int i1(EcalPreshowerGeometry::alignmentTransformIndexLocal(esid));
 
@@ -875,7 +869,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                      geom->getGeometry(closestCell)->getPosition().eta(),
                                      geom->getGeometry(closestCell)->getPosition().phi()));
         if (rr > 1.e-5)
-          std::cout << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr << std::endl;
+          edm::LogVerbatim("CaloGeom") << "For " << HcalDetId(i) << " closest is " << closestCell << " HCAL dR=" << rr;
       }
       // test getCells against base class version every so often
       if (0 == ht.detId2denseId(closestCell) % 30) {
@@ -902,8 +896,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                        geom->getGeometry(closestCell)->getPosition().eta(),
                                        geom->getGeometry(closestCell)->getPosition().phi()));
           if (rr > 1.e-5)
-            std::cout << "For " << HcalCastorDetId(i) << " closest is " << HcalCastorDetId(closestCell) << " dR=" << rr
-                      << std::endl;
+            edm::LogVerbatim("CaloGeom") << "For " << HcalCastorDetId(i) << " closest is " << HcalCastorDetId(closestCell) << " dR=" << rr;
         }
       }
       // test getCells against base class version every so often
@@ -932,8 +925,7 @@ void CaloGeometryAnalyzer::build(const CaloGeometry* cg,
                                        geom->getGeometry(closestCell)->getPosition().eta(),
                                        geom->getGeometry(closestCell)->getPosition().phi()));
           if (rr > 1.e-5)
-            std::cout << "For " << HcalZDCDetId(i) << " closest is " << HcalZDCDetId(closestCell) << " dR=" << rr
-                      << std::endl;
+            edm::LogVerbatim("CaloGeom") << "For " << HcalZDCDetId(i) << " closest is " << HcalZDCDetId(closestCell) << " dR=" << rr;
         }
       }
       // test getCells against base class version every so often
@@ -988,7 +980,7 @@ void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Even
                          dct.size() + dca.size() + dzd.size());
 
   if (sum != allDetId.size()) {
-    std::cout << "Sums differ! One is " << allDetId.size() << " and the other is " << sum << std::endl;
+    edm::LogVerbatim("CaloGeom") << "Sums differ! One is " << allDetId.size() << " and the other is " << sum;
   }
 
   assert(sum == allDetId.size());
@@ -998,15 +990,11 @@ void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Even
   // get the ecal & hcal geometry
   //
   if (pass_ == 0) {
-    std::cout << "**Ecal Barrel avg Radius = "
-              << dynamic_cast<const EcalBarrelGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))
-                     ->avgRadiusXYFrontFaceCenter()
-              << std::endl;
+    edm::LogVerbatim("CaloGeom") << "**Ecal Barrel avg Radius = "
+				 << dynamic_cast<const EcalBarrelGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalBarrel))->avgRadiusXYFrontFaceCenter();
 
-    std::cout << "**Ecal Endcap avg Zabs = "
-              << dynamic_cast<const EcalEndcapGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))
-                     ->avgAbsZFrontFaceCenter()
-              << std::endl;
+    edm::LogVerbatim("CaloGeom") << "**Ecal Endcap avg Zabs = "
+				 << dynamic_cast<const EcalEndcapGeometry*>(pG.getSubdetectorGeometry(DetId::Ecal, EcalEndcap))->avgAbsZFrontFaceCenter();
 
     m_allOK = true;
 
@@ -1022,9 +1010,7 @@ void CaloGeometryAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Even
     // Castor has been removed from CMS
     build(cG, pT, DetId::Calo, HcalZDCDetId::SubdetectorId, "zd", 9);
 
-    std::cout << "\n\n*********** Validation of cell centers and corners " << (m_allOK ? "SUCCEEDS!! " : "FAILS!! ")
-              << "**********************\n\n\n"
-              << std::endl;
+    edm::LogVerbatim("CaloGeom") << "\n\n*********** Validation of cell centers and corners " << (m_allOK ? "SUCCEEDS!! " : "FAILS!! ") << "**********************\n\n\n";
   }
 
   pass_++;

--- a/Geometry/CaloEventSetup/test/DumpEcalTrigTowerMapping.cc
+++ b/Geometry/CaloEventSetup/test/DumpEcalTrigTowerMapping.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -113,12 +114,10 @@ void DumpEcalTrigTowerMapping::build(const CaloGeometry& cg,
     h->GetYaxis()->CenterTitle(true);
     const std::vector<DetId>& eeDetIds = cg.getValidDetIds(det, subdetn);
 
-    std::cout << "*** testing endcap trig tower mapping **" << std::endl;
+    edm::LogVerbatim("CaloGeom") << "*** testing endcap trig tower mapping **";
     for (const auto& eeDetId : eeDetIds) {
       EEDetId myId(eeDetId);
       EcalTrigTowerDetId myTower = etmap.towerOf(eeDetId);
-
-      //	  std::cout<<"eedetid="<<EEDetId(eeDetIds[i])<<", myTower="<<myTower<<std::endl;
 
       assert(myTower == EcalTrigTowerDetId::detIdFromDenseIndex(myTower.denseIndex()));
 
@@ -170,7 +169,7 @@ void DumpEcalTrigTowerMapping::build(const CaloGeometry& cg,
     h->GetYaxis()->CenterTitle(true);
     const std::vector<DetId>& ebDetIds = cg.getValidDetIds(det, subdetn);
 
-    std::cout << "*** testing barrel trig tower mapping **" << std::endl;
+    edm::LogVerbatim("CaloGeom") << "*** testing barrel trig tower mapping **";
     for (const auto& ebDetId : ebDetIds) {
       EBDetId myId(ebDetId);
       EcalTrigTowerDetId myTower = etmap.towerOf(ebDetId);
@@ -188,7 +187,7 @@ void DumpEcalTrigTowerMapping::build(const CaloGeometry& cg,
 }
 
 void DumpEcalTrigTowerMapping::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
-  std::cout << "Here I am " << std::endl;
+  edm::LogVerbatim("CaloGeom") << "Here I am ";
 
   const auto& eTTmap = iSetup.getData(eTTmapToken_);
   const auto& pG = iSetup.getData(geometryToken_);

--- a/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
+++ b/Geometry/CaloEventSetup/test/TestEcalGetWindow.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/CaloTopologyRecord.h"
@@ -173,7 +174,7 @@ void TestEcalGetWindow::build(
 }
 // ------------ method called to produce the data  ------------
 void TestEcalGetWindow::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
-  std::cout << "Here I am " << std::endl;
+  edm::LogVerbatim("CaloGeom") << "Here I am ";
 
   const auto& theCaloTopology = iSetup.getData(topologyToken_);
   const auto& pG = iSetup.getData(geometryToken_);

--- a/Geometry/CaloEventSetup/test/runMaster_cfg.py
+++ b/Geometry/CaloEventSetup/test/runMaster_cfg.py
@@ -25,6 +25,8 @@ process.load("Geometry.CaloEventSetup.CaloTopology_cfi")
 process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryAlign_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryAlign_cfg.py
@@ -10,6 +10,8 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['mc']
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryDBDD4hep_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryDBDD4hep_cfg.py
@@ -16,6 +16,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2021', '')
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )
 
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.etta = cms.EDAnalyzer("DumpEcalTrigTowerMapping")
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryDB_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryDB_cfg.py
@@ -11,6 +11,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )
 
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.etta = cms.EDAnalyzer("DumpEcalTrigTowerMapping")
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryDD4hep_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryDD4hep_cfg.py
@@ -8,6 +8,8 @@ process = cms.Process("GeometryTest", Run3_dd4hep)
 process.load('Configuration.Geometry.GeometryDD4hepExtended2021Reco_cff')
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryDDD_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryDDD_cfg.py
@@ -5,6 +5,8 @@ process = cms.Process("GeometryTest")
 process.load('Configuration.Geometry.GeometryExtended_cff')
 process.load('Configuration.Geometry.GeometryExtendedReco_cff')
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryLocalDBDD4hep_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryLocalDBDD4hep_cfg.py
@@ -10,6 +10,10 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2021', '')
 
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
+
 process.source = cms.Source("EmptySource")
 
 process.maxEvents = cms.untracked.PSet(

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryLocalDB_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryLocalDB_cfg.py
@@ -6,6 +6,10 @@ process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
+
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['run1_mc']
 

--- a/Geometry/CaloEventSetup/test/runTestCaloGeometryXMLDB_cfg.py
+++ b/Geometry/CaloEventSetup/test/runTestCaloGeometryXMLDB_cfg.py
@@ -8,6 +8,9 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['mc']
 
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.CaloGeom=dict()
+
 process.source = cms.Source("EmptySource")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(4) )


### PR DESCRIPTION
#### PR description:

Use edm::LogVerbatim instead of std::cout in Geometry/CaloEventSetup

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special