### PR TITLE
improve `HLTMuonValidator` and `HLTMuonPlotter` (no UB, consider only `HLTFilter` modules) [`13_0_X`]

### DIFF
--- a/HLTriggerOffline/Muon/BuildFile.xml
+++ b/HLTriggerOffline/Muon/BuildFile.xml
@@ -14,6 +14,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="MuonAnalysis/MuonAssociators"/>
 <flags EDM_PLUGIN="1"/>

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -6,10 +6,10 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
 
     hltProcessName = cms.string("HLT"),
     hltPathsToCheck = cms.vstring(
-        "HLT_(L[12])?(Iso)?(Tk)?Mu[0-9]*(Open)?(_NoVertex)?(_eta2p1)?(_v[0-9]*)?$",
+        "HLT_(HighPt)?(L[12])?(Iso)?(Tk)?Mu[0-9]*(Open)?(_NoVertex)?(_eta2p1)?(_v[0-9]*)?$",
         "HLT_Mu17_NoFilters?(_v[0-9]*)?$",
-        "HLT_Dimuon0_Jpsi_v10",
-        "HLT_Dimuon13_Jpsi_Barrel_v5",
+        "HLT_Dimuon0_Jpsi(_v[0-9]*)?$",
+        "HLT_Dimuon13_Jpsi_Barrel(_v[0-9]*)?$",
         ),
 
     genParticleLabel = cms.string("genParticles"       ),

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -1,71 +1,79 @@
-
-/** \file HLTMuonPlotter.cc
- */
-
 #include "DataFormats/Candidate/interface/CandMatchMap.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "HLTriggerOffline/Muon/interface/HLTMuonPlotter.h"
-
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/path_configuration.h"
+#include "HLTriggerOffline/Muon/interface/HLTMuonPlotter.h"
 
-using namespace std;
-using namespace edm;
-using namespace reco;
-using namespace trigger;
+#include <algorithm>
+
+#include "TPRegexp.h"
+#include "TObjArray.h"
+#include "TObjString.h"
 
 namespace {
   const unsigned int kNull = (unsigned int)-1;
 }
 
