### PR TITLE
[CORE] Various fixes/improvements for unit test

### DIFF
--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags USE_UNITTEST_DIR="1"/>
 <library file="StuckAnalyzer.cc" name="StuckAnalyzer">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>
@@ -10,10 +11,10 @@
 </library>
 
 <ifrelease name="!_ASAN_">
-  <bin file="TestFWCoreServicesDriver.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_sitelocalconfig.sh test_resource.sh test_zombiekiller.sh test_cpu.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="TestFWCoreServicesDriver_sitelocalconfig" command="test_sitelocalconfig.sh"/>
+  <test name="TestFWCoreServicesDriver_resource"        command="test_resource.sh"/>
+  <test name="TestFWCoreServicesDriver_zombiekiller"    command="test_zombiekiller.sh"/>
+  <test name="TestFWCoreServicesDriver_cpu"             command="test_cpu.sh"/>
 </ifrelease>
 
 <bin file="test_catch2_*.cc" name="testFWCoreServicesCatch2">

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -23,7 +23,4 @@
   <use name="FWCore/Services"/>
 </bin>
 
-<bin file="TestFWCoreServicesDriver.cpp" name="TestResourceInformationService">
-  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_resourceInformationService.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestResourceInformationService" command="test_resourceInformationService.sh"/>

--- a/FWCore/Services/test/TestFWCoreServicesDriver.cpp
+++ b/FWCore/Services/test/TestFWCoreServicesDriver.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/FWCore/Services/test/test_cpu.sh
+++ b/FWCore/Services/test/test_cpu.sh
@@ -3,7 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-F1=${LOCAL_TEST_DIR}/test_CPU.py
+F1=${SCRAM_TEST_PATH}/test_CPU.py
 
 (cmsRun -j test_CPU.xml $F1 ) || die "Failure using $F1" $?
 grep -v '""' test_CPU.xml | grep -q CPUModels || die "CPUModels not found using $F1" $?

--- a/FWCore/Services/test/test_resource.sh
+++ b/FWCore/Services/test/test_resource.sh
@@ -3,6 +3,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 F1=${LOCAL_TEST_DIR}/test_resource_succeed_cfg.py
 F2=${LOCAL_TEST_DIR}/test_resource_rss_fail_cfg.py
 F3=${LOCAL_TEST_DIR}/test_resource_time_fail_cfg.py

--- a/FWCore/Services/test/test_resourceInformationService.sh
+++ b/FWCore/Services/test/test_resourceInformationService.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 
-LOCAL_TEST_DIR=${CMSSW_BASE}/src/FWCore/Services/test
-LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
-
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-pushd ${LOCAL_TMP_DIR}
-
-cmsRun -p ${LOCAL_TEST_DIR}/test_resourceInformationService_cfg.py &> test_resourceInformationService.log || die "cmsRun test_resourceInformationService_cfg.py" $?
+cmsRun -p ${SCRAM_TEST_PATH}/test_resourceInformationService_cfg.py &> test_resourceInformationService.log || die "cmsRun test_resourceInformationService_cfg.py" $?
 
 grep -A 1 "acceleratorTypes:" test_resourceInformationService.log | grep "GPU" || die "Check for existence of GPU acceleratorType" $?
 grep -A 1 "cpu models:" test_resourceInformationService.log | grep "None" && die "Check there is at least one model (not None)" 1
-popd
 
 exit 0

--- a/FWCore/Services/test/test_sitelocalconfig.sh
+++ b/FWCore/Services/test/test_sitelocalconfig.sh
@@ -3,31 +3,32 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-mkdir -p ${CMSSW_BASE}/test/SITECONF
-mkdir -p ${CMSSW_BASE}/test/SITECONF/local
-mkdir -p ${CMSSW_BASE}/test/SITECONF/local/JobConfig
-mkdir -p ${CMSSW_BASE}/test/SITECONF/DUMMY_CROSS_SITE
+mkdir -p SITECONF
+mkdir -p SITECONF/local
+mkdir -p SITECONF/local/JobConfig
+mkdir -p SITECONF/DUMMY_CROSS_SITE
 
