### PR TITLE
use unique names for outputs of HLT-DQM unit tests [`13_0_X`]

### DIFF
--- a/DQM/HLTEvF/test/testTriggerMonitors_dqm_cfg.py
+++ b/DQM/HLTEvF/test/testTriggerMonitors_dqm_cfg.py
@@ -11,7 +11,7 @@ options.setDefault('inputFiles', [
 ])
 options.setDefault('maxEvents', 200)
 options.setType('outputFile', options.varType.string)
-options.setDefault('outputFile', 'DQMIO.root')
+options.setDefault('outputFile', 'testTriggerMonitors_DQMIO.root')
 options.parseArguments()
 
 # Process

--- a/DQM/HLTEvF/test/testTriggerMonitors_harvesting_cfg.py
+++ b/DQM/HLTEvF/test/testTriggerMonitors_harvesting_cfg.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing('analysis')
 options.register('nThreads', 4, options.multiplicity.singleton, options.varType.int, 'number of threads')
 options.register('nStreams', 0, options.multiplicity.singleton, options.varType.int, 'number of streams')
-options.setDefault('inputFiles', ['file:DQMIO.root'])
+options.setDefault('inputFiles', ['file:testTriggerMonitors_DQMIO.root'])
 options.parseArguments()
 
 # Process

--- a/DQMOffline/Trigger/test/harvesting_cfg.py
+++ b/DQMOffline/Trigger/test/harvesting_cfg.py
@@ -17,7 +17,7 @@ parser.add_argument('-s', '--nStreams', type = int, help = 'Number of EDM stream
                     default = 0)
 
 parser.add_argument('-i', '--inputFiles', nargs = '+', help = 'List of DQMIO input files',
-                    default = ['file:DQMIO.root'])
+                    default = ['file:testHLTFiltersDQMonitor_DQMIO.root'])
 
 argv = sys.argv[:]
 if '--' in argv:

--- a/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py
+++ b/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py
@@ -23,7 +23,7 @@ parser.add_argument('-n', '--maxEvents', type = int, help = 'Number of input eve
                     default = 100)
 
 parser.add_argument('-o', '--outputFile', type = str, help = 'Path to output file in DQMIO format',
-                    default = 'DQMIO.root')
+                    default = 'testHLTFiltersDQMonitor_DQMIO.root')
 
 parser.add_argument('--wantSummary', action = 'store_true', help = 'Value of process.options.wantSummary',
                     default = False)


### PR DESCRIPTION
backport of #40928

#### PR description:

This PR is a possible solution to #40904. It adjusts some of the HLT-DQM unit tests to use unique names for their output files.

#### PR validation:

None beyond the checks done for #40928.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#40928

Fix to HLT-DQM unit tests