### PR TITLE
Changed binary to logical operation in OptimalHelixPlaneCrossing

### DIFF
--- a/TrackingTools/GeomPropagators/interface/OptimalHelixPlaneCrossing.h
+++ b/TrackingTools/GeomPropagators/interface/OptimalHelixPlaneCrossing.h
@@ -20,7 +20,7 @@ public:
       // barrel plane:
       // instantiate HelixBarrelPlaneCrossing,
       new (get()) HelixBarrelPlaneCrossingByCircle(args...);
-    } else if ((std::abs(u.x()) < small) & (std::abs(u.y()) < small)) {
+    } else if ((std::abs(u.x()) < small) && (std::abs(u.y()) < small)) {
       // forward plane:
       // instantiate HelixForwardPlaneCrossing
       new (get()) HelixForwardPlaneCrossing(args...);


### PR DESCRIPTION

#### PR description:

This got rid of a clang warning.

#### PR validation:

Compiling the code under clang no longer issues the warning.