-export SITECONFIG_PATH=${CMSSW_BASE}/test/SITECONF/local
+export SITECONFIG_PATH=${PWD}/SITECONF/local
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/no_source/site-local-config.xml ${CMSSW_BASE}/test/SITECONF/local/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/no_source/site-local-config.xml ${SITECONFIG_PATH}/JobConfig/
 F1=${LOCAL_TEST_DIR}/test_sitelocalconfig_no_source_cfg.py
 (cmsRun $F1 ) || die "Failure using $F1" $?
 
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/source/site-local-config.xml ${CMSSW_BASE}/test/SITECONF/local/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/source/site-local-config.xml ${SITECONFIG_PATH}/JobConfig/
 F2=${LOCAL_TEST_DIR}/test_sitelocalconfig_source_cfg.py
 (cmsRun $F2 ) || die "Failure using $F2" $?
 
 F3=${LOCAL_TEST_DIR}/test_sitelocalconfig_override_cfg.py
 (cmsRun $F3 ) || die "Failure using $F3" $?
 
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/no_source/site-local-config.xml ${CMSSW_BASE}/test/SITECONF/local/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/no_source/site-local-config.xml ${SITECONFIG_PATH}/JobConfig/
 F3=${LOCAL_TEST_DIR}/test_sitelocalconfig_override_cfg.py
 (cmsRun $F3 ) || die "Failure using $F3 with no-source site-local-config" $?
 
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/site-local-config.xml  ${CMSSW_BASE}/test/SITECONF/local/JobConfig/
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/local/storage.json ${CMSSW_BASE}/test/SITECONF/local/
-cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/dummycross/storage.json ${CMSSW_BASE}/test/SITECONF/DUMMY_CROSS_SITE/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/local/storage.json ${SITECONFIG_PATH}/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/catalog/dummycross/storage.json ${SITECONFIG_PATH}/../DUMMY_CROSS_SITE/
 F4=${LOCAL_TEST_DIR}/test_sitelocalconfig_catalog_cfg.py
 (cmsRun $F4 ) || die "Failure using $F4" $?
 

--- a/FWCore/Services/test/test_zombiekiller.sh
+++ b/FWCore/Services/test/test_zombiekiller.sh
@@ -3,8 +3,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-F1=${LOCAL_TEST_DIR}/test_zombiekiller_succeed_cfg.py
-F2=${LOCAL_TEST_DIR}/test_zombiekiller_fail_cfg.py
+F1=${SCRAM_TEST_PATH}/test_zombiekiller_succeed_cfg.py
+F2=${SCRAM_TEST_PATH}/test_zombiekiller_fail_cfg.py
 
 (cmsRun $F1 ) || die "Failure using $F1" $?
 !(cmsRun $F2 ) || die "Failure using $F2" $?

--- a/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
+++ b/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
@@ -4,7 +4,6 @@
 function die { echo $1: status $2 ;  exit $2; }
 
 dir=${PWD}
-cd ${LOCALTOP}
 
 #test programs are placed on PATH when tests are run by scram
 testpath="testFWCoreSharedMemoryMonitorThread"

--- a/IOPool/Common/test/BuildFile.xml
+++ b/IOPool/Common/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags USE_UNITTEST_DIR="1"/>
 <test name="TestEdmFastMerge" command="TestEdmFastMerge.sh"/>
 <test name="TestEdmConfigDump" command="run_TestEdmConfigDump.sh"/>
 <test name="testIOPoolCommonLumiOverlap" command="test_overlap_lumi_fast_copy.sh"/>

