### PR TITLE
Zero-padding optimization for DeepSC inference

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -316,6 +316,7 @@ void PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC(CalibratedPFClusterVect
   ecalClusterGraph_.selectClusters();
   // Extract the final SuperCluster collection
   reco::EcalClustersGraph::EcalGraphOutput windows = ecalClusterGraph_.getGraphOutput();
+  LogDebug("PFEcalSuperClusterAlgo") << "End of EcalClusterGraph evaluation";
   for (auto& [seed, clustered] : windows) {
     bool isEE = false;
     if (seed.ptr()->layer() == PFLayer::ECAL_ENDCAP)

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -8,14 +8,16 @@ from Configuration.ProcessModifiers.ecal_deepsc_cff import ecal_deepsc
 _particleFlowSuperClusterECALDeepSC = _particleFlowSuperClusterECALMustache.clone(
     ClusteringType = "DeepSC",
     deepSuperClusterConfig = cms.PSet(
-        modelFiles = cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/model.pb",
-                                 "RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/model.pb"),
-        configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_clusters_inputs.txt"),
-        configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_window_inputs.txt"),
-        configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_hits_inputs.txt"),
+        modelFiles =  cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thresUL18/model_smallpadding.pb",
+                                  "RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thresUL18/model_largepadding.pb"),
+        configFileClusterFeatures =  cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thresUL18/scaler_config_cls_norm.txt"),
+        configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thresUL18/scaler_config_wind_norm.txt"),
+        configFileHitsFeatures =  cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thresUL18/config_hits_inputs.txt"),
         collectionStrategy = cms.string("Cascade"),
         maxNClusters = cms.vuint32(15,60),
-        maxNRechits = cms.vuint32(20,60)
+        maxNRechits = cms.vuint32(20,60),
+        nClusterFeatures = cms.uint32(17),
+        nWindowFeatures = cms.uint32(6)
     )
 )
 ecal_deepsc.toReplaceWith(particleFlowSuperClusterECAL, _particleFlowSuperClusterECALDeepSC)

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -8,11 +8,14 @@ from Configuration.ProcessModifiers.ecal_deepsc_cff import ecal_deepsc
 _particleFlowSuperClusterECALDeepSC = _particleFlowSuperClusterECALMustache.clone(
     ClusteringType = "DeepSC",
     deepSuperClusterConfig = cms.PSet(
-        modelFile = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/model.pb"),
+        modelFiles = cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/model.pb",
+                                 "RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/model.pb"),
         configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_clusters_inputs.txt"),
         configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_window_inputs.txt"),
         configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_hits_inputs.txt"),
-        collectionStrategy = cms.string("Cascade")
+        collectionStrategy = cms.string("Cascade"),
+        maxNClusters = cms.vuint32(15,30),
+        maxNRechits = cms.vuint32(20,60)
     )
 )
 ecal_deepsc.toReplaceWith(particleFlowSuperClusterECAL, _particleFlowSuperClusterECALDeepSC)

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -14,7 +14,7 @@ _particleFlowSuperClusterECALDeepSC = _particleFlowSuperClusterECALMustache.clon
         configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_window_inputs.txt"),
         configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/EOY_2018/config_hits_inputs.txt"),
         collectionStrategy = cms.string("Cascade"),
-        maxNClusters = cms.vuint32(15,30),
+        maxNClusters = cms.vuint32(15,60),
         maxNRechits = cms.vuint32(20,60)
     )
 )

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -387,16 +387,15 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<bool>("dropUnseedable", false);
 
   edm::ParameterSetDescription deepSCParams;
-  deepSCParams.add<std::string>("modelFile", "");
+  deepSCParams.add<std::vector<std::string>>("modelFiles", {});
   deepSCParams.add<std::string>("configFileClusterFeatures", "");
   deepSCParams.add<std::string>("configFileWindowFeatures", "");
   deepSCParams.add<std::string>("configFileHitsFeatures", "");
   deepSCParams.add<uint>("nClusterFeatures", 12);
   deepSCParams.add<uint>("nWindowFeatures", 18);
   deepSCParams.add<uint>("nHitsFeatures", 4);
-  deepSCParams.add<uint>("maxNClusters", 40);
-  deepSCParams.add<uint>("maxNRechits", 40);
-  deepSCParams.add<uint>("batchSize", 64);
+  deepSCParams.add<std::vector<uint>>("maxNClusters", {15, 30});
+  deepSCParams.add<std::vector<uint>>("maxNRechits", {20, 60});
   deepSCParams.add<std::string>("collectionStrategy", "Cascade");
 
   EmptyGroupDescription emptyGroup;

--- a/RecoEcal/EgammaCoreTools/interface/DeepSCGraphEvaluation.h
+++ b/RecoEcal/EgammaCoreTools/interface/DeepSCGraphEvaluation.h
@@ -17,16 +17,15 @@
 namespace reco {
 
   struct DeepSCConfiguration {
-    std::string modelFile;
+    std::vector<std::string> modelFiles;
     std::string configFileClusterFeatures;
     std::string configFileWindowFeatures;
     std::string configFileHitsFeatures;
     uint nClusterFeatures;
     uint nWindowFeatures;
     uint nHitsFeatures;
-    uint maxNClusters;
-    uint maxNRechits;
-    uint batchSize;
+    std::vector<uint> maxNClusters;
+    std::vector<uint> maxNRechits;
     std::string collectionStrategy;
   };
 
@@ -56,6 +55,7 @@ namespace reco {
       std::vector<std::vector<std::vector<std::vector<float>>>> hitsX;
       std::vector<std::vector<float>> windowX;
       std::vector<std::vector<bool>> isSeed;
+      std::vector<size_t> maxNRechits;
     };
 
   };  // namespace DeepSCInputs
@@ -89,8 +89,7 @@ namespace reco {
                                                        const std::vector<std::string>& availableInputs) const;
 
     const DeepSCConfiguration cfg_;
-    std::unique_ptr<tensorflow::GraphDef> graphDef_;
-    tensorflow::Session* session_;
+    std::map<uint, tensorflow::Session*> sessions_;
   };
 
 };  // namespace reco

