### PR TITLE
[GEOMETRY-UPGRADE] Various fixes/improvements for unit test

### DIFF
--- a/Geometry/MTDCommonData/test/runTest.sh
+++ b/Geometry/MTDCommonData/test/runTest.sh
@@ -11,7 +11,7 @@ function checkDiff {
     fi
 }
 
-TEST_DIR=src/Geometry/MTDCommonData/test
+TEST_DIR=$CMSSW_BASE/src/Geometry/MTDCommonData/test
 
 F1=${TEST_DIR}/testMTDinDDD.py
 F2=${TEST_DIR}/testMTDinDD4hep.py

--- a/Geometry/MTDGeometryBuilder/test/runTest.sh
+++ b/Geometry/MTDGeometryBuilder/test/runTest.sh
@@ -11,7 +11,7 @@ function checkDiff {
     fi
 }
 
-TEST_DIR=src/Geometry/MTDGeometryBuilder/test
+TEST_DIR=$CMSSW_BASE/src/Geometry/MTDGeometryBuilder/test
 
 F1=${TEST_DIR}/mtd_cfg.py
 F2=${TEST_DIR}/dd4hep_mtd_cfg.py

--- a/Geometry/MTDNumberingBuilder/test/runTest.sh
+++ b/Geometry/MTDNumberingBuilder/test/runTest.sh
@@ -11,7 +11,7 @@ function checkDiff {
     fi
 }
 
-TEST_DIR=src/Geometry/MTDNumberingBuilder/test
+TEST_DIR=$CMSSW_BASE/src/Geometry/MTDNumberingBuilder/test
 
 F1=${TEST_DIR}/mtd_cfg.py
 F2=${TEST_DIR}/dd4hep_mtd_cfg.py


### PR DESCRIPTION
Use full path to package e.g `$CMSSW_BASE/src` instead of `src`. This change will allow us to run unit tests from their own individual test directories.