### PR TITLE
Payload Inspector plugin for Jet Resolution and SF

### DIFF
--- a/CondCore/JetMETPlugins/plugins/BuildFile.xml
+++ b/CondCore/JetMETPlugins/plugins/BuildFile.xml
@@ -1,22 +1,8 @@
 <library file="JetResolution_PayloadInspector.cc" name="JetResolutionObject_PayloadInspector">
   <use   name="DataFormats/Common"/>
-  <use   name="DataFormats/Math"/>
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="CondFormats/JetMETObjects"/>
-  <use   name="FWCore/MessageLogger"/>
-  <use   name="FWCore/Utilities"/>
-  <use   name="FWCore/ParameterSet"/>
-  <use   name="FWCore/Reflection"/>
-  <use   name="FWCore/SOA" source_only="1"/>
   <use   name="CommonTools/Utils"/>
-  <use   name="boost_python"/>
-  <use   name="root"/>
-  <use   name="roothistmatrix"/>
-  <use   name="rootmath"/>
-  <use   name="tbb"/>
-  <use   name="clhep"/>
-  <use   name="boost"/>
-  <use   name="boost_regex"/>
 </library>

--- a/CondCore/JetMETPlugins/plugins/BuildFile.xml
+++ b/CondCore/JetMETPlugins/plugins/BuildFile.xml
@@ -1,0 +1,7 @@
+<library file="JetResolution_PayloadInspector.cc" name="JetResolutionObject_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="CondFormats/JetMETObjects"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/JetMETPlugins/plugins/BuildFile.xml
+++ b/CondCore/JetMETPlugins/plugins/BuildFile.xml
@@ -1,7 +1,22 @@
 <library file="JetResolution_PayloadInspector.cc" name="JetResolutionObject_PayloadInspector">
+  <use   name="DataFormats/Common"/>
+  <use   name="DataFormats/Math"/>
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="CondFormats/JetMETObjects"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="FWCore/Utilities"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/Reflection"/>
+  <use   name="FWCore/SOA" source_only="1"/>
+  <use   name="CommonTools/Utils"/>
   <use   name="boost_python"/>
+  <use   name="root"/>
+  <use   name="roothistmatrix"/>
+  <use   name="rootmath"/>
+  <use   name="tbb"/>
+  <use   name="clhep"/>
+  <use   name="boost"/>
+  <use   name="boost_regex"/>
 </library>

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -1,3 +1,5 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
@@ -9,8 +11,22 @@
 
 #include <memory>
 #include <sstream>
