### PR TITLE
[Core] Unit tests fixes/improvements

### DIFF
--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags USE_UNITTEST_DIR="1"/>
 <use name="boost"/>
 <library file="DummyData.cc,DummyRecord.cc,DepRecord.cc,Dummy2Record.cc,DepOn2Record.cc" name="FWCoreFrameworkTestDummyForEventSetup">
   <use name="FWCore/Framework"/>
@@ -31,10 +32,7 @@
   <use name="FWCore/ParameterSet"/>
 </library>
 
-<bin name="TestFWCoreFrameworkTBBTasks" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_tbbTasks.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkTBBTasks" command="run_tbbTasks.sh"/>
 
 <test name="TestFWCoreFrameworkOptions" command="run_testOptions.sh ${value}" for="0,4"/>
 
@@ -254,55 +252,25 @@
   <use name="cppunit"/>
 </bin>
 
-<bin name="TestFWCoreFrameworkCmsRun" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_cmsRun.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkCmsRun" command="run_cmsRun.sh"/>
 
-<bin name="TestFWCoreFrameworkESRefer" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_es_refer_tests.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkESRefer" command="run_es_refer_tests.sh"/>
 
-<bin name="TestFWCoreFrameworkUnscheduled" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_unscheduled.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkUnscheduled" command="run_unscheduled.sh"/>
 
-<bin name="TestFWCoreFrameworkGlobalStreamOne" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_global_stream_one.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkGlobalStreamOne" command="run_global_stream_one.sh"/>
 
-<bin name="TestFWCoreFrameworkMayConsumesDeadlock" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_deadlock_test.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkMayConsumesDeadlock" command="run_deadlock_test.sh"/>
 
-<bin name="TestFWCoreFrameworkReplace" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_replace_tests.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkReplace" command="run_replace_tests.sh"/>
 
-<bin name="TestFWCoreFrameworkESProducerLooper" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_esproducerlooper.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkESProducerLooper" command="run_esproducerlooper.sh"/>
 
-<bin name="TestFWCoreFrameworkTrigBit" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_trigbit.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkTrigBit" command="run_trigbit.sh"/>
 
-<bin name="TestFWCoreFrameworkTrigMask" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_trigmask.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkTrigMask" command="run_trigmask.sh"/>
 
-<bin name="TestXMLSafeException" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_XMLException.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestXMLSafeException" command="run_XMLException.sh"/>
 
 <bin name="TestFWCoreFrameworkProductSelector" file="ProductSelector_t.cpp">
   <use name="DataFormats/Provenance"/>
@@ -359,40 +327,19 @@
   <use name="boost_program_options"/>
 </bin>
 
-<bin name="TestFWCoreFrameworkStatemachineSH" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_statemachine.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkStatemachineSH" command="run_statemachine.sh"/>
 
-<bin name="TestFWCoreFrameworkInputTagFailure" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_InputTag_cache_failure.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkInputTagFailure" command="test_InputTag_cache_failure.sh"/>
 
-<bin name="TestFWCoreFrameworkDeleteEarly" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_deleteEarly.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+test name="TestFWCoreFrameworkDeleteEarly" command="test_deleteEarly.sh"/>
 
-<bin name="TestFWCoreFrameworkEarlyTerminationSignal" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_earlyTerminationSignal.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkEarlyTerminationSignal" command="test_earlyTerminationSignal.sh"/>
 
-<bin name="TestFWCoreFrameworkPrintDependencies" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_PrintDependencies.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkPrintDependencies" command="run_PrintDependencies.sh"/>
 
-<bin name="TestFWCoreFrameworkTransitions" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test transition_test.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkTransitions" command="transition_test.sh"/>
 
-<bin name="TestFWCoreFrameworkEmptyPath" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test test_emptyPath.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestFWCoreFrameworkEmptyPath" command="test_emptyPath.sh"/>
 
 <bin file="test_catch2_main.cc,test_catch2notTP_*.cc" name="TestFWCoreFrameworkCatch2notTP">
   <use name="catch2"/>

--- a/FWCore/Framework/test/TestDriver.cpp
+++ b/FWCore/Framework/test/TestDriver.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/Framework/test/run_PrintDependencies.sh
+++ b/FWCore/Framework/test/run_PrintDependencies.sh
@@ -3,10 +3,11 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 F1=${LOCAL_TEST_DIR}/testPrintDependencies.py
 