-typedef vector<ParameterSet> Parameters;
-
-HLTMuonPlotter::HLTMuonPlotter(const ParameterSet &pset,
-                               string hltPath,
-                               const std::vector<string> &moduleLabels,
-                               const std::vector<string> &stepLabels,
-                               const edm::EDGetTokenT<trigger::TriggerEventWithRefs> &triggerEventToken,
+HLTMuonPlotter::HLTMuonPlotter(const edm::ParameterSet &pset,
+                               const std::string &hltPath,
+                               const std::vector<std::string> &moduleLabels,
+                               const std::vector<std::string> &stepLabels,
+                               const edm::EDGetTokenT<trigger::TriggerEventWithRefs> &triggerEventWithRefsToken,
                                const edm::EDGetTokenT<reco::GenParticleCollection> &genParticlesToken,
                                const edm::EDGetTokenT<reco::MuonCollection> &recoMuonsToken,
                                const L1MuonMatcherAlgoForDQM &l1Matcher)
-    : l1Matcher_(l1Matcher) {
-  hltPath_ = hltPath;
-  moduleLabels_ = moduleLabels;
-  stepLabels_ = stepLabels;
-  hltProcessName_ = pset.getParameter<string>("hltProcessName");
-
-  cutsDr_ = pset.getParameter<vector<double>>("cutsDr");
-
-  parametersEta_ = pset.getParameter<vector<double>>("parametersEta");
-  parametersPhi_ = pset.getParameter<vector<double>>("parametersPhi");
-  parametersTurnOn_ = pset.getParameter<vector<double>>("parametersTurnOn");
-
-  genMuonCut_ = pset.getParameter<string>("genMuonCut");
-  recMuonCut_ = pset.getParameter<string>("recMuonCut");
-
-  genMuonSelector_ = nullptr;
-  recMuonSelector_ = nullptr;
-
-  hltTriggerSummaryRAW_ = triggerEventToken;
-  genParticleLabel_ = genParticlesToken;
-  recMuonLabel_ = recoMuonsToken;
+    : hltPath_(hltPath),
+      hltProcessName_(pset.getParameter<std::string>("hltProcessName")),
+      moduleLabels_(moduleLabels),
+      stepLabels_(stepLabels),
+      triggerEventWithRefsToken_(triggerEventWithRefsToken),
+      genParticleToken_(genParticlesToken),
+      recMuonToken_(recoMuonsToken),
+      genMuonSelector_(pset.getParameter<std::string>("genMuonCut")),
+      recMuonSelector_(pset.getParameter<std::string>("recMuonCut")),
+      cutsDr_(pset.getParameter<std::vector<double>>("cutsDr")),
+      parametersEta_(pset.getParameter<std::vector<double>>("parametersEta")),
+      parametersPhi_(pset.getParameter<std::vector<double>>("parametersPhi")),
+      parametersTurnOn_(pset.getParameter<std::vector<double>>("parametersTurnOn")),
+      l1Matcher_(l1Matcher),
+      isInvalid_(false) {
+  if (moduleLabels_.empty()) {
+    edm::LogError("HLTMuonPlotter") << "Invalid inputs: 'moduleLabels_' is empty."
+                                    << "\nMonitorElements for HLT path '" << hltPath_ << "' will not be produced.";
+    isInvalid_ = true;
+  } else if (stepLabels_.size() != moduleLabels_.size() + 1) {
+    edm::LogError err("HLTMuonPlotter");
+    err << "Invalid inputs: 'stepLabels_.size()' must equal 'moduleLabels_.size() + 1'.";
+    err << "\nMonitorElements for HLT path '" << hltPath_ << "' will not be produced.";
+    err << "\n  stepLabels_ = (";
+    for (auto const &foo : stepLabels_)
+      err << " " << foo;
+    err << " )";
+    err << "\n  moduleLabels_ = (";
+    for (auto const &foo : moduleLabels_)
+      err << " " << foo;
+    err << " )";
+    isInvalid_ = true;
+  }
 }
 
-void HLTMuonPlotter::beginJob() {}
+void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const edm::Run &iRun, const edm::EventSetup &iSetup) {
+  if (isInvalid_)
+    return;
 
-void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const Run &iRun, const EventSetup &iSetup) {
   l1Matcher_.init(iSetup);
 
   cutMaxEta_ = 2.4;
-  if (hltPath_.find("eta2p1") != string::npos)
+  if (hltPath_.find("eta2p1") != std::string::npos)
     cutMaxEta_ = 2.1;
 
   // Choose a pT cut for gen/rec muons based on the pT cut in the hltPath_
@@ -83,10 +91,10 @@ void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const Run &iRun, const
   if (cutMinPt_ < 0.)
     cutMinPt_ = 0.;
 
-  string baseDir = "HLT/Muon/Distributions/";
+  std::string baseDir = "HLT/Muon/Distributions/";
   iBooker.setCurrentFolder(baseDir + hltPath_);
 
-  vector<string> sources(2);
+  std::vector<std::string> sources(2);
   sources[0] = "gen";
   sources[1] = "rec";
 
@@ -96,7 +104,7 @@ void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const Run &iRun, const
   elements_["CutMaxEta"]->Fill(cutMaxEta_);
 
   for (size_t i = 0; i < sources.size(); i++) {
-    string source = sources[i];
+    std::string source = sources[i];
     for (size_t j = 0; j < stepLabels_.size(); j++) {
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Eta");
       bookHist(iBooker, hltPath_, stepLabels_[j], source, "Phi");
@@ -106,171 +114,238 @@ void HLTMuonPlotter::beginRun(DQMStore::IBooker &iBooker, const Run &iRun, const
   }
 }
 
-void HLTMuonPlotter::analyze(const Event &iEvent, const EventSetup &iSetup) {
-  LogTrace("HLTMuonVal") << "In HLTMuonPlotter::analyze,  "
-                         << "Event: " << iEvent.id();
+void HLTMuonPlotter::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  if (isInvalid_)
+    return;
 
-  // cout << hltPath_ << endl;
-  // for (size_t i = 0; i < moduleLabels_.size(); i++)
-  //   cout << "    " << moduleLabels_[i] << endl;
-
-  Handle<TriggerEventWithRefs> rawTriggerEvent;
-  Handle<MuonCollection> recMuons;
-  Handle<GenParticleCollection> genParticles;
-
-  iEvent.getByToken(hltTriggerSummaryRAW_, rawTriggerEvent);
-  if (rawTriggerEvent.failedToGet()) {
-    LogError("HLTMuonVal") << "No trigger summary found";
+  auto const triggerEventWithRefsHandle = iEvent.getHandle(triggerEventWithRefsToken_);
+  if (triggerEventWithRefsHandle.failedToGet()) {
+    edm::LogError("HLTMuonPlotter") << "No trigger summary found";
     return;
   }
-  iEvent.getByToken(recMuonLabel_, recMuons);
-  iEvent.getByToken(genParticleLabel_, genParticles);
 
-  vector<string> sources;
-  if (genParticles.isValid())
+  auto const recoMuonsHandle = iEvent.getHandle(recMuonToken_);
+  auto const genParticlesHandle = iEvent.getHandle(genParticleToken_);
+
+  LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter] --------------";
+  LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter] Event: " << iEvent.id();
+
+  const int nFilters = moduleLabels_.size();
+  const int nSteps = stepLabels_.size();
+  const bool hasStepL1 = (stepLabels_.size() > 1 and stepLabels_[1] == "L1");
+  const int nStepsHlt = hasStepL1 ? nSteps - 2 : nSteps - 1;
+  const bool isDoubleMuonPath = (hltPath_.find("Double") != std::string::npos);
+  const int nObjectsToPassPath = (isDoubleMuonPath) ? 2 : 1;
+
+  LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter] HLTPath=" << hltPath_ << " nFilters=" << nFilters
+                             << " nSteps=" << nSteps << " hasStepL1=" << hasStepL1 << " nStepsHlt=" << nStepsHlt
+                             << " isDoubleMuonPath=" << isDoubleMuonPath
+                             << " nObjectsToPassPath=" << nObjectsToPassPath;
+
+  if (nFilters + 1 == nSteps) {
+    LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]   stepLabels | moduleLabels";
+    for (int istep = 0; istep < nSteps; ++istep) {
+      if (istep == 0)
+        LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]   " << stepLabels_[istep] << " | [N/A]";
+      else
+        LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]   " << stepLabels_[istep] << " | " << moduleLabels_[istep - 1];
+    }
+  }
+
+  std::vector<std::string> sources;
+  if (genParticlesHandle.isValid())
     sources.push_back("gen");
