### PR TITLE
stop using bare ROOT objects in `HLTDQMHist*` classes [`12_5_X`]

### DIFF
--- a/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
+++ b/DQMOffline/Trigger/interface/HLTDQMFilterEffHists.h
@@ -18,22 +18,18 @@
 //
 //***********************************************************************************
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
-#include "DQMServices/Core/interface/DQMStore.h"
-
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
-
 #include "DQMOffline/Trigger/interface/HLTDQMHist.h"
 #include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
 #include "DQMOffline/Trigger/interface/FunctionDefs.h"
 #include "DQMOffline/Trigger/interface/UtilFuncs.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 template <typename ObjType>
 class HLTDQMFilterEffHists {
 public:
-  typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
 
   explicit HLTDQMFilterEffHists(const edm::ParameterSet& config, std::string baseHistName, std::string hltProcess);
@@ -52,8 +48,8 @@ private:
   void book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig);
 
 private:
-  std::vector<std::unique_ptr<HLTDQMHist<ObjType> > > histsPass_;
-  std::vector<std::unique_ptr<HLTDQMHist<ObjType> > > histsTot_;
+  std::vector<std::unique_ptr<HLTDQMHist<ObjType>>> histsPass_;
+  std::vector<std::unique_ptr<HLTDQMHist<ObjType>>> histsTot_;
   VarRangeCutColl<ObjType> rangeCuts_;
   std::string filterName_;
   std::string histTitle_;
@@ -66,7 +62,7 @@ template <typename ObjType>
 HLTDQMFilterEffHists<ObjType>::HLTDQMFilterEffHists(const edm::ParameterSet& config,
                                                     std::string baseHistName,
                                                     std::string hltProcess)
-    : rangeCuts_(config.getParameter<std::vector<edm::ParameterSet> >("rangeCuts")),
+    : rangeCuts_(config.getParameter<std::vector<edm::ParameterSet>>("rangeCuts")),
       filterName_(config.getParameter<std::string>("filterName")),
       histTitle_(config.getParameter<std::string>("histTitle")),
       folderName_(config.getParameter<std::string>("folderName")),
@@ -89,11 +85,11 @@ edm::ParameterSetDescription HLTDQMFilterEffHists<ObjType>::makePSetDescriptionH
 
   //what this is doing is trival and is left as an exercise to the reader
   auto histDescCases =
