### PR TITLE
Fix generator interface to Geant4

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -475,7 +475,8 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
       LogDebug("SimG4CoreGenerator::::particleAssignDaughters")
           << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
-    if ((status == 2 || (status >= 23 && status < 100)) && (*vpdec)->end_vertex() != nullptr) {
+    if ((status == 2 || (status == 23 && std::abs(vp->pdg_id()) == 1000015) || (status > 50 && status < 100)) &&
+        (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -472,8 +472,8 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
 
     int status = (*vpdec)->status();
     if (verbose > 1)
-      LogDebug("SimG4CoreGenerator::::particleAssignDaughters") 
-	  << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
+      LogDebug("SimG4CoreGenerator::::particleAssignDaughters")
+          << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
     if ((status == 2 || (status >= 23 && status < 100)) && (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();

--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -470,17 +470,19 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     // value of the code compute inside TrackWithHistory
     setGenId(g4daught, (*vpdec)->barcode());
 
-    if (verbose > 2)
-      LogDebug("SimG4CoreGenerator") << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id();
+    int status = (*vpdec)->status();
+    if (verbose > 1)
+      LogDebug("SimG4CoreGenerator::::particleAssignDaughters") 
+	  << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id() << " status=" << status;
 
-    if (((*vpdec)->status() == 2 || (*vpdec)->status() > 3) && (*vpdec)->end_vertex() != nullptr) {
+    if ((status == 2 || (status >= 23 && status < 100)) && (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();
       double dd = std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2));
       particleAssignDaughters(g4daught, *vpdec, dd);
     }
-    (*vpdec)->set_status(1000 + (*vpdec)->status());
+    (*vpdec)->set_status(1000 + status);
     g4p->SetDaughter(g4daught);
 
     if (verbose > 1)


### PR DESCRIPTION
#### PR description:
New problem is discussed after the fix #39427  was introduced. Now for displaced jets.
In this PR the previous condition for select predefined daughters decays is restored and a new one is added , which is less strict then one in #39427.


#### PR validation:
incomplete

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
if will be approved should be backported to MC production releases.

