### PR TITLE
[13_0_X] Allow access to const edm::{Event,EventSetup} from device::{Event,EventSetup}

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
@@ -47,6 +47,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
     auto streamID() const { return constEvent_.streamID(); }
     auto id() const { return constEvent_.id(); }
 
+    // To be able to interact with non-Alpaka helper code that needs
+    // to access edm::Event
+    operator edm::Event const &() const { return constEvent_; }
+
     Device device() const { return metadata_->device(); }
 
     // Alpaka operations do not accept a temporary as an argument

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h
@@ -22,6 +22,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
   public:
     EventSetup(edm::EventSetup const& iSetup, Device const& dev) : setup_(iSetup), device_(dev) {}
 
+    // To be able to interact with non-Alpaka helper code that needs
+    // to access edm::EventSetup
+    operator edm::EventSetup const &() const { return setup_; }
+
     // getData()
 
     template <typename T, typename R>

--- a/HeterogeneousCore/AlpakaTest/interface/TestHostOnlyHelperClass.h
+++ b/HeterogeneousCore/AlpakaTest/interface/TestHostOnlyHelperClass.h
@@ -1,0 +1,29 @@
+#ifndef HeterogeneousCore_AlpakaTest_interface_TestHostOnlyHelperClass_h
+#define HeterogeneousCore_AlpakaTest_interface_TestHostOnlyHelperClass_h
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/ESTestData.h"
+
+namespace cms::alpakatest {
+  class TestHostOnlyHelperClass {
+  public:
+    TestHostOnlyHelperClass(edm::ParameterSet const& iConfig, edm::ConsumesCollector iC);
+
+    static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
+
+    int run(edm::Event const& iEvent, edm::EventSetup const& iSetup) const;
+
+  private:
+    edm::EDGetTokenT<edmtest::IntProduct> const edToken_;
+    edm::ESGetToken<cms::alpakatest::ESTestDataA, AlpakaESTestRecordA> const esToken_;
+  };
+}  // namespace cms::alpakatest
+
+#endif

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducer.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/TestHostOnlyHelperClass.h"
 
 #include "TestHelperClass.h"
 
@@ -13,6 +14,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    *   - consumes a device EDProduct
    *   - consumes a host ESProduct
    *   - consumes a device ESProduct
+   * - uses a non-Alpaka-aware helper class (need to use edm::ConsumesCollector), that
+   *   - consumes a host EDProduct
+   *   - consumes a host ESProduct
    * - consumes a device ESProduct
    * - produces a host EDProduct
    * - synchronizes in a non-blocking way with the ExternalWork module
@@ -21,10 +25,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlpakaStreamSynchronizingProducer : public stream::SynchronizingEDProducer<> {
   public:
     TestAlpakaStreamSynchronizingProducer(edm::ParameterSet const& iConfig)
-        : esTokenDevice_(esConsumes()), putToken_{produces()}, helper_{iConfig, consumesCollector()} {}
+        : esTokenDevice_(esConsumes()),
+          putToken_{produces()},
+          helper_{iConfig, consumesCollector()},
+          hostHelper_{iConfig, consumesCollector()},
+          expectedInt_{iConfig.getParameter<int>("expectedInt")} {}
 
     void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override {
       [[maybe_unused]] auto const& esData = iSetup.getData(esTokenDevice_);
+
+      int const value = hostHelper_.run(iEvent, iSetup);
+      if (value != expectedInt_) {
+        throw cms::Exception("Assert") << "Expected value " << expectedInt_ << ", but got " << value;
+      }
 
       helper_.makeAsync(iEvent, iSetup);
     }
@@ -35,7 +48,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("source");
+      TestHelperClass::fillPSetDescription(desc);
+      cms::alpakatest::TestHostOnlyHelperClass::fillPSetDescription(desc);
+      desc.add<int>("expectedInt");
       descriptions.addWithDefaultLabel(desc);
     }
 
@@ -44,6 +59,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const edm::EDPutTokenT<portabletest::TestHostCollection> putToken_;
 
     TestHelperClass helper_;
+    cms::alpakatest::TestHostOnlyHelperClass const hostHelper_;
+    int const expectedInt_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.cc
@@ -1,3 +1,5 @@
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
 #include "TestHelperClass.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -5,6 +7,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       : getToken_(iC.consumes(iConfig.getParameter<edm::InputTag>("source"))),
         esTokenHost_(iC.esConsumes()),
         esTokenDevice_(iC.esConsumes()) {}
+
+  void TestHelperClass::fillPSetDescription(edm::ParameterSetDescription& iDesc) { iDesc.add<edm::InputTag>("source"); }
 
   void TestHelperClass::makeAsync(device::Event const& iEvent, device::EventSetup const& iSetup) {
     [[maybe_unused]] auto esDataHostHandle = iSetup.getHandle(esTokenHost_);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestHelperClass.h
@@ -19,6 +19,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     TestHelperClass(edm::ParameterSet const& iConfig, edm::ConsumesCollector iC);
 
+    static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
+
     void makeAsync(device::Event const& iEvent, device::EventSetup const& iSetup);
 
     portabletest::TestHostCollection moveFrom() { return std::move(hostProduct_); }

--- a/HeterogeneousCore/AlpakaTest/src/TestHostOnlyHelperClass.cc
+++ b/HeterogeneousCore/AlpakaTest/src/TestHostOnlyHelperClass.cc
@@ -1,0 +1,18 @@
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/AlpakaTest/interface/TestHostOnlyHelperClass.h"
+
+namespace cms::alpakatest {
+  TestHostOnlyHelperClass::TestHostOnlyHelperClass(edm::ParameterSet const& iConfig, edm::ConsumesCollector iC)
+      : edToken_(iC.consumes(iConfig.getParameter<edm::InputTag>("intSource"))), esToken_(iC.esConsumes()) {}
+
+  void TestHostOnlyHelperClass::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+    iDesc.add<edm::InputTag>("intSource");
+  }
+
+  int TestHostOnlyHelperClass::run(edm::Event const& iEvent, edm::EventSetup const& iSetup) const {
+    auto const& ed = iEvent.get(edToken_);
+    auto const& es = iSetup.getData(esToken_);
+
+    return ed.value + es.value();
+  }
+}  // namespace cms::alpakatest

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -85,7 +85,9 @@ process.alpakaStreamInstanceProducer = cms.EDProducer("TestAlpakaStreamProducer@
     )
 )
 process.alpakaStreamSynchronizingProducer = cms.EDProducer("TestAlpakaStreamSynchronizingProducer@alpaka",
-    source = cms.InputTag("alpakaGlobalProducer")
+    source = cms.InputTag("alpakaGlobalProducer"),
+    intSource = cms.InputTag("intProduct"),
+    expectedInt = cms.int32(84) # sum of intProduct and esProducerA
 )
 
 process.alpakaGlobalConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/40849. Original PR description
> Giving access to `edm::{Event,EventSetup}` from `device::{Event,EventSetup}` allows interaction with helper code needing `edm::{Event,EventSetup}` from Alpaka EDModules.

#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/40849

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #40849 to support Alpaka development (and eventual deployment) in 13_0_X.