### PR TITLE
Use frozen HLT menu `2022v15` in `13_0_X` Run-3 RelVals

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -10,7 +10,7 @@ autoHLT = {
   'relval2016' : 'Fake2',
   'relval2017' : 'Fake2',
   'relval2018' : 'Fake2',
-  'relval2022' : 'GRun',
+  'relval2022' : '2022v15',
   'relval2026' : '75e33',
   'test'       : 'GRun',
 }


### PR DESCRIPTION
#### PR description:

This PR is specific to the `13_0_X` release cycle.

It updates the alias `(HLT:)@relval2022` to use the frozen HLT menu which is currently in the `CMSSW_13_0_X` branch, i.e. `"2022v15"`.

(The `"2022v15"` frozen menu will be replaced in `13_0_X` (and `13_1_X`) in the next weeks once the first 2023 HLT menu becomes available. In the meantime, we switch to using the frozen `"2022v15"` menu, instead of the ever-changing `GRun`, for the Run-3 RelVals of `13_0_X`.)

#### PR validation:

TSG tests.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A