### PR TITLE
Remove the CUDAService from the HLT configuration

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -211,6 +211,15 @@ def customiseForOffline(process):
     return process
 
 
+# Remove the explicit CUDAService from the HLT configuration, and
+# rely on ProcessAcceleratorCUDA to load it if necessary
+def customizeHLTfor40852(process):
+    if hasattr(process, 'CUDAService'):
+        del process.CUDAService
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -218,5 +227,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customizeHLTfor40852(process)
 
     return process


### PR DESCRIPTION
#### PR description:

Remove the explicit `CUDAService` from the HLT configuration, and rely on `ProcessAcceleratorCUDA` to load it if necessary.

#### PR validation:

None.

#### Backport status

To be backported to 13.0.x for data taking.