### PR TITLE
Fix unit test EgammaTowerIso_t for clang

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
@@ -55,8 +55,10 @@ public:
 
   template <typename I>
   void compute(bool et, Sum& sum, reco::Candidate const& cand, I first, I last) const {
-    reco::SuperCluster const& sc = *cand.get<reco::SuperClusterRef>().get();
-    return compute(et, sum, sc, first, last);
+    reco::SuperCluster const* sc = cand.get<reco::SuperClusterRef>().get();
+    if (sc) {
+      compute(et, sum, *sc, first, last);
+    }
   }
   template <typename I>
   void compute(bool et, Sum& sum, reco::SuperCluster const& sc, I first, I last) const;

--- a/RecoEgamma/EgammaIsolationAlgos/test/EgammaTowerIso_t.cpp
+++ b/RecoEgamma/EgammaIsolationAlgos/test/EgammaTowerIso_t.cpp
@@ -7,7 +7,7 @@ int main() {
   float cutEx[2]{1.f, 2.f}, cutIn[2]{0.5f, 0.5f};
   EgammaTowerIsolationNew<2> iso(cutEx, cutIn, towers);
 
-  CaloTower cand;
+  reco::SuperCluster cand;
   EgammaTowerIsolationNew<2>::Sum sum;
   iso.compute(
       true, sum, cand, static_cast<CaloTowerDetId const*>(nullptr), static_cast<CaloTowerDetId const*>(nullptr));


### PR DESCRIPTION
#### PR description:

- avoid dereferencing a null pointer
- pass a SuperCluster to the compute method as that is the type it actually wants.

#### PR validation:

Building and running with clang no longer shows a failure.