### PR TITLE
updated tau HLT paths for disappearing tracks skim

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -20,10 +20,9 @@ hltDisappTrk = _hltHighLevel.hltHighLevel.clone(
       "HLT_Ele*_WPLoose_Gsf_v*",
       "HLT_IsoMu*_v*",
       "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*",
-      "HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*",
-      "HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*",
-      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*",
-      "HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1_v*"
+      "HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1_v*",
+      "HLT_DoubleMediumDeepTauPFTauHPS*_L2NN_eta2p1_*",
+      "HLT_LooseDeepTauPFTauHPS*_L2NN_eta2p1_v*"
    ]
 )
 


### PR DESCRIPTION
Updated HLT paths EXoDisappTrks skim for 2023 running. 

Removed:
"HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*"
"HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*"
"HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*"

Added:
"HLT_DoubleMediumDeepTauPFTauHPS*_L2NN_eta2p1_*",
"HLT_LooseDeepTauPFTauHPS*_L2NN_eta2p1_v*"

