### PR TITLE
Added DQM module for PPS dedicated random stream

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -149,6 +149,7 @@ void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
                                                     kNplaneMAX_,
                                                     0,
                                                     kNplaneMAX_);
+        h2HitsVsBXRandoms_[indexP]->getTH2F()->SetOption("colz");
 
       }  // end for(int rp=0; rp<kNRPotsMAX_;...
     }    // end of for(int stn=0; stn<

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -51,7 +51,7 @@ private:
   static constexpr int kStationIDMAX_ = 4;  // possible range of ID
   static constexpr int kRPotsIDMAX_ = 8;    // possible range of ID
 
-  const std::string folderName_ = "CTPPS/RandomPixel";
+  const std::string folderName_ = "PPSRANDOM/RandomPixel";
 
   unsigned int rpStatusWord_ = 0x8008;          // 220_fr_hr(stn2rp3)+ 210_fr_hr
   int rpStatus_[kStationIDMAX_][kRPotsIDMAX_];  // symmetric in both arms
@@ -79,7 +79,7 @@ private:
 
 CTPPSRandomDQMSource::CTPPSRandomDQMSource(const edm::ParameterSet &ps)
     : tokenDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi>>(ps.getParameter<edm::InputTag>("tagRPixDigi"))),
-      folderName_(ps.getUntrackedParameter<std::string>("folderName", "CTPPS/RandomPixel")),
+      folderName_(ps.getUntrackedParameter<std::string>("folderName", "PPSRANDOM/RandomPixel")),
       rpStatusWord_(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
   for (int stn = 0; stn < kStationIDMAX_; stn++) {
     stationStatus_[stn] = 0;
@@ -196,7 +196,7 @@ void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
 void CTPPSRandomDQMSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer"));
-  desc.addUntracked<std::string>("folderName", "CTPPS/RandomPixel");
+  desc.addUntracked<std::string>("folderName", "PPSRANDOM/RandomPixel");
   desc.addUntracked<unsigned int>("RPStatusWord", 0x8008);
   descriptions.add("ctppsRandomDQMSource", desc);
 }

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -33,128 +33,124 @@
 class CTPPSRandomDQMSource : public DQMEDAnalyzer {
 public:
   CTPPSRandomDQMSource(const edm::ParameterSet &ps);
-  ~CTPPSRandomDQMSource() override;
+  ~CTPPSRandomDQMSource() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 protected:
-  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
 
 private:
-  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelDigi>> tokenDigi;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelDigi>> const tokenDigi_;
 
-  static constexpr int NArms = 2;
-  static constexpr int NStationMAX = 3;  // in an arm
-  static constexpr int NRPotsMAX = 6;    // per station
-  static constexpr int NplaneMAX = 6;    // per RPot
-  static constexpr int RPn_first = 3, RPn_last = 4;
-  static constexpr int StationIDMAX = 4;  // possible range of ID
-  static constexpr int RPotsIDMAX = 8;    // possible range of ID
+  static constexpr int kNArms_ = 2;
+  static constexpr int kNStationMAX_ = 3;  // in an arm
+  static constexpr int kNRPotsMAX_ = 6;    // per station
+  static constexpr int kNplaneMAX_ = 6;    // per RPot
+  static constexpr int kFirstRPn_ = 3, kLastRPn_ = 4;
+  static constexpr int kStationIDMAX_ = 4;  // possible range of ID
+  static constexpr int kRPotsIDMAX_ = 8;    // possible range of ID
 
-  unsigned int rpStatusWord = 0x8008;      // 220_fr_hr(stn2rp3)+ 210_fr_hr
-  int RPstatus[StationIDMAX][RPotsIDMAX];  // symmetric in both arms
-  int StationStatus[StationIDMAX];         // symmetric in both arms
-  const int IndexNotValid = 0;
+  const std::string folderName_ = "CTPPS/RandomPixel";
 
-  MonitorElement *hBX;
+  unsigned int rpStatusWord_ = 0x8008;          // 220_fr_hr(stn2rp3)+ 210_fr_hr
+  int rpStatus_[kStationIDMAX_][kRPotsIDMAX_];  // symmetric in both arms
+  int stationStatus_[kStationIDMAX_];           // symmetric in both arms
+  const int kIndexNotValid = 0;
 
-  static constexpr int RPotsTotalNumber = NArms * NStationMAX * NRPotsMAX;
+  MonitorElement *hBX_;
 
-  int RPindexValid[RPotsTotalNumber];
-  MonitorElement *h2HitsVsBXRandoms[RPotsTotalNumber];
+  static constexpr int kRPotsTotalNumber_ = kNArms_ * kNStationMAX_ * kNRPotsMAX_;
 
-  int getRPindex(int arm, int station, int rp) {
+  int RPindexValid_[kRPotsTotalNumber_];
+  MonitorElement *h2HitsVsBXRandoms_[kRPotsTotalNumber_];
+
+  int getRPindex(int arm, int station, int rp) const {
     if (arm < 0 || station < 0 || rp < 0)
-      return (IndexNotValid);
-    if (arm > 1 || station >= NStationMAX || rp >= NRPotsMAX)
-      return (IndexNotValid);
-    int rc = (arm * NStationMAX + station) * NRPotsMAX + rp;
+      return (kIndexNotValid);
+    if (arm > 1 || station >= kNStationMAX_ || rp >= kNRPotsMAX_)
+      return (kIndexNotValid);
+    int rc = (arm * kNStationMAX_ + station) * kNRPotsMAX_ + rp;
     return (rc);
   }
 };
 
-//----------------------------------------------------------------------------------
-
-using namespace std;
-using namespace edm;
-
 //-------------------------------------------------------------------------------
 
 CTPPSRandomDQMSource::CTPPSRandomDQMSource(const edm::ParameterSet &ps)
-    : rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
-  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"));
+    : tokenDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"))),
+      folderName_(ps.getUntrackedParameter<std::string>("folderName", "CTPPS/RandomPixel")),
+      rpStatusWord_(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
+  for (int stn = 0; stn < kStationIDMAX_; stn++) {
+    stationStatus_[stn] = 0;
+    for (int rp = 0; rp < kRPotsIDMAX_; rp++)
+      rpStatus_[stn][rp] = 0;
+  }
+
+  unsigned int rpSts = rpStatusWord_ << 1;
+  for (int stn = 0; stn < kNStationMAX_; stn++) {
+    int stns = 0;
+    for (int rp = 0; rp < kNRPotsMAX_; rp++) {
+      rpSts = (rpSts >> 1);
+      rpStatus_[stn][rp] = rpSts & 1;
+      if (rpStatus_[stn][rp] > 0)
+        stns = 1;
+    }
+    stationStatus_[stn] = stns;
+  }
+
+  for (int index = 0; index < 2 * 3 * kNRPotsMAX_; index++)
+    RPindexValid_[index] = 0;
 }
 
 //--------------------------------------------------------------------------
 
-void CTPPSRandomDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const &) {
-  for (int stn = 0; stn < StationIDMAX; stn++) {
-    StationStatus[stn] = 0;
-    for (int rp = 0; rp < RPotsIDMAX; rp++)
-      RPstatus[stn][rp] = 0;
-  }
-
-  unsigned int rpSts = rpStatusWord << 1;
-  for (int stn = 0; stn < NStationMAX; stn++) {
-    int stns = 0;
-    for (int rp = 0; rp < NRPotsMAX; rp++) {
-      rpSts = (rpSts >> 1);
-      RPstatus[stn][rp] = rpSts & 1;
-      if (RPstatus[stn][rp] > 0)
-        stns = 1;
-    }
-    StationStatus[stn] = stns;
-  }
-
-  for (int index = 0; index < 2 * 3 * NRPotsMAX; index++)
-    RPindexValid[index] = 0;
-}
-
-//-------------------------------------------------------------------------------------
-
 void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
   ibooker.cd();
-  ibooker.setCurrentFolder("CTPPS/TrackingPixel");
+  ibooker.setCurrentFolder(folderName_);
 
-  hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. + 0.5);
+  hBX_ = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. + 0.5);
 
