### PR TITLE
use std::stof with try/catch instead of std::regex

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CandIsolatorFromDeposits.cc
@@ -60,12 +60,6 @@ using namespace edm;
 using namespace reco;
 using namespace reco::isodeposit;
 
-bool isNumber(const std::string &str) {
-  static const std::regex re("^[+-]?(\\d+\\.?|\\d*\\.\\d*)$");
-  return regex_match(str.c_str(), re);
-}
-double toNumber(const std::string &str) { return atof(str.c_str()); }
-
 CandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet &iConfig, edm::ConsumesCollector &&iC)
     : srcToken_(iC.consumes<reco::IsoDepositMap>(iConfig.getParameter<edm::InputTag>("src"))),
       deltaR_(iConfig.getParameter<double>("deltaR")),
@@ -108,15 +102,12 @@ CandIsolatorFromDeposits::SingleDeposit::SingleDeposit(const edm::ParameterSet &
       evdepVetos_.push_back(evdep);
   }
   std::string weight = iConfig.getParameter<std::string>("weight");
-  if (isNumber(weight)) {
-    //std::cout << "Weight is a simple number, " << toNumber(weight) << std::endl;
-    weight_ = toNumber(weight);
+  try {
+    weight_ = std::stof(weight);
     usesFunction_ = false;
-  } else {
+  } catch (...) {
     usesFunction_ = true;
-    //std::cout << "Weight is a function, this might slow you down... " << std::endl;
   }
-  //std::cout << "CandIsolatorFromDeposits::SingleDeposit::SingleDeposit: Total of " << vetos_.size() << " vetos" << std::endl;
 }
 void CandIsolatorFromDeposits::SingleDeposit::cleanup() {
   for (AbsVetos::iterator it = vetos_.begin(), ed = vetos_.end(); it != ed; ++it) {


### PR DESCRIPTION
Follow up on https://github.com/cms-sw/cmssw/issues/40902 , this Pr proposes to use std::stof with try/catch to convert a string to double instead of using regex. This should avoid the ASAN relval failure we are getting after enabling LTO. Local tests shows that workflow `1.0` runs for ASAN

```
1.0_ProdMinBias Step0-PASSED Step1-PASSED Step2-PASSED  - time date Wed Mar  1 14:43:30 2023-date Wed Mar  1 14:35:32 2023; exit: 0 0 0
1 1 1 tests passed, 0 0 0 failed

```