### PR TITLE
Modify L1TGlobal menu code and CondFormats to remove reinterpret_cast to and from utm firmware "es" types

### DIFF
--- a/CondFormats/L1TObjects/BuildFile.xml
+++ b/CondFormats/L1TObjects/BuildFile.xml
@@ -7,6 +7,8 @@
 <use name="CondFormats/External"/>
 <use name="DataFormats/L1CaloTrigger"/>
 <use name="FWCore/MessageLogger"/>
+<use name="xerces-c"/>
+<use name="utm"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include "tmEventSetup/esAlgorithm.hh"
 
 /**
  *  This class implements data structure for Algorithm
@@ -29,6 +30,33 @@ public:
         module_id_(),
         module_index_(),
         version(0){};
+  L1TUtmAlgorithm(std::string name,
+                  std::string expression,
+                  std::string expression_in_condition,
+                  std::vector<std::string> rpn_vector,
+                  unsigned int index,
+                  unsigned int module_id,
+                  unsigned int module_index,
+                  unsigned int ver)
+      : name_(name),
+        expression_(expression),
+        expression_in_condition_(expression_in_condition),
+        rpn_vector_(rpn_vector),
+        index_(index),
+        module_id_(module_id),
+        module_index_(module_index),
+        version(ver){};
+
+  L1TUtmAlgorithm(const tmeventsetup::esAlgorithm& esAlg)
+      : L1TUtmAlgorithm(esAlg.getName(),
+                        esAlg.getExpression(),
+                        esAlg.getExpressionInCondition(),
+                        esAlg.getRpnVector(),
+                        esAlg.getIndex(),
+                        esAlg.getModuleId(),
+                        esAlg.getModuleIndex(),
+                        0  //There is no version retrieval in esAlgorithm. However, it seems pretty hard coded to 0
+        ){};
 
   virtual ~L1TUtmAlgorithm() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmBin.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmBin.h
@@ -12,6 +12,7 @@
 
 #include <limits>
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include "tmEventSetup/esBin.hh"
 
 /**
  *  This class implements data structure for Bin
@@ -26,6 +27,10 @@ public:
 
   L1TUtmBin(const unsigned int id, const double min, const double max)
       : hw_index(id), minimum(min), maximum(max), version(0){};
+
+  L1TUtmBin(const tmeventsetup::esBin& bin) : L1TUtmBin(bin.hw_index, bin.minimum, bin.maximum){};
+
+  operator tmeventsetup::esBin() const { return tmeventsetup::esBin(hw_index, minimum, maximum); }
 
   virtual ~L1TUtmBin() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmCondition.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmCondition.h
@@ -14,6 +14,8 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmObject.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include "tmEventSetup/esCondition.hh"
+
 #include <string>
 #include <vector>
 
@@ -23,6 +25,19 @@
 class L1TUtmCondition {
 public:
   L1TUtmCondition() : name_(), type_(-9999), objects_(), cuts_(), version(0){};
+  L1TUtmCondition(
+      std::string name, int type, std::vector<L1TUtmObject> objects, std::vector<L1TUtmCut> cuts, unsigned int vers)
+      : name_(name), type_(type), objects_(objects), cuts_(cuts), version(vers){};
+
+  L1TUtmCondition(const tmeventsetup::esCondition& esCond)
+      : name_(esCond.getName()), type_(esCond.getType()), version(0) {
+    objects_.reserve(esCond.getObjects().size());
+    for (auto it = esCond.getObjects().begin(); it != esCond.getObjects().end(); ++it)
+      objects_.emplace_back(L1TUtmObject(*it));
+    cuts_.reserve(esCond.getCuts().size());
+    for (auto it = esCond.getCuts().begin(); it != esCond.getCuts().end(); ++it)
+      cuts_.emplace_back(L1TUtmCut(*it));
+  };
 
   virtual ~L1TUtmCondition() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmCut.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmCut.h
@@ -13,6 +13,8 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmCutValue.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include "tmEventSetup/esCut.hh"
+
 #include <string>
 
 /**
@@ -21,6 +23,32 @@
 class L1TUtmCut {
 public:
   L1TUtmCut() : name_(), object_type_(), cut_type_(), minimum_(), maximum_(), data_(), key_(), version(0){};
+  L1TUtmCut(std::string name,
+            int object_type,
+            int cut_type,
+            L1TUtmCutValue minimum,
+            L1TUtmCutValue maximum,
+            std::string data,
+            std::string key,
+            unsigned int vers)
+      : name_(name),
+        object_type_(object_type),
+        cut_type_(cut_type),
+        minimum_(minimum),
+        maximum_(maximum),
+        data_(data),
+        key_(key),
+        version(vers){};
+
+  L1TUtmCut(const tmeventsetup::esCut& esC)
+      : L1TUtmCut(esC.getName(),
+                  esC.getObjectType(),
+                  esC.getCutType(),
+                  L1TUtmCutValue(esC.getMinimum()),
+                  L1TUtmCutValue(esC.getMaximum()),
+                  esC.getData(),
+                  esC.getKey(),
+                  0){};
 
   virtual ~L1TUtmCut() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmCutValue.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmCutValue.h
@@ -12,6 +12,7 @@
 
 #include <limits>
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include "tmEventSetup/esCutValue.hh"
 
 /**
  *  This class implements data structure for CutValue
@@ -19,6 +20,7 @@
 struct L1TUtmCutValue {
   L1TUtmCutValue()
       : value(std::numeric_limits<double>::max()), index(std::numeric_limits<unsigned int>::max()), version(0){};
+  L1TUtmCutValue(const tmeventsetup::esCutValue& esCV) : value(esCV.value), index(esCV.index), version(esCV.version){};
 
   virtual ~L1TUtmCutValue() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmObject.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmObject.h
@@ -13,6 +13,8 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmCut.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include "tmEventSetup/esObject.hh"
+
 #include <limits>
 #include <string>
 #include <vector>
@@ -32,6 +34,38 @@ public:
         ext_channel_id_(std::numeric_limits<unsigned int>::max()),
         cuts_(),
         version(0){};
+  L1TUtmObject(std::string name,
+               int type,
+               int comparison_operator,
+               int bx_offset,
+               double threshold,
+               std::string ext_signal_name,
+               unsigned int ext_channel_id,
+               std::vector<L1TUtmCut> cuts,
+               unsigned int vers)
+      : name_(name),
+        type_(type),
+        comparison_operator_(comparison_operator),
+        bx_offset_(bx_offset),
+        threshold_(threshold),
+        ext_signal_name_(ext_signal_name),
+        ext_channel_id_(ext_channel_id),
+        cuts_(cuts),
+        version(vers){};
+
+  L1TUtmObject(const tmeventsetup::esObject& esObj)
+      : name_(esObj.getName()),
+        type_(esObj.getType()),
+        comparison_operator_(esObj.getComparisonOperator()),
+        bx_offset_(esObj.getBxOffset()),
+        threshold_(esObj.getThreshold()),
+        ext_signal_name_(esObj.getExternalSignalName()),
+        ext_channel_id_(esObj.getExternalChannelId()),
+        version(0) {
+    cuts_.reserve(esObj.getCuts().size());
+    for (auto it = esObj.getCuts().begin(); it != esObj.getCuts().end(); ++it)
+      cuts_.emplace_back(L1TUtmCut(*it));
+  };
 
   virtual ~L1TUtmObject() = default;
 

--- a/CondFormats/L1TObjects/interface/L1TUtmScale.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmScale.h
@@ -13,6 +13,8 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmBin.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include "tmEventSetup/esScale.hh"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -24,7 +26,49 @@ class L1TUtmScale {
 public:
   L1TUtmScale() : name_(), object_(), type_(), minimum_(), maximum_(), step_(), n_bits_(), bins_(), version(0){};
 
+  L1TUtmScale(std::string name,
+              int object,
+              int type,
+              double minimum,
+              double maximum,
+              double step,
+              unsigned int n_bits,
+              std::vector<L1TUtmBin> bins,
+              unsigned int vers)
+      : name_(name),
+        object_(object),
+        type_(type),
+        minimum_(minimum),
+        maximum_(maximum),
+        step_(step),
+        n_bits_(n_bits),
+        bins_(bins),
+        version(vers){};
+
+  L1TUtmScale(const tmeventsetup::esScale& esSc)
+      : name_(esSc.getName()),
+        object_(esSc.getObjectType()),
+        type_(esSc.getScaleType()),
+        minimum_(esSc.getMinimum()),
+        maximum_(esSc.getMaximum()),
+        step_(esSc.getStep()),
+        n_bits_(esSc.getNbits()),
+        version(0) {
+    bins_.reserve(esSc.getBins().size());
+    for (auto it = esSc.getBins().begin(); it != esSc.getBins().end(); ++it)
+      bins_.emplace_back(L1TUtmBin(*it));
+  };
+
   virtual ~L1TUtmScale() = default;
+
+  operator tmeventsetup::esScale() const {
+    std::vector<tmeventsetup::esBin> bins;
+    bins.reserve(getBins().size());
+    for (const auto& it : getBins())
+      bins.emplace_back(tmeventsetup::esBin(it.hw_index, it.minimum, it.maximum));
+    return tmeventsetup::esScale(
+        getName(), getObjectType(), getScaleType(), getMinimum(), getMaximum(), getStep(), getNbits(), bins);
+  }
 
   /** get scale name */
   const std::string& getName() const { return name_; };

