### PR TITLE
Phase2-gex154A Fix the issue of 2026D94 which can now work in the dd4hep version

### DIFF
--- a/Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py
+++ b/Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from Geometry.HGCalCommonData.hgcalEEParametersInitialize_cfi import *
+from Geometry.HGCalCommonData.hgcalEEParametersInitialization_cfi import *
 
 hfnoseParametersInitialize = hgcalEEParametersInitialize.clone(
     name  = "HGCalHFNoseSensitive",
@@ -9,10 +9,4 @@ hfnoseParametersInitialize = hgcalEEParametersInitialize.clone(
     nameC = "HFNoseCell",
     nameT = "HFNose",
     nameX = "HGCalHFNoseSensitive"
-)
-
-from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-
-dd4hep.toModify(hfnoseParametersInitialize,
-                fromDD4hep = True
 )

--- a/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
+++ b/Geometry/HGCalCommonData/plugins/HGCalNumberingInitialization.cc
@@ -55,7 +55,9 @@ HGCalNumberingInitialization::~HGCalNumberingInitialization() {}
 
 // ------------ method called to produce the data  ------------
 HGCalNumberingInitialization::ReturnType HGCalNumberingInitialization::produce(const IdealGeometryRecord& iRecord) {
+#ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "in HGCalNumberingInitialization::produce for " << name_;
+#endif
   const auto& pHGpar = iRecord.get(hgParToken_);
   return std::make_unique<HGCalDDDConstants>(&pHGpar, name_);
 }


### PR DESCRIPTION
#### PR description:

Fix the issue of 2026D94 which can now work in the dd4hep version. In the earlier version, any cmdim job with this scenario and dd4hep used to crash in the very first event with 
in HGCalNumberingInitialization::produce for HGCalHEScintillatorSensitive
----- Begin Fatal Exception 20-Feb-2023 11:02:17 CET-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing global begin Run run: 1
   [1] Prefetching for module OscarMTProducer/'g4SimHits'
   [2] Prefetching for EventSetup module HGCalNumberingInitialization/'hgcalEENu
mberingInitialize'
   [3] Calling method for EventSetup module HGCalParametersESModule/'hgcalEEParametersInitialize'
Exception Message:
No data of type "DDCompactView" with label "" in record "IdealGeometryRecord"

Now this step goes through successfully 

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It is a bug fix and need to be back ported to 13_0_X