### PR TITLE
Initialize CSCCathodeLCTProcessor::ispretrig_ array

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -88,6 +88,10 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
       stagger[i_layer] = 1;
   }
 
+  for (int i = 0; i < CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER; ++i) {
+    ispretrig_[i] = false;
+  }
+
   // which patterns should we use?
   if (runCCLUT_) {
     clct_pattern_ = CSCPatternBank::clct_pattern_run3_;


### PR DESCRIPTION
#### PR description:

An inheriting class reads the entire range of values, not just those being used in the job. 

This should fix an UBSAN failure.

#### PR validation:

Code compiles.