-  if (recMuons.isValid())
+  if (recoMuonsHandle.isValid())
     sources.push_back("rec");
 
   for (size_t sourceNo = 0; sourceNo < sources.size(); sourceNo++) {
-    string source = sources[sourceNo];
+    std::string const &source = sources[sourceNo];
 
-    // If this is the first event, initialize selectors
-    if (!genMuonSelector_)
-      genMuonSelector_ = new StringCutObjectSelector<reco::GenParticle>(genMuonCut_);
-    if (!recMuonSelector_)
-      recMuonSelector_ = new StringCutObjectSelector<reco::Muon>(recMuonCut_);
+    LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter] source=" << source;
 
     // Make each good gen/rec muon into the base cand for a MatchStruct
-    vector<MatchStruct> matches;
-    if (source == "gen" && genParticles.isValid())
-      for (size_t i = 0; i < genParticles->size(); i++)
-        if ((*genMuonSelector_)(genParticles->at(i)))
-          matches.push_back(MatchStruct(&genParticles->at(i)));
-    if (source == "rec" && recMuons.isValid())
-      for (size_t i = 0; i < recMuons->size(); i++)
-        if ((*recMuonSelector_)(recMuons->at(i)))
-          matches.push_back(MatchStruct(&recMuons->at(i)));
+    std::vector<MatchStruct> matches;
+
+    if (source == "gen") {
+      if (genParticlesHandle.isValid()) {
+        matches.reserve(matches.size() + genParticlesHandle->size());
+        for (auto const &genp : *genParticlesHandle)
+          if (genMuonSelector_(genp))
+            matches.emplace_back(MatchStruct(&genp));
+      }
+    } else if (source == "rec") {
+      if (recoMuonsHandle.isValid()) {
+        matches.reserve(matches.size() + recoMuonsHandle->size());
+        for (auto const &recomu : *recoMuonsHandle)
+          if (recMuonSelector_(recomu))
+            matches.emplace_back(MatchStruct(&recomu));
+      }
+    }
 
     // Sort the MatchStructs by pT for later filling of turn-on curve
-    sort(matches.begin(), matches.end(), matchesByDescendingPt());
+    std::sort(matches.begin(), matches.end(), matchesByDescendingPt());
 
-    const bool isDoubleMuonPath = (hltPath_.find("Double") != string::npos);
-    const size_t nFilters = moduleLabels_.size();
-    const size_t nSteps = stepLabels_.size();
-    const size_t nStepsHlt = nSteps - 2;
-    const int nObjectsToPassPath = (isDoubleMuonPath) ? 2 : 1;
     l1t::MuonVectorRef candsL1;
-    vector<vector<RecoChargedCandidateRef>> refsHlt(nStepsHlt);
-    vector<vector<const RecoChargedCandidate *>> candsHlt(nStepsHlt);
+    std::vector<std::vector<reco::RecoChargedCandidateRef>> refsHlt(nStepsHlt);
+    std::vector<std::vector<const reco::RecoChargedCandidate *>> candsHlt(nStepsHlt);
 
