### PR TITLE
[Nano] Fix JetTable genJetIdx matching

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetMC_cff.py
@@ -12,7 +12,8 @@ jetMCTable = simpleCandidateFlatTableProducer.clone(
     variables = cms.PSet(
         partonFlavour = Var("partonFlavour()", "int16", doc="flavour from parton matching"),
         hadronFlavour = Var("hadronFlavour()", "uint8", doc="flavour from hadron ghost clustering"),
-        genJetIdx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1", "int16", doc="index of matched gen jet"),
+        # cut should follow genJetTable.cut
+        genJetIdx = Var("?genJetFwdRef().backRef().isNonnull() && genJetFwdRef().backRef().pt() > 10.?genJetFwdRef().backRef().key():-1", "int16", doc="index of matched gen jet"),
     )
 )
 genJetTable = simpleCandidateFlatTableProducer.clone(
@@ -90,6 +91,7 @@ fatJetMCTable = simpleCandidateFlatTableProducer.clone(
         nBHadrons = Var("jetFlavourInfo().getbHadrons().size()", "uint8", doc="number of b-hadrons"),
         nCHadrons = Var("jetFlavourInfo().getcHadrons().size()", "uint8", doc="number of c-hadrons"),
         hadronFlavour = Var("hadronFlavour()", "uint8", doc="flavour from hadron ghost clustering"),
+        # cut should follow genJetAK8Table.cut
         genJetAK8Idx = Var("?genJetFwdRef().backRef().isNonnull() && genJetFwdRef().backRef().pt() > 100.?genJetFwdRef().backRef().key():-1", "int16", doc="index of matched gen AK8 jet"),
     )
 )


### PR DESCRIPTION
#### PR description:

Same as https://github.com/cms-sw/cmssw/pull/33839 but for regular jets instead of fat jets: in some rare cases, the index of the genJet matched to a jet points to a genJet which is not stored, because of the pt cut applied to the GenJet collection.

This fix frees the user from having to check that `Jet_genJetIdx < nGenJet`.