### PR TITLE
drop cms type specification in SiPixel_OfflineMonitoring_cff

### DIFF
--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -7,7 +7,7 @@ from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
-                                                   TTRHBuilder = cms.string('WithTrackAngle')) # no templates at HLT
+                                                   TTRHBuilder = 'WithTrackAngle') # no templates at HLT
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer


### PR DESCRIPTION
#### PR description:

as requested [here](https://github.com/cms-sw/cmssw/pull/40873#discussion_r1118726275).

#### PR validation:

```
runTheMatrix.py -l 140.063 -t 4 -j 8
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported in https://github.com/cms-sw/cmssw/pull/40875