-      "1D" >> (edm::ParameterDescription<std::vector<double> >("binLowEdges", std::vector<double>(), true) and
+      "1D" >> (edm::ParameterDescription<std::vector<double>>("binLowEdges", std::vector<double>(), true) and
                edm::ParameterDescription<std::string>("nameSuffex", "", true) and
                edm::ParameterDescription<std::string>("vsVar", "", true)) or
-      "2D" >> (edm::ParameterDescription<std::vector<double> >("xBinLowEdges", std::vector<double>(), true) and
-               edm::ParameterDescription<std::vector<double> >("yBinLowEdges", std::vector<double>(), true) and
+      "2D" >> (edm::ParameterDescription<std::vector<double>>("xBinLowEdges", std::vector<double>(), true) and
+               edm::ParameterDescription<std::vector<double>>("yBinLowEdges", std::vector<double>(), true) and
                edm::ParameterDescription<std::string>("nameSuffex", "", true) and
                edm::ParameterDescription<std::string>("xVar", "", true) and
                edm::ParameterDescription<std::string>("yVar", "", true));
@@ -121,7 +117,7 @@ void HLTDQMFilterEffHists<ObjType>::bookHists(DQMStore::IBooker& iBooker,
 
 template <typename ObjType>
 void HLTDQMFilterEffHists<ObjType>::book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig) {
-  auto binLowEdgesDouble = histConfig.getParameter<std::vector<double> >("binLowEdges");
+  auto binLowEdgesDouble = histConfig.getParameter<std::vector<double>>("binLowEdges");
   std::vector<float> binLowEdges;
   binLowEdges.reserve(binLowEdgesDouble.size());
   for (double lowEdge : binLowEdgesDouble)
@@ -131,28 +127,28 @@ void HLTDQMFilterEffHists<ObjType>::book1D(DQMStore::IBooker& iBooker, const edm
                                (histTitle_ + nameSuffex + " Pass").c_str(),
                                binLowEdges.size() - 1,
                                &binLowEdges[0]);
-  std::unique_ptr<HLTDQMHist<ObjType> > hist;
+  std::unique_ptr<HLTDQMHist<ObjType>> hist;
   auto vsVar = histConfig.getParameter<std::string>("vsVar");
   auto vsVarFunc = hltdqm::getUnaryFuncFloat<ObjType>(vsVar);
   if (!vsVarFunc) {
     throw cms::Exception("ConfigError") << " vsVar " << vsVar << " is giving null ptr (likely empty) in " << __FILE__
                                         << "," << __LINE__ << std::endl;
   }
-  VarRangeCutColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet> >("rangeCuts"));
-  hist = std::make_unique<HLTDQMHist1D<ObjType, float> >(mePass->getTH1(), vsVar, vsVarFunc, rangeCuts);
+  VarRangeCutColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet>>("rangeCuts"));
+  hist = std::make_unique<HLTDQMHist1D<ObjType, float>>(mePass, vsVar, vsVarFunc, rangeCuts);
   histsPass_.emplace_back(std::move(hist));
   auto meTot = iBooker.book1D((baseHistName_ + filterName_ + nameSuffex + "_tot").c_str(),
                               (histTitle_ + nameSuffex + " Total").c_str(),
                               binLowEdges.size() - 1,
                               &binLowEdges[0]);
-  hist = std::make_unique<HLTDQMHist1D<ObjType, float> >(meTot->getTH1(), vsVar, vsVarFunc, rangeCuts);
+  hist = std::make_unique<HLTDQMHist1D<ObjType, float>>(meTot, vsVar, vsVarFunc, rangeCuts);
   histsTot_.emplace_back(std::move(hist));
 }
 
 template <typename ObjType>
 void HLTDQMFilterEffHists<ObjType>::book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig) {
-  auto xBinLowEdgesDouble = histConfig.getParameter<std::vector<double> >("xBinLowEdges");
-  auto yBinLowEdgesDouble = histConfig.getParameter<std::vector<double> >("yBinLowEdges");
+  auto xBinLowEdgesDouble = histConfig.getParameter<std::vector<double>>("xBinLowEdges");
+  auto yBinLowEdgesDouble = histConfig.getParameter<std::vector<double>>("yBinLowEdges");
   std::vector<float> xBinLowEdges;
   std::vector<float> yBinLowEdges;
   xBinLowEdges.reserve(xBinLowEdgesDouble.size());
@@ -168,7 +164,7 @@ void HLTDQMFilterEffHists<ObjType>::book2D(DQMStore::IBooker& iBooker, const edm
                                &xBinLowEdges[0],
                                yBinLowEdges.size() - 1,
                                &yBinLowEdges[0]);
-  std::unique_ptr<HLTDQMHist<ObjType> > hist;
+  std::unique_ptr<HLTDQMHist<ObjType>> hist;
   auto xVar = histConfig.getParameter<std::string>("xVar");
   auto yVar = histConfig.getParameter<std::string>("yVar");
   auto xVarFunc = hltdqm::getUnaryFuncFloat<ObjType>(xVar);
@@ -177,11 +173,9 @@ void HLTDQMFilterEffHists<ObjType>::book2D(DQMStore::IBooker& iBooker, const edm
     throw cms::Exception("ConfigError") << " xVar " << xVar << " or yVar " << yVar
                                         << " is giving null ptr (likely empty str passed)" << std::endl;
   }
-  VarRangeCutColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet> >("rangeCuts"));
+  VarRangeCutColl<ObjType> rangeCuts(histConfig.getParameter<std::vector<edm::ParameterSet>>("rangeCuts"));
 
-  //really? really no MonitorElement::getTH2...sigh
-  hist = std::make_unique<HLTDQMHist2D<ObjType, float> >(
-      static_cast<TH2*>(mePass->getTH1()), xVar, yVar, xVarFunc, yVarFunc, rangeCuts);
+  hist = std::make_unique<HLTDQMHist2D<ObjType, float>>(mePass, xVar, yVar, xVarFunc, yVarFunc, rangeCuts);
   histsPass_.emplace_back(std::move(hist));
 
   auto meTot = iBooker.book2D((baseHistName_ + filterName_ + nameSuffex + "_tot").c_str(),
@@ -191,8 +185,7 @@ void HLTDQMFilterEffHists<ObjType>::book2D(DQMStore::IBooker& iBooker, const edm
                               yBinLowEdges.size() - 1,
                               &yBinLowEdges[0]);
 
-  hist = std::make_unique<HLTDQMHist2D<ObjType, float> >(
-      static_cast<TH2*>(meTot->getTH1()), xVar, yVar, xVarFunc, yVarFunc, rangeCuts);
+  hist = std::make_unique<HLTDQMHist2D<ObjType, float>>(meTot, xVar, yVar, xVarFunc, yVarFunc, rangeCuts);
   histsTot_.emplace_back(std::move(hist));
 }
 

