### PR TITLE
DAQ: New input source (13_1_X)

### DIFF
--- a/EventFilter/Utilities/BuildFile.xml
+++ b/EventFilter/Utilities/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="tbb"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/TCDS"/>
+<use name="DataFormats/L1Trigger"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -1,0 +1,200 @@
+#ifndef EventFilter_Utilities_DAQSource_h
+#define EventFilter_Utilities_DAQSource_h
+
+#include <condition_variable>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "oneapi/tbb/concurrent_queue.h"
+#include "oneapi/tbb/concurrent_vector.h"
+
+#include "FWCore/Sources/interface/RawInputSource.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+
+//import InputChunk
+#include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+
+class FEDRawDataCollection;
+class InputSourceDescription;
+class ParameterSet;
+
+class RawInputFile;
+class DataMode;
+
+class DataModeFRD;
+
+namespace evf {
+  class FastMonitoringService;
+  namespace FastMonState {
+    enum InputState : short;
+  }
+}  // namespace evf
+
+class DAQSource : public edm::RawInputSource {
+  friend class RawInputFile;
+  friend struct InputChunk;
+
+public:
+  explicit DAQSource(edm::ParameterSet const&, edm::InputSourceDescription const&);
+  ~DAQSource() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  std::pair<bool, unsigned int> getEventReport(unsigned int lumi, bool erase);
+  bool useL1EventID() const { return useL1EventID_; }
+  int currentLumiSection() const { return currentLumiSection_; }
+  int eventRunNumber() const { return eventRunNumber_; }
+  void makeEventWrapper(edm::EventPrincipal& eventPrincipal, edm::EventAuxiliary& aux) {
+    makeEvent(eventPrincipal, aux);
+  }
+  bool fileListLoopMode() { return fileListLoopMode_; }
+
+  edm::ProcessHistoryID& processHistoryID() { return processHistoryID_; }
+
+protected:
+  Next checkNext() override;
+  void read(edm::EventPrincipal& eventPrincipal) override;
+  void setMonState(evf::FastMonState::InputState state);
+  void setMonStateSup(evf::FastMonState::InputState state);
+
+private:
+  void rewind_() override;
+  inline evf::EvFDaqDirector::FileStatus getNextEventFromDataBlock();
+  inline evf::EvFDaqDirector::FileStatus getNextDataBlock();
+
+  void maybeOpenNewLumiSection(const uint32_t lumiSection);
+
+  void readSupervisor();
+  void dataArranger();
+  void readWorker(unsigned int tid);
+  void threadError();
+  bool exceptionState() { return setExceptionState_; }
+
+  //monitoring
+  void reportEventsThisLumiInSource(unsigned int lumi, unsigned int events);
+
+  long initFileList();
+  evf::EvFDaqDirector::FileStatus getFile(unsigned int& ls, std::string& nextFile, uint64_t& lockWaitTime);
+
+  //variables
+  evf::FastMonitoringService* fms_ = nullptr;
+  evf::EvFDaqDirector* daqDirector_ = nullptr;
+
+  const std::string dataModeConfig_;
+  uint64_t eventChunkSize_;   // for buffered read-ahead
+  uint64_t maxChunkSize_;     // for buffered read-ahead
+  uint64_t eventChunkBlock_;  // how much read(2) asks at the time
+  unsigned int readBlocks_;
+  unsigned int numBuffers_;
+  unsigned int maxBufferedFiles_;
+  unsigned int numConcurrentReads_;
+  std::atomic<unsigned int> readingFilesCount_;
+
+  // get LS from filename instead of event header
+  const bool alwaysStartFromFirstLS_;
+  const bool verifyChecksum_;
+  const bool useL1EventID_;
+  const std::vector<unsigned int> testTCDSFEDRange_;
+  std::vector<std::string> listFileNames_;
+  bool useFileBroker_;
+  //std::vector<std::string> fileNamesSorted_;
+
+  const bool fileListMode_;
+  unsigned int fileListIndex_ = 0;
+  const bool fileListLoopMode_;
+  unsigned int loopModeIterationInc_ = 0;
+
+  edm::RunNumber_t runNumber_;
+  std::string fuOutputDir_;
+
+  edm::ProcessHistoryID processHistoryID_;
+
+  unsigned int currentLumiSection_;
+  uint32_t eventRunNumber_ = 0;
+  uint32_t GTPEventID_ = 0;
+  unsigned int eventsThisLumi_;
+  unsigned long eventsThisRun_ = 0;
+  std::default_random_engine rng_;
+
+  /*
+   *
+   * Multithreaded file reader
+   *
+   **/
+
+  typedef std::pair<RawInputFile*, InputChunk*> ReaderInfo;
+
+  std::unique_ptr<RawInputFile> currentFile_;
+  bool chunkIsFree_ = false;
+
+  bool startedSupervisorThread_ = false;
+  std::unique_ptr<std::thread> readSupervisorThread_;
+  std::unique_ptr<std::thread> dataArrangerThread_;
+  std::vector<std::thread*> workerThreads_;
+
+  tbb::concurrent_queue<unsigned int> workerPool_;
+  std::vector<ReaderInfo> workerJob_;
+
+  tbb::concurrent_queue<InputChunk*> freeChunks_;
+  tbb::concurrent_queue<std::unique_ptr<RawInputFile>> fileQueue_;
+
+  std::mutex mReader_;
+  std::vector<std::condition_variable*> cvReader_;
+  std::vector<unsigned int> tid_active_;
+
+  std::atomic<bool> quit_threads_;
+  std::vector<unsigned int> thread_quit_signal;
+  bool setExceptionState_ = false;
+  std::mutex startupLock_;
+  std::condition_variable startupCv_;
+
+  int currentFileIndex_ = -1;
+  std::list<std::pair<int, std::unique_ptr<InputFile>>> filesToDelete_;
+  std::mutex fileDeleteLock_;
+  std::vector<int> streamFileTracker_;
+  unsigned int nStreams_ = 0;
+  unsigned int checkEvery_ = 10;
+
+  //supervisor thread wakeup
+  std::mutex mWakeup_;
+  std::condition_variable cvWakeup_;
+
+  //variables for the single buffered mode
+  int fileDescriptor_ = -1;
+
+  std::atomic<bool> threadInit_;
+
+  std::map<unsigned int, unsigned int> sourceEventsReport_;
+  std::mutex monlock_;
+
+  std::shared_ptr<DataMode> dataMode_;
+};
+
+class RawInputFile : public InputFile {
+public:
+  RawInputFile(evf::EvFDaqDirector::FileStatus status,
+               unsigned int lumi = 0,
+               std::string const& name = std::string(),
+               bool deleteFile = true,
+               int rawFd = -1,
+               uint64_t fileSize = 0,
+               uint16_t rawHeaderSize = 0,
+               uint32_t nChunks = 0,
+               int nEvents = 0,
+               DAQSource* parent = nullptr)
+      : InputFile(status, lumi, name, deleteFile, rawFd, fileSize, rawHeaderSize, nChunks, nEvents, nullptr),
+        sourceParent_(parent) {}
+  bool advance(unsigned char*& dataPosition, const size_t size);
+
+private:
+  DAQSource* sourceParent_;
+};
+
+#endif  // EventFilter_Utilities_DAQSource_h

--- a/EventFilter/Utilities/interface/DAQSourceModels.h
+++ b/EventFilter/Utilities/interface/DAQSourceModels.h
@@ -1,0 +1,72 @@
+#ifndef EventFilter_Utilities_DAQSourceModels_h
+#define EventFilter_Utilities_DAQSourceModels_h
+
+#include <condition_variable>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "tbb/concurrent_queue.h"
+#include "tbb/concurrent_vector.h"
+
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+#include "FWCore/Sources/interface/RawInputSource.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Sources/interface/DaqProvenanceHelper.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "IOPool/Streamer/interface/FRDEventMessage.h"
+
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
+
+//import InputChunk
+#include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+
+class DAQSource;
+
+//evf?
+class DataMode {
+public:
+  DataMode(DAQSource* daqSource) : daqSource_(daqSource) {}
+  virtual ~DataMode() = default;
+  virtual std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() = 0;
+  virtual void readEvent(edm::EventPrincipal& eventPrincipal) = 0;
+  virtual int dataVersion() const = 0;
+  virtual void detectVersion(unsigned char* fileBuf, uint32_t fileHeaderOffset) = 0;
+  virtual uint32_t headerSize() const = 0;
+  virtual bool versionCheck() const = 0;
+  virtual uint64_t dataBlockSize() const = 0;
+  virtual void makeDataBlockView(unsigned char* addr,
+                                 size_t maxSize,
+                                 std::vector<uint64_t> const& fileSizes,
+                                 size_t fileHeaderSize) = 0;
+  virtual bool nextEventView() = 0;
+  virtual bool checksumValid() = 0;
+  virtual std::string getChecksumError() const = 0;
+  virtual bool isRealData() const = 0;
+  virtual uint32_t run() const = 0;
+  virtual bool dataBlockCompleted() const = 0;
+  virtual bool requireHeader() const = 0;
+  virtual bool fitToBuffer() const = 0;
+
+  virtual bool dataBlockInitialized() const = 0;
+  virtual void setDataBlockInitialized(bool) = 0;
+
+  virtual void setTCDSSearchRange(uint16_t, uint16_t) = 0;
+  virtual std::pair<bool, std::vector<std::string>> defineAdditionalFiles(std::string const& primaryName,
+                                                                          bool fileListMode) const = 0;
+
+  virtual bool isMultiDir() { return false; }
+  virtual void makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) = 0;
+  void setTesting(bool testing) { testing_ = testing; }
+
+protected:
+  DAQSource* daqSource_;
+  bool testing_ = false;
+};
+
+#endif  // EventFilter_Utilities_DAQSourceModels_h

--- a/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsFRD.h
@@ -1,0 +1,200 @@
+#ifndef EventFilter_Utilities_DAQSourceModelsFRD_h
+#define EventFilter_Utilities_DAQSourceModelsFRD_h
+
+#include <filesystem>
+
+#include "EventFilter/Utilities/interface/DAQSourceModels.h"
+
+class FEDRawDataCollection;
+
+class DataModeFRD : public DataMode {
+public:
+  DataModeFRD(DAQSource* daqSource) : DataMode(daqSource) {}
+  ~DataModeFRD() override{};
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
+  void readEvent(edm::EventPrincipal& eventPrincipal) override;
+
+  //non-virtual
+  edm::Timestamp fillFEDRawDataCollection(FEDRawDataCollection& rawData,
+                                          bool& tcdsInRange,
+                                          unsigned char*& tcds_pointer);
+
+  int dataVersion() const override { return detectedFRDversion_; }
+  void detectVersion(unsigned char* fileBuf, uint32_t fileHeaderOffset) override {
+    detectedFRDversion_ = *((uint16_t*)(fileBuf + fileHeaderOffset));
+  }
+
+  uint32_t headerSize() const override { return FRDHeaderVersionSize[detectedFRDversion_]; }
+
+  bool versionCheck() const override { return detectedFRDversion_ <= FRDHeaderMaxVersion; }
+
+  uint64_t dataBlockSize() const override { return event_->size(); }
+
+  void makeDataBlockView(unsigned char* addr,
+                         size_t maxSize,
+                         std::vector<uint64_t> const& fileSizes,
+                         size_t fileHeaderSize) override {
+    dataBlockAddr_ = addr;
+    dataBlockMax_ = maxSize;
+    eventCached_ = false;
+    nextEventView();
+    eventCached_ = true;
+  }
+
+  bool nextEventView() override;
+  bool checksumValid() override;
+  std::string getChecksumError() const override;
+
+  bool isRealData() const override { return event_->isRealData(); }
+
+  uint32_t run() const override { return event_->run(); }
+
+  //true for DAQ3 FRD
+  bool dataBlockCompleted() const override { return true; }
+
+  bool requireHeader() const override { return true; }
+
+  bool fitToBuffer() const override { return false; }
+  bool dataBlockInitialized() const override { return true; }
+
+  void setDataBlockInitialized(bool) override{};
+
+  void setTCDSSearchRange(uint16_t MINTCDSuTCAFEDID, uint16_t MAXTCDSuTCAFEDID) override {
+    MINTCDSuTCAFEDID_ = MINTCDSuTCAFEDID;
+    MAXTCDSuTCAFEDID_ = MAXTCDSuTCAFEDID;
+  }
+
+  void makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) override {}
+
+  std::pair<bool, std::vector<std::string>> defineAdditionalFiles(std::string const& primaryName, bool) const override {
+    return std::make_pair(true, std::vector<std::string>());
+  }
+
+private:
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>> daqProvenanceHelpers_;
+  uint16_t detectedFRDversion_ = 0;
+  size_t headerSize_ = 0;
+  std::unique_ptr<FRDEventMsgView> event_;
+  uint32_t crc_ = 0;
+  unsigned char* dataBlockAddr_ = nullptr;
+  size_t dataBlockMax_ = 0;
+  size_t fileHeaderSize_ = 0;
+  uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
+  uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
+  bool eventCached_ = false;
+};
+
+/* 
+ * Demo for FRD source reading files from multiple striped destinations
+ *
+ * */
+
+class DataModeFRDStriped : public DataMode {
+public:
+  DataModeFRDStriped(DAQSource* daqSource) : DataMode(daqSource) {}
+  ~DataModeFRDStriped() override{};
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
+  void readEvent(edm::EventPrincipal& eventPrincipal) override;
+
+  //non-virtual
+  edm::Timestamp fillFRDCollection(FEDRawDataCollection& rawData, bool& tcdsInRange, unsigned char*& tcds_pointer);
+
+  int dataVersion() const override { return detectedFRDversion_; }
+  void detectVersion(unsigned char* fileBuf, uint32_t fileHeaderOffset) override {
+    detectedFRDversion_ = *((uint16_t*)(fileBuf + fileHeaderOffset));
+  }
+
+  uint32_t headerSize() const override { return FRDHeaderVersionSize[detectedFRDversion_]; }
+
+  bool versionCheck() const override { return detectedFRDversion_ <= FRDHeaderMaxVersion; }
+
+  uint64_t dataBlockSize() const override {
+    //just get first event size
+    if (events_.empty())
+      throw cms::Exception("DataModeFRDStriped::dataBlockSize") << " empty event array";
+    return events_[0]->size();
+  }
+
+  void makeDataBlockView(unsigned char* addr,
+                         size_t maxSize,
+                         std::vector<uint64_t> const& fileSizes,
+                         size_t fileHeaderSize) override {
+    fileHeaderSize_ = fileHeaderSize;
+    numFiles_ = fileSizes.size();
+    //add offset address for each file payload
+    dataBlockAddrs_.clear();
+    dataBlockAddrs_.push_back(addr);
+    dataBlockMaxAddrs_.clear();
+    dataBlockMaxAddrs_.push_back(addr + fileSizes[0] - fileHeaderSize);
+    auto fileAddr = addr;
+    for (unsigned int i = 1; i < fileSizes.size(); i++) {
+      fileAddr += fileSizes[i - 1];
+      dataBlockAddrs_.push_back(fileAddr);
+      dataBlockMaxAddrs_.push_back(fileAddr + fileSizes[i] - fileHeaderSize);
+    }
+
+    dataBlockMax_ = maxSize;
+    blockCompleted_ = false;
+    //set event cached as we set initial address here
+    bool result = makeEvents();
+    assert(result);
+    eventCached_ = true;
+    setDataBlockInitialized(true);
+  }
+
+  bool nextEventView() override;
+  bool checksumValid() override;
+  std::string getChecksumError() const override;
+
+  bool isRealData() const override {
+    assert(!events_.empty());
+    return events_[0]->isRealData();
+  }
+
+  uint32_t run() const override {
+    assert(!events_.empty());
+    return events_[0]->run();
+  }
+
+  bool dataBlockCompleted() const override { return blockCompleted_; }
+
+  bool requireHeader() const override { return true; }
+
+  bool fitToBuffer() const override { return true; }
+
+  bool dataBlockInitialized() const override { return dataBlockInitialized_; }
+
+  void setDataBlockInitialized(bool val) override { dataBlockInitialized_ = val; };
+
+  void setTCDSSearchRange(uint16_t MINTCDSuTCAFEDID, uint16_t MAXTCDSuTCAFEDID) override {
+    MINTCDSuTCAFEDID_ = MINTCDSuTCAFEDID;
+    MAXTCDSuTCAFEDID_ = MAXTCDSuTCAFEDID;
+  }
+
+  void makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) override;
+
+  std::pair<bool, std::vector<std::string>> defineAdditionalFiles(std::string const& primaryName,
+                                                                  bool fileListMode) const override;
+
+private:
+  bool makeEvents();
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>> daqProvenanceHelpers_;  //
+  uint16_t detectedFRDversion_ = 0;
+  size_t fileHeaderSize_ = 0;
+  size_t headerSize_ = 0;
+  std::vector<std::unique_ptr<FRDEventMsgView>> events_;
+  std::string crcMsg_;
+  unsigned char* dataBlockAddr_ = nullptr;
+  std::vector<unsigned char*> dataBlockAddrs_;
+  std::vector<unsigned char*> dataBlockMaxAddrs_;
+  size_t dataBlockMax_ = 0;
+  short numFiles_ = 0;
+  bool dataBlockInitialized_ = false;
+  bool blockCompleted_ = true;
+  bool eventCached_ = false;
+  uint16_t MINTCDSuTCAFEDID_ = FEDNumbering::MINTCDSuTCAFEDID;
+  uint16_t MAXTCDSuTCAFEDID_ = FEDNumbering::MAXTCDSuTCAFEDID;
+  std::vector<std::filesystem::path> buPaths_;
+};
+
+#endif  // EventFilter_Utilities_DAQSourceModelsFRD_h

