### PR TITLE
Fix BeamSpot Z value in Realistic25ns13p6TeVEOY2022Collision VtxSmearing scenario

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -840,7 +840,7 @@ Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters = cms.PSet(
     TimeOffset = cms.double(0.0),
     X0 = cms.double(0.1027975),
     Y0 = cms.double(-0.016762),
-    Z0 = cms.double(0.607956)
+    Z0 = cms.double(0.101756)
 )
 
 # Test HF offset

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
@@ -5,3 +5,4 @@ VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters,
     VtxSmearedCommon
 )
+


### PR DESCRIPTION
#### PR description:
This is a bug-fix to the `Realistic25ns13p6TeVEOY2022Collision` VtxSmearing scenario introduced in #40662.

The correct Z position should have been computed as (BeamSpot Z minus BPIX barycenter Z):
```
-0.2531-(-0.354856) = 0.101756 [cm]
```
while in the original PR a `"-"` sign was lost and the Z position was wrongly set to:
```
0.2531-(-0.354856) = 0.607956 [cm]
```
This PR fixes the issue by changing:
```diff
-    Z0 = cms.double(0.607956)
+    Z0 = cms.double(0.101756)
```
I profit of this PR to also fix the "missing line at the end of file" as requested in https://github.com/cms-sw/cmssw/pull/40662#discussion_r1093417281

#### PR validation:
None as nothing is really using this VtxSmearing at the moment.

#### Backport:
Not a backport - a backport to 13_0_X will be provided in order to have a correct smearing in 13_0_0.
