### PR TITLE
[13_0_X] Fix implicit host-to-device copy for ES data products with labels in Alpaka ESProducers

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h
@@ -33,6 +33,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
   protected:
+    ESProducer(edm::ParameterSet const& iConfig);
+
     template <typename T>
     auto setWhatProduced(T* iThis, edm::es::Label const& label = {}) {
       return setWhatProduced(iThis, &T::produce, label);
@@ -52,7 +54,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               return std::optional{CopyT::copyAsync(iRecord.queue(), *handle)};
             },
             label);
-        *tokenPtr = ccDev.consumes();
+        *tokenPtr = ccDev.consumes(edm::ESInputTag{moduleLabel_, label.default_ + appendToDataLabel_});
       }
       return cc;
     }
@@ -129,6 +131,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     static void throwSomeNullException();
+
+    std::string const moduleLabel_;
+    std::string const appendToDataLabel_;
   };
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/HeterogeneousCore/AlpakaCore/src/alpaka/ESProducer.cc
+++ b/HeterogeneousCore/AlpakaCore/src/alpaka/ESProducer.cc
@@ -2,6 +2,10 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  ESProducer::ESProducer(edm::ParameterSet const& iConfig)
+      : moduleLabel_(iConfig.getParameter<std::string>("@module_label")),
+        appendToDataLabel_(iConfig.getParameter<std::string>("appendToDataLabel")) {}
+
   void ESProducer::throwSomeNullException() {
     throw edm::Exception(edm::errors::UnimplementedFeature)
         << "The Alpaka backend has multiple devices. The device-specific produce() function returned a null product "

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerA.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerA.cc
@@ -17,7 +17,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class TestAlpakaESProducerA : public ESProducer {
   public:
-    TestAlpakaESProducerA(edm::ParameterSet const& iConfig) {
+    TestAlpakaESProducerA(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
       auto cc = setWhatProduced(this);
       token_ = cc.consumes();
     }

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerB.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerB.cc
@@ -21,7 +21,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class TestAlpakaESProducerB : public ESProducer {
   public:
-    TestAlpakaESProducerB(edm::ParameterSet const& iConfig) {
+    TestAlpakaESProducerB(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
       auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("explicitLabel"));
       token_ = cc.consumes();
     }

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerC.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerC.cc
@@ -20,7 +20,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class TestAlpakaESProducerC : public ESProducer {
   public:
-    TestAlpakaESProducerC(edm::ParameterSet const& iConfig) {
+    TestAlpakaESProducerC(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
       auto cc = setWhatProduced(this);
       token_ = cc.consumes();
     }

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerD.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerD.cc
@@ -22,7 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
    */
   class TestAlpakaESProducerD : public ESProducer {
   public:
-    TestAlpakaESProducerD(edm::ParameterSet const& iConfig) {
+    TestAlpakaESProducerD(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
       auto cc = setWhatProduced(this);
       tokenA_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("srcA"));
       tokenB_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("srcB"));

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducer.cc
@@ -21,7 +21,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlpakaGlobalProducer : public global::EDProducer<> {
   public:
     TestAlpakaGlobalProducer(edm::ParameterSet const& config)
-        : esToken_(esConsumes()),
+        : esToken_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"))),
           deviceToken_{produces()},
           size_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
               EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {}
@@ -39,6 +39,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      desc.add("eventSetupSource", edm::ESInputTag{});
 
       edm::ParameterSetDescription psetSize;
       psetSize.add<int32_t>("alpaka_serial_sync");

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamProducer.cc
@@ -27,7 +27,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : size_{config.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
               EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {
       getToken_ = consumes(config.getParameter<edm::InputTag>("source"));
-      esToken_ = esConsumes();
+      esToken_ = esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"));
       devicePutToken_ = produces(config.getParameter<std::string>("productInstanceName"));
     }
 
@@ -46,6 +46,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("source");
+      desc.add("eventSetupSource", edm::ESInputTag{});
       desc.add<std::string>("productInstanceName", "");
 
       edm::ParameterSetDescription psetSize;

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -50,10 +50,8 @@ process.esProducerB = cms.ESProducer("cms::alpakatest::TestESProducerB", value =
 process.esProducerC = cms.ESProducer("cms::alpakatest::TestESProducerC", value = cms.int32(27))
 
 from HeterogeneousCore.AlpakaTest.testAlpakaESProducerA_cfi import testAlpakaESProducerA 
-process.alpakaESProducerA = testAlpakaESProducerA.clone()
-process.alpakaESProducerAdataLabel = process.alpakaESProducerA.clone(appendToDataLabel = cms.string("appendedLabel"))
-process.alpakaESProducerB = cms.ESProducer("TestAlpakaESProducerB@alpaka")
-process.alpakaESProducerBexplicitLabel = process.alpakaESProducerB.clone(explicitLabel = cms.string("explicitLabel"))
+process.alpakaESProducerA = testAlpakaESProducerA.clone(appendToDataLabel = cms.string("appendedLabel"))
+process.alpakaESProducerB = cms.ESProducer("TestAlpakaESProducerB@alpaka", explicitLabel = cms.string("explicitLabel"))
 process.alpakaESProducerC = cms.ESProducer("TestAlpakaESProducerC@alpaka")
 process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka",
     srcA = cms.ESInputTag("", "appendedLabel"),
@@ -64,6 +62,7 @@ process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
 
 from HeterogeneousCore.AlpakaTest.testAlpakaGlobalProducer_cfi import testAlpakaGlobalProducer
 process.alpakaGlobalProducer = testAlpakaGlobalProducer.clone(
+    eventSetupSource = cms.ESInputTag("alpakaESProducerA", "appendedLabel"),
     size = dict(
         alpaka_serial_sync = 10,
         alpaka_cuda_async = 20
@@ -71,6 +70,7 @@ process.alpakaGlobalProducer = testAlpakaGlobalProducer.clone(
 )
 process.alpakaStreamProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",
     source = cms.InputTag("intProduct"),
+    eventSetupSource = cms.ESInputTag("alpakaESProducerB", "explicitLabel"),
     size = cms.PSet(
         alpaka_serial_sync = cms.int32(5),
         alpaka_cuda_async = cms.int32(25)
@@ -78,6 +78,7 @@ process.alpakaStreamProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",
 )
 process.alpakaStreamInstanceProducer = cms.EDProducer("TestAlpakaStreamProducer@alpaka",
     source = cms.InputTag("intProduct"),
+    eventSetupSource = cms.ESInputTag("alpakaESProducerB", "explicitLabel"),
     productInstanceName = cms.string("testInstance"),
     size = cms.PSet(
         alpaka_serial_sync = cms.int32(6),


### PR DESCRIPTION
#### PR description:

Backport of #41019, original description

> It was noticed during the Patatrack hackathon that the implicit host-to-device copy of EventSetup data products did not work correctly in Alpaka ESProducers when the data product had a label set (either via explicit argument to `setWhatProduced()` or via the `appendToDataLabel` configuration parameter). The test code that I added in #40813 turned out to have a flaw, because of which the problem was not caught earlier.

#### PR validation:

None beyond #41019

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #41019 in light of the future Alpaka use.