### PR TITLE
Disentangle `TrackerTrackHitFilter` from phase-0 Strip conditions and activate common alignment track refitter sequence for phase-2

### DIFF
--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -30,10 +30,7 @@ _isMC = True
 _allFromGT = True
 _applyBows = True
 _applyExtraConditions = True
-if(options.isPhase2):
-     _theRefitter = RefitType.STANDARD # FIXME: once the sequence is cleared out    
-else: 
-     _theRefitter = RefitType.COMMON  
+_theRefitter = RefitType.COMMON # RefitType.STANDARD (other option not involving filtering)
 _theTrackCollection = 'generalTracks' # FIXME: 'ALCARECOTkAlMinBias' once a sample is available
 
 ###################################################################

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -59,7 +59,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
     threshold = cms.untracked.string("INFO"),
     default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
     FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
-                                   reportEvery = cms.untracked.int32(1000)
+                                   reportEvery = cms.untracked.int32(1)
                                    ),                                                      
     PrimaryVertexValidation = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
     SplitVertexResolution   = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
@@ -295,7 +295,10 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
                                       TkClusParameters = switchClusterizerParameters(isDA)
                                       )
 
-process.TrackerTrackHitFilter.isPhase2 = cms.untracked.bool(True)
+####################################################################
+# Needed to avoid dependency from Phase-0 strip conditions
+####################################################################
+#process.TrackerTrackHitFilter.isPhase2 = cms.bool(True)
 
 ####################################################################
 # Path

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -12,7 +12,7 @@ isMC = True
 allFromGT = True
 applyBows = True
 applyExtraConditions = True
-theRefitter = RefitType.STANDARD
+theRefitter = RefitType.COMMON
 _theTrackCollection = "generalTracks" #"ALCARECOTkAlMinBias" unfortunately not yet
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
@@ -193,7 +193,7 @@ if(theRefitter == RefitType.COMMON):
      # Load and Configure Common Track Selection and refitting sequence
      ####################################################################
      import Alignment.CommonAlignment.tools.trackselectionRefitting as trackselRefit
-     process.seqTrackselRefit = trackselRefit.getSequence(process, 'ALCARECOTkAlMinBias',
+     process.seqTrackselRefit = trackselRefit.getSequence(process, _theTrackCollection ,
                                                           isPVValidation=True, 
                                                           TTRHBuilder='WithAngleAndTemplate',
                                                           usePixelQualityFlag=True,
@@ -295,6 +295,8 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
                                       TkClusParameters = switchClusterizerParameters(isDA)
                                       )
 
+process.TrackerTrackHitFilter.isPhase2 = cms.untracked.bool(True)
+
 ####################################################################
 # Path
 ####################################################################
@@ -348,10 +350,10 @@ process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
                                                  runControl = cms.untracked.bool(True),
                                                  runControlNumber = cms.untracked.vuint32(int(runboundary))
                                                  )
+#process.Tracer = cms.Service("Tracer")
 
 process.p2 = cms.Path(process.HLTFilter                               +
                       process.seqTrackselRefit                        +
                       process.offlinePrimaryVerticesFromRefittedTrks  +
                       process.PrimaryVertexResolution                 +
-                      process.myanalysis
-                      )
+                      process.myanalysis)

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -5,6 +5,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
@@ -84,6 +86,8 @@ namespace reco {
                                  const Trajectory *itt,
                                  std::vector<TrackingRecHit *> &hits);
       void produceFromTrack(const edm::EventSetup &iSetup, const Track *itt, std::vector<TrackingRecHit *> &hits);