--- a/RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h
@@ -87,12 +87,12 @@ namespace reco {
     // the Mustache dimension
     std::array<double, 3> dynamicWindow(double seedEta) const;
 
-    DeepSCInputs::FeaturesMap computeVariables(const CaloCluster* seed, const CaloCluster* cluster) const;
+    DeepSCInputs::FeaturesMap computeVariables(const CaloCluster* seed, const CaloCluster* cluster);
     std::vector<std::vector<float>> fillHits(const CaloCluster* cluster) const;
     DeepSCInputs::FeaturesMap computeWindowVariables(const std::vector<DeepSCInputs::FeaturesMap>& clusters) const;
 
     std::pair<double, double> computeCovariances(const CaloCluster* cluster);
-    std::vector<double> computeShowerShapes(const CaloCluster* cluster, bool full5x5);
+    void computeShowerShapes(const CaloCluster* cluster, DeepSCInputs::FeaturesMap&, bool full5x5);
 
     CalibratedPFClusterVector clusters_;
     uint nSeeds_;

--- a/RecoEcal/EgammaCoreTools/interface/GraphMap.h
+++ b/RecoEcal/EgammaCoreTools/interface/GraphMap.h
@@ -31,7 +31,7 @@ namespace reco {
     //Getters
     const std::vector<uint> &getOutEdges(const uint i) const;
     const std::vector<uint> &getInEdges(const uint i) const;
-    uint getAdjMatrix(const uint i, const uint j) const;
+    float getAdjMatrix(const uint i, const uint j) const;
     std::vector<float> getAdjMatrixRow(const uint i) const;
     std::vector<float> getAdjMatrixCol(const uint j) const;
 

--- a/RecoEcal/EgammaCoreTools/interface/SCProducerCache.h
+++ b/RecoEcal/EgammaCoreTools/interface/SCProducerCache.h
@@ -15,16 +15,15 @@ namespace reco {
 
       if (clustering_type == "DeepSC") {
         const auto& pset_dnn = conf.getParameter<edm::ParameterSet>("deepSuperClusterConfig");
-        config.modelFile = pset_dnn.getParameter<std::string>("modelFile");
+        config.modelFiles = pset_dnn.getParameter<std::vector<std::string>>("modelFiles");
         config.configFileClusterFeatures = pset_dnn.getParameter<std::string>("configFileClusterFeatures");
         config.configFileWindowFeatures = pset_dnn.getParameter<std::string>("configFileWindowFeatures");
         config.configFileHitsFeatures = pset_dnn.getParameter<std::string>("configFileHitsFeatures");
         config.nClusterFeatures = pset_dnn.getParameter<uint>("nClusterFeatures");
         config.nWindowFeatures = pset_dnn.getParameter<uint>("nWindowFeatures");
         config.nHitsFeatures = pset_dnn.getParameter<uint>("nHitsFeatures");
-        config.maxNClusters = pset_dnn.getParameter<uint>("maxNClusters");
-        config.maxNRechits = pset_dnn.getParameter<uint>("maxNRechits");
-        config.batchSize = pset_dnn.getParameter<uint>("batchSize");
+        config.maxNClusters = pset_dnn.getParameter<std::vector<uint>>("maxNClusters");
+        config.maxNRechits = pset_dnn.getParameter<std::vector<uint>>("maxNRechits");
         config.collectionStrategy = pset_dnn.getParameter<std::string>("collectionStrategy");
         deepSCEvaluator = std::make_unique<DeepSCGraphEvaluation>(config);
       }

--- a/RecoEcal/EgammaCoreTools/src/DeepSCGraphEvaluation.cc
+++ b/RecoEcal/EgammaCoreTools/src/DeepSCGraphEvaluation.cc
@@ -17,14 +17,93 @@ const std::vector<std::string> DeepSCGraphEvaluation::availableClusterInputs = {
                                                                                 "cl_seed_dPhi",
                                                                                 "cl_seed_dEnergy",
                                                                                 "cl_seed_dEt",
-                                                                                "cl_nxtals"};
+                                                                                "cl_etaWidth",
+                                                                                "cl_phiWidth",
+                                                                                "cl_nxtals",
+                                                                                "cl_swissCross",
+                                                                                "cl_r9",
+                                                                                "cl_sigmaIetaIeta",
+                                                                                "cl_sigmaIetaIphi",
+                                                                                "cl_sigmaIphiIphi",
+                                                                                "cl_f5_swissCross",
+                                                                                "cl_f5_r9",
+                                                                                "cl_f5_sigmaIetaIeta",
+                                                                                "cl_f5_sigmaIetaIphi",
+                                                                                "cl_f5_sigmaIphiIphi"};
 const std::vector<std::string> DeepSCGraphEvaluation::availableWindowInputs = {
-    "max_cl_energy", "max_cl_et",        "max_cl_eta",       "max_cl_phi",          "max_cl_ieta",     "max_cl_iphi",
-    "max_cl_iz",     "max_cl_seed_dEta", "max_cl_seed_dPhi", "max_cl_seed_dEnergy", "max_cl_seed_dEt", "max_cl_nxtals",
-    "min_cl_energy", "min_cl_et",        "min_cl_eta",       "min_cl_phi",          "min_cl_ieta",     "min_cl_iphi",
-    "min_cl_iz",     "min_cl_seed_dEta", "min_cl_seed_dPhi", "min_cl_seed_dEnergy", "min_cl_seed_dEt", "min_cl_nxtals",
-    "avg_cl_energy", "avg_cl_et",        "avg_cl_eta",       "avg_cl_phi",          "avg_cl_ieta",     "avg_cl_iphi",
-    "avg_cl_iz",     "avg_cl_seed_dEta", "avg_cl_seed_dPhi", "avg_cl_seed_dEnergy", "avg_cl_seed_dEt", "avg_cl_nxtals"};
+    "max_cl_energy",
+    "max_cl_et",
+    "max_cl_eta",
+    "max_cl_phi",
+    "max_cl_ieta",
+    "max_cl_iphi",
+    "max_cl_iz",
+    "max_cl_seed_dEta",
+    "max_cl_seed_dPhi",
+    "max_cl_seed_dEnergy",
+    "max_cl_seed_dEt",
+    "max_cl_nxtals",
+    "max_cl_etaWidth",
+    "max_cl_phiWidth",
+    "max_cl_swissCross",
+    "max_cl_r9",
+    "max_cl_sigmaIetaIeta",
+    "max_cl_sigmaIetaIphi",
+    "max_cl_sigmaIphiIphi",
+    "max_cl_f5_swissCross",
+    "max_cl_f5_r9",
+    "max_cl_f5_sigmaIetaIeta",
+    "max_cl_f5_sigmaIetaIphi",
+    "max_cl_f5_sigmaIphiIphi",
+    "min_cl_energy",
+    "min_cl_et",
+    "min_cl_eta",
+    "min_cl_phi",
+    "min_cl_ieta",
+    "min_cl_iphi",
+    "min_cl_iz",
+    "min_cl_seed_dEta",
+    "min_cl_seed_dPhi",
+    "min_cl_seed_dEnergy",
+    "min_cl_seed_dEt",
+    "min_cl_nxtals",
+    "min_cl_etaWidth",
+    "min_cl_phiWidth",
+    "min_cl_swissCross",
+    "min_cl_r9",
+    "min_cl_sigmaIetaIeta",
+    "min_cl_sigmaIetaIphi",
+    "min_cl_sigmaIphiIphi",
+    "min_cl_f5_swissCross",
+    "min_cl_f5_r9",
+    "min_cl_f5_sigmaIetaIeta",
+    "min_cl_f5_sigmaIetaIphi",
+    "min_cl_f5_sigmaIphiIphi",
+    "avg_cl_energy",
+    "avg_cl_et",
+    "avg_cl_eta",
+    "avg_cl_phi",
+    "avg_cl_ieta",
+    "avg_cl_iphi",
+    "avg_cl_iz",
+    "avg_cl_seed_dEta",
+    "avg_cl_seed_dPhi",
+    "avg_cl_seed_dEnergy",
+    "avg_cl_seed_dEt",
+    "avg_cl_nxtals",
+    "avg_cl_etaWidth",
+    "avg_cl_phiWidth",
+    "avg_cl_swissCross",
+    "avg_cl_r9",
+    "avg_cl_sigmaIetaIeta",
+    "avg_cl_sigmaIetaIphi",
+    "avg_cl_sigmaIphiIphi",
+    "avg_cl_f5_swissCross",
+    "avg_cl_f5_r9",
+    "avg_cl_f5_sigmaIetaIeta",
+    "avg_cl_f5_sigmaIetaIphi",
+    "avg_cl_f5_sigmaIphiIphi",
+};
 const std::vector<std::string> DeepSCGraphEvaluation::availableHitsInputs = {"ieta", "iphi", "iz", "en_withfrac"};
 
 DeepSCGraphEvaluation::DeepSCGraphEvaluation(const DeepSCConfiguration& cfg) : cfg_(cfg) {
@@ -52,17 +131,21 @@ DeepSCGraphEvaluation::DeepSCGraphEvaluation(const DeepSCConfiguration& cfg) : c
 }
 
 DeepSCGraphEvaluation::~DeepSCGraphEvaluation() {
-  if (session_ != nullptr)
-    tensorflow::closeSession(session_);
+  for (auto& [i, s] : sessions_) {
+    if (s != nullptr)
+      LogDebug("DeepSCGraphEvaluation") << "Closing sessions: " << i;
+    tensorflow::closeSession(s);
+  }
 }
 
 void DeepSCGraphEvaluation::initTensorFlowGraphAndSession() {
   // load the graph definition
-  LogDebug("DeepSCGraphEvaluation") << "Loading graph";
-  graphDef_ =
-      std::unique_ptr<tensorflow::GraphDef>(tensorflow::loadGraphDef(edm::FileInPath(cfg_.modelFile).fullPath()));
-  LogDebug("DeepSCGraphEvaluation") << "Starting TF sessions";
-  session_ = tensorflow::createSession(graphDef_.get());
+  uint imodel = 0;
+  for (const auto& modelFile : cfg_.modelFiles) {
+    LogDebug("DeepSCGraphEvaluation") << "Loading graph: " << modelFile << " and starting the TF session";
+    sessions_[imodel] = tensorflow::createSession(tensorflow::loadGraphDef(edm::FileInPath(modelFile).fullPath()));
+    imodel++;
+  }
   LogDebug("DeepSCGraphEvaluation") << "TF ready";
 }
 
@@ -120,120 +203,156 @@ std::vector<float> DeepSCGraphEvaluation::getScaledInputs(const DeepSCInputs::Fe
 std::vector<std::vector<float>> DeepSCGraphEvaluation::evaluate(const DeepSCInputs::Inputs& inputs) const {
   LogDebug("DeepSCGraphEvaluation") << "Starting evaluation";
 
-  // Final output
-  std::vector<std::vector<float>> outputs_clustering;
-
   // We need to split the total inputs in N batches of size batchSize (configured in the producer)
   // being careful with the last batch which will have less than batchSize elements
   size_t nInputs = inputs.clustersX.size();
-  uint iB = -1;  // batch index
-  while (nInputs > 0) {
-    iB++;  // go to next batch
-    size_t nItems;
-    if (nInputs >= cfg_.batchSize) {
-      nItems = cfg_.batchSize;
-      nInputs -= cfg_.batchSize;
+  // Final output
+  std::vector<std::vector<float>> outputs_clustering(nInputs);
+
+  // Preparing the two sets of inputs for the small and large model
+  std::map<uint, std::vector<size_t>> windowModelMapping = {{0, {}}, {1, {}}};  // Map between window -> Model
+  // Quickly checking the dimension of each window to assig it to the correct model
+  LogDebug("DeepSCGraphEvaluation") << "Assigning windows to models. Max Ncls " << cfg_.maxNClusters[0]
+                                    << " max Nrechit:" << cfg_.maxNRechits[0];
+  for (size_t i = 0; i < nInputs; i++) {
+    if ((inputs.clustersX[i].size() > cfg_.maxNClusters[0]) || (inputs.maxNRechits[i] > cfg_.maxNRechits[0])) {
+      LogDebug("DeepSCGraphEvaluation") << "wind: " << i << " to model: 1. Nrechits:  " << inputs.maxNRechits[i]
+                                        << " nclusters: " << inputs.clustersX[i].size();
+      windowModelMapping[1].push_back(i);
     } else {
-      nItems = nInputs;
-      nInputs = 0;
+      LogDebug("DeepSCGraphEvaluation") << "wind: " << i << " to model: 0. Nrechits:  " << inputs.maxNRechits[i]
+                                        << " nclusters: " << inputs.clustersX[i].size();
+      windowModelMapping[0].push_back(i);
     }
+  }
 
-    // Inputs
-    tensorflow::Tensor clsX_{tensorflow::DT_FLOAT,
-                             {static_cast<long int>(nItems), cfg_.maxNClusters, cfg_.nClusterFeatures}};
-    tensorflow::Tensor windX_{tensorflow::DT_FLOAT, {static_cast<long int>(nItems), cfg_.nWindowFeatures}};
-    tensorflow::Tensor hitsX_{tensorflow::DT_FLOAT,
-                              {static_cast<long int>(nItems), cfg_.maxNClusters, cfg_.maxNRechits, cfg_.nHitsFeatures}};
-    tensorflow::Tensor isSeedX_{tensorflow::DT_FLOAT, {static_cast<long int>(nItems), cfg_.maxNClusters, 1}};
-    tensorflow::Tensor nClsSize_{tensorflow::DT_FLOAT, {static_cast<long int>(nItems)}};
+  auto nsamples0 = static_cast<long int>(windowModelMapping[0].size());
+  std::map<uint, std::map<std::string, tensorflow::Tensor>> tfInputs = {
+      {0,
+       {{"clsX", {tensorflow::DT_FLOAT, {nsamples0, cfg_.maxNClusters[0], cfg_.nClusterFeatures}}},
+        {"windX", {tensorflow::DT_FLOAT, {nsamples0, cfg_.nWindowFeatures}}},
+        {"hitsX", {tensorflow::DT_FLOAT, {nsamples0, cfg_.maxNClusters[0], cfg_.maxNRechits[0], cfg_.nHitsFeatures}}},
+        {"isSeedX", {tensorflow::DT_FLOAT, {nsamples0, cfg_.maxNClusters[0]}}},
+        {"maskCls", {tensorflow::DT_FLOAT, {nsamples0, cfg_.maxNClusters[0]}}},
+        {"maskRechits", {tensorflow::DT_FLOAT, {nsamples0, cfg_.maxNClusters[0], cfg_.maxNRechits[0]}}}}}};
 
-    // Look on batch dim
-    for (size_t b = 0; b < nItems; b++) {
-      const auto& cls_data = inputs.clustersX[iB * cfg_.batchSize + b];
+  auto nsamples1 = static_cast<long int>(windowModelMapping[1].size());
+  if (nsamples1 > 0) {
+    tfInputs[1] = {
+        {"clsX", {tensorflow::DT_FLOAT, {nsamples1, cfg_.maxNClusters[1], cfg_.nClusterFeatures}}},
+        {"windX", {tensorflow::DT_FLOAT, {nsamples1, cfg_.nWindowFeatures}}},
+        {"hitsX", {tensorflow::DT_FLOAT, {nsamples1, cfg_.maxNClusters[1], cfg_.maxNRechits[1], cfg_.nHitsFeatures}}},
+        {"isSeedX", {tensorflow::DT_FLOAT, {nsamples1, cfg_.maxNClusters[1]}}},
+        {"maskCls", {tensorflow::DT_FLOAT, {nsamples1, cfg_.maxNClusters[1]}}},
+        {"maskRechits", {tensorflow::DT_FLOAT, {nsamples1, cfg_.maxNClusters[1], cfg_.maxNRechits[1]}}}};
+  }
+  // The input tensors are now ready to be filled
+  // Now we can loop on all the elements and fill the correct tensor
+  for (const auto& [modelIdx, windIdx] : windowModelMapping) {
+    auto tf = tfInputs[modelIdx];
+    for (size_t b = 0; b < windIdx.size(); b++) {
+      auto iwindow = windIdx[b];
+      LogTrace("DeepSC") << "Filling window " << iwindow << " row: " << b << " model: " << modelIdx;
+
+      auto tf_clsX = tf["clsX"];
+      auto tf_maskCls = tf["maskCls"];
+
+      const auto& cls_data = inputs.clustersX[iwindow];
       // Loop on clusters
-      for (size_t k = 0; k < cfg_.maxNClusters; k++) {
+      for (size_t k = 0; k < cfg_.maxNClusters[modelIdx]; k++) {
         // Loop on features
         for (size_t z = 0; z < cfg_.nClusterFeatures; z++) {
           if (k < cls_data.size()) {
-            clsX_.tensor<float, 3>()(b, k, z) = float(cls_data[k][z]);
+            tf_clsX.tensor<float, 3>()(b, k, z) = float(cls_data[k][z]);
+            // Clusters mask
+            tf_maskCls.matrix<float>()(b, k) = 1.0;
           } else {
-            clsX_.tensor<float, 3>()(b, k, z) = 0.;
+            tf_clsX.tensor<float, 3>()(b, k, z) = 0.;
+            tf_maskCls.matrix<float>()(b, k) = 0.;
           }
         }
       }
-    }
 
-    // Look on batch dim
-    for (size_t b = 0; b < nItems; b++) {
-      const auto& wind_features = inputs.windowX[iB * cfg_.batchSize + b];
+      auto tf_windX = tf["windX"];
+      const auto& wind_features = inputs.windowX[iwindow];
       // Loop on features
       for (size_t k = 0; k < cfg_.nWindowFeatures; k++) {
-        windX_.matrix<float>()(b, k) = float(wind_features[k]);
+        tf_windX.matrix<float>()(b, k) = float(wind_features[k]);
       }
-    }
 
-    // Look on batch dim
-    for (size_t b = 0; b < nItems; b++) {
-      const auto& hits_data = inputs.hitsX[iB * cfg_.batchSize + b];
+      auto tf_hitsX = tf["hitsX"];
+      auto tf_maskRechits = tf["maskRechits"];
+      const auto& hits_data = inputs.hitsX[iwindow];
       size_t ncls_in_window = hits_data.size();
       // Loop on clusters
-      for (size_t k = 0; k < cfg_.maxNClusters; k++) {
+      for (size_t k = 0; k < cfg_.maxNClusters[modelIdx]; k++) {
         // Check padding
         size_t nhits_in_cluster;
         if (k < ncls_in_window)
           nhits_in_cluster = hits_data[k].size();
         else
           nhits_in_cluster = 0;
-
         // Loop on hits
-        for (size_t j = 0; j < cfg_.maxNRechits; j++) {
+        for (size_t j = 0; j < cfg_.maxNRechits[modelIdx]; j++) {
           // Check the number of clusters and hits for padding
           bool ok = j < nhits_in_cluster;
+          // Rechits masc
+          if (ok) {
+            tf_maskRechits.tensor<float, 3>()(b, k, j) = 1.;
+          } else {
+            tf_maskRechits.tensor<float, 3>()(b, k, j) = 0.;
+          }
           // Loop on rechits features
           for (size_t z = 0; z < cfg_.nHitsFeatures; z++) {
-            if (ok)
-              hitsX_.tensor<float, 4>()(b, k, j, z) = float(hits_data[k][j][z]);
-            else
-              hitsX_.tensor<float, 4>()(b, k, j, z) = 0.;
+            if (ok) {
+              tf_hitsX.tensor<float, 4>()(b, k, j, z) = float(hits_data[k][j][z]);
+            } else {
+              tf_hitsX.tensor<float, 4>()(b, k, j, z) = 0.;
+            }
           }
         }
       }
-    }
 
-    // Look on batch dim
-    for (size_t b = 0; b < nItems; b++) {
-      const auto& isSeed_data = inputs.isSeed[iB * cfg_.batchSize + b];
+      auto tf_isSeedX = tf["isSeedX"];
+      const auto& isSeed_data = inputs.isSeed[iwindow];
       // Loop on clusters
-      for (size_t k = 0; k < cfg_.maxNClusters; k++) {
+      for (size_t k = 0; k < cfg_.maxNClusters[modelIdx]; k++) {
         if (k < isSeed_data.size()) {
-          isSeedX_.tensor<float, 3>()(b, k, 0) = float(isSeed_data[k]);
+          tf_isSeedX.matrix<float>()(b, k) = float(isSeed_data[k]);
         } else {
-          isSeedX_.tensor<float, 3>()(b, k, 0) = 0.;
+          tf_isSeedX.matrix<float>()(b, k) = 0.;
         }
       }
-    }
+    }  //---> loop on rows for each model
+  }    // --> loop on models
 
-    for (size_t b = 0; b < nItems; b++) {
-      nClsSize_.vec<float>()(b) = float(inputs.clustersX[iB * cfg_.batchSize + b].size());
-    }
+  // prepare tensorflow outputs
+  for (auto& [modelIdx, tfInputs] : tfInputs) {
+    // Skip the evaluation if we don't have rows for this model
+    if (windowModelMapping[modelIdx].empty())
+      continue;
+    // Run the models
+    LogDebug("DeepSCGraphEvaluation") << "Run model: " << modelIdx;
 
-    std::vector<std::pair<std::string, tensorflow::Tensor>> feed_dict = {
-        {"input_1", clsX_}, {"input_2", windX_}, {"input_3", hitsX_}, {"input_4", isSeedX_}, {"input_5", nClsSize_}};
+    std::vector<std::pair<std::string, tensorflow::Tensor>> feed_dict = {{"input_1", tfInputs["clsX"]},
+                                                                         {"input_2", tfInputs["windX"]},
+                                                                         {"input_3", tfInputs["hitsX"]},
+                                                                         {"input_4", tfInputs["isSeedX"]},
+                                                                         {"input_5", tfInputs["maskCls"]},
+                                                                         {"input_6", tfInputs["maskRechits"]}};
 
-    // prepare tensorflow outputs
+    // Define the output and run
     std::vector<tensorflow::Tensor> outputs_tf;
-    // // Define the output and run
-    // // Run the models
-    LogDebug("DeepSCGraphEvaluation") << "Run model";
-    tensorflow::run(session_, feed_dict, {"cl_class", "wind_class"}, &outputs_tf);
+    tensorflow::run(sessions_.at(modelIdx), feed_dict, {"cl_class", "wind_class"}, &outputs_tf);
     // Reading the 1st output: clustering probability
     const auto& y_cl = outputs_tf[0].tensor<float, 3>();
     // Iterate on the clusters for each window
-    for (size_t b = 0; b < nItems; b++) {
-      uint ncls = inputs.clustersX[iB * cfg_.batchSize + b].size();
+    for (size_t b = 0; b < windowModelMapping[modelIdx].size(); b++) {
+      auto originalWindIdx = windowModelMapping[modelIdx][b];
+      auto ncls = inputs.clustersX[originalWindIdx].size();
       std::vector<float> cl_output(ncls);
       for (size_t iC = 0; iC < ncls; iC++) {
-        if (iC < cfg_.maxNClusters) {
+        if (iC < cfg_.maxNClusters[modelIdx]) {
           float y = y_cl(b, iC, 0);
           // Applying sigmoid to logit
           cl_output[iC] = 1 / (1 + std::exp(-y));
@@ -242,9 +361,10 @@ std::vector<std::vector<float>> DeepSCGraphEvaluation::evaluate(const DeepSCInpu
           cl_output[iC] = 0;
         }
       }
-      outputs_clustering.push_back(cl_output);
+      // Assign the output to the correct window in the initial ordering
+      // using the model mapping
+      outputs_clustering[originalWindIdx] = cl_output;
     }
   }
-
   return outputs_clustering;
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
@@ -418,6 +418,9 @@ void EcalClustersGraph::evaluateScores() {
       // Fill the scores from seed --> node (i --> j)
       // Not symmetrically, in order to save multiple values for seeds in other
       // seeds windows.
+      // Put the seed self-link score to 1 to make sure that the window is always including the seed
+      // itself.
+      if (i == k) graphMap_.setAdjMatrix(i,j, 1.);
       graphMap_.setAdjMatrix(i, j, scores[i][k]);
       LogTrace("EcalClustersGraph") << "\t" << i << "-->" << j << ": " << scores[i][k];
       k++;

--- a/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
@@ -143,10 +143,6 @@ void EcalClustersGraph::initWindows() {
 
     // The graph associated to each seed includes only other seeds if they have a smaller energy.
     // This is imposed to be consistent with the current trained model, which has been training on "non-overalapping windows".
-    // The effect of connecting all the seeds, and not only the smaller energy ones has been already tested: the reconstruction
-    // differences are negligible (tested with Cascade collection algo).
-    // In the next version of the training this requirement will be relaxed to have a model that fully matches the reconstruction
-    // mechanism in terms of overlapping seeds.
     for (uint icl = is + 1; icl < nCls_; icl++) {
       if (is == icl)
         continue;
@@ -211,7 +207,9 @@ DeepSCInputs::FeaturesMap EcalClustersGraph::computeVariables(const CaloCluster*
   double seed_eta = seed->eta();
   double seed_phi = seed->phi();
   clFeatures["cl_energy"] = cl_energy;                                                                //cl_energy
+  clFeatures["cl_energy_log"] = std::log(cl_energy);                                                  //cl_energy_log
   clFeatures["cl_et"] = cl_energy / std::cosh(cl_eta);                                                //cl_et
+  clFeatures["cl_et_log"] = std::log(clFeatures["cl_et"]);                                            //cl_et_log
   clFeatures["cl_eta"] = cl_eta;                                                                      //cl_eta
   clFeatures["cl_phi"] = cl_phi;                                                                      //cl_phi
   clFeatures["cl_ieta"] = clusterLocal[0];                                                            //cl_ieta/ix

--- a/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClustersGraph.cc
@@ -420,9 +420,12 @@ void EcalClustersGraph::evaluateScores() {
       // seeds windows.
       // Put the seed self-link score to 1 to make sure that the window is always including the seed
       // itself.
-      if (i == k) graphMap_.setAdjMatrix(i,j, 1.);
-      graphMap_.setAdjMatrix(i, j, scores[i][k]);
-      LogTrace("EcalClustersGraph") << "\t" << i << "-->" << j << ": " << scores[i][k];
+      if (j == i)
+        graphMap_.setAdjMatrix(i, j, 1.);
+      else
+        graphMap_.setAdjMatrix(i, j, scores[i][k]);
+      LogTrace("EcalClustersGraph") << "\t" << i << "-->" << j << ": "
+                                    << " score: " << scores[i][k] << " adjmatrix:" << graphMap_.getAdjMatrix(i, j);
       k++;
     }
   }
@@ -442,10 +445,13 @@ void EcalClustersGraph::selectClusters() {
 EcalClustersGraph::EcalGraphOutput EcalClustersGraph::getGraphOutput() {
   EcalClustersGraph::EcalGraphOutput finalWindows_;
   const auto& finalSuperClusters_ = graphMap_.getGraphOutput();
+  LogTrace("EcalClustersGraph") << "Final SuperClusters";
   for (const auto& [is, cls] : finalSuperClusters_) {
+    LogTrace("EcalClustersGraph") << "seed: " << is << ": ";
     CalibratedPFCluster seed = clusters_[is];
     CalibratedPFClusterVector clusters_inWindow;
     for (const auto& ic : cls) {
+      LogTrace("EcalClustersGraph") << "\t\tcl: " << ic;
       clusters_inWindow.push_back(clusters_[ic]);
     }
     finalWindows_.push_back({seed, clusters_inWindow});

--- a/RecoEcal/EgammaCoreTools/src/GraphMap.cc
+++ b/RecoEcal/EgammaCoreTools/src/GraphMap.cc
@@ -42,7 +42,7 @@ const std::vector<uint> &GraphMap::getOutEdges(const uint i) const { return edge
 
 const std::vector<uint> &GraphMap::getInEdges(const uint i) const { return edgesIn_.at(i); };
 
-uint GraphMap::getAdjMatrix(const uint i, const uint j) const { return adjMatrix_.at({i, j}); };
+float GraphMap::getAdjMatrix(const uint i, const uint j) const { return adjMatrix_.at({i, j}); };
 
 std::vector<float> GraphMap::getAdjMatrixRow(const uint i) const {
   std::vector<float> out;

--- a/RecoEcal/EgammaCoreTools/test/testDeepSCinference.py
+++ b/RecoEcal/EgammaCoreTools/test/testDeepSCinference.py
@@ -1,0 +1,281 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: --python_filename step3_RECO_Mustache_cfg.py --eventcontent RECOSIM --datatier GEN-SIM-RECO --fileout file:step3.root --conditions 123X_mcRun3_2021_realistic_v11 --step RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --geometry DB:Extended --filein file:step2.root --era Run3,ctpps_2018 --no_exec --mc --procModifier ecal_deepsc
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('standard')
+options.register('inputFile',
+                 'file:step2.root',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "intputFile")
+options.register('outputFile',
+                 'file:step3.root',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "outputFile")
+                
+options.parseArguments()
+
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+from Configuration.ProcessModifiers.ecal_deepsc_cff import ecal_deepsc
+
+process = cms.Process('ECALClustering',Run3,ctpps_2018,ecal_deepsc)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.RecoSim_cff')
+process.load('PhysicsTools.PatAlgos.slimming.metFilterPaths_cff')
+process.load('Configuration.StandardSequences.PATMC_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(options.inputFile),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('--python_filename nevts:1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-RECO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('step3.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '125X_mcRun3_2022_realistic_v4', '')
+
+# Setup the PFRechitThreshold configuration
+process.myPFRechitThres = cms.ESSource("PoolDBESSource",
+     connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+     toGet = cms.VPSet(
+         cms.PSet(
+             record = cms.string('EcalPFRecHitThresholdsRcd'),
+             tag = cms.string('EcalPFRecHitThresholds_UL_2018_2e3sig')
+         )
+     )
+)
+process.es_prefer_pfRechitThres = cms.ESPrefer("PoolDBESSource","myPFRechitThres")
+
+process.myTPGLinearization = cms.ESSource("PoolDBESSource",
+     connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+     toGet = cms.VPSet(
+         cms.PSet(
+             record = cms.string('EcalTPGLinearizationConstRcd'),
+             tag = cms.string('EcalTPGLinearizationConst_UL_2018_mc')
+         )
+     )
+)
+process.es_prefer_tpgLinearization = cms.ESPrefer("PoolDBESSource","myTPGLinearization")
+
+process.TFileService = cms.Service("TFileService",
+                                   #fileName = cms.string(options.outputFile)
+                                   fileName = cms.string('output.root')
+)
+
+
+# DEBUG logging
+# process.load("FWCore.MessageService.MessageLogger_cfi")
+# process.MessageLogger.cerr.threshold = "DEBUG"
+# process.MessageLogger.debugModules = ["particleFlowSuperClusterECAL"]
+
+
+
+#### DeepSC customization
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.modelFiles = \
+    cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_smallpadding.pb",
+                "RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_largepadding.pb")
+
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_clusters_inputs.txt")
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_window_inputs.txt")
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_hits_inputs.txt")
+
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(15)
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,30)
+process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
+
+
+# Same customization for OOTEcal producer
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.modelFiles = \
+    cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_smallpadding.pb",
+                "RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_largepadding.pb")
+
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_clusters_inputs.txt")
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_window_inputs.txt")
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_hits_inputs.txt")
+
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(15)
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,30)
+process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
+
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.recosim_step = cms.Path(process.recosim)
+process.Flag_BadChargedCandidateFilter = cms.Path(process.BadChargedCandidateFilter)
+process.Flag_BadChargedCandidateSummer16Filter = cms.Path(process.BadChargedCandidateSummer16Filter)
+process.Flag_BadPFMuonDzFilter = cms.Path(process.BadPFMuonDzFilter)
+process.Flag_BadPFMuonFilter = cms.Path(process.BadPFMuonFilter)
+process.Flag_BadPFMuonSummer16Filter = cms.Path(process.BadPFMuonSummer16Filter)
+process.Flag_CSCTightHalo2015Filter = cms.Path(process.CSCTightHalo2015Filter)
+process.Flag_CSCTightHaloFilter = cms.Path(process.CSCTightHaloFilter)
+process.Flag_CSCTightHaloTrkMuUnvetoFilter = cms.Path(process.CSCTightHaloTrkMuUnvetoFilter)
+process.Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(process.EcalDeadCellBoundaryEnergyFilter)
+process.Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(process.EcalDeadCellTriggerPrimitiveFilter)
+process.Flag_HBHENoiseFilter = cms.Path(process.HBHENoiseFilterResultProducer+process.HBHENoiseFilter)
+process.Flag_HBHENoiseIsoFilter = cms.Path(process.HBHENoiseFilterResultProducer+process.HBHENoiseIsoFilter)
+process.Flag_HcalStripHaloFilter = cms.Path(process.HcalStripHaloFilter)
+process.Flag_METFilters = cms.Path(process.metFilters)
+process.Flag_chargedHadronTrackResolutionFilter = cms.Path(process.chargedHadronTrackResolutionFilter)
+process.Flag_ecalBadCalibFilter = cms.Path(process.ecalBadCalibFilter)
+process.Flag_ecalLaserCorrFilter = cms.Path(process.ecalLaserCorrFilter)
+process.Flag_eeBadScFilter = cms.Path(process.eeBadScFilter)
+process.Flag_globalSuperTightHalo2016Filter = cms.Path(process.globalSuperTightHalo2016Filter)
+process.Flag_globalTightHalo2016Filter = cms.Path(process.globalTightHalo2016Filter)
+process.Flag_goodVertices = cms.Path(process.primaryVertexFilter)
+process.Flag_hcalLaserEventFilter = cms.Path(process.hcalLaserEventFilter)
+process.Flag_hfNoisyHitsFilter = cms.Path(process.hfNoisyHitsFilter)
+process.Flag_muonBadTrackFilter = cms.Path(process.muonBadTrackFilter)
+process.Flag_trackingFailureFilter = cms.Path(process.goodVertices+process.trackingFailureFilter)
+process.Flag_trkPOGFilters = cms.Path(process.trkPOGFilters)
+process.Flag_trkPOG_logErrorTooManyClusters = cms.Path(~process.logErrorTooManyClusters)
+process.Flag_trkPOG_manystripclus53X = cms.Path(~process.manystripclus53X)
+process.Flag_trkPOG_toomanystripclus53X = cms.Path(~process.toomanystripclus53X)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+
+# from RecoEgamma.EgammaElectronProducers.gsfElectrons_cfi import *
+# process.ecalDrivenGsfElectrons.EleDNNPFid= dict(
+#         modelsFiles = [
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.pb",
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb"
+#         ],
+#         scalersFiles = [
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_scaler.txt",
+#             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt"
+#         ]
+# )
+# process.ecalDrivenGsfElectrons.EleDNNPFid.enabled = False
+
+# from RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi import *
+# process.gedPhotons.PhotonDNNPFid = dict(
+#         modelsFiles = [ 
+#             "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_modelDNN.pb",
+#             "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_modelDNN.pb"
+#         ],
+#         scalersFiles = [
+#             "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EB/barrel_scaler.txt",
+#             "RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/Run3Summer21_120X/EE/endcap_scaler.txt" 
+#         ]
+# )
+# process.gedPhotons.PhotonDNNPFid.enabled = False
+# process.particleFlowTmp.PFEGammaFiltersParameters.useElePFidDnn = False
+# process.particleFlowTmp.PFEGammaFiltersParameters.usePhotonPFidDnn = False
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.recosim_step,process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadPFMuonDzFilter,process.Flag_hfNoisyHitsFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilter, process.endjob_step)
+process.schedule.associate(process.patTask)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+
+# customisation of the process.
+# Automatic addition of the customisation function from Validation.Performance.IgProfInfo
+from Validation.Performance.IgProfInfo import customise 
+#call to customisation function customise imported from Validation.Performance.IgProfInfo
+process = customise(process)
+
+
+
+# Automatic addition of the customisation function from PhysicsTools.PatAlgos.slimming.miniAOD_tools
+from PhysicsTools.PatAlgos.slimming.miniAOD_tools import miniAOD_customizeAllMC 
+
+#call to customisation function miniAOD_customizeAllMC imported from PhysicsTools.PatAlgos.slimming.miniAOD_tools
+process = miniAOD_customizeAllMC(process)
+
+
+
+# End of customisation functions
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/RecoEcal/EgammaCoreTools/test/testDeepSCinference.py
+++ b/RecoEcal/EgammaCoreTools/test/testDeepSCinference.py
@@ -111,7 +111,124 @@ process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '125X_mcRun3_2022_realistic_v4', '')
 
-# Setup the PFRechitThreshold configuration
+'''
+process.mySCReg = cms.ESSource("PoolDBESSource",
+     toGet = cms.VPSet(
+       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EBCorrection_offline_v2"),
+         tag = cms.string("pfscecal_EBCorrection_offline_v2_2022GammasDeepSCAlgoA"),
+         connect = cms.string("sqlite_file:scReg_2022GammasDeepSCAlgoA.db")),
+       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EECorrection_offline_v2"),
+         tag = cms.string("pfscecal_EECorrection_offline_v2_2022GammasDeepSCAlgoA"),
+         connect = cms.string("sqlite_file:scReg_2022GammasDeepSCAlgoA.db")),
+      cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EBUncertainty_offline_v2"),
+         tag = cms.string("pfscecal_EBUncertainty_offline_v2_2022GammasDeepSCAlgoA"),
+         connect = cms.string("sqlite_file:scReg_2022GammasDeepSCAlgoA.db")),
+      cms.PSet(record = cms.string("GBRDWrapperRcd"),
+         label = cms.untracked.string("pfscecal_EEUncertainty_offline_v2"),
+         tag = cms.string("pfscecal_EEUncertainty_offline_v2_2022GammasDeepSCAlgoA"),
+         connect = cms.string("sqlite_file:scReg_2022GammasDeepSCAlgoA.db")),
+     )
+)
+process.es_prefer_scReg = cms.ESPrefer("PoolDBESSource","mySCReg")
+'''
+
+# process.mySCReg = cms.ESSource("PoolDBESSource",
+#      toGet = cms.VPSet(
+#        cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("pfscecal_EBCorrection_offline_v2"),
+#          tag = cms.string("pfscecal_EBCorrection_offline_v2_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:scReg_2022ElectronsDeepSCAlgoA.db")),
+#        cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("pfscecal_EECorrection_offline_v2"),
+#          tag = cms.string("pfscecal_EECorrection_offline_v2_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:scReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("pfscecal_EBUncertainty_offline_v2"),
+#          tag = cms.string("pfscecal_EBUncertainty_offline_v2_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:scReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("pfscecal_EEUncertainty_offline_v2"),
+#          tag = cms.string("pfscecal_EEUncertainty_offline_v2_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:scReg_2022ElectronsDeepSCAlgoA.db")),
+#      )
+# )
+# process.es_prefer_scReg = cms.ESPrefer("PoolDBESSource","mySCReg")
+
+# process.myPhoReg = cms.ESSource("PoolDBESSource",
+#      toGet = cms.VPSet(
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("photon_eb_ecalOnly_5To300_0p2To2_mean"),
+#          tag = cms.string("photon_eb_ecalOnly_5To300_0p2To2_mean_2022PhotonsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:phoReg_2022PhotonsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("photon_ee_ecalOnly_5To300_0p2To2_mean"),
+#          tag = cms.string("photon_ee_ecalOnly_5To300_0p2To2_mean_2022PhotonsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:phoReg_2022PhotonsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("photon_eb_ecalOnly_5To300_0p0002To0p5_sigma"),
+#          tag = cms.string("photon_eb_ecalOnly_5To300_0p0002To0p5_sigma_2022PhotonsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:phoReg_2022PhotonsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("photon_ee_ecalOnly_5To300_0p0002To0p5_sigma"),
+#          tag = cms.string("photon_ee_ecalOnly_5To300_0p0002To0p5_sigma_2022PhotonsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:phoReg_2022PhotonsDeepSCAlgoA.db")),
+#      ) 
+# )
+# process.es_prefer_phoReg = cms.ESPrefer("PoolDBESSource","myPhoReg")
+
+# process.myEleReg = cms.ESSource("PoolDBESSource",
+#      toGet = cms.VPSet(
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_eb_ecalOnly_1To300_0p2To2_mean"),
+#          tag = cms.string("electron_eb_ecalOnly_1To300_0p2To2_mean_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_ee_ecalOnly_1To300_0p2To2_mean"),
+#          tag = cms.string("electron_ee_ecalOnly_1To300_0p2To2_mean_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_eb_ecalOnly_1To300_0p0002To0p5_sigma"),
+#          tag = cms.string("electron_eb_ecalOnly_1To300_0p0002To0p5_sigma_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_ee_ecalOnly_1To300_0p0002To0p5_sigma"),
+#          tag = cms.string("electron_ee_ecalOnly_1To300_0p0002To0p5_sigma_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_eb_ecalTrk_1To300_0p2To2_mean"),
+#          tag = cms.string("electron_eb_ecalTrk_1To300_0p2To2_mean_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_ee_ecalTrk_1To300_0p2To2_mean"),
+#          tag = cms.string("electron_ee_ecalTrk_1To300_0p2To2_mean_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_eb_ecalTrk_1To300_0p0002To0p5_sigma"),
+#          tag = cms.string("electron_eb_ecalTrk_1To300_0p0002To0p5_sigma_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db")),
+#       cms.PSet(record = cms.string("GBRDWrapperRcd"),
+#          label = cms.untracked.string("electron_ee_ecalTrk_1To300_0p0002To0p5_sigma"),
+#          tag = cms.string("electron_ee_ecalTrk_1To300_0p0002To0p5_sigma_2022ElectronsDeepSCAlgoA"),
+#          connect = cms.string("sqlite_file:EleReg_2022ElectronsDeepSCAlgoA.db"))
+#      ) 
+# )
+# process.es_prefer_eleReg = cms.ESPrefer("PoolDBESSource","myEleReg")
+
+
+#process.myICs = cms.ESSource("PoolDBESSource",
+#     connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+#     toGet = cms.VPSet(
+#         cms.PSet(
+#             record = cms.string('EcalIntercalibConstantsRcd'),
+#             tag = cms.string('EcalIntercalibConstants_MC_Digi_2018')
+#         )
+#     )
+#)
+#process.es_prefer_icReco = cms.ESPrefer("PoolDBESSource","myICs")
+
 process.myPFRechitThres = cms.ESSource("PoolDBESSource",
      connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
      toGet = cms.VPSet(
@@ -141,41 +258,44 @@ process.TFileService = cms.Service("TFileService",
 
 
 # DEBUG logging
-# process.load("FWCore.MessageService.MessageLogger_cfi")
-# process.MessageLogger.cerr.threshold = "DEBUG"
-# process.MessageLogger.debugModules = ["particleFlowSuperClusterECAL"]
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["particleFlowSuperClusterECAL"]
 
 
 
-#### DeepSC customization
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.modelFiles = \
-    cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_smallpadding.pb",
-                "RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_largepadding.pb")
+# #### DeepSC customization
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.modelFiles = \
+#     cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/model_smallpadding.pb",
+#                 "RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/model_largepadding.pb")
 
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_clusters_inputs.txt")
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_window_inputs.txt")
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_hits_inputs.txt")
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/scaler_config_cls_norm.txt")
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/scaler_config_wind_norm.txt")
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/config_hits_inputs.txt")
 
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(15)
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,30)
-process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(17)
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,60)
+# process.particleFlowSuperClusterECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
 
 
-# Same customization for OOTEcal producer
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.modelFiles = \
-    cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_smallpadding.pb",
-                "RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/simpler_rechits/model_largepadding.pb")
+# # # Same customization for OOTEcal producer
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.modelFiles = \
+#     cms.vstring("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/model_smallpadding.pb",
+#                 "RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/model_largepadding.pb")
 
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_clusters_inputs.txt")
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_window_inputs.txt")
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/ACAT2022/config_hits_inputs.txt")
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileClusterFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/scaler_config_cls_norm.txt")
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileWindowFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/scaler_config_wind_norm.txt")
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.configFileHitsFeatures = cms.string("RecoEcal/EgammaClusterProducers/data/DeepSCModels/models_pfthres/model_noise235fb_thres235fb/config_hits_inputs.txt")
 
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(15)
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,30)
-process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nClusterFeatures = cms.uint32(17)
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.nWindowFeatures = cms.uint32(6)
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNClusters = cms.vuint32(15,60)
+# process.particleFlowSuperClusterOOTECAL.deepSuperClusterConfig.maxNRechits = cms.vuint32(20,60)
 
+
+# process.load('RecoSimStudies.Dumpers.RecoSimDumper_cfi')
+# process.dumper_step = cms.Path(process.recosimdumper)
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)
@@ -245,7 +365,7 @@ process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
 # process.particleFlowTmp.PFEGammaFiltersParameters.usePhotonPFidDnn = False
 
 # Schedule definition
-process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.recosim_step,process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadPFMuonDzFilter,process.Flag_hfNoisyHitsFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilter, process.endjob_step)
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.recosim_step,process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadPFMuonDzFilter,process.Flag_hfNoisyHitsFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilters, process.endjob_step)
 process.schedule.associate(process.patTask)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)


### PR DESCRIPTION
#### PR description:

This PR implements an optimization of the DeepSC model inference in Tensorflow. 

Given the large timing difference between models with small/large zero-padded inputs, the idea is to evaluate two different models (with the same weights), but exported with a different internal padding size.

One model with a small zero-padding dimension (N. clusters = 15, max N. rechits = 20, configurable in the producer) and one has  the maximum dimension (N. clusters = 60, max N. rechits = 60).  The correct model to run is selected dynamically by the CMSSW code.    N.B: only one model is trained, and then exported with two different input size (TensorFlow technicality).

In general, the dynamic zero-padding strategy speeds up the evaluation up to ~8X.
The improvement is due to the fact that on average 90% of the windows are evaluated with the smaller
zero-padding, much faster, model. 

Moreover the DeepSC model has been simplified from the version currently available in CMSSW to get a 4X speed-up (simpler rechits layer).

![](https://dvalsecc.web.cern.ch/public/images/perf/cmssw_timing.png)

#### Profiling

Profiled the model on 100 ttbar events

  - no zero-padding optimization [igprof](https://dvalsecc.web.cern.ch/cgi-bin/igprof-navigator/DeepSC/PR131X/pfthres_cl60_rl60_step3_igprofCPU/69).    `PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC`  Rank [69] Reco time: 1.90%
  - zero padding optimization [igprof](https://dvalsecc.web.cern.ch/cgi-bin/igprof-navigator/DeepSC/PR131X/pfthres_cl15_rl20_step3_igprofCPU/252).  `PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC`  Rank [252] Reco time: 0.35%


#### Documentation
- [Poster](https://dvalsecc.web.cern.ch/public/posts/acat2202-deepsc-cms/) at ACAT2022: 
- Presentation at ML production meeting:  [indico](https://indico.cern.ch/event/1219538/#4-deepsc-inference-time-optimi )

#### PR validation:

To be tested along with the updated models in PR https://github.com/cms-data/RecoEcal-EgammaClusterProducers/pull/4.
