### PR TITLE
extended existing HLT tau-jet correlation module [13_0_X]

### DIFF
--- a/RecoTauTag/HLTProducers/src/HLTPFDiJetCorrCheckerWithDiTau.cc
+++ b/RecoTauTag/HLTProducers/src/HLTPFDiJetCorrCheckerWithDiTau.cc
@@ -91,7 +91,6 @@ void HLTPFDiJetCorrCheckerWithDiTau::produce(edm::StreamID iSId, edm::Event& iEv
             continue;
 
           correctComb = true;
-          break;
         } else {
           for (unsigned int iTau2 = iTau1 + 1; iTau2 < taus.size(); iTau2++) {
             if (taus[iTau1]->pt() < extraTauPtCut_ && taus[iTau2]->pt() < extraTauPtCut_)
@@ -143,5 +142,5 @@ void HLTPFDiJetCorrCheckerWithDiTau::fillDescriptions(edm::ConfigurationDescript
 //
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(HLTPFDiJetCorrCheckerWithDiTau);
-using HLTDiPFJetPlusTausFilter = HLTPFDiJetCorrCheckerWithDiTau;
-DEFINE_FWK_MODULE(HLTDiPFJetPlusTausFilter);
+using HLTDiPFJetPlusTausCandidatePFJetProducer = HLTPFDiJetCorrCheckerWithDiTau;
+DEFINE_FWK_MODULE(HLTDiPFJetPlusTausCandidatePFJetProducer);

--- a/RecoTauTag/HLTProducers/src/HLTPFDiJetCorrCheckerWithDiTau.cc
+++ b/RecoTauTag/HLTProducers/src/HLTPFDiJetCorrCheckerWithDiTau.cc
@@ -1,10 +1,13 @@
 /** Description: Check correlation between PFJet pairs and filtered PFTau pairs and store the PFJet pairs.
 For (j1, j2, t1, t2) where j1, j2 from the PFJet collection and t1, t2 from the filtered PFTau collection,
-the module checks if there is no overlap (within dRmin) between j1, j2, t1, t2, i.e. they are 4 different objects.
+the module checks if there is no overlap (within dRmin) between j1, j2, t1, t2, i.e. there are 4 different objects.
 In addition, the module imposes the following cuts:
 * mjjMin: the min invariant mass cut on (j1, j2)
 * extraTauPtCut: the leading tau pt cut on (t1, t2) (under the assumption t1, t2 are products of a subleading pt filter with minN = 2)
 The module stores j1, j2 of any (j1, j2, t1, t2) that satisfies the conditions above. */
+
+/* Extended for the case of j1, j2, t1 (no t2, i.e. there are only 3 different objects)
+ */
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -68,22 +71,28 @@ void HLTPFDiJetCorrCheckerWithDiTau::produce(edm::StreamID iSId, edm::Event& iEv
 
   std::set<unsigned int> indices;
 
-  if (pfJets.size() > 1 && taus.size() > 1) {
-    for (unsigned int iJet1 = 0; iJet1 < pfJets.size(); iJet1++) {
-      for (unsigned int iJet2 = iJet1 + 1; iJet2 < pfJets.size(); iJet2++) {
-        bool correctComb = false;
-        const reco::PFJet& myPFJet1 = pfJets[iJet1];
-        const reco::PFJet& myPFJet2 = pfJets[iJet2];
+  for (unsigned int iJet1 = 0; iJet1 < pfJets.size(); iJet1++) {
+    for (unsigned int iJet2 = iJet1 + 1; iJet2 < pfJets.size(); iJet2++) {
+      bool correctComb = false;
+      const reco::PFJet& myPFJet1 = pfJets[iJet1];
+      const reco::PFJet& myPFJet2 = pfJets[iJet2];
 
-        if ((myPFJet1.p4() + myPFJet2.p4()).M() < mjjMin_)
+      if ((myPFJet1.p4() + myPFJet2.p4()).M() < mjjMin_)
+        continue;
+
+      for (unsigned int iTau1 = 0; iTau1 < taus.size(); iTau1++) {
+        if (reco::deltaR2(taus[iTau1]->p4(), myPFJet1.p4()) < dRmin2_)
+          continue;
+        if (reco::deltaR2(taus[iTau1]->p4(), myPFJet2.p4()) < dRmin2_)
           continue;
 
-        for (unsigned int iTau1 = 0; iTau1 < taus.size(); iTau1++) {
-          if (reco::deltaR2(taus[iTau1]->p4(), myPFJet1.p4()) < dRmin2_)
-            continue;
-          if (reco::deltaR2(taus[iTau1]->p4(), myPFJet2.p4()) < dRmin2_)
+        if (taus.size() == 1) {
+          if (taus[iTau1]->pt() < extraTauPtCut_)
             continue;
 
+          correctComb = true;
+          break;
+        } else {
           for (unsigned int iTau2 = iTau1 + 1; iTau2 < taus.size(); iTau2++) {
             if (taus[iTau1]->pt() < extraTauPtCut_ && taus[iTau2]->pt() < extraTauPtCut_)
               continue;
@@ -96,14 +105,14 @@ void HLTPFDiJetCorrCheckerWithDiTau::produce(edm::StreamID iSId, edm::Event& iEv
             correctComb = true;
             break;
           }
-          if (correctComb)
-            break;
         }
+        if (correctComb)
+          break;
+      }
 
-        if (correctComb) {
-          indices.insert(iJet1);
-          indices.insert(iJet2);
-        }
+      if (correctComb) {
+        indices.insert(iJet1);
+        indices.insert(iJet2);
       }
     }
 
@@ -134,3 +143,5 @@ void HLTPFDiJetCorrCheckerWithDiTau::fillDescriptions(edm::ConfigurationDescript
 //
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(HLTPFDiJetCorrCheckerWithDiTau);
+using HLTDiPFJetPlusTausFilter = HLTPFDiJetCorrCheckerWithDiTau;
+DEFINE_FWK_MODULE(HLTDiPFJetPlusTausFilter);


### PR DESCRIPTION
#### PR description:
To support a future VBF Single Tau HLT in the scenario that VBF Parking is accepted (see JIRA https://its.cern.ch/jira/browse/CMSLITDPG-1099 and https://its.cern.ch/jira/browse/CMSHLT-2702), a small change to an existing HLT module is necessary. The change extends the module's usage from only handling 2 Jet + 2 Tau events to also handling 2 Jet + 1 Tau events. This change depends on no other PRs and affects code used by one existing HLT path, and would allow the implementation of a future HLT path.  

#### PR validation:
In the course of estimating rate and gain for the proposed VBF Single Tau path, the same metrics were also computed for the VBF DiTau path with the module extension in place and no differences were found in past and current behavior of the path. 

#### Backport 
master PR is https://github.com/cms-sw/cmssw/pull/40993
It's necessary to Backport this change as current testing and HLT development is taking place in CMSSW_13_0_0