### PR TITLE
MTD geometry: update tests to scenario D95

### DIFF
--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -51,7 +51,7 @@ process.MessageLogger.files.mtdCommonDataDD4hep = cms.untracked.PSet(
 )
 
 process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
 
 process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
                                                      appendToDataLabel = cms.string('')

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -49,7 +49,7 @@ process.MessageLogger.files.mtdCommonDataDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D95_cff')
 
 process.testBTL = cms.EDAnalyzer("TestMTDIdealGeometry",
                                ddTopNodeName = cms.untracked.string('BarrelTimingLayer')

--- a/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
+++ b/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
@@ -279,6 +279,8 @@ void DD4hep_TestBTLPixelTopology::analyze(const edm::Event& iEvent, const edm::E
           recoCol = origCol;
         }
 
+        Local3DPoint recoRefLocal = topo.moduleToPixelLocalPoint(modLocal);
+
         // reconstructed global position from reco geometry and rectangluar MTD topology
 
         const auto& modGlobal = thedet->toGlobal(modLocal);
@@ -287,17 +289,30 @@ void DD4hep_TestBTLPixelTopology::analyze(const edm::Event& iEvent, const edm::E
         const double deltay = convertCmToMm(modGlobal.y()) - (refGlobalPoints[iloop].y() / dd4hep::mm);
         const double deltaz = convertCmToMm(modGlobal.z()) - (refGlobalPoints[iloop].z() / dd4hep::mm);
 
+        const double local_deltax = recoRefLocal.x() - cmRefLocal.x();
+        const double local_deltay = recoRefLocal.y() - cmRefLocal.y();
+        const double local_deltaz = recoRefLocal.z() - cmRefLocal.z();
+
         spix << "Ref#" << iloop << " local= " << fround(refLocalPoints[iloop].x() / dd4hep::mm)
              << fround(refLocalPoints[iloop].y() / dd4hep::mm) << fround(refLocalPoints[iloop].z() / dd4hep::mm)
              << " Orig global= " << fround(refGlobalPoints[iloop].x() / dd4hep::mm)
              << fround(refGlobalPoints[iloop].y() / dd4hep::mm) << fround(refGlobalPoints[iloop].z() / dd4hep::mm)
              << " Reco global= " << fround(convertCmToMm(modGlobal.x())) << fround(convertCmToMm(modGlobal.y()))
              << fround(convertCmToMm(modGlobal.z())) << " Delta= " << fround(deltax) << fround(deltay) << fround(deltaz)
-             << "\n";
+             << " Local Delta= " << fround(local_deltax) << fround(local_deltay) << fround(local_deltaz) << "\n";
         if (std::abs(deltax) > tolerance || std::abs(deltay) > tolerance || std::abs(deltaz) > tolerance) {
           std::stringstream warnmsg;
           warnmsg << "DIFFERENCE detId/ref# " << theId.rawId() << " " << iloop << " dx/dy/dz= " << fround(deltax)
                   << fround(deltay) << fround(deltaz) << "\n";
+          spix << warnmsg.str();
+          sunitt << warnmsg.str();
+        }
+        if (std::abs(local_deltax) > tolerance || std::abs(local_deltay) > tolerance ||
+            std::abs(local_deltaz) > tolerance) {
+          std::stringstream warnmsg;
+          warnmsg << "DIFFERENCE detId/ref# " << theId.rawId() << " " << iloop
+                  << " local dx/dy/dz= " << fround(local_deltax) << fround(local_deltay) << fround(local_deltaz)
+                  << "\n";
           spix << warnmsg.str();
           sunitt << warnmsg.str();
         }

--- a/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
@@ -51,7 +51,7 @@ process.MessageLogger.files.mtdGeometryDD4hep = cms.untracked.PSet(
 )
 
 process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
 
 process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
                                                  appendToDataLabel = cms.string('')

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdGeometryDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -48,7 +48,7 @@ process.MessageLogger.files.mtdNumberingDD4hep = cms.untracked.PSet(
 )
 
 process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
 
 process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
                                                  appendToDataLabel = cms.string('')

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdNumberingDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 
@@ -58,4 +58,3 @@ process.Timing = cms.Service("Timing")
 process.prod = cms.EDAnalyzer("GeometricTimingDetAnalyzer")
 
 process.p1 = cms.Path(process.prod)
-

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -48,7 +48,7 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/Validation/Geometry/test/runP_Mtd_cfg.py
+++ b/Validation/Geometry/test/runP_Mtd_cfg.py
@@ -7,7 +7,7 @@ process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 
 #Geometry
 #
-process.load("Configuration.Geometry.GeometryExtended2026D77Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
 
 #Magnetic Field
 #

--- a/Validation/MtdValidation/test/mtdHarvesting_cfg.py
+++ b/Validation/MtdValidation/test/mtdHarvesting_cfg.py
@@ -9,7 +9,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D88Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -10,7 +10,7 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D88Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag


### PR DESCRIPTION
#### PR description:

In all (unit) test configurations used for MTD geometry scrutiny, the default scenario to be used is moved to D95, following the proposed update of the default for general tests. The test of the BTL RectangularMTDTopology is at the same time extended to probe the conversion from module to crystal reference frame.

This update requires also the update of the unit test reference files in ```cms-data/Geometry-TestReference```.

#### PR validation:

The code is running, and it has been used to produce the references. The additional test is showing no error.