--- a/CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h
@@ -16,6 +16,8 @@
 #include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include "tmEventSetup/esTriggerMenu.hh"
+
 #include <map>
 #include <string>
 
@@ -38,6 +40,49 @@ public:
         scale_set_name_(),
         n_modules_(),
         version(0){};
+  L1TUtmTriggerMenu(std::map<std::string, L1TUtmAlgorithm> algorithm_map,
+                    std::map<std::string, L1TUtmCondition> condition_map,
+                    std::map<std::string, L1TUtmScale> scale_map,
+                    std::string name,
+                    std::string ver_s,
+                    std::string comment,
+                    std::string datetime,
+                    std::string uuid_firmware,
+                    std::string scale_set_name,
+                    unsigned int n_modules,
+                    unsigned int ver_i)
+      : algorithm_map_(algorithm_map),
+        condition_map_(condition_map),
+        scale_map_(scale_map),
+        external_map_(),
+        token_to_condition_(),
+        name_(name),
+        version_(ver_s),
+        comment_(comment),
+        datetime_(datetime),
+        uuid_firmware_(uuid_firmware),
+        scale_set_name_(scale_set_name),
+        n_modules_(n_modules),
+        version(ver_i){};
+
+  L1TUtmTriggerMenu(const tmeventsetup::esTriggerMenu& esMenu)
+      : external_map_(),        //These are null to my best knowledge
+        token_to_condition_(),  //These are null to my best knowledge
+        name_(esMenu.getName()),
+        version_(esMenu.getVersion()),
+        comment_(esMenu.getComment()),
+        datetime_(esMenu.getDatetime()),
+        uuid_firmware_(esMenu.getFirmwareUuid()),
+        scale_set_name_(esMenu.getScaleSetName()),
+        n_modules_(esMenu.getNmodules()),
+        version(0) {
+    for (const auto& it : esMenu.getAlgorithmMap())
+      algorithm_map_.emplace(std::make_pair(it.first, L1TUtmAlgorithm(it.second)));
+    for (const auto& it : esMenu.getConditionMap())
+      condition_map_.emplace(std::make_pair(it.first, L1TUtmCondition(it.second)));
+    for (const auto& it : esMenu.getScaleMap())
+      scale_map_.emplace(std::make_pair(it.first, L1TUtmScale(it.second)));
+  };
 
   virtual ~L1TUtmTriggerMenu() = default;
 

