### PR TITLE
Update debug printouts for MTD in several packages, fix simulation LogDebug

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/BTLUncalibRecHitAlgo.cc
@@ -1,6 +1,7 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "RecoLocalFastTime/FTLCommonAlgos/interface/MTDUncalibratedRecHitAlgoBase.h"
 #include "RecoLocalFastTime/FTLClusterizer/interface/BTLRecHitsErrorEstimatorIM.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CommonTools/Utils/interface/FormulaEvaluator.h"
 
@@ -58,6 +59,9 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
 
   double nHits = 0.;
 
+  LogDebug("BTLUncalibRecHit") << "Original input time t1,t2 " << float(sampleRight.toa()) * toaLSBToNS_ << ", "
+                               << float(sampleLeft.toa()) * toaLSBToNS_ << std::endl;
+
   if (sampleRight.data() > 0) {
     amplitude.first = float(sampleRight.data()) * adcLSB_;
     time.first = float(sampleRight.toa()) * toaLSBToNS_;
@@ -90,14 +94,17 @@ FTLUncalibratedRecHit BTLUncalibRecHitAlgo::makeRecHit(const BTLDataFrame& dataF
 
   // Calculate the position
   // Distance from center of bar to hit
+
   float position = 0.5f * (c_LYSO_ * (time.second - time.first));
   float positionError = BTLRecHitsErrorEstimatorIM::positionError();
 
+  LogDebug("BTLUncalibRecHit") << "DetId: " << dataFrame.id().rawId() << " x position = " << position << " +/- "
+                               << positionError;
   LogDebug("BTLUncalibRecHit") << "ADC+: set the charge to: (" << amplitude.first << ", " << amplitude.second << ")  ("
-                               << sampleRight.data() << ", " << sampleLeft.data() << "  " << adcLSB_ << ' '
+                               << sampleRight.data() << ", " << sampleLeft.data() << ") " << adcLSB_ << ' '
                                << std::endl;
   LogDebug("BTLUncalibRecHit") << "TDC+: set the time to: (" << time.first << ", " << time.second << ")  ("
-                               << sampleRight.toa() << ", " << sampleLeft.toa() << "  " << toaLSBToNS_ << ' '
+                               << sampleRight.toa() << ", " << sampleLeft.toa() << ") " << toaLSBToNS_ << ' '
                                << std::endl;
 
   return FTLUncalibratedRecHit(

--- a/RecoMTD/DetLayers/src/MTDDetTray.cc
+++ b/RecoMTD/DetLayers/src/MTDDetTray.cc
@@ -44,9 +44,11 @@ vector<GeometricSearchDet::DetWithState> MTDDetTray::compatibleDets(const Trajec
                                                                     const Propagator& prop,
                                                                     const MeasurementEstimator& est) const {
   LogTrace("MTDDetLayers") << "MTDDetTray::compatibleDets, Surface at R,phi: " << surface().position().perp() << ","
-                           << surface().position().phi() << "     DetRod pos.";
-  // FIXME	    << " TS at R,phi: " << startingState.position().perp() << ","
-  // 		    << startingState.position().phi()
+                           << surface().position().phi() << "     DetRod pos."
+                           << " TS at R,phi: " << startingState.globalPosition().perp() << ","
+                           << startingState.globalPosition().phi() << " TSOS dx/dy "
+                           << std::sqrt(startingState.localError().positionError().xx()) << " "
+                           << std::sqrt(startingState.localError().positionError().yy());
 
   vector<DetWithState> result;
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -958,6 +958,14 @@ namespace {
               if (!est.first)
                 continue;
 
+              LogTrace("TrackExtenderWithMTD")
+                  << "Spatial compatibility DetId " << detWithState.first->geographicalId().rawId() << " TSOS dx/dy "
+                  << std::fixed << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().xx())
+                  << " " << std::fixed << std::setw(14)
+                  << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy " << std::fixed
+                  << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed << std::setw(14)
+                  << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed << std::setw(14) << est.second;
+
               TrackTofPidInfo tof = computeTrackTofPidInfo(lastpmag2,
                                                            std::abs(pl.second),
                                                            trs0,

--- a/SimFastTiming/FastTimingCommon/test/MTDDigiDump.cc
+++ b/SimFastTiming/FastTimingCommon/test/MTDDigiDump.cc
@@ -55,14 +55,12 @@ void MTDDigiDump::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
   if (!h_BTL_digi->empty()) {
     std::cout << " ----------------------------------------" << std::endl;
-    std::cout << " BTL DIGI collection:" << std::endl;
+    std::cout << " BTL DIGI collection: \n" << std::endl;
 
     for (const auto& dataFrame : *h_BTL_digi) {
       // --- detector element ID:
-      std::cout << "   det ID:  det = " << dataFrame.id().det() << "  subdet = " << dataFrame.id().mtdSubDetector()
-                << "  side = " << dataFrame.id().mtdSide() << "  rod = " << dataFrame.id().mtdRR()
-                << "  mod = " << dataFrame.id().module() << "  type = " << dataFrame.id().modType()
-                << "  crystal = " << dataFrame.id().crystal() << std::endl;
+      std::cout << "\n BTL DIGI:  row = " << dataFrame.row() << " col = " << dataFrame.column()
+                << " BTLDetId = " << dataFrame.id();
 
       // --- loop over the dataFrame samples
       for (int isample = 0; isample < dataFrame.size(); ++isample) {
@@ -74,7 +72,8 @@ void MTDDigiDump::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
           continue;
         }
         std::cout << "  amplitude = " << sample.data() << "  time1 = " << sample.toa() << "  time2 = " << sample.toa2()
-                  << std::endl;
+                  << " r/c = " << (uint32_t)sample.row() << " / " << (uint32_t)sample.column()
+                  << " th = " << sample.threshold() << " mode = " << sample.mode() << std::endl;
 
       }  // isaple loop
 
@@ -85,14 +84,13 @@ void MTDDigiDump::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   // --- ETL DIGIs:
 
   if (!h_ETL_digi->empty()) {
-    std::cout << " ----------------------------------------" << std::endl;
-    std::cout << " ETL DIGI collection:" << std::endl;
+    std::cout << "\n ----------------------------------------" << std::endl;
+    std::cout << " ETL DIGI collection: \n" << std::endl;
 
     for (const auto& dataFrame : *h_ETL_digi) {
       // --- detector element ID:
-      std::cout << "   det ID:  det = " << dataFrame.id().det() << "  subdet = " << dataFrame.id().mtdSubDetector()
-                << "  side = " << dataFrame.id().mtdSide() << "  ring = " << dataFrame.id().mtdRR()
-                << "  mod = " << dataFrame.id().module() << "  type = " << dataFrame.id().modType() << std::endl;
+      std::cout << "\n ETL DIGI:  row = " << dataFrame.row() << " col = " << dataFrame.column()
+                << " ETLDetId = " << dataFrame.id();
 
       // --- loop over the dataFrame samples
       for (int isample = 0; isample < dataFrame.size(); ++isample) {
@@ -103,7 +101,9 @@ void MTDDigiDump::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
           std::cout << std::endl;
           continue;
         }
-        std::cout << "  amplitude = " << sample.data() << "  time = " << sample.toa() << std::endl;
+        std::cout << "  amplitude = " << sample.data() << "  time = " << sample.toa() << " r/c = " << sample.row()
+                  << " / " << sample.column() << " th = " << sample.threshold() << " mode = " << sample.mode()
+                  << std::endl;
 
       }  // isample loop
 

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -339,7 +339,7 @@ void SimTrackManager::cleanTracksWithHistory() {
 #ifdef DebugLog
   LogDebug("SimTrackManager") << " AFTER CLEANING, I GET " << (*m_trksForThisEvent).size()
                               << " tracks to be saved persistently";
-  for (unsigned int it < (*m_trksForThisEvent).size(); ++it) {
+  for (unsigned int it = 0; it < (*m_trksForThisEvent).size(); ++it) {
     LogDebug("SimTrackManager") << " Track in position " << it << " G4 track number "
                                 << (*m_trksForThisEvent)[it]->trackID() << " mother "
                                 << (*m_trksForThisEvent)[it]->parentID() << " Status "


### PR DESCRIPTION
#### PR description:

This PR updates a number of debug printout statements in several reconstruction and simulation packages. There updates are used in MTD-related developments.

#### PR validation:

Code compiles and runs, if activated. The update in ```SimG4Core/Notification``` is needed to get the code compiling, since the original version produces:

```
/gpfs/cms/users/cossutti/Timing/digi/CMSSW_13_0_0_pre4/src/SimG4Core/Notification/src/SimTrackManager.cc: In member function 'void SimTrackManager::cleanTracksWithHistory()':
/gpfs/cms/users/cossutti/Timing/digi/CMSSW_13_0_0_pre4/src/SimG4Core/Notification/src/SimTrackManager.cc:344:23: error: expected ';' before '<' token
  344 |   for (unsigned int it < (*m_trksForThisEvent).size(); ++it) {
      |                       ^~
      |                       ;
/gpfs/cms/users/cossutti/Timing/digi/CMSSW_13_0_0_pre4/src/SimG4Core/Notification/src/SimTrackManager.cc:344:24: error: expected primary-expression before '<' token
  344 |   for (unsigned int it < (*m_trksForThisEvent).size(); ++it) {
      |                        ^
gmake: *** [config/SCRAM/GMake/Makefile.rules:1740: tmp/el8_amd64_gcc11/src/SimG4Core/Notification/src/SimG4CoreNotification/SimTrackManager.cc.o] Error 1
gmake: *** [There are compilation/build errors. Please see the detail log above.] Error 2
``` 