### PR TITLE
Have ExternalGeneratorFilter throw an generator specific exception

### DIFF
--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -77,8 +77,9 @@ namespace externalgen {
       if (not channel_.doTransition(
               [&value, &iDeserializer]() { value = iDeserializer.deserialize(); }, iTrans, iTransitionID)) {
         externalFailed_ = true;
-        throw cms::Exception("ExternalFailed") << "failed waiting for external process " << channel_.uniqueID()
-                                               << ". Timed out after " << channel_.maxWaitInSeconds() << " seconds.";
+        throw edm::Exception(edm::errors::EventGenerationFailure)
+            << "failed waiting for external process " << channel_.uniqueID() << ". Timed out after "
+            << channel_.maxWaitInSeconds() << " seconds.";
       }
       return value;
     }


### PR DESCRIPTION
#### PR description:

Looking at log files from failed jobs showed that the external failures at event time where all caused by the generators being run in the external process. Throwing a generator specific exception will cause cmsRun to exit with a specific code which will help evaluate failures in the production system.

#### PR validation:

Code compiles.