-  for (int arm = 0; arm < NArms; arm++) {
+  for (int arm = 0; arm < kNArms_; arm++) {
     CTPPSDetId ID(CTPPSDetId::sdTrackingPixel, arm, 0);
-    string sd;
-    ID.armName(sd, CTPPSDetId::nPath);
+    std::string sd;
+    ID.armName(sd, CTPPSDetId::nShort);
+    sd = folderName_ + "/sector " + sd;
 
     ibooker.setCurrentFolder(sd);
 
-    for (int stn = 0; stn < NStationMAX; stn++) {
-      if (StationStatus[stn] == 0)
+    for (int stn = 0; stn < kNStationMAX_; stn++) {
+      if (stationStatus_[stn] == 0)
         continue;
       ID.setStation(stn);
-      string stnd;
-      CTPPSDetId(ID.stationId()).stationName(stnd, CTPPSDetId::nPath);
+      std::string stnd;
+      CTPPSDetId(ID.stationId()).stationName(stnd, CTPPSDetId::nShort);
+      stnd = sd + "/station " + stnd;
 
       ibooker.setCurrentFolder(stnd);
 
-      for (int rp = RPn_first; rp < RPn_last; rp++) {  // only installed pixel pots
+      for (int rp = kFirstRPn_; rp < kLastRPn_; rp++) {  // only installed pixel pots
         ID.setRP(rp);
-        string rpd, rpTitle;
+        std::string rpd, rpTitle;
         CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nFull);
-        CTPPSDetId(ID.rpId()).rpName(rpd, CTPPSDetId::nPath);
+        CTPPSDetId(ID.rpId()).rpName(rpd, CTPPSDetId::nShort);
+        rpd = stnd + "/" + rpd;
 
         ibooker.setCurrentFolder(rpd);
 
         int indexP = getRPindex(arm, stn, rp);
-        RPindexValid[indexP] = 1;
+        RPindexValid_[indexP] = 1;
 
-        h2HitsVsBXRandoms[indexP] = ibooker.book2D("Digi per plane per BX - random triggers",
-                                                   rpTitle + ";Event.BX;Plane",
-                                                   4002,
-                                                   -1.5,
-                                                   4000. + 0.5,
-                                                   NplaneMAX,
-                                                   0,
-                                                   NplaneMAX);
+        h2HitsVsBXRandoms_[indexP] = ibooker.book2D("Digi per plane per BX - random triggers",
+                                                    rpTitle + ";Event.BX;Plane",
+                                                    4002,
+                                                    -1.5,
+                                                    4000. + 0.5,
+                                                    kNplaneMAX_,
+                                                    0,
+                                                    kNplaneMAX_);
 
-      }  // end for(int rp=0; rp<NRPotsMAX;...
+      }  // end for(int rp=0; rp<kNRPotsMAX_;...
     }    // end of for(int stn=0; stn<
   }      // end of for(int arm=0; arm<2;...
 
@@ -164,37 +160,45 @@ void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
 //-------------------------------------------------------------------------------
 
 void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
-  Handle<DetSetVector<CTPPSPixelDigi>> pixDigi;
-  event.getByToken(tokenDigi, pixDigi);
+  auto const pixDigi = event.getHandle(tokenDigi_);
 
-  cout << "Before checking digi" << endl;
   if (!pixDigi.isValid())
     return;
-  cout << "After checking digi" << endl;
 
-  hBX->Fill(event.bunchCrossing());
+  hBX_->Fill(event.bunchCrossing());
 
   for (int arm = 0; arm < 2; arm++) {
-    for (int stn = 0; stn < NStationMAX; stn++) {
-      if (!StationStatus[stn])
+    for (int stn = 0; stn < kNStationMAX_; stn++) {
+      if (!stationStatus_[stn])
         continue;
-      for (int rp = 0; rp < NRPotsMAX; rp++) {
-        if (!RPstatus[stn][rp])
+      for (int rp = 0; rp < kNRPotsMAX_; rp++) {
+        if (!rpStatus_[stn][rp])
           continue;
         int index = getRPindex(arm, stn, rp);
-        if (RPindexValid[index] == 0)
+        if (RPindexValid_[index] == 0)
           continue;
 
-        for (int p = 0; p < NplaneMAX; p++) {
+        for (int p = 0; p < kNplaneMAX_; p++) {
           CTPPSPixelDetId planeId(arm, stn, rp, p);
-          if ((*pixDigi).find(planeId.rawId()) != (*pixDigi).end()) {
-            int n_digis = (*pixDigi)[planeId.rawId()].size();
-            h2HitsVsBXRandoms[index]->Fill(event.bunchCrossing(), p, n_digis);
+          auto pix_d = pixDigi->find(planeId.rawId());
+          if (pix_d != pixDigi->end()) {
+            int n_digis = pix_d->size();
+            h2HitsVsBXRandoms_[index]->Fill(event.bunchCrossing(), p, n_digis);
           }
         }
-      }  // end for (int rp=0; rp<NRPotsMAX; rp++) {
-    }    // end for (int stn = 0; stn < NStationMAX; stn++) {
+      }  // end for (int rp=0; rp<kNRPotsMAX_; rp++) {
+    }    // end for (int stn = 0; stn < kNStationMAX_; stn++) {
   }      // end for (int arm=0; arm<2; arm++) {
+}
+
+//---------------------------------------------------------------------------
+
+void CTPPSRandomDQMSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer"));
+  desc.addUntracked<std::string>("folderName", "CTPPS/RandomPixel");
+  desc.addUntracked<unsigned int>("RPStatusWord", 0x8008);
+  descriptions.add("ctppsRandomDQMSource", desc);
 }
 
 //---------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -78,7 +78,7 @@ private:
 //-------------------------------------------------------------------------------
 
 CTPPSRandomDQMSource::CTPPSRandomDQMSource(const edm::ParameterSet &ps)
-    : tokenDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"))),
+    : tokenDigi_(consumes<edm::DetSetVector<CTPPSPixelDigi>>(ps.getParameter<edm::InputTag>("tagRPixDigi"))),
       folderName_(ps.getUntrackedParameter<std::string>("folderName", "CTPPS/RandomPixel")),
       rpStatusWord_(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
   for (int stn = 0; stn < kStationIDMAX_; stn++) {
@@ -195,7 +195,7 @@ void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
 
 void CTPPSRandomDQMSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.addUntracked<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer"));
+  desc.add<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer"));
   desc.addUntracked<std::string>("folderName", "CTPPS/RandomPixel");
   desc.addUntracked<unsigned int>("RPStatusWord", 0x8008);
   descriptions.add("ctppsRandomDQMSource", desc);

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -33,7 +33,7 @@
 class CTPPSRandomDQMSource : public DQMEDAnalyzer {
 public:
   CTPPSRandomDQMSource(const edm::ParameterSet &ps);
-  ~CTPPSRandomDQMSource() {};
+  ~CTPPSRandomDQMSource() override;
 
 protected:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
@@ -71,7 +71,6 @@ private:
     int rc = (arm * NStationMAX + station) * NRPotsMAX + rp;
     return (rc);
   }
-
 };
 
 //----------------------------------------------------------------------------------
@@ -82,14 +81,13 @@ using namespace edm;
 //-------------------------------------------------------------------------------
 
 CTPPSRandomDQMSource::CTPPSRandomDQMSource(const edm::ParameterSet &ps)
-  : rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)){
+    : rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
   tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"));
 }
 
 //--------------------------------------------------------------------------
 
 void CTPPSRandomDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const &) {
-
   for (int stn = 0; stn < StationIDMAX; stn++) {
     StationStatus[stn] = 0;
     for (int rp = 0; rp < RPotsIDMAX; rp++)
@@ -110,18 +108,16 @@ void CTPPSRandomDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup cons
 
   for (int index = 0; index < 2 * 3 * NRPotsMAX; index++)
     RPindexValid[index] = 0;
-
 }
 
 //-------------------------------------------------------------------------------------
 
 void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
-
   ibooker.cd();
   ibooker.setCurrentFolder("CTPPS/TrackingPixel");
 
   hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. + 0.5);
