### PR TITLE
Overlap recheck

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -23,12 +23,12 @@ SRCS := $(wildcard ${CMS_DIR}/src/*.cc) $(wildcard ${SACMS}/*.cc)
 ifdef WITH_ROOT
 SRCS += ${SACMS}/tkNtuple/WriteMemoryFile.cc
 WriteMemFileDict.cc ${WMF_DICT_PCM}: ${SACMS}/tkNtuple/DictsLinkDef.h
-	rootcling -f WriteMemFileDict.cc $<
+	rootcling -I${SRCDIR} -f WriteMemFileDict.cc $<
 	mv WriteMemFileDict_rdict.pcm ${WMF_DICT_PCM}
 
 SRCS += ShellDict.cc
 ShellDict.cc ${SHELL_DICT_PCM}: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
-	rootcling -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+	rootcling -I${SRCDIR} -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
 	mv ShellDict_rdict.pcm ${SHELL_DICT_PCM}
 endif
 SRCB := $(notdir ${SRCS})
@@ -61,7 +61,7 @@ ${LIB_CMS}: ${CMS_OBJS}
 ${MAIN}: ${LIB_CMS} mkFit.o
 	${CXX} ${CXXFLAGS} ${VEC_HOST} ${LDFLAGS} mkFit.o -o $@ ${LDFLAGS_HOST} -ltbb -L.. -lMicCore -lMicCMS -Wl,-rpath=.
 
-${WRMEMF}: WriteMemoryFile.o DictsDict.o
+${WRMEMF}: WriteMemoryFile.o WriteMemFileDict.o
 	${CXX} ${CXXFLAGS} ${LDFLAGS} $^ -o $@ ${LDFLAGS_HOST} -ltbb -L.. -lMicCore -Wl,-rpath=.
 
 ${OBJS}: %.o: %.cc %.d

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -24,11 +24,13 @@ namespace mkfit {
 
   void CandCloner::begin_eta_bin(EventOfCombCandidates *e_o_ccs,
                                  std::vector<UpdateIndices> *update_list,
+                                 std::vector<UpdateIndices> *overlap_list,
                                  std::vector<std::vector<TrackCand>> *extra_cands,
                                  int start_seed,
                                  int n_seeds) {
     mp_event_of_comb_candidates = e_o_ccs;
     mp_kalman_update_list = update_list;
+    mp_kalman_overlap_list = overlap_list;
     mp_extra_cands = extra_cands;
     m_start_seed = start_seed;
     m_n_seeds = n_seeds;
@@ -50,6 +52,7 @@ namespace mkfit {
     m_idx_max_prev = 0;
 
     mp_kalman_update_list->clear();
+    mp_kalman_overlap_list->clear();
 
 #ifdef CC_TIME_LAYER
     t_lay = dtime();
@@ -193,14 +196,13 @@ namespace mkfit {
             break;
 
           if (h2a.hitIdx >= 0) {
-            mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx));
-
-            // set the overlap if we have it and and pT > pTCutOverlap
+            // set the overlap if we have it and pT > pTCutOverlap
             HitMatch *hm;
             if (tc.pT() > mp_iteration_params->pTCutOverlap &&
                 (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
-              tc.addHitIdx(hm->m_hit_idx, m_layer, 0);
-              tc.incOverlapCount();
+              mp_kalman_overlap_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
+            } else {
+              mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, -1));
             }
           }
 

--- a/RecoTracker/MkFitCore/src/CandCloner.h
+++ b/RecoTracker/MkFitCore/src/CandCloner.h
@@ -25,6 +25,7 @@ namespace mkfit {
 
     void begin_eta_bin(EventOfCombCandidates *e_o_ccs,
                        std::vector<UpdateIndices> *update_list,
+                       std::vector<UpdateIndices> *overlap_list,
                        std::vector<std::vector<TrackCand>> *extra_cands,
                        int start_seed,
                        int n_seeds);
@@ -56,7 +57,7 @@ namespace mkfit {
 
     const IterationParams *mp_iteration_params = nullptr;
     EventOfCombCandidates *mp_event_of_comb_candidates;
-    std::vector<UpdateIndices> *mp_kalman_update_list;
+    std::vector<UpdateIndices> *mp_kalman_update_list, *mp_kalman_overlap_list;
     std::vector<std::vector<TrackCand>> *mp_extra_cands;
 
 #if defined(CC_TIME_ETA) or defined(CC_TIME_LAYER)

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -15,6 +15,10 @@ namespace mkfit {
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, MPlexQI &, \
       const int, const PropagationFlags, const bool
 
+#define COMPUTE_CHI2_AND_UPDATE_ARGS \
+  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLS &, MPlexLV &, \
+      MPlexQI &, const int, const PropagationFlags, const bool
+
   class FindingFoos {
   public:
     void (*m_compute_chi2_foo)(COMPUTE_CHI2_ARGS);

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -136,6 +136,19 @@ namespace mkfit {
     }
   }
 
+  void MkFinder::inputOverlapHits(const LayerOfHits &layer_of_hits,
+                                  const std::vector<UpdateIndices> &idxs,
+                                  int beg,
+                                  int end) {
+    // Copy overlap hit values in.
+
+    for (int i = beg, imp = 0; i < end; ++i, ++imp) {
+      const Hit &hit = layer_of_hits.refHit(idxs[i].ovlp_idx);
+      m_msErr.copyIn(imp, hit.errArray());
+      m_msPar.copyIn(imp, hit.posArray());
+    }
+  }
+
   void MkFinder::inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                                       const std::vector<std::pair<int, IdxChi2List>> &idxs,
                                       int beg,
@@ -1373,6 +1386,26 @@ namespace mkfit {
     //     m_Par[iC].copySlot(i, m_Par[iP]);
     //   }
     // }
+  }
+
+  void MkFinder::chi2OfLoadedHit(int N_proc, const FindingFoos &fnd_foos) {
+    // We expect input in iC slots from above function.
+    // See comment in MkBuilder::find_tracks_in_layer() about intra / inter flags used here
+    // for propagation to the hit.
+    clearFailFlag();
+    (*fnd_foos.m_compute_chi2_foo)(m_Err[iC],
+                                   m_Par[iC],
+                                   m_Chg,
+                                   m_msErr,
+                                   m_msPar,
+                                   m_Chi2,
+                                   m_Par[iP],
+                                   m_FailFlag,
+                                   N_proc,
+                                   m_prop_config->finding_inter_layer_pflags,
+                                   m_prop_config->finding_requires_propagation_to_hit_pos);
+
+    // PROP-FAIL-ENABLE .... removed here
   }
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -32,8 +32,9 @@ namespace mkfit {
     int seed_idx;
     int cand_idx;
     int hit_idx;
+    int ovlp_idx;
 
-    UpdateIndices(int si, int ci, int hi) : seed_idx(si), cand_idx(ci), hit_idx(hi) {}
+    UpdateIndices(int si, int ci, int hi, int oi) : seed_idx(si), cand_idx(ci), hit_idx(hi), ovlp_idx(oi) {}
   };
 
   class MkFinder : public MkBase {
@@ -81,6 +82,10 @@ namespace mkfit {
                             int beg,
                             int end,
                             bool inputProp);
+    void inputOverlapHits(const LayerOfHits &layer_of_hits,
+                          const std::vector<UpdateIndices> &idxs,
+                          int beg,
+                          int end);
 
     void inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                               const std::vector<std::pair<int, IdxChi2List>> &idxs,
@@ -137,6 +142,8 @@ namespace mkfit {
                                    const FindingFoos &fnd_foos);
 
     void updateWithLoadedHit(int N_proc, const FindingFoos &fnd_foos);
+
+    void chi2OfLoadedHit(int N_proc, const FindingFoos &fnd_foos);
 
     void copyOutParErr(std::vector<CombCandidate> &seed_cand_vec, int N_proc, bool outputProp) const;
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -240,7 +240,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                     << "   r=" << std::setprecision(9) << r[n - nmin] << " r0=" << std::setprecision(9) << r0[n - nmin]
                     << " id=" << std::setprecision(9) << id[n - nmin] << " dr=" << std::setprecision(9)
                     << r[n - nmin] - r0[n - nmin] << " cosa=" << cosa[n - nmin] << " sina=" << sina[n - nmin]
-                    << " dir_cos(rad,pT)=" << 1.0f / oodotp[n]);
+                    << " 1/dir_cos(rad,pT)=" << oodotp[n - nmin]);
     }
 
     //update derivatives on total distance


### PR DESCRIPTION
Recheck overlap hit chi2 after the update with the primary hit.

Use the new chi2 to select wich overlap hits to append to the candidate, for the moment still not either adding the overlap chi2 to the cand score nor using the overlap to update the parameters. These could both be considered in the future but would require even further tuning of the scoring function.

Post-update chi2 distribution has a horrendous tail up to 10^7.

[chi2-full.pdf](https://github.com/cms-sw/cmssw/files/10826191/chi2-full.pdf)
[chi2-10k-cum.pdf](https://github.com/cms-sw/cmssw/files/10826199/chi2-10k-cum.pdf)

MTV plots: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/overlap-recheck-1/
- chi2-60: about 35% of overlap hits are kept;
- chi2-1100: 66%;
- -chi2-10000: 90%.



