### PR TITLE
remove one HLT-related histogram from (Jet)MET offline DQM

### DIFF
--- a/DQMOffline/JetMET/interface/METAnalyzer.h
+++ b/DQMOffline/JetMET/interface/METAnalyzer.h
@@ -214,11 +214,6 @@ private:
   edm::InputTag triggerResultsLabel_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
 
-  // list of Jet or MB HLT triggers
-  //  std::vector<std::string > HLTPathsJetMBByName_;
-  std::vector<std::string> allTriggerNames_;
-  std::vector<int> allTriggerDecisions_;
-
   std::string HBHENoiseStringMiniAOD;
   std::string HBHEIsoNoiseStringMiniAOD;
 
@@ -305,12 +300,8 @@ private:
   // lines commented out have been removed to improve the bin usage of JetMET DQM
 
   //for all MET types
-  bool hTriggerLabelsIsSet_;
-  //only in for PF
-  //  MonitorElement* meTriggerName_PhysDec;
 
   MonitorElement* lumisecME;
-  MonitorElement* hTrigger;
   //MonitorElement* hNevents;
   MonitorElement* hMEx;
   MonitorElement* hMEy;

--- a/DQMOffline/JetMET/src/METAnalyzer.cc
+++ b/DQMOffline/JetMET/src/METAnalyzer.cc
@@ -102,7 +102,6 @@ METAnalyzer::METAnalyzer(const edm::ParameterSet& pSet) {
   fill_met_high_level_histo = parameters.getParameter<bool>("fillMetHighLevel");
   fillCandidateMap_histos = parameters.getParameter<bool>("fillCandidateMaps");
 
-  hTriggerLabelsIsSet_ = false;
   //jet cleanup parameters
   cleaningParameters_ = pSet.getParameter<ParameterSet>("CleaningParameters");
 
@@ -324,16 +323,6 @@ void METAnalyzer::bookMonitorElement(std::string DirName,
   }
 
   if (!fillZPlots) {
-    hTrigger = ibooker.book1D("triggerResults", "triggerResults", 500, 0, 500);
-    for (unsigned int i = 0; i < allTriggerNames_.size(); i++) {
-      if (i < (unsigned int)hTrigger->getNbinsX()) {
-        if (!hTriggerLabelsIsSet_) {
-          hTrigger->setBinLabel(i + 1, allTriggerNames_[i]);
-        }
-      }
-    }
-    hTriggerLabelsIsSet_ = true;
-
     hMEx = ibooker.book1D("MEx", "MEx", 200, -500, 500);
     hMEy = ibooker.book1D("MEy", "MEy", 200, -500, 500);
     hMET = ibooker.book1D("MET", "MET", 200, 0, 1000);
@@ -359,7 +348,6 @@ void METAnalyzer::bookMonitorElement(std::string DirName,
     hMET_logx->setAxisTitle("log(MET) [GeV]", 1);
     hSumET_logx->setAxisTitle("log(SumET) [GeV]", 1);
 
-    map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "triggerResults", hTrigger));
     map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "MEx", hMEx));
     map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "MEy", hMEy));
     map_of_MEs.insert(std::pair<std::string, MonitorElement*>(DirName + "/" + "MET", hMET));
@@ -1208,12 +1196,6 @@ void METAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
                 << " config extraction failure with process name " << triggerResultsLabel_.process() << std::endl;
   }
 
-  allTriggerNames_.clear();
-  for (unsigned int i = 0; i < hltConfig_.size(); i++) {
-    allTriggerNames_.push_back(hltConfig_.triggerName(i));
-  }
-  //  std::cout<<"Length: "<<allTriggerNames_.size()<<std::endl;
-
   triggerSelectedSubFolders_ = parameters.getParameter<edm::VParameterSet>("triggerSelectedSubFolders");
   for (std::vector<GenericTriggerEventFlag*>::const_iterator it = triggerFolderEventFlag_.begin();
        it != triggerFolderEventFlag_.end();
@@ -1463,11 +1445,6 @@ void METAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       unsigned int pos = it - triggerFolderEventFlag_.begin();
       bool fd = (*it)->accept(iEvent, iSetup);
       triggerFolderDecisions_[pos] = fd;
-    }
-    allTriggerDecisions_.clear();
-    for (unsigned int i = 0; i < allTriggerNames_.size(); ++i) {
-      allTriggerDecisions_.push_back((*triggerResults).accept(i));
-      //std::cout<<"TR "<<(*triggerResults).size()<<" "<<(*triggerResults).accept(i)<<" "<<allTriggerNames_[i]<<std::endl;
     }
   }
 
@@ -2260,15 +2237,6 @@ void METAnalyzer::fillMonitorElement(const edm::Event& iEvent,
 
     if (!subFolderName.empty()) {
       DirName = DirName + "/" + subFolderName;
-    }
-
-    hTrigger = map_of_MEs[DirName + "/triggerResults"];
-    if (hTrigger && hTrigger->getRootObject()) {
-      for (unsigned int i = 0; i < allTriggerDecisions_.size(); i++) {
-        if (i < (unsigned int)hTrigger->getNbinsX()) {
-          hTrigger->Fill(i + .5, allTriggerDecisions_[i]);
-        }
-      }
     }
 
     hMEx = map_of_MEs[DirName + "/" + "MEx"];


### PR DESCRIPTION
#### PR description:

This PR follows the same rationale as #40788, in that it removes a HLT-related histogram from the (Jet)MET offline DQM. The histogram in question show the results of the first 500 HLT Paths in `TriggerResults::HLT` (where 500 is an arbitrary number). In my opinion, this particular histogram is not useful in this part of the DQM (the HLT outputs are already monitored by other dedicated DQM plugins). A similar histogram has led to confusion in #40700 (see also #40788).

Merely technical. No changes expected, except for the removal of the histogram in question.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A