-cmsRun $F1 2>&1 | grep "depends on data products" >& ${LOCAL_TEST_DIR}/dependencies.txt || die "Failure using $F1" $?
-diff -q ${LOCAL_TEST_DIR}/dependencies.txt ${LOCAL_TEST_DIR}/unit_test_outputs/dependencies.txt || die "dependencies differ" $?
+cmsRun $F1 2>&1 | grep "depends on data products" >& dependencies.txt || die "Failure using $F1" $?
+diff -q dependencies.txt ${LOCAL_TEST_DIR}/unit_test_outputs/dependencies.txt || die "dependencies differ" $?
 
-rm -f ${LOCAL_TEST_DIR}/dependencies.txt
+rm -f dependencies.txt
 

--- a/FWCore/Framework/test/run_XMLException.sh
+++ b/FWCore/Framework/test/run_XMLException.sh
@@ -2,11 +2,6 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-pushd ${LOCAL_TMP_DIR}
-  echo ${LOCAL_TMP_DIR}
-  cmsRun -j testXMLSafeException.xml -p ${LOCAL_TEST_DIR}/testXMLSafeException_cfg.py
-  xmllint testXMLSafeException.xml || die "cmsRun testXMLSafeException_cfg.py produced invalid XML job report" $?
-
-popd
-
-exit 0
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
+cmsRun -j testXMLSafeException.xml -p ${LOCAL_TEST_DIR}/testXMLSafeException_cfg.py
+xmllint testXMLSafeException.xml || die "cmsRun testXMLSafeException_cfg.py produced invalid XML job report" $?

--- a/FWCore/Framework/test/run_cmsRun.sh
+++ b/FWCore/Framework/test/run_cmsRun.sh
@@ -3,6 +3,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
+
 (cmsRun --help ) || die 'Failure running cmsRun --help' $?
 
 # This test is supposed to throw an exception.

--- a/FWCore/Framework/test/run_deadlock_test.sh
+++ b/FWCore/Framework/test/run_deadlock_test.sh
@@ -3,6 +3,6 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-F1=${LOCAL_TEST_DIR}/test_mayConsumes_deadlocking_cfg.py
+F1=${CMSSW_BASE}/src/FWCore/Framework/test/test_mayConsumes_deadlocking_cfg.py
 (cmsRun $F1 ) || die "Failure using $F1" $?
 

--- a/FWCore/Framework/test/run_es_refer_tests.sh
+++ b/FWCore/Framework/test/run_es_refer_tests.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 (cmsRun ${LOCAL_TEST_DIR}/test_es_prefer_prods_cfg.py ) || die 'Failure using test_es_prefer_prods_cfg.py' $?
 (cmsRun ${LOCAL_TEST_DIR}/test_es_prefer_sources_cfg.py ) || die 'Failure using test_es_prefer_sources_cfg.py' $?
 (cmsRun ${LOCAL_TEST_DIR}/test_es_prefer_source_beats_prod_cfg.py ) || die 'Failure using test_es_prefer_source_beats_prod_cfg.py' $?

--- a/FWCore/Framework/test/run_esproducerlooper.sh
+++ b/FWCore/Framework/test/run_esproducerlooper.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 (cmsRun ${LOCAL_TEST_DIR}/test_esproducerlooper_cfg.py ) || die 'Failure using test_esproducerlooper_cfg.py' $?
 (cmsRun ${LOCAL_TEST_DIR}/test_esproducerlooper_stop_cfg.py ) || die 'Failure using test_esproducerlooper_stop_cfg.py' $?
 (cmsRun ${LOCAL_TEST_DIR}/test_esproducerlooper_override_cfg.py ) || die 'Failure using test_esproducerlooper_override_cfg.py' $?

--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -3,7 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ; echo === Log file === ; cat ${3:-/dev/null} ; echo === End log file === ; exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 
 F1=${LOCAL_TEST_DIR}/test_global_modules_cfg.py
 F2=${LOCAL_TEST_DIR}/test_stream_modules_cfg.py
@@ -36,5 +36,3 @@ cat log_test_limited_concurrent_module | tail -n 3 | grep -v ' 0 ' | grep -v 'e-
 
 echo cmsRun modules_2_concurrent_lumis_cfg.py
 (cmsRun ${LOCAL_TEST_DIR}/modules_2_concurrent_lumis_cfg.py ) &> log_modules_2_concurrent_lumis || die "cmsRun modules_2_concurrent_lumis_cfg.py" $? log_modules_2_concurrent_lumis
-
-popd

--- a/FWCore/Framework/test/run_module_delete_tests.sh
+++ b/FWCore/Framework/test/run_module_delete_tests.sh
@@ -3,7 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-TEST_DIR=src/FWCore/Framework/test
+TEST_DIR=$CMSSW_BASE/src/FWCore/Framework/test
 
 cmsRun $TEST_DIR/test_module_delete_cfg.py || die "module deletion test failed" $?
 echo "module deletion test succeeded"

