### PR TITLE
[CORE] Various fixes/improvements for unit test

### DIFF
--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -206,54 +206,33 @@
   <flags NO_TESTRUN="1"/>
 </bin>
 
-<bin file="testRunner.cpp" name="standAloneWithMessageLoggerRunner">
+<test name="standAloneWithMessageLoggerRunner" command="standAlone_1.sh">
   <flags PRE_TEST="standAloneWithMessageLogger"/>
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test standAlone_1.sh"/>
-</bin>
+</test>
 
 <bin file="trivial_main.cpp">
   <use name="FWCore/MessageLogger"/>
 </bin>
 
-<bin file="testLoggerInCmsRun.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test testLoggerInCmsRun.sh"/>
-</bin>
+<test name="testLoggerInCmsRun" command="testLoggerInCmsRun.sh"/>
 
-<bin file="unitTestsGroup_d.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u1d.sh u13d.sh u16.sh u19d.sh u33d.sh"/>
-</bin>
+<test name="unitTestsGroup_d" command="${value}.sh" foreach="u1d,u13d,u16,u19d,u33d"/>
 
-<bin file="unitTestsGroup_1.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u1.sh u2.sh u6.sh u21.sh"/>
-</bin>
+<test name="unitTestsGroup_1" command="${value}.sh" foreach="u1,u2,u6,u21"/>
 
-<bin file="unitTestsStatistics.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u3.sh u4.sh u5.sh u28.sh"/>
-</bin>
+<test name="unitTestsStatistics" command="${value}.sh" foreach="u3,u4,u5,u28"/>
 
-<bin file="unitTestsLimits.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u7.sh u8.sh u11.sh u36.sh"/>
-</bin>
+<test name="unitTestsLimits" command="${value}.sh" foreach="u7,u8,u11,u36"/>
 
-<bin file="unitTestsGroup_2.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u9.sh u12.sh u13.sh u14.sh u15.sh"/>
-</bin>
+<test name="unitTestsGroup_2" command="${value}.sh" foreach="u9,u12,u13,u14,u15"/>
 
-<bin file="unitTestsGroup_3.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u10.sh u17.sh u34.sh u35.sh"/>
-</bin>
+<test name="unitTestsGroup_3" command="${value}.sh" foreach="u10,u17,u34,u35"/>
 
-<bin file="unitTestsGroup_4.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u18.sh u19.sh u20.sh"/>
-</bin>
+<test name="unitTestsGroup_4" command="${value}.sh" foreach="u18,u19,u20"/>
 
-<bin file="unitTestsGroup_5.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u22.sh u24.sh u25.sh"/>
-</bin>
+<test name="unitTestsGroup_5" command="${value}.sh" foreach="u22,u24,u25"/>
 
-<bin file="unitTestsGroup_6.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/MessageService/test u23.sh u27.sh u30.sh u31.sh u33.sh"/>
-</bin>
+<test name="unitTestsGroup_6" command="${value}.sh" foreach="u23,u27,u30,u31,u33"/>
 
 <bin name="makeJobReport" file="makeJobReport.cpp">
   <use name="boost_program_options"/>

--- a/FWCore/MessageService/test/standAlone_1.sh
+++ b/FWCore/MessageService/test/standAlone_1.sh
@@ -3,8 +3,6 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f standAloneWithMessageLogger.cerr
@@ -13,15 +11,13 @@ standAloneWithMessageLogger > standAloneWithMessageLogger.cerr 2>&1
 
 for file in standAloneWithMessageLogger.cerr
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/testLoggerInCmsRun.cpp
+++ b/FWCore/MessageService/test/testLoggerInCmsRun.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/testLoggerInCmsRun.sh
+++ b/FWCore/MessageService/test/testLoggerInCmsRun.sh
@@ -3,8 +3,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-export STD_OUT=${LOCAL_TMP_DIR}/cout.txt
-export STD_ERR=${LOCAL_TMP_DIR}/cerr.txt
+export STD_OUT=./cout.txt
+export STD_ERR=./cerr.txt
 