--- a/EventFilter/Utilities/interface/DAQSourceModelsScouting.h
+++ b/EventFilter/Utilities/interface/DAQSourceModelsScouting.h
@@ -1,0 +1,268 @@
+#ifndef EventFilter_Utilities_DAQSourceModelsScouting_h
+#define EventFilter_Utilities_DAQSourceModelsScouting_h
+
+#include <memory>
+
+#include "EventFilter/Utilities/interface/DAQSourceModels.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+
+namespace scouting {
+  struct muon {
+    uint32_t f;
+    uint32_t s;
+  };
+
+  struct block {
+    uint32_t bx;
+    uint32_t orbit;
+    muon mu[16];
+  };
+
+  struct masks {
+    static constexpr uint32_t phiext = 0x3ff;
+    static constexpr uint32_t pt = 0x1ff;
+    static constexpr uint32_t qual = 0xf;
+    static constexpr uint32_t etaext = 0x1ff;
+    static constexpr uint32_t etaextv = 0xff;
+    static constexpr uint32_t etaexts = 0x100;
+    static constexpr uint32_t iso = 0x3;
+    static constexpr uint32_t chrg = 0x1;
+    static constexpr uint32_t chrgv = 0x1;
+    static constexpr uint32_t index = 0x7f;
+    static constexpr uint32_t phi = 0x3ff;
+    static constexpr uint32_t eta = 0x1ff;
+    static constexpr uint32_t etav = 0xff;
+    static constexpr uint32_t etas = 0x100;
+    static constexpr uint32_t phiv = 0x1ff;
+    static constexpr uint32_t phis = 0x200;
+    static constexpr uint32_t sv = 0x3;
+  };
+
+  struct shifts {
+    static constexpr uint32_t phiext = 0;
+    static constexpr uint32_t pt = 10;
+    static constexpr uint32_t qual = 19;
+    static constexpr uint32_t etaext = 23;
+    static constexpr uint32_t iso = 0;
+    static constexpr uint32_t chrg = 2;
+    static constexpr uint32_t chrgv = 3;
+    static constexpr uint32_t index = 4;
+    static constexpr uint32_t phi = 11;
+    static constexpr uint32_t eta = 21;
+    static constexpr uint32_t rsv = 30;
+  };
+
+  struct gmt_scales {
+    static constexpr float pt_scale = 0.5;
+    static constexpr float phi_scale = 2. * M_PI / 576.;
+    static constexpr float eta_scale = 0.0870 / 8;  //9th MS bit is sign
+    static constexpr float phi_range = M_PI;
+  };
+
+  struct header_shifts {
+    static constexpr uint32_t bxmatch = 24;
+    static constexpr uint32_t mAcount = 16;
+    static constexpr uint32_t orbitmatch = 8;
+    static constexpr uint32_t mBcount = 0;
+  };
+
+  struct header_masks {
+    static constexpr uint32_t bxmatch = 0xff << header_shifts::bxmatch;
+    static constexpr uint32_t mAcount = 0xf << header_shifts::mAcount;
+    static constexpr uint32_t orbitmatch = 0xff << header_shifts::orbitmatch;
+    static constexpr uint32_t mBcount = 0xf;
+  };
+
+}  //namespace scouting
+
+class DataModeScoutingRun2Muon : public DataMode {
+public:
+  DataModeScoutingRun2Muon(DAQSource* daqSource) : DataMode(daqSource) {
+    dummyLVec_ = std::make_unique<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>>();
+  }
+
+  ~DataModeScoutingRun2Muon() override{};
+
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
+  void readEvent(edm::EventPrincipal& eventPrincipal) override;
+
+  int dataVersion() const override { return detectedFRDversion_; }
+  void detectVersion(unsigned char* fileBuf, uint32_t fileHeaderOffset) override {
+    detectedFRDversion_ = *((uint16_t*)(fileBuf + fileHeaderOffset));
+  }
+
+  uint32_t headerSize() const override { return FRDHeaderVersionSize[detectedFRDversion_]; }
+
+  bool versionCheck() const override { return detectedFRDversion_ <= FRDHeaderMaxVersion; }
+
+  uint64_t dataBlockSize() const override { return event_->size(); }
+
+  void makeDataBlockView(unsigned char* addr,
+                         size_t maxSize,
+                         std::vector<uint64_t> const& fileSizes,
+                         size_t fileHeaderSize) override {
+    dataBlockAddr_ = addr;
+    dataBlockMax_ = maxSize;
+    eventCached_ = false;
+    nextEventView();
+    eventCached_ = true;
+  }
+
+  bool nextEventView() override;
+  bool checksumValid() override;
+  std::string getChecksumError() const override;
+
+  bool isRealData() const override { return event_->isRealData(); }
+
+  uint32_t run() const override { return event_->run(); }
+
+  //true for scouting muon
+  bool dataBlockCompleted() const override { return true; }
+
+  bool requireHeader() const override { return true; }
+
+  bool fitToBuffer() const override { return true; }
+
+  bool dataBlockInitialized() const override { return true; }
+
+  void setDataBlockInitialized(bool) override{};
+
+  void setTCDSSearchRange(uint16_t MINTCDSuTCAFEDID, uint16_t MAXTCDSuTCAFEDID) override { return; }
+
+  void makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) override {}
+
+  std::pair<bool, std::vector<std::string>> defineAdditionalFiles(std::string const& primaryName, bool) const override {
+    return std::make_pair(true, std::vector<std::string>());
+  }
+
+  char* readPayloadPos() { return (char*)event_->payload(); }
+
+private:
+  void unpackOrbit(BXVector<l1t::Muon>* muons, char* buf, size_t len);
+
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>> daqProvenanceHelpers_;
+  uint16_t detectedFRDversion_ = 0;
+  size_t headerSize_ = 0;
+  std::unique_ptr<FRDEventMsgView> event_;
+
+  std::unique_ptr<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>> dummyLVec_;
+
+  unsigned char* dataBlockAddr_ = nullptr;
+  size_t dataBlockMax_ = 0;
+  bool eventCached_ = false;
+};
+
+class DataModeScoutingRun2Multi : public DataMode {
+public:
+  DataModeScoutingRun2Multi(DAQSource* daqSource) : DataMode(daqSource) {
+    dummyLVec_ = std::make_unique<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>>();
+  }
+
+  ~DataModeScoutingRun2Multi() override{};
+
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& makeDaqProvenanceHelpers() override;
+  void readEvent(edm::EventPrincipal& eventPrincipal) override;
+
+  int dataVersion() const override { return detectedFRDversion_; }
+  void detectVersion(unsigned char* fileBuf, uint32_t fileHeaderOffset) override {
+    detectedFRDversion_ = *((uint16_t*)(fileBuf + fileHeaderOffset));
+  }
+
+  uint32_t headerSize() const override { return FRDHeaderVersionSize[detectedFRDversion_]; }
+
+  bool versionCheck() const override { return detectedFRDversion_ <= FRDHeaderMaxVersion; }
+
+  uint64_t dataBlockSize() const override {
+    //TODO: adjust to multiple objects
+    return events_[0]->size();
+  }
+
+  void makeDataBlockView(unsigned char* addr,
+                         size_t maxSize,
+                         std::vector<uint64_t> const& fileSizes,
+                         size_t fileHeaderSize) override {
+    fileHeaderSize_ = fileHeaderSize;
+    numFiles_ = fileSizes.size();
+    //add offset address for each file payload
+    startAddrs_.clear();
+    startAddrs_.push_back(addr);
+    dataBlockAddrs_.clear();
+    dataBlockAddrs_.push_back(addr);
+    dataBlockMaxAddrs_.clear();
+    dataBlockMaxAddrs_.push_back(addr + fileSizes[0] - fileHeaderSize);
+    auto fileAddr = addr;
+    for (unsigned int i = 1; i < fileSizes.size(); i++) {
+      fileAddr += fileSizes[i - 1];
+      startAddrs_.push_back(fileAddr);
+      dataBlockAddrs_.push_back(fileAddr);
+      dataBlockMaxAddrs_.push_back(fileAddr + fileSizes[i] - fileHeaderSize);
+    }
+
+    dataBlockMax_ = maxSize;
+    blockCompleted_ = false;
+    //set event cached as we set initial address here
+    bool result = makeEvents();
+    assert(result);
+    eventCached_ = true;
+    setDataBlockInitialized(true);
+  }
+
+  bool nextEventView() override;
+  bool checksumValid() override;
+  std::string getChecksumError() const override;
+
+  bool isRealData() const override {
+    assert(!events_.empty());
+    return events_[0]->isRealData();
+  }
+
+  uint32_t run() const override {
+    assert(!events_.empty());
+    return events_[0]->run();
+  }
+
+  //true for DAQ3 FRD
+  bool dataBlockCompleted() const override { return blockCompleted_; }
+
+  bool requireHeader() const override { return true; }
+
+  bool dataBlockInitialized() const override { return dataBlockInitialized_; }
+
+  void setDataBlockInitialized(bool val) override { dataBlockInitialized_ = val; };
+
+  void setTCDSSearchRange(uint16_t MINTCDSuTCAFEDID, uint16_t MAXTCDSuTCAFEDID) override { return; }
+
+  void makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) override {
+    //receive directory paths for multiple input files ('striped')
+  }
+
+  std::pair<bool, std::vector<std::string>> defineAdditionalFiles(std::string const& primaryName,
+                                                                  bool fileListMode) const override;
+
+private:
+  bool makeEvents();
+  void unpackMuonOrbit(BXVector<l1t::Muon>* muons, char* buf, size_t len);
+
+  std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>> daqProvenanceHelpers_;
+  uint16_t detectedFRDversion_ = 0;
+  size_t headerSize_ = 0;
+  std::vector<std::unique_ptr<FRDEventMsgView>> events_;
+
+  std::unique_ptr<ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>> dummyLVec_;
+
+  unsigned char* dataBlockAddr_ = nullptr;
+
+  //debugging
+  std::vector<unsigned char*> startAddrs_;
+  std::vector<unsigned char*> dataBlockAddrs_;
+  std::vector<unsigned char*> dataBlockMaxAddrs_;
+  size_t dataBlockMax_ = 0;
+  size_t fileHeaderSize_ = 0;
+  short numFiles_ = 0;
+  bool eventCached_ = false;
+  bool dataBlockInitialized_ = false;
+  bool blockCompleted_ = true;
+};
+
+#endif  // EventFilter_Utilities_DAQSourceModelsScouting_h

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -39,6 +39,7 @@
 */
 
 class FedRawDataInputSource;
+class DAQSource;
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -219,6 +220,7 @@ namespace evf {
     }
     std::string getRunDirName() const { return runDirectory_.stem().string(); }
     void setInputSource(FedRawDataInputSource* inputSource) { inputSource_ = inputSource; }
+    void setInputSource(DAQSource* inputSource) { daqInputSource_ = inputSource; }
     void setInState(FastMonState::InputState inputState) { inputState_ = inputState; }
     void setInStateSup(FastMonState::InputState inputState) { inputSupervisorState_ = inputState; }
 
