### PR TITLE
Initialise local variables to null pointers

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h
@@ -42,8 +42,8 @@ namespace cms {
       if (LIKELY(result == CUDA_SUCCESS))
         return true;
 
-      const char* error;
-      const char* message;
+      const char* error = nullptr;
+      const char* message = nullptr;
       cuGetErrorName(result, &error);
       cuGetErrorString(result, &message);
       abortOnCudaError(file, line, cmd, error, message, description);


### PR DESCRIPTION
#### PR description:

Initialise C strings to null pointers. Otherwise, when CUDA is not available, the CUDA stub library functions will not (re)set them, leaving them uninitialised.

#### PR validation:

Fixes `testCudaCheck` on ARM.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a bug fix, and should be backported to CMSSW 13.0.x.