-  
+
   for (int arm = 0; arm < NArms; arm++) {
     CTPPSDetId ID(CTPPSDetId::sdTrackingPixel, arm, 0);
     string sd;
@@ -145,12 +141,18 @@ void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
         CTPPSDetId(ID.rpId()).rpName(rpd, CTPPSDetId::nPath);
 
         ibooker.setCurrentFolder(rpd);
-    
+
         int indexP = getRPindex(arm, stn, rp);
         RPindexValid[indexP] = 1;
 
-        h2HitsVsBXRandoms[indexP] = ibooker.book2D(
-            "Digi per plane per BX - random triggers", rpTitle + ";Event.BX;Plane", 4002, -1.5, 4000. + 0.5, NplaneMAX, 0, NplaneMAX);
+        h2HitsVsBXRandoms[indexP] = ibooker.book2D("Digi per plane per BX - random triggers",
+                                                   rpTitle + ";Event.BX;Plane",
+                                                   4002,
+                                                   -1.5,
+                                                   4000. + 0.5,
+                                                   NplaneMAX,
+                                                   0,
+                                                   NplaneMAX);
 
       }  // end for(int rp=0; rp<NRPotsMAX;...
     }    // end of for(int stn=0; stn<
@@ -162,7 +164,6 @@ void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run c
 //-------------------------------------------------------------------------------
 
 void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
