### PR TITLE
[ALCA-DB] Various fixes/improvements for unit test

### DIFF
--- a/CondFormats/Common/test/BuildFile.xml
+++ b/CondFormats/Common/test/BuildFile.xml
@@ -15,9 +15,4 @@
 <bin file="testSerializationCommon.cpp">
 </bin>
 
-<environment>
-  <bin file="testDropboxMetadataDB.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash CondFormats/Common/test createTestDBObjects.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-</environment>
+<test name="testDropboxMetadataDB" command="createTestDBObjects.sh"/>

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -17,11 +17,11 @@ process.source = cms.Source("EmptySource",
                             )
 
 # process.PoolDBOutputService.DBParameters.messageLevel = 3
-import json
+import json, os
 
 def encodeJsonInString(filename):
     """This function open the json file and encodes it in a string replacing probelamtic characters"""
-    thefile = open("../data/"+filename)
+    thefile = open(os.path.join(os.path.dirname(__file__), "..", "data", filename))
     thejson = json.load(thefile)
     thefile.close()
     return json.JSONEncoder().encode(thejson).replace('"',"&quot;")

--- a/CondFormats/Common/test/createTestDBObjects.sh
+++ b/CondFormats/Common/test/createTestDBObjects.sh
@@ -3,9 +3,8 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo -e "TESTING Dropbox Metadata DB codes ...\n\n"
-cd ${LOCAL_TEST_DIR}/
-cmsRun ProduceDropBoxMetadata.py  || die "Failure running ProduceDropBoxMetadata.py" $? 
+cmsRun ${CMSSW_BASE}/src/CondFormats/Common/test/ProduceDropBoxMetadata.py  || die "Failure running ProduceDropBoxMetadata.py" $?
 
 echo -e "TESTING Dropbox Metadata DB Reader code ...\n Reading local sqlite DropBoxMetadata.db \n\n "
-cmsRun DropBoxMetadataReader.py || die "Failure running DropBoxMetadataReader.py" $?
+cmsRun ${CMSSW_BASE}/src/CondFormats/Common/test/DropBoxMetadataReader.py || die "Failure running DropBoxMetadataReader.py" $?
 

--- a/CondFormats/Common/test/testDropboxMetadataDB.cpp
+++ b/CondFormats/Common/test/testDropboxMetadataDB.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()


### PR DESCRIPTION
Updated unit tests so that they can be run from their own separate directory. Mostly 
- convert `<bin ...>` to `<test....>`
- use full path e.g `CMSSW_BASE/src/...` instead of `./src/`