### PR TITLE
Link cmsRunJEProf with jemalloc-prof version of jemalloc lib

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc"/>
+  <use name="jemalloc-prof"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>

--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc-prof"/>
+  <use name="jemalloc"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>
@@ -75,6 +75,20 @@
   <use name="boost_program_options"/>
   <use name="tcmalloc"/>
   <use name="gperf"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ParameterSetReader"/>
+</bin>
+
+<bin name="cmsRunJEProf" file="cmsRun.cpp">
+  <use name="tbb"/>
+  <use name="boost"/>
+  <use name="boost_program_options"/>
+  <use name="jemalloc-prof"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
Link `cmsRunJEProf` against `jemalloc-prof` a version of the jemalloc library with profiling enabled during compilation.