-
   Handle<DetSetVector<CTPPSPixelDigi>> pixDigi;
   event.getByToken(tokenDigi, pixDigi);
 
@@ -170,7 +171,7 @@ void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
   if (!pixDigi.isValid())
     return;
   cout << "After checking digi" << endl;
-  
+
   hBX->Fill(event.bunchCrossing());
 
   for (int arm = 0; arm < 2; arm++) {
@@ -179,22 +180,21 @@ void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
         continue;
       for (int rp = 0; rp < NRPotsMAX; rp++) {
         if (!RPstatus[stn][rp])
-          continue;        
+          continue;
         int index = getRPindex(arm, stn, rp);
         if (RPindexValid[index] == 0)
           continue;
 
         for (int p = 0; p < NplaneMAX; p++) {
-          CTPPSPixelDetId planeId(arm,stn,rp,p);
-          if((*pixDigi).find(planeId.rawId()) != (*pixDigi).end()){
-            int n_digis = (*pixDigi)[planeId.rawId()].size();           
+          CTPPSPixelDetId planeId(arm, stn, rp, p);
+          if ((*pixDigi).find(planeId.rawId()) != (*pixDigi).end()) {
+            int n_digis = (*pixDigi)[planeId.rawId()].size();
             h2HitsVsBXRandoms[index]->Fill(event.bunchCrossing(), p, n_digis);
           }
         }
       }  // end for (int rp=0; rp<NRPotsMAX; rp++) {
     }    // end for (int stn = 0; stn < NStationMAX; stn++) {
   }      // end for (int arm=0; arm<2; arm++) {
