### PR TITLE
add double PFTau HLT filter [13_0_X]

### DIFF
--- a/HLTrigger/HLTfilters/plugins/plugins.cc
+++ b/HLTrigger/HLTfilters/plugins/plugins.cc
@@ -105,6 +105,7 @@ typedef HLTDoublet<PFJet, PFJet> HLT2PFJetPFJet;
 typedef HLTDoublet<PFJet, CaloMET> HLT2PFJetCaloMET;
 typedef HLTDoublet<PFJet, MET> HLT2PFJetMET;
 typedef HLTDoublet<PFJet, PFMET> HLT2PFJetPFMET;
+typedef HLTDoublet<PFTau, PFTau> HLT2PFTauPFTau;
 
 typedef HLTDoublet<Electron, CaloJet> HLT2ElectronTau;
 typedef HLTDoublet<RecoEcalCandidate, CaloJet> HLT2PhotonTau;
@@ -157,6 +158,7 @@ DEFINE_FWK_MODULE(HLT2ElectronPFMET);
 DEFINE_FWK_MODULE(HLT2MuonPFMET);
 DEFINE_FWK_MODULE(HLT2PhotonMET);
 DEFINE_FWK_MODULE(HLT2PhotonPFMET);
+DEFINE_FWK_MODULE(HLT2PFTauPFTau);
 
 DEFINE_FWK_MODULE(HLT3DoublePFTauPFJet);
 DEFINE_FWK_MODULE(HLT3MuonPFTauPFJet);


### PR DESCRIPTION
#### PR description:

Just add a new alias for a PFTau-PFTau doublet filter in HLT. Needed for a new W->3pi HLT path.

#### PR validation:

Just verified scram compilation and used in HLT (no modification of existing code).

