### PR TITLE
Run3-alca238X Modify the output content for 2 isolated bunch AlCaReco modules of HCAL (backporting PR #40952 to CMSSW_13_0_X)

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsolatedBunchFilter_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsolatedBunchFilter_Output_cff.py
@@ -15,6 +15,7 @@ OutALCARECOHcalCalIsolatedBunchFilter_noDrop = cms.PSet(
         'keep *_hltTriggerSummaryAOD_*_*',
         'keep *_TriggerResults_*_*',
         'keep HcalNoiseSummary_hcalnoise_*_*',
+        'keep *_HBHEChannelInfo_*_*',
         'keep  FEDRawDataCollection_rawDataCollector_*_*',
         'keep  FEDRawDataCollection_source_*_*',
         )

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsolatedBunchSelector_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalIsolatedBunchSelector_Output_cff.py
@@ -15,6 +15,7 @@ OutALCARECOHcalCalIsolatedBunchSelector_noDrop = cms.PSet(
         'keep *_hltTriggerSummaryAOD_*_*',
         'keep *_TriggerResults_*_*',
         'keep HcalNoiseSummary_hcalnoise_*_*',
+        'keep *_HBHEChannelInfo_*_*',
         'keep  FEDRawDataCollection_rawDataCollector_*_*',
         'keep  FEDRawDataCollection_source_*_*',
         )


### PR DESCRIPTION
#### PR description:

Modify the output content for 2 isolated bunch AlCaReco modules of HCAL (back porting PR #40952 to CMSSW_13_0_X)

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of PR #40952