### PR TITLE
Removed unused variables in SiPixelChargeReweightingAlgorithm

### DIFF
--- a/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
@@ -388,7 +388,7 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   // Local variables
   int i, j, k, l, kclose;
   int nclusx, nclusy, success;
-  float xsize, ysize, q50i, q100i, q50r, q10r, q100r, xhit2D, yhit2D, qclust, dist2, dmin2;
+  float xsize, ysize, q50i, q100i, q50r, q10r, xhit2D, yhit2D, dist2, dmin2;
   float xy_in[BXM2][BYM2], xy_rewgt[BXM2][BYM2], xy_clust[TXSIZE][TYSIZE];
   int denx_clust[TXSIZE][TYSIZE], deny_clust[TXSIZE][TYSIZE];
   int goodWeightsUsed, nearbyWeightsUsed, noWeightsUsed;
@@ -474,15 +474,11 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
 
   // Sum initial charge in the cluster
 
-  qclust = 0.f;
   for (i = 0; i < TYSIZE; ++i) {
     for (j = 0; j < TXSIZE; ++j) {
       xy_clust[j][i] = 0.f;
       denx_clust[j][i] = 0;
       deny_clust[j][i] = 0;
-      if (cluster[j][i] > q100i) {
-        qclust += cluster[j][i];
-      }
     }
   }
 
@@ -498,7 +494,6 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   }
 
   q50r = templ2D.s50();
-  q100r = 2.f * q50r;
   q10r = 0.2f * q50r;
 
   // Find all non-zero denominator pixels in the input template and generate "inside" weights
@@ -509,7 +504,6 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   std::vector<int> xtclust;
   std::vector<int> ycclust;
   std::vector<int> xcclust;
-  qclust = 0.f;
   for (i = 0; i < TYSIZE; ++i) {
     for (j = 0; j < TXSIZE; ++j) {
       if (xy_in[j + 1][i + 1] > q100i) {
@@ -559,9 +553,6 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
     for (j = 0; j < TXSIZE; ++j) {
       if (xy_clust[j][i] > 0.f) {
         cluster[j][i] = xy_clust[j][i] * clust[denx_clust[j][i]][deny_clust[j][i]];
-        if (cluster[j][i] > q100r) {
-          qclust += cluster[j][i];
-        }
         if (cluster[j][i] > 0) {
           goodWeightsUsed++;
         }
@@ -593,9 +584,6 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
       if (dmin2 < 5.f) {
         nearbyWeightsUsed++;
         cluster[j][i] *= xy_clust[xtclust[kclose]][ytclust[kclose]];
-        if (cluster[j][i] > q100r) {
-          qclust += cluster[j][i];
-        }
       } else {
         noWeightsUsed++;
         cluster[j][i] = 0.f;


### PR DESCRIPTION
#### PR description:

This fixes a clang warning.

#### PR validation:

Compiling the code with clang does not generate any warnings.