### PR TITLE
Make jets in TauGenJetProducer from taus which are not decayed

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
@@ -31,7 +31,6 @@ public:
 
 private:
   /// Input PFCandidates
-  const edm::InputTag inputTagGenParticles_;
   const edm::EDGetTokenT<reco::GenParticleCollection> tokenGenParticles_;
 
   /// if yes, neutrinos will be included, for debug purposes


### PR DESCRIPTION
#### PR description:

Instead of creating a dummy empty jet, taus which were not decayed by the generator are now used to create a jet based on the tau's own data. This avoids failures in the integration builds.

Did some minor code cleanups.

#### PR validation:

Code compiles.