### PR TITLE
remove one HLT-related histogram from E/Gamma offline DQM

### DIFF
--- a/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
@@ -32,11 +32,6 @@ ElectronGeneralAnalyzer::ElectronGeneralAnalyzer(const edm::ParameterSet& conf) 
   vertexCollection_ = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexCollection"));
   gsftrackCollection_ = consumes<reco::GsfTrackCollection>(conf.getParameter<edm::InputTag>("GsfTrackCollection"));
   beamSpotTag_ = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("BeamSpot"));
-  triggerResults_ = consumes<edm::TriggerResults>(conf.getParameter<edm::InputTag>("TriggerResults"));
-
-  //  // for trigger
-  //  HLTPathsByName_= conf.getParameter<std::vector<std::string > >("HltPaths");
-  //  HLTPathsByIndex_.resize(HLTPathsByName_.size());
 }
 
 ElectronGeneralAnalyzer::~ElectronGeneralAnalyzer() {}
@@ -53,7 +48,6 @@ void ElectronGeneralAnalyzer::bookHistograms(DQMStore::IBooker& iBooker, edm::Ru
   py_ele_nTracksVsLs = bookP1(iBooker, "nTracksVsLs", "# tracks vs LS", 150, 0., 1500., 0., 100., "LS", "<N_{gen tk}>");
   py_ele_nVerticesVsLs =
       bookP1(iBooker, "nVerticesVsLs", "# vertices vs LS", 150, 0., 1500., 0., 10., "LS", "<N_{vert}>");
-  h1_ele_triggers = bookH1(iBooker, "triggers", "hlt triggers", 256, 0., 256., "HLT bit");
 }
 
 void ElectronGeneralAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -85,16 +79,4 @@ void ElectronGeneralAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   py_ele_nGsfTracksVsLs->Fill(float(ils), (*gsfTracks).size());
   py_ele_nTracksVsLs->Fill(float(ils), (*tracks).size());
   py_ele_nVerticesVsLs->Fill(float(ils), (*vertices).size());
-
-  // trigger
-  edm::Handle<edm::TriggerResults> triggerResults;
-  iEvent.getByToken(triggerResults_, triggerResults);
-  if (triggerResults.isValid()) {
-    unsigned int i, n = triggerResults->size();
-    for (i = 0; i != n; ++i) {
-      if (triggerResults->accept(i)) {
-        h1_ele_triggers->Fill(float(i));
-      }
-    }
-  }
 }

--- a/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.h
+++ b/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.h
@@ -1,4 +1,3 @@
-
 #ifndef DQMOffline_EGamma_ElectronGeneralAnalyzer_h
 #define DQMOffline_EGamma_ElectronGeneralAnalyzer_h
 
@@ -40,17 +39,6 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
 
-  // for trigger
-  edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
-  //std::vector<std::string > HLTPathsByName_;
-  //
-  //    //=========================================
-  //    // general attributes and utility methods
-  //    //=========================================
-  //
-  //    bool trigger( const edm::Event & e ) ;
-  //    std::vector<unsigned int> HLTPathsByIndex_;
-
   //=========================================
   // histograms
   //=========================================
@@ -61,7 +49,6 @@ private:
   MonitorElement *py_ele_nGsfTracksVsLs;
   MonitorElement *py_ele_nTracksVsLs;
   MonitorElement *py_ele_nVerticesVsLs;
-  MonitorElement *h1_ele_triggers;
 };
 
 #endif

--- a/DQMOffline/EGamma/python/electronGeneralAnalyzer_cfi.py
+++ b/DQMOffline/EGamma/python/electronGeneralAnalyzer_cfi.py
@@ -17,9 +17,6 @@ dqmElectronGeneralAnalysis = DQMEDAnalyzer('ElectronGeneralAnalyzer',
     GsfTrackCollection = cms.InputTag("electronGsfTracks"),
     VertexCollection = cms.InputTag("offlinePrimaryVertices"),
     BeamSpot = cms.InputTag("offlineBeamSpot"),
-    TriggerResults = cms.InputTag("TriggerResults::HLT")
-    #HltPaths = cms.vstring('HLT_Ele10_SW_L1R','HLT_Ele15_SW_L1R','HLT_Ele15_SW_EleId_L1R','HLT_Ele15_SW_LooseTrackIso_L1R','HLT_Ele15_SC15_SW_LooseTrackIso_L1R','HLT_Ele15_SC15_SW_EleId_L1R','HLT_Ele20_SW_L1R','HLT_Ele20_SC15_SW_L1R','HLT_Ele25_SW_L1R','HLT_Ele25_SW_EleId_LooseTrackIso_L1R','HLT_DoubleEle10_SW_L1R')
-
 )
 
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal


### PR DESCRIPTION
#### PR description:

This PR removes an histogram related to HLT from the outputs of the E/Gamma offline DQM. This histogram is sensitive to the list of triggers in the HLT menu, and it has led to confusion in #40700. In my opinion, this histogram is not helpful in this part of the DQM (the HLT outputs are already monitored by other dedicated DQM plugins).

Merely technical. No changes expected, except for the removal of the histogram in question.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A