@@ -232,6 +234,7 @@ namespace evf {
     //Encoding encModule_;
     //std::vector<Encoding> encPath_;
     FedRawDataInputSource* inputSource_ = nullptr;
+    DAQSource* daqInputSource_ = nullptr;
     std::atomic<FastMonState::InputState> inputState_{FastMonState::InputState::inInit};
     std::atomic<FastMonState::InputState> inputSupervisorState_{FastMonState::InputState::inInit};
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <random>
+#include <algorithm>
 
 #include "oneapi/tbb/concurrent_queue.h"
 #include "oneapi/tbb/concurrent_vector.h"
@@ -27,7 +29,7 @@ class FEDRawDataCollection;
 class InputSourceDescription;
 class ParameterSet;
 
-struct InputFile;
+class InputFile;
 struct InputChunk;
 
 namespace evf {
@@ -38,7 +40,7 @@ namespace evf {
 }  // namespace evf
 
 class FedRawDataInputSource : public edm::RawInputSource {
-  friend struct InputFile;
+  friend class InputFile;
   friend struct InputChunk;
 
 public:
@@ -187,37 +189,56 @@ private:
 struct InputChunk {
   unsigned char* buf_;
   InputChunk* next_ = nullptr;
-  uint32_t size_;
-  uint32_t usedSize_ = 0;
-  unsigned int index_;
-  unsigned int offset_;
+  uint64_t size_;
+  uint64_t usedSize_ = 0;
+  //unsigned int index_;
+  uint64_t offset_;
   unsigned int fileIndex_;
   std::atomic<bool> readComplete_;
 
-  InputChunk(unsigned int index, uint32_t size) : size_(size), index_(index) {
+  InputChunk(uint64_t size) : size_(size) {
     buf_ = new unsigned char[size_];
     reset(0, 0, 0);
   }
-  void reset(unsigned int newOffset, unsigned int toRead, unsigned int fileIndex) {
+  void reset(uint64_t newOffset, uint64_t toRead, unsigned int fileIndex) {
     offset_ = newOffset;
     usedSize_ = toRead;
     fileIndex_ = fileIndex;
     readComplete_ = false;
   }
 
+  bool resize(uint64_t wantedSize, uint64_t maxSize) {
+    if (wantedSize > maxSize)
+      return false;
+    if (size_ < wantedSize) {
+      size_ = uint64_t(wantedSize * 1.05);
+      delete[] buf_;
+      buf_ = new unsigned char[size_];
+    }
+    return true;
+  }
+
   ~InputChunk() { delete[] buf_; }
 };
 
-struct InputFile {
+class InputFile {
+public:
   FedRawDataInputSource* parent_;
   evf::EvFDaqDirector::FileStatus status_;
   unsigned int lumi_;
   std::string fileName_;
+  //used by DAQSource
+  std::vector<std::string> fileNames_;
+  std::vector<uint64_t> diskFileSizes_;
+  std::vector<uint64_t> bufferOffsets_;
+  std::vector<uint64_t> fileSizes_;
+  std::vector<unsigned int> fileOrder_;
   bool deleteFile_;
   int rawFd_;
   uint64_t fileSize_;
   uint16_t rawHeaderSize_;
-  uint32_t nChunks_;
+  uint16_t nChunks_;
+  uint16_t numFiles_;
   int nEvents_;
   unsigned int nProcessed_;
 
@@ -234,7 +255,7 @@ struct InputFile {
             int rawFd = -1,
             uint64_t fileSize = 0,
             uint16_t rawHeaderSize = 0,
-            uint32_t nChunks = 0,
+            uint16_t nChunks = 0,
             int nEvents = 0,
             FedRawDataInputSource* parent = nullptr)
       : parent_(parent),
@@ -246,14 +267,38 @@ struct InputFile {
         fileSize_(fileSize),
         rawHeaderSize_(rawHeaderSize),
         nChunks_(nChunks),
+        numFiles_(1),
         nEvents_(nEvents),
         nProcessed_(0) {
+    fileNames_.push_back(name);
+    fileOrder_.push_back(fileOrder_.size());
+    diskFileSizes_.push_back(fileSize);
+    fileSizes_.push_back(0);
+    bufferOffsets_.push_back(0);
+    chunks_.reserve(nChunks_);
     for (unsigned int i = 0; i < nChunks; i++)
       chunks_.push_back(nullptr);
   }
-  ~InputFile();
+  virtual ~InputFile();
 
-  InputFile(std::string& name) : fileName_(name) {}
+  void setChunks(uint16_t nChunks) {
+    nChunks_ = nChunks;
+    chunks_.clear();
+    chunks_.reserve(nChunks_);
+    for (unsigned int i = 0; i < nChunks_; i++)
+      chunks_.push_back(nullptr);
+  }
+
+  void appendFile(std::string const& name, uint64_t size) {
+    size_t prevOffset = bufferOffsets_.back();
+    size_t prevSize = diskFileSizes_.back();
+    numFiles_++;
+    fileNames_.push_back(name);
+    fileOrder_.push_back(fileOrder_.size());
+    diskFileSizes_.push_back(size);
+    fileSizes_.push_back(0);
+    bufferOffsets_.push_back(prevOffset + prevSize);
+  }
 
   bool waitForChunk(unsigned int chunkid) {
     //some atomics to make sure everything is cache synchronized for the main thread
@@ -263,6 +308,10 @@ struct InputFile {
   void moveToPreviousChunk(const size_t size, const size_t offset);
   void rewindChunk(const size_t size);
   void unsetDeleteFile() { deleteFile_ = false; }
+  void randomizeOrder(std::default_random_engine& rng) {
+    std::shuffle(std::begin(fileOrder_), std::end(fileOrder_), rng);
+  }
+  uint64_t currentChunkSize() const { return chunks_[currentChunk_]->size_; }
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h

--- a/EventFilter/Utilities/plugins/DumpMuonScouting.cc
+++ b/EventFilter/Utilities/plugins/DumpMuonScouting.cc
@@ -1,0 +1,112 @@
+///
+/// \class l1t::DumpMuonScouting.cc
+///
+/// Description: Dump/Analyze Moun Scouting stored in BXVector
+///
+/// Implementation:
+///    Based off of Michael Mulhearn's YellowParamTester
+///
+/// \author: Brian Winer Ohio State
+///
+
+//
+//  This simple module simply retreives the YellowParams object from the event
+//  setup, and sends its payload as an INFO message, for debugging purposes.
+//
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+// system include files
+#include <fstream>
+#include <iomanip>
+#include <memory>
+
+// user include files
+//   base class
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+using namespace edm;
+using namespace std;
+
+// class declaration
+class DumpMuonScouting : public edm::stream::EDAnalyzer<> {
+public:
+  explicit DumpMuonScouting(const edm::ParameterSet&);
+  ~DumpMuonScouting() override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  EDGetTokenT<BXVector<l1t::Muon>> muToken;
+
+  int m_minBx;
+  int m_maxBx;
+
+private:
+  int m_tvVersion;
+};
+
+DumpMuonScouting::DumpMuonScouting(const edm::ParameterSet& iConfig) {
+  muToken = consumes<l1t::MuonBxCollection>(iConfig.getParameter<InputTag>("muInputTag"));
+
+  m_minBx = iConfig.getParameter<int>("minBx");
+  m_maxBx = iConfig.getParameter<int>("maxBx");
+}
+
+// loop over events
+void DumpMuonScouting::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
+  //input
+  Handle<BXVector<l1t::Muon>> muons = iEvent.getHandle(muToken);
+
+  {
+    cout << " -----------------------------------------------------  " << endl;
+    cout << " *********** Run " << std::dec << iEvent.id().run() << " Event " << iEvent.id().event()
+         << " **************  " << endl;
+    cout << " ----------------------------------------------------- " << endl;
+
+    //Loop over BX
+    for (int i = m_minBx; i <= m_maxBx; ++i) {
+      //Loop over Muons
+      //cout << " ------ Muons --------" << endl;
+      if (muons.isValid()) {
+        if (i >= muons->getFirstBX() && i <= muons->getLastBX()) {
+          for (std::vector<l1t::Muon>::const_iterator mu = muons->begin(i); mu != muons->end(i); ++mu) {
+            cout << "  " << std::dec << std::setw(2) << std::setfill(' ') << std::setfill('0') << ")";
+            cout << "   Pt " << std::dec << std::setw(3) << mu->hwPt() << " (0x" << std::hex << std::setw(3)
+                 << std::setfill('0') << mu->hwPt() << ")";
+            cout << "   EtaAtVtx " << std::dec << std::setw(3) << mu->hwEtaAtVtx() << " (0x" << std::hex << std::setw(3)
+                 << std::setfill('0') << (mu->hwEtaAtVtx() & 0x1ff) << ")";
+            cout << "   Eta " << std::dec << std::setw(3) << mu->hwEta() << " (0x" << std::hex << std::setw(3)
+                 << std::setfill('0') << (mu->hwEta() & 0x1ff) << ")";
+            cout << "   PhiAtVtx " << std::dec << std::setw(3) << mu->hwPhiAtVtx() << " (0x" << std::hex << std::setw(3)
+                 << std::setfill('0') << mu->hwPhiAtVtx() << ")";
+            cout << "   Phi " << std::dec << std::setw(3) << mu->hwPhi() << " (0x" << std::hex << std::setw(3)
+                 << std::setfill('0') << mu->hwPhi() << ")";
+            cout << "   Iso " << std::dec << std::setw(1) << mu->hwIso();
+            cout << "   Qual " << std::dec << std::setw(1) << mu->hwQual();
+            cout << "   Chrg " << std::dec << std::setw(1) << mu->hwCharge();
+            cout << endl;
+          }
+        } else {
+          cout << "No Muons stored for this bx " << i << endl;
+        }
+      } else {
+        cout << "No Muon Data in this event " << endl;
+      }
+
+    }  //loop over Bx
+    cout << std::dec << endl;
+  }  //if dumpGtRecord
+}
+
+DEFINE_FWK_MODULE(DumpMuonScouting);

--- a/EventFilter/Utilities/plugins/FRDOutputModule.h
+++ b/EventFilter/Utilities/plugins/FRDOutputModule.h
@@ -29,7 +29,7 @@ private:
   void beginLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
   void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
-  void finishFileWrite(int ls);
+  void finishFileWrite(unsigned int run, int ls);
   uint32_t adler32() const { return (adlerb_ << 16) | adlera_; }
 
   const edm::EDGetTokenT<FEDRawDataCollection> token_;

--- a/EventFilter/Utilities/plugins/modules.cc
+++ b/EventFilter/Utilities/plugins/modules.cc
@@ -2,6 +2,7 @@
 #include "EventFilter/Utilities/interface/EvFOutputModule.h"
 #include "EventFilter/Utilities/interface/FastMonitoringService.h"
 #include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+#include "EventFilter/Utilities/interface/DAQSource.h"
 #include "EventFilter/Utilities/plugins/DaqFakeReader.h"
 #include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
 #include "EventFilter/Utilities/plugins/EvFFEDSelector.h"
@@ -31,3 +32,4 @@ DEFINE_FWK_MODULE(EvFFEDExcluder);
 DEFINE_FWK_MODULE(EvFOutputModule);
 DEFINE_FWK_MODULE(DaqFakeReader);
 DEFINE_FWK_INPUT_SOURCE(FedRawDataInputSource);
+DEFINE_FWK_INPUT_SOURCE(DAQSource);

--- a/EventFilter/Utilities/scripts/scoutingToRaw.py
+++ b/EventFilter/Utilities/scripts/scoutingToRaw.py
@@ -1,0 +1,259 @@
+#!/bin/env python3
+
+import struct
+import os,sys
+import json
+import shutil
+
+os.umask(0)
+
+#struct muon{
+#  uint32_t f;
+#  uint32_t s;
+#};
+
+#struct block{
+#  uint32_t bx;
+#  uint32_t orbit;
+#  muon mu[16];
+#};
+
+#class masks:
+#  phiext  = 0x3ff
+#  pt      = 0x1ff
+#  qual    = 0xf
+#  etaext  = 0x1ff
+#  etaextv = 0xff
+#  etaexts = 0x100
+#  iso     = 0x3
+#  chrg    = 0x1
+#  chrgv   = 0x1
+#  index   = 0x7f
+#  phi     = 0x3ff
+#  eta     = 0x1ff
+#  etav    = 0xff
+#  etas    = 0x100
+#  phiv    = 0x1ff
+#  phis    = 0x200
+#  sv      = 0x3
+
+#class shifts:
+#  phiext  = 0
+#  pt      = 10
+#  qual    = 19
+#  etaext  = 23
+#  iso     = 0
+#  chrg    = 2
+#  chrgv   = 3
+#  index   = 4
+#  phi     = 11
+#  eta     = 21
+#  rsv     = 30
+
+#class gmt_scales:
+#  pt_scale    = 0.5
+#  phi_scale   = 2.*M_PI/576.
+#  eta_scale   = 0.0870/8 #9th MS bit is sign
+#  phi_range   = M_PI
+
+
+#need to read this to find orbit ("event") boundary and calculate size per orbit
+class header_shifts:
+  bxmatch    = 32;
+  mAcount    = 16;
+  orbitmatch = 8;
+  mBcount    = 0;
+
+class header_masks:
+  bxmatch    = 0xff << header_shifts.bxmatch;
+  mAcount    = 0xf  << header_shifts.mAcount;
+  orbitmatch = 0xff << header_shifts.orbitmatch;
+  mBcount    = 0xf
+
+
+#new V2 FRD file header (32 bytes)
+class frd_file_header_v2:
+  ver_id = "RAW_0002".encode() # 64 (offset 0B)
+  header_size = 32 #16 (offset 8B)
+  data_type = 20 #16 (offset 10)
+  event_count = 0 #32 (offset 12B)
+  run_number = 0 #32 (offset 16B)
+  lumisection = 0 #32 (offset 20B)
+  file_size = 0 #64 (offset 24B)
+
+
+def parseMuonScoutingRawFile(infilepath, outdir, rn_override, maxorbits):
+
+  if infilepath != 'stdin':
+    fin = open(infilepath,'rb')
+  else:
+    fin = sys.stdin.buffer 
+
+  #sys.stdout.flush()
+
+  #orbit count per file
+  orbitcount=0
+  #total
+  orbitcount_total=0
+
+  last_ls = 0
+
+  orbit_data = bytes()
+  orbit_nr = 0
+  orbit_size = 0
+  flags = 0
+  c_crc32c = 0
+
+  #ls = 1
+  #event header (FRD format) const
+  version = 6
+
+  #files
+  fout = None
+  if infilepath != 'stdin':
+    fin = open(infilepath,'rb')
+  else:
+    fin = sys.stdin.buffer 
+
+
+  #write header before closing the file
+  def update_header():
+      nonlocal orbitcount
+      nonlocal last_ls
+      h = frd_file_header_v2()
+      h.event_count = orbitcount
+      h.run_number = rn_override 
+      h.lumisection = last_ls
+      h.file_size = fout.tell() 
+      fout.seek(0, 0) 
+      fout.write(frd_file_header_v2.ver_id)
+      fout.write(struct.pack('H',h.header_size))
+      fout.write(struct.pack('H',h.data_type))
+      fout.write(struct.pack('I',h.event_count))
+      fout.write(struct.pack('I',h.run_number))
+      fout.write(struct.pack('I',h.lumisection))
+      fout.write(struct.pack('Q',h.file_size))
+
+      orbitcount = 0
+      print(h.ver_id, h.header_size, h.data_type, h.event_count, h.lumisection, h.file_size)
+
+
+  #write orbit when next one is detected or file is closed
+  def write_orbit():
+          nonlocal orbit_size
+          nonlocal orbit_data
+          if not orbit_size:
+              return
+
+          #print(fout.tell(), struct.pack('H',version))
+          fout.write(struct.pack('H',version)) #could be 8 bytes
+          fout.write(struct.pack('H',flags)) #could be 8 bytes
+          fout.write(struct.pack('I',rn_override)) #run
+          #fout.write(struct.pack('I',ls)) #ls
+          fout.write(struct.pack('I',last_ls)) #ls
+          fout.write(struct.pack('I',orbit_nr)) #eid (orbit number, 32-bit)
+          fout.write(struct.pack('I',orbit_size)) #payload size
+          fout.write(struct.pack('I',c_crc32c)) #payload checksum (not used)
+          fout.write(orbit_data)
+
+          orbit_data = bytes()
+          orbit_size = 0
+
+  def writeout_close():
+      write_orbit()
+      update_header()
+      fout.close()
+      orbit_nr = 0
+
+  #read loop
+  while True:
+
+          #check if exceeded max orbits specified
+          if orbitcount_total > maxorbits:
+              print(f"finish: {orbitcount_total-1}/{maxorbits} orbits")
+              writeout_close()
+
+              if infilepath != 'stdin':
+                  fin.close()
+              sys.exit(0)
+
+          try:
+              h_raw = fin.read(4)
+              bxmatch = struct.unpack('B', h_raw[3:4])[0]
+              mAcount = struct.unpack('B', h_raw[2:3])[0]
+              orbitmatch = struct.unpack('B', h_raw[1:2])[0]
+              mBcount = struct.unpack('B', h_raw[0:1])[0]
+
+              #print("bxmatch", bxmatch, "mA", mAcount, "orbitmatch", orbitmatch, "mB", mBcount)
+ 
+              bx_raw = fin.read(4)
+              bx = struct.unpack('i', bx_raw)[0]
+              #print("bx",bx)
+              orbit_raw = fin.read(4)
+              orbit = struct.unpack('i', orbit_raw)[0]
+
+              new_ls = orbit >> 18
+
+              if new_ls > last_ls:
+              #open a new output file if crossing LS boundary or on first orbit
+                  if last_ls:
+                      write_orbit()
+                      update_header()
+                      fout.close()
+                      orbitcount = 0
+
+                  last_ls = new_ls
+                  fout = open(os.path.join(outdir, f'run{rn_override}_ls{str(new_ls).zfill(4)}_index000000.raw') ,'wb')
+                  #empty file header, will be updated later
+                  fout.write(frd_file_header_v2.ver_id)
+#                  fout.write(bytes(16))
+                  fout.write(bytes(24))
+
+              read_len = 8*(mAcount+mBcount)
+              mu_blk = fin.read(8*(mAcount+mBcount))
+              if len(mu_blk) != read_len:
+                  print('incomplete read')
+                  sys.exit(1)
+
+              if not orbit_nr or orbit != orbit_nr:
+                  #received new orbit, write previous one
+                  if orbit_nr:
+                      write_orbit()
+
+                  #should not decrease:
+                  if orbit < orbit_nr:
+                      orbit_count = -1
+                      print("got smaller orbit than earlier!")
+                      sys.exit(1)
+
+                  print("new orbit", orbit)
+                  orbit_nr = orbit
+
+                  #per LS file counter:
+                  orbitcount += 1
+                  #total counter:
+                  orbitcount_total += 1
+
+              #update orbit size and data variables
+              orbit_size += 12 + read_len
+              orbit_data += (h_raw + bx_raw + orbit_raw) + mu_blk
+
+          except Exception as ex:
+              #reached premature end of the file?
+              print(f"exception: {ex}")
+              #writeout_close()
+              #if infilepath != 'stdin':
+              #    fin.close()
+              sys.exit(1)
+
+          #print count," : ",version,run,lumi,eid,esize,crc32c,"override id/ls/run:",count,1,rn_override
+          #lumi=1
+
+if len(sys.argv) < 5:
+  print("parameters: input file (or stdin), output directory, run number (use same as input file), orbits to write")
+else:
+  parseMuonScoutingRawFile(sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]))
+
+
+
+

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -1,0 +1,1449 @@
+#include <sstream>
+#include <unistd.h>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+
+#include "EventFilter/Utilities/interface/DAQSource.h"
+#include "EventFilter/Utilities/interface/DAQSourceModels.h"
+#include "EventFilter/Utilities/interface/DAQSourceModelsFRD.h"
+#include "EventFilter/Utilities/interface/DAQSourceModelsScouting.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/InputSourceDescription.h"
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/DataPointDefinition.h"
+#include "EventFilter/Utilities/interface/FFFNamingSchema.h"
+#include "EventFilter/Utilities/interface/crc32c.h"
+
+//JSON file reader
+#include "EventFilter/Utilities/interface/reader.h"
+
+using namespace evf::FastMonState;
+
+DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
+    : edm::RawInputSource(pset, desc),
+      dataModeConfig_(pset.getUntrackedParameter<std::string>("dataMode")),
+      eventChunkSize_(uint64_t(pset.getUntrackedParameter<unsigned int>("eventChunkSize")) << 20),
+      maxChunkSize_(uint64_t(pset.getUntrackedParameter<unsigned int>("maxChunkSize")) << 20),
+      eventChunkBlock_(uint64_t(pset.getUntrackedParameter<unsigned int>("eventChunkBlock")) << 20),
+      numBuffers_(pset.getUntrackedParameter<unsigned int>("numBuffers")),
+      maxBufferedFiles_(pset.getUntrackedParameter<unsigned int>("maxBufferedFiles")),
+      alwaysStartFromFirstLS_(pset.getUntrackedParameter<bool>("alwaysStartFromFirstLS", false)),
+      verifyChecksum_(pset.getUntrackedParameter<bool>("verifyChecksum")),
+      useL1EventID_(pset.getUntrackedParameter<bool>("useL1EventID")),
+      testTCDSFEDRange_(pset.getUntrackedParameter<std::vector<unsigned int>>("testTCDSFEDRange")),
+      listFileNames_(pset.getUntrackedParameter<std::vector<std::string>>("fileNames")),
+      fileListMode_(pset.getUntrackedParameter<bool>("fileListMode")),
+      fileListLoopMode_(pset.getUntrackedParameter<bool>("fileListLoopMode", false)),
+      runNumber_(edm::Service<evf::EvFDaqDirector>()->getRunNumber()),
+      processHistoryID_(),
+      currentLumiSection_(0),
+      eventsThisLumi_(0),
+      rng_(std::chrono::system_clock::now().time_since_epoch().count()) {
+  char thishost[256];
+  gethostname(thishost, 255);
+
+  if (maxChunkSize_ == 0)
+    maxChunkSize_ = eventChunkSize_;
+  else if (maxChunkSize_ < eventChunkSize_)
+    throw cms::Exception("DAQSource::DAQSource") << "maxChunkSize must be equal or larger than eventChunkSize";
+
+  if (eventChunkBlock_ == 0)
+    eventChunkBlock_ = eventChunkSize_;
+  else if (eventChunkBlock_ > eventChunkSize_)
+    throw cms::Exception("DAQSource::DAQSource") << "eventChunkBlock must be equal or smaller than eventChunkSize";
+
+  edm::LogInfo("DAQSource") << "Construction. read-ahead chunk size -: " << std::endl
+                            << (eventChunkSize_ >> 20) << " MB on host " << thishost << " in mode " << dataModeConfig_;
+
+  uint16_t MINTCDSuTCAFEDID = FEDNumbering::MINTCDSuTCAFEDID;
+  uint16_t MAXTCDSuTCAFEDID = FEDNumbering::MAXTCDSuTCAFEDID;
+
+  if (!testTCDSFEDRange_.empty()) {
+    if (testTCDSFEDRange_.size() != 2) {
+      throw cms::Exception("DAQSource::DAQSource") << "Invalid TCDS Test FED range parameter";
+    }
+    MINTCDSuTCAFEDID = testTCDSFEDRange_[0];
+    MAXTCDSuTCAFEDID = testTCDSFEDRange_[1];
+  }
+
+  //load mode class based on parameter
+  if (dataModeConfig_ == "FRD") {
+    dataMode_.reset(new DataModeFRD(this));
+  } else if (dataModeConfig_ == "FRDStriped") {
+    dataMode_.reset(new DataModeFRDStriped(this));
+  } else
+    throw cms::Exception("DAQSource::DAQSource") << "Unknown data mode " << dataModeConfig_;
+
+  daqDirector_ = edm::Service<evf::EvFDaqDirector>().operator->();
+
+  dataMode_->setTCDSSearchRange(MINTCDSuTCAFEDID, MAXTCDSuTCAFEDID);
+  dataMode_->setTesting(pset.getUntrackedParameter<bool>("testing", false));
+
+  long autoRunNumber = -1;
+  if (fileListMode_) {
+    autoRunNumber = initFileList();
+    if (!fileListLoopMode_) {
+      if (autoRunNumber < 0)
+        throw cms::Exception("DAQSource::DAQSource") << "Run number not found from filename";
+      //override run number
+      runNumber_ = (edm::RunNumber_t)autoRunNumber;
+      daqDirector_->overrideRunNumber((unsigned int)autoRunNumber);
+    }
+  }
+
+  dataMode_->makeDirectoryEntries(daqDirector_->getBUBaseDirs(), daqDirector_->runString());
+
+  auto& daqProvenanceHelpers = dataMode_->makeDaqProvenanceHelpers();
+  for (const auto& daqProvenanceHelper : daqProvenanceHelpers)
+    processHistoryID_ = daqProvenanceHelper->daqInit(productRegistryUpdate(), processHistoryRegistryForUpdate());
+  setNewRun();
+  //todo:autodetect from file name (assert if names differ)
+  setRunAuxiliary(new edm::RunAuxiliary(runNumber_, edm::Timestamp::beginOfTime(), edm::Timestamp::invalidTimestamp()));
+
+  //make sure that chunk size is N * block size
+  assert(eventChunkSize_ >= eventChunkBlock_);
+  readBlocks_ = eventChunkSize_ / eventChunkBlock_;
+  if (readBlocks_ * eventChunkBlock_ != eventChunkSize_)
+    eventChunkSize_ = readBlocks_ * eventChunkBlock_;
+
+  if (!numBuffers_)
+    throw cms::Exception("DAQSource::DAQSource") << "no reading enabled with numBuffers parameter 0";
+
+  numConcurrentReads_ = numBuffers_ - 1;
+  assert(numBuffers_ > 1);
+  readingFilesCount_ = 0;
+
+  if (!crc32c_hw_test())
+    edm::LogError("DAQSource::DAQSource") << "Intel crc32c checksum computation unavailable";
+
+  //get handles to DaqDirector and FastMonitoringService because getting them isn't possible in readSupervisor thread
+  if (fileListMode_) {
+    try {
+      fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+    } catch (cms::Exception const&) {
+      edm::LogInfo("DAQSource") << "No FastMonitoringService found in the configuration";
+    }
+  } else {
+    fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+    if (!fms_) {
+      throw cms::Exception("DAQSource") << "FastMonitoringService not found";
+    }
+  }
+
+  daqDirector_ = edm::Service<evf::EvFDaqDirector>().operator->();
+  if (!daqDirector_)
+    cms::Exception("DAQSource") << "EvFDaqDirector not found";
+
+  edm::LogInfo("DAQSource") << "EvFDaqDirector/Source configured to use file service";
+  //set DaqDirector to delete files in preGlobalEndLumi callback
+  daqDirector_->setDeleteTracking(&fileDeleteLock_, &filesToDelete_);
+  if (fms_) {
+    daqDirector_->setFMS(fms_);
+    fms_->setInputSource(this);
+    fms_->setInState(inInit);
+    fms_->setInStateSup(inInit);
+  }
+  //should delete chunks when run stops
+  for (unsigned int i = 0; i < numBuffers_; i++) {
+    freeChunks_.push(new InputChunk(eventChunkSize_));
+  }
+
+  quit_threads_ = false;
+
+  for (unsigned int i = 0; i < numConcurrentReads_; i++) {
+    std::unique_lock<std::mutex> lk(startupLock_);
+    //issue a memory fence here and in threads (constructor was segfaulting without this)
+    thread_quit_signal.push_back(false);
+    workerJob_.push_back(ReaderInfo(nullptr, nullptr));
+    cvReader_.push_back(new std::condition_variable);
+    tid_active_.push_back(0);
+    threadInit_.store(false, std::memory_order_release);
+    workerThreads_.push_back(new std::thread(&DAQSource::readWorker, this, i));
+    startupCv_.wait(lk);
+  }
+
+  runAuxiliary()->setProcessHistoryID(processHistoryID_);
+}
+
+DAQSource::~DAQSource() {
+  quit_threads_ = true;
+
+  //delete any remaining open files
+  if (!fms_ || !fms_->exceptionDetected()) {
+    std::unique_lock<std::mutex> lkw(fileDeleteLock_);
+    for (auto it = filesToDelete_.begin(); it != filesToDelete_.end(); it++)
+      it->second.reset();
+  } else {
+    //skip deleting files with exception
+    std::unique_lock<std::mutex> lkw(fileDeleteLock_);
+    for (auto it = filesToDelete_.begin(); it != filesToDelete_.end(); it++) {
+      if (fms_->isExceptionOnData(it->second->lumi_))
+        it->second->unsetDeleteFile();
+      else
+        it->second.reset();
+    }
+    //disable deleting current file with exception
+    if (currentFile_.get())
+      if (fms_->isExceptionOnData(currentFile_->lumi_))
+        currentFile_->unsetDeleteFile();
+  }
+
+  if (startedSupervisorThread_) {
+    readSupervisorThread_->join();
+  } else {
+    //join aux threads in case the supervisor thread was not started
+    for (unsigned int i = 0; i < workerThreads_.size(); i++) {
+      std::unique_lock<std::mutex> lk(mReader_);
+      thread_quit_signal[i] = true;
+      cvReader_[i]->notify_one();
+      lk.unlock();
+      workerThreads_[i]->join();
+      delete workerThreads_[i];
+    }
+  }
+  for (unsigned int i = 0; i < numConcurrentReads_; i++)
+    delete cvReader_[i];
+  /*
+  for (unsigned int i=0;i<numConcurrentReads_+1;i++) {
+    InputChunk *ch;
+    while (!freeChunks_.try_pop(ch)) {}
+    delete ch;
+  }
+  */
+}
+
+void DAQSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("File-based Filter Farm input source for reading raw data from BU ramdisk (unified)");
+  desc.addUntracked<std::string>("dataMode", "FRD")->setComment("Data mode: event 'FRD', 'FRSStriped', 'ScoutingRun2'");
+  desc.addUntracked<unsigned int>("eventChunkSize", 64)->setComment("Input buffer (chunk) size");
+  desc.addUntracked<unsigned int>("maxChunkSize", 0)
+      ->setComment("Maximum chunk size allowed if buffer is resized to fit data. If 0 is specifier, use chunk size");
+  desc.addUntracked<unsigned int>("eventChunkBlock", 0)
+      ->setComment(
+          "Block size used in a single file read call (must be smaller or equal to the initial chunk buffer size). If "
+          "0 is specified, use chunk size.");
+
+  desc.addUntracked<unsigned int>("numBuffers", 2)->setComment("Number of buffers used for reading input");
+  desc.addUntracked<unsigned int>("maxBufferedFiles", 2)
+      ->setComment("Maximum number of simultaneously buffered raw files");
+  desc.addUntracked<unsigned int>("alwaysStartFromfirstLS", false)
+      ->setComment("Force source to start from LS 1 if server provides higher lumisection number");
+  desc.addUntracked<bool>("verifyChecksum", true)
+      ->setComment("Verify event CRC-32C checksum of FRDv5 and higher or Adler32 with v3 and v4");
+  desc.addUntracked<bool>("useL1EventID", false)
+      ->setComment("Use L1 event ID from FED header if true or from TCDS FED if false");
+  desc.addUntracked<std::vector<unsigned int>>("testTCDSFEDRange", std::vector<unsigned int>())
+      ->setComment("[min, max] range to search for TCDS FED ID in test setup");
+  desc.addUntracked<bool>("fileListMode", false)
+      ->setComment("Use fileNames parameter to directly specify raw files to open");
+  desc.addUntracked<std::vector<std::string>>("fileNames", std::vector<std::string>())
+      ->setComment("file list used when fileListMode is enabled");
+  desc.setAllowAnything();
+  descriptions.add("source", desc);
+}
+
+edm::RawInputSource::Next DAQSource::checkNext() {
+  if (!startedSupervisorThread_) {
+    std::unique_lock<std::mutex> lk(startupLock_);
+
+    //this thread opens new files and dispatches reading to worker readers
+    readSupervisorThread_ = std::make_unique<std::thread>(&DAQSource::readSupervisor, this);
+    startedSupervisorThread_ = true;
+
+    startupCv_.wait(lk);
+  }
+
+  //signal hltd to start event accounting
+  if (!currentLumiSection_)
+    daqDirector_->createProcessingNotificationMaybe();
+  setMonState(inWaitInput);
+
+  auto nextEvent = [this]() {
+    auto getNextEvent = [this]() {
+      //for some models this is always true (if one event is one block)
+      if (dataMode_->dataBlockCompleted()) {
+        return getNextDataBlock();
+      } else {
+        return getNextEventFromDataBlock();
+      }
+    };
+
+    evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
+    while ((status = getNextEvent()) == evf::EvFDaqDirector::noFile) {
+      if (edm::shutdown_flag.load(std::memory_order_relaxed))
+        break;
+    }
+    return status;
+  };
+
+  switch (nextEvent()) {
+    case evf::EvFDaqDirector::runEnded: {
+      //maybe create EoL file in working directory before ending run
+      struct stat buf;
+      //also create EoR file in FU data directory
+      bool eorFound = (stat(daqDirector_->getEoRFilePathOnFU().c_str(), &buf) == 0);
+      if (!eorFound) {
+        int eor_fd = open(daqDirector_->getEoRFilePathOnFU().c_str(),
+                          O_RDWR | O_CREAT,
+                          S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+        close(eor_fd);
+      }
+      reportEventsThisLumiInSource(currentLumiSection_, eventsThisLumi_);
+      eventsThisLumi_ = 0;
+      resetLuminosityBlockAuxiliary();
+      edm::LogInfo("DAQSource") << "----------------RUN ENDED----------------";
+      return Next::kStop;
+    }
+    case evf::EvFDaqDirector::noFile: {
+      //this is not reachable
+      return Next::kEvent;
+    }
+    case evf::EvFDaqDirector::newLumi: {
+      //std::cout << "--------------NEW LUMI---------------" << std::endl;
+      return Next::kEvent;
+    }
+    default: {
+      if (fileListMode_ || fileListLoopMode_)
+        eventRunNumber_ = runNumber_;
+      else
+        eventRunNumber_ = dataMode_->run();
+
+      setEventCached();
+
+      return Next::kEvent;
+    }
+  }
+}
+
+void DAQSource::maybeOpenNewLumiSection(const uint32_t lumiSection) {
+  if (!luminosityBlockAuxiliary() || luminosityBlockAuxiliary()->luminosityBlock() != lumiSection) {
+    currentLumiSection_ = lumiSection;
+
+    resetLuminosityBlockAuxiliary();
+
+    timeval tv;
+    gettimeofday(&tv, nullptr);
+    const edm::Timestamp lsopentime((unsigned long long)tv.tv_sec * 1000000 + (unsigned long long)tv.tv_usec);
+
+    edm::LuminosityBlockAuxiliary* lumiBlockAuxiliary = new edm::LuminosityBlockAuxiliary(
+        runAuxiliary()->run(), lumiSection, lsopentime, edm::Timestamp::invalidTimestamp());
+
+    setLuminosityBlockAuxiliary(lumiBlockAuxiliary);
+    luminosityBlockAuxiliary()->setProcessHistoryID(processHistoryID_);
+
+    edm::LogInfo("DAQSource") << "New lumi section was opened. LUMI -: " << lumiSection;
+  }
+}
+
+evf::EvFDaqDirector::FileStatus DAQSource::getNextEventFromDataBlock() {
+  setMonState(inChecksumEvent);
+
+  bool found = dataMode_->nextEventView();
+  //file(s) completely parsed
+  if (!found) {
+    if (dataMode_->dataBlockInitialized()) {
+      dataMode_->setDataBlockInitialized(false);
+      //roll position to the end of the file to close it
+      currentFile_->bufferPosition_ = currentFile_->fileSize_;
+    }
+    return evf::EvFDaqDirector::noFile;
+  }
+
+  if (verifyChecksum_ && !dataMode_->checksumValid()) {
+    if (fms_)
+      fms_->setExceptionDetected(currentLumiSection_);
+    throw cms::Exception("DAQSource::getNextEvent") << dataMode_->getChecksumError();
+  }
+  setMonState(inCachedEvent);
+
+  currentFile_->nProcessed_++;
+
+  return evf::EvFDaqDirector::sameFile;
+}
+
+evf::EvFDaqDirector::FileStatus DAQSource::getNextDataBlock() {
+  if (setExceptionState_)
+    threadError();
+  if (!currentFile_.get()) {
+    evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
+    setMonState(inWaitInput);
+    if (!fileQueue_.try_pop(currentFile_)) {
+      //sleep until wakeup (only in single-buffer mode) or timeout
+      std::unique_lock<std::mutex> lkw(mWakeup_);
+      if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout || !currentFile_.get())
+        return evf::EvFDaqDirector::noFile;
+    }
+    status = currentFile_->status_;
+    if (status == evf::EvFDaqDirector::runEnded) {
+      setMonState(inRunEnd);
+      currentFile_.reset();
+      return status;
+    } else if (status == evf::EvFDaqDirector::runAbort) {
+      throw cms::Exception("DAQSource::getNextEvent") << "Run has been aborted by the input source reader thread";
+    } else if (status == evf::EvFDaqDirector::newLumi) {
+      setMonState(inNewLumi);
+      if (currentFile_->lumi_ > currentLumiSection_) {
+        reportEventsThisLumiInSource(currentLumiSection_, eventsThisLumi_);
+        eventsThisLumi_ = 0;
+        maybeOpenNewLumiSection(currentFile_->lumi_);
+      }
+      currentFile_.reset();
+      return status;
+    } else if (status == evf::EvFDaqDirector::newFile) {
+      currentFileIndex_++;
+    } else
+      assert(false);
+  }
+  setMonState(inProcessingFile);
+
+  //file is empty
+  if (!currentFile_->fileSize_) {
+    readingFilesCount_--;
+    //try to open new lumi
+    assert(currentFile_->nChunks_ == 0);
+    if (currentFile_->lumi_ > currentLumiSection_) {
+      reportEventsThisLumiInSource(currentLumiSection_, eventsThisLumi_);
+      eventsThisLumi_ = 0;
+      maybeOpenNewLumiSection(currentFile_->lumi_);
+    }
+    //immediately delete empty file
+    currentFile_.reset();
+    return evf::EvFDaqDirector::noFile;
+  }
+
+  //file is finished
+  if (currentFile_->bufferPosition_ == currentFile_->fileSize_) {
+    readingFilesCount_--;
+    //release last chunk (it is never released elsewhere)
+    freeChunks_.push(currentFile_->chunks_[currentFile_->currentChunk_]);
+    if (currentFile_->nEvents_ >= 0 && currentFile_->nEvents_ != int(currentFile_->nProcessed_)) {
+      throw cms::Exception("DAQSource::getNextEvent")
+          << "Fully processed " << currentFile_->nProcessed_ << " from the file " << currentFile_->fileName_
+          << " but according to BU JSON there should be " << currentFile_->nEvents_ << " events";
+    }
+    if (!daqDirector_->isSingleStreamThread() && !fileListMode_) {
+      //put the file in pending delete list;
+      std::unique_lock<std::mutex> lkw(fileDeleteLock_);
+      filesToDelete_.push_back(
+          std::pair<int, std::unique_ptr<RawInputFile>>(currentFileIndex_, std::move(currentFile_)));
+    } else {
+      //in single-thread and stream jobs, events are already processed
+      currentFile_.reset();
+    }
+    return evf::EvFDaqDirector::noFile;
+  }
+
+  //assert(currentFile_->status_ == evf::EvFDaqDirector::newFile);
+
+  //handle RAW file header
+  if (currentFile_->bufferPosition_ == 0 && currentFile_->rawHeaderSize_ > 0) {
+    if (currentFile_->fileSize_ <= currentFile_->rawHeaderSize_) {
+      if (currentFile_->fileSize_ < currentFile_->rawHeaderSize_)
+        throw cms::Exception("DAQSource::getNextEvent") << "Premature end of input file while reading file header";
+
+      edm::LogWarning("DAQSource") << "File with only raw header and no events received in LS " << currentFile_->lumi_;
+      if (currentFile_->lumi_ > currentLumiSection_) {
+        reportEventsThisLumiInSource(currentLumiSection_, eventsThisLumi_);
+        eventsThisLumi_ = 0;
+        maybeOpenNewLumiSection(currentFile_->lumi_);
+      }
+    }
+
+    //advance buffer position to skip file header (chunk will be acquired later)
+    currentFile_->chunkPosition_ += currentFile_->rawHeaderSize_;
+    currentFile_->bufferPosition_ += currentFile_->rawHeaderSize_;
+  }
+
+  //file is too short
+  if (currentFile_->fileSize_ - currentFile_->bufferPosition_ < dataMode_->headerSize()) {
+    throw cms::Exception("DAQSource::getNextEvent") << "Premature end of input file while reading event header";
+  }
+
+  //multibuffer mode
+  //wait for the current chunk to become added to the vector
+  setMonState(inWaitChunk);
+  while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
+    usleep(10000);
+    if (setExceptionState_)
+      threadError();
+  }
+  setMonState(inChunkReceived);
+
+  //check if header is at the boundary of two chunks
+  chunkIsFree_ = false;
+  unsigned char* dataPosition;
+
+  //read event header, copy it to a single chunk if necessary
+  bool chunkEnd = currentFile_->advance(dataPosition, dataMode_->headerSize());
+
+  //get buffer size of current chunk (can be resized)
+  uint64_t currentChunkSize = currentFile_->currentChunkSize();
+
+  dataMode_->makeDataBlockView(dataPosition, currentChunkSize, currentFile_->fileSizes_, currentFile_->rawHeaderSize_);
+
+  const size_t msgSize = dataMode_->dataBlockSize() - dataMode_->headerSize();
+
+  if (currentFile_->fileSize_ - currentFile_->bufferPosition_ < msgSize) {
+    throw cms::Exception("DAQSource::getNextEvent") << "Premature end of input file while reading event data";
+  }
+
+  //for cross-buffer models
+  if (chunkEnd) {
+    //header was at the chunk boundary, we will have to move payload as well
+    currentFile_->moveToPreviousChunk(msgSize, dataMode_->headerSize());
+    chunkIsFree_ = true;
+  } else {
+    //header was contiguous, but check if payload fits the chunk
+    if (currentChunkSize - currentFile_->chunkPosition_ < msgSize) {
+      //rewind to header start position
+      currentFile_->rewindChunk(dataMode_->headerSize());
+      //copy event to a chunk start and move pointers
+
+      setMonState(inWaitChunk);
+
+      //can already move buffer
+      chunkEnd = currentFile_->advance(dataPosition, dataMode_->headerSize() + msgSize);
+
+      setMonState(inChunkReceived);
+
+      assert(chunkEnd);
+      chunkIsFree_ = true;
+      //header is moved
+      dataMode_->makeDataBlockView(
+          dataPosition, currentFile_->currentChunkSize(), currentFile_->fileSizes_, currentFile_->rawHeaderSize_);
+    } else {
+      //everything is in a single chunk, only move pointers forward
+      chunkEnd = currentFile_->advance(dataPosition, msgSize);
+      assert(!chunkEnd);
+      chunkIsFree_ = false;
+    }
+  }
+  //prepare event
+  return getNextEventFromDataBlock();
+}
+
+void DAQSource::read(edm::EventPrincipal& eventPrincipal) {
+  setMonState(inReadEvent);
+
+  dataMode_->readEvent(eventPrincipal);
+
+  eventsThisLumi_++;
+  setMonState(inReadCleanup);
+
+  //resize vector if needed
+  while (streamFileTracker_.size() <= eventPrincipal.streamID())
+    streamFileTracker_.push_back(-1);
+
+  streamFileTracker_[eventPrincipal.streamID()] = currentFileIndex_;
+
+  //this old file check runs no more often than every 10 events
+  if (!((currentFile_->nProcessed_ - 1) % (checkEvery_))) {
+    //delete files that are not in processing
+    std::unique_lock<std::mutex> lkw(fileDeleteLock_);
+    auto it = filesToDelete_.begin();
+    while (it != filesToDelete_.end()) {
+      bool fileIsBeingProcessed = false;
+      for (unsigned int i = 0; i < nStreams_; i++) {
+        if (it->first == streamFileTracker_.at(i)) {
+          fileIsBeingProcessed = true;
+          break;
+        }
+      }
+      if (!fileIsBeingProcessed && !(fms_ && fms_->isExceptionOnData(it->second->lumi_))) {
+        it = filesToDelete_.erase(it);
+      } else
+        it++;
+    }
+  }
+  if (dataMode_->dataBlockCompleted() && chunkIsFree_) {
+    freeChunks_.push(currentFile_->chunks_[currentFile_->currentChunk_ - 1]);
+    chunkIsFree_ = false;
+  }
+  setMonState(inNoRequest);
+  return;
+}
+
+void DAQSource::rewind_() {}
+
+void DAQSource::dataArranger() {}
+
+void DAQSource::readSupervisor() {
+  bool stop = false;
+  unsigned int currentLumiSection = 0;
+
+  {
+    std::unique_lock<std::mutex> lk(startupLock_);
+    startupCv_.notify_one();
+  }
+
+  uint32_t ls = 0;
+  uint32_t monLS = 1;
+  uint32_t lockCount = 0;
+  uint64_t sumLockWaitTimeUs = 0.;
+
+  bool requireHeader = dataMode_->requireHeader();
+
+  while (!stop) {
+    //wait for at least one free thread and chunk
+    int counter = 0;
+
+    while (workerPool_.empty() || freeChunks_.empty() || readingFilesCount_ >= maxBufferedFiles_) {
+      //report state to monitoring
+      if (fms_) {
+        bool copy_active = false;
+        for (auto j : tid_active_)
+          if (j)
+            copy_active = true;
+        if (readingFilesCount_ >= maxBufferedFiles_)
+          setMonStateSup(inSupFileLimit);
+        else if (freeChunks_.empty()) {
+          if (copy_active)
+            setMonStateSup(inSupWaitFreeChunkCopying);
+          else
+            setMonStateSup(inSupWaitFreeChunk);
+        } else {
+          if (copy_active)
+            setMonStateSup(inSupWaitFreeThreadCopying);
+          else
+            setMonStateSup(inSupWaitFreeThread);
+        }
+      }
+      std::unique_lock<std::mutex> lkw(mWakeup_);
+      //sleep until woken up by condition or a timeout
+      if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout) {
+        counter++;
+        //if (!(counter%50)) edm::LogInfo("DAQSource") << "No free chunks or threads...";
+        LogDebug("DAQSource") << "No free chunks or threads...";
+      } else {
+        assert(!workerPool_.empty() || freeChunks_.empty());
+      }
+      if (quit_threads_.load(std::memory_order_relaxed) || edm::shutdown_flag.load(std::memory_order_relaxed)) {
+        stop = true;
+        break;
+      }
+    }
+    //if this is reached, there are enough buffers and threads to proceed or processing is instructed to stop
+
+    if (stop)
+      break;
+
+    //look for a new file
+    std::string nextFile;
+    int64_t fileSizeFromMetadata;
+
+    if (fms_) {
+      setMonStateSup(inSupBusy);
+      fms_->startedLookingForFile();
+    }
+    bool fitToBuffer = dataMode_->fitToBuffer();
+
+    evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
+    uint16_t rawHeaderSize = 0;
+    uint32_t lsFromRaw = 0;
+    int32_t serverEventsInNewFile = -1;
+    int rawFd = -1;
+
+    int backoff_exp = 0;
+
+    //entering loop which tries to grab new file from ramdisk
+    while (status == evf::EvFDaqDirector::noFile) {
+      //check if hltd has signalled to throttle input
+      counter = 0;
+      while (daqDirector_->inputThrottled()) {
+        if (quit_threads_.load(std::memory_order_relaxed) || edm::shutdown_flag.load(std::memory_order_relaxed))
+          break;
+
+        unsigned int nConcurrentLumis = daqDirector_->numConcurrentLumis();
+        unsigned int nOtherLumis = nConcurrentLumis > 0 ? nConcurrentLumis - 1 : 0;
+        unsigned int checkLumiStart = currentLumiSection > nOtherLumis ? currentLumiSection - nOtherLumis : 1;
+        bool hasDiscardedLumi = false;
+        for (unsigned int i = checkLumiStart; i <= currentLumiSection; i++) {
+          if (daqDirector_->lumisectionDiscarded(i)) {
+            edm::LogWarning("DAQSource") << "Source detected that the lumisection is discarded -: " << i;
+            hasDiscardedLumi = true;
+            break;
+          }
+        }
+        if (hasDiscardedLumi)
+          break;
+
+        setMonStateSup(inThrottled);
+        if (!(counter % 50))
+          edm::LogWarning("DAQSource") << "Input throttled detected, reading files is paused...";
+        usleep(100000);
+        counter++;
+      }
+
+      if (quit_threads_.load(std::memory_order_relaxed) || edm::shutdown_flag.load(std::memory_order_relaxed)) {
+        stop = true;
+        break;
+      }
+
+      assert(rawFd == -1);
+      uint64_t thisLockWaitTimeUs = 0.;
+      setMonStateSup(inSupLockPolling);
+      if (fileListMode_) {
+        //return LS if LS not set, otherwise return file
+        status = getFile(ls, nextFile, thisLockWaitTimeUs);
+        if (status == evf::EvFDaqDirector::newFile) {
+          uint16_t rawDataType;
+          if (evf::EvFDaqDirector::parseFRDFileHeader(nextFile,
+                                                      rawFd,
+                                                      rawHeaderSize,  ///possibility to use by new formats
+                                                      rawDataType,
+                                                      lsFromRaw,
+                                                      serverEventsInNewFile,
+                                                      fileSizeFromMetadata,
+                                                      requireHeader,
+                                                      false,
+                                                      false) != 0) {
+            //error
+            setExceptionState_ = true;
+            stop = true;
+            break;
+          }
+        }
+      } else {
+        status = daqDirector_->getNextFromFileBroker(currentLumiSection,
+                                                     ls,
+                                                     nextFile,
+                                                     rawFd,
+                                                     rawHeaderSize,  //which format?
+                                                     serverEventsInNewFile,
+                                                     fileSizeFromMetadata,
+                                                     thisLockWaitTimeUs,
+                                                     requireHeader);
+      }
+
+      setMonStateSup(inSupBusy);
+
+      //cycle through all remaining LS even if no files get assigned
+      if (currentLumiSection != ls && status == evf::EvFDaqDirector::runEnded)
+        status = evf::EvFDaqDirector::noFile;
+
+      //monitoring of lock wait time
+      if (thisLockWaitTimeUs > 0.)
+        sumLockWaitTimeUs += thisLockWaitTimeUs;
+      lockCount++;
+      if (ls > monLS) {
+        monLS = ls;
+        if (lockCount)
+          if (fms_)
+            fms_->reportLockWait(monLS, sumLockWaitTimeUs, lockCount);
+        lockCount = 0;
+        sumLockWaitTimeUs = 0;
+      }
+
+      if (status == evf::EvFDaqDirector::runEnded) {
+        fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::runEnded));
+        stop = true;
+        break;
+      }
+
+      //error from filelocking function
+      if (status == evf::EvFDaqDirector::runAbort) {
+        fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::runAbort, 0));
+        stop = true;
+        break;
+      }
+      //queue new lumisection
+      if (ls > currentLumiSection) {
+        //new file service
+        if (currentLumiSection == 0 && !alwaysStartFromFirstLS_) {
+          if (daqDirector_->getStartLumisectionFromEnv() > 1) {
+            //start transitions from LS specified by env, continue if not reached
+            if (ls < daqDirector_->getStartLumisectionFromEnv()) {
+              //skip file if from earlier LS than specified by env
+              if (rawFd != -1) {
+                close(rawFd);
+                rawFd = -1;
+              }
+              status = evf::EvFDaqDirector::noFile;
+              continue;
+            } else {
+              fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::newLumi, ls));
+            }
+          } else if (ls < 100) {
+            //look at last LS file on disk to start from that lumisection (only within first 100 LS)
+            unsigned int lsToStart = daqDirector_->getLumisectionToStart();
+
+            for (unsigned int nextLS = std::min(lsToStart, ls); nextLS <= ls; nextLS++) {
+              fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::newLumi, nextLS));
+            }
+          } else {
+            //start from current LS
+            fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::newLumi, ls));
+          }
+        } else {
+          //queue all lumisections after last one seen to avoid gaps
+          for (unsigned int nextLS = currentLumiSection + 1; nextLS <= ls; nextLS++) {
+            fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::newLumi, nextLS));
+          }
+        }
+        currentLumiSection = ls;
+      }
+      //else
+      if (currentLumiSection > 0 && ls < currentLumiSection) {
+        edm::LogError("DAQSource") << "Got old LS (" << ls
+                                   << ") file from EvFDAQDirector! Expected LS:" << currentLumiSection
+                                   << ". Aborting execution." << std::endl;
+        if (rawFd != -1)
+          close(rawFd);
+        rawFd = -1;
+        fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::runAbort, 0));
+        stop = true;
+        break;
+      }
+
+      int dbgcount = 0;
+      if (status == evf::EvFDaqDirector::noFile) {
+        setMonStateSup(inSupNoFile);
+        dbgcount++;
+        if (!(dbgcount % 20))
+          LogDebug("DAQSource") << "No file for me... sleep and try again...";
+
+        backoff_exp = std::min(4, backoff_exp);  // max 1.6 seconds
+        //backoff_exp=0; // disabled!
+        int sleeptime = (int)(100000. * pow(2, backoff_exp));
+        usleep(sleeptime);
+        backoff_exp++;
+      } else
+        backoff_exp = 0;
+    }
+    //end of file grab loop, parse result
+    if (status == evf::EvFDaqDirector::newFile) {
+      setMonStateSup(inSupNewFile);
+      LogDebug("DAQSource") << "The director says to grab -: " << nextFile;
+
+      std::string rawFile;
+      //file service will report raw extension
+      rawFile = nextFile;
+
+      struct stat st;
+      int stat_res = stat(rawFile.c_str(), &st);
+      if (stat_res == -1) {
+        edm::LogError("DAQSource") << "Can not stat file (" << errno << "):-" << rawFile << std::endl;
+        setExceptionState_ = true;
+        break;
+      }
+      uint64_t fileSize = st.st_size;
+
+      if (fms_) {
+        setMonStateSup(inSupBusy);
+        fms_->stoppedLookingForFile(ls);
+        setMonStateSup(inSupNewFile);
+      }
+      int eventsInNewFile;
+      if (fileListMode_) {
+        if (fileSize == 0)
+          eventsInNewFile = 0;
+        else
+          eventsInNewFile = -1;
+      } else {
+        eventsInNewFile = serverEventsInNewFile;
+        assert(eventsInNewFile >= 0);
+        assert((eventsInNewFile > 0) ==
+               (fileSize > rawHeaderSize));  //file without events must be empty or contain only header
+      }
+
+      std::pair<bool, std::vector<std::string>> additionalFiles =
+          dataMode_->defineAdditionalFiles(rawFile, fileListMode_);
+      if (!additionalFiles.first) {
+        //skip secondary files from file broker
+        if (rawFd > -1)
+          close(rawFd);
+        continue;
+      }
+
+      std::unique_ptr<RawInputFile> newInputFile(new RawInputFile(evf::EvFDaqDirector::FileStatus::newFile,
+                                                                  ls,
+                                                                  rawFile,
+                                                                  !fileListMode_,
+                                                                  rawFd,
+                                                                  fileSize,
+                                                                  rawHeaderSize,  //for which format
+                                                                  0,
+                                                                  eventsInNewFile,
+                                                                  this));
+
+      uint64_t neededSize = fileSize;
+      for (const auto& addFile : additionalFiles.second) {
+        struct stat buf;
+        //wait for secondary files to appear
+        unsigned int fcnt = 0;
+        while (stat(addFile.c_str(), &buf) != 0) {
+          if (fileListMode_) {
+            edm::LogError("DAQSource") << "additional file is missing -: " << addFile;
+            stop = true;
+            setExceptionState_ = true;
+            break;
+          }
+          usleep(10000);
+          fcnt++;
+          //report and EoR check every 30 seconds
+          if ((fcnt && fcnt % 3000 == 0) || quit_threads_.load(std::memory_order_relaxed)) {
+            edm::LogWarning("DAQSource") << "Additional file is still missing after 30 seconds -: " << addFile;
+            struct stat bufEoR;
+            auto secondaryPath = std::filesystem::path(addFile).parent_path();
+            auto eorName = std::filesystem::path(daqDirector_->getEoRFileName());
+            std::string mainEoR = (std::filesystem::path(daqDirector_->buBaseRunDir()) / eorName).generic_string();
+            std::string secondaryEoR = (secondaryPath / eorName).generic_string();
+            bool prematureEoR = false;
+            if (stat(secondaryEoR.c_str(), &bufEoR) == 0) {
+              if (stat(addFile.c_str(), &bufEoR) != 0) {
+                edm::LogError("DAQSource")
+                    << "EoR file appeared in -: " << secondaryPath << " while waiting for index file " << addFile;
+                prematureEoR = true;
+              }
+            } else if (stat(mainEoR.c_str(), &bufEoR) == 0) {
+              //wait another 10 seconds
+              usleep(10000000);
+              if (stat(addFile.c_str(), &bufEoR) != 0) {
+                edm::LogError("DAQSource")
+                    << "Main EoR file appeared -: " << mainEoR << " while waiting for index file " << addFile;
+                prematureEoR = true;
+              }
+            }
+            if (prematureEoR) {
+              //queue EoR since this is not FU error
+              fileQueue_.push(std::make_unique<RawInputFile>(evf::EvFDaqDirector::runEnded, 0));
+              stop = true;
+              break;
+            }
+          }
+
+          if (quit_threads_) {
+            edm::LogError("DAQSource") << "Quitting while waiting for file -: " << addFile;
+            stop = true;
+            setExceptionState_ = true;
+            break;
+          }
+        }
+        LogDebug("DAQSource") << " APPEND NAME " << addFile;
+        if (stop)
+          break;
+
+        newInputFile->appendFile(addFile, buf.st_size);
+        neededSize += buf.st_size;
+      }
+      if (stop)
+        break;
+
+      //calculate number of needed chunks and size if resizing will be applied
+      uint16_t neededChunks;
+      uint64_t chunkSize;
+
+      if (fitToBuffer) {
+        chunkSize = std::min(maxChunkSize_, std::max(eventChunkSize_, neededSize));
+        neededChunks = 1;
+      } else {
+        chunkSize = eventChunkSize_;
+        neededChunks = neededSize / eventChunkSize_ + uint16_t((neededSize % eventChunkSize_) > 0);
+      }
+      newInputFile->setChunks(neededChunks);
+
+      newInputFile->randomizeOrder(rng_);
+
+      readingFilesCount_++;
+      auto newInputFilePtr = newInputFile.get();
+      fileQueue_.push(std::move(newInputFile));
+
+      for (size_t i = 0; i < neededChunks; i++) {
+        if (fms_) {
+          bool copy_active = false;
+          for (auto j : tid_active_)
+            if (j)
+              copy_active = true;
+          if (copy_active)
+            setMonStateSup(inSupNewFileWaitThreadCopying);
+          else
+            setMonStateSup(inSupNewFileWaitThread);
+        }
+        //get thread
+        unsigned int newTid = 0xffffffff;
+        while (!workerPool_.try_pop(newTid)) {
+          usleep(100000);
+          if (quit_threads_.load(std::memory_order_relaxed)) {
+            stop = true;
+            break;
+          }
+        }
+
+        if (fms_) {
+          bool copy_active = false;
+          for (auto j : tid_active_)
+            if (j)
+              copy_active = true;
+          if (copy_active)
+            setMonStateSup(inSupNewFileWaitChunkCopying);
+          else
+            setMonStateSup(inSupNewFileWaitChunk);
+        }
+        InputChunk* newChunk = nullptr;
+        while (!freeChunks_.try_pop(newChunk)) {
+          usleep(100000);
+          if (quit_threads_.load(std::memory_order_relaxed)) {
+            stop = true;
+            break;
+          }
+        }
+
+        if (newChunk == nullptr) {
+          //return unused tid if we received shutdown (nullptr chunk)
+          if (newTid != 0xffffffff)
+            workerPool_.push(newTid);
+          stop = true;
+          break;
+        }
+        if (stop)
+          break;
+        setMonStateSup(inSupNewFile);
+
+        std::unique_lock<std::mutex> lk(mReader_);
+
+        uint64_t toRead = chunkSize;
+        if (i == (uint64_t)neededChunks - 1 && neededSize % chunkSize)
+          toRead = neededSize % chunkSize;
+        newChunk->reset(i * chunkSize, toRead, i);
+
+        workerJob_[newTid].first = newInputFilePtr;
+        workerJob_[newTid].second = newChunk;
+
+        //wake up the worker thread
+        cvReader_[newTid]->notify_one();
+      }
+    }
+  }
+  setMonStateSup(inRunEnd);
+  //make sure threads finish reading
+  unsigned int numFinishedThreads = 0;
+  while (numFinishedThreads < workerThreads_.size()) {
+    unsigned int tid = 0;
+    while (!workerPool_.try_pop(tid)) {
+      usleep(10000);
+    }
+    std::unique_lock<std::mutex> lk(mReader_);
+    thread_quit_signal[tid] = true;
+    cvReader_[tid]->notify_one();
+    numFinishedThreads++;
+  }
+  for (unsigned int i = 0; i < workerThreads_.size(); i++) {
+    workerThreads_[i]->join();
+    delete workerThreads_[i];
+  }
+}
+
+void DAQSource::readWorker(unsigned int tid) {
+  bool init = true;
+  threadInit_.exchange(true, std::memory_order_acquire);
+
+  while (true) {
+    tid_active_[tid] = false;
+    std::unique_lock<std::mutex> lk(mReader_);
+    workerJob_[tid].first = nullptr;
+    workerJob_[tid].first = nullptr;
+
+    assert(!thread_quit_signal[tid]);  //should never get it here
+    workerPool_.push(tid);
+
+    if (init) {
+      std::unique_lock<std::mutex> lk(startupLock_);
+      init = false;
+      startupCv_.notify_one();
+    }
+    cvReader_[tid]->wait(lk);
+
+    if (thread_quit_signal[tid])
+      return;
+    tid_active_[tid] = true;
+
+    RawInputFile* file;
+    InputChunk* chunk;
+
+    assert(workerJob_[tid].first != nullptr && workerJob_[tid].second != nullptr);
+
+    file = workerJob_[tid].first;
+    chunk = workerJob_[tid].second;
+
+    bool fitToBuffer = dataMode_->fitToBuffer();
+
+    //resize if multi-chunked reading is not possible
+    if (fitToBuffer) {
+      uint64_t accum = 0;
+      for (auto s : file->diskFileSizes_)
+        accum += s;
+      if (accum > eventChunkSize_) {
+        if (!chunk->resize(accum, maxChunkSize_)) {
+          edm::LogError("DAQSource")
+              << "maxChunkSize can not accomodate the file set. Try increasing chunk size and/or chunk maximum size.";
+          if (file->rawFd_ != -1 && (numConcurrentReads_ == 1 || chunk->offset_ == 0))
+            close(file->rawFd_);
+          setExceptionState_ = true;
+          continue;
+        } else {
+          edm::LogInfo("DAQSource") << "chunk size was increased to " << (chunk->size_ >> 20) << " MB";
+        }
+      }
+    }
+
+    //skip reading initial header size in first chunk if inheriting file descriptor (already set at appropriate position)
+    unsigned int bufferLeftInitial = (chunk->offset_ == 0 && file->rawFd_ != -1) ? file->rawHeaderSize_ : 0;
+    const uint16_t readBlocks = chunk->size_ / eventChunkBlock_ + uint16_t(chunk->size_ % eventChunkBlock_ > 0);
+
+    auto readPrimary = [&](uint64_t bufferLeft) {
+      //BEGIN reading primary file - check if file descriptor is already open
+      //in multi-threaded chunked mode, only first thread will use already open fd for reading the first file
+      //fd will not be closed in other case (used by other threads)
+      int fileDescriptor = -1;
+      bool fileOpenedHere = false;
+
+      if (numConcurrentReads_ == 1) {
+        fileDescriptor = file->rawFd_;
+        file->rawFd_ = -1;
+        if (fileDescriptor == -1) {
+          fileDescriptor = open(file->fileName_.c_str(), O_RDONLY);
+          fileOpenedHere = true;
+        }
+      } else {
+        if (chunk->offset_ == 0) {
+          fileDescriptor = file->rawFd_;
+          file->rawFd_ = -1;
+          if (fileDescriptor == -1) {
+            fileDescriptor = open(file->fileName_.c_str(), O_RDONLY);
+            fileOpenedHere = true;
+          }
+        } else {
+          fileDescriptor = open(file->fileName_.c_str(), O_RDONLY);
+          fileOpenedHere = true;
+        }
+      }
+
+      if (fileDescriptor == -1) {
+        edm::LogError("DAQSource") << "readWorker failed to open file -: " << file->fileName_
+                                   << " fd:" << fileDescriptor << " error: " << strerror(errno);
+        setExceptionState_ = true;
+        return;
+      }
+
+      if (fileOpenedHere) {  //fast forward to this chunk position
+        off_t pos = lseek(fileDescriptor, chunk->offset_, SEEK_SET);
+        if (pos == -1) {
+          edm::LogError("DAQSource") << "readWorker failed to seek file -: " << file->fileName_
+                                     << " fd:" << fileDescriptor << " to offset " << chunk->offset_
+                                     << " error: " << strerror(errno);
+          setExceptionState_ = true;
+          return;
+        }
+      }
+
+      LogDebug("DAQSource") << "Reader thread opened file -: TID: " << tid << " file: " << file->fileName_
+                            << " at offset " << lseek(fileDescriptor, 0, SEEK_CUR);
+
+      size_t skipped = bufferLeft;
+      auto start = std::chrono::high_resolution_clock::now();
+      for (unsigned int i = 0; i < readBlocks; i++) {
+        ssize_t last;
+        edm::LogInfo("DAQSource") << "readWorker read -: " << (int64_t)(chunk->usedSize_ - bufferLeft) << " or "
+                                  << (int64_t)eventChunkBlock_;
+
+        //protect against reading into next block
+        last = ::read(fileDescriptor,
+                      (void*)(chunk->buf_ + bufferLeft),
+                      std::min((int64_t)(chunk->usedSize_ - bufferLeft), (int64_t)eventChunkBlock_));
+
+        if (last < 0) {
+          edm::LogError("DAQSource") << "readWorker failed to read file -: " << file->fileName_
+                                     << " fd:" << fileDescriptor << " last: " << last << " error: " << strerror(errno);
+          setExceptionState_ = true;
+          break;
+        }
+        if (last > 0) {
+          bufferLeft += last;
+        }
+        if ((uint64_t)last < eventChunkBlock_) {  //last read
+          edm::LogInfo("DAQSource") << "chunkUsedSize" << chunk->usedSize_ << " u-s:" << (chunk->usedSize_ - skipped)
+                                    << " ix:" << i * eventChunkBlock_ << " " << (size_t)last;
+          //check if this is last block if single file, then total read size must match file size
+          if (file->numFiles_ == 1 && !(chunk->usedSize_ - skipped == i * eventChunkBlock_ + (size_t)last)) {
+            edm::LogError("DAQSource") << "readWorker failed to read file -: " << file->fileName_
+                                       << " fd:" << fileDescriptor << " last:" << last
+                                       << " expectedChunkSize:" << chunk->usedSize_
+                                       << " readChunkSize:" << (skipped + i * eventChunkBlock_ + last)
+                                       << " skipped:" << skipped << " block:" << (i + 1) << "/" << readBlocks
+                                       << " error: " << strerror(errno);
+            setExceptionState_ = true;
+          }
+          break;
+        }
+      }
+      if (setExceptionState_)
+        return;
+
+      file->fileSizes_[0] = bufferLeft;
+
+      if (chunk->offset_ + bufferLeft == file->fileSize_) {  //file reading finished using same fd
+        close(fileDescriptor);
+        fileDescriptor = -1;
+      }
+      //close if first thread reading this fd
+      if (numConcurrentReads_ > 1 && fileDescriptor != -1)
+        close(fileDescriptor);
+
+      if (fitToBuffer && bufferLeft != file->diskFileSizes_[0]) {
+        edm::LogError("DAQSource") << "mismatch between read file size for file -: " << file->fileNames_[0]
+                                   << " read:" << bufferLeft << " expected:" << file->diskFileSizes_[0];
+        setExceptionState_ = true;
+        return;
+      }
+
+      auto end = std::chrono::high_resolution_clock::now();
+      auto diff = end - start;
+      std::chrono::milliseconds msec = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
+      LogDebug("DAQSource") << " finished reading block -: " << (bufferLeft >> 20) << " MB"
+                            << " in " << msec.count() << " ms (" << (bufferLeft >> 20) / double(msec.count())
+                            << " GB/s)";
+    };
+    //END primary function
+
+    //SECONDARY files function
+    auto readSecondary = [&](uint64_t bufferLeft, unsigned int j) {
+      size_t fileLen = 0;
+
+      std::string const& addFile = file->fileNames_[j];
+      int fileDescriptor = open(addFile.c_str(), O_RDONLY);
+
+      if (fileDescriptor < 0) {
+        edm::LogError("DAQSource") << "readWorker failed to open file -: " << addFile << " fd:" << fileDescriptor
+                                   << " error: " << strerror(errno);
+        setExceptionState_ = true;
+        return;
+      }
+
+      LogDebug("DAQSource") << "Reader thread opened file -: TID: " << tid << " file: " << addFile << " at offset "
+                            << lseek(fileDescriptor, 0, SEEK_CUR);
+
+      //size_t skipped = 0;//file is newly opened, read with header
+      auto start = std::chrono::high_resolution_clock::now();
+      for (unsigned int i = 0; i < readBlocks; i++) {
+        ssize_t last;
+
+        //protect against reading into next block
+        //use bufferLeft for the write offset
+        last = ::read(fileDescriptor,
+                      (void*)(chunk->buf_ + bufferLeft),
+                      std::min((uint64_t)file->diskFileSizes_[j], (uint64_t)eventChunkBlock_));
+
+        if (last < 0) {
+          edm::LogError("DAQSource") << "readWorker failed to read file -: " << addFile << " fd:" << fileDescriptor
+                                     << " error: " << strerror(errno);
+          setExceptionState_ = true;
+          close(fileDescriptor);
+          break;
+        }
+        if (last > 0) {
+          bufferLeft += last;
+          fileLen += last;
+          file->fileSize_ += last;
+        }
+      };
+
+      close(fileDescriptor);
+      file->fileSizes_[j] = fileLen;
+      assert(fileLen > 0);
+
+      if (fitToBuffer && fileLen != file->diskFileSizes_[j]) {
+        edm::LogError("DAQSource") << "mismatch between read file size for file -: " << file->fileNames_[j]
+                                   << " read:" << fileLen << " expected:" << file->diskFileSizes_[j];
+        setExceptionState_ = true;
+        return;
+      }
+
+      auto end = std::chrono::high_resolution_clock::now();
+      auto diff = end - start;
+      std::chrono::milliseconds msec = std::chrono::duration_cast<std::chrono::milliseconds>(diff);
+      LogDebug("DAQSource") << " finished reading block -: " << (bufferLeft >> 20) << " MB"
+                            << " in " << msec.count() << " ms (" << (bufferLeft >> 20) / double(msec.count())
+                            << " GB/s)";
+    };
+
+    //randomized order multi-file loop
+    for (unsigned int j : file->fileOrder_) {
+      if (j == 0) {
+        readPrimary(bufferLeftInitial);
+      } else
+        readSecondary(file->bufferOffsets_[j], j);
+
+      if (setExceptionState_)
+        break;
+    }
+
+    if (setExceptionState_)
+      continue;
+
+    //detect FRD event version. Skip file Header if it exists
+    if (dataMode_->dataVersion() == 0 && chunk->offset_ == 0) {
+      dataMode_->detectVersion(chunk->buf_, file->rawHeaderSize_);
+    }
+    assert(dataMode_->versionCheck());
+
+    chunk->readComplete_ =
+        true;  //this is atomic to secure the sequential buffer fill before becoming available for processing)
+    file->chunks_[chunk->fileIndex_] = chunk;  //put the completed chunk in the file chunk vector at predetermined index
+  }
+}
+
+void DAQSource::threadError() {
+  quit_threads_ = true;
+  throw cms::Exception("DAQSource:threadError") << " file reader thread error ";
+}
+
+void DAQSource::setMonState(evf::FastMonState::InputState state) {
+  if (fms_)
+    fms_->setInState(state);
+}
+
+void DAQSource::setMonStateSup(evf::FastMonState::InputState state) {
+  if (fms_)
+    fms_->setInStateSup(state);
+}
+
+bool RawInputFile::advance(unsigned char*& dataPosition, const size_t size) {
+  //wait for chunk
+
+  while (!waitForChunk(currentChunk_)) {
+    sourceParent_->setMonState(inWaitChunk);
+    usleep(100000);
+    sourceParent_->setMonState(inChunkReceived);
+    if (sourceParent_->exceptionState())
+      sourceParent_->threadError();
+  }
+
+  dataPosition = chunks_[currentChunk_]->buf_ + chunkPosition_;
+  size_t currentLeft = chunks_[currentChunk_]->size_ - chunkPosition_;
+
+  if (currentLeft < size) {
+    //we need next chunk
+    while (!waitForChunk(currentChunk_ + 1)) {
+      sourceParent_->setMonState(inWaitChunk);
+      usleep(100000);
+      sourceParent_->setMonState(inChunkReceived);
+      if (sourceParent_->exceptionState())
+        sourceParent_->threadError();
+    }
+    //copy everything to beginning of the first chunk
+    dataPosition -= chunkPosition_;
+    assert(dataPosition == chunks_[currentChunk_]->buf_);
+    memmove(chunks_[currentChunk_]->buf_, chunks_[currentChunk_]->buf_ + chunkPosition_, currentLeft);
+    memcpy(chunks_[currentChunk_]->buf_ + currentLeft, chunks_[currentChunk_ + 1]->buf_, size - currentLeft);
+    //set pointers at the end of the old data position
+    bufferPosition_ += size;
+    chunkPosition_ = size - currentLeft;
+    currentChunk_++;
+    return true;
+  } else {
+    chunkPosition_ += size;
+    bufferPosition_ += size;
+    return false;
+  }
+}
+
+void DAQSource::reportEventsThisLumiInSource(unsigned int lumi, unsigned int events) {
+  std::lock_guard<std::mutex> lock(monlock_);
+  auto itr = sourceEventsReport_.find(lumi);
+  if (itr != sourceEventsReport_.end())
+    itr->second += events;
+  else
+    sourceEventsReport_[lumi] = events;
+}
+
+std::pair<bool, unsigned int> DAQSource::getEventReport(unsigned int lumi, bool erase) {
+  std::lock_guard<std::mutex> lock(monlock_);
+  auto itr = sourceEventsReport_.find(lumi);
+  if (itr != sourceEventsReport_.end()) {
+    std::pair<bool, unsigned int> ret(true, itr->second);
+    if (erase)
+      sourceEventsReport_.erase(itr);
+    return ret;
+  } else
+    return std::pair<bool, unsigned int>(false, 0);
+}
+
+long DAQSource::initFileList() {
+  std::sort(listFileNames_.begin(), listFileNames_.end(), [](std::string a, std::string b) {
+    if (a.rfind('/') != std::string::npos)
+      a = a.substr(a.rfind('/'));
+    if (b.rfind('/') != std::string::npos)
+      b = b.substr(b.rfind('/'));
+    return b > a;
+  });
+
+  if (!listFileNames_.empty()) {
+    //get run number from first file in the vector
+    std::filesystem::path fileName = listFileNames_[0];
+    std::string fileStem = fileName.stem().string();
+    if (fileStem.find("file://") == 0)
+      fileStem = fileStem.substr(7);
+    else if (fileStem.find("file:") == 0)
+      fileStem = fileStem.substr(5);
+    auto end = fileStem.find('_');
+
+    if (fileStem.find("run") == 0) {
+      std::string runStr = fileStem.substr(3, end - 3);
+      try {
+        //get long to support test run numbers < 2^32
+        long rval = std::stol(runStr);
+        edm::LogInfo("DAQSource") << "Autodetected run number in fileListMode -: " << rval;
+        return rval;
+      } catch (const std::exception&) {
+        edm::LogWarning("DAQSource") << "Unable to autodetect run number in fileListMode from file -: " << fileName;
+      }
+    }
+  }
+  return -1;
+}
+
+evf::EvFDaqDirector::FileStatus DAQSource::getFile(unsigned int& ls, std::string& nextFile, uint64_t& lockWaitTime) {
+  if (fileListIndex_ < listFileNames_.size()) {
+    nextFile = listFileNames_[fileListIndex_];
+    if (nextFile.find("file://") == 0)
+      nextFile = nextFile.substr(7);
+    else if (nextFile.find("file:") == 0)
+      nextFile = nextFile.substr(5);
+    std::filesystem::path fileName = nextFile;
+    std::string fileStem = fileName.stem().string();
+    if (fileStem.find("ls"))
+      fileStem = fileStem.substr(fileStem.find("ls") + 2);
+    if (fileStem.find('_'))
+      fileStem = fileStem.substr(0, fileStem.find('_'));
+
+    if (!fileListLoopMode_)
+      ls = std::stoul(fileStem);
+    else  //always starting from LS 1 in loop mode
+      ls = 1 + loopModeIterationInc_;
+
+    //fsize = 0;
+    //lockWaitTime = 0;
+    fileListIndex_++;
+    return evf::EvFDaqDirector::newFile;
+  } else {
+    if (!fileListLoopMode_)
+      return evf::EvFDaqDirector::runEnded;
+    else {
+      //loop through files until interrupted
+      loopModeIterationInc_++;
+      fileListIndex_ = 0;
+      return getFile(ls, nextFile, lockWaitTime);
+    }
+  }
+}

