### PR TITLE
Fix expected version number of uGT with muon shower support

### DIFF
--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -13,7 +13,7 @@ gtStage2Raw = cms.EDProducer(
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
     EtSumInputTag  = cms.InputTag("simCaloStage2Digis"),
     FedId = cms.int32(1404),
-    FWId = cms.uint32(0x1130),  # FW w/ displaced muon info.
+    FWId = cms.uint32(0x113b),  # FW w/ displaced muon info and hadronic showers.
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -32,4 +32,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x10f01)) # FW w/ displaced muon info and hadronic showers.
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x113b)) # FW w/ displaced muon info and hadronic showers.

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -264,7 +264,7 @@ void l1t::MuonRawDigiTranslator::generate64bitDataWord(
 }
 
 bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, unsigned int fwId) {
-  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x113b)) {
     return ((shower_word >> showerShift_) & 1) == 1;
   }
   return false;


### PR DESCRIPTION
#### PR description:

This PR fixes a typo in the expected version number for uGT firmware that has support for muon showers.

#### PR validation:

Ran on 2022G data to confirm that the firmware check now succeeds.
