### PR TITLE
Customize to produce & save ECAL-only caloparticles

### DIFF
--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -1,5 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
+def customize_ecalclustering_caloparticle(process):
+    process.load('SimGeneral.MixingModule.caloTruthProducer_cfi')
+    process.caloParticles.simHitCollections = cms.PSet(
+        #hcal = cms.VInputTag(cms.InputTag('g4SimHits','HcalHits')),
+        ecal = cms.VInputTag(
+            cms.InputTag('g4SimHits','EcalHitsEE'),
+            cms.InputTag('g4SimHits','EcalHitsEB'),
+            cms.InputTag('g4SimHits','EcalHitsES'),
+        )
+    )
+    process.caloParticles.doHGCAL = False
+    process.caloParticles.allowDifferentSimHitProcesses = False
+    process.mix.digitizers.caloParticles = process.caloParticles
+    process.mix.digitizers.mergedtruth.ignoreTracksOutsideVolume = False
+    process.mix.digitizers.mergedtruth.allowDifferentSimHitProcesses = False
+    process.mix.digitizers.mergedtruth.select.signalOnlyTP = True
+
+    process.PREMIXRAWoutput.outputCommands.append('keep *_*_MergedCaloTruth_*')
+    process.PREMIXRAWoutput.outputCommands.append('keep *_*_MergedTrackTruth_*')
+    return process
+
 def customize_step2(process):
     process.load('SimGeneral.MixingModule.caloTruthProducer_cfi')
     process.caloParticles.simHitCollections = cms.PSet(

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -18,7 +18,6 @@ def customize_ecalclustering_caloparticle(process):
     process.mix.digitizers.mergedtruth.select.signalOnlyTP = True
 
     process.PREMIXRAWoutput.outputCommands.append('keep *_*_MergedCaloTruth_*')
-    process.PREMIXRAWoutput.outputCommands.append('keep *_*_MergedTrackTruth_*')
     return process
 
 def customize_step2(process):


### PR DESCRIPTION
#### PR description:

Customization for running and saving ECAL caloParticles during the DIGI step.

#### PR validation:

Validation done on lxplus in CMSSW_13_1_X_2023-03-07-1100, demonstrating that thanks to this customization, ECAL caloParticles are produced and saved in the GEN-SIM-RAW format, running the standard Premixing sequence.
