### PR TITLE
`SiPixelPayloadInspectorHelper`: fix warning: '<anonymous>' may be used uninitialized

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -36,7 +36,7 @@
 
 namespace SiPixelPI {
 
-  enum phase { zero = 0, one = 1, two = 2 };
+  enum phase { zero = 0, one = 1, two = 2, undefined = 999 };
 
   // size of the phase-0 pixel detID list
   static const unsigned int phase0size = 1440;
@@ -664,7 +664,7 @@ namespace SiPixelPI {
     int m_side;
     int m_ring;
     bool m_isInternal;
-    SiPixelPI::phase* m_Phase;
+    SiPixelPI::phase m_Phase;
 
   public:
     void init();
@@ -687,6 +687,7 @@ namespace SiPixelPI {
   inline void topolInfo::init()
   /*--------------------------------------------------------------------*/
   {
+    m_Phase = SiPixelPI::undefined;
     m_rawid = 0;
     m_subdetid = -1;
     m_layer = -1;
@@ -710,7 +711,7 @@ namespace SiPixelPI {
   /*--------------------------------------------------------------------*/
   {
     // set the phase
-    m_Phase = const_cast<SiPixelPI::phase*>(&ph);
+    m_Phase = ph;
     unsigned int subdetId = static_cast<unsigned int>(detId.subdetId());
 
     m_rawid = detId.rawId();
@@ -733,7 +734,7 @@ namespace SiPixelPI {
   {
     SiPixelPI::regions ret = SiPixelPI::NUM_OF_REGIONS;
 
-    if (m_Phase == nullptr) {
+    if (m_Phase == SiPixelPI::undefined) {
       throw cms::Exception("LogicError") << "Cannot call filterThePartition BEFORE filling the geometry info!";
     }
 
@@ -769,7 +770,7 @@ namespace SiPixelPI {
           m_side > 1 ? ret = SiPixelPI::FPixpL3 : ret = SiPixelPI::FPixmL3;
           break;
         default:
-          if (*m_Phase < SiPixelPI::phase::two) {
+          if (m_Phase < SiPixelPI::phase::two) {
             // warning message only if the phase2 is < 2
             edm::LogWarning("LogicError") << "Unknow FPix disk: " << m_layer;
           }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -197,6 +197,8 @@ namespace {
         case SiPixelPI::phase::two:
           inputFile = "Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml";
           break;
+        default:
+          throw cms::Exception("SiPixelDynamicInefficiency_PayloadInspector") << "checkPhase: unrecongnized phase!";
       }
 
       // create the standalone tracker topology


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/40945

#### PR description:

Title says it all, solved by removing the usage of pointers (which are not needed) in `SiPixelPI::topolInfo`.

#### PR validation:

Compiled in `CMSSW_13_1_DBG_X_2023-03-02-2300`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A