+#include <fstream>
+#include <iostream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
 
 namespace JME{
+
+  using namespace cond::payloadInspector;
 
   /*******************************************************
  *    
@@ -20,38 +36,73 @@ namespace JME{
 
   // inherit from one of the predefined plot class: Histogram1D
 
-  class JetResolutionEta : public cond::payloadInspector::Histogram1D<JetResolutionObject> {
+  class JetResolutionEta : public cond::payloadInspector::Histogram1D<JetResolutionObject, SINGLE_IOV> {
     public:
       static const int MIN_ETA = -5.5;
       static const int MAX_ETA =  5.5;
 
-    JetResolutionEta() : cond::payloadInspector::Histogram1D<JetResolutionObject>( "Jet Energy Resolution", "#eta", 50, MIN_ETA, MAX_ETA, "Resolution"){
+    JetResolutionEta() : cond::payloadInspector::Histogram1D<JetResolutionObject, SINGLE_IOV>( "Jet Energy Resolution", "#eta", 50, MIN_ETA, MAX_ETA, "Resolution"){
       Base::setSingleIov( true );
     }
 
-    // Histogram1D::fill (virtual) needs be overridden - the implementation should use fillWithValue
-    bool fill( const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs)override{
-      std::cout << "filling iovs\n";
-      for(size_t idx = 0; idx<50; idx++)
-        fillWithBinAndValue(idx, -1.);
-      //fillWithValue(-1.2);
-      for(auto const &iov: iovs){
-        //std::cout << "looping iovs" << std::endl;
-        fillWithValue( 1.);
-        std::shared_ptr<JetResolutionObject> payload = Base::fetchPayload( std::get<1>(iov) );
-        if( payload.get() ){
-          //std::cout << "payload fetched" << std::endl;
-          fillWithValue( 1.2);
-          // test dump
-          payload->dump();
-          payload->saveToFile("output.txt");
-          // looping over the 
-//          return true;
-        } // payload
-      } // iov
-      return true;
-    } // fill
-  };  // class
+    bool fill()override{
+      auto tag = PlotBase::getTag<0>();
+        for (auto const& iov : tag.iovs) {
+          std::shared_ptr<JetResolutionObject> payload = Base::fetchPayload(std::get<1>(iov));
+          if (payload.get()) {
+//            const std::vector<Binning>& bins = payload->getDefinition().getBins();
+//            edm::LogWarning("JetResObj_PI") << "Bins size: " << payload->getDefinition().getBins().size() << "\n";
+//            edm::LogWarning("JetResObj_PI") << "No. of binning variables: " << payload->getDefinition().nBins() << "\n";
+//            for (const auto& bin: payload->getDefinition().getBinsName()) {
+//              edm::LogWarning("JetResObj_PI") << bin << ", ";
+//            }
+//
+//            edm::LogWarning("JetResObj_PI") << "No. of variables: " << payload->getDefinition().nVariables() << "\n";
+//            for (const auto& bin: payload->getDefinition().getVariablesName()) {
+//              edm::LogWarning("JetResObj_PI") << bin << ", ";
+//            }
+
+            edm::LogWarning("JetResObj_PI") << "Formula: " << payload->getDefinition().getFormulaString() << std::endl;
+
+            edm::LogWarning("JetResObj_PI") << "Records: " << payload->getRecords().size() << "\n";
+
+            for(const auto& record : payload->getRecords()){ 
+              // Check Eta
+              if(record.getVariablesRange().size()>0 && 
+                 payload->getDefinition().getVariableName(0) == "JetPt" &&
+                 record.getVariablesRange()[0].is_inside(100.)){
+                if(record.getBinsRange().size()>1 &&
+                    payload->getDefinition().getBinName(1) == "Rho" &&
+                    record.getBinsRange()[1].is_inside(20.)){
+                   if(record.getBinsRange().size()>0 &&
+                      payload->getDefinition().getBinName(0) == "JetEta"){
+                     reco::FormulaEvaluator f(payload->getDefinition().getFormulaString());
+
+                     for(size_t idx = 0; idx < 50; idx++){
+                       double x_axis = (idx+0.5)*(MAX_ETA-MIN_ETA)/50.+MIN_ETA;
+                       if(record.getBinsRange()[0].is_inside(x_axis)){
+                         std::vector<double> var={100.};
+                         std::vector<double> param;// = record.getParametersValues();
+                         for(size_t i = 0; i < record.getParametersValues().size(); i++){
+                           double par = record.getParametersValues()[i];
+                           param.push_back(par);
+                         }
+                         float res = f.evaluate(var, param);
+                         fillWithBinAndValue(idx, res);
+                       }
+                     }
+                   }
+                 }
+              }
+            }
+              
+          }    // payload
+        }      // iovs
+        return true;
+//        return false;
+    }  // fill
+      
+};  // class
 
 // Register the classes as boost python plugin
 PAYLOAD_INSPECTOR_MODULE( JetResolutionObject ){
@@ -59,3 +110,4 @@ PAYLOAD_INSPECTOR_MODULE( JetResolutionObject ){
 }
 
 }  // namespace
+

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -1,0 +1,61 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/JetMETObjects/interface/JetResolution.h"
+#include "CondFormats/JetMETObjects/interface/JetResolutionObject.h"
+#include <CondFormats/JetMETObjects/interface/Utilities.h>
+
+#include <memory>
+#include <sstream>
+
+namespace JME{
+
+  /*******************************************************
+ *    
+ *         1d histogram of JetResolution in Eta of 1 IOV 
+ *
+   *******************************************************/
+
+  // inherit from one of the predefined plot class: Histogram1D
+
+  class JetResolutionEta : public cond::payloadInspector::Histogram1D<JetResolutionObject> {
+    public:
+      static const int MIN_ETA = -5.5;
+      static const int MAX_ETA =  5.5;
+
+    JetResolutionEta() : cond::payloadInspector::Histogram1D<JetResolutionObject>( "Jet Energy Resolution", "#eta", 50, MIN_ETA, MAX_ETA, "Resolution"){
+      Base::setSingleIov( true );
+    }
+
+    // Histogram1D::fill (virtual) needs be overridden - the implementation should use fillWithValue
+    bool fill( const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs)override{
+      std::cout << "filling iovs\n";
+      for(size_t idx = 0; idx<50; idx++)
+        fillWithBinAndValue(idx, -1.);
+      //fillWithValue(-1.2);
+      for(auto const &iov: iovs){
+        //std::cout << "looping iovs" << std::endl;
+        fillWithValue( 1.);
+        std::shared_ptr<JetResolutionObject> payload = Base::fetchPayload( std::get<1>(iov) );
+        if( payload.get() ){
+          //std::cout << "payload fetched" << std::endl;
+          fillWithValue( 1.2);
+          // test dump
+          payload->dump();
+          payload->saveToFile("output.txt");
+          // looping over the 
+//          return true;
+        } // payload
+      } // iov
+      return true;
+    } // fill
+  };  // class
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE( JetResolutionObject ){
+  PAYLOAD_INSPECTOR_CLASS( JetResolutionEta );
+}
+
+}  // namespace

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -230,7 +230,11 @@ namespace JME{
               }
             }
           }  // records
