### PR TITLE
Include product instance name for the data product copied implicitly to host in Alpaka EDProducers

### DIFF
--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerB.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerB.cc
@@ -16,16 +16,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    * Alpaka buffer that is then moved into an object of a class that
    * is templated over the device type, and implicitly transfers the
    * data product to device
+   *
+   * This class also tests the explicit label for ESProducts works
    */
   class TestAlpakaESProducerB : public ESProducer {
   public:
     TestAlpakaESProducerB(edm::ParameterSet const& iConfig) {
-      auto cc = setWhatProduced(this);
+      auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("explicitLabel"));
       token_ = cc.consumes();
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.add("explicitLabel", std::string{});
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerD.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerD.cc
@@ -1,6 +1,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
@@ -23,12 +24,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     TestAlpakaESProducerD(edm::ParameterSet const& iConfig) {
       auto cc = setWhatProduced(this);
-      tokenA_ = cc.consumes();
-      tokenB_ = cc.consumes();
+      tokenA_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("srcA"));
+      tokenB_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("srcB"));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.add("srcA", edm::ESInputTag{});
+      desc.add("srcB", edm::ESInputTag{});
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -18,7 +18,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    * This class demonstrates a stream EDProducer that
    * - consumes a host EDProduct
    * - consumes a device ESProduct
-   * - produces a device EDProduct (that can get transferred to host automatically)
+   * - produces a device EDProduct (that gets transferred to host automatically if needed)
+   * - optionally uses a product instance label
    */
   class TestAlpakaStreamProducer : public stream::EDProducer<> {
   public:
@@ -27,7 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {
       getToken_ = consumes(config.getParameter<edm::InputTag>("source"));
       esToken_ = esConsumes();
-      devicePutToken_ = produces();
+      devicePutToken_ = produces(config.getParameter<std::string>("productInstanceName"));
     }
 
     void produce(device::Event& iEvent, device::EventSetup const& iSetup) override {
@@ -45,6 +46,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("source");
+      desc.add<std::string>("productInstanceName", "");
 
       edm::ParameterSetDescription psetSize;
       psetSize.add<int32_t>("alpaka_serial_sync");

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -51,9 +51,14 @@ process.esProducerC = cms.ESProducer("cms::alpakatest::TestESProducerC", value =
 
 from HeterogeneousCore.AlpakaTest.testAlpakaESProducerA_cfi import testAlpakaESProducerA 
 process.alpakaESProducerA = testAlpakaESProducerA.clone()
+process.alpakaESProducerAdataLabel = process.alpakaESProducerA.clone(appendToDataLabel = cms.string("appendedLabel"))
 process.alpakaESProducerB = cms.ESProducer("TestAlpakaESProducerB@alpaka")
+process.alpakaESProducerBexplicitLabel = process.alpakaESProducerB.clone(explicitLabel = cms.string("explicitLabel"))
 process.alpakaESProducerC = cms.ESProducer("TestAlpakaESProducerC@alpaka")
-process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka")
+process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka",
+    srcA = cms.ESInputTag("", "appendedLabel"),
+    srcB = cms.ESInputTag("", "explicitLabel"),
+)
 
 process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
 


### PR DESCRIPTION
#### PR description:

@fwyzard Reported privately that in an Alpaka EDProducer that sets a product instance name for a product, the product instance name gets lost when the device-side product is implicitly copied to the host. This PR enhances the tests to catch the problem, and fixes the it. The PR also enhances the EventSetup side tests to exercise both the `appendToDataLabel` parameter, and a case where the product label is set explicitly in the user ESProducer code.

Needs to be rebased after a few other Alpaka-related PRs have gotten merged.

#### PR validation:

Unit tests run in machines with and without NVIDIA GPU.