### PR TITLE
avoid duplicates in `HLTPMMassFilter` plugin

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTPMMassFilter.h
@@ -39,6 +39,8 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  bool isGoodPair(TLorentzVector const& v1, TLorentzVector const& v2) const;
+
   TLorentzVector approxMomAtVtx(const MagneticField& magField,
                                 const GlobalPoint& xvert,
                                 const reco::SuperClusterRef sc,


### PR DESCRIPTION
#### PR description:

This PR modifies the plugin `HLTPMMassFilter` in order to (1) consider a given pair of candidates only once when counting how many pairs pass the selection requirements, and (2) avoid duplicates in the candidates added to the `TriggerFilterObjectWithRefs` output product of this plugin.

Discussed in [CMSHLT-2635](https://its.cern.ch/jira/browse/CMSHLT-2635).

#### PR description:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_0_X`