--- a/FWCore/Framework/test/run_replace_tests.sh
+++ b/FWCore/Framework/test/run_replace_tests.sh
@@ -3,5 +3,6 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 (cmsRun ${LOCAL_TEST_DIR}/test_replace_with_unnamed_esproducer_cfg.py ) || die 'Failure using test_replace_with_unnamed_esproducer_cfg.py' $?
 (cmsRun ${LOCAL_TEST_DIR}/test_replace_with_unnamed_essource_cfg.py ) || die 'Failure using test_replace_with_unnamed_essource_cfg.py' $?

--- a/FWCore/Framework/test/run_statemachine.sh
+++ b/FWCore/Framework/test/run_statemachine.sh
@@ -7,6 +7,7 @@
 #LOCAL_TMP_DIR=/uscms_data/d1/wdd/CMSSW_1_8_0_pre2/tmp/slc4_ia32_gcc345
 #LOCAL_TEST_DIR=/uscms_data/d1/wdd/CMSSW_1_8_0_pre2/src/FWCore/Framework/test
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 exe=TestFWCoreFrameworkStatemachine
 input=${LOCAL_TEST_DIR}/unit_test_outputs/statemachine_
 output=statemachine_output_
@@ -14,10 +15,8 @@ reference_output=${LOCAL_TEST_DIR}/unit_test_outputs/statemachine_output_
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-pushd ${LOCAL_TMP_DIR}
-
-  for i in 1 2 5 6 7 8 9 10 11
-  do
+for i in 1 2 5 6 7 8 9 10 11
+do
 
     ${exe} -i ${input}${i}.txt -o ${output}${i}.txt || die "TestFWCoreFrameworkStatemachine with input ${i}" $?
     diff ${reference_output}${i}.txt ${output}${i}.txt || die "comparing ${output}${i}.txt" $?  
@@ -38,17 +37,13 @@ pushd ${LOCAL_TMP_DIR}
     ${exe} -i ${input}${i}.txt -o ${output}${i}.txt || die "TestFWCoreFrameworkStatemachine with input ${i}" $?
     diff ${reference_output}${i}.txt ${output}${i}.txt || die "comparing ${output}${i}.txt" $?  
 
-  done
+done
 
 #testing exceptions
-  for i in 20 21 22 23
-  do
+for i in 20 21 22 23
+do
 
     ${exe} -i ${input}${i}.txt -o ${output}${i}.txt || die "TestFWCoreFrameworkStatemachine with input ${i}" $?
     diff ${reference_output}${i}.txt ${output}${i}.txt || die "comparing ${output}${i}.txt" $?
 
-  done
-
-popd
-
-exit 0
+done

--- a/FWCore/Framework/test/run_tbbTasks.sh
+++ b/FWCore/Framework/test/run_tbbTasks.sh
@@ -3,6 +3,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
+
 F1=${LOCAL_TEST_DIR}/test_tbb_threads_cfg.py
 F2="-n 8 ${LOCAL_TEST_DIR}/test_tbb_threads_from_commandline_cfg.py"
 F3="--numThreads 8 ${LOCAL_TEST_DIR}/test_tbb_threads_from_commandline_cfg.py"

--- a/FWCore/Framework/test/run_testOptions.sh
+++ b/FWCore/Framework/test/run_testOptions.sh
@@ -4,11 +4,8 @@
 # argument from 0 to 4 specifying which test to run
 
 LOCAL_TEST_DIR=${CMSSW_BASE}/src/FWCore/Framework/test
-LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
-
-pushd ${LOCAL_TMP_DIR}
 
 echo "Running run_testOptions.sh $1"
 
