### PR TITLE
Minor improvements to Alpaka tests [13.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
@@ -68,10 +68,10 @@ TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestKernel), s_tag)
     // buffer size
     constexpr size_t size = 1024 * 1024;
 
-    // allocate input and output host buffers
-    auto in1_h = cms::alpakatools::make_host_buffer<float[]>(size);
-    auto in2_h = cms::alpakatools::make_host_buffer<float[]>(size);
-    auto out_h = cms::alpakatools::make_host_buffer<float[]>(size);
+    // allocate input and output host buffers in pinned memory accessible by the Platform devices
+    auto in1_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto in2_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto out_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for (size_t i = 0; i < size; ++i) {
@@ -158,10 +158,10 @@ TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestKernel3D), s_ta
     constexpr Vec3D ndsize = {50, 125, 16};
     constexpr size_t size = ndsize.prod();
 
-    // allocate input and output host buffers
-    auto in1_h = cms::alpakatools::make_host_buffer<float[]>(size);
-    auto in2_h = cms::alpakatools::make_host_buffer<float[]>(size);
-    auto out_h = cms::alpakatools::make_host_buffer<float[]>(size);
+    // allocate input and output host buffers in pinned memory accessible by the Platform devices
+    auto in1_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto in2_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto out_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
 
     // fill the input buffers with random data, and the output buffer with zeros
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
+++ b/HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h
@@ -51,7 +51,7 @@ namespace cms::alpakatools {
       // of that activity (which has nothing to do with the memory here).
       auto dstBuffer = cms::alpakatools::make_device_buffer<int[]>(queue, srcData.size());
       alpaka::memcpy(queue, dstBuffer, srcData.buffer());
-      return cms::alpakatest::AlpakaESTestDataB<typename alpaka::trait::DevType<TQueue>::type>(std::move(dstBuffer));
+      return cms::alpakatest::AlpakaESTestDataB<alpaka::Dev<TQueue>>(std::move(dstBuffer));
     }
   };
 }  // namespace cms::alpakatools

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -4,7 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -73,14 +73,14 @@ namespace {
 
 }  // namespace
 
-class TestAlpakaAnalyzer : public edm::stream::EDAnalyzer<> {
+class TestAlpakaAnalyzer : public edm::global::EDAnalyzer<> {
 public:
   TestAlpakaAnalyzer(edm::ParameterSet const& config)
       : source_{config.getParameter<edm::InputTag>("source")},
         token_{consumes(source_)},
         expectSize_(config.getParameter<int>("expectSize")) {}
 
-  void analyze(edm::Event const& event, edm::EventSetup const&) override {
+  void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const&) const override {
     portabletest::TestHostCollection const& product = event.get(token_);
     auto const& view = product.const_view();
     auto& mview = product.view();

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -9,19 +9,19 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
-#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 #include "TestAlgo.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
-  class TestAlpakaProducer : public stream::EDProducer<> {
+  class TestAlpakaProducer : public global::EDProducer<> {
   public:
     TestAlpakaProducer(edm::ParameterSet const& config)
         : deviceToken_{produces()}, size_{config.getParameter<int32_t>("size")} {}
 
-    void produce(device::Event& event, device::EventSetup const&) override {
+    void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {
       // run the algorithm, potentially asynchronously
       portabletest::TestDeviceCollection deviceProduct{size_, event.queue()};
       algo_.fill(event.queue(), deviceProduct);

--- a/HeterogeneousCore/AlpakaTest/test/writer.py
+++ b/HeterogeneousCore/AlpakaTest/test/writer.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
 
 process = cms.Process('Writer')
 


### PR DESCRIPTION
#### PR description:

This PR makes some minor improvements to the Alpaka stand-alone and framework-based tests, that came up during the Alpaka tutorials on the 16-17 February:
  - remove one leftover import from `writer.py`
  - simplify getting the `Device` type from the `Queue` in `AlpakaESTestData.h`
  - migrate the test modules from `stream` to `global`
  - allocate host buffers in pinned memory accessible by the `Platform` devices in `testKernel.dev.cc`

#### PR validation:

All unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/40808 to 13.0.x for consistency.