### PR TITLE
Update L1 menu tag for data RelVals and 2023/2024, Phase2 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -74,19 +74,19 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v2',
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v2',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v2',
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v3',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '130X_mcRun4_realistic_v2'
+    'phase2_realistic'             : '130X_mcRun4_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2022_v1_4_0-d1_xml' , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-01-28 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2023_v1_0_0_xml' , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-03-08 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:
This PR updates the Run3 2023/2024 and Phase2 MC GTs with the latest L1 Menu tag, i.e. ```L1Menu_Collisions2023_v1_0_0_xml``` as requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-2023-l1-menu-tag-l1menu-collisions2023-v1-0-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/21177) [1].

In addition, it also updates the Run3 RelVal GTs. 

FYI @missirol @elfontan 

[1] https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-2023-l1-menu-tag-l1menu-collisions2023-v1-0-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/21177

The GT differences are here:

- **2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_v2/130X_mcRun3_2023_design_v3

- **2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v3/130X_mcRun3_2023_realistic_v4

- **2023 cosmic realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v2/130X_mcRun3_2023cosmics_realistic_deco_v3

- **2023 cosmic design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_v2/130X_mcRun3_2023cosmics_design_deco_v3

- **2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v3/130X_mcRun3_2023_realistic_HI_v4

- **2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v3/130X_mcRun3_2024_realistic_v4

- **Phase2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun4_realistic_v2/130X_mcRun4_realistic_v3



#### PR validation:
Successfully tested with:
```runTheMatrix.py -l 139.001,12434.0,12834.0,23234.0 -j10 --ibeos```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport but will be backported to 130X
