### PR TITLE
[CORE] Various fixes/improvements for unit test

### DIFF
--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -232,7 +232,7 @@ void testmakepset::fileinpathAux() {
 
     CPPUNIT_ASSERT(!fullpath.empty());
 
-    tmpout = fullpath.substr(0, fullpath.find("FWCore/PythonParameterSet/test/fip.txt")) + "tmp.py";
+    tmpout = fullpath.substr(0, fullpath.find("src/FWCore/PythonParameterSet/test/fip.txt")) + "tmp/tmp.py";
 
     edm::FileInPath topo = innerps.getParameter<edm::FileInPath>("topo");
     // if the file is local, then just disable this check as then it is expected to fail


### PR DESCRIPTION
Avoid creating tmp files in src tree. This needs https://github.com/cms-sw/cmsdist/pull/8369 which adds cmssw_base/tmp to CMSSW_SEARCH_PATH.