### PR TITLE
PerfTools/JeProf: Make a library that allows a call to jemalloc profile heap dump function.

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc"/>
+  <use name="jemalloc-prof"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>

--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc-prof"/>
+  <use name="jemalloc"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>
@@ -75,6 +75,20 @@
   <use name="boost_program_options"/>
   <use name="tcmalloc"/>
   <use name="gperf"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+</bin>
+
+<bin name="cmsRunJEProf" file="cmsRun.cpp">
+  <use name="tbb"/>
+  <use name="boost"/>
+  <use name="boost_program_options"/>
+  <use name="jemalloc-prof"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>

--- a/PerfTools/JeProf/BuildFile.xml
+++ b/PerfTools/JeProf/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="sockets"/>
+<use name="FWCore/MessageLogger"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/PerfTools/JeProf/interface/jeprof.h
+++ b/PerfTools/JeProf/interface/jeprof.h
@@ -1,0 +1,4 @@
+
+namespace cms::jeprof {
+  void makeHeapDump(const char *);
+}

--- a/PerfTools/JeProf/plugins/BuildFile.xml
+++ b/PerfTools/JeProf/plugins/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="PerfTools/JeProf"/>
-<use name="jemalloc-prof"/>
 <library file="*.cc" name="JeProfPlugin">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/PerfTools/JeProf/plugins/BuildFile.xml
+++ b/PerfTools/JeProf/plugins/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="PerfTools/JeProf"/>
+<use name="jemalloc-prof"/>
 <library file="*.cc" name="JeProfPlugin">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/PerfTools/JeProf/src/jeprof.cc
