### PR TITLE
Herwig lhe matching fix

### DIFF
--- a/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
@@ -6,7 +6,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,

--- a/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,
@@ -40,7 +40,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
 )
 
 

--- a/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -7,5 +7,5 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
   args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/UL/13TeV/madgraph/V5_2.6.5/dyellell01234j_5f_LO_MLM_v2/DYJets_HT-incl_slc6_amd64_gcc630_CMSSW_9_3_16_tarball.tar.xz','false','slc6_amd64_gcc630','CMSSW_9_3_16'),
   nEvents = cms.untracked.uint32(10),
   generateConcurrently = cms.untracked.bool(True),
-  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7LHECommonSettingsBlock = cms.PSet(
 
         # set the weight option (e.g. for MC@NLO)
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
 
         'set /Herwig/Generators/EventGenerator:EventHandler /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7MGMergingSettingsBlock = cms.PSet(
         'set LesHouchesHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',
         'set LesHouchesHandler:DecayHandler /Herwig/Decays/DecayHandler',
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
         'set /Herwig/Generators/EventGenerator:EventHandler  /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',
         'cd /Herwig/EventHandlers',

--- a/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
+++ b/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
@@ -7,7 +7,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7LHECommonSettings_cfi import
 from Configuration.Generator.Herwig7Settings.Herwig7LHEPowhegSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7LHECommonSettingsBlock,

--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -7,7 +7,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )
 
 #Link to datacards:

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -52,9 +52,11 @@ namespace lhef {
 
     int npLO() const { return npLO_; }
     int npNLO() const { return npNLO_; }
+    int evtnum() const { return evtnum_; }
 
     void setNpLO(int n) { npLO_ = n; }
     void setNpNLO(int n) { npNLO_ = n; }
+    void setEvtNum(int n) { evtnum_ = n; }
 
     void addComment(const std::string &line) { comments.push_back(line); }
 
@@ -93,6 +95,7 @@ namespace lhef {
     std::vector<float> scales_;  //scale value used to exclude EWK-produced partons from matching
     int npLO_;                   //number of partons for LO process (used to steer matching/merging)
     int npNLO_;                  //number of partons for NLO process (used to steer matching/merging)
+    int evtnum_;  //The number of the event (needed to ensure the correct LHE events are saved for MG +Herwig)
   };
 
 }  // namespace lhef

--- a/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
+++ b/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+import logging
+import argparse
+import sys
+import os
+import re
+
+
+def number_events(input_file, output_file=None, offset=0):
+    if output_file is None:
+        output_file = input_file
+    if not os.path.exists(os.path.dirname(os.path.realpath(output_file))):
+        os.makedirs(os.path.dirname(os.path.realpath(output_file)))
+
+    nevent = offset
+    with open('tmp.txt', 'w') as fw:
+        with open(input_file, 'r') as ftmp:
+            for line in ftmp:
+                if re.search('\s*</event>', line):
+                    nevent += 1
+                    fw.write('<event_num num="' + str(nevent) +  '"> ' + str(nevent) + '</event_num>\n')
+                fw.write(line)
+    if output_file is not None:
+        os.rename("tmp.txt", output_file)
+    else:
+        os.rename("tmp.txt", input_file)
+    return nevent
+
+
+if __name__=="__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Add numbers to lhe")
+    parser.add_argument("input_file", type=str,
+                        help="Input LHE file path.")
+    parser.add_argument("-o", "--output-file", default=None, type=str,
+                        help="Output LHE file path. If not specified, output to input file")
+    args = parser.parse_args()
+
+    logging.info('>>> launch addLHEnumbers.py in %s' % os.path.abspath(os.getcwd()))
+
+    logging.info('>>> Input file: [%s]' % args.input_file)
+    logging.info('>>> Write to output: %s ' % args.output_file)
+
+    number_events(args.input_file, args.output_file)

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -141,6 +141,7 @@ namespace lhef {
     int npLO;
     int npNLO;
     std::vector<float> scales;
+    int evtnum = -1;
   };
 
   static void attributesToDom(DOMElement *dom, const Attributes &attributes) {
@@ -215,6 +216,9 @@ namespace lhef {
 
           scales.push_back(scaleval);
         }
+      } else if (name == "event_num") {
+        const char *evtnumstr = XMLSimpleStr(attributes.getValue(XMLString::transcode("num")));
+        sscanf(evtnumstr, "%d", &evtnum);
       }
       xmlEventNodes.push_back(elem);
       return;
@@ -526,6 +530,8 @@ namespace lhef {
           }
           lheevent->setNpLO(handler->npLO);
           lheevent->setNpNLO(handler->npNLO);
+          lheevent->setEvtNum(handler->evtnum);
+          handler->evtnum = -1;
           //fill scales
           if (!handler->scales.empty()) {
             lheevent->setScales(handler->scales);


### PR DESCRIPTION
#### PR description:

Adds a HadronizerFilter mode to the Herwig7Interface, which uses numbering of LHE events to ensure that the LHE and Gen level events in the CMS event record match up- previously this was not the case for processes with merging, as Herwig would skip events silently. Should be tested with https://github.com/cms-sw/cmsdist/pull/8349, which propagates the LHE numbering through Herwig.

#### PR validation:

Have tested the functionality works in CMSSW_10_6. Have also updated all Herwig validation examples with the new HadronizerFilter, and they all work
