### PR TITLE
Initialize error and message variables in cudaCheck_()

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -42,8 +42,8 @@ namespace cms {
       if (LIKELY(result == CUDA_SUCCESS))
         return true;
 
-      const char* error;
-      const char* message;
+      const char* error = nullptr;
+      const char* message = nullptr;
       cuGetErrorName(result, &error);
       cuGetErrorString(result, &message);
       abortOnCudaError(file, line, cmd, error, message, description);


### PR DESCRIPTION
#### PR description:

Seems that on LTO build on ARM without a GPU the CUDA driver API calls `cuGetErrorName()` and `cuGetErrorString()` do not initialize the argument pointers. This PR initializes the pointers to `nullptr`.

Resolves https://github.com/cms-sw/cmssw/issues/40834

#### PR validation:

The unit test succeeds on ARM in the LTO build.