### PR TITLE
[PDMV-UPGRADE] Cleanup USE_UNITTEST_DIR which is now enabled at project level

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -1,6 +1,4 @@
 <test name="test-das-selected-lumis" command="test-das-selected-lumis.sh">
-  <flags USE_UNITTEST_DIR="1"/>
 </test>
 <test name="test-runTheMatrix-interactive" command="test-runTheMatrix_interactive.sh">
-  <flags USE_UNITTEST_DIR="1"/>
 </test>


### PR DESCRIPTION
This flag is not needed any more at package/BuildFile.xml level as it has been enabled at project level