### PR TITLE
[HLT validation and DQM] update for new EXO displaced photon + HT path for 2023 (13_1_X)

### DIFF
--- a/DQMOffline/Trigger/python/PhotonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cff.py
@@ -43,26 +43,12 @@ SinglePhoton165_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon165_R9Id90_HE10_IsoM_v*"])
 )
 
-Photon60_monitoring = hltPhotonmonitoring.clone(
-    FolderName = 'HLT/EGM/Photon/Photon60/',
+Photon60_DisplacedIdL_PFHT350_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL_PFHT350/',
     photonSelection = "pt > 20 && r9() < 0.1 && ((eta<1.4442 && hadTowOverEm<0.0597 && full5x5_sigmaIetaIeta()<0.01031 && chargedHadronIso<1.295) || (eta<2.5 && eta>1.566 && hadTowOverEm<0.0481 && full5x5_sigmaIetaIeta()<0.03013 && chargedHadronIso<1.011))",
-    denGenericTriggerEventPSet = dict(hltPaths = []),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*"])
-)
-
-
-Photon60_DisplacedIdL_monitoring = Photon60_monitoring.clone(
-    FolderName = 'HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL/',
-    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*"]),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v*"])
-)
-
-
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring = Photon60_DisplacedIdL_monitoring.clone(
-    FolderName = 'HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL_PFJet350MinPFJet15/',
     denGenericTriggerEventPSet = dict(andOrHlt = False,
-                                      hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*","HLT_PFHT350MinPFJet15_v*"]),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v*"])
+                                      hltPaths = ["HLT_Photon50_R9Id90_HE10_IsoM_v*","HLT_PFHT350_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350_v*"])
 )
 
 
@@ -114,9 +100,7 @@ Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_monitoring = hltobjmonitoring
 exoHLTPhotonmonitoring = cms.Sequence(
     SinglePhoton300_monitoring
     + SinglePhoton200_monitoring
-    + Photon60_monitoring
-    + Photon60_DisplacedIdL_monitoring
-    + Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring
+    + Photon60_DisplacedIdL_PFHT350_monitoring
     + SinglePhoton50_R9Id90_HE10_IsoM_monitoring
     + SinglePhoton75_R9Id90_HE10_IsoM_monitoring
     + SinglePhoton90_R9Id90_HE10_IsoM_monitoring

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 HighPtPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Photon175_v",  # Run2 proposal # Claimed path for Run3
-        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017 # Claimed path for Run3
+        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350_v", # Path updated for 2023
         "HLT_Photon110EB_TightID_TightIso_v", # Claimed path for Run3 
         "HLT_Photon200_v" # Claimed path for Run3
         ),


### PR DESCRIPTION
#### PR description:

This PR updates the HLT validation and offline DQM for a new EXO displaced photon + HT path for 2023. It also cleans up the monitoring of photon +HT paths that have been dropped in the 2023 menu.

As a result of this PR, some DQM plots will be removed, and some will be added (more histograms removed than added).



#### PR validation:

Using the 11634.0 ttbar workflow, I have tested that the correct histograms are produced and filled in the harvested DQM file.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 13_0_X for the 2023 HLT menu.