-
 }
 
 //---------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -1,0 +1,201 @@
+/******************************************
+ *
+ * This is a part of CTPPSDQM software.
+ * Authors:
+ *   A. Bellora (Universita' e INFN Torino)
+ *
+ *******************************************/
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "CondFormats/PPSObjects/interface/CTPPSPixelIndices.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h"
+#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelCluster.h"
+#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+
+#include <string>
+
+//-----------------------------------------------------------------------------
+
+class CTPPSRandomDQMSource : public DQMEDAnalyzer {
+public:
+  CTPPSRandomDQMSource(const edm::ParameterSet &ps);
+  ~CTPPSRandomDQMSource() {};
+
+protected:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void analyze(edm::Event const &e, edm::EventSetup const &eSetup) override;
+
+private:
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelDigi>> tokenDigi;
+
+  static constexpr int NArms = 2;
+  static constexpr int NStationMAX = 3;  // in an arm
+  static constexpr int NRPotsMAX = 6;    // per station
+  static constexpr int NplaneMAX = 6;    // per RPot
+  static constexpr int RPn_first = 3, RPn_last = 4;
+  static constexpr int StationIDMAX = 4;  // possible range of ID
+  static constexpr int RPotsIDMAX = 8;    // possible range of ID
+
+  unsigned int rpStatusWord = 0x8008;      // 220_fr_hr(stn2rp3)+ 210_fr_hr
+  int RPstatus[StationIDMAX][RPotsIDMAX];  // symmetric in both arms
+  int StationStatus[StationIDMAX];         // symmetric in both arms
+  const int IndexNotValid = 0;
+
+  MonitorElement *hBX;
+
+  static constexpr int RPotsTotalNumber = NArms * NStationMAX * NRPotsMAX;
+
+  int RPindexValid[RPotsTotalNumber];
+  MonitorElement *h2HitsVsBXRandoms[RPotsTotalNumber];
+
+  int getRPindex(int arm, int station, int rp) {
+    if (arm < 0 || station < 0 || rp < 0)
+      return (IndexNotValid);
+    if (arm > 1 || station >= NStationMAX || rp >= NRPotsMAX)
+      return (IndexNotValid);
+    int rc = (arm * NStationMAX + station) * NRPotsMAX + rp;
+    return (rc);
+  }
+
+};
+
+//----------------------------------------------------------------------------------
+
+using namespace std;
+using namespace edm;
+
+//-------------------------------------------------------------------------------
+
+CTPPSRandomDQMSource::CTPPSRandomDQMSource(const edm::ParameterSet &ps)
+  : rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)){
+  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"));
+}
+
+//--------------------------------------------------------------------------
+
+void CTPPSRandomDQMSource::dqmBeginRun(edm::Run const &run, edm::EventSetup const &) {
+
+  for (int stn = 0; stn < StationIDMAX; stn++) {
+    StationStatus[stn] = 0;
+    for (int rp = 0; rp < RPotsIDMAX; rp++)
+      RPstatus[stn][rp] = 0;
+  }
+
+  unsigned int rpSts = rpStatusWord << 1;
+  for (int stn = 0; stn < NStationMAX; stn++) {
+    int stns = 0;
+    for (int rp = 0; rp < NRPotsMAX; rp++) {
+      rpSts = (rpSts >> 1);
+      RPstatus[stn][rp] = rpSts & 1;
+      if (RPstatus[stn][rp] > 0)
+        stns = 1;
+    }
+    StationStatus[stn] = stns;
+  }
+
+  for (int index = 0; index < 2 * 3 * NRPotsMAX; index++)
+    RPindexValid[index] = 0;
+
+}
+
+//-------------------------------------------------------------------------------------
+
+void CTPPSRandomDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run const &, edm::EventSetup const &) {
+
+  ibooker.cd();
+  ibooker.setCurrentFolder("CTPPS/TrackingPixel");
+
+  hBX = ibooker.book1D("events per BX", "ctpps_pixel;Event.BX", 4002, -1.5, 4000. + 0.5);
+  
+  for (int arm = 0; arm < NArms; arm++) {
+    CTPPSDetId ID(CTPPSDetId::sdTrackingPixel, arm, 0);
+    string sd;
+    ID.armName(sd, CTPPSDetId::nPath);
+
+    ibooker.setCurrentFolder(sd);
+
+    for (int stn = 0; stn < NStationMAX; stn++) {
+      if (StationStatus[stn] == 0)
+        continue;
+      ID.setStation(stn);
+      string stnd;
+      CTPPSDetId(ID.stationId()).stationName(stnd, CTPPSDetId::nPath);
+
+      ibooker.setCurrentFolder(stnd);
+
+      for (int rp = RPn_first; rp < RPn_last; rp++) {  // only installed pixel pots
+        ID.setRP(rp);
+        string rpd, rpTitle;
+        CTPPSDetId(ID.rpId()).rpName(rpTitle, CTPPSDetId::nFull);
+        CTPPSDetId(ID.rpId()).rpName(rpd, CTPPSDetId::nPath);
+
+        ibooker.setCurrentFolder(rpd);
+    
+        int indexP = getRPindex(arm, stn, rp);
+        RPindexValid[indexP] = 1;
+
+        h2HitsVsBXRandoms[indexP] = ibooker.book2D(
+            "Digi per plane per BX - random triggers", rpTitle + ";Event.BX;Plane", 4002, -1.5, 4000. + 0.5, NplaneMAX, 0, NplaneMAX);
+
+      }  // end for(int rp=0; rp<NRPotsMAX;...
+    }    // end of for(int stn=0; stn<
+  }      // end of for(int arm=0; arm<2;...
+
+  return;
+}
+
+//-------------------------------------------------------------------------------
+
+void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup const &eventSetup) {
+
+  Handle<DetSetVector<CTPPSPixelDigi>> pixDigi;
+  event.getByToken(tokenDigi, pixDigi);
+
+  cout << "Before checking digi" << endl;
+  if (!pixDigi.isValid())
+    return;
+  cout << "After checking digi" << endl;
+  
+  hBX->Fill(event.bunchCrossing());
+
+  for (int arm = 0; arm < 2; arm++) {
+    for (int stn = 0; stn < NStationMAX; stn++) {
+      if (!StationStatus[stn])
+        continue;
+      for (int rp = 0; rp < NRPotsMAX; rp++) {
+        if (!RPstatus[stn][rp])
+          continue;        
+        int index = getRPindex(arm, stn, rp);
+        if (RPindexValid[index] == 0)
+          continue;
+
+        for (int p = 0; p < NplaneMAX; p++) {
+          CTPPSPixelDetId planeId(arm,stn,rp,p);
+          if((*pixDigi).find(planeId.rawId()) != (*pixDigi).end()){
+            int n_digis = (*pixDigi)[planeId.rawId()].size();           
+            h2HitsVsBXRandoms[index]->Fill(event.bunchCrossing(), p, n_digis);
+          }
+        }
+      }  // end for (int rp=0; rp<NRPotsMAX; rp++) {
+    }    // end for (int stn = 0; stn < NStationMAX; stn++) {
+  }      // end for (int arm=0; arm<2; arm++) {
+
+}
+
+//---------------------------------------------------------------------------
+DEFINE_FWK_MODULE(CTPPSRandomDQMSource);

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -17,6 +17,8 @@ from DQM.CTPPS.elasticPlotDQMSource_cfi import *
 
 from DQM.CTPPS.ctppsCommonDQMSource_cfi import *
 
