### PR TITLE
[13_0_X] Fix `cudaMemcpyAsync` for `localCoordToHostAsync`

### DIFF
--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHitSoADevice.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHitSoADevice.h
@@ -48,8 +48,10 @@ public:
   cms::cuda::host::unique_ptr<float[]> localCoordToHostAsync(cudaStream_t stream) const {
     auto ret = cms::cuda::make_host_unique<float[]>(4 * nHits(), stream);
     size_t rowSize = sizeof(float) * nHits();
-    cudaCheck(cudaMemcpyAsync(ret.get(), view().xLocal(), rowSize * 4, cudaMemcpyDefault, stream));
-
+    
+    size_t srcPitch = ptrdiff_t(view().yLocal()) - ptrdiff_t(view().xLocal());
+    cudaCheck(cudaMemcpy2DAsync(ret.get(), rowSize, view().xLocal(), srcPitch, rowSize, 4, cudaMemcpyDeviceToHost, stream));
+  
     return ret;
   }  //move to utilities
 

--- a/CUDADataFormats/TrackingRecHit/interface/TrackingRecHitSoADevice.h
+++ b/CUDADataFormats/TrackingRecHit/interface/TrackingRecHitSoADevice.h
@@ -48,10 +48,11 @@ public:
   cms::cuda::host::unique_ptr<float[]> localCoordToHostAsync(cudaStream_t stream) const {
     auto ret = cms::cuda::make_host_unique<float[]>(4 * nHits(), stream);
     size_t rowSize = sizeof(float) * nHits();
-    
+
     size_t srcPitch = ptrdiff_t(view().yLocal()) - ptrdiff_t(view().xLocal());
-    cudaCheck(cudaMemcpy2DAsync(ret.get(), rowSize, view().xLocal(), srcPitch, rowSize, 4, cudaMemcpyDeviceToHost, stream));
-  
+    cudaCheck(
+        cudaMemcpy2DAsync(ret.get(), rowSize, view().xLocal(), srcPitch, rowSize, 4, cudaMemcpyDeviceToHost, stream));
+
     return ret;
   }  //move to utilities
 


### PR DESCRIPTION
#### PR description:

In `TrackingRecHitSoADevice::localCoordToHostAsync` used in `SiPixelRecHitFromCUDA` to fill the legacy hits,`cudaMemcpyAsync` is not taking into account the SoA layout buffer padding. So it's copying some wrong portions of memory. This was noted in https://github.com/cms-sw/cmssw/issues/40604 and this solves it.

This fix is quick and dirty, given also this CUDA to legacy copy will be dropped soon.

This is a back-port to `13_0_X` of #40869. 

#### PR validation:

Run 11634.59x.