--- a/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsFRD.cc
@@ -1,0 +1,355 @@
+#include "EventFilter/Utilities/interface/DAQSource.h"
+#include "EventFilter/Utilities/interface/DAQSourceModelsFRD.h"
+
+#include <iostream>
+#include <sstream>
+#include <sys/types.h>
+#include <sys/file.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <vector>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
+#include "DataFormats/TCDS/interface/TCDSRaw.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "EventFilter/Utilities/interface/GlobalEventNumber.h"
+#include "EventFilter/Utilities/interface/DAQSourceModels.h"
+#include "EventFilter/Utilities/interface/DAQSource.h"
+
+#include "EventFilter/Utilities/interface/AuxiliaryMakers.h"
+
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "EventFilter/Utilities/interface/crc32c.h"
+
+void DataModeFRD::readEvent(edm::EventPrincipal& eventPrincipal) {
+  std::unique_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
+  bool tcdsInRange;
+  unsigned char* tcds_pointer = nullptr;
+  edm::Timestamp tstamp = fillFEDRawDataCollection(*rawData, tcdsInRange, tcds_pointer);
+
+  if (daqSource_->useL1EventID()) {
+    uint32_t L1EventID = event_->event();
+    edm::EventID eventID = edm::EventID(daqSource_->eventRunNumber(), daqSource_->currentLumiSection(), L1EventID);
+    edm::EventAuxiliary aux(
+        eventID, daqSource_->processGUID(), tstamp, event_->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
+    aux.setProcessHistoryID(daqSource_->processHistoryID());
+    daqSource_->makeEventWrapper(eventPrincipal, aux);
+  } else if (tcds_pointer == nullptr) {
+    uint32_t L1EventID = event_->event();
+    throw cms::Exception("DAQSource::read") << "No TCDS FED in event with FEDHeader EID -: " << L1EventID;
+  } else {
+    const FEDHeader fedHeader(tcds_pointer);
+    tcds::Raw_v1 const* tcds = reinterpret_cast<tcds::Raw_v1 const*>(tcds_pointer + FEDHeader::length);
+    edm::EventAuxiliary aux =
+        evf::evtn::makeEventAuxiliary(tcds,
+                                      daqSource_->eventRunNumber(),      //TODO_ eventRunNumber_
+                                      daqSource_->currentLumiSection(),  //currentLumiSection_
+                                      event_->isRealData(),
+                                      static_cast<edm::EventAuxiliary::ExperimentType>(fedHeader.triggerType()),
+                                      daqSource_->processGUID(),
+                                      !daqSource_->fileListLoopMode(),
+                                      !tcdsInRange);
+    aux.setProcessHistoryID(daqSource_->processHistoryID());
+    daqSource_->makeEventWrapper(eventPrincipal, aux);
+  }
+
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
+  eventPrincipal.put(
+      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+}
+
+edm::Timestamp DataModeFRD::fillFEDRawDataCollection(FEDRawDataCollection& rawData,
+                                                     bool& tcdsInRange,
+                                                     unsigned char*& tcds_pointer) {
+  edm::TimeValue_t time;
+  timeval stv;
+  gettimeofday(&stv, nullptr);
+  time = stv.tv_sec;
+  time = (time << 32) + stv.tv_usec;
+  edm::Timestamp tstamp(time);
+
+  uint32_t eventSize = event_->eventSize();
+  unsigned char* event = (unsigned char*)event_->payload();
+  tcds_pointer = nullptr;
+  tcdsInRange = false;
+  uint16_t selectedTCDSFed = 0;
+  while (eventSize > 0) {
+    assert(eventSize >= FEDTrailer::length);
+    eventSize -= FEDTrailer::length;
+    const FEDTrailer fedTrailer(event + eventSize);
+    const uint32_t fedSize = fedTrailer.fragmentLength() << 3;  //trailer length counts in 8 bytes
+    assert(eventSize >= fedSize - FEDHeader::length);
+    eventSize -= (fedSize - FEDHeader::length);
+    const FEDHeader fedHeader(event + eventSize);
+    const uint16_t fedId = fedHeader.sourceID();
+    if (fedId > FEDNumbering::MAXFEDID) {
+      throw cms::Exception("DAQSource::fillFEDRawDataCollection") << "Out of range FED ID : " << fedId;
+    } else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
+      if (!selectedTCDSFed) {
+        selectedTCDSFed = fedId;
+        tcds_pointer = event + eventSize;
+        if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
+          tcdsInRange = true;
+        }
+      } else
+        throw cms::Exception("DAQSource::fillFEDRawDataCollection")
+            << "Second TCDS FED ID " << fedId << " found. First ID: " << selectedTCDSFed;
+    }
+    //take event ID from GTPE FED
+    FEDRawData& fedData = rawData.FEDData(fedId);
+    fedData.resize(fedSize);
+    memcpy(fedData.data(), event + eventSize, fedSize);
+  }
+  assert(eventSize == 0);
+
+  return tstamp;
+}
+
+std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& DataModeFRD::makeDaqProvenanceHelpers() {
+  //set FRD data collection
+  daqProvenanceHelpers_.clear();
+  daqProvenanceHelpers_.emplace_back(std::make_shared<const edm::DaqProvenanceHelper>(
+      edm::TypeID(typeid(FEDRawDataCollection)), "FEDRawDataCollection", "FEDRawDataCollection", "DAQSource"));
+  return daqProvenanceHelpers_;
+}
+
+bool DataModeFRD::nextEventView() {
+  if (eventCached_)
+    return true;
+  event_ = std::make_unique<FRDEventMsgView>(dataBlockAddr_);
+  if (event_->size() > dataBlockMax_) {
+    throw cms::Exception("DAQSource::getNextEvent")
+        << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
+        << " of size:" << event_->size() << " bytes does not fit into a chunk of size:" << dataBlockMax_ << " bytes";
+  }
+  return true;
+}
+
+bool DataModeFRD::checksumValid() {
+  crc_ = 0;
+  if (event_->version() >= 5) {
+    crc_ = crc32c(crc_, (const unsigned char*)event_->payload(), event_->eventSize());
+    if (crc_ != event_->crc32c())
+      return false;
+  }
+  return true;
+}
+
+std::string DataModeFRD::getChecksumError() const {
+  std::stringstream ss;
+  ss << "Found a wrong crc32c checksum: expected 0x" << std::hex << event_->crc32c() << " but calculated 0x" << crc_;
+  return ss.str();
+}
+
+/*
+ * FRD Multi Test
+ */
+
+void DataModeFRDStriped::makeDirectoryEntries(std::vector<std::string> const& baseDirs, std::string const& runDir) {
+  std::filesystem::path runDirP(runDir);
+  for (auto& baseDir : baseDirs) {
+    std::filesystem::path baseDirP(baseDir);
+    buPaths_.emplace_back(baseDirP / runDirP);
+  }
+}
+
+void DataModeFRDStriped::readEvent(edm::EventPrincipal& eventPrincipal) {
+  assert(!events_.empty());
+  std::unique_ptr<FEDRawDataCollection> rawData(new FEDRawDataCollection);
+  bool tcdsInRange;
+  unsigned char* tcds_pointer = nullptr;
+  edm::Timestamp tstamp = fillFRDCollection(*rawData, tcdsInRange, tcds_pointer);
+
+  auto const& event = events_[0];
+  if (daqSource_->useL1EventID()) {
+    uint32_t L1EventID = event->event();
+    edm::EventID eventID = edm::EventID(daqSource_->eventRunNumber(), daqSource_->currentLumiSection(), L1EventID);
+    edm::EventAuxiliary aux(
+        eventID, daqSource_->processGUID(), tstamp, event->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
+    aux.setProcessHistoryID(daqSource_->processHistoryID());
+    daqSource_->makeEventWrapper(eventPrincipal, aux);
+  } else if (tcds_pointer == nullptr) {
+    uint32_t L1EventID = event->event();
+    throw cms::Exception("DAQSource::read") << "No TCDS FED in event with FEDHeader EID -: " << L1EventID;
+  } else {
+    const FEDHeader fedHeader(tcds_pointer);
+    tcds::Raw_v1 const* tcds = reinterpret_cast<tcds::Raw_v1 const*>(tcds_pointer + FEDHeader::length);
+    edm::EventAuxiliary aux =
+        evf::evtn::makeEventAuxiliary(tcds,
+                                      daqSource_->eventRunNumber(),
+                                      daqSource_->currentLumiSection(),
+                                      event->isRealData(),
+                                      static_cast<edm::EventAuxiliary::ExperimentType>(fedHeader.triggerType()),
+                                      daqSource_->processGUID(),
+                                      !daqSource_->fileListLoopMode(),
+                                      !tcdsInRange);
+    aux.setProcessHistoryID(daqSource_->processHistoryID());
+    daqSource_->makeEventWrapper(eventPrincipal, aux);
+  }
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<FEDRawDataCollection>(std::move(rawData)));
+  eventPrincipal.put(
+      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+  eventCached_ = false;
+}
+
+edm::Timestamp DataModeFRDStriped::fillFRDCollection(FEDRawDataCollection& rawData,
+                                                     bool& tcdsInRange,
+                                                     unsigned char*& tcds_pointer) {
+  edm::TimeValue_t time;
+  timeval stv;
+  gettimeofday(&stv, nullptr);
+  time = stv.tv_sec;
+  time = (time << 32) + stv.tv_usec;
+  edm::Timestamp tstamp(time);
+
+  tcds_pointer = nullptr;
+  tcdsInRange = false;
+  uint16_t selectedTCDSFed = 0;
+  int selectedTCDSFileIndex = -1;
+  for (size_t index = 0; index < events_.size(); index++) {
+    uint32_t eventSize = events_[index]->eventSize();
+    unsigned char* event = (unsigned char*)events_[index]->payload();
+    while (eventSize > 0) {
+      assert(eventSize >= FEDTrailer::length);
+      eventSize -= FEDTrailer::length;
+      const FEDTrailer fedTrailer(event + eventSize);
+      const uint32_t fedSize = fedTrailer.fragmentLength() << 3;  //trailer length counts in 8 bytes
+      assert(eventSize >= fedSize - FEDHeader::length);
+      eventSize -= (fedSize - FEDHeader::length);
+      const FEDHeader fedHeader(event + eventSize);
+      const uint16_t fedId = fedHeader.sourceID();
+      if (fedId > FEDNumbering::MAXFEDID) {
+        throw cms::Exception("DataModeFRDStriped:::fillFRDCollection") << "Out of range FED ID : " << fedId;
+      } else if (fedId >= MINTCDSuTCAFEDID_ && fedId <= MAXTCDSuTCAFEDID_) {
+        if (!selectedTCDSFed) {
+          selectedTCDSFed = fedId;
+          selectedTCDSFileIndex = index;
+          tcds_pointer = event + eventSize;
+          if (fedId >= FEDNumbering::MINTCDSuTCAFEDID && fedId <= FEDNumbering::MAXTCDSuTCAFEDID) {
+            tcdsInRange = true;
+          }
+        } else if (!testing_)
+          throw cms::Exception("DataModeFRDStriped:::fillFRDCollection")
+              << "Second TCDS FED ID " << fedId << " found in file " << selectedTCDSFileIndex
+              << ". First ID: " << selectedTCDSFed << " in file " << index;
+      }
+      FEDRawData& fedData = rawData.FEDData(fedId);
+      fedData.resize(fedSize);
+      memcpy(fedData.data(), event + eventSize, fedSize);
+    }
+    assert(eventSize == 0);
+  }
+
+  return tstamp;
+}
+
+std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& DataModeFRDStriped::makeDaqProvenanceHelpers() {
+  //set FRD data collection
+  daqProvenanceHelpers_.clear();
+  daqProvenanceHelpers_.emplace_back(std::make_shared<const edm::DaqProvenanceHelper>(
+      edm::TypeID(typeid(FEDRawDataCollection)), "FEDRawDataCollection", "FEDRawDataCollection", "DAQSource"));
+  return daqProvenanceHelpers_;
+}
+
+/* TODO: adapt to multi-fils
+bool DataModeFRD::nextEventView() {
+  if (eventCached_) return true;
+  event_ = std::make_unique<FRDEventMsgView>(dataBlockAddr_);
+  if (event_->size() > dataBlockMax_) {
+    throw cms::Exception("DAQSource::getNextEvent")
+      << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
+      << " of size:" << event_->size() << " bytes does not fit into a chunk of size:" << dataBlockMax_
+      << " bytes";
+  }
+  return true;
+}
+*/
+
+bool DataModeFRDStriped::checksumValid() {
+  bool status = true;
+  for (size_t i = 0; i < events_.size(); i++) {
+    uint32_t crc = 0;
+    auto const& event = events_[i];
+    if (event->version() >= 5) {
+      crc = crc32c(crc, (const unsigned char*)event->payload(), event->eventSize());
+      if (crc != event->crc32c()) {
+        std::ostringstream ss;
+        ss << "Found a wrong crc32c checksum at readout index " << i << ": expected 0x" << std::hex << event->crc32c()
+           << " but calculated 0x" << crc << ". ";
+        crcMsg_ += ss.str();
+        status = false;
+      }
+    }
+  }
+  return status;
+}
+
+std::string DataModeFRDStriped::getChecksumError() const { return crcMsg_; }
+
+/*
+  read multiple input files for this model
+*/
+
+std::pair<bool, std::vector<std::string>> DataModeFRDStriped::defineAdditionalFiles(std::string const& primaryName,
+                                                                                    bool fileListMode) const {
+  std::vector<std::string> additionalFiles;
+
+  if (fileListMode) {
+    //for the unit test
+    additionalFiles.push_back(primaryName + "_1");
+    return std::make_pair(true, additionalFiles);
+  }
+
+  auto fullpath = std::filesystem::path(primaryName);
+  auto fullname = fullpath.filename();
+
+  for (size_t i = 1; i < buPaths_.size(); i++) {
+    std::filesystem::path newPath = buPaths_[i] / fullname;
+    additionalFiles.push_back(newPath.generic_string());
+  }
+  return std::make_pair(true, additionalFiles);
+}
+
+bool DataModeFRDStriped::nextEventView() {
+  blockCompleted_ = false;
+  if (eventCached_)
+    return true;
+  for (unsigned int i = 0; i < events_.size(); i++) {
+    //add last event length to each stripe
+    dataBlockAddrs_[i] += events_[i]->size();
+  }
+  return makeEvents();
+}
+
+bool DataModeFRDStriped::makeEvents() {
+  events_.clear();
+  assert(!blockCompleted_);
+  for (int i = 0; i < numFiles_; i++) {
+    if (dataBlockAddrs_[i] >= dataBlockMaxAddrs_[i]) {
+      //must be exact
+      assert(dataBlockAddrs_[i] == dataBlockMaxAddrs_[i]);
+      blockCompleted_ = true;
+      return false;
+    } else {
+      if (blockCompleted_)
+        throw cms::Exception("DataModeFRDStriped::makeEvents")
+            << "not all striped blocks were completed at the same time";
+    }
+    if (blockCompleted_)
+      continue;
+    events_.emplace_back(std::make_unique<FRDEventMsgView>(dataBlockAddrs_[i]));
+    if (dataBlockAddrs_[i] + events_[i]->size() > dataBlockMaxAddrs_[i])
+      throw cms::Exception("DAQSource::getNextEvent")
+          << " event id:" << events_[i]->event() << " lumi:" << events_[i]->lumi() << " run:" << events_[i]->run()
+          << " of size:" << events_[i]->size() << " bytes does not fit into the buffer or has corrupted header";
+  }
+  return !blockCompleted_;
+}

--- a/EventFilter/Utilities/src/DAQSourceModelsScouting.cc
+++ b/EventFilter/Utilities/src/DAQSourceModelsScouting.cc
@@ -1,0 +1,312 @@
+#include "EventFilter/Utilities/interface/DAQSource.h"
+#include "EventFilter/Utilities/interface/DAQSourceModelsScouting.h"
+
+#include <sstream>
+#include <sys/types.h>
+#include <vector>
+#include <regex>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Provenance/interface/EventAuxiliary.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+
+using namespace scouting;
+
+void DataModeScoutingRun2Muon::readEvent(edm::EventPrincipal& eventPrincipal) {
+  edm::TimeValue_t time;
+  timeval stv;
+  gettimeofday(&stv, nullptr);
+  time = stv.tv_sec;
+  time = (time << 32) + stv.tv_usec;
+  edm::Timestamp tstamp(time);
+
+  std::unique_ptr<BXVector<l1t::Muon>> rawData(new BXVector<l1t::Muon>);
+  //allow any bx
+  rawData->setBXRange(0, 4000);
+
+  unpackOrbit(rawData.get(), (char*)event_->payload(), event_->eventSize());
+
+  uint32_t hdrEventID = event_->event();
+  edm::EventID eventID = edm::EventID(daqSource_->eventRunNumber(), daqSource_->currentLumiSection(), hdrEventID);
+  edm::EventAuxiliary aux(
+      eventID, daqSource_->processGUID(), tstamp, event_->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
+
+  aux.setProcessHistoryID(daqSource_->processHistoryID());
+  daqSource_->makeEventWrapper(eventPrincipal, aux);
+
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<BXVector<l1t::Muon>>(std::move(rawData)));
+  eventPrincipal.put(
+      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+}
+
+void DataModeScoutingRun2Muon::unpackOrbit(BXVector<l1t::Muon>* muons, char* buf, size_t len) {
+  using namespace scouting;
+  size_t pos = 0;
+  uint32_t o_test = 0;
+  while (pos < len) {
+    assert(pos + 4 <= len);
+    uint32_t header = *((uint32*)(buf + pos));
+    uint32_t mAcount = (header & header_masks::mAcount) >> header_shifts::mAcount;
+    uint32_t mBcount = (header & header_masks::mBcount) >> header_shifts::mBcount;
+
+    block* bl = (block*)(buf + pos + 4);
+
+    pos += 12 + (mAcount + mBcount) * 8;
+    assert(pos <= len);
+
+    uint32_t bx = bl->bx;
+
+    uint32_t orbit = bl->orbit;
+    o_test = orbit;
+
+    //should cuts should be applied
+    bool excludeIntermediate = true;
+
+    for (size_t i = 0; i < (mAcount + mBcount); i++) {
+      //unpack new muon
+      //variables: index, ietaext, ipt, qual, iphiext, iso, chrg, iphi, ieta
+
+      // remove intermediate if required
+      // index==0 and ietaext==0 are a necessary and sufficient condition
+      uint32_t index = (bl->mu[i].s >> shifts::index) & masks::index;
+      int32_t ietaext = ((bl->mu[i].f >> shifts::etaext) & masks::etaextv);
+      if (((bl->mu[i].f >> shifts::etaext) & masks::etaexts) != 0)
+        ietaext -= 256;
+
+      if (excludeIntermediate && index == 0 && ietaext == 0)
+        continue;
+
+      //extract pt and quality and apply cut if required
+      uint32_t ipt = (bl->mu[i].f >> shifts::pt) & masks::pt;
+      //cuts??
+      //        if((ipt-1)<ptcut) {discarded++; continue;}
+      uint32_t qual = (bl->mu[i].f >> shifts::qual) & masks::qual;
+      //        if(qual < qualcut) {discarded++; continue;}
+
+      //extract integer value for extrapolated phi
+      int32_t iphiext = ((bl->mu[i].f >> shifts::phiext) & masks::phiext);
+
+      // extract iso bits and charge
+      uint32_t iso = (bl->mu[i].s >> shifts::iso) & masks::iso;
+      int32_t chrg = 0;
+      if (((bl->mu[i].s >> shifts::chrgv) & masks::chrgv) == 1) {
+        chrg = ((bl->mu[i].s >> shifts::chrg) & masks::chrg) == 1 ? -1 : 1;
+      }
+
+      // extract eta and phi at muon station
+      int32_t iphi = ((bl->mu[i].s >> shifts::phi) & masks::phi);
+      int32_t ieta = (bl->mu[i].s >> shifts::eta) & masks::etav;
+      if (((bl->mu[i].s >> shifts::eta) & masks::etas) != 0)
+        ieta -= 256;
+
+      l1t::Muon muon(
+          *dummyLVec_, ipt, ieta, iphi, qual, chrg, chrg != 0, iso, -1, 0, false, 0, 0, 0, 0, ietaext, iphiext);
+      muons->push_back(bx, muon);
+    }
+  }
+  std::cout << "end read ... " << o_test << std::endl << std::flush;
+}  //unpackOrbit
+
+std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& DataModeScoutingRun2Muon::makeDaqProvenanceHelpers() {
+  //set FRD data collection
+  daqProvenanceHelpers_.clear();
+  daqProvenanceHelpers_.emplace_back(std::make_shared<const edm::DaqProvenanceHelper>(
+      edm::TypeID(typeid(l1t::MuonBxCollection)), "l1t::MuonBxCollection", "l1tMuonBxCollection", "DAQSource"));
+  return daqProvenanceHelpers_;
+}
+
+bool DataModeScoutingRun2Muon::nextEventView() {
+  if (eventCached_)
+    return true;
+  event_ = std::make_unique<FRDEventMsgView>(dataBlockAddr_);
+  if (event_->size() > dataBlockMax_) {
+    throw cms::Exception("DAQSource::getNextEvent")
+        << " event id:" << event_->event() << " lumi:" << event_->lumi() << " run:" << event_->run()
+        << " of size:" << event_->size() << " bytes does not fit into a chunk of size:" << dataBlockMax_ << " bytes";
+  }
+  return true;
+}
+
+bool DataModeScoutingRun2Muon::checksumValid() { return true; }
+
+std::string DataModeScoutingRun2Muon::getChecksumError() const { return std::string(); }
+
+//
+//2nd model: read multiple input files with different data type
+//
+
+std::pair<bool, std::vector<std::string>> DataModeScoutingRun2Multi::defineAdditionalFiles(
+    std::string const& primaryName, bool fileListMode) const {
+  std::vector<std::string> additionalFiles;
+
+  auto fullpath = std::filesystem::path(primaryName);
+  auto fullname = fullpath.filename();
+  std::string stem = fullname.stem().string();
+  std::string ext = fullname.extension().string();
+  std::regex regexz("_");
+  std::vector<std::string> nameTokens = {std::sregex_token_iterator(stem.begin(), stem.end(), regexz, -1),
+                                         std::sregex_token_iterator()};
+
+  if (nameTokens.size() < 3) {
+    throw cms::Exception("DAQSource::getNextEvent")
+        << primaryName << " name doesn't start with run#_ls#_index#_*.ext syntax";
+  }
+
+  //Can also filter out non-matching primary files (if detected by DaqDirector). false will tell source to skip the primary file.
+  if (nameTokens.size() > 3 && nameTokens[3].rfind("secondary", 0) == 0)
+    return std::make_pair(false, additionalFiles);
+
+  //TODO: provisional, name syntax should be better defined
+
+  additionalFiles.push_back(fullpath.parent_path().string() + "/" + nameTokens[0] + "_" + nameTokens[1] + "_" +
+                            nameTokens[2] + "_secondary" + ext);
+  //additionalFiles.push_back(fullpath.parent_path.string() + "/" + nameTokens[0] + "_" + nameTokens[1] + "_" + nameTokens[2] + "_tertiary" + ".raw");
+
+  return std::make_pair(true, additionalFiles);
+}
+
+void DataModeScoutingRun2Multi::readEvent(edm::EventPrincipal& eventPrincipal) {
+  edm::TimeValue_t time;
+  timeval stv;
+  gettimeofday(&stv, nullptr);
+  time = stv.tv_sec;
+  time = (time << 32) + stv.tv_usec;
+  edm::Timestamp tstamp(time);
+
+  std::unique_ptr<BXVector<l1t::Muon>> rawData(new BXVector<l1t::Muon>);
+  //allow any bx
+  rawData->setBXRange(0, 4000);
+
+  unpackMuonOrbit(rawData.get(), (char*)events_[0]->payload(), events_[0]->eventSize());
+
+  //TODO: implement here other object type (e.g. unpackCaloOrbit)
+  //
+  std::unique_ptr<BXVector<l1t::Muon>> rawDataSec(new BXVector<l1t::Muon>);
+  //allow any bx
+  rawDataSec->setBXRange(0, 4000);
+
+  unpackMuonOrbit(rawDataSec.get(), (char*)events_[1]->payload(), events_[1]->eventSize());
+
+  uint32_t hdrEventID = events_[0]->event();  //take from 1st file
+  edm::EventID eventID = edm::EventID(daqSource_->eventRunNumber(), daqSource_->currentLumiSection(), hdrEventID);
+  edm::EventAuxiliary aux(
+      eventID, daqSource_->processGUID(), tstamp, events_[0]->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
+
+  aux.setProcessHistoryID(daqSource_->processHistoryID());
+  daqSource_->makeEventWrapper(eventPrincipal, aux);
+
+  std::unique_ptr<edm::WrapperBase> edp(new edm::Wrapper<BXVector<l1t::Muon>>(std::move(rawData)));
+  eventPrincipal.put(
+      daqProvenanceHelpers_[0]->branchDescription(), std::move(edp), daqProvenanceHelpers_[0]->dummyProvenance());
+
+  //TODO: use other object and provenance helper (duplicate is just for demonstration)
+  //  std::unique_ptr<edm::WrapperBase> edpSec(new edm::Wrapper<BXVector<l1t::Muon>>(std::move(rawDataSec)));
+  //  eventPrincipal.put(daqProvenanceHelpers_[1]->branchDescription(), std::move(edpSec), daqProvenanceHelpers_[1]->dummyProvenance());
+
+  eventCached_ = false;
+}
+
+void DataModeScoutingRun2Multi::unpackMuonOrbit(BXVector<l1t::Muon>* muons, char* buf, size_t len) {
+  using namespace scouting;
+  size_t pos = 0;
+  //uint32_t o_test = 0;
+  while (pos < len) {
+    assert(pos + 4 <= len);
+    uint32_t header = *((uint32*)(buf + pos));
+    uint32_t mAcount = (header & header_masks::mAcount) >> header_shifts::mAcount;
+    uint32_t mBcount = (header & header_masks::mBcount) >> header_shifts::mBcount;
+
+    block* bl = (block*)(buf + pos + 4);
+
+    pos += 12 + (mAcount + mBcount) * 8;
+    assert(pos <= len);
+
+    uint32_t bx = bl->bx;
+
+    //uint32_t orbit = bl->orbit;
+    //o_test = orbit;
+
+    //should cuts should be applied
+    bool excludeIntermediate = true;
+
+    for (size_t i = 0; i < (mAcount + mBcount); i++) {
+      //unpack new muon
+      //variables: index, ietaext, ipt, qual, iphiext, iso, chrg, iphi, ieta
+
+      // remove intermediate if required
+      // index==0 and ietaext==0 are a necessary and sufficient condition
+      uint32_t index = (bl->mu[i].s >> shifts::index) & masks::index;
+      int32_t ietaext = ((bl->mu[i].f >> shifts::etaext) & masks::etaextv);
+      if (((bl->mu[i].f >> shifts::etaext) & masks::etaexts) != 0)
+        ietaext -= 256;
+
+      if (excludeIntermediate && index == 0 && ietaext == 0)
+        continue;
+
+      //extract pt and quality and apply cut if required
+      uint32_t ipt = (bl->mu[i].f >> shifts::pt) & masks::pt;
+      //cuts??
+      //        if((ipt-1)<ptcut) {discarded++; continue;}
+      uint32_t qual = (bl->mu[i].f >> shifts::qual) & masks::qual;
+      //        if(qual < qualcut) {discarded++; continue;}
+
+      //extract integer value for extrapolated phi
+      int32_t iphiext = ((bl->mu[i].f >> shifts::phiext) & masks::phiext);
+
+      // extract iso bits and charge
+      uint32_t iso = (bl->mu[i].s >> shifts::iso) & masks::iso;
+      int32_t chrg = 0;
+      if (((bl->mu[i].s >> shifts::chrgv) & masks::chrgv) == 1) {
+        chrg = ((bl->mu[i].s >> shifts::chrg) & masks::chrg) == 1 ? -1 : 1;
+      }
+
+      // extract eta and phi at muon station
+      int32_t iphi = ((bl->mu[i].s >> shifts::phi) & masks::phi);
+      int32_t ieta = (bl->mu[i].s >> shifts::eta) & masks::etav;
+      if (((bl->mu[i].s >> shifts::eta) & masks::etas) != 0)
+        ieta -= 256;
+
+      l1t::Muon muon(
+          *dummyLVec_, ipt, ieta, iphi, qual, chrg, chrg != 0, iso, -1, 0, false, 0, 0, 0, 0, ietaext, iphiext);
+      muons->push_back(bx, muon);
+    }
+  }
+}  //unpackOrbit
+
+std::vector<std::shared_ptr<const edm::DaqProvenanceHelper>>& DataModeScoutingRun2Multi::makeDaqProvenanceHelpers() {
+  //set FRD data collection
+  daqProvenanceHelpers_.clear();
+  daqProvenanceHelpers_.emplace_back(std::make_shared<const edm::DaqProvenanceHelper>(
+      edm::TypeID(typeid(l1t::MuonBxCollection)), "l1t::MuonBxCollection", "l1tMuonBxCollection", "DAQSource"));
+  //Note: two same kind of objects can not be put in the event from the source, so this example will be changed
+  daqProvenanceHelpers_.emplace_back(std::make_shared<const edm::DaqProvenanceHelper>(
+      edm::TypeID(typeid(l1t::MuonBxCollection)), "l1t::MuonBxCollection", "l1tMuonBxCollection", "DAQSource"));
+  return daqProvenanceHelpers_;
+}
+
+bool DataModeScoutingRun2Multi::nextEventView() {
+  blockCompleted_ = false;
+  if (eventCached_)
+    return true;
+  for (unsigned int i = 0; i < events_.size(); i++) {
+    //add last event length..
+    dataBlockAddrs_[i] += events_[i]->size();
+  }
+  return makeEvents();
+}
+
+bool DataModeScoutingRun2Multi::makeEvents() {
+  events_.clear();
+  for (int i = 0; i < numFiles_; i++) {
+    if (dataBlockAddrs_[i] >= dataBlockMaxAddrs_[i]) {
+      blockCompleted_ = true;
+      return false;
+    }
+    events_.emplace_back(std::make_unique<FRDEventMsgView>(dataBlockAddrs_[i]));
+  }
+  return true;
+}
+
+bool DataModeScoutingRun2Multi::checksumValid() { return true; }
+
+std::string DataModeScoutingRun2Multi::getChecksumError() const { return std::string(); }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -7,6 +7,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "EventFilter/Utilities/interface/FastMonitoringService.h"
@@ -38,6 +39,7 @@ namespace evf {
   EvFDaqDirector::EvFDaqDirector(const edm::ParameterSet& pset, edm::ActivityRegistry& reg)
       : base_dir_(pset.getUntrackedParameter<std::string>("baseDir")),
         bu_base_dir_(pset.getUntrackedParameter<std::string>("buBaseDir")),
+        bu_base_dirs_all_(pset.getUntrackedParameter<std::vector<std::string>>("buBaseDirsAll")),
         run_(pset.getUntrackedParameter<unsigned int>("runNumber")),
         useFileBroker_(pset.getUntrackedParameter<bool>("useFileBroker")),
         fileBrokerHostFromCfg_(pset.getUntrackedParameter<bool>("fileBrokerHostFromCfg", true)),
@@ -204,13 +206,13 @@ namespace evf {
       retval = mkdir(bu_run_dir_.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
       if (retval != 0 && errno != EEXIST) {
         throw cms::Exception("DaqDirector")
-            << " Error creating bu run dir -: " << bu_run_dir_ << " mkdir error:" << strerror(errno) << "\n";
+            << " Error creating bu run dir -: " << bu_run_dir_ << " mkdir error:" << strerror(errno);
       }
       bu_run_open_dir_ = bu_run_dir_ + "/open";
       retval = mkdir(bu_run_open_dir_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
       if (retval != 0 && errno != EEXIST) {
         throw cms::Exception("DaqDirector")
-            << " Error creating bu run open dir -: " << bu_run_open_dir_ << " mkdir error:" << strerror(errno) << "\n";
+            << " Error creating bu run open dir -: " << bu_run_open_dir_ << " mkdir error:" << strerror(errno);
       }
 
       // the BU director does not need to know about the fu lock
@@ -238,7 +240,7 @@ namespace evf {
           retval = mkdir(tmphltdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
           if (retval != 0 && errno != EEXIST)
             throw cms::Exception("DaqDirector")
-                << " Error creating bu run dir -: " << hltdir << " mkdir error:" << strerror(errno) << "\n";
+                << " Error creating bu run dir -: " << hltdir << " mkdir error:" << strerror(errno);
 
           std::filesystem::copy_file(hltSourceDirectory_ + "/HltConfig.py", tmphltdir + "/HltConfig.py");
           std::filesystem::copy_file(hltSourceDirectory_ + "/fffParameters.jsn", tmphltdir + "/fffParameters.jsn");
@@ -259,15 +261,44 @@ namespace evf {
     } else {
       // for FU, check if bu base dir exists
 
-      retval = mkdir(bu_base_dir_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-      if (retval != 0 && errno != EEXIST) {
-        throw cms::Exception("DaqDirector")
-            << " Error checking for bu base dir -: " << bu_base_dir_ << " mkdir error:" << strerror(errno) << "\n";
+      auto checkExists = [=](std::string const& bu_base_dir) -> void {
+        int retval = mkdir(bu_base_dir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+        if (retval != 0 && errno != EEXIST) {
+          throw cms::Exception("DaqDirector")
+              << " Error checking for bu base dir -: " << bu_base_dir << " mkdir error:" << strerror(errno);
+        }
+      };
+
+      auto waitForDir = [=](std::string const& bu_base_dir) -> void {
+        int cnt = 0;
+        while (!edm::shutdown_flag.load(std::memory_order_relaxed)) {
+          int retval = mkdir(bu_base_dir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+          if (retval != 0 && errno != EEXIST) {
+            usleep(500000);
+            cnt++;
+            if (cnt % 20 == 0)
+              edm::LogWarning("DaqDirector") << "waiting for " << bu_base_dir;
+            if (cnt > 120)
+              throw cms::Exception("DaqDirector") << " Error checking for bu base dir after 1 minute -: " << bu_base_dir
+                                                  << " mkdir error:" << strerror(errno);
+          }
+          break;
+        }
+      };
+
+      if (!bu_base_dirs_all_.empty()) {
+        checkExists(bu_base_dirs_all_[0]);
+        bu_run_dir_ = bu_base_dirs_all_[0] + "/" + run_string_;
+        for (unsigned int i = 1; i < bu_base_dirs_all_.size(); i++)
+          waitForDir(bu_base_dirs_all_[i]);
+      } else {
+        checkExists(bu_base_dir_);
+        bu_run_dir_ = bu_base_dir_ + "/" + run_string_;
       }
 
-      bu_run_dir_ = bu_base_dir_ + "/" + run_string_;
       fulockfile_ = bu_run_dir_ + "/fu.lock";
-      openFULockfileStream(false);
+      if (!useFileBroker_)
+        openFULockfileStream(false);
     }
 
     pthread_mutex_init(&init_lock_, nullptr);
@@ -332,6 +363,8 @@ namespace evf {
         "Service used for file locking arbitration and for propagating information between other EvF components");
     desc.addUntracked<std::string>("baseDir", ".")->setComment("Local base directory for run output");
     desc.addUntracked<std::string>("buBaseDir", ".")->setComment("BU base ramdisk directory ");
+    desc.addUntracked<std::vector<std::string>>("buBaseDirsAll", std::vector<std::string>())
+        ->setComment("BU base ramdisk directories for multi-file DAQSource models");
     desc.addUntracked<unsigned int>("runNumber", 0)->setComment("Run Number in ramdisk to open");
     desc.addUntracked<bool>("useFileBroker", false)
         ->setComment("Use BU file service to grab input data instead of NFS file locking");
@@ -493,6 +526,8 @@ namespace evf {
 
   std::string EvFDaqDirector::getEoRFilePath() const { return bu_run_dir_ + "/" + fffnaming::eorFileName(run_); }
 
+  std::string EvFDaqDirector::getEoRFileName() const { return fffnaming::eorFileName(run_); }
+
   std::string EvFDaqDirector::getEoRFilePathOnFU() const { return run_dir_ + "/" + fffnaming::eorFileName(run_); }
 
   std::string EvFDaqDirector::getFFFParamsFilePathOnBU() const { return bu_run_dir_ + "/hlt/fffParameters.jsn"; }
@@ -503,8 +538,6 @@ namespace evf {
       edm::LogError("EvFDaqDirector") << "Could not remove used file -: " << filename
                                       << ". error = " << strerror(errno);
   }
-
-  void EvFDaqDirector::removeFile(unsigned int ls, unsigned int index) { removeFile(getRawFilePath(ls, index)); }
 
   EvFDaqDirector::FileStatus EvFDaqDirector::updateFuLock(unsigned int& ls,
                                                           std::string& nextFile,
@@ -971,6 +1004,7 @@ namespace evf {
   int EvFDaqDirector::parseFRDFileHeader(std::string const& rawSourcePath,
                                          int& rawFd,
                                          uint16_t& rawHeaderSize,
+                                         uint16_t& rawDataType,
                                          uint32_t& lsFromHeader,
                                          int32_t& eventsFromHeader,
                                          int64_t& fileSizeFromHeader,
@@ -986,6 +1020,7 @@ namespace evf {
         return parseFRDFileHeader(rawSourcePath,
                                   rawFd,
                                   rawHeaderSize,
+                                  rawDataType,
                                   lsFromHeader,
                                   eventsFromHeader,
                                   fileSizeFromHeader,
@@ -1004,37 +1039,19 @@ namespace evf {
       }
     }
 
-    constexpr std::size_t buf_sz = sizeof(FRDFileHeader_v1);  //try to read v1 FRD header size
-    FRDFileHeader_v1 fileHead;
-
-    ssize_t sz_read = ::read(infile, (char*)&fileHead, buf_sz);
-    if (closeFile) {
-      close(infile);
-      infile = -1;
-    }
-
-    if (sz_read < 0) {
-      edm::LogError("EvFDaqDirector") << "parseFRDFileHeader - unable to read " << rawSourcePath << " : "
-                                      << strerror(errno);
-      if (infile != -1)
-        close(infile);
+    //v2 is the largest possible read
+    char hdr[sizeof(FRDFileHeader_v2)];
+    if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderIdentifier), rawSourcePath))
       return -1;
-    }
-    if ((size_t)sz_read < buf_sz) {
-      edm::LogError("EvFDaqDirector") << "parseFRDFileHeader - file smaller than header: " << rawSourcePath;
-      if (infile != -1)
-        close(infile);
-      return -1;
-    }
 
-    uint16_t frd_version = getFRDFileHeaderVersion(fileHead.id_, fileHead.version_);
+    FRDFileHeaderIdentifier* fileId = (FRDFileHeaderIdentifier*)hdr;
+    uint16_t frd_version = getFRDFileHeaderVersion(fileId->id_, fileId->version_);
 
     if (frd_version == 0) {
       //no header (specific sequence not detected)
       if (requireHeader) {
         edm::LogError("EvFDaqDirector") << "no header or invalid version string found in:" << rawSourcePath;
-        if (infile != -1)
-          close(infile);
+        close(infile);
         return -1;
       } else {
         //no header, but valid file
@@ -1044,24 +1061,69 @@ namespace evf {
         eventsFromHeader = -1;
         fileSizeFromHeader = -1;
       }
-    } else {
+    } else if (frd_version == 1) {
       //version 1 header
-      uint32_t headerSizeRaw = fileHead.headerSize_;
-      if (headerSizeRaw < buf_sz) {
+      if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderContent_v1), rawSourcePath))
+        return -1;
+      FRDFileHeaderContent_v1* fhContent = (FRDFileHeaderContent_v1*)hdr;
+      uint32_t headerSizeRaw = fhContent->headerSize_;
+      if (headerSizeRaw != sizeof(FRDFileHeader_v1)) {
         edm::LogError("EvFDaqDirector") << "inconsistent header size: " << rawSourcePath << " size: " << headerSizeRaw
                                         << " v:" << frd_version;
-        if (infile != -1)
-          close(infile);
+        close(infile);
         return -1;
       }
       //allow header size to exceed read size. Future header versions will not break this, but the size can change.
-      lsFromHeader = fileHead.lumiSection_;
-      eventsFromHeader = (int32_t)fileHead.eventCount_;
-      fileSizeFromHeader = (int64_t)fileHead.fileSize_;
-      rawHeaderSize = fileHead.headerSize_;
+      rawDataType = 0;
+      lsFromHeader = fhContent->lumiSection_;
+      eventsFromHeader = (int32_t)fhContent->eventCount_;
+      fileSizeFromHeader = (int64_t)fhContent->fileSize_;
+      rawHeaderSize = fhContent->headerSize_;
+
+    } else if (frd_version == 2) {
+      //version 2 heade
+      if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderContent_v2), rawSourcePath))
+        return -1;
+      FRDFileHeaderContent_v2* fhContent = (FRDFileHeaderContent_v2*)hdr;
+      uint32_t headerSizeRaw = fhContent->headerSize_;
+      if (headerSizeRaw != sizeof(FRDFileHeader_v2)) {
+        edm::LogError("EvFDaqDirector") << "inconsistent header size: " << rawSourcePath << " size: " << headerSizeRaw
+                                        << " v:" << frd_version;
+        close(infile);
+        return -1;
+      }
+      //allow header size to exceed read size. Future header versions will not break this, but the size can change.
+      rawDataType = fhContent->dataType_;
+      lsFromHeader = fhContent->lumiSection_;
+      eventsFromHeader = (int32_t)fhContent->eventCount_;
+      fileSizeFromHeader = (int64_t)fhContent->fileSize_;
+      rawHeaderSize = fhContent->headerSize_;
     }
+
+    if (closeFile) {
+      close(infile);
+      infile = -1;
+    }
+
     rawFd = infile;
     return 0;  //OK
+  }
+
+  bool EvFDaqDirector::checkFileRead(char* buf, int infile, std::size_t buf_sz, std::string const& path) {
+    ssize_t sz_read = ::read(infile, buf, buf_sz);
+    if (sz_read < 0) {
+      edm::LogError("EvFDaqDirector") << "rawFileHasHeader - unable to read " << path << " : " << strerror(errno);
+      if (infile != -1)
+        close(infile);
+      return false;
+    }
+    if ((size_t)sz_read < buf_sz) {
+      edm::LogError("EvFDaqDirector") << "rawFileHasHeader - file smaller than header: " << path;
+      if (infile != -1)
+        close(infile);
+      return false;
+    }
+    return true;
   }
 
   bool EvFDaqDirector::rawFileHasHeader(std::string const& rawSourcePath, uint16_t& rawHeaderSize) {
@@ -1071,34 +1133,31 @@ namespace evf {
                                         << strerror(errno);
       return false;
     }
-    constexpr std::size_t buf_sz = sizeof(FRDFileHeader_v1);  //try to read v1 FRD header size
-    FRDFileHeader_v1 fileHead;
-
-    ssize_t sz_read = ::read(infile, (char*)&fileHead, buf_sz);
-
-    if (sz_read < 0) {
-      edm::LogError("EvFDaqDirector") << "rawFileHasHeader - unable to read " << rawSourcePath << " : "
-                                      << strerror(errno);
-      if (infile != -1)
-        close(infile);
+    //try to read FRD header size (v2 is the biggest, use read buffer of that size)
+    char hdr[sizeof(FRDFileHeader_v2)];
+    if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderIdentifier), rawSourcePath))
       return false;
-    }
-    if ((size_t)sz_read < buf_sz) {
-      edm::LogError("EvFDaqDirector") << "rawFileHasHeader - file smaller than header: " << rawSourcePath;
-      if (infile != -1)
-        close(infile);
-      return false;
-    }
+    FRDFileHeaderIdentifier* fileId = (FRDFileHeaderIdentifier*)hdr;
+    uint16_t frd_version = getFRDFileHeaderVersion(fileId->id_, fileId->version_);
 
-    uint16_t frd_version = getFRDFileHeaderVersion(fileHead.id_, fileHead.version_);
+    if (frd_version == 1) {
+      if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderContent_v1), rawSourcePath))
+        return false;
+      FRDFileHeaderContent_v1* fhContent = (FRDFileHeaderContent_v1*)hdr;
+      rawHeaderSize = fhContent->headerSize_;
+      close(infile);
+      return true;
+    } else if (frd_version == 2) {
+      if (!checkFileRead(hdr, infile, sizeof(FRDFileHeaderContent_v2), rawSourcePath))
+        return false;
+      FRDFileHeaderContent_v2* fhContent = (FRDFileHeaderContent_v2*)hdr;
+      rawHeaderSize = fhContent->headerSize_;
+      close(infile);
+      return true;
+    } else
+      edm::LogError("EvFDaqDirector") << "rawFileHasHeader - unknown version: " << frd_version;
 
     close(infile);
-
-    if (frd_version > 0) {
-      rawHeaderSize = fileHead.headerSize_;
-      return true;
-    }
-
     rawHeaderSize = 0;
     return false;
   }
@@ -1109,7 +1168,8 @@ namespace evf {
                                           int64_t& fileSizeFromHeader,
                                           bool& fileFound,
                                           uint32_t serverLS,
-                                          bool closeFile) {
+                                          bool closeFile,
+                                          bool requireHeader) {
     fileFound = true;
 
     //take only first three tokens delimited by "_" in the renamed raw file name
@@ -1131,8 +1191,17 @@ namespace evf {
     uint32_t lsFromRaw;
     int32_t nbEventsWrittenRaw;
     int64_t fileSizeFromRaw;
-    auto ret = parseFRDFileHeader(
-        rawSourcePath, rawFd, rawHeaderSize, lsFromRaw, nbEventsWrittenRaw, fileSizeFromRaw, true, true, closeFile);
+    uint16_t rawDataType;
+    auto ret = parseFRDFileHeader(rawSourcePath,
+                                  rawFd,
+                                  rawHeaderSize,
+                                  rawDataType,
+                                  lsFromRaw,
+                                  nbEventsWrittenRaw,
+                                  fileSizeFromRaw,
+                                  requireHeader,
+                                  true,
+                                  closeFile);
     if (ret != 0) {
       if (ret == 1)
         fileFound = false;
@@ -1733,7 +1802,8 @@ namespace evf {
                                                                    uint16_t& rawHeaderSize,
                                                                    int32_t& serverEventsInNewFile,
                                                                    int64_t& fileSizeFromMetadata,
-                                                                   uint64_t& thisLockWaitTimeUs) {
+                                                                   uint64_t& thisLockWaitTimeUs,
+                                                                   bool requireHeader) {
     EvFDaqDirector::FileStatus fileStatus = noFile;
 
     //int retval = -1;
@@ -1811,8 +1881,8 @@ namespace evf {
 
     if (fileStatus == newFile) {
       if (rawHeader > 0)
-        serverEventsInNewFile =
-            grabNextJsonFromRaw(nextFileRaw, rawFd, rawHeaderSize, fileSizeFromMetadata, fileFound, serverLS, false);
+        serverEventsInNewFile = grabNextJsonFromRaw(
+            nextFileRaw, rawFd, rawHeaderSize, fileSizeFromMetadata, fileFound, serverLS, false, requireHeader);
       else
         serverEventsInNewFile = grabNextJsonFile(nextFileJson, nextFileRaw, fileSizeFromMetadata, fileFound);
     }

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -9,6 +9,7 @@
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+#include "EventFilter/Utilities/interface/DAQSource.h"
 #include "EventFilter/Utilities/interface/FileIO.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
@@ -546,8 +547,9 @@ namespace evf {
       return;
     }
 
-    if (inputSource_) {
-      auto sourceReport = inputSource_->getEventReport(lumi, true);
+    if (inputSource_ || daqInputSource_) {
+      auto sourceReport =
+          inputSource_ ? inputSource_->getEventReport(lumi, true) : daqInputSource_->getEventReport(lumi, true);
       if (sourceReport.first) {
         if (sourceReport.second != processedEventsPerLumi_[lumi].first) {
           throw cms::Exception("FastMonitoringService") << "MISMATCH with SOURCE update. LUMI -: " << lumi
@@ -556,6 +558,7 @@ namespace evf {
         }
       }
     }
+
     edm::LogInfo("FastMonitoringService")
         << "Statistics for lumisection -: lumi = " << lumi << " events = " << lumiProcessedJptr->value()
         << " time = " << usecondsForLumi / 1000000 << " size = " << accuSize << " thr = " << throughput;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -150,7 +150,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
   }
   //should delete chunks when run stops
   for (unsigned int i = 0; i < numBuffers_; i++) {
-    freeChunks_.push(new InputChunk(i, eventChunkSize_));
+    freeChunks_.push(new InputChunk(eventChunkSize_));
   }
 
   quit_threads_ = false;
@@ -882,9 +882,11 @@ void FedRawDataInputSource::readSupervisor() {
         //return LS if LS not set, otherwise return file
         status = getFile(ls, nextFile, fileSizeIndex, thisLockWaitTimeUs);
         if (status == evf::EvFDaqDirector::newFile) {
+          uint16_t rawDataType;
           if (evf::EvFDaqDirector::parseFRDFileHeader(nextFile,
                                                       rawFd,
                                                       rawHeaderSize,
+                                                      rawDataType,
                                                       lsFromRaw,
                                                       serverEventsInNewFile,
                                                       fileSizeFromMetadata,
@@ -1343,8 +1345,9 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
       ssize_t last;
 
       //protect against reading into next block
-      last = ::read(
-          fileDescriptor, (void*)(chunk->buf_ + bufferLeft), std::min(chunk->usedSize_ - bufferLeft, eventChunkBlock_));
+      last = ::read(fileDescriptor,
+                    (void*)(chunk->buf_ + bufferLeft),
+                    std::min(chunk->usedSize_ - bufferLeft, (uint64_t)eventChunkBlock_));
 
       if (last < 0) {
         edm::LogError("FedRawDataInputSource") << "readWorker failed to read file -: " << file->fileName_
@@ -1356,7 +1359,7 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
         bufferLeft += last;
       if (last < eventChunkBlock_) {  //last read
         //check if this is last block, then total read size must match file size
-        if (!(chunk->usedSize_ - skipped == i * eventChunkBlock_ + last)) {
+        if (!(chunk->usedSize_ - skipped == i * eventChunkBlock_ + (unsigned int)last)) {
           edm::LogError("FedRawDataInputSource")
               << "readWorker failed to read file -: " << file->fileName_ << " fd:" << fileDescriptor << " last:" << last
               << " expectedChunkSize:" << chunk->usedSize_
@@ -1452,7 +1455,7 @@ inline bool InputFile::advance(unsigned char*& dataPosition, const size_t size) 
   }
 }
 
-inline void InputFile::moveToPreviousChunk(const size_t size, const size_t offset) {
+void InputFile::moveToPreviousChunk(const size_t size, const size_t offset) {
   //this will fail in case of events that are too large
   assert(size < chunks_[currentChunk_]->size_ - chunkPosition_);
   assert(size - offset < chunks_[currentChunk_]->size_);
@@ -1461,7 +1464,7 @@ inline void InputFile::moveToPreviousChunk(const size_t size, const size_t offse
   bufferPosition_ += size;
 }
 
-inline void InputFile::rewindChunk(const size_t size) {
+void InputFile::rewindChunk(const size_t size) {
   chunkPosition_ -= size;
   bufferPosition_ -= size;
 }
@@ -1470,21 +1473,25 @@ InputFile::~InputFile() {
   if (rawFd_ != -1)
     close(rawFd_);
 
-  if (deleteFile_ && !fileName_.empty()) {
-    const std::filesystem::path filePath(fileName_);
-    try {
-      //sometimes this fails but file gets deleted
-      LogDebug("FedRawDataInputSource:InputFile") << "Deleting input file -:" << fileName_;
-      std::filesystem::remove(filePath);
-      return;
-    } catch (const std::filesystem::filesystem_error& ex) {
-      edm::LogError("FedRawDataInputSource:InputFile")
-          << " - deleteFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what() << ". Trying again.";
-    } catch (std::exception& ex) {
-      edm::LogError("FedRawDataInputSource:InputFile")
-          << " - deleteFile std::exception CAUGHT -: " << ex.what() << ". Trying again.";
+  if (deleteFile_) {
+    for (auto& fileName : fileNames_) {
+      if (!fileName.empty()) {
+        const std::filesystem::path filePath(fileName);
+        try {
+          //sometimes this fails but file gets deleted
+          LogDebug("FedRawDataInputSource:InputFile") << "Deleting input file -:" << fileName;
+          std::filesystem::remove(filePath);
+          continue;
+        } catch (const std::filesystem::filesystem_error& ex) {
+          edm::LogError("FedRawDataInputSource:InputFile")
+              << " - deleteFile BOOST FILESYSTEM ERROR CAUGHT -: " << ex.what() << ". Trying again.";
+        } catch (std::exception& ex) {
+          edm::LogError("FedRawDataInputSource:InputFile")
+              << " - deleteFile std::exception CAUGHT -: " << ex.what() << ". Trying again.";
+        }
+        std::filesystem::remove(filePath);
+      }
     }
-    std::filesystem::remove(filePath);
   }
 }
 

--- a/EventFilter/Utilities/test/FU_scouting.py
+++ b/EventFilter/Utilities/test/FU_scouting.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+
+options = VarParsing.VarParsing ('analysis')
+
+options.register ('runNumber',
+#                  325175, # default value
+                  325172, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Run Number")
+
+options.register ('buBaseDir',
+                  'ramdisk', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fuBaseDir',
+                  'data', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "FFF base directory")
+
+options.register ('numThreads',
+                  4, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW threads")
+
+options.register ('numFwkStreams',
+                  4, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW streams")
+
+
+options.parseArguments()
+
+cmsswbase = os.path.expandvars("$CMSSW_BASE/")
+
+process = cms.Process("TESTFU")
+process.maxEvents.input - -1
+
+process.options = dict(
+    numberOfThreads = options.numThreads,
+    numberOfStreams = options.numFwkStreams,
+#    numberOfConcurrentLuminosityBlocks = 1
+)
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string( "ERROR" )),
+    destinations = cms.untracked.vstring( 'cout' )
+)
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+    sleepTime = cms.untracked.int32(1)
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHostFromCfg = cms.untracked.bool(True),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False),
+)
+
+try:
+  os.makedirs(options.fffBaseDir+"/"+options.fuBaseDir+"/run"+str(options.runNumber).zfill(6))
+except Exception as ex:
+  print(str(ex))
+  pass
+
+ram_dir_path=options.buBaseDir+"/run"+str(options.runNumber).zfill(6)+"/"
+
+process.source = cms.Source("DAQSource",
+    dataMode = cms.untracked.string("ScoutingRun2"),
+    verifyChecksum = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
+    eventChunkSize = cms.untracked.uint32(8),
+    eventChunkBlock = cms.untracked.uint32(8),
+    numBuffers = cms.untracked.uint32(2),
+    maxBufferedFiles = cms.untracked.uint32(2),
+    fileListMode = cms.untracked.bool(True),
+    fileNames = cms.untracked.vstring(
+#        ram_dir_path+"run325175_ls0001_index000001.raw"
+        ram_dir_path+"run325172_ls0455_index000000.raw"
+    )
+
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('file:PoolOutputTest.root'),
+    outputCommands = cms.untracked.vstring("drop *","keep *_rawDataCollector_*_*")
+    )
+
+
+process.ep = cms.EndPath(
+#  process.streamA
+#  + process.streamB
+#  + process.streamC
+# + process.streamD
+  process.output
+)

--- a/EventFilter/Utilities/test/FU_scouting_2.py
+++ b/EventFilter/Utilities/test/FU_scouting_2.py
@@ -1,0 +1,117 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+
+options = VarParsing.VarParsing ('analysis')
+
+options.register ('runNumber',
+#                  325175, # default value
+                  325172, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Run Number")
+
+options.register ('buBaseDir',
+                  'ramdisk', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fuBaseDir',
+                  'data', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "FFF base directory")
+
+options.register ('numThreads',
+                  1, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW threads")
+
+options.register ('numFwkStreams',
+                  1, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW streams")
+
+
+options.parseArguments()
+
+cmsswbase = os.path.expandvars("$CMSSW_BASE/")
+
+process = cms.Process("TESTFU")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(options.numThreads),
+    numberOfStreams = cms.untracked.uint32(options.numFwkStreams),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1) # ShmStreamConsumer requires synchronization at LuminosityBlock boundaries
+)
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
+    destinations = cms.untracked.vstring( 'cout' )
+)
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+    sleepTime = cms.untracked.int32(1)
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHostFromCfg = cms.untracked.bool(True),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False),
+)
+
+try:
+  os.makedirs(options.fffBaseDir+"/"+options.fuBaseDir+"/run"+str(options.runNumber).zfill(6))
+except Exception as ex:
+  print(str(ex))
+  pass
+
+ram_dir_path=options.buBaseDir+"/run"+str(options.runNumber).zfill(6)+"/"
+
+process.source = cms.Source("DAQSource",
+#    dataMode = cms.untracked.string("ScoutingRun2Muon"),
+    dataMode = cms.untracked.string("ScoutingRun2Multi"),
+    verifyChecksum = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
+    eventChunkSize = cms.untracked.uint32(8),
+    eventChunkBlock = cms.untracked.uint32(8),
+    numBuffers = cms.untracked.uint32(2),
+    maxBufferedFiles = cms.untracked.uint32(2),
+    fileListMode = cms.untracked.bool(True),
+    fileNames = cms.untracked.vstring(
+#        ram_dir_path+"run325175_ls0001_index000001.raw"
+        ram_dir_path+"run325172_ls0010_index000000.raw",
+        ram_dir_path+"run325172_ls0380_index000000.raw"
+    )
+
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('file:PoolOutputTest.root'),
+    outputCommands = cms.untracked.vstring("drop *","keep *_rawDataCollector_*_*")
+    )
+
+
+process.ep = cms.EndPath(
+#  process.streamA
+#  + process.streamB
+#  + process.streamC
+# + process.streamD
+  process.output
+)

--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -36,13 +35,14 @@ mkdir ${OUTDIR}
 cp ${SCRIPTDIR}/startBU.py ${OUTDIR}
 cp ${SCRIPTDIR}/startFU.py ${OUTDIR}
 cp ${SCRIPTDIR}/unittest_FU.py ${OUTDIR}
+cp ${SCRIPTDIR}/unittest_FU_daqsource.py ${OUTDIR}
 cp ${SCRIPTDIR}/test_dqmstream.py ${OUTDIR}
 cd ${OUTDIR}
 
 rm -rf $OUTDIR/{ramdisk,data,dqmdisk,*.log}
 
 runnumber="100101"
-echo "Running test with FRD file header (no index JSONs)"
+echo "Running test with FRD file header v1 (no index JSONs)"
 CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=1"
 #CMDLINE_STARTFU="cmsRun startFU.py runNumber=${runnumber} fffBaseDir=${OUTDIR}"
 CMDLINE_STARTFU="cmsRun ${FUSCRIPT} runNumber=${runnumber} fffBaseDir=${OUTDIR}"
@@ -58,6 +58,37 @@ echo '{"data": [12950, 1620, 0, "run'${runnumber}'_ls0001_streamDQM_test.dat", 4
 
 CMDLINE_STARTDQM="cmsRun test_dqmstream.py runInputDir=./dqmdisk runNumber=100101"
 ${CMDLINE_STARTDQM} > out_2_dqm.log 2>&1 || diedqm "${CMDLINE_STARTDQM}" $? $OUTDIR
+
+rm -rf $OUTDIR/{ramdisk,data,*.log}
+
+echo "Running test with FRD file header v2"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2"
+CMDLINE_STARTFU="cmsRun unittest_FU.py runNumber=${runnumber} fffBaseDir=${OUTDIR}"
+${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
+${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR
+
+rm -rf $OUTDIR/{ramdisk,data,*.log}
+
+echo "running DAQSource test with full event FRD"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=1"
+CMDLINE_STARTFU="cmsRun unittest_FU_daqsource.py daqSourceMode=FRD runNumber=${runnumber} fffBaseDir=${OUTDIR}"
+${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
+${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
+
+#no failures, clean up everything including logs if there are no errors
+rm -rf $OUTDIR/{ramdisk,data,*.log}
+
+echo "running DAQSource test with striped FRD"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=2"
+CMDLINE_STARTFU="cmsRun unittest_FU_daqsource.py daqSourceMode=FRDStriped runNumber=${runnumber} fffBaseDir=${OUTDIR}"
+${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
+#duplicate files
+cp ramdisk/run${runnumber}/run${runnumber}_ls0001_index000000.raw ramdisk/run${runnumber}/run${runnumber}_ls0001_index000000.raw_1
+cp ramdisk/run${runnumber}/run${runnumber}_ls0001_index000001.raw ramdisk/run${runnumber}/run${runnumber}_ls0001_index000001.raw_1
+cp ramdisk/run${runnumber}/run${runnumber}_ls0002_index000000.raw ramdisk/run${runnumber}/run${runnumber}_ls0002_index000000.raw_1
+cp ramdisk/run${runnumber}/run${runnumber}_ls0002_index000001.raw ramdisk/run${runnumber}/run${runnumber}_ls0002_index000001.raw_1
+#run reader
+${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR out_2_fu.log
 
 #no failures, clean up everything including logs if there are no errors
 echo "Completed sucessfully"

--- a/EventFilter/Utilities/test/dumpMuonScouting.py
+++ b/EventFilter/Utilities/test/dumpMuonScouting.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process( "DUMP" )
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:PoolOutputTest.root")
+)
+
+process.dump = cms.EDAnalyzer("DumpMuonScouting",
+    muInputTag = cms.InputTag("rawDataCollector"),
+    minBx = cms.int32(0),
+    maxBx = cms.int32(4000)
+)
+
+
+process.p = cms.Path(
+  process.dump
+)
+

--- a/EventFilter/Utilities/test/unittest_FU_daqsource.py
+++ b/EventFilter/Utilities/test/unittest_FU_daqsource.py
@@ -1,0 +1,188 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+
+options = VarParsing.VarParsing ('analysis')
+
+options.register ('runNumber',
+                  100101, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Run Number")
+
+options.register ('daqSourceMode',
+                  '', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "DAQ source data mode")
+
+options.register ('buBaseDir',
+                  'ramdisk', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fuBaseDir',
+                  'data', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "BU base directory")
+
+options.register ('fffBaseDir',
+                  '.', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "FFF base directory")
+
+options.register ('numThreads',
+                  2, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW threads")
+
+options.register ('numFwkStreams',
+                  2, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,          # string, int, or float
+                  "Number of CMSSW streams")
+
+
+options.parseArguments()
+
+cmsswbase = os.path.expandvars("$CMSSW_BASE/")
+
+process = cms.Process("TESTFU")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(options.numThreads),
+    numberOfStreams = cms.untracked.uint32(options.numFwkStreams),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1) # ShmStreamConsumer requires synchronization at LuminosityBlock boundaries
+)
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string( "INFO" )),
+    destinations = cms.untracked.vstring( 'cout' )
+)
+
+process.FastMonitoringService = cms.Service("FastMonitoringService",
+    sleepTime = cms.untracked.int32(1)
+)
+
+process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+    useFileBroker = cms.untracked.bool(False),
+    fileBrokerHostFromCfg = cms.untracked.bool(True),
+    fileBrokerHost = cms.untracked.string("htcp40.cern.ch"),
+    runNumber = cms.untracked.uint32(options.runNumber),
+    baseDir = cms.untracked.string(options.fffBaseDir+"/"+options.fuBaseDir),
+    buBaseDir = cms.untracked.string(options.fffBaseDir+"/"+options.buBaseDir),
+    directorIsBU = cms.untracked.bool(False),
+)
+
+try:
+  os.makedirs(options.fffBaseDir+"/"+options.fuBaseDir+"/run"+str(options.runNumber).zfill(6))
+except Exception as ex:
+  print(str(ex))
+  pass
+
+ram_dir_path=options.buBaseDir+"/run"+str(options.runNumber).zfill(6)+"/"
+
+process.source = cms.Source("DAQSource",
+    testing = cms.untracked.bool(True),
+    dataMode = cms.untracked.string(options.daqSourceMode),
+    verifyChecksum = cms.untracked.bool(True),
+    useL1EventID = cms.untracked.bool(False),
+    eventChunkBlock = cms.untracked.uint32(2),
+    eventChunkSize = cms.untracked.uint32(3),
+    maxChunkSize = cms.untracked.uint32(10),
+    numBuffers = cms.untracked.uint32(2),
+    maxBufferedFiles = cms.untracked.uint32(2),
+    fileListMode = cms.untracked.bool(True),
+    fileNames = cms.untracked.vstring(
+        ram_dir_path + "run" + str(options.runNumber) + "_ls0001_index000000.raw",
+        ram_dir_path + "run" + str(options.runNumber) + "_ls0001_index000001.raw",
+        ram_dir_path + "run" + str(options.runNumber) + "_ls0002_index000000.raw",
+        ram_dir_path + "run" + str(options.runNumber) + "_ls0002_index000001.raw"
+    )
+
+)
+
+process.PrescaleService = cms.Service( "PrescaleService",
+                                       forceDefault = cms.bool( False ),
+                                       prescaleTable = cms.VPSet( 
+                                         cms.PSet(  pathName = cms.string( "p1" ),
+                                         prescales = cms.vuint32( 10)
+                                         ),
+                                         cms.PSet(  pathName = cms.string( "p2" ),
+                                         prescales = cms.vuint32( 100 )
+                                         )
+                                       ),
+                                       lvl1DefaultLabel = cms.string( "Default" ),
+                                       lvl1Labels = cms.vstring( 'Default' )
+                                       )
+
+process.filter1 = cms.EDFilter("HLTPrescaler",
+                               L1GtReadoutRecordTag = cms.InputTag( "hltGtDigis" )
+                               )
+process.filter2 = cms.EDFilter("HLTPrescaler",
+                               L1GtReadoutRecordTag = cms.InputTag( "hltGtDigis" )
+                               )
+
+process.a = cms.EDAnalyzer("ExceptionGenerator",
+    defaultAction = cms.untracked.int32(0),
+    defaultQualifier = cms.untracked.int32(58))
+
+process.b = cms.EDAnalyzer("ExceptionGenerator",
+    defaultAction = cms.untracked.int32(0),
+    defaultQualifier = cms.untracked.int32(5))
+
+process.tcdsRawToDigi = cms.EDProducer("TcdsRawToDigi",
+    InputLabel = cms.InputTag("rawDataCollector")
+)
+
+process.p1 = cms.Path(process.a*process.tcdsRawToDigi*process.filter1)
+process.p2 = cms.Path(process.b*process.filter2)
+
+process.streamA = cms.OutputModule("EvFOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p1' ))
+)
+
+process.streamB = cms.OutputModule("EvFOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+)
+
+process.streamC = cms.OutputModule("EvFOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+)
+
+process.streamD = cms.OutputModule("GlobalEvFOutputModule",
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
+)
+
+process.hltJson = cms.EDAnalyzer("HLTriggerJSONMonitoring")
+
+process.DQMStore = cms.Service( "DQMStore",
+    verbose = cms.untracked.int32( 0 ),
+    saveByLumi = cms.untracked.bool( False ),
+)
+
+from DQMServices.FileIO.DQMFileSaverPB_cfi import dqmSaver
+process.hltDQMFileSaver = dqmSaver
+
+
+process.daqHistoTest = cms.EDProducer("DaqTestHistograms",
+    numberOfHistograms = cms.untracked.uint32(50),
+    lumisectionRange =  cms.untracked.uint32(20)
+)
+
+process.ep = cms.EndPath(
+  process.streamA
+  + process.streamB
+  + process.streamC
+# + process.streamD
+  + process.hltJson
+  + process.daqHistoTest
+  + process.hltDQMFileSaver
+)

--- a/FWCore/Sources/interface/DaqProvenanceHelper.h
+++ b/FWCore/Sources/interface/DaqProvenanceHelper.h
@@ -28,6 +28,10 @@ namespace edm {
     typedef std::map<ProcessHistoryID, ProcessHistoryID> ProcessHistoryIDMap;
     typedef oneapi::tbb::concurrent_unordered_map<ParentageID, ParentageID, dqh::parentage_hash> ParentageIDMap;
     explicit DaqProvenanceHelper(TypeID const& rawDataType);
+    explicit DaqProvenanceHelper(TypeID const& rawDataType,
+                                 std::string const& collectionName,
+                                 std::string const& friendlyName,
+                                 std::string const& sourceLabel);
     ProcessHistoryID daqInit(ProductRegistry& productRegistry, ProcessHistoryRegistry& processHistoryRegistry) const;
     void saveInfo(BranchDescription const& oldBD, BranchDescription const& newBD) {
       oldProcessName_ = oldBD.processName();

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -15,16 +15,19 @@
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
 namespace {
-  edm::BranchDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType) {
+  edm::BranchDescription makeDescriptionForDaqProvHelper(edm::TypeID const& rawDataType,
+                                                         std::string const& collectionName,
+                                                         std::string const& friendlyName,
+                                                         std::string const& sourceLabel) {
     edm::BranchDescription desc(edm::InEvent,
                                 "rawDataCollector",
                                 // "source",
                                 "LHC",
                                 // "HLT",
-                                "FEDRawDataCollection",
-                                "FEDRawDataCollection",
+                                collectionName,
+                                friendlyName,
                                 "",
-                                "FedRawDataInputSource",
+                                sourceLabel,
                                 edm::ParameterSetID(),
                                 edm::TypeWithDict(rawDataType.typeInfo()),
                                 false);
@@ -34,8 +37,12 @@ namespace {
 }  // namespace
 
 namespace edm {
-  DaqProvenanceHelper::DaqProvenanceHelper(TypeID const& rawDataType)
-      : constBranchDescription_(makeDescriptionForDaqProvHelper(rawDataType)),
+  DaqProvenanceHelper::DaqProvenanceHelper(TypeID const& rawDataType,
+                                           std::string const& collectionName,
+                                           std::string const& friendlyName,
+                                           std::string const& sourceLabel)
+      : constBranchDescription_(
+            makeDescriptionForDaqProvHelper(rawDataType, collectionName, friendlyName, sourceLabel)),
         dummyProvenance_(constBranchDescription_.branchID()),
         processParameterSet_(),
         oldProcessName_(),
@@ -79,6 +86,10 @@ namespace edm {
 
     //std::cerr << processParameterSet_.dump() << std::endl;
   }
+
+  //default
+  DaqProvenanceHelper::DaqProvenanceHelper(TypeID const& rawDataType)
+      : DaqProvenanceHelper(rawDataType, "FEDRawDataCollection", "FEDRawDataCollection", "FedRawDataInputSource") {}
 
   ProcessHistoryID DaqProvenanceHelper::daqInit(ProductRegistry& productRegistry,
                                                 ProcessHistoryRegistry& processHistoryRegistry) const {

--- a/IOPool/Streamer/interface/FRDFileHeader.h
+++ b/IOPool/Streamer/interface/FRDFileHeader.h
@@ -20,24 +20,61 @@
 
 constexpr std::array<unsigned char, 4> FRDFileHeader_id{{0x52, 0x41, 0x57, 0x5f}};
 constexpr std::array<unsigned char, 4> FRDFileVersion_1{{0x30, 0x30, 0x30, 0x31}};
+constexpr std::array<unsigned char, 4> FRDFileVersion_2{{0x30, 0x30, 0x30, 0x32}};
 
-struct FRDFileHeader_v1 {
-  FRDFileHeader_v1() = default;
+struct FRDFileHeaderIdentifier {
+  FRDFileHeaderIdentifier(const std::array<uint8_t, 4>& id, const std::array<uint8_t, 4>& version)
+      : id_(id), version_(version) {}
 
-  FRDFileHeader_v1(uint16_t eventCount, uint32_t lumiSection, uint64_t fileSize)
-      : id_{FRDFileHeader_id},
-        version_{FRDFileVersion_1},
-        headerSize_(sizeof(FRDFileHeader_v1)),
+  std::array<uint8_t, 4> id_;
+  std::array<uint8_t, 4> version_;
+};
+
+struct FRDFileHeaderContent_v1 {
+  FRDFileHeaderContent_v1(uint16_t eventCount, uint32_t lumiSection, uint64_t fileSize)
+      : headerSize_(sizeof(FRDFileHeaderContent_v1) + sizeof(FRDFileHeaderIdentifier)),
         eventCount_(eventCount),
         lumiSection_(lumiSection),
         fileSize_(fileSize) {}
 
-  std::array<uint8_t, 4> id_;
-  std::array<uint8_t, 4> version_;
   uint16_t headerSize_;
   uint16_t eventCount_;
   uint32_t lumiSection_;
   uint64_t fileSize_;
+};
+
+struct FRDFileHeader_v1 {
+  FRDFileHeader_v1(uint16_t eventCount, uint32_t lumiSection, uint64_t fileSize)
+      : id_(FRDFileHeader_id, FRDFileVersion_1), c_(eventCount, lumiSection, fileSize) {}
+
+  FRDFileHeaderIdentifier id_;
+  FRDFileHeaderContent_v1 c_;
+};
+
+struct FRDFileHeaderContent_v2 {
+  FRDFileHeaderContent_v2(
+      uint16_t dataType, uint16_t eventCount, uint32_t runNumber, uint32_t lumiSection, uint64_t fileSize)
+      : headerSize_(sizeof(FRDFileHeaderContent_v2) + sizeof(FRDFileHeaderIdentifier)),
+        dataType_(dataType),
+        eventCount_(eventCount),
+        runNumber_(runNumber),
+        lumiSection_(lumiSection),
+        fileSize_(fileSize) {}
+
+  uint16_t headerSize_;
+  uint16_t dataType_;
+  uint32_t eventCount_;
+  uint32_t runNumber_;
+  uint32_t lumiSection_;
+  uint64_t fileSize_;
+};
+
+struct FRDFileHeader_v2 {
+  FRDFileHeader_v2(uint16_t dataType, uint16_t eventCount, uint32_t runNumber, uint32_t lumiSection, uint64_t fileSize)
+      : id_(FRDFileHeader_id, FRDFileVersion_2), c_(dataType, eventCount, runNumber, lumiSection, fileSize) {}
+
+  FRDFileHeaderIdentifier id_;
+  FRDFileHeaderContent_v2 c_;
 };
 
 inline uint16_t getFRDFileHeaderVersion(const std::array<uint8_t, 4>& id, const std::array<uint8_t, 4>& version) {


### PR DESCRIPTION
#### PR description:

New modular DAQ input source for phase2 and L1 scouting. Also implements supports for the current DAQ3 data model (potentially as replacement for FedRawDataInputSource)

- modified shared input file abstractions to support some modes of the new source and support 64-bit file and buffer size (> 4 GB).
- new DAQProvenanceHelper constructor to support putting specific products into event.
- FRD format updated to be used as orbit container for scouting data, with updated unit test
- discovery of multiple input file locations in DaqDirector (for use in some modes)
- currently includes run2 scouting support as a test, which will be replaced by run 3 scouting model (in development)


#### PR validation:

Added several test scripts. Currently they are not part of automated testing since new input source development is still not finished. Also tested in DAQ test cluster (openstack VMs)


