### PR TITLE
[RFC:2] Use ROOT lossy compression for P3 and position of reco::Track 

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,8 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="20">
+  <class name="reco::GsfTrack" ClassVersion="21">
+   <version ClassVersion="21" checksum="1617233394"/>
    <version ClassVersion="20" checksum="3090385640"/>
    <version ClassVersion="19" checksum="2111870580"/>
    <version ClassVersion="18" checksum="1193413886"/>

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -2,7 +2,7 @@
 #define TrackReco_TrackBase_h
 /** \class reco::TrackBase TrackBase.h DataFormats/TrackReco/interface/TrackBase.h
  *
- * Common base class to all track types, including Muon fits.
+* Common base class to all track types, including Muon fits.
  * Internally, the following information is stored: <BR>
  *   <DT> A reference position on the track: (vx,vy,vz) </DT>
  *   <DT> Momentum at this given reference point on track: (px,py,pz) </DT>
@@ -55,6 +55,7 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Error.h"
+#include "Rtypes.h"
 #include <bitset>
 
 namespace reco {
@@ -453,7 +454,7 @@ namespace reco {
     HitPattern hitPattern_;
 
     /// perigee 5x5 covariance matrix
-    float covariance_[covarianceSize];
+    Float16_t covariance_[covarianceSize];  //[0,0,10]
 
     /// errors for time and velocity (separate from cov for now)
     float covt0t0_, covbetabeta_;

--- a/DataFormats/TrackReco/src/TrackMomentumStorage.h
+++ b/DataFormats/TrackReco/src/TrackMomentumStorage.h
@@ -1,0 +1,42 @@
+#ifndef DataFormats_TrackReco_TrackMomentumStorage_h
+#define DataFormats_TrackReco_TrackMomentumStorage_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/TrackReco
+// Class  :     TrackMomentumStorage
+//
+/**\class TrackMomentumStorage TrackMomentumStorage.h "TrackMomentumStorage.h"
+
+ Description: Floating point lossy compressed cartesian 3d
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 12 Sep 2022 15:12:10 GMT
+//
+
+// system include files
+
+// user include files
+#include "Rtypes.h"
+
+// forward declarations
+namespace reco {
+  namespace storage {
+    struct TrackMomentumValues {
+      TrackMomentumValues() : fX(0.), fY(0.), fZ(0.) {}
+      Double32_t fX;  //[0,0,13]
+      Double32_t fY;  //[0,0,13]
+      Double32_t fZ;  //[0,0,13]
+    };
+
+    struct TrackMomentumStorage {
+    public:
+      TrackMomentumValues fCoordinates;
+    };
+  }  // namespace storage
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/src/TrackPositionStorage.h
+++ b/DataFormats/TrackReco/src/TrackPositionStorage.h
@@ -1,0 +1,42 @@
+#ifndef DataFormats_TrackReco_TrackPositionStorage_h
+#define DataFormats_TrackReco_TrackPositionStorage_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/TrackReco
+// Class  :     TrackPositionStorage
+//
+/**\class TrackPositionStorage TrackPositionStorage.h "TrackPositionStorage.h"
+
+ Description: Floating point lossy compressed cartesian 3d
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 12 Sep 2022 15:12:10 GMT
+//
+
+// system include files
+
+// user include files
+#include "Rtypes.h"
+
+// forward declarations
+namespace reco {
+  namespace storage {
+    struct TrackPositionValues {
+      TrackPositionValues() : fX(0.), fY(0.), fZ(0.) {}
+      Double32_t fX;  //[-1100,1100,24]
+      Double32_t fY;  //[-1100,1100,24]
+      Double32_t fZ;
+    };
+
+    struct TrackPositionStorage {
+    public:
+      TrackPositionValues fCoordinates;
+    };
+  }  // namespace storage
+}  // namespace reco
+#endif

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -30,5 +30,7 @@
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
+#include "DataFormats/TrackReco/src/TrackMomentumStorage.h"
+#include "DataFormats/TrackReco/src/TrackPositionStorage.h"
 
 #include <vector>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -1,5 +1,39 @@
 <lcgdict>
 
+  <class name="reco::storage::TrackMomentumValues" ClassVersion="3">
+    <version ClassVersion="3" checksum="3766989023"/>
+  </class>
+  <class name="reco::storage::TrackMomentumStorage" ClassVersion="3">
+      <version ClassVersion="3" checksum="4153617590"/>
+  </class>
+  <ioread
+   sourceClass="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>"
+    targetClass="reco::storage::TrackMomentumStorage"
+    version="[1-]"
+></ioread>
+<ioread
+   sourceClass="ROOT::Math::Cartesian3D<Double32_t>"
+    targetClass="reco::storage::TrackMomentumValues"
+    version="[1-]"
+></ioread>
+
+  <class name="reco::storage::TrackPositionValues" ClassVersion="3">
+    <version ClassVersion="3" checksum="2475690070"/>
+  </class>
+  <class name="reco::storage::TrackPositionStorage" ClassVersion="3">
+      <version ClassVersion="3" checksum="1497277170"/>
+  </class>
+  <ioread
+   sourceClass="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>"
+    targetClass="reco::storage::TrackPositionStorage"
+    version="[1-]"
+></ioread>
+<ioread
+   sourceClass="ROOT::Math::Cartesian3D<Double32_t>"
+    targetClass="reco::storage::TrackPositionValues"
+    version="[1-]"
+></ioread>
+
   <class name="reco::TrackBase::AlgoMask"/>
   <class name="reco::HitPattern" ClassVersion="13">
       <version ClassVersion="13" checksum="2211596316"/>
@@ -10,7 +44,8 @@
    <version ClassVersion="11" checksum="639174599"/>
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="20">
+  <class name="reco::TrackBase" ClassVersion="21">
+   <version ClassVersion="21" checksum="3137401909"/>
    <version ClassVersion="20" checksum="1589774059"/>
    <version ClassVersion="19" checksum="4090229239"/>
    <version ClassVersion="18" checksum="1935215297"/>
@@ -20,12 +55,10 @@
    <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
    <version ClassVersion="12" checksum="2704717983"/>
-    <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
-    <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
+    <field name="vertex_" iotype="reco::storage::TrackPositionStorage" /> 
+    <field name="momentum_" iotype="reco::storage::TrackMomentumStorage" /> 
 
    <version ClassVersion="10" checksum="3019978065"/>
-    <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
-    <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>
  <ioread
     sourceClass="reco::HitPattern"
@@ -336,7 +369,8 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="20">
+  <class name="reco::Track" ClassVersion="21">
+   <version ClassVersion="21" checksum="2061134770"/>
    <version ClassVersion="20" checksum="2864582648"/>
    <version ClassVersion="19" checksum="362503460"/>
    <version ClassVersion="18" checksum="3235158110"/>


### PR DESCRIPTION
#### PR description:

- added classes used by ROOT when doing storage which specify lossy compression.
  - 3 momentum has mantissa truncated to 13 bits
  - covariance matrix has mantisa truncated to 10 bits
  - position is truncated to 24 bits in the range +-1100
- added iotypes rule to use new classes

#### PR validation:

Copied an AOD file from workflow 11834.21 into the new format. It reduced the file size by 13.5%. This compares to the previous PR (#39554) which on the exact same size reduced the file size by 13.9%.