### PR TITLE
[ALCA] Cleanup USE_UNITTEST_DIR which is now enabled at project level

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -5,7 +5,6 @@
   <use name="CondFormats/Alignment"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-<flags USE_UNITTEST_DIR="1"/>
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ./test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
 <test name="test-pede" command="pede -t">


### PR DESCRIPTION
This flag is not needed any more at package/BuildFile.xml level as it has been enabled at project level