-#(totalview cmsRun -a --parameter-set ${LOCAL_TEST_DIR}/messageLogger_cfg.py > ${STD_OUT}  2> ${STD_ERR} ) || die 'Failure using messageLogger_cfg.py' $?
-(cmsRun --parameter-set ${LOCAL_TEST_DIR}/messageLogger_cfg.py > ${STD_OUT}  2> ${STD_ERR} ) || die 'Failure using messageLogger_cfg.py' $?
+#(totalview cmsRun -a --parameter-set ${SCRAM_TEST_PATH}/messageLogger_cfg.py > ${STD_OUT}  2> ${STD_ERR} ) || die 'Failure using messageLogger_cfg.py' $?
+(cmsRun --parameter-set ${SCRAM_TEST_PATH}/messageLogger_cfg.py > ${STD_OUT}  2> ${STD_ERR} ) || die 'Failure using messageLogger_cfg.py' $?

--- a/FWCore/MessageService/test/testRunner.cpp
+++ b/FWCore/MessageService/test/testRunner.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/u1.sh
+++ b/FWCore/MessageService/test/u1.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u1_errors.log u1_warnings.log u1_infos.log u1_debugs.log u1_default.log u1_job_report.mxml 
 
-cmsRun -j u1_job_report.mxml -p $LOCAL_TEST_DIR/u1_cfg.py || exit $?
+cmsRun -j u1_job_report.mxml -p ${SCRAM_TEST_PATH}/u1_cfg.py || exit $?
  
 for file in u1_errors.log u1_warnings.log u1_infos.log u1_debugs.log u1_default.log u1_job_report.mxml   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u10.sh
+++ b/FWCore/MessageService/test/u10.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u10_warnings.log u10_job_report.xml
 
-cmsRun -j u10_job_report.xml -p $LOCAL_TEST_DIR/u10_cfg.py || exit $?
+cmsRun -j u10_job_report.xml -p ${SCRAM_TEST_PATH}/u10_cfg.py || exit $?
  
 for file in u10_warnings.log u10_job_report.xml
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u11.sh
+++ b/FWCore/MessageService/test/u11.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u11_overall_unnamed.log u11_overall_specific.log u11_supercede_specific.log u11_non_supercede_common.log u11_specific.log
 
-cmsRun -p $LOCAL_TEST_DIR/u11_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u11_cfg.py || exit $?
  
 for file in u11_overall_unnamed.log u11_overall_specific.log u11_supercede_specific.log u11_non_supercede_common.log u11_specific.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u12.sh
+++ b/FWCore/MessageService/test/u12.sh
@@ -3,18 +3,16 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f  u12_warnings.log u12_placeholder.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u12_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u12_cfg.py || exit $?
  
 for file in  u12_warnings.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
@@ -30,7 +28,5 @@ do
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u13.sh
+++ b/FWCore/MessageService/test/u13.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u13_infos.log u13_debugs.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u13_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u13_cfg.py || exit $?
  
 for file in u13_infos.log u13_debugs.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u13d.sh
+++ b/FWCore/MessageService/test/u13d.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u13d_infos.log u13d_debugs.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u13d_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u13d_cfg.py || exit $?
  
 for file in u13d_infos.log u13d_debugs.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u14.sh
+++ b/FWCore/MessageService/test/u14.sh
@@ -3,26 +3,22 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u14_errors.log u14_warnings.log u14_infos.log u14_debugs.log u14_default.log u14_job_report.mxml 
 
-cmsRun -j u14_job_report.mxml -p $LOCAL_TEST_DIR/u14_cfg.py || exit $?
+cmsRun -j u14_job_report.mxml -p ${SCRAM_TEST_PATH}/u14_cfg.py || exit $?
  
 for file in u14_errors.log u14_warnings.log u14_infos.log u14_debugs.log u14_default.log u14_job_report.mxml   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