--- a/IOPool/Common/test/TestEdmFastMerge.sh
+++ b/IOPool/Common/test/TestEdmFastMerge.sh
@@ -9,61 +9,61 @@ LOCAL_TMP_DIR=.
 # Create first input file
 #---------------------------
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreFastMergeTest_1_cfg.py || die 'Failure using PreFastMergeTest_1_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreFastMergeTest_1_cfg.py || die 'Failure using PreFastMergeTest_1_cfg.py' $?
 
 #---------------------------
 # Create first input file with extra branch
 #---------------------------
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreFastMergeTest_1x_cfg.py || die 'Failure using PreFastMergeTest_1x_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreFastMergeTest_1x_cfg.py || die 'Failure using PreFastMergeTest_1x_cfg.py' $?
 
 #---------------------------
 # Create second input file
 #---------------------------
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreFastMergeTest_2_cfg.py || die 'Failure using PreFastMergeTest_2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreFastMergeTest_2_cfg.py || die 'Failure using PreFastMergeTest_2_cfg.py' $?
 
 #---------------------------
 # Create files with different ancestors
 #---------------------------
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreFastMergeTest_ancestor1_cfg.py || die 'Failure using PreFastMergeTest_ancestor1_cfg.py' $?
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreFastMergeTest_ancestor2_cfg.py || die 'Failure using PreFastMergeTest_ancestor2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreFastMergeTest_ancestor1_cfg.py || die 'Failure using PreFastMergeTest_ancestor1_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreFastMergeTest_ancestor2_cfg.py || die 'Failure using PreFastMergeTest_ancestor2_cfg.py' $?
 
 
 #---------------------------
 # Merge files
 #---------------------------
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR_ancestor.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTest_ancestor_cfg.py || die 'Failure using FastMergeTest_ancestor_cfg.py' $?
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR_ancestor2.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTest_ancestor2_cfg.py || die 'Failure using FastMergeTest_ancestor2_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR_ancestor.xml ${LOCAL_TEST_DIR}/FastMergeTest_ancestor_cfg.py || die 'Failure using FastMergeTest_ancestor_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR_ancestor2.xml ${LOCAL_TEST_DIR}/FastMergeTest_ancestor2_cfg.py || die 'Failure using FastMergeTest_ancestor2_cfg.py' $?
 
 
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTest_x_cfg.py || die 'Failure using FastMergeTest_x_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx.xml ${LOCAL_TEST_DIR}/FastMergeTest_x_cfg.py || die 'Failure using FastMergeTest_x_cfg.py' $?
 #need to filter items in job report which always change
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjrx_output > $LOCAL_TMP_DIR/proper_fjrx_output_filtered
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_filtered.xml
 diff $LOCAL_TMP_DIR/proper_fjrx_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJRx_filtered.xml || die 'output framework job report is wrong for proper_fjrx_output_filtered' $?
 
-#cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx_second.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTest_x_second_cfg.py || die 'Failure using FastMergeTest_x_second_cfg.py' $?
+#cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJRx_second.xml ${LOCAL_TEST_DIR}/FastMergeTest_x_second_cfg.py || die 'Failure using FastMergeTest_x_second_cfg.py' $?
 ##need to filter items in job report which always change
 #egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjrx_second_output > $LOCAL_TMP_DIR/proper_fjrx_second_output_filtered
 #egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJRx_second.xml  > $LOCAL_TMP_DIR/TestFastMergeFJRx_second_filtered.xml
 #diff $LOCAL_TMP_DIR/proper_fjrx_second_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJRx_second_filtered.xml || die 'output framework job report is wrong for proper_fjrx_second_output_filtered' $?
 
 
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTest_cfg.py || die 'Failure using FastMergeTest_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeFJR.xml ${LOCAL_TEST_DIR}/FastMergeTest_cfg.py || die 'Failure using FastMergeTest_cfg.py' $?
 #need to filter items in job report which always change
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_fjr_output > $LOCAL_TMP_DIR/proper_fjr_output_filtered
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeFJR_filtered.xml
 diff $LOCAL_TMP_DIR/proper_fjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeFJR_filtered.xml || die 'output framework job report is wrong for proper_fjr_output_filtered' $?
 
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRLFJR.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTestRL_cfg.py || die 'Failure using FastMergeTestRL_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRLFJR.xml ${LOCAL_TEST_DIR}/FastMergeTestRL_cfg.py || die 'Failure using FastMergeTestRL_cfg.py' $?
 #need to filter items in job report which always change
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_RLfjr_output > $LOCAL_TMP_DIR/proper_RLfjr_output_filtered
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeRLFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRLFJR_filtered.xml
 diff $LOCAL_TMP_DIR/proper_RLfjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeRLFJR_filtered.xml || die 'output run lumi framework job report is wrong for proper_RLfjr_output_filtered' $?
 
-cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRFJR.xml --parameter-set ${LOCAL_TEST_DIR}/FastMergeTestR_cfg.py || die 'Failure using FastMergeTestR_cfg.py' $?
+cmsRun -j ${LOCAL_TMP_DIR}/TestFastMergeRFJR.xml ${LOCAL_TEST_DIR}/FastMergeTestR_cfg.py || die 'Failure using FastMergeTestR_cfg.py' $?
 #need to filter items in job report which always change
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TEST_DIR/proper_Rfjr_output > $LOCAL_TMP_DIR/proper_Rfjr_output_filtered
 egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeRFJR.xml  > $LOCAL_TMP_DIR/TestFastMergeRFJR_filtered.xml

