### PR TITLE
Add plugin to use existing HLTDoubleSinglet module with two PFJets and one RecoEcalCandidate

### DIFF
--- a/HLTrigger/HLTfilters/plugins/plugins.cc
+++ b/HLTrigger/HLTfilters/plugins/plugins.cc
@@ -130,6 +130,7 @@ typedef HLTDoublet<RecoEcalCandidate, PFMET> HLT2PhotonPFMET;
 #include "HLTDoubletSinglet.h"
 typedef HLTDoubletSinglet<PFTau, PFTau, PFJet> HLT3DoublePFTauPFJet;
 typedef HLTDoubletSinglet<RecoChargedCandidate, PFTau, PFJet> HLT3MuonPFTauPFJet;
+typedef HLTDoubletSinglet<PFJet, PFJet, RecoEcalCandidate> HLT3DoublePFJetPhoton;
 
 DEFINE_FWK_MODULE(HLTBool);
 DEFINE_FWK_MODULE(HLTFiltCand);
@@ -162,6 +163,7 @@ DEFINE_FWK_MODULE(HLT2PFTauPFTau);
 
 DEFINE_FWK_MODULE(HLT3DoublePFTauPFJet);
 DEFINE_FWK_MODULE(HLT3MuonPFTauPFJet);
+DEFINE_FWK_MODULE(HLT3DoublePFJetPhoton);
 
 DEFINE_FWK_MODULE(HLT1Electron);
 DEFINE_FWK_MODULE(HLT1Photon);


### PR DESCRIPTION
#### PR description:

To support future VBF Electron and VBF Photon HLTs in the scenario that VBF Parking is accepted (see JIRA https://its.cern.ch/jira/browse/CMSLITDPG-1099), one plugin is added to the existing plugins file of HLTrigger/HLTfilters.

#### PR validation:

With the changed file in place, the rates of VBF Electron and VBF Photon were estimated after changing by-hand the EDFilter type to use for the final filter of each path. It was found that events pass both paths and use the triplet filter in the expected way (cross-cleaning a RecoEcalCandidate from two PFJets).

NB: It wasn't obvious to me this was the case at first, but using the same EDFilter module for both electrons and photons is in-line with existing HLT paths and code (see the Ele-Tau cross trigger, which uses a HLT2PhotonTau EDFilter in its cross-cleaning module, hltOverlapFilterIsoEle24IsoTau30WPTightGsfCaloJet5).