### PR TITLE
Migrate consumesMany to GetterOfProducts in DQMServices

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.cc
@@ -8,6 +8,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
 #include "DataFormats/Histograms/interface/DQMToken.h"
 
 #include "DQMFileSaverBase.h"
@@ -43,8 +45,12 @@ DQMFileSaverBase::DQMFileSaverBase(const edm::ParameterSet &ps) {
   runNumber_ = ps.getUntrackedParameter<int>("runNumber", 111);
 
   // This makes sure a file saver runs in a very end
-  consumesMany<DQMToken, edm::InLumi>();
-  consumesMany<DQMToken, edm::InRun>();
+  lumigetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InLumi);
+  rungetter_ = edm::GetterOfProducts<DQMToken>(edm::ProcessMatch("*"), this, edm::InRun);
+  callWhenNewProductsRegistered([this](edm::BranchDescription const &bd) {
+    this->lumigetter_(bd);
+    this->rungetter_(bd);
+  });
 }
 
 DQMFileSaverBase::~DQMFileSaverBase() = default;

--- a/DQMServices/FileIO/plugins/DQMFileSaverBase.h
+++ b/DQMServices/FileIO/plugins/DQMFileSaverBase.h
@@ -9,6 +9,10 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
+
+#include "DataFormats/Histograms/interface/DQMToken.h"
 
 #include <sys/time.h>
 #include <string>
@@ -71,10 +75,12 @@ namespace dqm {
     FileParameters initial_fp_;
     int runNumber_;
 
+    edm::GetterOfProducts<DQMToken> lumigetter_;
+    edm::GetterOfProducts<DQMToken> rungetter_;
+
   public:
     static void fillDescription(edm::ParameterSetDescription &d);
   };
-
 }  // namespace dqm
 
 #endif  // DQMSERVICES_COMPONENTS_DQMFILESAVERBASE_H


### PR DESCRIPTION
#### PR description:
Based on PR #40167 .
Migrate DQMServices core codes away from consumesMany() to use edm::GetterOfProducts().

        modified:   DQMServices/Components/plugins/MEtoEDMConverter.cc
        modified:   DQMServices/FileIO/plugins/DQMFileSaverBase.cc
        modified:   DQMServices/FileIO/plugins/DQMFileSaverBase.h


#### PR validation:
Tested in CMSSW_13_0_0_pre4, the basic test passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)