-    for (size_t i = 0; i < nFilters; i++) {
-      const int hltStep = i - 1;
-      InputTag tag = InputTag(moduleLabels_[i], "", hltProcessName_);
-      size_t iFilter = rawTriggerEvent->filterIndex(tag);
-      if (iFilter < rawTriggerEvent->size()) {
-        if (i == 0)
-          rawTriggerEvent->getObjects(iFilter, TriggerL1Mu, candsL1);
-        else
-          rawTriggerEvent->getObjects(iFilter, TriggerMuon, refsHlt[hltStep]);
-      } else
-        LogTrace("HLTMuonVal") << "No collection with label " << tag;
-    }
-    for (size_t i = 0; i < nStepsHlt; i++)
-      for (size_t j = 0; j < refsHlt[i].size(); j++)
-        if (refsHlt[i][j].isAvailable()) {
-          candsHlt[i].push_back(&*refsHlt[i][j]);
-        } else {
-          LogWarning("HLTMuonPlotter") << "Ref refsHlt[i][j]: product not available " << i << " " << j;
+    for (int idx = 0; idx < nFilters; ++idx) {
+      auto const moduleLabelStripped =
+          edm::path_configuration::removeSchedulingTokensFromModuleLabel(moduleLabels_[idx]);
+      auto const iTag = edm::InputTag(moduleLabelStripped, "", hltProcessName_);
+      auto const iFilter = triggerEventWithRefsHandle->filterIndex(iTag);
+      auto const iFilterValid = (iFilter < triggerEventWithRefsHandle->size());
+
+      LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]   InputTag[" << idx << "]: " << moduleLabels_[idx]
+                                 << "::" << hltProcessName_ << " (filterIndex = " << iFilter
+                                 << ", valid = " << iFilterValid << ")";
+
+      if (iFilterValid) {
+        if (idx == 0 and hasStepL1)
+          triggerEventWithRefsHandle->getObjects(iFilter, trigger::TriggerL1Mu, candsL1);
+        else {
+          auto const hltStep = hasStepL1 ? idx - 1 : idx;
+          triggerEventWithRefsHandle->getObjects(iFilter, trigger::TriggerMuon, refsHlt[hltStep]);
         }
+      } else
+        LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]    No collection with " << iTag;
+    }
+
+    for (int i = 0; i < nStepsHlt; i++) {
+      for (size_t j = 0; j < refsHlt[i].size(); j++) {
+        if (refsHlt[i][j].isAvailable())
+          candsHlt[i].push_back(&*refsHlt[i][j]);
+        else
+          edm::LogWarning("HLTMuonPlotter") << "Ref refsHlt[i][j]: product not available " << i << " " << j;
+      }
+    }
 
     // Add trigger objects to the MatchStructs
     findMatches(matches, candsL1, candsHlt);
 
-    vector<size_t> matchesInEtaRange;
-    vector<bool> hasMatch(matches.size(), true);
+    LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]   Number of Candidates = " << matches.size();
 
-    for (size_t step = 0; step < nSteps; step++) {
-      size_t hltStep = (step >= 2) ? step - 2 : 0;
-      if (nSteps == 6)
-        hltStep = hltStep - 1;  // case of the tracker muon (it has no L2)
+    for (auto const &match_i : matches) {
+      if (!match_i.candBase)
+        continue;
+      LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]    CandBase: pt=" << match_i.candBase->pt()
+                                 << " eta=" << match_i.candBase->eta() << " phi=" << match_i.candBase->phi();
+      if (match_i.candL1)
+        LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]      CandL1: pt=" << match_i.candL1->pt()
+                                   << " eta=" << match_i.candL1->eta() << " phi=" << match_i.candL1->phi();
+      else
+        LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]      CandL1: NULL";
+
+      int ihlt = -1;
+      for (auto const *chlt : match_i.candHlt) {
+        ++ihlt;
+        if (chlt)
+          LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]      CandHLT[" << ihlt << "]: pt=" << chlt->pt()
+                                     << " eta=" << chlt->eta() << " phi=" << chlt->phi();
+        else
+          LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]      CandHLT[" << ihlt << "]: NULL";
+      }
+    }
+
+    std::vector<size_t> matchesInEtaRange;
+    std::vector<bool> hasMatch(matches.size(), true);
+
+    for (int step = 0; step < nSteps; step++) {
+      int const hltStep = hasStepL1 ? step - 2 : step - 1;
       size_t level = 0;
-      if ((stepLabels_[step].find("L3TkIso") != string::npos) || (stepLabels_[step].find("TkTkIso") != string::npos))
+      if ((stepLabels_[step].find("L3TkIso") != std::string::npos) ||
+          (stepLabels_[step].find("TkTkIso") != std::string::npos))
         level = 6;
-      else if ((stepLabels_[step].find("L3HcalIso") != string::npos) ||
-               (stepLabels_[step].find("TkEcalIso") != string::npos))
+      else if ((stepLabels_[step].find("L3HcalIso") != std::string::npos) ||
+               (stepLabels_[step].find("TkEcalIso") != std::string::npos))
         level = 5;
-      else if ((stepLabels_[step].find("L3EcalIso") != string::npos) ||
-               (stepLabels_[step].find("TkEcalIso") != string::npos))
+      else if ((stepLabels_[step].find("L3EcalIso") != std::string::npos) ||
+               (stepLabels_[step].find("TkEcalIso") != std::string::npos))
         level = 4;
-      else if ((stepLabels_[step].find("L3") != string::npos) || (stepLabels_[step].find("Tk") != string::npos))
+      else if ((stepLabels_[step].find("L3") != std::string::npos) ||
+               (stepLabels_[step].find("Tk") != std::string::npos))
         level = 3;
-      else if (stepLabels_[step].find("L2") != string::npos)
+      else if (stepLabels_[step].find("L2") != std::string::npos)
         level = 2;
-      else if (stepLabels_[step].find("L1") != string::npos)
+      else if (stepLabels_[step].find("L1") != std::string::npos)
         level = 1;
 
       for (size_t j = 0; j < matches.size(); j++) {
         if (level == 0) {
-          if (fabs(matches[j].candBase->eta()) < cutMaxEta_)
+          if (std::abs(matches[j].candBase->eta()) < cutMaxEta_)
             matchesInEtaRange.push_back(j);
         } else if (level == 1) {
           if (matches[j].candL1 == nullptr)
             hasMatch[j] = false;
         } else if (level >= 2) {
-          if (matches[j].candHlt[hltStep] == nullptr)
+          if (matches[j].candHlt.at(hltStep) == nullptr)
             hasMatch[j] = false;
           else if (!hasMatch[j]) {
-            LogTrace("HLTMuonVal") << "Match found for HLT step " << hltStep << " of " << nStepsHlt
-                                   << " without previous match!";
+            LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]     match found for " << source << " candidate " << j
+                                       << " in HLT step " << hltStep << " of " << nStepsHlt
+                                       << " without previous match!";
             break;
           }
         }
       }
 
