### PR TITLE
Delete unused code related to EventSetup

### DIFF
--- a/FWCore/Concurrency/interface/include_first_syncWait.h
+++ b/FWCore/Concurrency/interface/include_first_syncWait.h
@@ -3,8 +3,6 @@
 //
 //  syncWait.h
 //
-//  This file must be included before any other file that include tbb headers
-//
 //  Created by Chris Jones on 2/24/21.
 //
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -21,7 +21,6 @@
 
 // system include files
 #include <atomic>
-#include <memory>
 
 // user include files
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -29,7 +28,6 @@
 
 // forward declarations
 namespace edm {
-  class ActivityRegistry;
   class EventSetupImpl;
   class ServiceToken;
   class ESParentContext;
@@ -56,12 +54,6 @@ namespace edm {
                          ServiceToken const&,
                          ESParentContext const&) const;
 
-      void const* get(EventSetupRecordImpl const&,
-                      DataKey const&,
-                      bool iTransiently,
-                      ActivityRegistry const*,
-                      EventSetupImpl const*,
-                      ESParentContext const&) const;
       void const* getAfterPrefetch(const EventSetupRecordImpl& iRecord, const DataKey& iKey, bool iTransiently) const;
 
       ///returns the description of the DataProxyProvider which owns this Proxy

--- a/FWCore/Framework/interface/ESSourceDataProxyBase.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyBase.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/EventSetupRecordDetails.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 // forward declarations
 

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -51,11 +51,9 @@
 
 // system include files
 #include <exception>
-#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <atomic>
 #include <cassert>
 #include <limits>
 
@@ -69,12 +67,11 @@ class testEventsetupRecord;
 
 namespace edm {
   class ESHandleExceptionFactory;
-  class ESInputTag;
+  class ESParentContext;
   class EventSetupImpl;
 
   namespace eventsetup {
     struct ComponentDescription;
-    class DataProxy;
     class EventSetupRecordKey;
 
     class EventSetupRecord {
@@ -174,7 +171,7 @@ namespace edm {
         ComponentDescription const* desc = nullptr;
         std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
 
-        impl_->getImplementation(value, proxyIndex, H<T>::transientAccessOnly, desc, whyFailedFactory, eventSetupImpl_);
+        impl_->getImplementation(value, proxyIndex, H<T>::transientAccessOnly, desc, whyFailedFactory);
 
         if UNLIKELY (not value) {
           return H<T>(std::move(whyFailedFactory));
@@ -187,8 +184,6 @@ namespace edm {
       ESProxyIndex const* getTokenIndices() const noexcept { return getTokenIndices_; }
 
       ESParentContext const* esParentContext() const noexcept { return context_; }
-
-      void validate(ComponentDescription const*, ESInputTag const&) const;
 
       void addTraceInfoToCmsException(cms::Exception& iException,
                                       char const* iName,
@@ -217,10 +212,6 @@ namespace edm {
           return std::make_exception_ptr(ex);
         })};
       }
-
-      void const* getFromProxy(DataKey const& iKey,
-                               ComponentDescription const*& iDesc,
-                               bool iTransientAccessOnly) const;
 
       static std::exception_ptr makeUninitializedTokenException(EventSetupRecordKey const&, TypeTag const&);
       static std::exception_ptr makeInvalidTokenException(EventSetupRecordKey const&, TypeTag const&, unsigned int);

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -10,22 +10,11 @@
 // Created:     Thu Mar 31 12:49:19 EST 2005
 //
 
-// system include files
-#include <mutex>
-
-// user include files
-#include "FWCore/Concurrency/interface/include_first_syncWait.h"
-
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/Framework/interface/MakeDataException.h"
-#include "FWCore/Framework/interface/EventSetupRecord.h"
-#include "FWCore/Framework/interface/EventSetupImpl.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
-#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
-#include "FWCore/ServiceRegistry/interface/ESParentContext.h"
-#include "FWCore/Concurrency/interface/WaitingTaskList.h"
-#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Framework/interface/EventSetupRecordImpl.h"
+#include "FWCore/Utilities/interface/Likely.h"
 
 namespace edm {
   namespace eventsetup {
@@ -94,19 +83,6 @@ namespace edm {
         throwMakeException(iRecord, iKey);
       }
       return cache_;
-    }
-
-    const void* DataProxy::get(const EventSetupRecordImpl& iRecord,
-                               const DataKey& iKey,
-                               bool iTransiently,
-                               ActivityRegistry const* activityRegistry,
-                               EventSetupImpl const* iEventSetupImpl,
-                               ESParentContext const& iParent) const {
-      if (!cacheIsValid()) {
-        throw edm::Exception(errors::LogicError) << "DataProxy::get called without first doing prefetch.\nThis should "
-                                                    "not be able to happen.\nPlease contact framework developers";
-      }
-      return getAfterPrefetch(iRecord, iKey, iTransiently);
     }
 
   }  // namespace eventsetup

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -14,12 +14,13 @@
 #include <sstream>
 
 // user include files
+#include "FWCore/Framework/interface/DataKeyTags.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 
-#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/TypeIDBase.h"
 
 namespace {
   void throwWrongRecordType(const edm::TypeIDBase& aFromToken, const edm::eventsetup::EventSetupRecordKey& aRecord) {
@@ -30,8 +31,6 @@ namespace {
 
 namespace edm {
   namespace eventsetup {
-
-    typedef std::map<DataKey, const DataProxy*> Proxies;
 
     EventSetupRecord::EventSetupRecord() {}
 
@@ -58,27 +57,6 @@ namespace edm {
 
     edm::eventsetup::ComponentDescription const* EventSetupRecord::providerDescription(const DataKey& aKey) const {
       return impl_->providerDescription(aKey);
-    }
-
-    void EventSetupRecord::validate(const ComponentDescription* iDesc, const ESInputTag& iTag) const {
-      if (iDesc && !iTag.module().empty()) {
-        bool matched = false;
-        if (iDesc->label_.empty()) {
-          matched = iDesc->type_ == iTag.module();
-        } else {
-          matched = iDesc->label_ == iTag.module();
-        }
-        if (!matched) {
-          throw cms::Exception("EventSetupWrongModule")
-              << "EventSetup data was retrieved using an ESInputTag with the values\n"
-              << "  moduleLabel = '" << iTag.module() << "'\n"
-              << "  dataLabel = '" << iTag.data() << "'\n"
-              << "but the data matching the C++ class type and dataLabel comes from module type=" << iDesc->type_
-              << " label='" << iDesc->label_ << "'.\n Please either change the ESInputTag's 'module' label to be "
-              << (iDesc->label_.empty() ? iDesc->type_ : iDesc->label_) << "\n or add the EventSetup module "
-              << iTag.module() << " to the configuration.";
-        }
-      }
     }
 
     void EventSetupRecord::addTraceInfoToCmsException(cms::Exception& iException,

--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -126,8 +126,7 @@ namespace edm {
         ESProxyIndex iProxyIndex,
         bool iTransientAccessOnly,
         ComponentDescription const*& oDesc,
-        std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory,
-        EventSetupImpl const* iEventSetupImpl) const {
+        std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
       DataKey const* dataKey = nullptr;
 
       if (iProxyIndex.value() == std::numeric_limits<int>::max()) {
@@ -182,7 +181,7 @@ namespace edm {
       ComponentDescription const* desc = nullptr;
       std::shared_ptr<ESHandleExceptionFactory> whyFailedFactory;
 
-      impl_->getImplementation(pValue, proxyIndex, false, desc, whyFailedFactory, eventSetupImpl_);
+      impl_->getImplementation(pValue, proxyIndex, false, desc, whyFailedFactory);
 
       if UNLIKELY (not value.m_data) {
         std::rethrow_exception(whyFailedFactory->make());

--- a/RecoLuminosity/LumiProducer/interface/LumiCorrectionParam.h
+++ b/RecoLuminosity/LumiProducer/interface/LumiCorrectionParam.h
@@ -1,6 +1,7 @@
 #ifndef RecoLuminosity_LumiProducer_LumiCorrectionParam_h
 #define RecoLuminosity_LumiProducer_LumiCorrectionParam_h
 #include <iosfwd>
+#include <map>
 #include <string>
 #include "RecoLuminosity/LumiProducer/interface/LumiCorrectionParamRcd.h"
 #include "FWCore/Framework/interface/data_default_record_trait.h"


### PR DESCRIPTION
#### PR description:

Delete unused code related to EventSetup

This is mostly motivated by the recently completed
migration to use get functions based on consumes.
Mostly this is older code left over that supported
deprecated get methods. We missed this code when
those get methods were removed.

Note the ES module labels are now validated in another
way, so the deleted validate functions are no longer used.

Also deleted an unused function argument. Also reviewed
header includes in the files that were modified and there
was a side effect that we uncovered a missing include in
a file in RecoLuminosity.

#### PR validation:

This is mostly deletions. There is no new functionality.
This relies on existing unit tests. The fact that there are
no compilation failures verifies this is unused code.
