### PR TITLE
Drop unused lto flags in `BigProducts/Simulation` BuildFile

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -34,8 +34,3 @@
 <use name="g4hepemstatic"/>
 <flags DROP_DEP="geant4core"/>
 <flags DROP_DEP="g4hepemcore"/>
-<ifrelease name="!_LTO_">
-  <!-- Disable LTO in BigLibs, as it seems to clash with debugging symbols with gcc 4.9.X -->
-  <flags REM_BIGOBJ_CXXFLAGS="-flto"/>
-  <flags BIGOBJ_CXXFLAGS="-fno-lto"/>
-</ifrelease>


### PR DESCRIPTION
backport of #40857

Hello,

We are enabling LTO for IBs (See https://github.com/cms-sw/cmsdist/pull/8332 and https://github.com/cms-sw/cms-bot/pull/1943) and we have realized there is this build file dropping some flags in case release name does not contain `_LTO_`. Those flags are not used anymore, so we would need to drop this condition.

Thanks,
Andrea. 

FYI, @smuzaffar