--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -14,7 +14,6 @@
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-#include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
 
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -97,8 +96,6 @@ private:
   edm::EDGetTokenT<BasicJetCollection> JetAlgorithm;
 
   edm::ESGetToken<CastorDbService, CastorDbRecord> castorDbServiceToken_;
-
-  //  std::shared_ptr<l1t::L1TGlobalUtil> gtUtil_;
 
   std::unique_ptr<CastorRecHitMonitor> RecHitMon_;
   std::unique_ptr<CastorDigiMonitor> DigiMon_;

--- a/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuESProducer.cc
@@ -89,10 +89,10 @@ L1TUtmTriggerMenuESProducer::~L1TUtmTriggerMenuESProducer() {
 
 // ------------ method called to produce the data  ------------
 L1TUtmTriggerMenuESProducer::ReturnType L1TUtmTriggerMenuESProducer::produce(const L1TUtmTriggerMenuRcd& iRecord) {
-  //const L1TUtmTriggerMenu * cmenu = reinterpret_cast<const L1TUtmTriggerMenu *>(tmeventsetup::getTriggerMenu("/afs/cern.ch/user/t/tmatsush/public/tmGui/test-menu.xml"));
-  const L1TUtmTriggerMenu* cmenu =
-      reinterpret_cast<const L1TUtmTriggerMenu*>(tmeventsetup::getTriggerMenu(m_L1TriggerMenuFile));
-  return ReturnType(cmenu);
+  const tmeventsetup::esTriggerMenu* theEsMenu = tmeventsetup::getTriggerMenu(m_L1TriggerMenuFile);
+  auto l1Menu = L1TUtmTriggerMenu(*theEsMenu);
+  delete theEsMenu;
+  return make_unique<const L1TUtmTriggerMenu>(l1Menu);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -44,13 +44,16 @@
 #include "FWCore/MessageLogger/interface/MessageDrop.h"
 
 #include "tmEventSetup/tmEventSetup.hh"
-#include "tmEventSetup/esTriggerMenu.hh"
-#include "tmEventSetup/esAlgorithm.hh"
-#include "tmEventSetup/esCondition.hh"
-#include "tmEventSetup/esObject.hh"
-#include "tmEventSetup/esCut.hh"
-#include "tmEventSetup/esScale.hh"
+#include "tmEventSetup/esTypes.hh"
+
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmCondition.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmObject.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmCut.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmScale.h"
 #include "tmGrammar/Algorithm.hh"
+
 #include <cstdint>
 
 // constructor
@@ -172,19 +175,17 @@ void l1t::TriggerMenuParser::setGtAlgorithmAliasMap(const AlgorithmMap& algoMap)
 
 std::map<std::string, unsigned int> l1t::TriggerMenuParser::getExternalSignals(const L1TUtmTriggerMenu* utmMenu) {
   using namespace tmeventsetup;
-  const esTriggerMenu* menu = reinterpret_cast<const esTriggerMenu*>(utmMenu);
-  const std::map<std::string, esCondition>& condMap = menu->getConditionMap();
+  const std::map<std::string, L1TUtmCondition>& condMap = utmMenu->getConditionMap();
 
   std::map<std::string, unsigned int> extBitMap;
 
   //loop over the algorithms
-  for (std::map<std::string, esCondition>::const_iterator cit = condMap.begin(); cit != condMap.end(); cit++) {
-    const esCondition& condition = cit->second;
+  for (const auto& cit : condMap) {
+    const L1TUtmCondition& condition = cit.second;
     if (condition.getType() == esConditionType::Externals) {
       // Get object for External conditions
-      const std::vector<esObject>& objects = condition.getObjects();
-      for (size_t jj = 0; jj < objects.size(); jj++) {
-        const esObject object = objects.at(jj);
+      const std::vector<L1TUtmObject>& objects = condition.getObjects();
+      for (const auto& object : objects) {
         if (object.getType() == esObjectType::EXT) {
           unsigned int channelID = object.getExternalChannelId();
           std::string name = object.getExternalSignalName();
@@ -195,12 +196,7 @@ std::map<std::string, unsigned int> l1t::TriggerMenuParser::getExternalSignals(c
       }
     }
   }
-  /*
-  for (std::map<std::string, unsigned int>::const_iterator cit = extBitMap.begin();
-       cit != extBitMap.end(); cit++) {
-       std::cout << " Ext Map:  Name " << cit->first << " Bit " << cit->second << std::endl;
-  }
-*/
+
   return extBitMap;
 }
 
@@ -226,31 +222,31 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
   using namespace tmeventsetup;
   using namespace Algorithm;
 
-  const esTriggerMenu* menu = reinterpret_cast<const esTriggerMenu*>(utmMenu);
-
   //get the meta data
-  m_triggerMenuDescription = menu->getComment();
-  m_triggerMenuDate = menu->getDatetime();
-  m_triggerMenuImplementation = (getMmHashN(menu->getFirmwareUuid()) & 0xFFFFFFFF);  //make sure we only have 32 bits
-  m_triggerMenuName = menu->getName();
-  m_triggerMenuInterface = menu->getVersion();                     //BLW: correct descriptor?
-  m_triggerMenuUUID = (getMmHashN(menu->getName()) & 0xFFFFFFFF);  //make sure we only have 32 bits
+  m_triggerMenuDescription = utmMenu->getComment();
+  m_triggerMenuDate = utmMenu->getDatetime();
+  m_triggerMenuImplementation = (getMmHashN(utmMenu->getFirmwareUuid()) & 0xFFFFFFFF);  //make sure we only have 32 bits
+  m_triggerMenuName = utmMenu->getName();
+  m_triggerMenuInterface = utmMenu->getVersion();                     //BLW: correct descriptor?
+  m_triggerMenuUUID = (getMmHashN(utmMenu->getName()) & 0xFFFFFFFF);  //make sure we only have 32 bits
 
-  const std::map<std::string, esAlgorithm>& algoMap = menu->getAlgorithmMap();
-  const std::map<std::string, esCondition>& condMap = menu->getConditionMap();
-  const std::map<std::string, esScale>& scaleMap = menu->getScaleMap();
+  const std::map<std::string, L1TUtmAlgorithm>& algoMap = utmMenu->getAlgorithmMap();
+  const std::map<std::string, L1TUtmCondition>& condMap = utmMenu->getConditionMap();
+  //We use es types for scale map to use auxiliary functions without having to duplicate code
+  const std::map<std::string, tmeventsetup::esScale> scaleMap(std::begin(utmMenu->getScaleMap()),
+                                                              std::end(utmMenu->getScaleMap()));
 
   // parse the scales
-  m_gtScales.setScalesName(menu->getScaleSetName());
+  m_gtScales.setScalesName(utmMenu->getScaleSetName());
   parseScales(scaleMap);
 
   //loop over the algorithms
-  for (std::map<std::string, esAlgorithm>::const_iterator cit = algoMap.begin(); cit != algoMap.end(); cit++) {
+  for (const auto& cit : algoMap) {
     //condition chip (artifact)  TO DO: Update
     int chipNr = 0;
 
     //get algorithm
-    const esAlgorithm& algo = cit->second;
+    const L1TUtmAlgorithm& algo = cit.second;
 
     //parse the algorithm
     parseAlgorithm(algo, chipNr);  //blw
@@ -262,7 +258,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
       if (isGate(token))
         continue;
       //      long hash = getHash(token);
-      const esCondition& condition = condMap.find(token)->second;
+      const L1TUtmCondition& condition = condMap.find(token)->second;
 
       //check to see if this condtion already exists
       if ((m_conditionMap[chipNr]).count(condition.getName()) == 0) {
@@ -558,8 +554,9 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
   GlobalScales::ScaleParameters htmScales;
 
   // Start by parsing the Scale Map
-  for (std::map<std::string, esScale>::const_iterator cit = scaleMap.begin(); cit != scaleMap.end(); cit++) {
-    const esScale& scale = cit->second;
+  for (std::map<std::string, tmeventsetup::esScale>::const_iterator cit = scaleMap.begin(); cit != scaleMap.end();
+       cit++) {
+    const tmeventsetup::esScale& scale = cit->second;
 
     GlobalScales::ScaleParameters* scaleParam;
     if (scale.getObjectType() == esObjectType::Muon)
@@ -593,9 +590,9 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
           scaleParam->etStep = scale.getStep();
 
           //Get bin edges
-          const std::vector<esBin>& binsV = scale.getBins();
+          const std::vector<tmeventsetup::esBin>& binsV = scale.getBins();
           for (unsigned int i = 0; i < binsV.size(); i++) {
-            const esBin& bin = binsV.at(i);
+            const tmeventsetup::esBin& bin = binsV.at(i);
             std::pair<double, double> binLimits(bin.minimum, bin.maximum);
             scaleParam->etBins.push_back(binLimits);
           }
@@ -623,9 +620,9 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
           scaleParam->uptStep = scale.getStep();
 
           //Get bin edges
-          const std::vector<esBin>& binsV = scale.getBins();
+          const std::vector<tmeventsetup::esBin>& binsV = scale.getBins();
           for (unsigned int i = 0; i < binsV.size(); i++) {
-            const esBin& bin = binsV.at(i);
+            const tmeventsetup::esBin& bin = binsV.at(i);
             std::pair<double, double> binLimits(bin.minimum, bin.maximum);
             scaleParam->uptBins.push_back(binLimits);
           }
@@ -636,10 +633,10 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
           scaleParam->etaStep = scale.getStep();
 
           //Get bin edges
-          const std::vector<esBin>& binsV = scale.getBins();
+          const std::vector<tmeventsetup::esBin>& binsV = scale.getBins();
           scaleParam->etaBins.resize(pow(2, scale.getNbits()));
           for (unsigned int i = 0; i < binsV.size(); i++) {
-            const esBin& bin = binsV.at(i);
+            const tmeventsetup::esBin& bin = binsV.at(i);
             std::pair<double, double> binLimits(bin.minimum, bin.maximum);
             scaleParam->etaBins.at(bin.hw_index) = binLimits;
           }
@@ -650,10 +647,10 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
           scaleParam->phiStep = scale.getStep();
 
           //Get bin edges
-          const std::vector<esBin>& binsV = scale.getBins();
+          const std::vector<tmeventsetup::esBin>& binsV = scale.getBins();
           scaleParam->phiBins.resize(pow(2, scale.getNbits()));
           for (unsigned int i = 0; i < binsV.size(); i++) {
-            const esBin& bin = binsV.at(i);
+            const tmeventsetup::esBin& bin = binsV.at(i);
             std::pair<double, double> binLimits(bin.minimum, bin.maximum);
             scaleParam->phiBins.at(bin.hw_index) = binLimits;
           }
@@ -831,8 +828,8 @@ void l1t::TriggerMenuParser::parseCalMuEta_LUTS(std::map<std::string, tmeventset
   if (scaleMap.find(scLabel1) == scaleMap.end() || scaleMap.find(scLabel2) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
-  const esScale* scale2 = &scaleMap.find(scLabel2)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale2 = &scaleMap.find(scLabel2)->second;
 
   std::vector<long long> lut_cal_2_mu_eta;
   getCaloMuonEtaConversionLut(lut_cal_2_mu_eta, scale1, scale2);
@@ -858,8 +855,8 @@ void l1t::TriggerMenuParser::parseCalMuPhi_LUTS(std::map<std::string, tmeventset
   if (scaleMap.find(scLabel1) == scaleMap.end() || scaleMap.find(scLabel2) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
-  const esScale* scale2 = &scaleMap.find(scLabel2)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale2 = &scaleMap.find(scLabel2)->second;
 
   std::vector<long long> lut_cal_2_mu_phi;
   getCaloMuonPhiConversionLut(lut_cal_2_mu_phi, scale1, scale2);
@@ -884,7 +881,7 @@ void l1t::TriggerMenuParser::parsePt_LUTS(std::map<std::string, tmeventsetup::es
   if (scaleMap.find(scLabel1) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
 
   std::vector<long long> lut_pt;
   getLut(lut_pt, scale1, prec);
@@ -907,7 +904,7 @@ void l1t::TriggerMenuParser::parseUpt_LUTS(std::map<std::string, tmeventsetup::e
   if (scaleMap.find(scLabel1) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
 
   std::vector<long long> lut_pt;
   getLut(lut_pt, scale1, prec);
@@ -932,8 +929,8 @@ void l1t::TriggerMenuParser::parseDeltaEta_Cosh_LUTS(std::map<std::string, tmeve
   if (scaleMap.find(scLabel1) == scaleMap.end() || scaleMap.find(scLabel2) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
-  const esScale* scale2 = &scaleMap.find(scLabel2)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale2 = &scaleMap.find(scLabel2)->second;
   std::vector<double> val_delta_eta;
   std::vector<long long> lut_delta_eta;
   size_t n = getDeltaVector(val_delta_eta, scale1, scale2);
@@ -967,8 +964,8 @@ void l1t::TriggerMenuParser::parseDeltaPhi_Cos_LUTS(const std::map<std::string, 
   if (scaleMap.find(scLabel1) == scaleMap.end() || scaleMap.find(scLabel2) == scaleMap.end())
     return;
 
-  const esScale* scale1 = &scaleMap.find(scLabel1)->second;
-  const esScale* scale2 = &scaleMap.find(scLabel2)->second;
+  const tmeventsetup::esScale* scale1 = &scaleMap.find(scLabel1)->second;
+  const tmeventsetup::esScale* scale2 = &scaleMap.find(scLabel2)->second;
   std::vector<double> val_delta_phi;
   std::vector<long long> lut_delta_phi;
   size_t n = getDeltaVector(val_delta_phi, scale1, scale2);
@@ -1000,7 +997,7 @@ void l1t::TriggerMenuParser::parsePhi_Trig_LUTS(const std::map<std::string, tmev
   if (func != l1t::SIN and func != l1t::COS)
     return;
 
-  const esScale* scale = &scaleMap.find(scLabel)->second;
+  const tmeventsetup::esScale* scale = &scaleMap.find(scLabel)->second;
 
   const double step = scale->getStep();
   const double range = scale->getMaximum() - scale->getMinimum();
@@ -1037,9 +1034,8 @@ void l1t::TriggerMenuParser::parsePhi_Trig_LUTS(const std::map<std::string, tmev
  *
  */
 
-bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigned int chipNr, const bool corrFlag) {
+bool l1t::TriggerMenuParser::parseMuon(L1TUtmCondition condMu, unsigned int chipNr, const bool corrFlag) {
   using namespace tmeventsetup;
-
   // get condition, particle name (must be muon) and type name
   std::string condition = "muon";
   std::string particle = "muon";  //l1t2string( condMu.objectType() );
@@ -1101,9 +1097,9 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
 
   //  Look for cuts on the objects in the condition
   unsigned int chargeCorrelation = 1;
-  const std::vector<esCut>& cuts = condMu.getCuts();
+  const std::vector<L1TUtmCut>& cuts = condMu.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut& cut = cuts.at(jj);
+    const L1TUtmCut& cut = cuts.at(jj);
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
         chargeCorrelation = 2;
@@ -1124,9 +1120,9 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
   bool gEq = false;
 
   // Loop over objects and extract the cuts on the objects
-  const std::vector<esObject>& objects = condMu.getObjects();
+  const std::vector<L1TUtmObject>& objects = condMu.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -1150,9 +1146,9 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     int charge = -1;               //default value is to ignore unless specified
     int qualityLUT = 0xFFFF;       //default is to ignore unless specified.
 
-    const std::vector<esCut>& cuts = object.getCuts();
+    const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut& cut = cuts.at(kk);
+      const L1TUtmCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::UnconstrainedPt:
@@ -1304,7 +1300,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
   return true;
 }
 
-bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseMuonCorr(const L1TUtmObject* corrMu, unsigned int chipNr) {
   //    XERCES_CPP_NAMESPACE_USE
   using namespace tmeventsetup;
 
@@ -1382,9 +1378,9 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   int charge = -1;          //defaut is to ignore unless specified
   int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
-  const std::vector<esCut>& cuts = corrMu->getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrMu->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut& cut = cuts.at(kk);
+    const L1TUtmCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::UnconstrainedPt:  // Added for displaced muons
@@ -1544,9 +1540,7 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
  *
  */
 
-bool l1t::TriggerMenuParser::parseMuonShower(tmeventsetup::esCondition condMu,
-                                             unsigned int chipNr,
-                                             const bool corrFlag) {
+bool l1t::TriggerMenuParser::parseMuonShower(L1TUtmCondition condMu, unsigned int chipNr, const bool corrFlag) {
   using namespace tmeventsetup;
 
   // get condition, particle name (must be muon) and type name
@@ -1570,7 +1564,7 @@ bool l1t::TriggerMenuParser::parseMuonShower(tmeventsetup::esCondition condMu,
   }
 
   // Get the muon shower object
-  esObject object = condMu.getObjects().at(0);
+  L1TUtmObject object = condMu.getObjects().at(0);
   int relativeBx = object.getBxOffset();
 
   if (condMu.getType() == esConditionType::MuonShower0) {
@@ -1622,7 +1616,7 @@ bool l1t::TriggerMenuParser::parseMuonShower(tmeventsetup::esCondition condMu,
  *
  */
 
-bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsigned int chipNr, const bool corrFlag) {
+bool l1t::TriggerMenuParser::parseCalo(L1TUtmCondition condCalo, unsigned int chipNr, const bool corrFlag) {
   //    XERCES_CPP_NAMESPACE_USE
   using namespace tmeventsetup;
 
@@ -1747,9 +1741,9 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
   bool gEq = false;
 
   // Loop over objects and extract the cuts on the objects
-  const std::vector<esObject>& objects = condCalo.getObjects();
+  const std::vector<L1TUtmObject>& objects = condCalo.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -1770,9 +1764,9 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
                              // Note: Currently assumes that the LSB from hwQual() getter in L1Candidate provides the
                              // (single bit) information for the displacedLUT
 
-    const std::vector<esCut>& cuts = object.getCuts();
+    const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut& cut = cuts.at(kk);
+      const L1TUtmCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::Threshold:
@@ -1927,7 +1921,7 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
  *
  */
 
-bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCalo, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseCaloCorr(const L1TUtmObject* corrCalo, unsigned int chipNr) {
   //    XERCES_CPP_NAMESPACE_USE
   using namespace tmeventsetup;
 
@@ -2005,9 +1999,9 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
                            // Note:  Currently assume that the hwQual() getter in L1Candidate provides the
                            //        (single bit) information for the displacedLUT
 
-  const std::vector<esCut>& cuts = corrCalo->getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrCalo->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut& cut = cuts.at(kk);
+    const L1TUtmCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::Threshold:
@@ -2163,9 +2157,7 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
  *
  */
 
-bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergySum,
-                                            unsigned int chipNr,
-                                            const bool corrFlag) {
+bool l1t::TriggerMenuParser::parseEnergySum(L1TUtmCondition condEnergySum, unsigned int chipNr, const bool corrFlag) {
   //    XERCES_CPP_NAMESPACE_USE
   using namespace tmeventsetup;
 
@@ -2277,9 +2269,9 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
   //    l1t::EnergySumsObjectRequirement objPar = condEnergySum.objectRequirement();
 
   // Loop over objects and extract the cuts on the objects
-  const std::vector<esObject>& objects = condEnergySum.getObjects();
+  const std::vector<L1TUtmObject>& objects = condEnergySum.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     gEq = (object.getComparisonOperator() == esComparisonOperator::GE);
 
     //  BLW TO DO: This needs to be added to the Object Parameters
@@ -2291,9 +2283,9 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
 
-    const std::vector<esCut>& cuts = object.getCuts();
+    const std::vector<L1TUtmCut>& cuts = object.getCuts();
     for (size_t kk = 0; kk < cuts.size(); kk++) {
-      const esCut& cut = cuts.at(kk);
+      const L1TUtmCut& cut = cuts.at(kk);
 
       switch (cut.getCutType()) {
         case esCutType::Threshold:
@@ -2401,7 +2393,7 @@ bool l1t::TriggerMenuParser::parseEnergySum(tmeventsetup::esCondition condEnergy
  *
  */
 
-bool l1t::TriggerMenuParser::parseEnergySumCorr(const tmeventsetup::esObject* corrESum, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseEnergySumCorr(const L1TUtmObject* corrESum, unsigned int chipNr) {
   //    XERCES_CPP_NAMESPACE_USE
   using namespace tmeventsetup;
 
@@ -2467,9 +2459,9 @@ bool l1t::TriggerMenuParser::parseEnergySumCorr(const tmeventsetup::esObject* co
   int cntPhi = 0;
   unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
 
-  const std::vector<esCut>& cuts = corrESum->getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrESum->getCuts();
   for (size_t kk = 0; kk < cuts.size(); kk++) {
-    const esCut& cut = cuts.at(kk);
+    const L1TUtmCut& cut = cuts.at(kk);
 
     switch (cut.getCutType()) {
       case esCutType::Threshold:
@@ -2572,9 +2564,8 @@ bool l1t::TriggerMenuParser::parseEnergySumCorr(const tmeventsetup::esObject* co
  *
  */
 
-bool l1t::TriggerMenuParser::parseExternal(tmeventsetup::esCondition condExt, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseExternal(L1TUtmCondition condExt, unsigned int chipNr) {
   using namespace tmeventsetup;
-
   // get condition, particle name and type name
   std::string condition = "ext";
   std::string particle = "test-fix";
@@ -2596,9 +2587,9 @@ bool l1t::TriggerMenuParser::parseExternal(tmeventsetup::esCondition condExt, un
   unsigned int channelID = 0;
 
   // Get object for External conditions
-  const std::vector<esObject>& objects = condExt.getObjects();
+  const std::vector<L1TUtmObject>& objects = condExt.getObjects();
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     if (object.getType() == esObjectType::EXT) {
       relativeBx = object.getBxOffset();
       channelID = object.getExternalChannelId();
@@ -2647,9 +2638,8 @@ bool l1t::TriggerMenuParser::parseExternal(tmeventsetup::esCondition condExt, un
  *
  */
 
-bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseCorrelation(L1TUtmCondition corrCond, unsigned int chipNr) {
   using namespace tmeventsetup;
-
   std::string condition = "corr";
   std::string particle = "test-fix";
   std::string type = l1t2string(corrCond.getType());
@@ -2695,9 +2685,9 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
 
   // Get the correlation Cuts on the legs
   int cutType = 0;
-  const std::vector<esCut>& cuts = corrCond.getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrCond.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut& cut = cuts.at(jj);
+    const L1TUtmCut& cut = cuts.at(jj);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
@@ -2779,7 +2769,7 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
   corrParameter.corrCutType = cutType;
 
   // Get the two objects that form the legs
-  const std::vector<esObject>& objects = corrCond.getObjects();
+  const std::vector<L1TUtmObject>& objects = corrCond.getObjects();
   if (objects.size() != 2) {
     edm::LogError("TriggerMenuParser") << "incorrect number of objects for the correlation condition " << name
                                        << " corrFlag " << corrFlag << std::endl;
@@ -2788,7 +2778,7 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
 
   // loop over legs
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     LogDebug("TriggerMenuParser") << "      obj name = " << object.getName() << "\n";
     LogDebug("TriggerMenuParser") << "      obj type = " << object.getType() << "\n";
     LogDebug("TriggerMenuParser") << "      obj op = " << object.getComparisonOperator() << "\n";
@@ -2948,9 +2938,8 @@ bool l1t::TriggerMenuParser::parseCorrelation(tmeventsetup::esCondition corrCond
  *
  */
 
-bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition corrCond, unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseCorrelationThreeBody(L1TUtmCondition corrCond, unsigned int chipNr) {
   using namespace tmeventsetup;
-
   std::string condition = "corrThreeBody";
   std::string particle = "muon";
   std::string type = l1t2string(corrCond.getType());
@@ -2994,9 +2983,9 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
 
   // Get the correlation cuts on the legs
   int cutType = 0;
-  const std::vector<esCut>& cuts = corrCond.getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrCond.getCuts();
   for (size_t lll = 0; lll < cuts.size(); lll++) {  // START esCut lll
-    const esCut& cut = cuts.at(lll);
+    const L1TUtmCut& cut = cuts.at(lll);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
@@ -3034,7 +3023,7 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
   corrThreeBodyParameter.corrCutType = cutType;
 
   // Get the three objects that form the legs
-  const std::vector<esObject>& objects = corrCond.getObjects();
+  const std::vector<L1TUtmObject>& objects = corrCond.getObjects();
   if (objects.size() != 3) {
     edm::LogError("TriggerMenuParser") << "incorrect number of objects for the correlation condition " << name
                                        << " corrFlag " << corrFlag << std::endl;
@@ -3043,7 +3032,7 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
 
   // Loop over legs
   for (size_t lll = 0; lll < objects.size(); lll++) {
-    const esObject& object = objects.at(lll);
+    const L1TUtmObject& object = objects.at(lll);
     LogDebug("TriggerMenuParser") << "      obj name = " << object.getName() << "\n";
     LogDebug("TriggerMenuParser") << "      obj type = " << object.getType() << "\n";
     LogDebug("TriggerMenuParser") << "      obj bx = " << object.getBxOffset() << "\n";
@@ -3108,10 +3097,8 @@ bool l1t::TriggerMenuParser::parseCorrelationThreeBody(tmeventsetup::esCondition
  *
  */
 
-bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventsetup::esCondition& corrCond,
-                                                                unsigned int chipNr) {
+bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const L1TUtmCondition& corrCond, unsigned int chipNr) {
   using namespace tmeventsetup;
-
   std::string condition = "corrWithOverlapRemoval";
   std::string particle = "test-fix";
   std::string type = l1t2string(corrCond.getType());
@@ -3157,9 +3144,9 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
 
   // Get the correlation Cuts on the legs
   int cutType = 0;
-  const std::vector<esCut>& cuts = corrCond.getCuts();
+  const std::vector<L1TUtmCut>& cuts = corrCond.getCuts();
   for (size_t jj = 0; jj < cuts.size(); jj++) {
-    const esCut& cut = cuts.at(jj);
+    const L1TUtmCut& cut = cuts.at(jj);
 
     if (cut.getCutType() == esCutType::ChargeCorrelation) {
       if (cut.getData() == "ls")
@@ -3233,7 +3220,7 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
   corrParameter.corrCutType = cutType;
 
   // Get the two objects that form the legs
-  const std::vector<esObject>& objects = corrCond.getObjects();
+  const std::vector<L1TUtmObject>& objects = corrCond.getObjects();
   if (objects.size() != 3) {
     edm::LogError("TriggerMenuParser")
         << "incorrect number of objects for the correlation condition with overlap removal " << name << " corrFlag "
@@ -3243,7 +3230,7 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
 
   // Loop over legs
   for (size_t jj = 0; jj < objects.size(); jj++) {
-    const esObject& object = objects.at(jj);
+    const L1TUtmObject& object = objects.at(jj);
     LogDebug("TriggerMenuParser") << "      obj name = " << object.getName() << "\n";
     LogDebug("TriggerMenuParser") << "      obj type = " << object.getType() << "\n";
     LogDebug("TriggerMenuParser") << "      obj op = " << object.getComparisonOperator() << "\n";
@@ -3404,10 +3391,7 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const tmeventset
  *
  */
 
-bool l1t::TriggerMenuParser::parseAlgorithm(tmeventsetup::esAlgorithm algorithm, unsigned int chipNr) {
-  using namespace tmeventsetup;
-  //using namespace Algorithm;
-
+bool l1t::TriggerMenuParser::parseAlgorithm(L1TUtmAlgorithm algorithm, unsigned int chipNr) {
   // get alias
   std::string algAlias = algorithm.getName();
   const std::string& algName = algorithm.getName();
@@ -3461,5 +3445,4 @@ bool l1t::TriggerMenuParser::parseAlgorithm(tmeventsetup::esAlgorithm algorithm,
 
   return true;
 }
-
 // static class members

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.h
@@ -45,12 +45,13 @@
 
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 
-#include "tmEventSetup/esTriggerMenu.hh"
-#include "tmEventSetup/esAlgorithm.hh"
-#include "tmEventSetup/esCondition.hh"
-#include "tmEventSetup/esObject.hh"
-#include "tmEventSetup/esCut.hh"
-#include "tmEventSetup/esScale.hh"
+#include <cmath>
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmAlgorithm.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmCondition.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmObject.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmCut.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmScale.h"
 
 // forward declarations
 class GlobalCondition;
@@ -261,52 +262,52 @@ namespace l1t {
     int l1tstr2int(const std::string data);
 
     /// parse scales
-    /*     bool parseScale(tmeventsetup::esScale scale); */
-    //    bool parseScales( tmeventsetup::esScale scale);
+    /*     bool parseScale(L1TUtmScale scale); */
+    //    bool parseScales( L1TUtmScale scale);
     bool parseScales(std::map<std::string, tmeventsetup::esScale> scaleMap);
 
     /// parse a muon condition
     /*     bool parseMuon(XERCES_CPP_NAMESPACE::DOMNode* node, */
     /*             const std::string& name, unsigned int chipNr = 0, */
     /*             const bool corrFlag = false); */
-    bool parseMuon(tmeventsetup::esCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
+    bool parseMuon(L1TUtmCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
 
-    bool parseMuonCorr(const tmeventsetup::esObject* condMu, unsigned int chipNr = 0);
+    bool parseMuonCorr(const L1TUtmObject* condMu, unsigned int chipNr = 0);
 
     /// parse a muon shower condition
-    bool parseMuonShower(tmeventsetup::esCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
+    bool parseMuonShower(L1TUtmCondition condMu, unsigned int chipNr = 0, const bool corrFlag = false);
 
     /// parse a calorimeter condition
     /*     bool parseCalo(XERCES_CPP_NAMESPACE::DOMNode* node, */
     /*             const std::string& name, unsigned int chipNr = 0, */
     /*             const bool corrFlag = false); */
-    bool parseCalo(tmeventsetup::esCondition condCalo, unsigned int chipNr = 0, const bool corrFlag = false);
+    bool parseCalo(L1TUtmCondition condCalo, unsigned int chipNr = 0, const bool corrFlag = false);
 
-    bool parseCaloCorr(const tmeventsetup::esObject* corrCalo, unsigned int chipNr = 0);
+    bool parseCaloCorr(const L1TUtmObject* corrCalo, unsigned int chipNr = 0);
 
     /// parse an "energy sum" condition
     /* bool parseEnergySum(XERCES_CPP_NAMESPACE::DOMNode* node, */
     /*         const std::string& name, unsigned int chipNr = 0, */
     /*         const bool corrFlag = false); */
 
-    bool parseEnergySum(tmeventsetup::esCondition condEnergySums, unsigned int chipNr = 0, const bool corrFlag = false);
+    bool parseEnergySum(L1TUtmCondition condEnergySums, unsigned int chipNr = 0, const bool corrFlag = false);
 
-    bool parseEnergySumCorr(const tmeventsetup::esObject* corrESum, unsigned int chipNr = 0);
+    bool parseEnergySumCorr(const L1TUtmObject* corrESum, unsigned int chipNr = 0);
 
-    bool parseExternal(tmeventsetup::esCondition condExt, unsigned int chipNr = 0);
+    bool parseExternal(L1TUtmCondition condExt, unsigned int chipNr = 0);
 
     /// parse a correlation condition
-    bool parseCorrelation(tmeventsetup::esCondition corrCond, unsigned int chipNr = 0);
+    bool parseCorrelation(L1TUtmCondition corrCond, unsigned int chipNr = 0);
 
     /// parse a three-body correlation condition
-    bool parseCorrelationThreeBody(tmeventsetup::esCondition corrCond, unsigned int chipNr = 0);
+    bool parseCorrelationThreeBody(L1TUtmCondition corrCond, unsigned int chipNr = 0);
 
     /// parse a correlation condition with overlap removal
-    bool parseCorrelationWithOverlapRemoval(const tmeventsetup::esCondition& corrCond, unsigned int chipNr = 0);
+    bool parseCorrelationWithOverlapRemoval(const L1TUtmCondition& corrCond, unsigned int chipNr = 0);
 
     /// parse all algorithms
     //bool parseAlgorithms(XERCES_CPP_NAMESPACE::XercesDOMParser* parser);
-    bool parseAlgorithm(tmeventsetup::esAlgorithm algorithm, unsigned int chipNr = 0);
+    bool parseAlgorithm(L1TUtmAlgorithm algorithm, unsigned int chipNr = 0);
 
     // Parse LUT for Cal Mu Eta
     void parseCalMuEta_LUTS(std::map<std::string, tmeventsetup::esScale> scaleMap, std::string obj1, std::string obj2);


### PR DESCRIPTION
### PR description:

This PR changes L1TGlobal code and CondFormats to remove three instances of `reinterpret_cast` (one in `L1TUtmTriggerMenuESProducer`, and two in `TriggerMenuParser`) that were attempting to reinterpret pointers of [utm Trigger Menu code/objects](https://gitlab.cern.ch/arnold/utm) to CMSSW `L1TUtm` objects (with undefined behavior). To achieve this, constructors were added to equivalent `L1TUtm` objects that can accept firmware `utm/es` objects and create exact (or at the least, more _defined_) copies by copying values. These `L1TUtm` objects should now be used with preference in CMSSW and across L1TGlobal code.

This code _**should not**_ produce any change in global trigger results. Any change in trigger results is incorrect and should not be merged.

These changes were requested in review of https://github.com/cms-sw/cmsdist/pull/8352 and may address an issue seen in the testing of that PR. Regardless of whether it fixes that issue, these changes were requested.

These changes should in theory close https://github.com/cms-sw/cmssw/issues/30819

@elfontan I figured you might like to be kept apprised of these changes.

### PR validation:

All code compiles, and passes all unit tests, with special attention paid to the `testL1TGlobalProducer`, which produces identical results. Run the matrix seems to produce reasonable output. I have also confirmed (using print statements) that the now copied-by-value `L1TUtmTriggerMenu` members should be entirely identical to the `L1TUtmTriggerMenu` produced previously by `reinterpret_cast`

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport. This PR may need to be backported to 13_0 to match the corresponding utm firmware update backport, if this PR solves the issue seen in https://github.com/cms-sw/cmsdist/pull/8352. @epalencia may be able to clarify if that is necessary.
