### PR TITLE
[ALCA] Various fixes/improvements for unit test

### DIFF
--- a/Alignment/CommonAlignment/test/BuildFile.xml
+++ b/Alignment/CommonAlignment/test/BuildFile.xml
@@ -1,4 +1,4 @@
 <bin file="test_AlignableObjectId.cc">
   <use name="Alignment/CommonAlignment"/>
 </bin>
-<test name="test_CreateFileLists" command="tkal_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
+<test name="test_CreateFileLists" command="tkal_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ./mps_create_file_lists -n 200000 --iov 42 --iov 174"/>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -5,18 +5,14 @@
   <use name="CondFormats/Alignment"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-<test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>
+<flags USE_UNITTEST_DIR="1"/>
+<test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ./test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
 <test name="test-pede" command="pede -t">
   <use name="millepede"/>
-  <flags USE_UNITTEST_DIR="1"/>
 </test>
-<bin name="testPedeCampaign" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Alignment/MillePedeAlignmentAlgorithm/test test_pede.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
-<bin name="testPayloadSanity" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Alignment/MillePedeAlignmentAlgorithm/test test_payload_sanity.sh"/>
+<test name="testPedeCampaign" command="test_pede.sh"/>
+<test name="testPayloadSanity" command="test_payload_sanity.sh">
   <flags PRE_TEST="testPedeCampaign"/>
   <use name="FWCore/Utilities"/>
-</bin>
+</test>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/TestDriver.cpp
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
-INPUTFILE=${LOCAL_TEST_DIR}/alignments_MP.db
-(cmsRun ${LOCAL_TEST_DIR}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker'
+INPUTFILE=${SCRAM_TEST_PATH}/alignments_MP.db
+(cmsRun ${SCRAM_TEST_PATH}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker'
 rm $INPUTFILE

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
-if [ "${SCRAM_TEST_NAME}" != "" ] ; then
-  mkdir ${SCRAM_TEST_NAME}
-  cd ${SCRAM_TEST_NAME}
-fi
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
 clean_up(){
     echo "cleaning the local test area"

--- a/Alignment/TrackerAlignment/test/BuildFile.xml
+++ b/Alignment/TrackerAlignment/test/BuildFile.xml
@@ -24,5 +24,5 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="test_PixelBaryCentreTool" command="pixelPositions.sh ${LOCALTOP}/tmp/PixelBaryCentreTool"/>
+<test name="test_PixelBaryCentreTool" command="pixelPositions.sh"/>
 <test name="test_ProduceSystematicMisalignment" command="testProduceAllMisalignments.sh"/>

--- a/CalibCalorimetry/EcalLaserSorting/test/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserSorting/test/BuildFile.xml
@@ -1,4 +1,1 @@
-<bin file="RunThis_t.cpp" name="CalibCalorimetryEcalLaserSortingRunStreamer">
-  <use name="FWCore/Utilities"/> 
-  <flags TEST_RUNNER_ARGS="/bin/bash CalibCalorimetry/EcalLaserSorting/test RunStreamer.sh"/>
-</bin>
+<test name="CalibCalorimetryEcalLaserSortingRunStreamer" command="RunStreamer.sh"/>

--- a/CalibCalorimetry/EcalLaserSorting/test/RunStreamer.sh
+++ b/CalibCalorimetry/EcalLaserSorting/test/RunStreamer.sh
@@ -2,46 +2,32 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-if [ -z  $LOCAL_TEST_DIR ]; then
-LOCAL_TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -z  $SCRAM_TEST_PATH ]; then
+SCRAM_TEST_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
-echo "LOCAL_TEST_DIR = $LOCAL_TEST_DIR"
-
-if [ -z  $LOCAL_TMP_DIR ]; then
-LOCAL_TMP_DIR="/tmp"
-fi
-echo "LOCAL_TMP_DIR = $LOCAL_TMP_DIR"
-
-cd $LOCAL_TEST_DIR
+echo "LOCAL_TEST_DIR = $SCRAM_TEST_PATH"
 
 RC=0
-P=$$
-PREFIX=results_${USER}${P}
-OUTDIR=${LOCAL_TMP_DIR}/${PREFIX}
-
-mkdir ${OUTDIR}
-cp *_cfg.py ${OUTDIR}
-cd ${OUTDIR}
 
 mkdir inDir
-cmsRun streamOut_cfg.py > out 2>&1 || die "cmsRun streamOut_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/streamOut_cfg.py > out 2>&1 || die "cmsRun streamOut_cfg.py" $?
 cp teststreamfile.dat teststreamfile.original
 mv teststreamfile.dat inDir
-timeout --signal SIGTERM 180 cmsRun streamIn_cfg.py  > in  2>&1 || die "cmsRun streamIn_cfg.py" $?
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > in  2>&1 || die "cmsRun streamIn_cfg.py" $?
 
 rm watcherSourceToken
 cp teststreamfile.original inDir/teststreamfile.dat
-cmsRun streamOutAlt_cfg.py  > outAlt 2>&1 || die "cmsRun streamOutAlt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/streamOutAlt_cfg.py  > outAlt 2>&1 || die "cmsRun streamOutAlt_cfg.py" $?
 mv teststreamfile_alt.dat inDir
-timeout --signal SIGTERM 180 cmsRun streamIn_cfg.py  >alt  2>&1 || die "cmsRun streamIn_cfg.py" $?
-#timeout --signal SIGTERM 180 cmsRun  streamInAlt_cfg.py  > alt  2>&1 || die "cmsRun streamInAlt_cfg.py" $?
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  >alt  2>&1 || die "cmsRun streamIn_cfg.py" $?
+#timeout --signal SIGTERM 180 cmsRun  ${SCRAM_TEST_PATH}/streamInAlt_cfg.py  > alt  2>&1 || die "cmsRun streamInAlt_cfg.py" $?
 
 rm watcherSourceToken
 cp teststreamfile.original inDir/teststreamfile.dat
-cmsRun streamOutExt_cfg.py  > outExt 2>&1 || die "cmsRun streamOutExt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/streamOutExt_cfg.py  > outExt 2>&1 || die "cmsRun streamOutExt_cfg.py" $?
 mv teststreamfile_ext.dat inDir
-timeout --signal SIGTERM 180 cmsRun streamIn_cfg.py  > ext  2>&1 || die "cmsRun streamIn_cfg.py" $?
-#timeout --signal SIGTERM 180 cmsRun streamInExt_cfg.py  > ext  2>&1 || die "cmsRun streamInExt_cfg.py" $?
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > ext  2>&1 || die "cmsRun streamIn_cfg.py" $?
+#timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamInExt_cfg.py  > ext  2>&1 || die "cmsRun streamInExt_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in
@@ -62,5 +48,4 @@ then
     RC=1
 fi
 
-#rm -rf ${OUTDIR}
 exit ${RC}

--- a/CalibCalorimetry/EcalLaserSorting/test/RunThis_t.cpp
+++ b/CalibCalorimetry/EcalLaserSorting/test/RunThis_t.cpp
@@ -1,8 +1,0 @@
-//------------------------------------------------------------
-//
-// Driver for shell scripts.
-//
-//------------------------------------------------------------
-
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()


### PR DESCRIPTION
Updated unit tests so that they can be run from their own separate directory. Mostly
- convert <bin ...> to <test....>
- avoid creating test output in cmssw/tmp
- added flag `USE_UNITTEST_DIR="1"` to run each tests in separate dir. Once all the tests can run it their own tmp path then we can enable  `USE_UNITTEST_DIR="1"` at project level and do cleanup