### PR TITLE
fix segmentation violation in `SiStripHitEffFromCalibTree` and `SiStripHitResolFromCalibTree` in ASAN_X

### DIFF
--- a/CalibTracker/SiStripHitResolution/test/SiStripHitResolutionFromCalibTree_cfg.py
+++ b/CalibTracker/SiStripHitResolution/test/SiStripHitResolutionFromCalibTree_cfg.py
@@ -4,6 +4,24 @@ process = cms.Process("HitEff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripHitResolFromCalibTree=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),
+    #SiStripHitResolFromCalibTree = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')  
 
@@ -24,7 +42,7 @@ InputFilePathEnd = '.root'
 
 FileName1 = InputFilePath + str(RunNumberBegin) + InputFilePathEnd
 
-process.SiStripHitEff = cms.EDAnalyzer("SiStripHitResolFromCalibTree",
+process.SiStripHitResolFromCalibTree = cms.EDAnalyzer("SiStripHitResolFromCalibTree",
     CalibTreeFilenames = cms.untracked.vstring(FileName1),
     Threshold         = cms.double(0.2),
     nModsMin          = cms.int32(25),
@@ -81,4 +99,4 @@ process.TFileService = cms.Service("TFileService",
         fileName = cms.string(RootFileName)  
 )
 
-process.allPath = cms.Path(process.SiStripHitEff)
+process.allPath = cms.Path(process.SiStripHitResolFromCalibTree)


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/37781

#### PR description:

The goal of this PR is to fix the SIGSEV issues observed in the master ASAN_X IBs:
   * [here](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc11/CMSSW_13_1_ASAN_X_2023-03-03-2300/unitTestLogs/CalibTracker/SiStripHitEfficiency#/11472-11472) for `CalibTracker/SiStripHitEfficiency`
   * [here](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc11/CMSSW_13_1_ASAN_X_2023-03-03-2300/unitTestLogs/CalibTracker/SiStripHitResolution#/255-255) for `CalibTracker/SiStripHitResolution`

#### PR validation:

Successfully run the package unit tests in `CMSSW_13_1_ASAN_X_2023-03-03-2300` (`el8_amd64_gcc11`):

```
scram b runtests
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A