### PR TITLE
Remove unused variables from RecoVertex/BeamSpotProducer

### DIFF
--- a/RecoVertex/BeamSpotProducer/test/BeamFit.cc
+++ b/RecoVertex/BeamSpotProducer/test/BeamFit.cc
@@ -390,7 +390,7 @@ void fitAll() {
   fit(xmat, Verr);  // get initial values
   fnthite++;
 
-  Double_t chi2cut = 20;
+  //Double_t chi2cut = 20;
 
   int fminNtrks = 100;
   double fconvergence = 0.9;
@@ -405,7 +405,7 @@ void fitAll() {
 
     fit(xmat, Verr);
     fd0cut /= 1.5;
-    chi2cut /= 1.5;
+    //chi2cut /= 1.5;
     if (tmpNtrks_ > fconvergence * zdata.size() && tmpNtrks_ > fminNtrks)
       fnthite++;
   }

--- a/RecoVertex/BeamSpotProducer/test/NtupleHelper.cc
+++ b/RecoVertex/BeamSpotProducer/test/NtupleHelper.cc
@@ -58,14 +58,12 @@ zData NtupleHelper::Loop(int maxEvents) {
 
   std::cout << " total number of entries: " << fChain->GetEntries() << std::endl;
 
-  Int_t nbytes = 0, nb = 0;
   int theevent = 0;
   for (Long64_t jentry = 0; jentry < nentries; jentry++) {
     Long64_t ientry = LoadTree(jentry);
     if (ientry < 0)
       break;
-    nb = fChain->GetEntry(jentry);
-    nbytes += nb;
+    fChain->GetEntry(jentry);
     //      if (sigmaD <0.05&&pt>4.0)
     //	{
 


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

Code compiles under clang without issuing warnings.