+
+      static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
     private:
       class Rule {
@@ -300,7 +304,7 @@ namespace reco {
           stripFrontInvalidHits_(iConfig.getParameter<bool>("stripFrontInvalidHits")),
           stripBackInvalidHits_(iConfig.getParameter<bool>("stripBackInvalidHits")),
           stripAllInvalidHits_(iConfig.getParameter<bool>("stripAllInvalidHits")),
-          isPhase2_(iConfig.getUntrackedParameter<bool>("isPhase2", false)),
+          isPhase2_(iConfig.getParameter<bool>("isPhase2")),
           rejectBadStoNHits_(iConfig.getParameter<bool>("rejectBadStoNHits")),
           CMNSubtractionMode_(iConfig.getParameter<std::string>("CMNSubtractionMode")),
           detsToIgnore_(iConfig.getParameter<std::vector<uint32_t> >("detsToIgnore")),
@@ -988,6 +992,39 @@ namespace reco {
 
     int TrackerTrackHitFilter::sideFromId(const DetId &id, const TrackerTopology *tTopo) const {
       return tTopo->side(id);
+    }
+
+    // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+    void TrackerTrackHitFilter::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.setComment("");
+      desc.add<edm::InputTag>("src", edm::InputTag("generalTracks"));
+      desc.add<uint32_t>("minimumHits", 3)->setComment("number of hits for refit");
+      desc.add<bool>("replaceWithInactiveHits", false)
+          ->setComment(
+              " instead of removing hits replace them with inactive hits, so you still consider the multiple "
+              "scattering");
+      desc.add<bool>("stripFrontInvalidHits", false)
+          ->setComment("strip invalid & inactive hits from any end of the track");
+      desc.add<bool>("stripBackInvalidHits", false)
+          ->setComment("strip invalid & inactive hits from any end of the track");
+      desc.add<bool>("stripAllInvalidHits", false)->setComment("dangerous to turn on, you might forget about MS");
+      desc.add<bool>("isPhase2", false);
+      desc.add<bool>("rejectBadStoNHits", false);
+      desc.add<std::string>("CMNSubtractionMode", std::string("Median"))->setComment("TT6");
+      desc.add<std::vector<uint32_t> >("detsToIgnore", {});
+      desc.add<bool>("useTrajectories", false);
+      desc.add<bool>("rejectLowAngleHits", false);
+      desc.add<double>("TrackAngleCut", 0.25)->setComment("rad");
+      desc.add<bool>("usePixelQualityFlag", false);
+      desc.add<double>("PxlTemplateProbXYCut", 0.000125);
+      desc.add<double>("PxlTemplateProbXYChargeCut", -99.);
+      desc.add<std::vector<int32_t> >("PxlTemplateqBinCut", {0, 3});
+      desc.add<double>("PxlCorrClusterChargeCut", -999.0);
+      desc.add<bool>("tagOverlaps", false);
+      desc.add<std::vector<std::string> >("commands", {})->setComment("layers to remove");
+      desc.add<std::vector<std::string> >("StoNcommands", {})->setComment("S/N cut per layer");
+      descriptions.addWithDefaultLabel(desc);
     }
 
   }  // namespace modules

--- a/RecoTracker/FinalTrackSelectors/python/TrackerTrackHitFilter_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/TrackerTrackHitFilter_cff.py
@@ -1,43 +1,46 @@
 import FWCore.ParameterSet.Config as cms
 
-TrackerTrackHitFilter = cms.EDProducer("TrackerTrackHitFilter",
-                              src = cms.InputTag("generalTracks"),
-                              minimumHits =cms.uint32(3), ##min number of hits for refit
-                              ## # layers to remove
-                              commands = cms.vstring(
-                                         "drop PXB",  "drop PXE"   ### same works for TIB, TID, TOB, TEC,
-                                        #"drop TIB 3",  ## you can also drop specific layers/wheel/disks
-                                        #"keep PXB 3",  ## you can also 'keep' some layer after
-                                                        ##having dropped the whole structure
-                               ),
-                              
-                              ###list of individual detids to turn off, in addition to the structures above
-                              detsToIgnore = cms.vuint32( ),
-                              
-                              ### what to do with invalid hits
-                              replaceWithInactiveHits =cms.bool(False), ## instead of removing hits replace
-                                                                        ## them with inactive hits, so you still
-                                                                        ## consider the multiple scattering
-                              stripFrontInvalidHits   =cms.bool(False),   ## strip invalid & inactive hits from
-                              stripBackInvalidHits    =cms.bool(False),   ## any end of the track
-                              
-                              stripAllInvalidHits = cms.bool(False), ##not sure if it's better 'true' or 'false'
-                                                                     ## might be dangerous to turn on
-                                                                     ## as you will forget about MS
+from RecoTracker.FinalTrackSelectors.trackerTrackHitFilter_cfi import trackerTrackHitFilter as _trackerTrackHitFilter
+TrackerTrackHitFilter = _trackerTrackHitFilter.clone(
+    src = "generalTracks",
+    minimumHits = 3, ##min number of hits for refit
+    ## # layers to remove
+    commands = ["drop PXB",  "drop PXE"],   ### same works for TIB, TID, TOB, TEC,
+                                            # "drop TIB 3",  ## you can also drop specific layers/wheel/disks
+                                            # "keep PXB 3",  ## you can also 'keep' some layer after
+                                            # having dropped the whole structure
 
-                              ### hit quality cuts
-                              rejectBadStoNHits = cms.bool(False),
-                              CMNSubtractionMode = cms.string("Median"), ## "TT6"
-                              StoNcommands = cms.vstring(
-                                                         "TIB 1.0 ", "TOB 1.0 999.0"
-                                                        ),
-                              useTrajectories=cms.bool(False),
-                              rejectLowAngleHits=cms.bool(False),
-                              TrackAngleCut=cms.double(0.25),       ## in radians
-                              tagOverlaps=cms.bool(False),
-                              usePixelQualityFlag=cms.bool(False),
-                              PxlTemplateProbXYCut=cms.double(0.000125), #recommended by experts
-                              PxlTemplateProbXYChargeCut=cms.double(-99.), #recommended by experts
-                              PxlTemplateqBinCut =cms.vint32(0, 3),       #recommended by experts
-                              PxlCorrClusterChargeCut = cms.double(-999.0)   
-                             )####end of module 
+    ###list of individual detids to turn off, in addition to the structures above
+    detsToIgnore = [],
+
+    ### what to do with invalid hits
+    replaceWithInactiveHits = False, ## instead of removing hits replace
+                                     ## them with inactive hits, so you still
+                                     ## consider the multiple scattering
+
+    stripFrontInvalidHits = False,   ## strip invalid & inactive hits from
+    stripBackInvalidHits = False,    ## any end of the track
+
+    stripAllInvalidHits = False, ## not sure if it's better 'true' or 'false'
+                                 ## might be dangerous to turn on
+                                 ## as you will forget about MS
+
+    ### hit quality cuts
+    isPhase2 = False,
+    rejectBadStoNHits = False,
+    CMNSubtractionMode = "Median", ## "TT6"
+    StoNcommands = ["TIB 1.0 ", "TOB 1.0 999.0"],
+    useTrajectories = False,
+    rejectLowAngleHits = False,
+    TrackAngleCut = 0.25,       ## in radians
+    tagOverlaps= False,
+    usePixelQualityFlag = False,
+    PxlTemplateProbXYCut = 0.000125,   # recommended by experts
+    PxlTemplateProbXYChargeCut = -99., # recommended by experts
+    PxlTemplateqBinCut = [0, 3],       # recommended by experts
+    PxlCorrClusterChargeCut = -999.0
+) #### end of module
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(TrackerTrackHitFilter,
+                        isPhase2 = True)


### PR DESCRIPTION
#### PR description:

The [common alignment track selection and refitting sequence](https://github.com/cms-sw/cmssw/blob/master/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py) currently cannot run in Phase-2 setups because of missing Phase-0 SiStrip conditions. The module `TrackerTrackHitFilter` indeed requires at construction time the following conditions:

```
----- Begin Fatal Exception 21-Feb-2023 12:46:22 CET-----------------------
An exception of category 'NoRecord' occurred while
   [0] Processing  Event run: 1 lumi: 67 event: 6602 stream: 0
   [1] Running path 'p2'
   [2] Prefetching for module TrackerTrackHitFilter/'TrackerTrackHitFilter'
   [3] Prefetching for EventSetup module SiStripQualityESProducer/'siStripQualityESProducer'
   [4] Calling method for EventSetup module SiStripConnectivity/'sistripconn'
   [5] While getting dependent Record from Record SiStripDetCablingRcd
Exception Message:
No "SiStripFedCablingRcd" record found in the EventSetup.

 Please add an ESSource or ESProducer that delivers such a record.
----- End Fatal Exception -------------------------------------------------
```
As it seems that adding Phase-0 SiStrip conditions (either in GT or by dedicated `ESSource`) would be a wrong design choice, the goal of this PR is allow `TrackerTrackHitFilter` to run without Phase-0 SiStrip conditions, by means of adding a new parameter `isPhase2` that governs if the `SiStripClusterInfo` object used in `TrackerTrackHitFilter` should be constructed or not with an `esConsumes` call.  ~~Please notice that I am not really happy about addition an additional  ad-hoc constructor to `SiStripClusterInfo` just for this purpose, that would anyway lead to runtime failure, if its method are then subsequently called. This PR is RFC for that reason.~~ 
This is achieved by using `std::optional` to declare the `SiStripClusterInfo` data member and construct it only if the workflow is not meant for Phase-2.

#### PR validation:

Run the dedicated test: `cmsRun $CMSSW_BASE/src/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py `

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it would probably make sense to backport down to 12.5.x to be used in the phase-2 alignment studies happening in that cycle (see [PdmV JIRA ticket](https://its.cern.ch/jira/browse/PDMVMCPROD-70?focusedCommentId=4748857&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4748857))
