### PR TITLE
remove duplicates from `PhysicsTools/TensorFlow/test/BuildFile.xml`

### DIFF
--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -19,7 +19,6 @@
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>
 </iftool>
@@ -42,7 +41,6 @@
     <use name="FWCore/ServiceRegistry"/>
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>
@@ -67,7 +65,6 @@
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>
 </iftool>
@@ -90,7 +87,6 @@
     <use name="FWCore/ServiceRegistry"/>
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>
@@ -115,7 +111,6 @@
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>
 </iftool>
@@ -138,7 +133,6 @@
     <use name="FWCore/ServiceRegistry"/>
     <use name="FWCore/Utilities"/>
     <use name="HeterogeneousCore/CUDAServices"/>
-    <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
     <use name="PhysicsTools/TensorFlow"/>
   </bin>


### PR DESCRIPTION
#### PR description:

This PR removes duplicates of
```xml
<use name="HeterogeneousCore/CUDAUtilities"/>
```
from `PhysicsTools/TensorFlow/test/BuildFile.xml`, as requested by `scram`.
```
***WARNING: Multiple usage of "HeterogeneousCore/CUDAUtilities". Please cleanup "use" in "export" section of "src/PhysicsTools/TensorFlow/test/BuildFile.xml"
```

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