+from DQM.CTPPS.ctppsRandomDQMSource_cfi import *
+
 # sequences used by the online DQM in normal running
 ctppsCommonDQMSourceOnline = ctppsCommonDQMSource.clone(
   makeProtonRecoPlots = False
@@ -49,6 +51,14 @@ _ctppsDQMCalibrationHarvest = cms.Sequence(
 # sequences used by the offline DQM
 ctppsCommonDQMSourceOffline = ctppsCommonDQMSource.clone(
   makeProtonRecoPlots = True
+)
+
+# sequences used by the dedicated random trigger stream
+_ctppsDQMRandomSource = cms.Sequence(
+  ctppsRandomDQMSource
+)
+
+_ctppsDQMRandomHarvest = cms.Sequence(
 )
 
 #Check if perLSsaving is enabled to mask MEs vs LS
@@ -99,3 +109,8 @@ ctppsDQMOfflineSource = cms.Sequence()
 ctppsDQMOfflineHarvest = cms.Sequence()
 ctpps.toReplaceWith(ctppsDQMOfflineSource, _ctppsDQMOfflineSource)
 ctpps.toReplaceWith(ctppsDQMOfflineHarvest, _ctppsDQMOfflineHarvest)
+
+ctppsDQMRandomSource = cms.Sequence()
+ctppsDQMRandomHarvest = cms.Sequence()
+ctpps.toReplaceWith(ctppsDQMRandomSource, _ctppsDQMRandomSource)
+ctpps.toReplaceWith(ctppsDQMRandomHarvest, _ctppsDQMRandomHarvest)

--- a/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
@@ -4,5 +4,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ctppsRandomDQMSource = DQMEDAnalyzer('CTPPSRandomDQMSource',
     tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
-    RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
+    folderName = cms.untracked.string("CTPPS/RandomPixel"),
+    RPStatusWord = cms.untracked.uint32(0x8008) # rpots in readout:220_fr_hr; 210_fr_hr
 )

--- a/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
@@ -4,6 +4,6 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ctppsRandomDQMSource = DQMEDAnalyzer('CTPPSRandomDQMSource',
     tagRPixDigi = cms.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
-    folderName = cms.untracked.string("CTPPS/RandomPixel"),
+    folderName = cms.untracked.string("PPSRANDOM/RandomPixel"),
     RPStatusWord = cms.untracked.uint32(0x8008) # rpots in readout:220_fr_hr; 210_fr_hr
 )

--- a/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+ctppsRandomDQMSource = DQMEDAnalyzer('CTPPSRandomDQMSource',
+    tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
+    RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
+)

--- a/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ctppsRandomDQMSource = DQMEDAnalyzer('CTPPSRandomDQMSource',
-    tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
+    tagRPixDigi = cms.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
     folderName = cms.untracked.string("CTPPS/RandomPixel"),
     RPStatusWord = cms.untracked.uint32(0x8008) # rpots in readout:220_fr_hr; 210_fr_hr
 )

--- a/DQM/CTPPS/test/pps_random_dqm_test_from_alcaraw_cfg.py
+++ b/DQM/CTPPS/test/pps_random_dqm_test_from_alcaraw_cfg.py
@@ -1,0 +1,62 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Modifier_ctpps_cff import ctpps
+process = cms.Process('ctppsRandomDQMfromRAW', ctpps)
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+  statistics = cms.untracked.vstring(),
+  destinations = cms.untracked.vstring('cerr'),
+  cerr = cms.untracked.PSet(
+      threshold = cms.untracked.string('WARNING')
+  )
+)
+
+# load DQM framework
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = "CTPPS"
+process.dqmEnv.eventInfoFolder = "EventInfo"
+process.dqmSaver.path = ""
+process.dqmSaver.tag = "CTPPS"
+
+# raw data source
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring(
+    '/store/group/dpg_ctpps/comm_ctpps/PixelRandomTrigger2023/outputExpressPPSRandom.root'
+  ),
+
+  inputCommands = cms.untracked.vstring(
+    'drop *',
+    'keep FEDRawDataCollection_*_*_*'
+  )
+)
+
+process.maxEvents = cms.untracked.PSet(
+  input = cms.untracked.int32(-1)
+)
+
+# global tag - conditions for P5 cluster
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+
+# raw-to-digi conversion
+from EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff import ctppsPixelDigis as _ctppsPixelDigis
+process.ctppsPixelDigisAlCaRecoProducer = _ctppsPixelDigis.clone(inputLabel = 'hltPPSCalibrationRaw')
+
+# CTPPS DQM modules
+process.load("DQM.CTPPS.ctppsDQM_cff")
+
+process.path = cms.Path(
+  process.ctppsPixelDigisAlCaRecoProducer *
+  process.ctppsDQMRandomSource *
+  process.ctppsDQMRandomHarvest
+)
+
+process.end_path = cms.EndPath(
+  process.dqmEnv +
+  process.dqmSaver
+)
+
+process.schedule = cms.Schedule(
+  process.path,
+  process.end_path
+)

