### PR TITLE
Modify EMTF unpacker to support new reduced DAQ window for 2023 data taking

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockGEM.cc
@@ -132,6 +132,9 @@ namespace l1t {
         bool run3_DAQ_format =
             (getAlgoVersion() >=
              11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for GEMs - EY 13.09.22
+        bool reducedDAQWindow =
+            (getAlgoVersion() >=
+             11656);  // Firmware from 08.12.22 which is used as a flag for new reduced readout window - EY 01.03.23
 
         int nTPs = run3_DAQ_format ? 2 : 1;
 
@@ -172,7 +175,10 @@ namespace l1t {
               GEM_.set_partition(GetHexBits(GEMa, 9, 11));
               GEM_.set_cluster_size(GetHexBits(GEMa, 12, 14));
 
-              GEM_.set_tbin(GetHexBits(GEMb, 0, 2));
+              if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+                GEM_.set_tbin(GetHexBits(GEMb, 0, 2) + 1);
+              else
+                GEM_.set_tbin(GetHexBits(GEMb, 0, 2));
               GEM_.set_vp(GetHexBits(GEMb, 3, 3));
               GEM_.set_bc0(GetHexBits(GEMb, 7, 7));
               GEM_.set_cluster_id(GetHexBits(GEMb, 8, 11));
@@ -182,7 +188,10 @@ namespace l1t {
               GEM_.set_partition(GetHexBits(GEMc, 9, 11));
               GEM_.set_cluster_size(GetHexBits(GEMc, 12, 14));
 
-              GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
+              if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+                GEM_.set_tbin(GetHexBits(GEMd, 0, 2) + 1);
+              else
+                GEM_.set_tbin(GetHexBits(GEMd, 0, 2));
               GEM_.set_vp(GetHexBits(GEMd, 3, 3));
               GEM_.set_bc0(GetHexBits(GEMd, 7, 7));
               GEM_.set_cluster_id(GetHexBits(GEMd, 8, 11));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -188,6 +188,9 @@ namespace l1t {
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
         bool run3_DAQ_format =
             (getAlgoVersion() >= 11460);  // Firmware from 04.06.22 which enabled new Run 3 DAQ format - EY 04.07.22
+        bool reducedDAQWindow =
+            (getAlgoVersion() >=
+             11656);  // Firmware from 08.12.22 which is used as a flag for new reduced readout window - EY 01.03.23
 
         // Set fields assuming Run 2 format. Modify for Run 3 later
         ME_.set_clct_pattern(GetHexBits(MEa, 0, 3));
@@ -205,7 +208,10 @@ namespace l1t {
         ME_.set_cik(GetHexBits(MEc, 13, 13));
         ME_.set_afff(GetHexBits(MEc, 14, 14));
 
-        ME_.set_tbin(GetHexBits(MEd, 0, 2));
+        if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+          ME_.set_tbin(GetHexBits(MEd, 0, 2) + 1);
+        else
+          ME_.set_tbin(GetHexBits(MEd, 0, 2));
         ME_.set_vp(GetHexBits(MEd, 3, 3));
         ME_.set_station(GetHexBits(MEd, 4, 6));
         ME_.set_af(GetHexBits(MEd, 7, 7));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockRPC.cc
@@ -126,6 +126,9 @@ namespace l1t {
         bool run3_DAQ_format =
             (getAlgoVersion() >=
              11546);  // Firmware from 26.08.22 which enabled new Run 3 DAQ format for RPCs - EY 13.09.22
+        bool reducedDAQWindow =
+            (getAlgoVersion() >=
+             11656);  // Firmware from 08.12.22 which is used as a flag for new reduced readout window - EY 01.03.23
 
         int nTPs = run3_DAQ_format ? 2 : 1;
 
@@ -165,7 +168,10 @@ namespace l1t {
               RPC_.set_word(GetHexBits(RPCa, 11, 12));
               RPC_.set_frame(GetHexBits(RPCa, 13, 14));
 
-              RPC_.set_tbin(GetHexBits(RPCb, 0, 2));
+              if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+                RPC_.set_tbin(GetHexBits(RPCb, 0, 2) + 1);
+              else
+                RPC_.set_tbin(GetHexBits(RPCb, 0, 2));
               RPC_.set_vp(GetHexBits(RPCb, 3, 3));
               RPC_.set_theta(GetHexBits(RPCb, 4, 8));
               RPC_.set_bc0(GetHexBits(RPCb, 9, 9));
@@ -175,7 +181,10 @@ namespace l1t {
               RPC_.set_word(GetHexBits(RPCc, 11, 12));
               RPC_.set_frame(GetHexBits(RPCc, 13, 14));
 
-              RPC_.set_tbin(GetHexBits(RPCd, 0, 2));
+              if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+                RPC_.set_tbin(GetHexBits(RPCd, 0, 2) + 1);
+              else
+                RPC_.set_tbin(GetHexBits(RPCd, 0, 2));
               RPC_.set_vp(GetHexBits(RPCd, 3, 3));
               RPC_.set_theta(GetHexBits(RPCd, 4, 8));
               RPC_.set_bc0(GetHexBits(RPCd, 9, 9));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -179,6 +179,9 @@ namespace l1t {
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
         bool useNNBits_ = getAlgoVersion() >= 11098;   // FW versions >= 26.10.2021
         bool useHMTBits_ = getAlgoVersion() >= 11306;  // FW versions >= 10.01.2022
+        bool reducedDAQWindow =
+            (getAlgoVersion() >=
+             11656);  // Firmware from 08.12.22 which is used as a flag for new reduced readout window - EY 01.03.23
 
         static constexpr int nominalShower_ = 1;
         static constexpr int tightShower_ = 3;
@@ -260,7 +263,10 @@ namespace l1t {
         SP_.set_me2_delay(GetHexBits(SP2b, 3, 5));
         SP_.set_me3_delay(GetHexBits(SP2b, 6, 8));
         SP_.set_me4_delay(GetHexBits(SP2b, 9, 11));
-        SP_.set_tbin(GetHexBits(SP2b, 12, 14));
+        if (reducedDAQWindow)  // reduced DAQ window is used only after run3 DAQ format
+          SP_.set_tbin(GetHexBits(SP2b, 12, 14) + 1);
+        else
+          SP_.set_tbin(GetHexBits(SP2b, 12, 14));
 
         if (useNNBits_) {
           SP_.set_pt_dxy_GMT(GetHexBits(SP2c, 0, 7));


### PR DESCRIPTION
#### PR description:

This PR adds a flag to shift BX assignment in EMTF unpacker based on firmware version. In 2023 EMTF will use a reduced DAQ readout window to limit deadtime in high PU scenarios. The unpacker change is done to shift the timing such that the BX range for EMTF is [-2,2] instead of [-3,1].

This option will be enabled in the unpacker for firmware versions dated after 08/12/2022. 

 
#### PR validation:

Validation done by `runTheMatrix.py -l limited -i all --ibeos` all tests passed.

Since `runTheMatrix` probably doesn't have any runs with the new readout I also ran a test on data from last week. See before and after images below. The central BX will be shifted to 0 on the firmware side soon and does not require another update to the unpacker.

Before:
![canvas_before](https://user-images.githubusercontent.com/53942290/222435763-1c3998eb-e959-4b07-b5bb-4fa34846a1d8.png)

After:
![canvas_after](https://user-images.githubusercontent.com/53942290/222435795-3a86bd35-7847-4486-9b8f-39c0e27d2f0f.png)

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 13_0_X to be used in data taking. However, this is not urgent since it only affects EMTF DQM.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->

FYI: @kbunkow @bundocka 
