### PR TITLE
Phase2 Tracker Digitizer updated to have the possibility to used planer pixel algorithm in 3D pixel

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -249,13 +249,12 @@ namespace cms {
       case TrackerGeometry::ModuleType::Ph2PXF:
         algotype = AlgorithmType::InnerPixel;
         break;
-      case TrackerGeometry::ModuleType::Ph2PXB3D:
-        algotype = (usePseudoPixel3DAlgo_) ? AlgorithmType::InnerPixel
-	                                  : AlgorithmType::InnerPixel3D;
-        break;
-      case TrackerGeometry::ModuleType::Ph2PXF3D:
-        algotype = AlgorithmType::InnerPixel3D;
-        break;
+      case TrackerGeometry::ModuleType::Ph2PXB3D: {
+        algotype = (usePseudoPixel3DAlgo_) ? AlgorithmType::InnerPixel : AlgorithmType::InnerPixel3D;
+      } break;
+      case TrackerGeometry::ModuleType::Ph2PXF3D: {
+        algotype = (usePseudoPixel3DAlgo_) ? AlgorithmType::InnerPixel : AlgorithmType::InnerPixel3D;
+      } break;
       case TrackerGeometry::ModuleType::Ph2PSP:
         algotype = AlgorithmType::PixelinPS;
         break;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -68,7 +68,9 @@ namespace cms {
         pSetupToken_(iC.esConsumes()),
         tTopoToken_(iC.esConsumes()),
         isOuterTrackerReadoutAnalog_(iConfig.getParameter<bool>("isOTreadoutAnalog")),
+        usePseudoPixel3DAlgo_(iConfig.getParameter<bool>("usePseudoPixel3DAlgo")),
         premixStage1_(iConfig.getParameter<bool>("premixStage1")),
+
         makeDigiSimLinks_(
             iConfig.getParameter<edm::ParameterSet>("AlgorithmCommon").getUntrackedParameter<bool>("makeDigiSimLinks")) {
     const std::string alias1("simSiPixelDigis");
@@ -248,7 +250,8 @@ namespace cms {
         algotype = AlgorithmType::InnerPixel;
         break;
       case TrackerGeometry::ModuleType::Ph2PXB3D:
-        algotype = AlgorithmType::InnerPixel3D;
+        algotype = (usePseudoPixel3DAlgo_) ? AlgorithmType::InnerPixel
+	                                  : AlgorithmType::InnerPixel3D;
         break;
       case TrackerGeometry::ModuleType::Ph2PXF3D:
         algotype = AlgorithmType::InnerPixel3D;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -106,6 +106,7 @@ namespace cms {
     const TrackerTopology* tTopo_ = nullptr;
     edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher_;
     const bool isOuterTrackerReadoutAnalog_;
+    const bool usePseudoPixel3DAlgo_;
     const bool premixStage1_;
     const bool makeDigiSimLinks_;
     // cache for detector types

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -44,7 +44,6 @@ Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& co
 
 Pixel3DDigitizerAlgorithm::~Pixel3DDigitizerAlgorithm() {}
 
-
 const bool Pixel3DDigitizerAlgorithm::is_inside_n_column_(const LocalPoint& p, const float& sensor_thickness) const {
   // The insensitive volume of the column: sensor thickness - column gap distance
   return (p.perp() <= np_column_radius_ && p.z() <= (sensor_thickness - np_column_gap_));

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -44,13 +44,6 @@ Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& co
 
 Pixel3DDigitizerAlgorithm::~Pixel3DDigitizerAlgorithm() {}
 
-//
-// -- Select the Hit for Digitization
-//
-bool Pixel3DDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, double& sigScale) const {
-  double time = hit.tof() - tCorr;
-  return (time >= theTofLowerCut_ && time < theTofUpperCut_);
-}
 
 const bool Pixel3DDigitizerAlgorithm::is_inside_n_column_(const LocalPoint& p, const float& sensor_thickness) const {
   // The insensitive volume of the column: sensor thickness - column gap distance
@@ -177,9 +170,9 @@ std::vector<digitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
     const Phase2TrackerGeomDetUnit* pixdet,
     const GlobalVector& bfield,
     const std::vector<digitizerUtility::EnergyDepositUnit>& ionization_points) const {
-  return drift(hit, pixdet, bfield, ionization_points, true);
+  return driftFor3DSensors(hit, pixdet, bfield, ionization_points, true);
 }
-std::vector<digitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
+std::vector<digitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::driftFor3DSensors(
     const PSimHit& hit,
     const Phase2TrackerGeomDetUnit* pixdet,
     const GlobalVector& bfield,
@@ -294,7 +287,7 @@ std::vector<digitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
                                                      << "MIGRATING (super-)charges"
                                                      << "****************";
         // Drift this charges on the other pixel
-        auto mig_colpoints = drift(hit, pixdet, bfield, migrated_charges, false);
+        auto mig_colpoints = driftFor3DSensors(hit, pixdet, bfield, migrated_charges, false);
         collection_points.insert(std::end(collection_points), mig_colpoints.begin(), mig_colpoints.end());
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "*****************"
                                                      << "DOME MIGRATION"

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -31,14 +31,13 @@ public:
   Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~Pixel3DDigitizerAlgorithm() override;
 
-  bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   std::vector<digitizerUtility::SignalPoint> drift(
       const PSimHit& hit,
       const Phase2TrackerGeomDetUnit* pixdet,
       const GlobalVector& bfield,
       const std::vector<digitizerUtility::EnergyDepositUnit>& ionization_points) const override;
   // overload drift
-  std::vector<digitizerUtility::SignalPoint> drift(
+  std::vector<digitizerUtility::SignalPoint> driftFor3DSensors(
       const PSimHit& hit,
       const Phase2TrackerGeomDetUnit* pixdet,
       const GlobalVector& bfield,

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -75,6 +75,7 @@ phase2TrackerDigitizer = cms.PSet(
     GeometryType = cms.string('idealForDigi'),
     isOTreadoutAnalog = cms.bool(False),#set this to true if you want analog readout for OT
 # Common for Algos
+    usePseudoPixel3DAlgo = cms.bool(False),
     premixStage1 = cms.bool(False),
     AlgorithmCommon = cms.PSet(
       DeltaProductionCut = cms.double(0.03),


### PR DESCRIPTION
#### PR description:
Update to include the possibility to use planer-pixel digitization algorithm (PixelDigitizerAlgorithm) for 3D-pixel modules. A configuration parameter  usePseudoPixel3DAlgo is introduced to activate/dis-activate this possibility. 

  - what changes are expected in the output if any : None
  - what other PRs or externals it depends upon if any : None
  
#### PR validation:

Used FourMuon events  (runTheMatrix option 20800.0) and compared the histograms 

@emiglior @tvami @duartej 