### PR TITLE
[13_0_X] Fix uGT shower unpacking

### DIFF
--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -13,7 +13,7 @@ gtStage2Raw = cms.EDProducer(
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
     EtSumInputTag  = cms.InputTag("simCaloStage2Digis"),
     FedId = cms.int32(1404),
-    FWId = cms.uint32(0x1130),  # FW w/ displaced muon info.
+    FWId = cms.uint32(0x113b),  # FW w/ displaced muon info and hadronic showers.
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -32,4 +32,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x10f01)) # FW w/ displaced muon info and hadronic showers.
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x113b)) # FW w/ displaced muon info and hadronic showers.

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -14,11 +14,11 @@ namespace l1t {
                          uint32_t raw_data_00_31,
                          uint32_t raw_data_32_63,
                          int fed,
-                         unsigned int fw,
+                         int fw,
                          int muInBx);
-    static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, unsigned int fw, int muInBx);
-    static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, unsigned int fw);
-    static bool showerFired(uint32_t shower_word, int fedId, unsigned int fwId);
+    static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, int fw, int muInBx);
+    static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int fw);
+    static bool showerFired(uint32_t shower_word, int fedId, int fwId);
     static void generatePackedMuonDataWords(const Muon& mu,
                                             uint32_t& raw_data_spare,
                                             uint32_t& raw_data_00_31,
@@ -28,7 +28,7 @@ namespace l1t {
                                             int muInBx);
     static void generate64bitDataWord(
         const Muon& mu, uint32_t& raw_data_spare, uint64_t& dataword, int fedId, int fwId, int muInBx);
-    static std::array<uint32_t, 4> getPackedShowerDataWords(const MuonShower& shower, int fedId, unsigned int fwId);
+    static std::array<uint32_t, 4> getPackedShowerDataWords(const MuonShower& shower, int fedId, int fwId);
     static int calcHwEta(const uint32_t& raw, unsigned absEtaShift, unsigned etaSignShift);
 
     static constexpr unsigned ptMask_ = 0x1FF;
@@ -59,6 +59,16 @@ namespace l1t {
     static constexpr unsigned etaMu1SignShift_ = 21;  // For Run-3
     static constexpr unsigned absEtaMu2Shift_ = 22;   // For Run-3
     static constexpr unsigned etaMu2SignShift_ = 30;  // For Run-3
+    static constexpr int kUgmtFedId = 1402;
+    static constexpr int kUgtFedId = 1404;
+    static constexpr int kUgmtFwVersionUntil2016 = 0x4010000;
+    static constexpr int kUgtFwVersionUntil2016 = 0x10A6;
+    static constexpr int kUgmtFwVersionUntil2017 = 0x6000000;
+    static constexpr int kUgtFwVersionUntil2017 = 0x1120;
+    static constexpr int kUgmtFwVersionRun3Start = 0x6000001;
+    static constexpr int kUgtFwVersionUntilRun3Start = 0x1130;
+    static constexpr int kUgmtFwVersionFirstWithShowers = 0x7000000;
+    static constexpr int kUgtFwVersionFirstWithShowers = 0x113B;
 
   private:
     static void fillMuonStableQuantities(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -264,7 +264,7 @@ void l1t::MuonRawDigiTranslator::generate64bitDataWord(
 }
 
 bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, unsigned int fwId) {
-  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x113b)) {
     return ((shower_word >> showerShift_) & 1) == 1;
   }
   return false;


### PR DESCRIPTION
#### PR description:

Fixed the uGT shower (un)packing logic.

Also use named constants for the uG(M)T firmware versions and FED IDs used by the (un)packers.

Backport of #40822 and #40841 for 13_0_X, required so shower (un)packing works as expected.

attn: @elfontan and @eyigitba