--- a/IOPool/Common/test/TestEdmFastMerge.sh
+++ b/IOPool/Common/test/TestEdmFastMerge.sh
@@ -2,9 +2,8 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-LOCAL_TEST_DIR=$CMSSW_BASE/src/IOPool/Common/test
-LOCAL_TMP_DIR=$CMSSW_BASE/tmp
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR=$SCRAM_TEST_PATH
+LOCAL_TMP_DIR=.
 
 #---------------------------
 # Create first input file
@@ -71,5 +70,3 @@ egrep -v "<GUID>|<PFN>|^$" $LOCAL_TMP_DIR/TestFastMergeRFJR.xml  > $LOCAL_TMP_DI
 diff $LOCAL_TMP_DIR/proper_Rfjr_output_filtered $LOCAL_TMP_DIR/TestFastMergeRFJR_filtered.xml || die 'output run framework job report is wrong for proper_Rfjr_output_filtered' $?
 
 cmsRun -p ${LOCAL_TEST_DIR}/ReadFastMergeTestOutput_cfg.py || die 'Failure using ReadFastMergeTestOutput_cfg.py' $?
-
-popd

--- a/IOPool/Common/test/run_TestEdmConfigDump.sh
+++ b/IOPool/Common/test/run_TestEdmConfigDump.sh
@@ -2,15 +2,11 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-LOCAL_TEST_DIR=$CMSSW_BASE/src/IOPool/Common/test
-LOCAL_TMP_DIR=$CMSSW_BASE/tmp
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR=$SCRAM_TEST_PATH
 
   cmsRun ${LOCAL_TEST_DIR}/testEdmConfigDump_cfg.py > testEdmConfigDump.log || die "cmsRun testEdmConfigDump_cfg.py" $?
   edmProvDump testEdmProvDump.root > provdump.log
   python3 ${LOCAL_TEST_DIR}/removeChangingParts.py provdump.log > provdump1.log
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/provdump.log provdump1.log  || die "comparing provdump.log" $?
-
-popd
 
 exit 0

--- a/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
+++ b/IOPool/Common/test/test_overlap_lumi_fast_copy.sh
@@ -2,7 +2,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-LOCAL_TEST_DIR=${CMSSW_BASE}/src/IOPool/Common/test
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
 cmsRun ${LOCAL_TEST_DIR}/make_overlap_lumi_cfg.py || die "cmsRun make_overlap_lumi_cfg.py failed" $?
 

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -1,8 +1,5 @@
 <environment>
-  <bin file="TestPoolInput.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/Input/test TestPoolInput.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="TestPoolInput" command="TestPoolInput.sh"/>
 
   <library file="IOExerciser.cc" name="IOExerciser">
     <flags EDM_PLUGIN="1"/>

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <environment>
+  <flags USE_UNITTEST_DIR="1"/>
   <test name="TestPoolInput" command="TestPoolInput.sh"/>
 
   <library file="IOExerciser.cc" name="IOExerciser">

