### PR TITLE
(13_0_X) Add additional track variables to the Run 3 scouting electron collection for low pT electrons.

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingElectron.h
@@ -13,15 +13,19 @@ public:
                        float eta,
                        float phi,
                        float m,
-                       float d0,
-                       float dz,
+                       std::vector<float> trkd0,
+                       std::vector<float> trkdz,
+                       std::vector<float> trkpt,
+                       std::vector<float> trketa,
+                       std::vector<float> trkphi,
+                       std::vector<float> trkchi2overndf,
                        float dEtaIn,
                        float dPhiIn,
                        float sigmaIetaIeta,
                        float hOverE,
                        float ooEMOop,
                        int missingHits,
-                       int charge,
+                       std::vector<int> trkcharge,
                        float ecalIso,
                        float hcalIso,
                        float trackIso,
@@ -37,15 +41,19 @@ public:
         eta_(eta),
         phi_(phi),
         m_(m),
-        d0_(d0),
-        dz_(dz),
+        trkd0_(std::move(trkd0)),
+        trkdz_(std::move(trkdz)),
+        trkpt_(std::move(trkpt)),
+        trketa_(std::move(trketa)),
+        trkphi_(std::move(trkphi)),
+        trkchi2overndf_(std::move(trkchi2overndf)),
         dEtaIn_(dEtaIn),
         dPhiIn_(dPhiIn),
         sigmaIetaIeta_(sigmaIetaIeta),
         hOverE_(hOverE),
         ooEMOop_(ooEMOop),
         missingHits_(missingHits),
-        charge_(charge),
+        trkcharge_(std::move(trkcharge)),
         ecalIso_(ecalIso),
         hcalIso_(hcalIso),
         trackIso_(trackIso),
@@ -63,15 +71,19 @@ public:
         eta_(0),
         phi_(0),
         m_(0),
-        d0_(0),
-        dz_(0),
+        trkd0_(0),
+        trkdz_(0),
+        trkpt_(0),
+        trketa_(0),
+        trkphi_(0),
+        trkchi2overndf_(0),
         dEtaIn_(0),
         dPhiIn_(0),
         sigmaIetaIeta_(0),
         hOverE_(0),
         ooEMOop_(0),
         missingHits_(0),
-        charge_(0),
+        trkcharge_(0),
         ecalIso_(0),
         hcalIso_(0),
         trackIso_(0),
@@ -86,15 +98,19 @@ public:
   float eta() const { return eta_; }
   float phi() const { return phi_; }
   float m() const { return m_; }
-  float d0() const { return d0_; }
-  float dz() const { return dz_; }
+  std::vector<float> const& trkd0() const { return trkd0_; }
+  std::vector<float> const& trkdz() const { return trkdz_; }
+  std::vector<float> const& trkpt() const { return trkpt_; }
+  std::vector<float> const& trketa() const { return trketa_; }
+  std::vector<float> const& trkphi() const { return trkphi_; }
+  std::vector<float> const& trkchi2overndf() const { return trkchi2overndf_; }
   float dEtaIn() const { return dEtaIn_; }
   float dPhiIn() const { return dPhiIn_; }
   float sigmaIetaIeta() const { return sigmaIetaIeta_; }
   float hOverE() const { return hOverE_; }
   float ooEMOop() const { return ooEMOop_; }
   int missingHits() const { return missingHits_; }
-  int charge() const { return charge_; }
+  std::vector<int> const& trkcharge() const { return trkcharge_; }
   float ecalIso() const { return ecalIso_; }
   float hcalIso() const { return hcalIso_; }
   float trackIso() const { return trackIso_; }
@@ -112,15 +128,19 @@ private:
   float eta_;
   float phi_;
   float m_;
-  float d0_;
-  float dz_;
+  std::vector<float> trkd0_;
+  std::vector<float> trkdz_;
+  std::vector<float> trkpt_;
+  std::vector<float> trketa_;
+  std::vector<float> trkphi_;
+  std::vector<float> trkchi2overndf_;
   float dEtaIn_;
   float dPhiIn_;
   float sigmaIetaIeta_;
   float hOverE_;
   float ooEMOop_;
   int missingHits_;
-  int charge_;
+  std::vector<int> trkcharge_;
   float ecalIso_;
   float hcalIso_;
   float trackIso_;

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -41,11 +41,39 @@
   <class name="Run3ScoutingVertex" ClassVersion="3">
       <version ClassVersion="3" checksum="316446070"/>
   </class>
-  <class name="Run3ScoutingElectron" ClassVersion="5">
+  <class name="Run3ScoutingElectron" ClassVersion="6">
       <version ClassVersion="3" checksum="1086011373"/>
       <version ClassVersion="4" checksum="1250202632"/>
       <version ClassVersion="5" checksum="2230390721"/>
+      <version ClassVersion="6" checksum="2815634332"/>
   </class>
+
+  <!-- Adding ioread rules for backwards compatibility -->
+  
+  <ioread sourceClass="Run3ScoutingElectron" version="[3-5]" 
+	  source="float d0_;" 
+	  targetClass="Run3ScoutingElectron" target="trkd0_">
+    <![CDATA[
+	     trkd0_.clear();
+	     trkd0_.push_back(onfile.d0_);]]>
+  </ioread>
+  
+  <ioread sourceClass="Run3ScoutingElectron" version="[3-5]" 
+	  source="float dz_;" 
+	  targetClass="Run3ScoutingElectron" target="trkdz_">
+    <![CDATA[
+	     trkdz_.clear();
+	     trkdz_.push_back(onfile.dz_);]]>
+  </ioread>
+  
+  <ioread sourceClass="Run3ScoutingElectron" version="[3-5]" 
+	  source="int charge_;" 
+	  targetClass="Run3ScoutingElectron" target="trkcharge_">
+    <![CDATA[
+	     trkcharge_.clear();
+	     trkcharge_.push_back(onfile.charge_);]]>
+  </ioread>
+  
   <class name="Run3ScoutingMuon" ClassVersion="4">
       <version ClassVersion="3" checksum="3882497397"/>
       <version ClassVersion="4" checksum="4206297195"/>


### PR DESCRIPTION
#### PR description:

  - The PR adds four variables to the Run3 scouting electron collection - pt, eta, phi and chi2/ndof.
  - This is necessary for low-energy electrons in the scouting collection.
  -  The dataset format of the scouting output files should be compatible with previous releases.
  - 
#### PR validation:

 - Code validated with privately produced J/PsiToEE MC. Full presentation validated at the scouting meeting [Scouting Meeting](https://indico.cern.ch/event/1252656/#5-jpsi-mc-studies).
 - Basic code-check and code-formatting done.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

 - Backport from CMSSW_13_1_X to CMSSW_13_0_X  release cycle.
 - Master PR is at [41025](https://github.com/cms-sw/cmssw/pull/41025).
