### PR TITLE
Add Correlator Layer-2 e/g objects to the Phase-2 event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -211,6 +211,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tLayer1HF_*_*',
         'keep *_l1tLayer1_*_*',
         'keep *_l1tLayer1EG_*_*',
+        'keep *_l1tLayer2EG_*_*',
         'keep *_l1tMETPFProducer_*_*',
         'keep *_l1tNNTauProducer_*_*',
         'keep *_l1tNNTauProducerPuppi_*_*',


### PR DESCRIPTION
#### PR description:

This PR adds the Correlator Layer-2 e/g products (`TkElectron` and `TkEM` collections) to the event content.
These are produced by the emulator for GT (and menu studies) consumption.
The corresponding task is already in the configuration.