@@ -24,7 +21,5 @@ grep "Number of Concurrent Lumis = ${expectedConcurrentLumis[$1]}" ${configFiles
 grep "Number of Concurrent IOVs = ${expectedConcurrentIOVs[$1]}" ${configFiles[$1]}.log || die "Failed number of concurrent IOVs test" $?
 
 rm ${configFiles[$1]}.log
-
-popd
 
 exit 0

--- a/FWCore/Framework/test/run_test_1_thread_es_prefetching.sh
+++ b/FWCore/Framework/test/run_test_1_thread_es_prefetching.sh
@@ -3,6 +3,6 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-TEST_DIR=src/FWCore/Framework/test
+TEST_DIR=$CMSSW_BASE/src/FWCore/Framework/test
 
 (cmsRun ${TEST_DIR}/test_1_thread_es_prefetch_cfg.py 2>&1) | grep 'Maximum concurrent running modules: 1' || die "grep failed to find 'Maximum concurrent running modules: 1'" $?

--- a/FWCore/Framework/test/run_trigbit.sh
+++ b/FWCore/Framework/test/run_trigbit.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 F1=${LOCAL_TEST_DIR}/testBitsPass_cfg.py
 F2=${LOCAL_TEST_DIR}/testBitsFail_cfg.py
 F3=${LOCAL_TEST_DIR}/testBitsMove_cfg.py

--- a/FWCore/Framework/test/run_trigmask.sh
+++ b/FWCore/Framework/test/run_trigmask.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 F1=${LOCAL_TEST_DIR}/testTrigBits0_cfg.py  
 F2=${LOCAL_TEST_DIR}/testTrigBits1_cfg.py  
 F3=${LOCAL_TEST_DIR}/testTrigBits2_cfg.py  

--- a/FWCore/Framework/test/run_unscheduled.sh
+++ b/FWCore/Framework/test/run_unscheduled.sh
@@ -3,7 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 
 F1=${LOCAL_TEST_DIR}/test_deepCall_unscheduled_cfg.py
 F2=${LOCAL_TEST_DIR}/test_deepCall_unscheduled_fail_cfg.py
@@ -22,6 +22,4 @@ diff ${LOCAL_TEST_DIR}/unit_test_outputs/test_deepCall_unscheduled.log test_deep
 diff ${LOCAL_TEST_DIR}/unit_test_outputs/test_onPath_unscheduled.log test_onPath_unscheduled.log || die "comparing test_onPath_unscheduled.log" $?
 
 !(cmsRun $F5 ) || die "Failure using $F5" $?
-
-popd
 

--- a/FWCore/Framework/test/test_InputTag_cache_failure.sh
+++ b/FWCore/Framework/test/test_InputTag_cache_failure.sh
@@ -3,5 +3,5 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-F1=${LOCAL_TEST_DIR}/test_InputTag_cache_failure_cfg.py
+F1=${CMSSW_BASE}/src/FWCore/Framework/test/test_InputTag_cache_failure_cfg.py
 (cmsRun $F1 ) || die "Failure using $F1" $?

--- a/FWCore/Framework/test/test_deleteEarly.sh
+++ b/FWCore/Framework/test/test_deleteEarly.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 F1=${LOCAL_TEST_DIR}/test_doNotDeleteEarly_cfg.py
 F2=${LOCAL_TEST_DIR}/test_simpleDeleteEarly_cfg.py
 F3=${LOCAL_TEST_DIR}/test_referencingDeleteEarly_cfg.py

--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -11,6 +11,7 @@ function test_failure {
     fi
 }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 echo "running cmsRun testEarlyTerminationSignal_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/testEarlyTerminationSignal_cfg.py 2>&1 | grep -q 'early termination of event: stream = 0 run = 1 lumi = 1 event = 10 : time = 50000001') || die "Early termination signal failed" $?
 

--- a/FWCore/Framework/test/test_emptyPath.sh
+++ b/FWCore/Framework/test/test_emptyPath.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 F1=${LOCAL_TEST_DIR}/test_emptyPathWithTask_cfg.py
 F2=${LOCAL_TEST_DIR}/test_emptyEndPathWithTask_cfg.py
 

--- a/FWCore/Framework/test/test_non_event_ordering.sh
+++ b/FWCore/Framework/test/test_non_event_ordering.sh
@@ -3,7 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-TEST_DIR=src/FWCore/Framework/test
+TEST_DIR=$CMSSW_BASE/src/FWCore/Framework/test
 
 echo test_non_event_ordering_beginLumi_cfg.py
 cmsRun $TEST_DIR/test_non_event_ordering_beginLumi_cfg.py || die "begin Lumi test failed" $?

--- a/FWCore/Framework/test/transition_test.sh
+++ b/FWCore/Framework/test/transition_test.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR="${CMSSW_BASE}/src/FWCore/Framework/test"
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 0 ) || die 'Failure running cmsRun transition_test_cfg.py 0' $?
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 1 ) || die 'Failure running cmsRun transition_test_cfg.py 1' $?
 (cmsRun ${LOCAL_TEST_DIR}/transition_test_cfg.py 2 ) || die 'Failure running cmsRun transition_test_cfg.py 2' $?


### PR DESCRIPTION
Updated unit tests so that they can be run from their own separate directory. Mostly 
- convert `<bin ...>` to `<test....>`
- use full path e.g `CMSSW_BASE/src/...` instead of `./src/`
- added flag `USE_UNITTEST_DIR="1"` to run each tests in separate dir. Once all the tests can run it their own tmp path then we can enable  `USE_UNITTEST_DIR="1"` at project level and cleanup `FWCore/Framework/test/BuildFile.xml`