--- a/IOPool/Input/test/TestPoolInput.cpp
+++ b/IOPool/Input/test/TestPoolInput.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -19,44 +19,44 @@ cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure u
 
 cp PoolInputTest.root PoolInputOther.root
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure using PoolInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure using PoolInputTest_cfg.py' $?
 cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
 grep 'event delayed read from source' PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skip_with_failure_cfg.py || die 'Failure using PoolInputTest_skip_with_failure_cfg.py' $?
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skipBadFiles_cfg.py  || die 'Failure using PoolInputTest_skipBadFiles_cfg.py ' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolInputTest_skip_with_failure_cfg.py || die 'Failure using PoolInputTest_skip_with_failure_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolInputTest_skipBadFiles_cfg.py  || die 'Failure using PoolInputTest_skipBadFiles_cfg.py ' $?
 
 cmsRun ${LOCAL_TEST_DIR}/PrePool2FileInputTest_cfg.py || die 'Failure using PrePool2FileInputTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/Pool2FileInputTest_cfg.py || die 'Failure using Pool2FileInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PrePoolInputTest2_cfg.py || die 'Failure using PrePoolInputTest2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest2_cfg.py || die 'Failure using PrePoolInputTest2_cfg.py' $?
 
 cp PoolInputTest.root PoolInputOther.root
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest2_cfg.py || die 'Failure using PoolInputTest2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolInputTest2_cfg.py || die 'Failure using PoolInputTest2_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest3_cfg.py || die 'Failure using PoolInputTest3_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolInputTest3_cfg.py || die 'Failure using PoolInputTest3_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolEmptyTest_cfg.py || die 'Failure using PoolEmptyTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolEmptyTest_cfg.py || die 'Failure using PoolEmptyTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolEmptyTest2_cfg.py || die 'Failure using PoolEmptyTest2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolEmptyTest2_cfg.py || die 'Failure using PoolEmptyTest2_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep1_cfg.py || die 'Failure using PoolAliasTestStep1_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep1_cfg.py || die 'Failure using PoolAliasTestStep1_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep2_cfg.py || die 'Failure using PoolAliasTestStep2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep2_cfg.py || die 'Failure using PoolAliasTestStep2_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep1_DifferentOrder_cfg.py || die 'Failure using PoolAliasTestStep1_DifferentOrder_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep1_DifferentOrder_cfg.py || die 'Failure using PoolAliasTestStep1_DifferentOrder_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep2_DifferentOrder_cfg.py || die 'Failure using PoolAliasTestStep2_DifferentOrder_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep2_DifferentOrder_cfg.py || die 'Failure using PoolAliasTestStep2_DifferentOrder_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep2A_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep2A_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep1C_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep1C_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasTestStep2C_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasTestStep2C_cfg.py || die 'Failure using PoolAliasTestStep2A_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasSubProcessTestStep1_cfg.py || die 'Failure using PoolAliasSubProcessTestStep1_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasSubProcessTestStep1_cfg.py || die 'Failure using PoolAliasSubProcessTestStep1_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasSubProcessTestStep2_cfg.py || die 'Failure using PoolAliasSubProcessTestStep2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolAliasSubProcessTestStep2_cfg.py || die 'Failure using PoolAliasSubProcessTestStep2_cfg.py' $?
 
 cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py RunPerLumiTest.root 50 1 25 1 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
 
@@ -83,11 +83,11 @@ cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py '
 
 #test merging of heterogeneous files with extra provenenace in subsequent files
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/preMerge_cfg.py || die 'Failure using preMerge_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/preMerge_cfg.py || die 'Failure using preMerge_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/preMerge2_cfg.py || die 'Failure using preMerge2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/preMerge2_cfg.py || die 'Failure using preMerge2_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/HeteroMerge_cfg.py || die 'Failure using HeteroMerge_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/HeteroMerge_cfg.py || die 'Failure using HeteroMerge_cfg.py' $?
 
 #test reading of the old format files
 IOPoolInputData=$CMSSW_BASE/src

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -2,7 +2,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
 cmsRun -j PoolInputTest_jobreport.xml ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py PoolInputTest.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
 
@@ -20,8 +20,8 @@ cmsRun ${LOCAL_TEST_DIR}/PoolGUIDTest_cfg.py file:${GUID_NAME} || die 'Failure u
 cp PoolInputTest.root PoolInputOther.root
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure using PoolInputTest_cfg.py' $?
-cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
-grep 'event delayed read from source' ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
+cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
+grep 'event delayed read from source' PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skip_with_failure_cfg.py || die 'Failure using PoolInputTest_skip_with_failure_cfg.py' $?
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skipBadFiles_cfg.py  || die 'Failure using PoolInputTest_skipBadFiles_cfg.py ' $?
 
@@ -60,12 +60,12 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolAliasSubProcessTestStep2_cfg.py || 
 
 cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py RunPerLumiTest.root 50 1 25 1 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/RunPerLumiTest_cfg.py 25 >& ${LOCAL_TMP_DIR}/RunPerLumiTest.txt || die 'Failure using RunPerLumiTest_cfg.py' $?
-grep 'record' ${LOCAL_TMP_DIR}/RunPerLumiTest.txt | cut -d ' ' -f 4-11 > ${LOCAL_TMP_DIR}/RunPerLumiTest.filtered.txt
-diff ${LOCAL_TEST_DIR}/unit_test_outputs/RunPerLumiTest.filtered.txt ${LOCAL_TMP_DIR}/RunPerLumiTest.filtered.txt || die 'incorrect output using RunPerLumiTest_cfg.py' $? 
+cmsRun ${LOCAL_TEST_DIR}/RunPerLumiTest_cfg.py 25 >& RunPerLumiTest.txt || die 'Failure using RunPerLumiTest_cfg.py' $?
+grep 'record' RunPerLumiTest.txt | cut -d ' ' -f 4-11 > RunPerLumiTest.filtered.txt
+diff ${LOCAL_TEST_DIR}/unit_test_outputs/RunPerLumiTest.filtered.txt RunPerLumiTest.filtered.txt || die 'incorrect output using RunPerLumiTest_cfg.py' $? 
 
