### PR TITLE
Fix Tracks related Pixel quantities at HLT DQM (backport)

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -46,8 +46,8 @@ process.ClusterShapeHitFilterESProducer = cms.ESProducer( "ClusterShapeHitFilter
 )
 #SiStrip Local Reco
 process.load("CalibTracker.SiStripCommon.TkDetMapESProducer_cfi")
-#SiPixelTemplate
-process.load("CalibTracker.SiPixelESProducers.SiPixelTemplateDBObjectESProducer_cfi")
+#Track refitters
+process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -46,6 +46,8 @@ process.ClusterShapeHitFilterESProducer = cms.ESProducer( "ClusterShapeHitFilter
 )
 #SiStrip Local Reco
 process.load("CalibTracker.SiStripCommon.TkDetMapESProducer_cfi")
+#SiPixelTemplate
+process.load("CalibTracker.SiPixelESProducers.SiPixelTemplateDBObjectESProducer_cfi")
 
 #---- for P5 (online) DB access
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")

--- a/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
+++ b/DQM/SiPixelPhase1Track/python/SiPixelPhase1TrackResiduals_cfi.py
@@ -134,8 +134,8 @@ SiPixelPhase1TrackResidualsConf = cms.VPSet(
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SiPixelPhase1TrackResidualsAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackResiduals',
-        trajectoryInput = cms.string("generalTracks"),
-        Tracks        = cms.InputTag("generalTracks"),
+        trajectoryInput = cms.string("refittedForPixelDQM"),
+        Tracks        = cms.InputTag("refittedForPixelDQM"),
         vertices = cms.InputTag("offlinePrimaryVertices"),
         histograms = SiPixelPhase1TrackResidualsConf,
         geometry = SiPixelPhase1Geometry,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -426,7 +426,7 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 hltSiPixelPhase1TrackClustersAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackClusters',
         VertexCut  = cms.untracked.bool(False),
         clusters   = cms.InputTag("hltSiPixelClusters"),
-        tracks     = cms.InputTag("hltMergedTracks"), #hltIter2Merged"
+        tracks     = cms.InputTag("hltrefittedForPixelDQM"), 
         clusterShapeCache = cms.InputTag("hltSiPixelClusterShapeCache"),
         vertices = cms.InputTag(""),
         histograms = hltSiPixelPhase1TrackClustersConf,

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -7,7 +7,7 @@ from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
-                                                   TTRHBuilder = cms.string('WithTrackAngle')) # no templates at HLT
+                                                   TTRHBuilder = 'WithTrackAngle') # no templates at HLT
  
 
 sipixelMonitorHLTsequence = cms.Sequence(

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -2,8 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Cluster_cff import *
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_TrackCluster_cff import *
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
+
+hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
+hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks')
 
 sipixelMonitorHLTsequence = cms.Sequence(
-    hltSiPixelPhase1ClustersAnalyzer
-    #+ hltSiPixelPhase1TrackClustersAnalyzer
+    hltSiPixelClusterShapeCache
+    + hltSiPixelPhase1ClustersAnalyzer
+    + refittedForPixelDQM
+    + hltSiPixelPhase1TrackClustersAnalyzer
 )    

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -11,6 +11,6 @@ hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks')
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer
-    + refittedForPixelDQM
+    + hltrefittedForPixelDQM
     + hltSiPixelPhase1TrackClustersAnalyzer
 )    

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -6,7 +6,9 @@ from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import 
 from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
-hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks')
+hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
+                                                   TTRHBuilder = cms.string('WithTrackAngle')) # no templates at HLT
+ 
 
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/SiPixelClusterShapeCacheProducer.cc
@@ -61,6 +61,13 @@ void SiPixelClusterShapeCacheProducer::produce(edm::StreamID, edm::Event& iEvent
   edm::Handle<InputCollection> input;
   iEvent.getByToken(token_, input);
 
+  if (!input.isValid()) {
+    edm::LogError("siPixelClusterShapeCache") << "input pixel cluster collection is not valid!";
+    auto output = std::make_unique<SiPixelClusterShapeCache>();
+    iEvent.put(std::move(output));
+    return;
+  }
+
   const auto& geom = &iSetup.getData(geomToken_);
 
   auto output = std::make_unique<SiPixelClusterShapeCache>(input);


### PR DESCRIPTION
#### PR description:

Monitor of the tracks related Pixel quantities at HLT DQM never works and it was disabled at some point, with this PR we introduce the changes needed (tracks refitting) in order to be able to monitor Pixel Tracks quantities at HLT DQM.
In this PR we also update the collection to be used by the Standard DQM Pixel Residuals Monitor in order to use the refitted tracks.

#### PR validation:

runTheMatrix.sh -l 140.063
Manually run the Online HLT client at P5 with old stored DQM stream file

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40873 
