### PR TITLE
Update short matrix to use Phase-2 D95 geometry

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -27,7 +27,7 @@ numWFIB.extend([22434.0]) #2026D92
 numWFIB.extend([22834.0]) #2026D93
 numWFIB.extend([23234.0]) #2026D94
 numWFIB.extend([23634.0,23634.103]) #2026D95 (NoPU, with aging)
-numWFIB.extend([23634.5,23634.9,23634.501,23634.502]) #2026D95 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
+numWFIB.extend([23634.5,23634.9]) #2026D95 pixelTrackingOnly, vector hits
 numWFIB.extend([23834.99,23834.999]) #2026D95 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test) 
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -26,7 +26,9 @@ numWFIB.extend([22034.0]) #2026D91
 numWFIB.extend([22434.0]) #2026D92
 numWFIB.extend([22834.0]) #2026D93
 numWFIB.extend([23234.0]) #2026D94
-numWFIB.extend([23634.0]) #2026D95
+numWFIB.extend([23634.0,23634.103]) #2026D95 (NoPU, with aging)
+numWFIB.extend([23634.5,23634.9,23634.501,23634.502]) #2026D95 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
+numWFIB.extend([23834.99,23834.999]) #2026D95 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test) 
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0]) #2026D98

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -16,7 +16,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 numWFIB = []
 numWFIB.extend([20034.0]) #2026D86
 numWFIB.extend([20834.0,20834.911,20834.103]) #2026D88 DDD XML, DD4hep XML, aging
-numWFIB.extend([20834.75,20834.76]) #2026D88 with HLT75e33 after RECO, HLTe33 with the same step with Digi+L1
 numWFIB.extend([21061.97]) #2026D88 premixing stage1 (NuGun+PU)
 numWFIB.extend([20834.5,20834.9,20834.501,20834.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([21034.99,21034.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
@@ -26,9 +25,11 @@ numWFIB.extend([22034.0]) #2026D91
 numWFIB.extend([22434.0]) #2026D92
 numWFIB.extend([22834.0]) #2026D93
 numWFIB.extend([23234.0]) #2026D94
-numWFIB.extend([23634.0,23634.103]) #2026D95 (NoPU, with aging)
+numWFIB.extend([23634.0,23634.911,23634.103]) #2026D95 DDD XML, DD4hep XML, aging
+numWFIB.extend([23861.97]) #2026D95 premixing stage1 (NuGun+PU)
 numWFIB.extend([23634.5,23634.9]) #2026D95 pixelTrackingOnly, vector hits
 numWFIB.extend([23834.99,23834.999]) #2026D95 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test) 
+numWFIB.extend([23634.21,23834.21,23834.9921]) #2026D95 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0]) #2026D98

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -36,6 +36,8 @@ numWFIB.extend([25234.0]) #2026D99
 #CloseByPGun for HGCAL
 numWFIB.extend([20896.0]) #CE_E_Front_120um D88
 numWFIB.extend([20900.0]) #CE_H_Coarse_Scint D88
+numWFIB.extend([23696.0]) #CE_E_Front_120um D95
+numWFIB.extend([23700.0]) #CE_H_Coarse_Scint D95
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3816,6 +3816,7 @@ defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49no
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
 defaultDataSets['2026D88']='CMSSW_12_3_0_pre5-123X_mcRun4_realistic_v4_2026D88noPU-v'
+defaultDataSets['2026D95']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D95noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
                      12434.0, #2023 ttbar
                      23634.0, #2026D95 ttbar (2023 new baseline)
                      #23634.911, #2026D95 ttbar DD4hep XML
-                     23834.999, #2026D88 ttbar premixing stage1+stage2, PU50
+                     23834.999, #2026D95 ttbar premixing stage1+stage2, PU50
                      23696.0, #CE_E_Front_120um D95
                      23700.0, #CE_H_Coarse_Scint D95
                      23234.0, #2026D94 ttbar (exercise with HFNose)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,13 +97,11 @@ if __name__ == '__main__':
                      13234.0, #2021 ttbar fastsim
                      13434.0, #2021 ttbar PU fastsim
                      12434.0, #2023 ttbar
-                     20834.0, #2026D88 ttbar (2022 new baseline)
-                     20834.75, #2026D88 ttbar with HLT75e33
-                     20834.76, #2026D88 ttbar with HLT75e33 in the same step as DIGI+L1
-                     #20834.911, #2026D88 ttbar DD4hep XML
-                     21034.999, #2026D88 ttbar premixing stage1+stage2, PU50
-                     20896.0, #CE_E_Front_120um D88
-                     20900.0, #CE_H_Coarse_Scint D88
+                     23634.0, #2026D95 ttbar (2023 new baseline)
+                     #23634.911, #2026D95 ttbar DD4hep XML
+                     23834.999, #2026D88 ttbar premixing stage1+stage2, PU50
+                     23696.0, #CE_E_Front_120um D95
+                     23700.0, #CE_H_Coarse_Scint D95
                      23234.0, #2026D94 ttbar (exercise with HFNose)
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix


### PR DESCRIPTION
#### PR description:
Following the green light to move Phase-2 baseline to D95, this PR updates short matrix to D95.
I use this PR also to clean up unused workflows of Phase-2 HLT workflows, after the merge of https://github.com/cms-sw/cmssw/pull/40412

The next step of migration is to define set of D95 workflows. This can be done when all relvals are done. Plan to make PR after this one.

FYI @cms-sw/reconstruction-l2 @cms-sw/mtd-dpg-l2 

#### PR validation:
Test with `23634.0` and `23834.999`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.