### PR TITLE
[DQM-GEOMETRY] Cleanup USE_UNITTEST_DIR which is now enabled at project level

### DIFF
--- a/Validation/Geometry/test/BuildFile.xml
+++ b/Validation/Geometry/test/BuildFile.xml
@@ -1,4 +1,3 @@
 <!--CMSBot IB tests-->
-<flags USE_UNITTEST_DIR="1"/>
 <test name="materialBudgetTrackerPlots" command="genTrackerPlots.sh"/>
 <test name="materialBudgetHGCalPlots" command="genHGCalPlots.sh"/>


### PR DESCRIPTION
This flag is not needed any more at package/BuildFile.xml level as it has been enabled at project level