+      LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]    (step=" << step << ", level=" << level
+                                 << ", hltStep=" << hltStep << ") matchesInEtaRange: [ "
+                                 << this->vector_to_string(matchesInEtaRange) << " ]";
+
+      LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]    (step=" << step << ", level=" << level
+                                 << ", hltStep=" << hltStep << ") hasMatch: [ " << this->vector_to_string(hasMatch)
+                                 << " ]";
+
       if (std::count(hasMatch.begin(), hasMatch.end(), true) < nObjectsToPassPath)
         break;
 
-      string pre = source + "Pass";
-      string post = "_" + stepLabels_[step];
+      std::string const pre = source + "Pass";
+      std::string const post = "_" + stepLabels_[step];
 
       for (size_t j = 0; j < matches.size(); j++) {
-        float pt = matches[j].candBase->pt();
-        float eta = matches[j].candBase->eta();
-        float phi = matches[j].candBase->phi();
+        float const pt = matches[j].candBase->pt();
+        float const eta = matches[j].candBase->eta();
+        float const phi = matches[j].candBase->phi();
         if (hasMatch[j]) {
-          if (!matchesInEtaRange.empty() && j == matchesInEtaRange[0])
+          if (!matchesInEtaRange.empty() && j == matchesInEtaRange[0]) {
             elements_[pre + "MaxPt1" + post]->Fill(pt);
-          if (matchesInEtaRange.size() >= 2 && j == matchesInEtaRange[1])
+            LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]     FILL(" << pre + "MaxPt1" + post << ") value = " << pt;
+          }
+          if (matchesInEtaRange.size() >= 2 && j == matchesInEtaRange[1]) {
             elements_[pre + "MaxPt2" + post]->Fill(pt);
+            LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]     FILL(" << pre + "MaxPt2" + post << ") value = " << pt;
+          }
           if (pt > cutMinPt_) {
             elements_[pre + "Eta" + post]->Fill(eta);
-            if (fabs(eta) < cutMaxEta_)
+            LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]     FILL(" << pre + "Eta" + post << ") value = " << eta;
+            if (std::abs(eta) < cutMaxEta_) {
               elements_[pre + "Phi" + post]->Fill(phi);
+              LogTrace("HLTMuonPlotter") << "[HLTMuonPlotter]     FILL(" << pre + "Phi" + post << ") value = " << phi;
+            }
           }
         }
       }
     }
-
   }  // End loop over sources
 }
 
-void HLTMuonPlotter::findMatches(vector<MatchStruct> &matches,
+void HLTMuonPlotter::findMatches(std::vector<MatchStruct> &matches,
                                  const l1t::MuonVectorRef &candsL1,
-                                 const std::vector<vector<const RecoChargedCandidate *>> &candsHlt) {
-  set<size_t>::iterator it;
+                                 const std::vector<std::vector<const reco::RecoChargedCandidate *>> &candsHlt) {
+  std::set<size_t>::iterator it;
 
-  set<size_t> indicesL1;
+  std::set<size_t> indicesL1;
   for (size_t i = 0; i < candsL1.size(); i++)
     indicesL1.insert(i);
 
-  vector<set<size_t>> indicesHlt(candsHlt.size());
+  std::vector<set<size_t>> indicesHlt(candsHlt.size());
   for (size_t i = 0; i < candsHlt.size(); i++)
     for (size_t j = 0; j < candsHlt[i].size(); j++)
       indicesHlt[i].insert(j);
 
   for (size_t i = 0; i < matches.size(); i++) {
-    const Candidate *cand = matches[i].candBase;
+    const reco::Candidate *cand = matches[i].candBase;
 
     double bestDeltaR = cutsDr_[0];
     size_t bestMatch = kNull;
@@ -290,7 +365,7 @@ void HLTMuonPlotter::findMatches(vector<MatchStruct> &matches,
         //   bestDeltaR = dR;
         // }
       } else {
-        LogWarning("HLTMuonPlotter") << "Ref candsL1[*it]: product not available " << *it;
+        edm::LogWarning("HLTMuonPlotter") << "Ref candsL1[*it]: product not available " << *it;
       }
     }
 
@@ -314,37 +389,31 @@ void HLTMuonPlotter::findMatches(vector<MatchStruct> &matches,
         matches[i].candHlt[j] = candsHlt[j][bestMatch];
       indicesHlt[j].erase(bestMatch);
     }
-
-    //     cout << "    Muon: " << cand->eta() << ", ";
-    //     if (matches[i].candL1) cout << matches[i].candL1->eta() << ", ";
-    //     else cout << "none, ";
-    //     for (size_t j = 0; j < candsHlt.size(); j++)
-    //       if (matches[i].candHlt[j]) cout << matches[i].candHlt[j]->eta() <<
-    //       ", "; else cout << "none, ";
-    //     cout << endl;
   }
 }
 
