### PR TITLE
[13_0_X] Update L1 menu tag for data RelVals and 2023/2024, Phase2 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -74,19 +74,19 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v2',
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v2',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v2',
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v3',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '130X_mcRun4_realistic_v2'
+    'phase2_realistic'             : '130X_mcRun4_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2022_v1_4_0-d1_xml' , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-01-28 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2023_v1_0_0_xml' , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-03-08 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:
Verbatim backport of #41005 (literally cherry-picked the commit).
This PR updates the L1T tag `L1Menu_Collisions2023_v1_0_0_xml` in the 2023 and PhaseII MC GTs, as well as the Run3 relval GTs (in the autoCondModifier file).
See master PR for more details and links

#### PR validation:
None - will need to be tested together with an udpate from HLT side (FYI @missirol )

#### Backport:
backport of #41005