### PR TITLE
Handle invalid entries in <data-access> of site-local-config.xml

### DIFF
--- a/FWCore/Catalog/src/FileLocator.cc
+++ b/FWCore/Catalog/src/FileLocator.cc
@@ -268,8 +268,8 @@ namespace edm {
     //let enforce that site-local-config.xml and storage.json contains valid catalogs in <data-access>, in which site defined in site-local-config.xml <data-access> should be found in storage.json
     if (found_site == json.end()) {
       cms::Exception ex("FileCatalog");
-      ex << "Can not find site and volume " << aCatalog.site << ", " << aCatalog.volume << " in " << filename_storage
-         << ". Check site-local-config.xml <data-access> and storage.json";
+      ex << "Can not find storage site \"" << aCatalog.storageSite << "\" and volume \"" << aCatalog.volume
+         << "\" in storage.json. Check site-local-config.xml <data-access> and storage.json";
       ex.addContext("edm::FileLocator:init()");
       throw ex;
     }
@@ -283,8 +283,9 @@ namespace edm {
     //let enforce that site-local-config.xml and storage.json contains valid catalogs, in which protocol defined in site-local-config.xml <data-access> should be found in storage.json
     if (found_protocol == protocols.end()) {
       cms::Exception ex("FileCatalog");
-      ex << "Can not find protocol " << aCatalog.protocol
-         << " in storage.json. Check site-local-config.xml <data-access> and storage.json";
+      ex << "Can not find protocol \"" << aCatalog.protocol << "\" for the storage site \"" << aCatalog.storageSite
+         << "\" and volume \"" << aCatalog.volume
+         << "\" in storage.json. Check site-local-config.xml <data-access> and storage.json";
       ex.addContext("edm::FileLocator:init()");
       throw ex;
     }


### PR DESCRIPTION
#### PR description:

In the previous implementation, when the first entry in \<data-access\> of site-local-config.xml contains invalid information such as protocol name an exception is thrown out from InputFileCatalog::init() and no further data catalogs are constructed from other entries in \<data-access\>. This pull request fixes this. All entries are tried and if no one is valid, the execution stops. Moreover, there are some improvements in exception messages for more readable (double quote added ...).