### PR TITLE
[13_0_X] Fix BeamSpot Z value in Realistic25ns13p6TeVEOY2022Collision VtxSmearing scenario

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -840,7 +840,7 @@ Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters = cms.PSet(
     TimeOffset = cms.double(0.0),
     X0 = cms.double(0.1027975),
     Y0 = cms.double(-0.016762),
-    Z0 = cms.double(0.607956)
+    Z0 = cms.double(0.101756)
 )
 
 # Test HF offset

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi.py
@@ -5,3 +5,4 @@ VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
     Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters,
     VtxSmearedCommon
 )
+


### PR DESCRIPTION
#### PR description:
Backport of #40807 
(bug-)Fixes the BeamSpot Z position of the `Realistic25ns13p6TeVEOY2022Collision` VtxSmearing scenario from
`0.607956` to `0.101756`.

#### PR validation:
None as this scenario is currently not used anywhere (yet).

#### Backport:
Backport of #40807 