-cmsRun ${LOCAL_TEST_DIR}/RunPerLumiTest_cfg.py 50 >& ${LOCAL_TMP_DIR}/tooManyLumis.txt && die 'RunPerLumiTest_cfg.py should have failed but did not' 1
-grep "MismatchedInputFiles" ${LOCAL_TMP_DIR}/tooManyLumis.txt || die  'RunPerLumiTest_cfg.py should have failed but did not' $?
+cmsRun ${LOCAL_TEST_DIR}/RunPerLumiTest_cfg.py 50 >& tooManyLumis.txt && die 'RunPerLumiTest_cfg.py should have failed but did not' 1
+grep "MismatchedInputFiles" tooManyLumis.txt || die  'RunPerLumiTest_cfg.py should have failed but did not' $?
 
 cmsRun ${LOCAL_TEST_DIR}/firstLuminosityBlockForEachRunTest_cfg.py 'file:RunPerLumiTest.root' 25 1 25 1 5 || die 'Failure using firstLuminosityBlockForEachRunTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/PrePoolInputTest_cfg.py firstLumiTest1.root 25 1 100 1 5 || die 'Failure using PrePoolInputTest_cfg.py' $?
@@ -144,5 +144,4 @@ cmsRun ${LOCAL_TEST_DIR}/test_read_multi_lumi_as_one_cfg.py || die 'Failure usin
 cmsRun ${LOCAL_TEST_DIR}/test_make_overlapping_lumis_cfg.py || die 'Failure using test_make_overlapping_lumis_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/test_read_overlapping_lumis_cfg.py || die 'Failure using test_read_overlapping_lumis_cfg.py' $?
 
-popd
 exit 0

--- a/IOPool/Output/test/BuildFile.xml
+++ b/IOPool/Output/test/BuildFile.xml
@@ -1,7 +1,1 @@
-<environment>
-  <bin file="TestPoolOutput.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/Output/test TestPoolOutput.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-
-</environment>
+<test name="TestPoolOutput" command="TestPoolOutput.sh"/>

--- a/IOPool/Output/test/BuildFile.xml
+++ b/IOPool/Output/test/BuildFile.xml
@@ -1,1 +1,2 @@
+<flags USE_UNITTEST_DIR="1"/>
 <test name="TestPoolOutput" command="TestPoolOutput.sh"/>

--- a/IOPool/Output/test/TestPoolOutput.cpp
+++ b/IOPool/Output/test/TestPoolOutput.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -2,7 +2,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR=$SCRAM_TEST_PATH
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 1' $?
 GUID1=$(edmFileUtil -u PoolOutputTest.root | fgrep uuid | awk '{print $10}')
@@ -74,5 +74,3 @@ if [ "x${GUID1}" == "x${GUID2}" ]; then
     echo "GUID from two output files are the same: ${GUID1}"
     exit 1
 fi
-
-popd

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -4,28 +4,28 @@ function die { echo $1: status $2 ;  exit $2; }
 
 LOCAL_TEST_DIR=$SCRAM_TEST_PATH
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 1' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 1' $?
 GUID1=$(edmFileUtil -u PoolOutputTest.root | fgrep uuid | awk '{print $10}')
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 2' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 2' $?
 GUID2=$(edmFileUtil -u PoolOutputTest.root | fgrep uuid | awk '{print $10}')
 if [ "x${GUID1}" == "x${GUID2}" ]; then
     echo "GUID from two executions are the same: ${GUID1}"
     exit 1
 fi
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolDropTest_cfg.py || die 'Failure using PoolDropTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolDropTest_cfg.py || die 'Failure using PoolDropTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolMissingTest_cfg.py || die 'Failure using PoolMissingTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolMissingTest_cfg.py || die 'Failure using PoolMissingTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputRead_cfg.py || die 'Failure using PoolOutputRead_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputRead_cfg.py || die 'Failure using PoolOutputRead_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolDropRead_cfg.py || die 'Failure using PoolDropRead_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolDropRead_cfg.py || die 'Failure using PoolDropRead_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolMissingRead_cfg.py || die 'Failure using PoolMissingRead_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolMissingRead_cfg.py || die 'Failure using PoolMissingRead_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolTransientTest_cfg.py || die 'Failure using PoolTransientTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolTransientTest_cfg.py || die 'Failure using PoolTransientTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolTransientRead_cfg.py || die 'Failure using PoolTransientRead_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolTransientRead_cfg.py || die 'Failure using PoolTransientRead_cfg.py' $?
 
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputEmptyEventsTest_cfg.py || die 'Failure using PoolOutputEmptyEventsTest_cfg.py' $?
 #reads file from above and from PoolOutputTest_cfg.py