--- a/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
@@ -30,7 +30,7 @@ else:
     'keep FEDRawDataCollection_*_*_*'
   )
   
-process.source.streamLabel = "streamExpressPPSRandom"
+process.source.streamLabel = "streamDQMPPSRandom"
 
 # DQM environment
 process.load("DQM.Integration.config.environment_cfi")

--- a/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,95 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process('CTPPSDQM', Run3)
+
+test = False
+unitTest = False
+
+if 'unitTest=True' in sys.argv:
+  unitTest=True
+
+# event source
+if unitTest:
+  process.load("DQM.Integration.config.unittestinputsource_cfi")
+  from DQM.Integration.config.unittestinputsource_cfi import options
+elif not test:
+  # for live online DQM in P5
+  process.load("DQM.Integration.config.inputsource_cfi")
+  from DQM.Integration.config.inputsource_cfi import options
+else:
+  # for testing in lxplus
+  process.load("DQM.Integration.config.fileinputsource_cfi")
+  from DQM.Integration.config.fileinputsource_cfi import options
+  process.source.fileNames = cms.untracked.vstring(
+    "/store/group/dpg_ctpps/comm_ctpps/PixelRandomTrigger2023/outputExpressPPSRandom.root"
+  )
+  process.source.inputCommands = cms.untracked.vstring(
+    'drop *',
+    'keep FEDRawDataCollection_*_*_*'
+  )
+
+# DQM environment
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = 'PPSRANDOM'
+process.dqmSaver.tag = 'PPSRANDOM'
+process.dqmSaver.runNumber = options.runNumber
+process.dqmSaverPB.tag = 'PPSRANDOM'
+process.dqmSaverPB.runNumber = options.runNumber
+
+if test:
+  process.dqmSaver.path = "."
+  process.dqmSaverPB.path = "./pb"
+
+process.load("DQMServices.Components.DQMProvInfo_cfi")
+
+# message logger
+process.MessageLogger = cms.Service("MessageLogger",
+  destinations = cms.untracked.vstring('cout'),
+  cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
+)
+
+# global tag - conditions for P5 cluster
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+
+# raw-to-digi conversion
+from EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff import ctppsPixelDigis as _ctppsPixelDigis
+process.ctppsPixelDigisAlCaRecoProducer = _ctppsPixelDigis.clone(inputLabel = 'hltPPSCalibrationRaw')
+
+# loading Meta tags used by commonDQM
+process.load('EventFilter.OnlineMetaDataRawToDigi.onlineMetaDataRawToDigi_cfi')
+process.onlineMetaDataDigis = cms.EDProducer('OnlineMetaDataRawToDigi')
+
+
+# DQM Modules
+process.load("DQM.CTPPS.ctppsDQM_cff")
+
+# processing path
+process.recoStep = cms.Sequence(
+  process.ctppsPixelDigisAlCaRecoProducer *
+  process.onlineMetaDataDigis
+)
+
+process.dqmModules = cms.Sequence(
+  process.ctppsDQMRandomSource *
+  process.ctppsDQMRandomHarvest
+)
+
+process.path = cms.Path(
+  process.recoStep *
+  process.dqmModules *
+
+  process.dqmEnv *
+  process.dqmSaver *
+  process.dqmSaverPB
+)
+
+process.schedule = cms.Schedule(process.path)
+
+process.dqmProvInfo.runType = process.runType.getRunTypeName()
+
+# Process customizations included here
+from DQM.Integration.config.online_customizations_cfi import *
+print("Final Source settings:", process.source)
+process = customise(process)

--- a/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
@@ -29,6 +29,8 @@ else:
     'drop *',
     'keep FEDRawDataCollection_*_*_*'
   )
+  
+process.source.streamLabel = "streamExpressPPSRandom"
 
 # DQM environment
 process.load("DQM.Integration.config.environment_cfi")


### PR DESCRIPTION
#### PR description:

This PR adds a DQM module meant to be run at T0-express with a new stream as input. 
The new express stream has been requested in https://its.cern.ch/jira/browse/CMSHLT-2606
The plots contain the number of digis per BX and plane in the PPS pixel detectors, which are necessary for monitoring the latency.
A backport to 13_0_0 will be submitted once the code is finalized.

#### PR validation:

Testing/validation of the module has been done running
`cmsRun DQM/CTPPS/test/pps_random_dqm_test_from_alcaraw_cfg.py` 
and using a test file produced following the instructions given in the HLT Jira ticket.

