### PR TITLE
Make sure variables are preserved in ReggeGribovPartonMCInterface

### DIFF
--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
@@ -6771,12 +6771,8 @@ c-----------------------------------------------------------------------
       parameter(mxclu=10000)
       integer ku(mxclu),kd(mxclu),ks(mxclu)
       character cfl*3,cen*6,cvol*6
-c... initialize
-      do i=1,nrclu
-         ku(i)=0.0
-         kd(i)=0.0
-         ks(i)=0.0
-      enddo
+      save ku,kd,ks
+      data ku/mxclu*0/,kd/mxclu*0/,ks/mxclu*0/
 
       if(iii.eq.0)then
       

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
@@ -6492,9 +6492,11 @@ c-----------------------------------------------------------------------
       parameter(mxclu=10000)
       real am(mxclu)
       character cen*6,cvol*6
+c     the code needs am to be kept between calls
+      save am
+      data am /mxclu*0/
 
       if(iii.eq.0)then
-
       am(nrclu)=amt
 
       return


### PR DESCRIPTION
#### PR description:

The compiler had warnings about possibly uninitialized values in the FORTRAN. Looking at the algorithm, the code expects the subroutine values to be preserved between calls. The portable way of doing that is to use the `save` keyword.

One of the previous uninitialized fixes incorrectly reset the value of an array each call rather than using `save` which is needed for the algorithm to properly work.

#### PR validation:

The code compiles. As the warning was in the aarch64 build and I do not have access to that machine, it is unclear if the warning will go away.