### PR TITLE
Improved initialisation of Geant4e propagator

### DIFF
--- a/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
+++ b/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
@@ -32,6 +32,7 @@
 #include "G4UImanager.hh"
 #include "G4ErrorPropagationNavigator.hh"
 #include "G4RunManagerKernel.hh"
+#include "G4StateManager.hh"
 
 // CLHEP
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
@@ -73,25 +74,22 @@ Geant4ePropagator::~Geant4ePropagator() {
  *  in global cartesian coordinates) to a plane.
  */
 
-void Geant4ePropagator::ensureGeant4eIsInitilized(bool forceInit) const {
-  LogDebug("Geant4e") << "ensureGeant4eIsInitilized called" << std::endl;
-  if (forceInit) {
-    LogDebug("Geant4e") << "Initializing G4 propagator" << std::endl;
+void Geant4ePropagator::ensureGeant4eIsInitilized(bool) const {
+  LogDebug("Geant4ePropagator") << "G4 propagator starts isInitialized, theField: " << theField;
 
-    //G4UImanager::GetUIpointer()->ApplyCommand("/exerror/setField -10. kilogauss");
-
-    auto man = G4RunManagerKernel::GetRunManagerKernel();
+  auto man = G4RunManagerKernel::GetRunManagerKernel();
+  if(G4StateManager::GetStateManager()->GetCurrentState() == G4State_PreInit) {
     man->SetVerboseLevel(0);
     theG4eManager->InitGeant4e();
 
-    const G4Field *field = G4TransportationManager::GetTransportationManager()->GetFieldManager()->GetDetectorField();
-    if (field == nullptr) {
-      edm::LogError("Geant4e") << "No G4 magnetic field defined";
-    }
-    LogDebug("Geant4e") << "G4 propagator initialized" << std::endl;
+    // define 10 mm step limit for propagator
+    G4UImanager::GetUIpointer()->ApplyCommand("/geant4e/limits/stepLength 10.0 mm");
   }
-  // define 10 mm step limit for propagator
-  G4UImanager::GetUIpointer()->ApplyCommand("/geant4e/limits/stepLength 10.0 mm");
+  const G4Field *field = G4TransportationManager::GetTransportationManager()->GetFieldManager()->GetDetectorField();
+  if (field == nullptr) {
+    edm::LogError("Geant4e") << "No G4 magnetic field defined";
+  }
+  LogDebug("Geant4ePropagator") << "G4 propagator initialized; field: " << field;
 }
 
 template <>

--- a/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
+++ b/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
@@ -78,7 +78,7 @@ void Geant4ePropagator::ensureGeant4eIsInitilized(bool) const {
   LogDebug("Geant4ePropagator") << "G4 propagator starts isInitialized, theField: " << theField;
 
   auto man = G4RunManagerKernel::GetRunManagerKernel();
-  if(G4StateManager::GetStateManager()->GetCurrentState() == G4State_PreInit) {
+  if (G4StateManager::GetStateManager()->GetCurrentState() == G4State_PreInit) {
     man->SetVerboseLevel(0);
     theG4eManager->InitGeant4e();
 


### PR DESCRIPTION
#### PR description:
There are long standing issue of extra warnings happens when Geant4e propagator is applied to the data with more than one luminosity blocks. This PR reduces number of such warnings.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