--- a/IOPool/SecondaryInput/test/BuildFile.xml
+++ b/IOPool/SecondaryInput/test/BuildFile.xml
@@ -1,8 +1,5 @@
 <environment>
-  <bin file="TestSecondaryInput.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/SecondaryInput/test TestSecondaryInput.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="TestSecondaryInput" command="TestSecondaryInput.sh"/>
 
   <library file="SecondaryProducer.cc" name="SecondaryProducer">
     <flags EDM_PLUGIN="1"/>

--- a/IOPool/SecondaryInput/test/BuildFile.xml
+++ b/IOPool/SecondaryInput/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <environment>
+  <flags USE_UNITTEST_DIR="1"/>
   <test name="TestSecondaryInput" command="TestSecondaryInput.sh"/>
 
   <library file="SecondaryProducer.cc" name="SecondaryProducer">

--- a/IOPool/SecondaryInput/test/TestSecondaryInput.cpp
+++ b/IOPool/SecondaryInput/test/TestSecondaryInput.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/IOPool/SecondaryInput/test/TestSecondaryInput.sh
+++ b/IOPool/SecondaryInput/test/TestSecondaryInput.sh
@@ -4,17 +4,17 @@ function die { echo $1: status $2 ;  exit $2; }
 
 LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreSecondaryInputTest2_cfg.py || die 'Failure using PreSecondaryInputTest2_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreSecondaryInputTest2_cfg.py || die 'Failure using PreSecondaryInputTest2_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreSecondaryInputTest_cfg.py || die 'Failure using PreSecondaryInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/PreSecondaryInputTest_cfg.py || die 'Failure using PreSecondaryInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondaryInputTest_cfg.py || die 'Failure using SecondaryInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/SecondaryInputTest_cfg.py || die 'Failure using SecondaryInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySeqInputTest_cfg.py || die 'Failure using SecondarySeqInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/SecondarySeqInputTest_cfg.py || die 'Failure using SecondarySeqInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondaryInLumiInputTest_cfg.py || die 'Failure using SecondaryInLumiInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/SecondaryInLumiInputTest_cfg.py || die 'Failure using SecondaryInLumiInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySeqInLumiInputTest_cfg.py || die 'Failure using SecondarySeqInLumiInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/SecondarySeqInLumiInputTest_cfg.py || die 'Failure using SecondarySeqInLumiInputTest_cfg.py' $?
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySpecInputTest_cfg.py || die 'Failure using SecondarySpecInputTest_cfg.py' $?
+cmsRun ${LOCAL_TEST_DIR}/SecondarySpecInputTest_cfg.py || die 'Failure using SecondarySpecInputTest_cfg.py' $?
 

--- a/IOPool/SecondaryInput/test/TestSecondaryInput.sh
+++ b/IOPool/SecondaryInput/test/TestSecondaryInput.sh
@@ -2,7 +2,7 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PreSecondaryInputTest2_cfg.py || die 'Failure using PreSecondaryInputTest2_cfg.py' $?
 
@@ -18,4 +18,3 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySeqInLumiInputTest_cfg.py || d
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/SecondarySpecInputTest_cfg.py || die 'Failure using SecondarySpecInputTest_cfg.py' $?
 
-popd

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -18,21 +18,13 @@
     <use name="IOPool/Streamer"/>
   </bin>
 
-  <bin file="RunThis_t.cpp" name="NewStreamerUNCOMPRESSED">
-    <flags TEST_RUNNER_ARGS="/bin/bash IOPool/Streamer/test RunUNCOMPRESSED.sh"/>
-  </bin>
+  <test name="NewStreamerUNCOMPRESSED" command="RunUNCOMPRESSED.sh"/>
 
-  <bin file="RunThis_t.cpp" name="NewStreamerZLIB">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunZLIB.sh"/>
-  </bin>
+  <test name="NewStreamerZLIB" command="RunZLIB.sh"/>
 
