### PR TITLE
[13_0_X] Fix RPC and GEM TP unpacking in EMTF unpacker

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -278,10 +278,10 @@ namespace l1t {
           //                               << ", roll " << Hit_.Roll() << ", pad " << Hit_.Pad() << std::endl;
 
           (res->at(iOut)).push_GEM(GEM_);
-          if (!exact_duplicate)
+          if (!exact_duplicate and Hit_.Valid())
             res_hit->push_back(Hit_);
 
-          if (!exact_duplicate)
+          if (!exact_duplicate and Hit_.Valid())
             res_GEM->insertDigi(Hit_.GEM_DetId(), Hit_.CreateGEMPadDigiCluster());
 
           // Finished with unpacking one GEM Data Record

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -275,9 +275,9 @@ namespace l1t {
                                         << ", phi " << Hit_.Phi_fp() / 4 << std::endl;
 
           (res->at(iOut)).push_RPC(RPC_);
-          if (!exact_duplicate)
+          if (!exact_duplicate and Hit_.Valid())
             res_hit->push_back(Hit_);
-          if (!exact_duplicate)
+          if (!exact_duplicate and Hit_.Valid())
             res_CPPF->push_back(Hit_.CreateCPPFDigi());
         }
 


### PR DESCRIPTION
#### PR description:

This is a backport of https://github.com/cms-sw/cmssw/pull/40797

As reported by RPC experts, EMTF unpacker is currently producing invalid RPC and GEM hits. This is a result of https://github.com/cms-sw/cmssw/pull/39388 where EMTF switched to packing 2 RPC/GEM TPs per dataword. I forgot to add a valid flag which wasn't needed before. However, in the current scenario if there is only one RPC/GEM TP in the dataword, the second TP is filled with garbage and results in invalid TPs in DQM plots.

These invalid TPs are later dropped by the EMTF emulator, so the only affected part is DQM plots. This PR adds the valid flag check to these unpackers. It is expected to see DQM mismatches in 2022 data after this PR.  

#### PR validation:

Validated by running on 2022 data to verify that the invalid TPs are now gone from DQM plots after the changes. Since the TPs should always be valid anyway, there is no other expected impact.

Before:
![frame_Before](https://user-images.githubusercontent.com/53942290/220354493-b2eb310a-85df-4861-8f3f-de27a28dc415.png)


After:
![frame](https://user-images.githubusercontent.com/53942290/220354501-d2a8cd22-7433-4fb2-bfcb-7873f6194ca7.png)



<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/40797

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
