### PR TITLE
[DB] Cleanup USE_UNITTEST_DIR which is now enabled at project level

### DIFF
--- a/CondFormats/JetMETObjects/test/BuildFile.xml
+++ b/CondFormats/JetMETObjects/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags USE_UNITTEST_DIR="1"/>
 <bin file="testSerializationJetMETObjects.cpp">
   <use name="CondFormats/JetMETObjects"/>
 </bin>


### PR DESCRIPTION
This flag is not needed any more at package/BuildFile.xml level as it has been enabled at project level