### PR TITLE
[CORE] Cleanup USE_UNITTEST_DIR which is now enabled at project level

### DIFF
--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags USE_UNITTEST_DIR="1"/>
 <use name="boost"/>
 <library file="DummyData.cc,DummyRecord.cc,DepRecord.cc,Dummy2Record.cc,DepOn2Record.cc" name="FWCoreFrameworkTestDummyForEventSetup">
   <use name="FWCore/Framework"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <flags USE_UNITTEST_DIR="1"/>
   <bin name="TestFWCoreIntegrationStandalone" file="testRunner.cpp,standalone_t.cppunit.cc">
     <use name="cppunit"/>
     <use name="FWCore/Framework"/>

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags USE_UNITTEST_DIR="1"/>
 <library file="StuckAnalyzer.cc" name="StuckAnalyzer">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Framework"/>

--- a/IOPool/Common/test/BuildFile.xml
+++ b/IOPool/Common/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<flags USE_UNITTEST_DIR="1"/>
 <test name="TestEdmFastMerge" command="TestEdmFastMerge.sh"/>
 <test name="TestEdmConfigDump" command="run_TestEdmConfigDump.sh"/>
 <test name="testIOPoolCommonLumiOverlap" command="test_overlap_lumi_fast_copy.sh"/>

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <flags USE_UNITTEST_DIR="1"/>
   <test name="TestPoolInput" command="TestPoolInput.sh"/>
 
   <library file="IOExerciser.cc" name="IOExerciser">

--- a/IOPool/Output/test/BuildFile.xml
+++ b/IOPool/Output/test/BuildFile.xml
@@ -1,2 +1,1 @@
-<flags USE_UNITTEST_DIR="1"/>
 <test name="TestPoolOutput" command="TestPoolOutput.sh"/>

--- a/IOPool/SecondaryInput/test/BuildFile.xml
+++ b/IOPool/SecondaryInput/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <flags USE_UNITTEST_DIR="1"/>
   <test name="TestSecondaryInput" command="TestSecondaryInput.sh"/>
 
   <library file="SecondaryProducer.cc" name="SecondaryProducer">

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <flags USE_UNITTEST_DIR="1"/>
   <use name="FWCore/Framework"/>
   <bin file="EventMessageTest.cpp">
     <use name="IOPool/Streamer"/>


### PR DESCRIPTION
This flag is not needed any more at package/BuildFile.xml level as it has been enabled at project level