### PR TITLE
fix unit test: avoid creating data files in src tree

### DIFF
--- a/CondFormats/JetMETObjects/test/BuildFile.xml
+++ b/CondFormats/JetMETObjects/test/BuildFile.xml
@@ -1,8 +1,10 @@
+<flags USE_UNITTEST_DIR="1"/>
 <bin file="testSerializationJetMETObjects.cpp">
   <use name="CondFormats/JetMETObjects"/>
 </bin>
 
 <bin name="TestCondFormatsJetMETObjectsJetCorrectorParameters" file="JetCorrectorParameters_t.cpp">
+  <flags TEST_RUNNER_CMD="run_TestCondFormatsJetMETObjectsJetCorrectorParameters.sh"/>
   <use name="FWCore/Utilities"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="cppunit"/>

--- a/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
+++ b/CondFormats/JetMETObjects/test/JetCorrectorParameters_t.cpp
@@ -121,8 +121,7 @@ void testJetCorrectorParameters::destroyCorrector() {
 }
 
 void testJetCorrectorParameters::generateFiles() {
-  string path = std::getenv("CMSSW_BASE");
-  path += "/src/CondFormats/JetMETObjects/data/";
+  string path = "CondFormats/JetMETObjects/data/";
   string name1D = "testJetCorrectorParameters_1D_L1FastJet_AK4PFchs.txt";
   string name3D = "testJetCorrectorParameters_3D_L1FastJet_AK4PFchs.txt";
 

--- a/CondFormats/JetMETObjects/test/run_TestCondFormatsJetMETObjectsJetCorrectorParameters.sh
+++ b/CondFormats/JetMETObjects/test/run_TestCondFormatsJetMETObjectsJetCorrectorParameters.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+mkdir -p CondFormats/JetMETObjects/data
+TestCondFormatsJetMETObjectsJetCorrectorParameters 


### PR DESCRIPTION
This change allows the unit test `TestCondFormatsJetMETObjectsJetCorrectorParameters` to not generate data files in src tree (` $CMSSW_BASE/src/CondFormats/JetMETObjects/data/` ) but use unit tests area for these temp files.