### PR TITLE
Disable clang's bitwise-instead-of-logical warnings for some parts of code

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -73,8 +73,8 @@ void PixelTripletLargeTipGenerator::fillDescriptions(edm::ParameterSetDescriptio
   desc.add<double>("phiPreFiltering", 0.3);
 }
 
-# Disable bitwise-instead-of-logical warning, see discussion in
-# https://github.com/cms-sw/cmssw/issues/39105
+// Disable bitwise-instead-of-logical warning, see discussion in
+// https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
 #  if __has_warning("-Wbitwise-instead-of-logical")

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -73,6 +73,16 @@ void PixelTripletLargeTipGenerator::fillDescriptions(edm::ParameterSetDescriptio
   desc.add<double>("phiPreFiltering", 0.3);
 }
 
+# Disable bitwise-instead-of-logical warning, see discussion in
+# https://github.com/cms-sw/cmssw/issues/39105
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#  endif
+#endif
+
 namespace {
   inline bool intersect(Range& range, const Range& second) {
     if ((range.min() > second.max()) | (range.max() < second.min()))
@@ -84,6 +94,12 @@ namespace {
     return range.first < range.second;
   }
 }  // namespace
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic pop
+#  endif
+#endif
 
 void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
                                                 OrderedHitTriplets& result,

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -77,10 +77,10 @@ void PixelTripletLargeTipGenerator::fillDescriptions(edm::ParameterSetDescriptio
 // https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
 #endif
 
 namespace {
@@ -96,9 +96,9 @@ namespace {
 }  // namespace
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic pop
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic pop
+#endif
 #endif
 
 void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,

--- a/TrackingTools/DetLayers/interface/rangesIntersect.h
+++ b/TrackingTools/DetLayers/interface/rangesIntersect.h
@@ -2,13 +2,23 @@
 #define TrackingTools_DetLayers_rangesIntersect_h
 
 /** Utility for checking efficiently if two one-dimantional intervals
- *  intersect. 
+ *  intersect.
  *  Precondition: the intervals are not empty, i.e. for i in a,b
  *  i.first <= i.second.
  *  The Range template argument is expected to have the std::pair
  *  interface, i.e. for Range instance r r.first is the beginning of
  *  the interval and r.second is the end of the interval.
  */
+
+# Disable bitwise-instead-of-logical warning, see discussion in
+# https://github.com/cms-sw/cmssw/issues/39105
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#  endif
+#endif
 
 template <typename Range>
 inline bool rangesIntersect(const Range& a, const Range& b) {
@@ -23,4 +33,11 @@ template <typename Range, typename T>
 inline bool rangesIntersect(const Range& a, const Range& b, bool (*less)(T, T)) {
   return !(less(b.second, a.first) | less(a.second, b.first));
 }
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic pop
+#  endif
+#endif
+
 #endif

--- a/TrackingTools/DetLayers/interface/rangesIntersect.h
+++ b/TrackingTools/DetLayers/interface/rangesIntersect.h
@@ -14,10 +14,10 @@
 // https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
 #endif
 
 template <typename Range>
@@ -35,9 +35,9 @@ inline bool rangesIntersect(const Range& a, const Range& b, bool (*less)(T, T)) 
 }
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic pop
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic pop
+#endif
 #endif
 
 #endif

--- a/TrackingTools/DetLayers/interface/rangesIntersect.h
+++ b/TrackingTools/DetLayers/interface/rangesIntersect.h
@@ -10,8 +10,8 @@
  *  the interval and r.second is the end of the interval.
  */
 
-# Disable bitwise-instead-of-logical warning, see discussion in
-# https://github.com/cms-sw/cmssw/issues/39105
+// Disable bitwise-instead-of-logical warning, see discussion in
+// https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
 #  if __has_warning("-Wbitwise-instead-of-logical")

--- a/TrackingTools/DetLayers/src/ForwardDetLayer.cc
+++ b/TrackingTools/DetLayers/src/ForwardDetLayer.cc
@@ -99,23 +99,23 @@ pair<bool, TrajectoryStateOnSurface> ForwardDetLayer::compatible(const Trajector
   // check r
   auto r2 = myState.localPosition().perp2();
 
-// Disable bitwise-instead-of-logical warning, see discussion in
-// https://github.com/cms-sw/cmssw/issues/39105
+  // Disable bitwise-instead-of-logical warning, see discussion in
+  // https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
 #endif
 
   if ((r2 > rmin() * rmin()) & (r2 < rmax() * rmax()))
     return make_pair(true, myState);
 
 #if defined(__clang__) && defined(__has_warning)
-#  if __has_warning("-Wbitwise-instead-of-logical")
-#    pragma clang diagnostic pop
-#  endif
+#if __has_warning("-Wbitwise-instead-of-logical")
+#pragma clang diagnostic pop
+#endif
 #endif
 
   // take into account the thickness of the layer

--- a/TrackingTools/DetLayers/src/ForwardDetLayer.cc
+++ b/TrackingTools/DetLayers/src/ForwardDetLayer.cc
@@ -99,8 +99,8 @@ pair<bool, TrajectoryStateOnSurface> ForwardDetLayer::compatible(const Trajector
   // check r
   auto r2 = myState.localPosition().perp2();
 
-# Disable bitwise-instead-of-logical warning, see discussion in
-# https://github.com/cms-sw/cmssw/issues/39105
+// Disable bitwise-instead-of-logical warning, see discussion in
+// https://github.com/cms-sw/cmssw/issues/39105
 
 #if defined(__clang__) && defined(__has_warning)
 #  if __has_warning("-Wbitwise-instead-of-logical")

--- a/TrackingTools/DetLayers/src/ForwardDetLayer.cc
+++ b/TrackingTools/DetLayers/src/ForwardDetLayer.cc
@@ -98,8 +98,25 @@ pair<bool, TrajectoryStateOnSurface> ForwardDetLayer::compatible(const Trajector
 
   // check r
   auto r2 = myState.localPosition().perp2();
+
+# Disable bitwise-instead-of-logical warning, see discussion in
+# https://github.com/cms-sw/cmssw/issues/39105
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wbitwise-instead-of-logical"
+#  endif
+#endif
+
   if ((r2 > rmin() * rmin()) & (r2 < rmax() * rmax()))
     return make_pair(true, myState);
+
+#if defined(__clang__) && defined(__has_warning)
+#  if __has_warning("-Wbitwise-instead-of-logical")
+#    pragma clang diagnostic pop
+#  endif
+#endif
 
   // take into account the thickness of the layer
   float deltaR = 0.5f * bounds().thickness() * myState.localDirection().perp() / std::abs(myState.localDirection().z());


### PR DESCRIPTION
#### PR description:

Silences clang warnings as discussed in https://github.com/cms-sw/cmssw/issues/39105#issuecomment-1220479108

#### PR validation:

Cosmetic changes, should not affect the actual execution of the code.