-void HLTMuonPlotter::bookHist(DQMStore::IBooker &iBooker, string path, string label, string source, string type) {
-  string sourceUpper = source;
+void HLTMuonPlotter::bookHist(DQMStore::IBooker &iBooker,
+                              std::string const &path,
+                              std::string const &label,
+                              std::string const &source,
+                              std::string const &type) {
+  std::string sourceUpper = source;
   sourceUpper[0] = toupper(sourceUpper[0]);
-  string name = source + "Pass" + type + "_" + label;
+  std::string name = source + "Pass" + type + "_" + label;
   TH1F *h;
 
-  if (type.find("MaxPt") != string::npos) {
-    string desc = (type == "MaxPt1") ? "Leading" : "Next-to-Leading";
-    string title = "pT of " + desc + " " + sourceUpper + " Muon " + "matched to " + label;
+  if (type.find("MaxPt") != std::string::npos) {
+    std::string desc = (type == "MaxPt1") ? "Leading" : "Next-to-Leading";
+    std::string title = "pT of " + desc + " " + sourceUpper + " Muon " + "matched to " + label;
     const size_t nBins = parametersTurnOn_.size() - 1;
     float *edges = new float[nBins + 1];
     for (size_t i = 0; i < nBins + 1; i++)
       edges[i] = parametersTurnOn_[i];
     h = new TH1F(name.c_str(), title.c_str(), nBins, edges);
-  }
-
-  else {
-    string symbol = (type == "Eta") ? "#eta" : "#phi";
-    string title = symbol + " of " + sourceUpper + " Muons " + "matched to " + label;
-    vector<double> params = (type == "Eta") ? parametersEta_ : parametersPhi_;
+  } else {
+    std::string symbol = (type == "Eta") ? "#eta" : "#phi";
+    std::string title = symbol + " of " + sourceUpper + " Muons " + "matched to " + label;
+    std::vector<double> params = (type == "Eta") ? parametersEta_ : parametersPhi_;
     int nBins = (int)params[0];
     double min = params[1];
     double max = params[2];

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -3,35 +3,21 @@
 // Package:     HLTMuonValidator
 // Class:       HLTMuonValidator
 //
-
-//
 // Jason Slaunwhite and Jeff Klukas
 //
-//
-
-// system include files
-#include <iostream>
-#include <memory>
-#include <tuple>
-
-// user include files
-#include "HLTriggerOffline/Muon/interface/HLTMuonPlotter.h"
+#include <algorithm>
+#include <string>
+#include <vector>
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "HLTriggerOffline/Muon/interface/HLTMuonPlotter.h"
 
-#include "TDirectory.h"
-#include "TFile.h"
 #include "TPRegexp.h"
-
-//////////////////////////////////////////////////////////////////////////////
-//////// Define the interface ////////////////////////////////////////////////
 
 class HLTMuonValidator : public DQMEDAnalyzer {
 public:
@@ -44,8 +30,10 @@ private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
   // Extra Methods
-  std::vector<std::string> moduleLabels(std::string);
-  std::vector<std::string> stepLabels(const std::vector<std::string> &);
+  void fillLabels(std::string const &path,
+                  std::vector<std::string> &moduleLabels,
+                  std::vector<std::string> &stepLabels) const;
+  std::string stepLabel(std::string const &moduleLabel) const;
 
   // Input from Configuration File
   edm::ParameterSet pset_;
@@ -63,86 +51,92 @@ private:
   HLTMuonPlotter::L1MuonMatcherAlgoForDQM const l1tMuonMatcherAlgo_;
 };
 
-//////////////////////////////////////////////////////////////////////////////
-//////// Namespaces, Typedefs, and Constants /////////////////////////////////
-
-using namespace std;
-using namespace edm;
-using namespace reco;
-using namespace trigger;
-
-typedef vector<string> vstring;
-
-//////////////////////////////////////////////////////////////////////////////
-//////// Class Methods ///////////////////////////////////////////////////////
-
-HLTMuonValidator::HLTMuonValidator(const ParameterSet &pset)
+HLTMuonValidator::HLTMuonValidator(const edm::ParameterSet &pset)
     : pset_(pset),
-      hltProcessName_(pset.getParameter<string>("hltProcessName")),
-      hltPathsToCheck_(pset.getParameter<vstring>("hltPathsToCheck")),
+      hltProcessName_(pset.getParameter<std::string>("hltProcessName")),
+      hltPathsToCheck_(pset.getParameter<std::vector<std::string>>("hltPathsToCheck")),
       triggerEventToken_(consumes(edm::InputTag("hltTriggerSummaryRAW"))),
-      genParticlesToken_(consumes(pset.getParameter<string>("genParticleLabel"))),
-      recoMuonsToken_(consumes(pset.getParameter<string>("recMuonLabel"))),
+      genParticlesToken_(consumes(pset.getParameter<std::string>("genParticleLabel"))),
+      recoMuonsToken_(consumes(pset.getParameter<std::string>("recMuonLabel"))),
       l1tMuonMatcherAlgo_(pset, consumesCollector()) {}
 
-vector<string> HLTMuonValidator::moduleLabels(string path) {
-  vector<string> modules = hltConfig_.moduleLabels(path);
-  vector<string>::iterator iter = modules.begin();
+void HLTMuonValidator::fillLabels(std::string const &path,
+                                  std::vector<std::string> &moduleLabels,
+                                  std::vector<std::string> &stepLabels) const {
+  auto const &hltFilters = hltConfig_.saveTagsModules(path);
 
-  while (iter != modules.end())
-    if (iter->find("Filtered") == string::npos)
-      iter = modules.erase(iter);
-    else
-      ++iter;
+  moduleLabels.clear();
+  moduleLabels.reserve(hltFilters.size());
 
-  return modules;
-}
+  stepLabels.clear();
+  stepLabels.reserve(hltFilters.size() + 1);
 
-vector<string> HLTMuonValidator::stepLabels(const vector<string> &modules) {
-  vector<string> steps(1, "All");
-  for (size_t i = 0; i < modules.size(); i++) {
-    if ((modules[i].find("IsoFiltered") != string::npos)) {
-      if (modules[i].find("L3") != string::npos)
-        steps.push_back("L3TkIso");
-      else
-        steps.push_back("L2Iso");
-    } else if ((modules[i].find("pfecalIsoRhoFiltered") != string::npos)) {
-      if (modules[i].find("L3") != string::npos)
-        steps.push_back("L3EcalIso");
-      else if (modules[i].find("TkFiltered") != string::npos)
-        steps.push_back("TkEcalIso");
-    } else if ((modules[i].find("pfhcalIsoRhoFiltered") != string::npos)) {
-      if (modules[i].find("L3") != string::npos)
-        steps.push_back("L3HcalIso");
-      else if (modules[i].find("TkFiltered") != string::npos)
-        steps.push_back("TkHcalIso");
-    } else if (modules[i].find("TkFiltered") != string::npos) {
-      steps.push_back("Tk");
-    } else if (modules[i].find("L3") != string::npos)
-      steps.push_back("L3");
-    else if (modules[i].find("L2") != string::npos)
-      steps.push_back("L2");
-    else if (modules[i].find("L1") != string::npos)
-      steps.push_back("L1");
-    else
-      return vector<string>();
+  for (auto const &module : hltFilters) {
+    if (module.find("Filtered") == std::string::npos)
+      continue;
+
+    auto const step_label = stepLabel(module);
+    if (step_label.empty() or std::find(stepLabels.begin(), stepLabels.end(), step_label) != stepLabels.end())
+      continue;
+
+    moduleLabels.emplace_back(module);
+    stepLabels.emplace_back(step_label);
   }
 
-  if (steps.size() < 2 || ((steps[1] != "L1") && (steps[1] != "Tk")))
-    return vector<string>();
-  return steps;
+  if (stepLabels.empty()) {
+    return;
+  }
+
+  if (stepLabels[0] != "L1" and std::find(stepLabels.begin(), stepLabels.end(), "L1") != stepLabels.end()) {
+    edm::LogWarning wrn("HLTMuonValidator");
+    wrn << "Unsupported list of 'step' labels (the label 'L1' is present, but is not the first one): stepLabels=(";
+    for (auto const &foo : stepLabels)
+      wrn << " " << foo;
+    wrn << " )";
+
+    moduleLabels.clear();
+    stepLabels.clear();
+    return;
+  }
+
+  stepLabels.insert(stepLabels.begin(), "All");
+}
+
+std::string HLTMuonValidator::stepLabel(std::string const &module) const {
+  if (module.find("IsoFiltered") != std::string::npos) {
+    return (module.find("L3") != std::string::npos) ? "L3TkIso" : "L2Iso";
+  } else if (module.find("pfecalIsoRhoFiltered") != std::string::npos) {
+    if (module.find("L3") != std::string::npos)
+      return "L3EcalIso";
+    else if (module.find("TkFiltered") != std::string::npos)
+      return "TkEcalIso";
+  } else if (module.find("pfhcalIsoRhoFiltered") != std::string::npos) {
+    if (module.find("L3") != std::string::npos)
+      return "L3HcalIso";
+    else if (module.find("TkFiltered") != std::string::npos)
+      return "TkHcalIso";
+  } else if (module.find("TkFiltered") != std::string::npos)
+    return "Tk";
+  else if (module.find("L3") != std::string::npos)
+    return "L3";
+  else if (module.find("L2") != std::string::npos)
+    return "L2";
+  else if (module.find("L1") != std::string::npos)
+    return "L1";
+
+  return "";
 }
 
 void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   // Initialize hltConfig
   bool changedConfig;
   if (!hltConfig_.init(iRun, iSetup, hltProcessName_, changedConfig)) {
-    LogError("HLTMuonVal") << "Initialization of HLTConfigProvider failed!!";
+    edm::LogError("HLTMuonVal") << "Initialization of HLTConfigProvider failed!!";
     return;
   }
 
   // Get the set of trigger paths we want to make plots for
-  set<string> hltPaths;
+  std::set<std::string> hltPaths;
   for (size_t i = 0; i < hltPathsToCheck_.size(); i++) {
     TPRegexp pattern(hltPathsToCheck_[i]);
     for (size_t j = 0; j < hltConfig_.triggerNames().size(); j++)
@@ -152,15 +146,16 @@ void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &
 
   // Initialize the analyzers
   analyzers_.clear();
-  set<string>::iterator iPath;
+  std::set<std::string>::iterator iPath;
   for (iPath = hltPaths.begin(); iPath != hltPaths.end(); iPath++) {
-    const string &path = *iPath;
-    string shortpath = path;
+    const std::string &path = *iPath;
+    std::string shortpath = path;
     if (path.rfind("_v") < path.length())
       shortpath = path.substr(0, path.rfind("_v"));
 
-    vector<string> labels = moduleLabels(path);
-    vector<string> steps = stepLabels(labels);
+    std::vector<std::string> labels;
+    std::vector<std::string> steps;
+    fillLabels(path, labels, steps);
 
     if (!labels.empty() && !steps.empty()) {
       HLTMuonPlotter analyzer(
@@ -172,18 +167,17 @@ void HLTMuonValidator::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &
 
 void HLTMuonValidator::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &iRun, edm::EventSetup const &iSetup) {
   // Call the beginRun (which books all the histograms)
-  vector<HLTMuonPlotter>::iterator iter;
-  for (iter = analyzers_.begin(); iter != analyzers_.end(); ++iter) {
-    iter->beginRun(iBooker, iRun, iSetup);
+  for (auto &analyzer : analyzers_) {
+    analyzer.beginRun(iBooker, iRun, iSetup);
   }
 }
 
-void HLTMuonValidator::analyze(const Event &iEvent, const EventSetup &iSetup) {
-  vector<HLTMuonPlotter>::iterator iter;
-  for (iter = analyzers_.begin(); iter != analyzers_.end(); ++iter) {
-    iter->analyze(iEvent, iSetup);
+void HLTMuonValidator::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  for (auto &analyzer : analyzers_) {
+    analyzer.analyze(iEvent, iSetup);
   }
 }
 
 // define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(HLTMuonValidator);


### PR DESCRIPTION
backport of #40753

#### PR description:

From the description of #40753:

>This PR aims to improve the plugin `HLTMuonValidator`, and its utility `HLTMuonPlotter`.
>
>This update was triggered by https://github.com/cms-sw/cmssw/pull/40708#issuecomment-1426337736, where it was noticed that `HLTMuonPlotter` has a bug that can lead to undefined behaviour [1].
>
>Further checks showed other shortcomings of `HLTMuonValidator`/`HLTMuonPlotter` (see review comments for more details); these shortcomings can lead to the DQM outputs of `HLTMuonValidator` being filled incorrectly in the current implementation. This PR tries to fix this (on top of fixing the original UB issue).
>
>`LogTrace` calls are added to ease debugging. In addition, technical changes to modernise both classes are applied (e.g. `const` correctness).
>
>Expect changes in the DQM outputs of `HLTMuonValidator` (and nowhere else).
>
>[1]
>The value of `hltStep` becomes `(size_t) -1` when `step == 2` and `nSteps == 6`, leading to undefined behaviour in
>https://github.com/cms-sw/cmssw/blob/6f5b833d1b878aa570c87d4237e638362684a7a6/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc#L221
>This was originally reported in #12056, but apparently not fixed back then.

#### PR validation:

None beyond the checks done for #40753.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40753

Fix to HLT offline DQM in release cycle for 2023 pp data-taking.