-# fancy_diffs $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file $LOCAL_TEST_DIR/$file.diffs
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
+# fancy_diffs ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file $LOCAL_TEST_DIR/$file.diffs
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u15.sh
+++ b/FWCore/MessageService/test/u15.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u15_infos.log u15_debugs.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u15_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u15_cfg.py || exit $?
  
 for file in u15_infos.log u15_debugs.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u16.sh
+++ b/FWCore/MessageService/test/u16.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u16_errors.mmlog u16_altWarnings.log u16_infos.mmlog u16_altDebugs.mmlog u16_default.log u16_job_report.mmxml u16_statistics.mslog 
 
-cmsRun -e -j u16_job_report.mmxml -p $LOCAL_TEST_DIR/u16_cfg.py || exit $?
+cmsRun -e -j u16_job_report.mmxml -p ${SCRAM_TEST_PATH}/u16_cfg.py || exit $?
  
 for file in u16_errors.mmlog u16_altWarnings.log u16_infos.mmlog u16_altDebugs.mmlog u16_default.log u16_job_report.mmxml u16_statistics.mslog  
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u17.sh
+++ b/FWCore/MessageService/test/u17.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u17_all.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u17_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u17_cfg.py || exit $?
  
 for file in u17_all.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u18.sh
+++ b/FWCore/MessageService/test/u18.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u18_system.log u18_everything.log
 
-cmsRun -p $LOCAL_TEST_DIR/u18_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u18_cfg.py || exit $?
  
 for file in u18_system.log u18_everything.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u19.sh
+++ b/FWCore/MessageService/test/u19.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u19_infos.log u19_debugs.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u19_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u19_cfg.py || exit $?
  
 for file in u19_infos.log u19_debugs.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u19d.sh
+++ b/FWCore/MessageService/test/u19d.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u19d_infos.log u19d_debugs.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u19d_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u19d_cfg.py || exit $?
  
 for file in u19d_infos.log u19d_debugs.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u1d.sh
+++ b/FWCore/MessageService/test/u1d.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u1d_errors.log u1d_warnings.log u1d_infos.log u1d_debugs.log u1d_default.log u1d_job_report.mxml 
 
-cmsRun -j u1d_job_report.mxml -p $LOCAL_TEST_DIR/u1d_cfg.py || exit $?
+cmsRun -j u1d_job_report.mxml -p ${SCRAM_TEST_PATH}/u1d_cfg.py || exit $?
  
 for file in u1d_errors.log u1d_warnings.log u1d_infos.log u1d_debugs.log u1d_default.log u1d_job_report.mxml   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u2.sh
+++ b/FWCore/MessageService/test/u2.sh
@@ -3,26 +3,22 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f  u2_warnings.log u2_cerr.mout 
 
-cmsRun -p $LOCAL_TEST_DIR/u2_cfg.py 2> $LOCAL_TMP_DIR/u2_cerr.mout || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u2_cfg.py 2> ./u2_cerr.mout || exit $?
 sed -n '/Disabling gnu++: clang has no __float128 support on this target!/!p' u2_cerr.mout > tmpf && mv tmpf u2_cerr.mout # remove clang output
 
 for file in u2_warnings.log u2_cerr.mout
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u20.sh
+++ b/FWCore/MessageService/test/u20.sh
@@ -3,26 +3,22 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u20_cerr.log FrameworkJobReport.xml
 
-cmsRun -e -p $LOCAL_TEST_DIR/u20_cfg.py 2> u20_cerr.log || exit $?
+cmsRun -e -p ${SCRAM_TEST_PATH}/u20_cfg.py 2> u20_cerr.log || exit $?
 sed -n '/Disabling gnu++: clang has no __float128 support on this target!/!p' u20_cerr.log > tmpf && mv tmpf u20_cerr.log # remove clang output
 
 for file in u20_cerr.log FrameworkJobReport.xml   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u21.sh
+++ b/FWCore/MessageService/test/u21.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u21_warnings.log u21_infos.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u21_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u21_cfg.py || exit $?
  
 for file in u21_warnings.log u21_infos.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u22.sh
