### PR TITLE
Fix Phase-1 Barrel Pixel Inner / Outer ladders numbering in several monitoring tools

### DIFF
--- a/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/PixelBaryCentreAnalyzer.cc
@@ -400,19 +400,19 @@ void PixelBaryCentreAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
           if (phase_ == 1) {
             if (layer != 4) {  // layer 1-3
 
-              if (ladder % 2 != 0) {  // odd ladder = inner = flipped
-                nmodulesLayer_Flipped += nmodules_bpix[layer][ladder];
-                BPIXLayer_Flipped += barycentreLayer[ladder];
-              } else {
+              if (ladder % 2 != 0) {  // odd ladder = outer ladder = unflipped
                 nmodulesLayer_NonFlipped += nmodules_bpix[layer][ladder];
                 BPIXLayer_NonFlipped += barycentreLayer[ladder];
+              } else {  // even ladder = inner ladder = flipped
+                nmodulesLayer_Flipped += nmodules_bpix[layer][ladder];
+                BPIXLayer_Flipped += barycentreLayer[ladder];
               }
             } else {  // layer-4
 
-              if (ladder % 2 == 0) {  // even ladder = inner = flipped
+              if (ladder % 2 != 0) {  // odd ladder = inner = flipped
                 nmodulesLayer_Flipped += nmodules_bpix[layer][ladder];
                 BPIXLayer_Flipped += barycentreLayer[ladder];
-              } else {  // odd ladder = outer = non-flipped
+              } else {  //even ladder = outer ladder  = unflipped
                 nmodulesLayer_NonFlipped += nmodules_bpix[layer][ladder];
                 BPIXLayer_NonFlipped += barycentreLayer[ladder];
               }

--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -330,6 +330,11 @@ namespace AlignmentPI {
   inline bool isBPixOuterLadder(const DetId& detid, const TrackerTopology& tTopo, bool isPhase0)
   /*--------------------------------------------------------------------*/
   {
+    // Using TrackerTopology
+    // Ladders have a staggered structure
+    // Non-flipped ladders are on the outer radius
+    // Phase 0: Outer ladders are odd for layer 1,3 and even for layer 2
+    // Phase 1: Outer ladders are odd for layer 1,2,3 and even for layer 4
     bool isOuter = false;
     int layer = tTopo.pxbLayer(detid.rawId());
     bool odd_ladder = tTopo.pxbLadder(detid.rawId()) % 2;
@@ -340,9 +345,9 @@ namespace AlignmentPI {
         isOuter = odd_ladder;
     } else {
       if (layer == 4)
-        isOuter = odd_ladder;
-      else
         isOuter = !odd_ladder;
+      else
+        isOuter = odd_ladder;
     }
     return isOuter;
   }

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -676,16 +676,22 @@ namespace SiPixelPI {
     void fillGeometryInfo(const DetId& detId, const TrackerTopology& tTopo, const SiPixelPI::phase& ph);
     SiPixelPI::regions filterThePartition();
     bool sanityCheck();
-    void printAll();
+    int subDetId() { return m_subdetid; }
+    int layer() { return m_layer; }
+    int side() { return m_side; }
+    int ring() { return m_ring; }
+    bool isInternal() { return m_isInternal; }
+
+    void printAll(std::stringstream& ss) const;
     virtual ~topolInfo() {}
   };
 
   /*--------------------------------------------------------------------*/
-  inline void topolInfo::printAll()
+  inline void topolInfo::printAll(std::stringstream& ss) const
   /*--------------------------------------------------------------------*/
   {
-    std::cout << " detId:" << m_rawid << " subdetid: " << m_subdetid << " layer: " << m_layer << " side: " << m_side
-              << " ring: " << m_ring << " isInternal:" << m_isInternal << std::endl;
+    ss << " detId: " << m_rawid << " subdetid: " << m_subdetid << " layer: " << m_layer << " side: " << m_side
+       << " ring: " << m_ring << " isInternal: " << m_isInternal;
   }
 
   /*--------------------------------------------------------------------*/

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -636,6 +636,11 @@ namespace SiPixelPI {
   inline bool isBPixOuterLadder(const DetId& detid, const TrackerTopology& tTopo, bool isPhase0)
   /*--------------------------------------------------------------------*/
   {
+    // Using TrackerTopology
+    // Ladders have a staggered structure
+    // Non-flipped ladders are on the outer radius
+    // Phase 0: Outer ladders are odd for layer 1,3 and even for layer 2
+    // Phase 1: Outer ladders are odd for layer 1,2,3 and even for layer 4
     bool isOuter = false;
     int layer = tTopo.pxbLayer(detid.rawId());
     bool odd_ladder = tTopo.pxbLadder(detid.rawId()) % 2;
@@ -646,9 +651,9 @@ namespace SiPixelPI {
         isOuter = odd_ladder;
     } else {
       if (layer == 4)
-        isOuter = odd_ladder;
-      else
         isOuter = !odd_ladder;
+      else
+        isOuter = odd_ladder;
     }
     return isOuter;
   }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc
@@ -800,11 +800,26 @@ namespace {
           const auto& regName = this->attachLocationLabel(modules, PhInfo);
           namesOfParts.push_back(regName);
 
-          edm::LogVerbatim(label_) << "region name: " << regName << " has the following modules attached: ";
+          /*
+	   *  The following is needed for internal
+	   *  debug / cross-check
+	   */
+
+          std::stringstream ss;
+          ss << "region name: " << regName << " has the following modules attached: [";
           for (const auto& module : modules) {
-            edm::LogVerbatim(label_) << module << ", ";
+            ss << module << ", ";
           }
-          edm::LogVerbatim(label_) << "\n\n";
+          ss.seekp(-2, std::ios_base::end);  // remove last two chars
+          ss << "] "
+             << " has representation (";
+          for (const auto& param : listOfParametrizations[index]) {
+            ss << param << ", ";
+          }
+          ss.seekp(-2, std::ios_base::end);  // remove last two chars
+          ss << ") ";
+          edm::LogPrint(label_) << ss.str() << "\n\n";
+          ss.str(std::string()); /* clear the stringstream */
         }
 
         // functional for polynomial of n-th degree


### PR DESCRIPTION
#### PR description:

In the (long) discussion begun at https://github.com/CMSTrackerDPG/Tasks/issues/1#issuecomment-1456164032 (and following), it became apparent that the convention used to define inner / outer Phase-1 Barrel Pixel ladders based on their offline numbering in several different places in `cmssw` has become wrong after the major geometry fix in PR https://github.com/cms-sw/cmssw/pull/18651, after which the right convention is:
   * evenly numbered ladder = inner ladder = flipped ladder (for BPix 1,2,3)
   * oddly numbered ladder = inner ladder = flipped ladder (for BPix 4)
   
![Screenshot from 2023-03-08 11-22-51](https://user-images.githubusercontent.com/5082376/223687757-fcdb30ec-33c7-4cc5-ad1e-db583f5f0542.png)

to be compared with a ~recent (2018) pixel hadrography from the material budget analysis  
   
![image](https://user-images.githubusercontent.com/5082376/223687912-6db2032d-72a4-4ca3-bd2f-0706cfca5b8e.png)

#### PR validation:

`cmssw` compiles. 

**We DO expect regressions**

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport PR, but it does need to be backported to at least 13_0_X for 2023 data-taking.

cc:
@sroychow @ferencek @mroguljic @tsusa @arossi83 @cardinia @antoniovagnerini 
