### PR TITLE
Phase2-gex154B Fix the issue of 2026D91 which can now work in the dd4hep version

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D91_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D91_cff.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D91.xml")
 
-from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D91_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D91_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D91XML_cfi import *
-from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -264,7 +264,7 @@ trackerDict = {
             'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         ],
         "sim" : [
-            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
             'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [

--- a/Configuration/StandardSequences/python/GeometryConf.py
+++ b/Configuration/StandardSequences/python/GeometryConf.py
@@ -53,6 +53,7 @@ GeometryConf={
     'Extended2026D88' : 'Extended2026D88,Extended2026D88Reco',
     'DD4hepExtended2026D88' : 'DD4hepExtended2026D88,DD4hepExtended2026D88Reco',
     'Extended2026D91' : 'Extended2026D91,Extended2026D91Reco',
+    'DD4hepExtended2026D91' : 'DD4hepExtended2026D91,DD4hepExtended2026D91Reco',
     'Extended2026D92' : 'Extended2026D92,Extended2026D92Reco',
     'DD4hepExtended2026D92' : 'DD4hepExtended2026D92,DD4hepExtended2026D92Reco',
     'Extended2026D93' : 'Extended2026D93,Extended2026D93Reco',

--- a/Geometry/HcalCommonData/python/GeometryExtended2016Reco_cff.py
+++ b/Geometry/HcalCommonData/python/GeometryExtended2016Reco_cff.py
@@ -17,7 +17,6 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
-from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon


### PR DESCRIPTION
#### PR description:

Fix the issue of 2026D91 which can now work in the dd4hep version. In the earlier version, any cmdim job with this scenario and dd4hep used to crash in the very first event with
----- Begin Fatal Exception 21-Feb-2023 12:20:44 CET-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Processing global begin Run run: 1
   [1] Prefetching for module OscarMTProducer/'g4SimHits'
   [2] Calling method for EventSetup module TrackerGeometricDetESModule/'trackerNumberingGeometry'
Exception Message:
No data of type "DDCompactView" with label "" in record "IdealGeometryRecord"

Now the dd4hep job with that scenario runs normally

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Need to be back ported to 13_0_X