### PR TITLE
`SiPixelDynamicInefficiency_PayloadInspector`: add region descriptor to title of inefficiency parametrization plots 

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -741,16 +741,16 @@ namespace SiPixelPI {
     if (m_subdetid == 1) {
       switch (m_layer) {
         case 1:
-          m_isInternal > 0 ? ret = SiPixelPI::BPixL1o : ret = SiPixelPI::BPixL1i;
+          m_isInternal ? ret = SiPixelPI::BPixL1i : ret = SiPixelPI::BPixL1o;
           break;
         case 2:
-          m_isInternal > 0 ? ret = SiPixelPI::BPixL2o : ret = SiPixelPI::BPixL2i;
+          m_isInternal ? ret = SiPixelPI::BPixL2i : ret = SiPixelPI::BPixL2o;
           break;
         case 3:
-          m_isInternal > 0 ? ret = SiPixelPI::BPixL3o : ret = SiPixelPI::BPixL3i;
+          m_isInternal ? ret = SiPixelPI::BPixL3i : ret = SiPixelPI::BPixL3o;
           break;
         case 4:
-          m_isInternal > 0 ? ret = SiPixelPI::BPixL4o : ret = SiPixelPI::BPixL4i;
+          m_isInternal ? ret = SiPixelPI::BPixL4i : ret = SiPixelPI::BPixL4o;
           break;
         default:
           edm::LogWarning("LogicError") << "Unknow BPix layer: " << m_layer;


### PR DESCRIPTION
#### PR description:

This is an immediate follow-up to https://github.com/cms-sw/cmssw/pull/40856 in order to add region descriptor to title of inefficiency parametrization plots introduced there (for ease of interpreting the results).
As a consequence, I've also found out a bug in the determination of inner / outer ladders in `SiPixelPI::topolInfo` which I correct in commit 3a96205c715998435bb018f53c75faf8234b4b34.

#### PR validation:

Relies on the existing unit tests introduced at:https://github.com/cms-sw/cmssw/pull/40856 .
Also run privately the following command 
```
getPayloadData.py \
    --plugin pluginSiPixelDynamicInefficiency_PayloadInspector \
    --plot plot_SiPixelDynamicInefficiencyPUParametrization \
    --tag SiPixelDynamicInefficiency_PhaseI_v9 \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;
```
and obtained the following plot:

![image](https://user-images.githubusercontent.com/5082376/221027743-849c7366-3744-4972-8171-78c7ab9cf7c4.png)
 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A