### PR TITLE
Add space for null termination in CSCChamberTimeCorrectionsValues

### DIFF
--- a/OnlineDB/CSCCondDB/interface/CSCChamberTimeCorrectionsValues.h
+++ b/OnlineDB/CSCCondDB/interface/CSCChamberTimeCorrectionsValues.h
@@ -225,7 +225,8 @@ inline CSCChamberTimeCorrections *CSCChamberTimeCorrectionsValues::prefill(bool 
   //Read in the cfeb_cable_delay values (0 or 1) and don't use a precision correction factor
   FILE *fdelay =
       fopen("/afs/cern.ch/user/d/deisher/public/TimingCorrections2009/cfeb_cable_delay_20100423_both.txt", "r");
-  char label[1024];
+  //must add space for null terminator
+  char label[1024 + 1];
   int delay;
   CSCIndexer indexer;
   while (!feof(fdelay)) {


### PR DESCRIPTION

#### PR description:

The array passed to fscanf needs space for a null termination to be added after the last character read.
This fixes a clang warning.

#### PR validation:

Building with clang no longer issues a warning.