### PR TITLE
[PileupJetId, Puppi] Backport of #40762 (Pileup ID input variable fix, puppi weight ValueMap access, optional photon protection for existing puppi weights) to CMSSW_12_6_X

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -372,6 +372,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           (lPack->pt() > fPtMaxPhotons) && fuseBugFix)
         curpupweight = 1;
 
+
       // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
       if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&
           (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons))

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -82,7 +82,7 @@ private:
   bool fUseExistingWeights;
   bool fApplyPhotonProtectionForExistingWeights;
   bool fClonePackedCands;
-  bool fapplybuggy;
+  bool fuseBugFix;
   int fVtxNdofCut;
   double fVtxZCut;
   bool fUsePUProxyValue;
@@ -107,7 +107,7 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
   fApplyPhotonProtectionForExistingWeights = iConfig.getParameter<bool>("applyPhotonProtectionForExistingWeights");
-  fapplybuggy = iConfig.getParameter<bool>("applybuggy");
+  fuseBugFix = iConfig.getParameter<bool>("useBugFix");
   fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
@@ -369,13 +369,13 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
       // Protect high pT photons (important for gamma to hadronic recoil balance)
       if ((fPtMaxPhotons > 0) && (lPack->pdgId() == 22) && (std::abs(lPack->eta()) < fEtaMaxPhotons) &&
-          (lPack->pt() > fPtMaxPhotons) && fapplybuggy)
+          (lPack->pt() > fPtMaxPhotons) && fuseBugFix)
         curpupweight = 1;
 
 
       // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
       if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&
-          (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons) && fapplybuggy)
+          (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons))
         curpupweight = 1;
       lWeights.push_back(curpupweight);
       lPackCtr++;
@@ -522,7 +522,7 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);
   desc.add<bool>("applyPhotonProtectionForExistingWeights", false);
-  desc.add<bool>("applybuggy",false);
+  desc.add<bool>("useBugFix",false);
   desc.add<bool>("clonePackedCands", false);
   desc.add<int>("vtxNdofCut", 4);
   desc.add<double>("vtxZCut", 24);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -80,7 +80,9 @@ private:
   uint fNumOfPUVtxsForCharged;
   double fDZCutForChargedFromPUVtxs;
   bool fUseExistingWeights;
+  bool fApplyPhotonProtectionForExistingWeights;
   bool fClonePackedCands;
+  bool fapplybuggy;
   int fVtxNdofCut;
   double fVtxZCut;
   bool fUsePUProxyValue;
@@ -104,6 +106,8 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
   fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
+  fApplyPhotonProtectionForExistingWeights = iConfig.getParameter<bool>("applyPhotonProtectionForExistingWeights");
+  fapplybuggy = iConfig.getParameter<bool>("applybuggy");
   fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
@@ -365,7 +369,13 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
       // Protect high pT photons (important for gamma to hadronic recoil balance)
       if ((fPtMaxPhotons > 0) && (lPack->pdgId() == 22) && (std::abs(lPack->eta()) < fEtaMaxPhotons) &&
-          (lPack->pt() > fPtMaxPhotons))
+          (lPack->pt() > fPtMaxPhotons) && fapplybuggy)
+        curpupweight = 1;
+
+
+      // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
+      if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&
+          (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons) && fapplybuggy)
         curpupweight = 1;
       lWeights.push_back(curpupweight);
       lPackCtr++;
@@ -511,6 +521,8 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<uint>("NumOfPUVtxsForCharged", 0);
   desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);
+  desc.add<bool>("applyPhotonProtectionForExistingWeights", false);
+  desc.add<bool>("applybuggy",false);
   desc.add<bool>("clonePackedCands", false);
   desc.add<int>("vtxNdofCut", 4);
   desc.add<double>("vtxZCut", 24);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -82,7 +82,6 @@ private:
   bool fUseExistingWeights;
   bool fApplyPhotonProtectionForExistingWeights;
   bool fClonePackedCands;
-  bool fuseBugFix;
   int fVtxNdofCut;
   double fVtxZCut;
   bool fUsePUProxyValue;
@@ -107,7 +106,6 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
   fApplyPhotonProtectionForExistingWeights = iConfig.getParameter<bool>("applyPhotonProtectionForExistingWeights");
-  fuseBugFix = iConfig.getParameter<bool>("useBugFix");
   fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
@@ -367,11 +365,6 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           curpupweight = lPack->puppiWeight();
         }
       }
-      // Protect high pT photons (important for gamma to hadronic recoil balance)
-      if ((fPtMaxPhotons > 0) && (lPack->pdgId() == 22) && (std::abs(lPack->eta()) < fEtaMaxPhotons) &&
-          (lPack->pt() > fPtMaxPhotons) && fuseBugFix)
-        curpupweight = 1;
-
 
       // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
       if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -80,6 +80,7 @@ private:
   uint fNumOfPUVtxsForCharged;
   double fDZCutForChargedFromPUVtxs;
   bool fUseExistingWeights;
+  bool fApplyPhotonProtectionForExistingWeights;
   bool fClonePackedCands;
   int fVtxNdofCut;
   double fVtxZCut;
@@ -104,6 +105,7 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
   fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
+  fApplyPhotonProtectionForExistingWeights = iConfig.getParameter<bool>("applyPhotonProtectionForExistingWeights");
   fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
@@ -363,9 +365,9 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           curpupweight = lPack->puppiWeight();
         }
       }
-      // Protect high pT photons (important for gamma to hadronic recoil balance)
-      if ((fPtMaxPhotons > 0) && (lPack->pdgId() == 22) && (std::abs(lPack->eta()) < fEtaMaxPhotons) &&
-          (lPack->pt() > fPtMaxPhotons))
+      // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
+      if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&
+          (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons))
         curpupweight = 1;
       lWeights.push_back(curpupweight);
       lPackCtr++;
@@ -511,6 +513,7 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<uint>("NumOfPUVtxsForCharged", 0);
   desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);
+  desc.add<bool>("applyPhotonProtectionForExistingWeights", false);
   desc.add<bool>("clonePackedCands", false);
   desc.add<int>("vtxNdofCut", 4);
   desc.add<double>("vtxZCut", 24);

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -274,7 +274,7 @@ def AddPileUpJetIDVars(proc, jetName="", jetSrc="", jetTableName="", jetTaskName
       applyJec  = False,
       usePuppi = True if "PUPPI" in jetName.upper() else False,
       srcConstituentWeights = "packedPFCandidatespuppi" if "PUPPI" in jetName.upper() else "",
-      applybuggy = False
+      useBugFix = False
     )
   )
   getattr(proc,jetTaskName).add(getattr(proc, puJetIdVarsCalculator))

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -272,7 +272,9 @@ def AddPileUpJetIDVars(proc, jetName="", jetSrc="", jetTableName="", jetTaskName
       vertexes  = "offlineSlimmedPrimaryVertices",
       inputIsCorrected = True,
       applyJec  = False,
-      usePuppi = True if "PUPPI" in jetName.upper() else False
+      usePuppi = True if "PUPPI" in jetName.upper() else False,
+      srcConstituentWeights = "packedPFCandidatespuppi" if "PUPPI" in jetName.upper() else "",
+      applybuggy = False
     )
   )
   getattr(proc,jetTaskName).add(getattr(proc, puJetIdVarsCalculator))

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -274,7 +274,7 @@ def AddPileUpJetIDVars(proc, jetName="", jetSrc="", jetTableName="", jetTaskName
       applyJec  = False,
       usePuppi = True if "PUPPI" in jetName.upper() else False,
       srcConstituentWeights = "packedPFCandidatespuppi" if "PUPPI" in jetName.upper() else "",
-      useBugFix = False
+      useBugFix = True
     )
   )
   getattr(proc,jetTaskName).add(getattr(proc, puJetIdVarsCalculator))

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -272,7 +272,7 @@ def AddPileUpJetIDVars(proc, jetName="", jetSrc="", jetTableName="", jetTaskName
       vertexes  = "offlineSlimmedPrimaryVertices",
       inputIsCorrected = True,
       applyJec  = False,
-      usePuppi = True if "PUPPI" in jetName.upper() else False
+      srcConstituentWeights = "packedPFCandidatespuppi" if "PUPPI" in jetName.upper() else ""
     )
   )
   getattr(proc,jetTaskName).add(getattr(proc, puJetIdVarsCalculator))

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -29,7 +29,7 @@ public:
   ~PileupJetIdAlgo();
 
   PileupJetIdentifier computeIdVariables(
-      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi, edm::ValueMap<float>& constituentWeights, bool applyConstituentWeight, bool applybuggy);
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi, edm::ValueMap<float>& constituentWeights, bool applyConstituentWeight, bool useBugFix);
 
   void set(const PileupJetIdentifier&);
   float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -28,13 +28,8 @@ public:
   PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
   ~PileupJetIdAlgo();
 