+
           gStyle->SetOptStat(0);
+          gStyle->SetLabelFont(42, "XYZ");
+          gStyle->SetLabelSize(0.05, "XYZ");
+          gStyle->SetFrameLineWidth(3);
 
           std::string title = Form("Summary Run %i", run);
           TCanvas canvas("Jet Resolution Summary", title.c_str(), 800, 1200);
@@ -240,18 +244,20 @@ namespace JME{
           resol_eta->SetTitle(tagname.c_str());
           resol_eta->SetXTitle("#eta");
           resol_eta->SetYTitle("Resolution");
-          resol_eta->Draw();
+          resol_eta->SetLineWidth(3);
+          resol_eta->Draw("");
 
           canvas.cd(2);
-          resol_pt->SetTitle(tagname.c_str());
+          //resol_pt->SetTitle(tagname.c_str());
           resol_pt->SetXTitle("p_{T} [GeV]");
           resol_pt->SetYTitle("Resolution");
-          resol_pt->Draw();
+          resol_pt->SetLineWidth(3);
+          resol_pt->Draw("][");
 
           canvas.SaveAs(m_imageFileName.c_str());
 
           return true;    
-      }//else // no payload.get()
+      }else // no payload.get()
         return false;
     }  // fill
 
@@ -342,9 +348,11 @@ namespace JME{
             }
           }
         }  // records
+
         gStyle->SetOptStat(0);
-        //gStyle->SetPadLeftMargin(0.16);
-        //gStyle->SetPadRightMargin(0.02);
+        gStyle->SetLabelFont(42, "XYZ");
+        gStyle->SetLabelSize(0.05, "XYZ");
+        gStyle->SetFrameLineWidth(3);
 
         std::string title = Form("Summary Run %i", run);
         TCanvas canvas("Jet ScaleFactor Summary", title.c_str(), 800, 600);

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -248,7 +248,6 @@ namespace JME{
           resol_eta->Draw("");
 
           canvas.cd(2);
-          //resol_pt->SetTitle(tagname.c_str());
           resol_pt->SetXTitle("p_{T} [GeV]");
           resol_pt->SetYTitle("Resolution");
           resol_pt->SetLineWidth(3);
@@ -297,10 +296,11 @@ namespace JME{
             }
           }  // records
           return true;    
-        }
-      }
+        }else
+          return false;
+      }  // for
       return false;
-    }
+    }  // fill
   };  // class
 
   typedef JetScaleFactorVsEta<NORM> JetScaleFactorVsEtaNORM;
@@ -381,8 +381,8 @@ namespace JME{
         canvas.SaveAs(m_imageFileName.c_str());
 
         return true;
-      }//else // no payload.get()
-      return false;
+      }else // no payload.get()
+        return false;
     }  // fill
 
   };  // class


### PR DESCRIPTION
#### PR description:

For the issue of wrong GT of Jet Resolution used, a payload inspector plugin is created for detector experts to check online. Individual histograms are available in Histogram1D. Summary plots on Jet Resolution and SF are in PlotImage.

#### PR validation:

Code checked with getPayloadData.py locally.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