+++ b/PerfTools/JeProf/src/jeprof.cc
@@ -1,0 +1,46 @@
+#include "PerfTools/JeProf/interface/jeprof.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <string>
+#include <dlfcn.h>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+
+extern "C" {
+typedef int (*mallctl_t)(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+}
+
+namespace {
+  bool initialize_prof();
+  mallctl_t mallctl = nullptr;
+  const bool have_jemalloc_and_prof = initialize_prof();
+
+  bool initialize_prof() {
+    // check if mallctl and friends are available, if we are using jemalloc
+    mallctl = (mallctl_t)::dlsym(RTLD_DEFAULT, "mallctl");
+    if (mallctl == nullptr)
+      return false;
+    // check if heap profiling available, if --enable-prof was specified at build time
+    bool enable_prof = false;
+    size_t bool_s = sizeof(bool);
+    mallctl("prof.active", &enable_prof, &bool_s, nullptr, 0);
+    return enable_prof;
+  }
+}  // namespace
+
+namespace cms::jeprof {
+  std::once_flag warning_flag;
+  void makeHeapDump(const char *fileName) {
+    std::once_flag warning_flag;
+    if (!have_jemalloc_and_prof) {
+      std::call_once(warning_flag, []() {
+        edm::LogWarning("JeProfModule") << "JeProfModule requested but application is not"
+                                        << " currently being profiled with jemalloc profiling enabled\n"
+                                        << "Enable jemalloc profiling by running\n"
+				        << "MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true cmsRunJEProf config.py\n";
+      });
+      return;
+    }
+    mallctl("prof.dump", nullptr, nullptr, &fileName, sizeof(const char *));
+  }
+}  // namespace cms::jeprof

--- a/PerfTools/JeProf/src/jeprof.cc
+++ b/PerfTools/JeProf/src/jeprof.cc
@@ -33,12 +33,14 @@ namespace cms::jeprof {
   void makeHeapDump(const char *fileName) {
     std::once_flag warning_flag;
     if (!have_jemalloc_and_prof) {
-      std::call_once(warning_flag, []() {
-        edm::LogWarning("JeProfModule") << "JeProfModule requested but application is not"
-                                        << " currently being profiled with jemalloc profiling enabled\n"
-                                        << "Enable jemalloc profiling by running\n"
-				        << "MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true cmsRunJEProf config.py\n";
-      });
+      std::call_once(warning_flag,
+                     []() {
+                       edm::LogWarning("JeProfModule")
+                           << "JeProfModule requested but application is not"
+                           << " currently being profiled with jemalloc profiling enabled\n"
+                           << "Enable jemalloc profiling by running\n"
+                           << "MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true cmsRunJEProf config.py\n";
+                     });
       return;
     }
     mallctl("prof.dump", nullptr, nullptr, &fileName, sizeof(const char *));

--- a/PerfTools/JeProf/test/BuildFile.xml
+++ b/PerfTools/JeProf/test/BuildFile.xml
@@ -1,9 +1,10 @@
 <bin name="jeprof_warn_t" file="jeprof_t.cc">
   <use name="jemalloc"/>
   <use name="PerfTools/JeProf"/>
+  <flags TEST_RUNNER_CMD="jeprof_warn_t.sh"/>
 </bin>
 <bin name="jeprof_nowarn_t" file="jeprof_t.cc">
   <use name="jemalloc-prof"/>
   <use name="PerfTools/JeProf"/>
-  <flags TEST_RUNNER_CMD="MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true jeprof_nowarn_t"/>
+  <flags TEST_RUNNER_CMD="jeprof_nowarn_t.sh"/>
 </bin>

--- a/PerfTools/JeProf/test/BuildFile.xml
+++ b/PerfTools/JeProf/test/BuildFile.xml
@@ -5,4 +5,5 @@
 <bin name="jeprof_nowarn_t" file="jeprof_t.cc">
   <use name="jemalloc-prof"/>
   <use name="PerfTools/JeProf"/>
+  <flags TEST_RUNNER_CMD="MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true jeprof_nowarn_t"/>
 </bin>

--- a/PerfTools/JeProf/test/BuildFile.xml
+++ b/PerfTools/JeProf/test/BuildFile.xml
@@ -1,0 +1,8 @@
+<bin name="jeprof_warn_t" file="jeprof_t.cc">
+  <use name="jemalloc"/>
+  <use name="PerfTools/JeProf"/>
+</bin>
+<bin name="jeprof_nowarn_t" file="jeprof_t.cc">
+  <use name="jemalloc-prof"/>
+  <use name="PerfTools/JeProf"/>
+</bin>

--- a/PerfTools/JeProf/test/jeprof_nowarn_t.sh
+++ b/PerfTools/JeProf/test/jeprof_nowarn_t.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+if  !(MALLOC_CONF=prof_leak:true,lg_prof_sample:10,prof_final:true jeprof_nowarn_t 2>&1 | tr '\n' ' ' | grep Leak) ; then
+  die "jeprof_nowarn_t | grep Leak" $?
+fi

--- a/PerfTools/JeProf/test/jeprof_t.cc
+++ b/PerfTools/JeProf/test/jeprof_t.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 int main() {
-  setenv("MALLOC_CONF","prof_leak:true,lg_prof_sample:10,prof_final:true",1);
+  setenv("MALLOC_CONF", "prof_leak:true,lg_prof_sample:10,prof_final:true", 1);
   std::string name("heap.dump");
   const char *fileName = name.c_str();
   cms::jeprof::makeHeapDump(fileName);

--- a/PerfTools/JeProf/test/jeprof_t.cc
+++ b/PerfTools/JeProf/test/jeprof_t.cc
@@ -1,0 +1,9 @@
+#include "PerfTools/JeProf/interface/jeprof.h"
+#include <string>
+
+int main() {
+  setenv("MALLOC_CONF","prof_leak:true,lg_prof_sample:10,prof_final:true",1);
+  std::string name("heap.dump");
+  const char *fileName = name.c_str();
+  cms::jeprof::makeHeapDump(fileName);
+}

--- a/PerfTools/JeProf/test/jeprof_t.cc
+++ b/PerfTools/JeProf/test/jeprof_t.cc
@@ -2,7 +2,6 @@
 #include <string>
 
 int main() {
-  setenv("MALLOC_CONF", "prof_leak:true,lg_prof_sample:10,prof_final:true", 1);
   std::string name("heap.dump");
   const char *fileName = name.c_str();
   cms::jeprof::makeHeapDump(fileName);

--- a/PerfTools/JeProf/test/jeprof_warn_t.sh
+++ b/PerfTools/JeProf/test/jeprof_warn_t.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+if !(jeprof_warn_t 2>&1 | tr '\n' ' ' | grep JeProfModule);then
+ die "jeprof_warn_t | grep MALLOC_CONF" $?
+fi


### PR DESCRIPTION
The proposed usage would be to add `<use="PerfTools/JeProf" />` to a package `Buildfile.xml` and then make a call to `cms::jeprof::makeHeapDump()` in your module code to produce a Heap Profile with the filename passed as an argument when your module config is run with `cmsRunJEProf`