-  PileupJetIdentifier computeIdVariables(const reco::Jet* jet,
-                                         float jec,
-                                         const reco::Vertex*,
-                                         const reco::VertexCollection&,
-                                         double rho,
-                                         edm::ValueMap<float>& constituentWeights,
-                                         bool applyConstituentWeight);
+  PileupJetIdentifier computeIdVariables(
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi, edm::ValueMap<float>& constituentWeights, bool applyConstituentWeight, bool useBugFix);
 
   void set(const PileupJetIdentifier&);
   float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -29,7 +29,7 @@ public:
   ~PileupJetIdAlgo();
 
   PileupJetIdentifier computeIdVariables(
-      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi);
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi, edm::ValueMap<float>& constituentWeights, bool applyConstituentWeight, bool applybuggy);
 
   void set(const PileupJetIdentifier&);
   float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -29,7 +29,7 @@ public:
   ~PileupJetIdAlgo();
 
   PileupJetIdentifier computeIdVariables(
-      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, bool usePuppi);
+      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, edm::ValueMap<float>& constituentWeights , bool applyConstituentWeight);
 
   void set(const PileupJetIdentifier&);
   float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -28,8 +28,13 @@ public:
   PileupJetIdAlgo(AlgoGBRForestsAndConstants const* cache);
   ~PileupJetIdAlgo();
 
-  PileupJetIdentifier computeIdVariables(
-      const reco::Jet* jet, float jec, const reco::Vertex*, const reco::VertexCollection&, double rho, edm::ValueMap<float>& constituentWeights , bool applyConstituentWeight);
+  PileupJetIdentifier computeIdVariables(const reco::Jet* jet,
+                                         float jec,
+                                         const reco::Vertex*,
+                                         const reco::VertexCollection&,
+                                         double rho,
+                                         edm::ValueMap<float>& constituentWeights,
+                                         bool applyConstituentWeight);
 
   void set(const PileupJetIdentifier&);
   float getMVAval(const std::vector<std::string>&, const std::unique_ptr<const GBRForest>&);

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -29,7 +29,7 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
       residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")),
       usePuppi_(iConfig.getParameter<bool>("usePuppi")),
       applyConstituentWeight_(false),
