### PR TITLE
Remove the CUDAService from the HLT configuration [13.0.x]

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -211,6 +211,15 @@ def customiseForOffline(process):
     return process
 
 
+# Remove the explicit CUDAService from the HLT configuration, and
+# rely on ProcessAcceleratorCUDA to load it if necessary
+def customizeHLTfor40851(process):
+    if hasattr(process, 'CUDAService'):
+        del process.CUDAService
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -218,5 +227,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customizeHLTfor40851(process)
 
     return process


### PR DESCRIPTION
#### PR description:

Remove the explicit `CUDAService` from the HLT configuration, and rely on `ProcessAcceleratorCUDA` to load it if necessary.

#### PR validation:

None.

#### Backport status

Backport of #40852 to 13.0.x for data taking.