### PR TITLE
Migrate consumesMany() to edm::GetterOfProducts() in GlobalRecHitsAnalyzer

### DIFF
--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -16,6 +16,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
 
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -177,6 +179,10 @@ private:
 
   MonitorElement *mehEcaln[3];
   MonitorElement *mehEcalRes[3];
+
+  edm::GetterOfProducts<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>> HBHERecHitgetter_;
+  edm::GetterOfProducts<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>> HFRecHitgetter_;
+  edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>> HORecHitgetter_;
 
   edm::InputTag ECalEBSrc_;
   edm::InputTag ECalUncalEBSrc_;

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -37,6 +37,8 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
   HORecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>(
       edm::ProcessMatch("*"), this);
   callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    // in case of EDAliases, consume only the aliased-for original products
+    if (bd.isAnyAlias()) return;
     this->HBHERecHitgetter_(bd);
     this->HFRecHitgetter_(bd);
     this->HORecHitgetter_(bd);

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -11,6 +11,8 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
 using namespace std;
 
 GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
@@ -28,9 +30,14 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
       cscGeomToken_(esConsumes()),
       rpcGeomToken_(esConsumes()),
       count(0) {
-  consumesMany<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>>();
-  consumesMany<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>>();
-  consumesMany<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>();
+  HBHERecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>>(edm::ProcessMatch("*"), this);
+  HFRecHitgetter_   = edm::GetterOfProducts<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>>(edm::ProcessMatch("*"), this);
+  HORecHitgetter_   = edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>(edm::ProcessMatch("*"), this);
+  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    this->HBHERecHitgetter_(bd);
+    this->HFRecHitgetter_(bd);
+    this->HORecHitgetter_(bd);
+});
   std::string MsgLoggerCat = "GlobalRecHitsAnalyzer_GlobalRecHitsAnalyzer";
 
   // get information from parameter set
@@ -602,8 +609,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent, const edm::EventS
   // get HBHE information
   ///////////////////////
   std::vector<edm::Handle<HBHERecHitCollection>> hbhe;
-  iEvent.getManyByType(hbhe);
-
+  HBHERecHitgetter_.fillHandles(iEvent, hbhe);
   bool validHBHE = hbhe[0].isValid();
 
   if (!validHBHE) {
@@ -647,7 +653,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent, const edm::EventS
   // get HF information
   ///////////////////////
   std::vector<edm::Handle<HFRecHitCollection>> hf;
-  iEvent.getManyByType(hf);
+  HFRecHitgetter_.fillHandles(iEvent, hf);
   bool validHF = hf[0].isValid();
   if (!validHF) {
     LogDebug(MsgLoggerCat) << "Unable to find any HFRecHitCollections in event!";
@@ -677,7 +683,7 @@ void GlobalRecHitsAnalyzer::fillHCal(const edm::Event& iEvent, const edm::EventS
   // get HO information
   ///////////////////////
   std::vector<edm::Handle<HORecHitCollection>> ho;
-  iEvent.getManyByType(ho);
+  HORecHitgetter_.fillHandles(iEvent, ho);
   bool validHO = ho[0].isValid();
   if (!validHO) {
     LogDebug(MsgLoggerCat) << "Unable to find any HORecHitCollections in event!";

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -38,7 +38,8 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
       edm::ProcessMatch("*"), this);
   callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
     // in case of EDAliases, consume only the aliased-for original products
-    if (bd.isAnyAlias()) return;
+    if (bd.isAnyAlias())
+      return;
     this->HBHERecHitgetter_(bd);
     this->HFRecHitgetter_(bd);
     this->HORecHitgetter_(bd);

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -30,14 +30,17 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet)
       cscGeomToken_(esConsumes()),
       rpcGeomToken_(esConsumes()),
       count(0) {
-  HBHERecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>>(edm::ProcessMatch("*"), this);
-  HFRecHitgetter_   = edm::GetterOfProducts<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>>(edm::ProcessMatch("*"), this);
-  HORecHitgetter_   = edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>(edm::ProcessMatch("*"), this);
+  HBHERecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>>(
+      edm::ProcessMatch("*"), this);
+  HFRecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>>(
+      edm::ProcessMatch("*"), this);
+  HORecHitgetter_ = edm::GetterOfProducts<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>>(
+      edm::ProcessMatch("*"), this);
   callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
     this->HBHERecHitgetter_(bd);
     this->HFRecHitgetter_(bd);
     this->HORecHitgetter_(bd);
-});
+  });
   std::string MsgLoggerCat = "GlobalRecHitsAnalyzer_GlobalRecHitsAnalyzer";
 
   // get information from parameter set


### PR DESCRIPTION
#### PR description:
Based on PR #40167 .
Migrate GlobalRecHitsAnalyzer away from consumesMany() to use edm::GetterOfProducts().

        modified:   Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
        modified:   Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc

#### PR validation:
Tested in CMSSW_13_0_0_pre4, the basic test passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)