-      applybuggy_(iConfig.getParameter<bool>("applybuggy")) {
+      useBugFix_(iConfig.getParameter<bool>("useBugFix")) {
   if (residualsFromTxt_) {
     residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
   }
@@ -183,7 +183,7 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     PileupJetIdentifier puIdentifier;
     if (gc->produceJetIds()) {
       // Compute the input variables
-      puIdentifier = ialgo->computeIdVariables(theJet, jec, &(*vtx), *vertexes, rho, gc->usePuppi(), constituentWeights, gc->applyConstituentWeight(), gc->applybuggy());
+      puIdentifier = ialgo->computeIdVariables(theJet, jec, &(*vtx), *vertexes, rho, gc->usePuppi(), constituentWeights, gc->applyConstituentWeight(), gc->useBugFix());
 
       ids.push_back(puIdentifier);
     } else {

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -30,7 +30,6 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
       usePuppi_(iConfig.getParameter<bool>("usePuppi")),
       applyConstituentWeight_(false),
       useBugFix_(iConfig.getParameter<bool>("useBugFix")) {
-
   if (residualsFromTxt_) {
     residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
   }
@@ -43,11 +42,11 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
   if (!runMvas_) {
     assert(algos.size() == 1);
   }
-
   edm::InputTag srcConstituentWeights = iConfig.getParameter<edm::InputTag>("srcConstituentWeights");
   if (!srcConstituentWeights.label().empty()){
     applyConstituentWeight_ = true;
   }
+
 }
 
 // ------------------------------------------------------------------------------------------
@@ -91,12 +90,11 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   Handle<View<Jet>> jetHandle;
   iEvent.getByToken(input_jet_token_, jetHandle);
   const View<Jet>& jets = *jetHandle;
-    
-  // Constituent weight (e.g PUPPI) Value Map
   edm::ValueMap<float> constituentWeights;
   if (!input_constituent_weights_token_.isUninitialized()) {
     constituentWeights = iEvent.get(input_constituent_weights_token_);
   }
+
 
   // input variables
   Handle<ValueMap<StoredPileupJetIdentifier>> vmap;

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -91,12 +91,7 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   Handle<View<Jet>> jetHandle;
   iEvent.getByToken(input_jet_token_, jetHandle);
   const View<Jet>& jets = *jetHandle;
-  edm::ValueMap<float> constituentWeights;
-  if (!input_constituent_weights_token_.isUninitialized()) {
-    constituentWeights = iEvent.get(input_constituent_weights_token_);
-  }
-
-
+    
   // Constituent weight (e.g PUPPI) Value Map
   edm::ValueMap<float> constituentWeights;
   if (!input_constituent_weights_token_.isUninitialized()) {

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -27,7 +27,7 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
       applyJec_(iConfig.getParameter<bool>("applyJec")),
       jec_(iConfig.getParameter<std::string>("jec")),
       residualsFromTxt_(iConfig.getParameter<bool>("residualsFromTxt")),
-      applyConstituentWeight_(false){
+      applyConstituentWeight_(false) {
   if (residualsFromTxt_) {
     residualsTxt_ = iConfig.getParameter<edm::FileInPath>("residualsTxt");
   }
@@ -42,10 +42,9 @@ GBRForestsAndConstants::GBRForestsAndConstants(edm::ParameterSet const& iConfig)
   }
 
   edm::InputTag srcConstituentWeights = iConfig.getParameter<edm::InputTag>("srcConstituentWeights");
-  if (!srcConstituentWeights.label().empty()){
+  if (!srcConstituentWeights.label().empty()) {
     applyConstituentWeight_ = true;
   }
-
 }
 
 // ------------------------------------------------------------------------------------------
@@ -70,11 +69,6 @@ PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig, GBRFo
   parameters_token_ = esConsumes(edm::ESInputTag("", globalCache->jec()));
 
 
-//  edm::InputTag src_ = iConfig.getParameter<edm::InputTag>("src");
-//  edm::InputTag srcWeights = iConfig.getParameter<edm::InputTag>("srcWeights");
-//  if (iConfig.getParameter<edm::InputTag>("src").label() == iConfig.getParameter<edm::InputTag>("srcConstituentWeights").label())
-//    edm::LogWarning("PileupJetIdAlgo")
-//        << "Particle and weights collection have the same label. You may be applying the same weights twice. \n";
   edm::InputTag srcConstituentWeights = iConfig.getParameter<edm::InputTag>("srcConstituentWeights");
   if (!srcConstituentWeights.label().empty()){
     input_constituent_weights_token_ = consumes<edm::ValueMap<float>>(srcConstituentWeights);
@@ -97,12 +91,12 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByToken(input_jet_token_, jetHandle);
   const View<Jet>& jets = *jetHandle;
 
-  // Constituent weight (e.g PUPPI) Value Map 
+  // Constituent weight (e.g PUPPI) Value Map
   edm::ValueMap<float> constituentWeights;
   if (!input_constituent_weights_token_.isUninitialized()) {
     constituentWeights = iEvent.get(input_constituent_weights_token_);
   }
-  
+
   // input variables
   Handle<ValueMap<StoredPileupJetIdentifier>> vmap;
   if (!gc->produceJetIds()) {
@@ -191,7 +185,8 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     if (gc->produceJetIds()) {
       // Compute the input variables
       ////////////////////////////// added PUPPI weight Value Map
-      puIdentifier = ialgo->computeIdVariables(theJet, jec, &(*vtx), *vertexes, rho, constituentWeights, gc->applyConstituentWeight());
+      puIdentifier = ialgo->computeIdVariables(
+          theJet, jec, &(*vtx), *vertexes, rho, constituentWeights, gc->applyConstituentWeight());
       ids.push_back(puIdentifier);
     } else {
       // Or read it from the value map

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -68,7 +68,6 @@ PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig, GBRFo
   input_rho_token_ = consumes<double>(iConfig.getParameter<edm::InputTag>("rho"));
   parameters_token_ = esConsumes(edm::ESInputTag("", globalCache->jec()));
 
-
   edm::InputTag srcConstituentWeights = iConfig.getParameter<edm::InputTag>("srcConstituentWeights");
   if (!srcConstituentWeights.label().empty()) {
     input_constituent_weights_token_ = consumes<edm::ValueMap<float>>(srcConstituentWeights);

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -70,7 +70,7 @@ PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig, GBRFo
 
 
   edm::InputTag srcConstituentWeights = iConfig.getParameter<edm::InputTag>("srcConstituentWeights");
-  if (!srcConstituentWeights.label().empty()){
+  if (!srcConstituentWeights.label().empty()) {
     input_constituent_weights_token_ = consumes<edm::ValueMap<float>>(srcConstituentWeights);
   }
 }

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -62,6 +62,8 @@ public:
   bool residualsFromTxt() const { return residualsFromTxt_; }
   edm::FileInPath const& residualsTxt() const { return residualsTxt_; }
   bool usePuppi() const { return usePuppi_; }
+  bool applyConstituentWeight() const { return applyConstituentWeight_; }
+  bool applybuggy() const {return applybuggy_; }
 
 private:
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> vAlgoGBRForestsAndConstants_;
@@ -74,6 +76,8 @@ private:
   bool residualsFromTxt_;
   edm::FileInPath residualsTxt_;
   bool usePuppi_;
+  bool applyConstituentWeight_;
+  bool applybuggy_;
 };
 
 class PileupJetIdProducer : public edm::stream::EDProducer<edm::GlobalCache<GBRForestsAndConstants>> {
@@ -99,6 +103,8 @@ private:
   std::unique_ptr<FactorizedJetCorrector> jecCor_;
   std::vector<JetCorrectorParameters> jetCorPars_;
 
+  edm::ValueMap<float> constituentWeights_;
+  edm::EDGetTokenT<edm::ValueMap<float>> input_constituent_weights_token_;
   edm::EDGetTokenT<edm::View<reco::Jet>> input_jet_token_;
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
   edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier>> input_vm_pujetid_token_;

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -61,7 +61,7 @@ public:
   std::string const& jec() const { return jec_; }
   bool residualsFromTxt() const { return residualsFromTxt_; }
   edm::FileInPath const& residualsTxt() const { return residualsTxt_; }
-  bool usePuppi() const { return usePuppi_; }
+  bool applyConstituentWeight() const { return applyConstituentWeight_; }
 
 private:
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> vAlgoGBRForestsAndConstants_;
@@ -73,7 +73,7 @@ private:
   std::string jec_;
   bool residualsFromTxt_;
   edm::FileInPath residualsTxt_;
-  bool usePuppi_;
+  bool applyConstituentWeight_;
 };
 
 class PileupJetIdProducer : public edm::stream::EDProducer<edm::GlobalCache<GBRForestsAndConstants>> {
@@ -99,6 +99,8 @@ private:
   std::unique_ptr<FactorizedJetCorrector> jecCor_;
   std::vector<JetCorrectorParameters> jetCorPars_;
 
+  edm::ValueMap<float> constituentWeights_;
+  edm::EDGetTokenT<edm::ValueMap<float>> input_constituent_weights_token_;
   edm::EDGetTokenT<edm::View<reco::Jet>> input_jet_token_;
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;
   edm::EDGetTokenT<edm::ValueMap<StoredPileupJetIdentifier>> input_vm_pujetid_token_;

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -63,7 +63,7 @@ public:
   edm::FileInPath const& residualsTxt() const { return residualsTxt_; }
   bool usePuppi() const { return usePuppi_; }
   bool applyConstituentWeight() const { return applyConstituentWeight_; }
-  bool applybuggy() const {return applybuggy_; }
+  bool useBugFix() const {return useBugFix_; }
 
 private:
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> vAlgoGBRForestsAndConstants_;
@@ -77,7 +77,7 @@ private:
   edm::FileInPath residualsTxt_;
   bool usePuppi_;
   bool applyConstituentWeight_;
-  bool applybuggy_;
+  bool useBugFix_;
 };
 
 class PileupJetIdProducer : public edm::stream::EDProducer<edm::GlobalCache<GBRForestsAndConstants>> {

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -65,7 +65,6 @@ public:
   bool applyConstituentWeight() const { return applyConstituentWeight_; }
   bool useBugFix() const {return useBugFix_; }
 
-
 private:
   std::vector<PileupJetIdAlgo::AlgoGBRForestsAndConstants> vAlgoGBRForestsAndConstants_;
 

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -34,7 +34,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      residualsFromTxt = cms.bool(False),
      usePuppi = cms.bool(False),
      srcConstituentWeights = cms.InputTag(""),
-     applybuggy = cms.bool(False)
+     useBugFix = cms.bool(False)
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
 

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -35,7 +35,6 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      usePuppi = cms.bool(False),
      srcConstituentWeights = cms.InputTag(""),
      useBugFix = cms.bool(False)
-
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
 

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -32,7 +32,7 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      applyJec = cms.bool(True),
      inputIsCorrected = cms.bool(False),
      residualsFromTxt = cms.bool(False),
-     usePuppi = cms.bool(False),
+     srcConstituentWeights = cms.InputTag(""),
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
 

--- a/RecoJets/JetProducers/python/PileupJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetID_cfi.py
@@ -33,6 +33,8 @@ pileupJetId = cms.EDProducer('PileupJetIdProducer',
      inputIsCorrected = cms.bool(False),
      residualsFromTxt = cms.bool(False),
      usePuppi = cms.bool(False),
+     srcConstituentWeights = cms.InputTag(""),
+     applybuggy = cms.bool(False)
 #     residualsTxt     = cms.FileInPath("RecoJets/JetProducers/data/download.url") # must be an existing file
 )
 

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -652,10 +652,6 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       float dphi = reco::deltaPhi(*icand, *jet);
       sum_deta += deta * weight2;
       sum_dphi += dphi * weight2;
-      if (sumW2 > 0) {
-        ave_deta = sum_deta / sumW2;
-        ave_dphi = sum_dphi / sumW2;
-      }
     }
   }
 
@@ -767,11 +763,11 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       float dphi = reco::deltaPhi(*part, *jet);
       sum_deta += deta * weight2;
       sum_dphi += dphi * weight2;
-      }
-    if (sumW2 > 0) {
-      ave_deta = sum_deta / sumW2;
-      ave_dphi = sum_dphi / sumW2;
     }
+  }
+  if (sumW2 > 0) {
+    ave_deta = sum_deta / sumW2;
+    ave_dphi = sum_dphi / sumW2;
   }
   float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
   

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -767,10 +767,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       float dphi = reco::deltaPhi(*part, *jet);
       sum_deta += deta * weight2;
       sum_dphi += dphi * weight2;
-      if (sumW2 > 0) {
-        ave_deta = sum_deta / sumW2;
-        ave_dphi = sum_dphi / sumW2;
       }
+    if (sumW2 > 0) {
+      ave_deta = sum_deta / sumW2;
+      ave_dphi = sum_dphi / sumW2;
     }
   }
   float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -263,7 +263,11 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
                                                         const reco::Vertex* vtx,
                                                         const reco::VertexCollection& allvtx,
                                                         double rho,
-                                                        bool usePuppi) {
+                                                        bool usePuppi,
+                                                        edm::ValueMap<float>& constituentWeights,
+                                                        bool applyConstituentWeight,
+                                                        bool applybuggy) {
+
   // initialize all variables to 0
   resetVariables();
 
@@ -315,6 +319,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   covMatrix = 0.;
   float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
   float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
+
+  float sumW2(0.0);
+  float sum_deta(0.0), sum_dphi(0.0);
+  float ave_deta(0.0), ave_dphi(0.0);
   float multNeut = 0.0;
   setPtEtaPhi(
       *jet, internalId_.jetPt_, internalId_.jetEta_, internalId_.jetPhi_);  // use corrected pt for jet kinematics
@@ -323,8 +331,20 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.rho_ = rho;
 
   float dRmin(1000);
-
-  for (unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i) {
+  float LeadcandWeight = 1.0;
+  float SecondcandWeight = 1.0;
+  float LeadNeutcandWeight = 1.0;
+  float LeadEmcandWeight = 1.0;
+  float LeadChcandWeight = 1.0;
+  float TrailcandWeight = 1.0;
+  unsigned nCandPtrs(0);
+  if (applybuggy) {
+    nCandPtrs = jet->numberOfDaughters();
+  }
+  else { 
+    nCandPtrs = jet->numberOfSourceCandidatePtrs();
+  }
+  for (unsigned i = 0; i < nCandPtrs; ++i) {
     reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
 
     const reco::Candidate* icand = pfJetConstituent.get();
@@ -335,9 +355,18 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       isPacked = false;
     }
     float candPuppiWeight = 1.0;
-    if (usePuppi && isPacked)
+    float candWeight = 1.0;
+    if (applybuggy && usePuppi && isPacked) {
       candPuppiWeight = lPack->puppiWeight();
-    float candPt = (icand->pt()) * candPuppiWeight;
+    }
+    else if (!applybuggy && applyConstituentWeight) { 
+      candWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+    }
+    float candPt = 0.0;
+    if (applybuggy)    
+      candPt = (icand->pt()) * candPuppiWeight;
+    else
+      candPt = (icand->pt()) * candWeight;
     float candPtFrac = candPt / jetPt;
     float candDr = reco::deltaR(*icand, *jet);
     float candDeta = icand->eta() - jet->eta();
@@ -349,13 +378,29 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       dRmin = candDr;
 
     // // all particles
-    if (lLead == nullptr || candPt > lLead->pt()) {
-      lSecond = lLead;
-      lLead = icand;
-    } else if ((lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
-      lSecond = icand;
+    if (applybuggy) {
+      if (lLead == nullptr || candPt > lLead->pt()) {
+        lSecond = lLead;
+        lLead = icand;
+      } else if ((lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
+        lSecond = icand;
+      }
     }
-
+    else {
+      if (lLead == nullptr || candPt > (lLead->pt())*LeadcandWeight) {
+        lSecond = lLead;
+        SecondcandWeight = LeadcandWeight;
+        lLead = icand;
+        if (applyConstituentWeight) {
+          LeadcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+        }
+      } else if ((lSecond == nullptr || candPt > (lSecond->pt())*SecondcandWeight) && (candPt < (lLead->pt())*LeadcandWeight)) {
+        lSecond = icand;
+        if (applyConstituentWeight) {
+          SecondcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+        }
+      }
+    }
     // // average shapes
     internalId_.dRMean_ += candPtDr;
     internalId_.dR2Mean_ += candPtDr * candPtDr;
@@ -375,8 +420,18 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
 
     // neutrals
     if (abs(icand->pdgId()) == 130) {
-      if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) {
-        lLeadNeut = icand;
+      if (applybuggy) {
+        if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) {
+          lLeadNeut = icand;
+        }
+      }
+      else {
+        if (lLeadNeut == nullptr || candPt > (lLeadNeut->pt())*LeadNeutcandWeight) {
+          lLeadNeut = icand;
+          if (applyConstituentWeight) {
+            LeadNeutcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+          }
+        }
       }
       internalId_.dRMeanNeut_ += candPtDr;
       fracNeut.push_back(candPtFrac);
@@ -385,55 +440,109 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       }
       internalId_.ptDNe_ += candPt * candPt;
       sumPtNe += candPt;
-      multNeut += candPuppiWeight;
+      if (applybuggy)
+        multNeut += candPuppiWeight;
+      else
+        multNeut += candWeight;
     }
     // EM candidated
     if (icand->pdgId() == 22) {
-      if (lLeadEm == nullptr || candPt > lLeadEm->pt()) {
-        lLeadEm = icand;
+      if (applybuggy) {
+        if (lLeadEm == nullptr || candPt > lLeadEm->pt()) {
+          lLeadEm = icand;
+        }
+        internalId_.dRMeanEm_ += candPtDr;
+        fracEm.push_back(candPtFrac);
+        if (icone < ncones) {
+          *coneEmFracs[icone] += candPt;
+        }
+        internalId_.ptDNe_ += candPt * candPt;
+        sumPtNe += candPt;
+        multNeut += candPuppiWeight;
       }
-      internalId_.dRMeanEm_ += candPtDr;
-      fracEm.push_back(candPtFrac);
-      if (icone < ncones) {
-        *coneEmFracs[icone] += candPt;
-      }
-      internalId_.ptDNe_ += candPt * candPt;
-      sumPtNe += candPt;
-      multNeut += candPuppiWeight;
-    }
-    if ((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2))
-      multNeut += candPuppiWeight;
-
-    // Charged  particles
-    if (icand->charge() != 0) {
-      if (lLeadCh == nullptr || candPt > lLeadCh->pt()) {
-        lLeadCh = icand;
-
-        const reco::Track* pfTrk = icand->bestTrack();
-        if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
-          reco::MuonRef lmuRef = lPF->muonRef();
-          if (lmuRef.isNonnull()) {
-            const reco::Muon& lmu = *lmuRef.get();
-            pfTrk = lmu.bestTrack();
-            edm::LogWarning("BadMuon")
-                << "Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
+      else {
+        if (lLeadEm == nullptr || candPt > (lLeadEm->pt())*LeadEmcandWeight) {
+          lLeadEm = icand;
+          if (applyConstituentWeight) {
+            LeadEmcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
           }
         }
-        if (pfTrk == nullptr) {  //protection against empty pointers for the miniAOD case
-          //To handle the electron case
-          if (isPacked) {
-            internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
-            internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
-          } else if (lPF != nullptr) {
-            pfTrk = (lPF->trackRef().get() == nullptr) ? lPF->gsfTrackRef().get() : lPF->trackRef().get();
+        internalId_.dRMeanEm_ += candPtDr;
+        fracEm.push_back(candPtFrac);
+        if (icone < ncones) {
+          *coneEmFracs[icone] += candPt;
+        }
+        internalId_.ptDNe_ += candPt * candPt;
+        sumPtNe += candPt;
+        multNeut += candWeight;
+      }
+    }
+    if (abs(icand->pdgId()) == 1 || abs(icand->pdgId()) == 2) {
+      if (applybuggy) 
+        multNeut += candPuppiWeight;
+      else
+        multNeut += candWeight;
+    }
+    // Charged  particles
+    if (icand->charge() != 0) {
+      if ((applybuggy) && (lLeadCh == nullptr || candPt > lLeadCh->pt())) {
+          lLeadCh = icand;
+        
+          const reco::Track* pfTrk = icand->bestTrack();
+          if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
+            reco::MuonRef lmuRef = lPF->muonRef();
+            if (lmuRef.isNonnull()) {
+              const reco::Muon& lmu = *lmuRef.get();
+              pfTrk = lmu.bestTrack();
+              edm::LogWarning("BadMuon")
+                  << "Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
+            }
+          }
+          if (pfTrk == nullptr) {  //protection against empty pointers for the miniAOD case
+            //To handle the electron case
+            if (isPacked) {
+              internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
+              internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
+            } else if (lPF != nullptr) {
+              pfTrk = (lPF->trackRef().get() == nullptr) ? lPF->gsfTrackRef().get() : lPF->trackRef().get();
+              internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+              internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+            }
+          } else {
             internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
             internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
           }
-        } else {
-          internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
-          internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
         }
-      }
+      else if ((!applybuggy) && (lLeadCh == nullptr || candPt > (lLeadCh->pt()) * LeadChcandWeight)) {
+          lLeadCh = icand;
+          if (applyConstituentWeight) {
+            LeadChcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+          }       
+          const reco::Track* pfTrk = icand->bestTrack();
+          if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
+            reco::MuonRef lmuRef = lPF->muonRef();
+            if (lmuRef.isNonnull()) {
+              const reco::Muon& lmu = *lmuRef.get();
+              pfTrk = lmu.bestTrack();
+              edm::LogWarning("BadMuon")
+                  << "Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
+            }
+          }
+          if (pfTrk == nullptr) {  //protection against empty pointers for the miniAOD case
+            //To handle the electron case
+            if (isPacked) {
+              internalId_.d0_ = std::abs(lPack->dxy(vtx->position()));
+              internalId_.dZ_ = std::abs(lPack->dz(vtx->position()));
+            } else if (lPF != nullptr) {
+              pfTrk = (lPF->trackRef().get() == nullptr) ? lPF->gsfTrackRef().get() : lPF->trackRef().get();
+              internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+              internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+            }
+          } else {
+            internalId_.d0_ = std::abs(pfTrk->dxy(vtx->position()));
+            internalId_.dZ_ = std::abs(pfTrk->dz(vtx->position()));
+          }
+        }
       internalId_.dRMeanCh_ += candPtDr;
       internalId_.ptDCh_ += candPt * candPt;
       fracCh.push_back(candPtFrac);
@@ -525,26 +634,92 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     }
 
     // trailing candidate
-    if (lTrail == nullptr || candPt < lTrail->pt()) {
+    if ((applybuggy) && (lTrail == nullptr || candPt < lTrail->pt())) {
       lTrail = icand;
+    }
+    else if ((!applybuggy) && (lTrail == nullptr || candPt < (lTrail->pt())*TrailcandWeight)){
+      lTrail = icand;
+      if (applyConstituentWeight) {
+        TrailcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+      }
+    }
+
+  // average for pull variavble
+    if (!applybuggy) {
+      float weight2 = candPt * candPt;
+      sumW2 += weight2;
+      float deta = icand->eta() - jet->eta();
+      float dphi = reco::deltaPhi(*icand, *jet);
+      sum_deta += deta * weight2;
+      sum_dphi += dphi * weight2;
+      if (sumW2 > 0) {
+        ave_deta = sum_deta / sumW2;
+        ave_dphi = sum_dphi / sumW2;
+      }
     }
   }
 
+
   // // Finalize all variables
   assert(!(lLead == nullptr));
+  if (applybuggy) {
+    if (lSecond == nullptr) {
+      lSecond = lTrail;
+    }
+    if (lLeadNeut == nullptr) {
+      lLeadNeut = lTrail;
+    }
+    if (lLeadEm == nullptr) {
+      lLeadEm = lTrail;
+    }
+    if (lLeadCh == nullptr) {
+      lLeadCh = lTrail;
+    }
+  }
+  else {
+    internalId_.leadPt_ = (lLead->pt())*LeadcandWeight;
+    internalId_.leadEta_ = lLead->eta();
+    internalId_.leadPhi_ = lLead->phi();
 
-  if (lSecond == nullptr) {
-    lSecond = lTrail;
+    if (lSecond != nullptr){
+      internalId_.secondPt_ = (lSecond->pt())*SecondcandWeight;
+      internalId_.secondEta_ = lSecond->eta();
+      internalId_.secondPhi_ = lSecond->phi();
+    } else { 
+      internalId_.secondPt_ = 0.0;
+      internalId_.secondEta_ = large_val;
+      internalId_.secondPhi_ = large_val;
+    }
+    if (lLeadNeut != nullptr){
+      internalId_.leadNeutPt_ = (lLeadNeut->pt())*LeadNeutcandWeight;
+      internalId_.leadNeutEta_ = lLeadNeut->eta();
+      internalId_.leadNeutPhi_ = lLeadNeut->phi();
+    } else {
+      internalId_.leadNeutPt_ = 0.0;
+      internalId_.leadNeutEta_ = large_val;
+      internalId_.leadNeutPhi_ = large_val;
+    }
+    if (lLeadEm != nullptr){
+      internalId_.leadEmPt_ = (lLeadEm->pt())*LeadEmcandWeight;
+      internalId_.leadEmEta_ = lLeadEm->eta();
+      internalId_.leadEmPhi_ = lLeadEm->phi();
+    } else {
+      internalId_.leadEmPt_ = 0.0;
+      internalId_.leadEmEta_ = large_val;
+      internalId_.leadEmPhi_ = large_val;
+    }
+    if (lLeadCh != nullptr){
+      internalId_.leadChPt_ = (lLeadCh->pt())*LeadChcandWeight;
+      internalId_.leadChEta_ = lLeadCh->eta();
+      internalId_.leadChPhi_ = lLeadCh->phi();
+    } else {
+      internalId_.leadChPt_ = 0.0;
+      internalId_.leadChEta_ = large_val;
+      internalId_.leadChPhi_ = large_val;
+    }
   }
-  if (lLeadNeut == nullptr) {
-    lLeadNeut = lTrail;
-  }
-  if (lLeadEm == nullptr) {
-    lLeadEm = lTrail;
-  }
-  if (lLeadCh == nullptr) {
-    lLeadCh = lTrail;
-  }
+
+
 
   if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
     internalId_.nCharged_ = patjet->chargedMultiplicity();
@@ -553,7 +728,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     internalId_.neuEMfrac_ = patjet->neutralEmEnergy() / jet->energy();
     internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy() / jet->energy();
     internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy() / jet->energy();
-    if (usePuppi)
+    if (usePuppi || applyConstituentWeight)
       internalId_.nNeutrals_ = multNeut;
   } else {
     internalId_.nCharged_ = pfjet->chargedMultiplicity();
@@ -566,52 +741,72 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.nParticles_ = jet->nConstituents();
 
   ///////////////////////pull variable///////////////////////////////////
-  float sumW2(0.0);
-  float sum_deta(0.0), sum_dphi(0.0);
-  float ave_deta(0.0), ave_dphi(0.0);
-  for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
-    const auto& part = jet->daughterPtr(j);
-    if (!(part.isAvailable() && part.isNonnull())) {
-      continue;
-    }
 
-    float partPuppiWeight = 1.0;
-    if (usePuppi) {
-      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
-      if (partpack != nullptr)
-        partPuppiWeight = partpack->puppiWeight();
-    }
+  if (applybuggy) {
+//    float sumW2(0.0);
+//    float sum_deta(0.0), sum_dphi(0.0);
+//    float ave_deta(0.0), ave_dphi(0.0);
+    for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
+      const auto& part = jet->daughterPtr(j);
+      if (!(part.isAvailable() && part.isNonnull())) {
+        continue;
+      }
 
-    float weight = (part->pt()) * partPuppiWeight;
-    float weight2 = weight * weight;
-    sumW2 += weight2;
-    float deta = part->eta() - jet->eta();
-    float dphi = reco::deltaPhi(*part, *jet);
-    sum_deta += deta * weight2;
-    sum_dphi += dphi * weight2;
-    if (sumW2 > 0) {
-      ave_deta = sum_deta / sumW2;
-      ave_dphi = sum_dphi / sumW2;
+      float partPuppiWeight = 1.0;
+      if (usePuppi) {
+        const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+        if (partpack != nullptr) {
+          partPuppiWeight = partpack->puppiWeight();
+        }
+      }
+
+      float weight = (part->pt()) * partPuppiWeight;
+      float weight2 = weight * weight;
+      sumW2 += weight2;
+      float deta = part->eta() - jet->eta();
+      float dphi = reco::deltaPhi(*part, *jet);
+      sum_deta += deta * weight2;
+      sum_dphi += dphi * weight2;
+      if (sumW2 > 0) {
+        ave_deta = sum_deta / sumW2;
+        ave_dphi = sum_dphi / sumW2;
+      }
     }
   }
-
   float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
-  for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
+  
+  for (size_t i = 0; i < nCandPtrs; i++) {
     const auto& part = jet->daughterPtr(i);
-    if (!(part.isAvailable() && part.isNonnull())) {
-      continue;
-    }
+    const reco::CandidatePtr temp_pfJetConsituent = jet->sourceCandidatePtr(i);
+    const reco::Candidate* fix_part = temp_pfJetConsituent.get();
+    float deta(0.0);
+    float dphi(0.0);
+    float weight(0.0);
+    if (applybuggy) {
+      if (!(part.isAvailable() && part.isNonnull())) {
+        continue;
+      }
 
-    float partPuppiWeight = 1.0;
-    if (usePuppi) {
-      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
-      if (partpack != nullptr)
-        partPuppiWeight = partpack->puppiWeight();
-    }
+      float partPuppiWeight = 1.0;
+      if (usePuppi) {
+        const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
+        if (partpack != nullptr)
+          partPuppiWeight = partpack->puppiWeight();
+      }
 
-    float weight = partPuppiWeight * (part->pt()) * partPuppiWeight * (part->pt());
-    float deta = part->eta() - jet->eta();
-    float dphi = reco::deltaPhi(*part, *jet);
+      weight = partPuppiWeight * (part->pt()) * partPuppiWeight * (part->pt());
+      deta = part->eta() - jet->eta();
+      dphi = reco::deltaPhi(*part, *jet);
+    } 
+    else {
+      float candWeight = 1.0;
+      if (applyConstituentWeight) {
+        candWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+      }
+      weight = candWeight * (part->pt()) * candWeight * (part->pt());
+      deta = fix_part->eta() - jet->eta();
+      dphi = reco::deltaPhi(*fix_part, *jet);
+    }
     float ddeta, ddphi, ddR;
     ddeta = deta - ave_deta;
     ddphi = dphi - ave_dphi;
@@ -626,13 +821,13 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   }
   internalId_.pull_ = pull_tmp;
   ///////////////////////////////////////////////////////////////////////
-
-  setPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
-  setPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
-  setPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
-  setPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
-  setPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
-
+  if (applybuggy) {
+    setPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
+    setPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
+    setPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
+    setPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
+    setPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
+  }
   std::sort(frac.begin(), frac.end(), std::greater<float>());
   std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
   std::sort(fracEm.begin(), fracEm.end(), std::greater<float>());
@@ -697,9 +892,18 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.sumPt_ = sumPt;
   internalId_.sumChPt_ = sumPtCh;
   internalId_.sumNePt_ = sumPtNe;
-
-  internalId_.jetR_ = lLead->pt() / sumPt;
-  internalId_.jetRchg_ = lLeadCh->pt() / sumPt;
+  if (applybuggy) {
+    internalId_.jetR_ = lLead->pt() / sumPt;
+    internalId_.jetRchg_ = lLeadCh->pt() / sumPt;
+  }
+  else {
+    internalId_.jetR_ = (lLead->pt())*LeadcandWeight / sumPt;
+    if (lLeadCh != nullptr) {
+      internalId_.jetRchg_ = (lLeadCh->pt())*LeadChcandWeight / sumPt;
+    } else { 
+      internalId_.jetRchg_ = 0; 
+    }
+  }
   internalId_.dRMatch_ = dRmin;
 
   if (sumTkPt != 0.) {

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -281,7 +281,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
 
   const reco::Candidate *lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr,
                         *lLeadCh = nullptr, *lTrail = nullptr;
-  
+
   std::vector<float> frac, fracCh, fracEm, fracNeut;
   float cones[] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
   size_t ncones = sizeof(cones) / sizeof(float);
@@ -335,7 +335,6 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   float LeadChcandWeight = 1.0;
   float TrailcandWeight = 1.0;
 
-
   for (unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i) {
     reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
     const reco::Candidate* icand = pfJetConstituent.get();
@@ -347,7 +346,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     }
 
     float candWeight = 1.0;
-    if (applyConstituentWeight){                   // PUPPI Jet weight should be pulled up from valuemap, not packed candidate
+    if (applyConstituentWeight) {  // PUPPI Jet weight should be pulled up from valuemap, not packed candidate
       candWeight = constituentWeights[jet->sourceCandidatePtr(i)];
     }
     float candPt = (icand->pt()) * candWeight;
@@ -362,14 +361,15 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       dRmin = candDr;
 
     // // all particles; PUPPI weights multiplied to leading and subleading constituent if it is for PUPPI
-    if (lLead == nullptr || candPt > (lLead->pt())*LeadcandWeight) {
+    if (lLead == nullptr || candPt > (lLead->pt()) * LeadcandWeight) {
       lSecond = lLead;
       SecondcandWeight = LeadcandWeight;
       lLead = icand;
       if (applyConstituentWeight) {
         LeadcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
       }
-    } else if ((lSecond == nullptr || candPt > (lSecond->pt())*SecondcandWeight) && (candPt < (lLead->pt())*LeadcandWeight)) {
+    } else if ((lSecond == nullptr || candPt > (lSecond->pt()) * SecondcandWeight) &&
+               (candPt < (lLead->pt()) * LeadcandWeight)) {
       lSecond = icand;
       if (applyConstituentWeight) {
         SecondcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
@@ -395,13 +395,13 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
 
     // neutrals Neutral hadrons
     if (abs(icand->pdgId()) == 130) {
-      if (lLeadNeut == nullptr || candPt > (lLeadNeut->pt())*LeadNeutcandWeight) {
+      if (lLeadNeut == nullptr || candPt > (lLeadNeut->pt()) * LeadNeutcandWeight) {
         lLeadNeut = icand;
         if (applyConstituentWeight) {
           LeadNeutcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
         }
       }
-        
+
       internalId_.dRMeanNeut_ += candPtDr;
       fracNeut.push_back(candPtFrac);
       if (icone < ncones) {
@@ -411,10 +411,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       sumPtNe += candPt;
       multNeut += candWeight;
     }
-    
+
     // EM candidated photon
     if (icand->pdgId() == 22) {
-      if (lLeadEm == nullptr || candPt > (lLeadEm->pt())*LeadEmcandWeight) {
+      if (lLeadEm == nullptr || candPt > (lLeadEm->pt()) * LeadEmcandWeight) {
         lLeadEm = icand;
         if (applyConstituentWeight) {
           LeadEmcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
@@ -429,13 +429,13 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       sumPtNe += candPt;
       multNeut += candWeight;
     }
-    // hadrons and EM in HF  
+    // hadrons and EM in HF
     if ((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2))
       multNeut += candWeight;
 
     // Charged  particles
     if (icand->charge() != 0) {
-      if (lLeadCh == nullptr || candPt > (lLeadCh->pt())*LeadChcandWeight) {
+      if (lLeadCh == nullptr || candPt > (lLeadCh->pt()) * LeadChcandWeight) {
         lLeadCh = icand;
         if (applyConstituentWeight) {
           LeadChcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
@@ -556,7 +556,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     }
 
     // trailing candidate
-    if (lTrail == nullptr || candPt < (lTrail->pt())*TrailcandWeight) {
+    if (lTrail == nullptr || candPt < (lTrail->pt()) * TrailcandWeight) {
       lTrail = icand;
       if (applyConstituentWeight) {
         TrailcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
@@ -580,24 +580,23 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   // // Finalize all variables
   // Most of Below values are not used for puID variable generation at the moment, except lLeadCh Pt for JetRchg, so I assign that zero if there is no charged constituent.
 
-
   assert(!(lLead == nullptr));
-  internalId_.leadPt_ = lLead->pt()*LeadcandWeight;
+  internalId_.leadPt_ = lLead->pt() * LeadcandWeight;
   internalId_.leadEta_ = lLead->eta();
   internalId_.leadPhi_ = lLead->phi();
 
-  if (lSecond != nullptr){
-    internalId_.secondPt_ = lSecond->pt()*SecondcandWeight;
+  if (lSecond != nullptr) {
+    internalId_.secondPt_ = lSecond->pt() * SecondcandWeight;
     internalId_.secondEta_ = lSecond->eta();
     internalId_.secondPhi_ = lSecond->phi();
-  } else { 
+  } else {
     internalId_.secondPt_ = 0.0;
     internalId_.secondEta_ = large_val;
     internalId_.secondPhi_ = large_val;
   }
 
-  if (lLeadNeut != nullptr){
-    internalId_.leadNeutPt_ = lLeadNeut->pt()*LeadNeutcandWeight;
+  if (lLeadNeut != nullptr) {
+    internalId_.leadNeutPt_ = lLeadNeut->pt() * LeadNeutcandWeight;
     internalId_.leadNeutEta_ = lLeadNeut->eta();
     internalId_.leadNeutPhi_ = lLeadNeut->phi();
   } else {
@@ -606,8 +605,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     internalId_.leadNeutPhi_ = large_val;
   }
 
-  if (lLeadEm != nullptr){
-    internalId_.leadEmPt_ = lLeadEm->pt()*LeadEmcandWeight;
+  if (lLeadEm != nullptr) {
+    internalId_.leadEmPt_ = lLeadEm->pt() * LeadEmcandWeight;
     internalId_.leadEmEta_ = lLeadEm->eta();
     internalId_.leadEmPhi_ = lLeadEm->phi();
   } else {
@@ -616,8 +615,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     internalId_.leadEmPhi_ = large_val;
   }
 
-  if (lLeadCh != nullptr){
-    internalId_.leadChPt_ = lLeadCh->pt()*LeadChcandWeight;
+  if (lLeadCh != nullptr) {
+    internalId_.leadChPt_ = lLeadCh->pt() * LeadChcandWeight;
     internalId_.leadChEta_ = lLeadCh->eta();
     internalId_.leadChPhi_ = lLeadCh->phi();
   } else {
@@ -625,9 +624,6 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     internalId_.leadChEta_ = large_val;
     internalId_.leadChPhi_ = large_val;
   }
-
-
-
 
   if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
     internalId_.nCharged_ = patjet->chargedMultiplicity();
@@ -654,10 +650,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
   for (unsigned k = 0; k < jet->numberOfSourceCandidatePtrs(); k++) {
     reco::CandidatePtr temp_pfJetConstituent = jet->sourceCandidatePtr(k);
-//    reco::CandidatePtr temp_weightpfJetConstituent = jet->sourceCandidatePtr(k);
+    //    reco::CandidatePtr temp_weightpfJetConstituent = jet->sourceCandidatePtr(k);
     const reco::Candidate* part = temp_pfJetConstituent.get();
- 
-   float candWeight = 1.0;
+
+    float candWeight = 1.0;
 
     if (applyConstituentWeight)
       candWeight = constituentWeights[jet->sourceCandidatePtr(k)];
@@ -679,7 +675,6 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   }
   internalId_.pull_ = pull_tmp;
   ///////////////////////////////////////////////////////////////////////
-
 
   std::sort(frac.begin(), frac.end(), std::greater<float>());
   std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
@@ -746,11 +741,11 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.sumChPt_ = sumPtCh;
   internalId_.sumNePt_ = sumPtNe;
 
-  internalId_.jetR_ = (lLead->pt())*LeadcandWeight / sumPt;
-  if (lLeadCh != nullptr){
-    internalId_.jetRchg_ = (lLeadCh->pt())*LeadChcandWeight / sumPt;
-  } else { 
-    internalId_.jetRchg_ = 0; 
+  internalId_.jetR_ = (lLead->pt()) * LeadcandWeight / sumPt;
+  if (lLeadCh != nullptr) {
+    internalId_.jetRchg_ = (lLeadCh->pt()) * LeadChcandWeight / sumPt;
+  } else {
+    internalId_.jetRchg_ = 0;
   }
 
   internalId_.dRMatch_ = dRmin;

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -263,7 +263,8 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
                                                         const reco::Vertex* vtx,
                                                         const reco::VertexCollection& allvtx,
                                                         double rho,
-                                                        bool usePuppi) {
+                                                        edm::ValueMap<float>& constituentWeights,
+                                                        bool applyConstituentWeight) {
   // initialize all variables to 0
   resetVariables();
 
@@ -280,6 +281,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
 
   const reco::Candidate *lLead = nullptr, *lSecond = nullptr, *lLeadNeut = nullptr, *lLeadEm = nullptr,
                         *lLeadCh = nullptr, *lTrail = nullptr;
+  
   std::vector<float> frac, fracCh, fracEm, fracNeut;
   float cones[] = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7};
   size_t ncones = sizeof(cones) / sizeof(float);
@@ -316,6 +318,9 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   float jetPt = jet->pt() / jec;  // use uncorrected pt for shape variables
   float sumPt = 0., sumPt2 = 0., sumTkPt = 0., sumPtCh = 0, sumPtNe = 0;
   float multNeut = 0.0;
+  float sumW2(0.0);
+  float sum_deta(0.0), sum_dphi(0.0);
+  float ave_deta(0.0), ave_dphi(0.0);
   setPtEtaPhi(
       *jet, internalId_.jetPt_, internalId_.jetEta_, internalId_.jetPhi_);  // use corrected pt for jet kinematics
   internalId_.jetM_ = jet->mass();
@@ -323,10 +328,16 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.rho_ = rho;
 
   float dRmin(1000);
+  float LeadcandWeight = 1.0;
+  float SecondcandWeight = 1.0;
+  float LeadNeutcandWeight = 1.0;
+  float LeadEmcandWeight = 1.0;
+  float LeadChcandWeight = 1.0;
+  float TrailcandWeight = 1.0;
+
 
   for (unsigned i = 0; i < jet->numberOfSourceCandidatePtrs(); ++i) {
     reco::CandidatePtr pfJetConstituent = jet->sourceCandidatePtr(i);
-
     const reco::Candidate* icand = pfJetConstituent.get();
     const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(icand);
     const reco::PFCandidate* lPF = dynamic_cast<const reco::PFCandidate*>(icand);
@@ -334,10 +345,12 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     if (lPack == nullptr) {
       isPacked = false;
     }
-    float candPuppiWeight = 1.0;
-    if (usePuppi && isPacked)
-      candPuppiWeight = lPack->puppiWeight();
-    float candPt = (icand->pt()) * candPuppiWeight;
+
+    float candWeight = 1.0;
+    if (applyConstituentWeight){                   // PUPPI Jet weight should be pulled up from valuemap, not packed candidate
+      candWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+    }
+    float candPt = (icand->pt()) * candWeight;
     float candPtFrac = candPt / jetPt;
     float candDr = reco::deltaR(*icand, *jet);
     float candDeta = icand->eta() - jet->eta();
@@ -348,12 +361,19 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     if (candDr < dRmin)
       dRmin = candDr;
 
-    // // all particles
-    if (lLead == nullptr || candPt > lLead->pt()) {
+    // // all particles; PUPPI weights multiplied to leading and subleading constituent if it is for PUPPI
+    if (lLead == nullptr || candPt > (lLead->pt())*LeadcandWeight) {
       lSecond = lLead;
+      SecondcandWeight = LeadcandWeight;
       lLead = icand;
-    } else if ((lSecond == nullptr || candPt > lSecond->pt()) && (candPt < lLead->pt())) {
+      if (applyConstituentWeight) {
+        LeadcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+      }
+    } else if ((lSecond == nullptr || candPt > (lSecond->pt())*SecondcandWeight) && (candPt < (lLead->pt())*LeadcandWeight)) {
       lSecond = icand;
+      if (applyConstituentWeight) {
+        SecondcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+      }
     }
 
     // // average shapes
@@ -373,11 +393,15 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       *coneFracs[icone] += candPt;
     }
 
-    // neutrals
+    // neutrals Neutral hadrons
     if (abs(icand->pdgId()) == 130) {
-      if (lLeadNeut == nullptr || candPt > lLeadNeut->pt()) {
+      if (lLeadNeut == nullptr || candPt > (lLeadNeut->pt())*LeadNeutcandWeight) {
         lLeadNeut = icand;
+        if (applyConstituentWeight) {
+          LeadNeutcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+        }
       }
+        
       internalId_.dRMeanNeut_ += candPtDr;
       fracNeut.push_back(candPtFrac);
       if (icone < ncones) {
@@ -385,12 +409,16 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       }
       internalId_.ptDNe_ += candPt * candPt;
       sumPtNe += candPt;
-      multNeut += candPuppiWeight;
+      multNeut += candWeight;
     }
-    // EM candidated
+    
+    // EM candidated photon
     if (icand->pdgId() == 22) {
-      if (lLeadEm == nullptr || candPt > lLeadEm->pt()) {
+      if (lLeadEm == nullptr || candPt > (lLeadEm->pt())*LeadEmcandWeight) {
         lLeadEm = icand;
+        if (applyConstituentWeight) {
+          LeadEmcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+        }
       }
       internalId_.dRMeanEm_ += candPtDr;
       fracEm.push_back(candPtFrac);
@@ -399,16 +427,19 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
       }
       internalId_.ptDNe_ += candPt * candPt;
       sumPtNe += candPt;
-      multNeut += candPuppiWeight;
+      multNeut += candWeight;
     }
+    // hadrons and EM in HF  
     if ((abs(icand->pdgId()) == 1) || (abs(icand->pdgId()) == 2))
-      multNeut += candPuppiWeight;
+      multNeut += candWeight;
 
     // Charged  particles
     if (icand->charge() != 0) {
-      if (lLeadCh == nullptr || candPt > lLeadCh->pt()) {
+      if (lLeadCh == nullptr || candPt > (lLeadCh->pt())*LeadChcandWeight) {
         lLeadCh = icand;
-
+        if (applyConstituentWeight) {
+          LeadChcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+        }
         const reco::Track* pfTrk = icand->bestTrack();
         if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr) {
           reco::MuonRef lmuRef = lPF->muonRef();
@@ -525,68 +556,19 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     }
 
     // trailing candidate
-    if (lTrail == nullptr || candPt < lTrail->pt()) {
+    if (lTrail == nullptr || candPt < (lTrail->pt())*TrailcandWeight) {
       lTrail = icand;
-    }
-  }
-
-  // // Finalize all variables
-  assert(!(lLead == nullptr));
-
-  if (lSecond == nullptr) {
-    lSecond = lTrail;
-  }
-  if (lLeadNeut == nullptr) {
-    lLeadNeut = lTrail;
-  }
-  if (lLeadEm == nullptr) {
-    lLeadEm = lTrail;
-  }
-  if (lLeadCh == nullptr) {
-    lLeadCh = lTrail;
-  }
-
-  if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
-    internalId_.nCharged_ = patjet->chargedMultiplicity();
-    internalId_.nNeutrals_ = patjet->neutralMultiplicity();
-    internalId_.chgEMfrac_ = patjet->chargedEmEnergy() / jet->energy();
-    internalId_.neuEMfrac_ = patjet->neutralEmEnergy() / jet->energy();
-    internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy() / jet->energy();
-    internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy() / jet->energy();
-    if (usePuppi)
-      internalId_.nNeutrals_ = multNeut;
-  } else {
-    internalId_.nCharged_ = pfjet->chargedMultiplicity();
-    internalId_.nNeutrals_ = pfjet->neutralMultiplicity();
-    internalId_.chgEMfrac_ = pfjet->chargedEmEnergy() / jet->energy();
-    internalId_.neuEMfrac_ = pfjet->neutralEmEnergy() / jet->energy();
-    internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy() / jet->energy();
-    internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy() / jet->energy();
-  }
-  internalId_.nParticles_ = jet->nConstituents();
-
-  ///////////////////////pull variable///////////////////////////////////
-  float sumW2(0.0);
-  float sum_deta(0.0), sum_dphi(0.0);
-  float ave_deta(0.0), ave_dphi(0.0);
-  for (size_t j = 0; j < jet->numberOfDaughters(); j++) {
-    const auto& part = jet->daughterPtr(j);
-    if (!(part.isAvailable() && part.isNonnull())) {
-      continue;
+      if (applyConstituentWeight) {
+        TrailcandWeight = constituentWeights[jet->sourceCandidatePtr(i)];
+      }
     }
 
-    float partPuppiWeight = 1.0;
-    if (usePuppi) {
-      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
-      if (partpack != nullptr)
-        partPuppiWeight = partpack->puppiWeight();
-    }
+    // average for pull variable
 
-    float weight = (part->pt()) * partPuppiWeight;
-    float weight2 = weight * weight;
+    float weight2 = candPt * candPt;
     sumW2 += weight2;
-    float deta = part->eta() - jet->eta();
-    float dphi = reco::deltaPhi(*part, *jet);
+    float deta = icand->eta() - jet->eta();
+    float dphi = reco::deltaPhi(*icand, *jet);
     sum_deta += deta * weight2;
     sum_dphi += dphi * weight2;
     if (sumW2 > 0) {
@@ -595,21 +577,92 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     }
   }
 
+  // // Finalize all variables
+  // Most of Below values are not used for puID variable generation at the moment, except lLeadCh Pt for JetRchg, so I assign that zero if there is no charged constituent.
+
+
+  assert(!(lLead == nullptr));
+  internalId_.leadPt_ = lLead->pt()*LeadcandWeight;
+  internalId_.leadEta_ = lLead->eta();
+  internalId_.leadPhi_ = lLead->phi();
+
+  if (lSecond != nullptr){
+    internalId_.secondPt_ = lSecond->pt()*SecondcandWeight;
+    internalId_.secondEta_ = lSecond->eta();
+    internalId_.secondPhi_ = lSecond->phi();
+  } else { 
+    internalId_.secondPt_ = 0.0;
+    internalId_.secondEta_ = large_val;
+    internalId_.secondPhi_ = large_val;
+  }
+
+  if (lLeadNeut != nullptr){
+    internalId_.leadNeutPt_ = lLeadNeut->pt()*LeadNeutcandWeight;
+    internalId_.leadNeutEta_ = lLeadNeut->eta();
+    internalId_.leadNeutPhi_ = lLeadNeut->phi();
+  } else {
+    internalId_.leadNeutPt_ = 0.0;
+    internalId_.leadNeutEta_ = large_val;
+    internalId_.leadNeutPhi_ = large_val;
+  }
+
+  if (lLeadEm != nullptr){
+    internalId_.leadEmPt_ = lLeadEm->pt()*LeadEmcandWeight;
+    internalId_.leadEmEta_ = lLeadEm->eta();
+    internalId_.leadEmPhi_ = lLeadEm->phi();
+  } else {
+    internalId_.leadEmPt_ = 0.0;
+    internalId_.leadEmEta_ = large_val;
+    internalId_.leadEmPhi_ = large_val;
+  }
+
+  if (lLeadCh != nullptr){
+    internalId_.leadChPt_ = lLeadCh->pt()*LeadChcandWeight;
+    internalId_.leadChEta_ = lLeadCh->eta();
+    internalId_.leadChPhi_ = lLeadCh->phi();
+  } else {
+    internalId_.leadChPt_ = 0.0;
+    internalId_.leadChEta_ = large_val;
+    internalId_.leadChPhi_ = large_val;
+  }
+
+
+
+
+  if (patjet != nullptr) {  // to enable running on MiniAOD slimmedJets
+    internalId_.nCharged_ = patjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = patjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = patjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = patjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = patjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = patjet->neutralHadronEnergy() / jet->energy();
+    if (applyConstituentWeight)
+      internalId_.nNeutrals_ = multNeut;
+  } else {
+    internalId_.nCharged_ = pfjet->chargedMultiplicity();
+    internalId_.nNeutrals_ = pfjet->neutralMultiplicity();
+    internalId_.chgEMfrac_ = pfjet->chargedEmEnergy() / jet->energy();
+    internalId_.neuEMfrac_ = pfjet->neutralEmEnergy() / jet->energy();
+    internalId_.chgHadrfrac_ = pfjet->chargedHadronEnergy() / jet->energy();
+    internalId_.neuHadrfrac_ = pfjet->neutralHadronEnergy() / jet->energy();
+    if (applyConstituentWeight)
+      internalId_.nNeutrals_ = multNeut;
+  }
+  internalId_.nParticles_ = jet->nConstituents();
+
+  ///////////////////////pull variable///////////////////////////////////
   float ddetaR_sum(0.0), ddphiR_sum(0.0), pull_tmp(0.0);
-  for (size_t i = 0; i < jet->numberOfDaughters(); i++) {
-    const auto& part = jet->daughterPtr(i);
-    if (!(part.isAvailable() && part.isNonnull())) {
-      continue;
-    }
+  for (unsigned k = 0; k < jet->numberOfSourceCandidatePtrs(); k++) {
+    reco::CandidatePtr temp_pfJetConstituent = jet->sourceCandidatePtr(k);
+//    reco::CandidatePtr temp_weightpfJetConstituent = jet->sourceCandidatePtr(k);
+    const reco::Candidate* part = temp_pfJetConstituent.get();
+ 
+   float candWeight = 1.0;
 
-    float partPuppiWeight = 1.0;
-    if (usePuppi) {
-      const pat::PackedCandidate* partpack = dynamic_cast<const pat::PackedCandidate*>(part.get());
-      if (partpack != nullptr)
-        partPuppiWeight = partpack->puppiWeight();
-    }
+    if (applyConstituentWeight)
+      candWeight = constituentWeights[jet->sourceCandidatePtr(k)];
 
-    float weight = partPuppiWeight * (part->pt()) * partPuppiWeight * (part->pt());
+    float weight = candWeight * (part->pt()) * candWeight * (part->pt());
     float deta = part->eta() - jet->eta();
     float dphi = reco::deltaPhi(*part, *jet);
     float ddeta, ddphi, ddR;
@@ -627,11 +680,6 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.pull_ = pull_tmp;
   ///////////////////////////////////////////////////////////////////////
 
-  setPtEtaPhi(*lLead, internalId_.leadPt_, internalId_.leadEta_, internalId_.leadPhi_);
-  setPtEtaPhi(*lSecond, internalId_.secondPt_, internalId_.secondEta_, internalId_.secondPhi_);
-  setPtEtaPhi(*lLeadNeut, internalId_.leadNeutPt_, internalId_.leadNeutEta_, internalId_.leadNeutPhi_);
-  setPtEtaPhi(*lLeadEm, internalId_.leadEmPt_, internalId_.leadEmEta_, internalId_.leadEmPhi_);
-  setPtEtaPhi(*lLeadCh, internalId_.leadChPt_, internalId_.leadChEta_, internalId_.leadChPhi_);
 
   std::sort(frac.begin(), frac.end(), std::greater<float>());
   std::sort(fracCh.begin(), fracCh.end(), std::greater<float>());
@@ -698,8 +746,13 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
   internalId_.sumChPt_ = sumPtCh;
   internalId_.sumNePt_ = sumPtNe;
 
-  internalId_.jetR_ = lLead->pt() / sumPt;
-  internalId_.jetRchg_ = lLeadCh->pt() / sumPt;
+  internalId_.jetR_ = (lLead->pt())*LeadcandWeight / sumPt;
+  if (lLeadCh != nullptr){
+    internalId_.jetRchg_ = (lLeadCh->pt())*LeadChcandWeight / sumPt;
+  } else { 
+    internalId_.jetRchg_ = 0; 
+  }
+
   internalId_.dRMatch_ = dRmin;
 
   if (sumTkPt != 0.) {


### PR DESCRIPTION
Backport from https://github.com/cms-sw/cmssw/pull/40762

Original PR description:

This PR has three main modifications:

Pileup Jet Id variable bug fix.
PileupJetIdProducer and PileupJetIdAlgo are used to compute input variables and the final discriminant for
the Pileup jet Id BDT. There was a bug for one of the variable calculation such that when there is no charged
constituent inside a jet, it assigns the very last constituent in the list of constituent as leading charged
constituent. This PR corrects this error and assigns zero pt and large phi and eta when there is no charged
constituent.

Correct puppi weight access implementation by ValueMap.
Previously, the puppi weight for each constituent was accessed from packedCandidate object in the code, but for the
compatibility with other codes in CMSSW, this weight must be implemented through ValueMap. In this PR, puppi
weight retrieval from ValueMap is implemented, just like PR https://github.com/cms-sw/cmssw/pull/40667. As in that PR, the naming of "puppi weight" is
generalized to "constituent weight". Furthermore, there are parts of PileupJetIdAlgo where comparison of constituent's pt
(in order to find, for example, leading charged constituent) was done incorrectly when weighted pt was compared with
unweighted pt. This error is also fixed.

The ValueMap implementation does not affect CHS jets. However, the fix in leading charged constituent selection could
have affected CHS jets. In further detail, CHS jets have more constituents in each jet in general and it is very rare
for CHS jets to have no charged constituent at all, so the effect of such fix was insignificant.

Add an option in PuppiProducer to apply photon protection for existing weights.
Previously the photon protection is applied also on existing puppi weights. This will confuse users who would want
PuppiProducer to provide ValueMap of weights with the same exact weights stored in packedPFCandidates in MiniAODs.
This PR adds a flag (default set to False) to enable photon protection on existing puppi weights.

PR validation:

Validation plots comparing the input variables for Pileup Jet Id training before and after fix can be found in this JMAR meeting [contribution](https://indico.cern.ch/event/1245910/#5-pu-jetid-training-for-puppi).
Passes the usual runTheMatrix test: runTheMatrix.py -l limited -i all --ibeos. Test done by @nurfikri89.
Passes reMiniAOD and reNanoAOD workflows: runTheMatrix.py -i all --ibeos -l 1325.518,2500.312. Test done by @nurfikri89.
Passes the JMENano workflows: runTheMatrix.py -i all --ibeos -l 10224.15,11024.15,25202.15,11634.15. Test done by @nurfikri89.