### PR TITLE
[13_0_X] Remove call to alpaka::getDev() in test code when allocating TestDeviceCollection

### DIFF
--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -29,7 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
 
-      portabletest::TestDeviceCollection deviceProduct{size_, alpaka::getDev(iEvent.queue())};
+      portabletest::TestDeviceCollection deviceProduct{size_, iEvent.queue()};
 
       // run the algorithm, potentially asynchronously
       algo_.fill(iEvent.queue(), deviceProduct);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerOffset.cc
@@ -30,7 +30,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
       auto const& esData = iSetup.getData(esToken_);
 
-      portabletest::TestDeviceCollection deviceProduct{esData->metadata().size(), alpaka::getDev(iEvent.queue())};
+      portabletest::TestDeviceCollection deviceProduct{esData->metadata().size(), iEvent.queue()};
 
       // run the algorithm, potentially asynchronously
       algo_.fill(iEvent.queue(), deviceProduct, x_);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -34,7 +34,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       [[maybe_unused]] auto inpData = iEvent.getHandle(getToken_);
       [[maybe_unused]] auto const& esData = iSetup.getData(esToken_);
 
-      auto deviceProduct = std::make_unique<portabletest::TestDeviceCollection>(size_, alpaka::getDev(iEvent.queue()));
+      auto deviceProduct = std::make_unique<portabletest::TestDeviceCollection>(size_, iEvent.queue());
 
       // run the algorithm, potentially asynchronously
       algo_.fill(iEvent.queue(), *deviceProduct);


### PR DESCRIPTION
#### PR description:

Backport of #40789 (same commit)

#### PR validation:

None beyond #40789

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40789 to 13_0_X in order to keep the Alpaka code consistent between 13_0_X and 13_1_X.