--- a/DQMOffline/Trigger/interface/HLTDQMTagAndProbeEff.h
+++ b/DQMOffline/Trigger/interface/HLTDQMTagAndProbeEff.h
@@ -58,7 +58,6 @@ namespace {
 template <typename TagType, typename TagCollType, typename ProbeType = TagType, typename ProbeCollType = TagCollType>
 class HLTDQMTagAndProbeEff {
 public:
-  typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
 
   explicit HLTDQMTagAndProbeEff(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc);

--- a/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/HLTTagAndProbeOfflineSource.cc
@@ -1,24 +1,11 @@
-
-#include "DQMServices/Core/interface/DQMStore.h"
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-
-#include "FWCore/Common/interface/TriggerNames.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/HLTReco/interface/TriggerEvent.h"
-#include "DataFormats/HLTReco/interface/TriggerObject.h"
-#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
-
+#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMOffline/Trigger/interface/HLTDQMTagAndProbeEff.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include <vector>
-#include <string>
 
 template <typename TagType, typename TagCollType, typename ProbeType = TagType, typename ProbeCollType = TagCollType>
 class HLTTagAndProbeOfflineSource : public DQMEDAnalyzer {
@@ -34,13 +21,13 @@ public:
   void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
 
 private:
-  std::vector<HLTDQMTagAndProbeEff<TagType, TagCollType, ProbeType, ProbeCollType> > tagAndProbeEffs_;
+  std::vector<HLTDQMTagAndProbeEff<TagType, TagCollType, ProbeType, ProbeCollType>> tagAndProbeEffs_;
 };
 
 template <typename TagType, typename TagCollType, typename ProbeType, typename ProbeCollType>
 HLTTagAndProbeOfflineSource<TagType, TagCollType, ProbeType, ProbeCollType>::HLTTagAndProbeOfflineSource(
     const edm::ParameterSet& config) {
-  auto histCollConfigs = config.getParameter<std::vector<edm::ParameterSet> >("tagAndProbeCollections");
+  auto histCollConfigs = config.getParameter<std::vector<edm::ParameterSet>>("tagAndProbeCollections");
   for (auto& histCollConfig : histCollConfigs) {
     tagAndProbeEffs_.emplace_back(
         HLTDQMTagAndProbeEff<TagType, TagCollType, ProbeType, ProbeCollType>(histCollConfig, consumesCollector()));
@@ -51,16 +38,10 @@ template <typename TagType, typename TagCollType, typename ProbeType, typename P
 void HLTTagAndProbeOfflineSource<TagType, TagCollType, ProbeType, ProbeCollType>::fillDescriptions(
     edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("objs", edm::InputTag(""));
   desc.addVPSet("tagAndProbeCollections",
                 HLTDQMTagAndProbeEff<TagType, TagCollType, ProbeType, ProbeCollType>::makePSetDescription(),
-                std::vector<edm::ParameterSet>());
-
-  // addDefault must be used here instead of add unless this function is specialized
-  // for different sets of template parameter types. Each specialization would need
-  // a different module label. Otherwise the generated cfi filenames will conflict
-  // for the different plugins.
-  descriptions.addDefault(desc);
+                {});
+  descriptions.addWithDefaultLabel(desc);
 }
 
 template <typename TagType, typename TagCollType, typename ProbeType, typename ProbeCollType>


### PR DESCRIPTION
backport of #40760

#### PR description:

From the description of #40760:

>This PR tries to implement the suggestion in https://github.com/cms-sw/cmssw/issues/40676#issuecomment-1428768169, to avoid accessing bare ROOT objects (via `MonitorElement`) in the `HLTDQMHist*D` classes of the HLT offline DQM.
>
>Minor cleanup is also applied to `HLTTagAndProbeOfflineSource<..>::fillDescriptions`.
>
>Merely technical. No changes expected.

#### PR validation:

None beyond the checks done for #40760.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40760

Backport of a possible fix to address #40676.