+++ b/FWCore/MessageService/test/u22.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f  u22_warnings.log
 
-cmsRun -p $LOCAL_TEST_DIR/u22_cfg.py  || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u22_cfg.py  || exit $?
  
 for file in u22_warnings.log  
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u23.sh
+++ b/FWCore/MessageService/test/u23.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u23_infos.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u23_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u23_cfg.py || exit $?
  
 for file in u23_infos.log 
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u23t.sh
+++ b/FWCore/MessageService/test/u23t.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u23_infos.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u23_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u23_cfg.py || exit $?
  
 for file in u23_infos.log 
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u24.sh
+++ b/FWCore/MessageService/test/u24.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u24.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u24_cfg.py && exit 1
+cmsRun -p ${SCRAM_TEST_PATH}/u24_cfg.py && exit 1
  
 for file in u24.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u25.sh
+++ b/FWCore/MessageService/test/u25.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u25_only.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u25_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u25_cfg.py || exit $?
  
 for file in u25_only.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u27.sh
+++ b/FWCore/MessageService/test/u27.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u27_infos.log u27FJR.xml
 
-cmsRun -j u27FJR.xml $LOCAL_TEST_DIR/u27_cfg.py || exit $?
+cmsRun -j u27FJR.xml ${SCRAM_TEST_PATH}/u27_cfg.py || exit $?
  
 for file in u27_infos.log u27FJR.xml
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u28.sh
+++ b/FWCore/MessageService/test/u28.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u28_output.log   
 
-cmsRun -p $LOCAL_TEST_DIR/u28_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u28_cfg.py || exit $?
  
 for file in u28_output.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u3.sh
+++ b/FWCore/MessageService/test/u3.sh
@@ -3,26 +3,22 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u3_infos.log u3_statistics.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u3_cfg.py || exit $?
-#/scratch2/mf/CMSSW_1_4_0_pre1/tmp/slc3_ia32_gcc323_dbg/src/FWCore/Framework/bin/cmsRun/cmsRun -p $LOCAL_TEST_DIR/u3_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u3_cfg.py || exit $?
+#/scratch2/mf/CMSSW_1_4_0_pre1/tmp/slc3_ia32_gcc323_dbg/src/FWCore/Framework/bin/cmsRun/cmsRun -p ${SCRAM_TEST_PATH}/u3_cfg.py || exit $?
  
 for file in u3_infos.log u3_statistics.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u30.sh
+++ b/FWCore/MessageService/test/u30.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u30_infos.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u30_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u30_cfg.py || exit $?
  
 for file in u30_infos.log 
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u31.sh
+++ b/FWCore/MessageService/test/u31.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u31_infos.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u31_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u31_cfg.py || exit $?
  
 for file in u31_infos.log 
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u33.sh
+++ b/FWCore/MessageService/test/u33.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u33_all.log
 
-cmsRun -p $LOCAL_TEST_DIR/u33_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u33_cfg.py || exit $?
  
 for file in u33_all.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u33d.sh
+++ b/FWCore/MessageService/test/u33d.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u33d_all.log
 
-cmsRun -p $LOCAL_TEST_DIR/u33d_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u33d_cfg.py || exit $?
  
 for file in u33d_all.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u34.sh
+++ b/FWCore/MessageService/test/u34.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u34_warnings.log
 
-cmsRun -p $LOCAL_TEST_DIR/u34_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u34_cfg.py || exit $?
  
 for file in u34_warnings.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u35.sh
+++ b/FWCore/MessageService/test/u35.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u35_infos.log u35_warnings.log
 
-cmsRun -p $LOCAL_TEST_DIR/u35_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u35_cfg.py || exit $?
  
 for file in u35_infos.log u35_warnings.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u36.sh
+++ b/FWCore/MessageService/test/u36.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u36_only.log
 
-cmsRun -p $LOCAL_TEST_DIR/u36_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u36_cfg.py || exit $?
  
 for file in u36_only.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u4.sh