-  <bin file="RunThis_t.cpp" name="NewStreamerLZMA">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunLZMA.sh"/>
-  </bin>
+  <test name="NewStreamerLZMA" command="RunLZMA.sh"/>
 
-  <bin file="RunThis_t.cpp" name="NewStreamerZSTD">
-    <flags TEST_RUNNER_ARGS=" /bin/bash IOPool/Streamer/test RunZSTD.sh"/>
-  </bin>
+  <test name="NewStreamerZSTD" command="RunZSTD.sh"/>
 
   <library file="StreamThingProducer.cc" name="StreamThingProducer">
     <flags EDM_PLUGIN="1"/>

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <environment>
+  <flags USE_UNITTEST_DIR="1"/>
   <use name="FWCore/Framework"/>
   <bin file="EventMessageTest.cpp">
     <use name="IOPool/Streamer"/>

--- a/IOPool/Streamer/test/RunLZMA.sh
+++ b/IOPool/Streamer/test/RunLZMA.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export TEST_COMPRESSION_ALGO="LZMA" 
-exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh
+export TEST_COMPRESSION_ALGO="LZMA"
+$(dirname $0)/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -18,13 +18,13 @@ cmsRun ${SCRAM_TEST_PATH}/NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} 
 cmsRun ${SCRAM_TEST_PATH}/NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
 cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
-cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -2,43 +2,29 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-if [ -z  $LOCAL_TEST_DIR ]; then
-LOCAL_TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -z  $SCRAM_TEST_PATH ]; then
+SCRAM_TEST_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
-echo "LOCAL_TEST_DIR = $LOCAL_TEST_DIR"
-
-if [ -z  $LOCAL_TMP_DIR ]; then
-LOCAL_TMP_DIR="/tmp"
-fi
-echo "LOCAL_TMP_DIR = $LOCAL_TMP_DIR"
+echo "LOCAL_TEST_DIR = $SCRAM_TEST_PATH"
 
 if [ -z  $TEST_COMPRESSION_ALGO ]; then
 TEST_COMPRESSION_ALGO="ZLIB"
 fi
 echo "TEST_COMPRESSION_ALGO = $TEST_COMPRESSION_ALGO"
 
-cd $LOCAL_TEST_DIR
-
 RC=0
-P=$$
-PREFIX=results_${USER}${P}
-OUTDIR=${LOCAL_TMP_DIR}/${PREFIX}
 
-mkdir ${OUTDIR}
-cp *_cfg.py ${OUTDIR}
-cd ${OUTDIR}
-
-cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun --parameter-set NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
-cmsRun --parameter-set NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
-cmsRun --parameter-set NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
-cmsRun --parameter-set NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
-cmsRun --parameter-set NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
-cmsRun --parameter-set NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
-cmsRun --parameter-set NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
 
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in
@@ -73,5 +59,4 @@ then
     RC=1
 fi
 
-#rm -rf ${OUTDIR}
 exit ${RC}

--- a/IOPool/Streamer/test/RunThis_t.cpp
+++ b/IOPool/Streamer/test/RunThis_t.cpp
@@ -1,8 +1,0 @@
-//------------------------------------------------------------
-//
-// Driver for shell scripts.
-//
-//------------------------------------------------------------
-
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/IOPool/Streamer/test/RunUNCOMPRESSED.sh
+++ b/IOPool/Streamer/test/RunUNCOMPRESSED.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export TEST_COMPRESSION_ALGO="UNCOMPRESSED" 
-exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh
+$(dirname $0)/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunZLIB.sh
+++ b/IOPool/Streamer/test/RunZLIB.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export TEST_COMPRESSION_ALGO="ZLIB" 
-exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh
+$(dirname $0)/RunSimple_NewStreamer.sh

--- a/IOPool/Streamer/test/RunZSTD.sh
+++ b/IOPool/Streamer/test/RunZSTD.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export TEST_COMPRESSION_ALGO="ZSTD" 
-exec ${SCRIPTDIR}/RunSimple_NewStreamer.sh
+$(dirname $0)/RunSimple_NewStreamer.sh


### PR DESCRIPTION
Updated unit tests so that they can be run from their own separate directory. Mostly
- convert <bin ...> to <test....>
- avoid creating test output in cmssw/tmp
- added flag `USE_UNITTEST_DIR="1"` to run each tests in separate dir. Once all the tests can run it their own tmp path then we can enable  `USE_UNITTEST_DIR="1"` at project level and do cleanup