### PR TITLE
Allow to Skim Unused Input Prototracks

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -45,6 +45,7 @@ void SeedGeneratorFromProtoTracksEDProducer::fillDescriptions(edm::Configuration
   desc.add<std::string>("TTRHBuilder", "TTRHBuilderWithoutAngle4PixelTriplets");
   desc.add<bool>("usePV", false);
   desc.add<bool>("includeFourthHit", false);
+  desc.add<bool>("produceComplement", false);
 
   edm::ParameterSetDescription psd0;
   psd0.add<std::string>("ComponentName", std::string("SeedFromConsecutiveHitsCreator"));
@@ -67,16 +68,22 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
       useEventsWithNoVertex(cfg.getParameter<bool>("useEventsWithNoVertex")),
       usePV_(cfg.getParameter<bool>("usePV")),
       includeFourthHit_(cfg.getParameter<bool>("includeFourthHit")),
+      produceComplement_(cfg.getParameter<bool>("produceComplement")),
       theInputCollectionTag(consumes<reco::TrackCollection>(cfg.getParameter<InputTag>("InputCollection"))),
       theInputVertexCollectionTag(
           consumes<reco::VertexCollection>(cfg.getParameter<InputTag>("InputVertexCollection"))),
       seedCreator_(cfg.getParameter<edm::ParameterSet>("SeedCreatorPSet"), consumesCollector()),
       config_(consumesCollector()) {
   produces<TrajectorySeedCollection>();
+  if (produceComplement_)
+  {
+    produces<reco::TrackCollection>();
+  }
 }
 
 void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
   auto result = std::make_unique<TrajectorySeedCollection>();
+  auto leftTracks = std::make_unique<reco::TrackCollection>();
   Handle<reco::TrackCollection> trks;
   ev.getByToken(theInputCollectionTag, trks);
 
@@ -117,6 +124,8 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         }
       }
     }
+    if(produceComplement_ and !keepTrack)
+      (*leftTracks).push_back(proto);
     if (!keepTrack)
       continue;
 
@@ -148,4 +157,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
   }
 
   ev.put(std::move(result));
+  if(produceComplement_)
+    ev.put(std::move(leftTracks));
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -75,8 +75,7 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
       seedCreator_(cfg.getParameter<edm::ParameterSet>("SeedCreatorPSet"), consumesCollector()),
       config_(consumesCollector()) {
   produces<TrajectorySeedCollection>();
-  if (produceComplement_)
-  {
+  if (produceComplement_) {
     produces<reco::TrackCollection>();
   }
 }
@@ -124,7 +123,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
         }
       }
     }
-    if(produceComplement_ and !keepTrack)
+    if (produceComplement_ and !keepTrack)
       (*leftTracks).push_back(proto);
     if (!keepTrack)
       continue;
@@ -157,6 +156,6 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
   }
 
   ev.put(std::move(result));
-  if(produceComplement_)
+  if (produceComplement_)
     ev.put(std::move(leftTracks));
 }

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -22,6 +22,7 @@ private:
   const bool useEventsWithNoVertex;
   const bool usePV_;
   const bool includeFourthHit_;
+  const bool produceComplement_;
   const edm::EDGetTokenT<reco::TrackCollection> theInputCollectionTag;
   const edm::EDGetTokenT<reco::VertexCollection> theInputVertexCollectionTag;
   SeedFromConsecutiveHitsCreator seedCreator_;


### PR DESCRIPTION
#### PR description:

This PR allows, via the `produceComplement` flag, to put in the event the tracks not used to produce the `TrajectorySeedCollection` in `SeedGeneratorFromProtoTracksEDProducer`. May be beneficial, e.g., if we want to reuse the discarded pixel tracks at HLT for PUPPI (investigations ongoing). 

#### PR validation:

Tests run. Technical PR.