+++ b/FWCore/MessageService/test/u4.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u4_errors.log u4_statistics.log u4_another.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u4_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u4_cfg.py || exit $?
  
 for file in u4_errors.log u4_statistics.log u4_another.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u5.sh
+++ b/FWCore/MessageService/test/u5.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u5_errors.log u5_default.log u5_noreset.log u5_reset.log 
 
-cmsRun -p $LOCAL_TEST_DIR/u5_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u5_cfg.py || exit $?
  
 for file in u5_errors.log u5_default.log u5_noreset.log u5_reset.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u5t.sh
+++ b/FWCore/MessageService/test/u5t.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u5_errors.log u5_default.log u5_noreset.log u5_reset.log 
 
-cmsRun --multithread -p $LOCAL_TEST_DIR/u5_cfg.py || exit $?
+cmsRun --multithread -p ${SCRAM_TEST_PATH}/u5_cfg.py || exit $?
  
 for file in u5_errors.log u5_default.log u5_noreset.log u5_reset.log
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u6.sh
+++ b/FWCore/MessageService/test/u6.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f  u6_warnings.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u6_cfg.py  || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u6_cfg.py  || exit $?
  
 for file in u6_warnings.log    
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u7.sh
+++ b/FWCore/MessageService/test/u7.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f  u7_log.log u7_restrict.log u7_job_report.mxml
 
-cmsRun -j u7_job_report.mxml -p $LOCAL_TEST_DIR/u7_cfg.py  || exit $?
+cmsRun -j u7_job_report.mxml -p ${SCRAM_TEST_PATH}/u7_cfg.py  || exit $?
  
 for file in  u7_log.log u7_restrict.log u7_job_report.mxml
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u8.sh
+++ b/FWCore/MessageService/test/u8.sh
@@ -3,25 +3,21 @@
 #sed on Linux and OS X have different command line options
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f u8_overall_unnamed.log u8_overall_specific.log u8_supercede_specific.log u8_non_supercede_common.log u8_specific.log
 
-cmsRun -p $LOCAL_TEST_DIR/u8_cfg.py || exit $?
+cmsRun -p ${SCRAM_TEST_PATH}/u8_cfg.py || exit $?
  
 for file in u8_overall_unnamed.log u8_overall_specific.log u8_supercede_specific.log u8_non_supercede_common.log u8_specific.log   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/u9.sh
+++ b/FWCore/MessageService/test/u9.sh
@@ -2,25 +2,21 @@
 
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
-pushd $LOCAL_TMP_DIR
-
 status=0
   
 rm -f warnings.log infos.log job_report.xml 
 
-cmsRun -j job_report.xml -p $LOCAL_TEST_DIR/u9_cfg.py || exit $?
+cmsRun -j job_report.xml -p ${SCRAM_TEST_PATH}/u9_cfg.py || exit $?
  
 for file in warnings.log infos.log job_report.xml   
 do
-  sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
-  diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  
+  sed $SED_OPT -f ${SCRAM_TEST_PATH}/filter-timestamps.sed $file
+  diff ${SCRAM_TEST_PATH}/unit_test_outputs/$file ./$file
   if [ $? -ne 0 ]  
   then
     echo The above discrepancies concern $file 
     status=1
   fi
 done
-
-popd
 
 exit $status

--- a/FWCore/MessageService/test/unitTestsGroup_1.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_1.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsGroup_2.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_2.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsGroup_3.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_3.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsGroup_4.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_4.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsGroup_5.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_5.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsGroup_d.cpp
+++ b/FWCore/MessageService/test/unitTestsGroup_d.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsLimits.cpp
+++ b/FWCore/MessageService/test/unitTestsLimits.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/MessageService/test/unitTestsStatistics.cpp
+++ b/FWCore/MessageService/test/unitTestsStatistics.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()


### PR DESCRIPTION
Updated unit tests so that they can be run from their own separate directory. Mostly 

- convert `<bin ...>` to `<test....>`
- make use of `SCRAM_TEST_PATH` instead
- cleanup unused unittest driver files

these changes will allow to run unit tests in separate unit test directories.