### PR TITLE
run tests in separate tests

### DIFF
--- a/CalibCalorimetry/EcalLaserSorting/test/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserSorting/test/BuildFile.xml
@@ -1,1 +1,2 @@
+<flags USE_UNITTEST_DIR="1"/>
 <test name="CalibCalorimetryEcalLaserSortingRunStreamer" command="RunStreamer.sh"/>

--- a/DQMServices/StreamerIO/test/BuildFile.xml
+++ b/DQMServices/StreamerIO/test/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags USE_UNITTEST_DIR="1"/>
 <use name="FWCore/Framework"/>
 <use name="IOPool/Streamer"/>
 <use name="EventFilter/Utilities"/>


### PR DESCRIPTION
This is a quick fix for unittests failing in IBs. Both tests generate same output files name [a] which also conflict with `out` directory generated by another test. For now I propose to run these tests in their own separate directory. Once we enable `USE_UNITTEST_DIR` for cmssw then these changes can be reverted.

[a]
```
Singularity> ls *
CalibCalorimetryEcalLaserSortingRunStreamer:
alt  corrupt  ext  gennums.txt  in  inDir  myout.root  out  outAlt  outExt  process  processed  teststreamfile.original  watcherSourceToken

DQMServicesStreamerIORunStreamer:
alt  ext  gennums.txt  in  myout.root  out  outAlt  outExt  run000001
```