### PR TITLE
`SiPixelDynamicInefficiency_PayloadInspector` fix issue with PU parametrization plot polynomial representation

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -799,6 +799,12 @@ namespace {
           auto PhInfo = SiPixelPI::PhaseInfo(SiPixelPI::phase1size);
           const auto& regName = this->attachLocationLabel(modules, PhInfo);
           namesOfParts.push_back(regName);
+
+          edm::LogVerbatim(label_) << "region name: " << regName << " has the following modules attached: ";
+          for (const auto& module : modules) {
+            edm::LogVerbatim(label_) << module << ", ";
+          }
+          edm::LogVerbatim(label_) << "\n\n";
         }
 
         // functional for polynomial of n-th degree
@@ -824,20 +830,13 @@ namespace {
 
           // push polynomial degree as first entry in the vector
           params.insert(params.begin(), n);
-
           // TF1::SetParameters needs a C-style array
           double* arr = params.data();
           f1->SetLineWidth(2);
 
-          if (n == 1) {
-            /* special case for constant
-	       using setParameters technically works, but leads to
-	       heap-buffer-overflow
-	     */
-            f1->SetParameter(0, arr[0]);
-            f1->SetParameter(1, arr[1]);
-          } else {
-            f1->SetParameters(arr);
+          // fill in the parameter
+          for (unsigned int j = 0; j < params.size(); j++) {
+            f1->SetParameter(j, arr[j]);
           }
 
           parametrizations.push_back(f1);


### PR DESCRIPTION
#### PR description:

Attempt to fix the issue described at https://github.com/CMSTrackerDPG/Tasks/issues/1#issuecomment-1457758909 .
It looks like that when the library is loaded from `cvmfs` instead that local installation, the very same plot that in local renders fine gets screwed up.
Added also some debug statement that were useful to address https://github.com/CMSTrackerDPG/Tasks/issues/1#issuecomment-1457826352

#### PR validation:

Run private tests:

```bash
setenv SCRAM_ARCH el8_amd64_gcc11
cmsrel CMSSW_13_1_X_2023-03-06-2300
cd CMSSW_13_1_X_2023-03-06-2300/src
git cms-addpkg CondCore/SiPixelPlugins
scram b -j 20
getPayloadData.py --plugin pluginSiPixelDynamicInefficiency_PayloadInspector --plot plot_SiPixelDynamicInefficiencyPUParametrization --tag SiPixelDynamicInefficiency_phase1_2023_v1_fix --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test 
```

Also I tested that in a local installation in `CMSSSW_13_1_0_pre1` in which the problem appeared, it went away, although I cannot be fully certain that this works fine until there is a pre-release with this included. 
Apparently there is a standing issue in using IBs in the central Payload Inspector web-service, see https://its.cern.ch/jira/browse/CMSDBBROWS-134

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
