### PR TITLE
[unit test] make sure copied directory has write permissions

### DIFF
--- a/Alignment/TrackerAlignment/test/pixelPositions.sh
+++ b/Alignment/TrackerAlignment/test/pixelPositions.sh
@@ -154,6 +154,7 @@ EOF
     then
        mkdir ${PLOTDIR}
        cp -r $PLOTMILLEPEDEDIR/* ${PLOTDIR}
+       chmod -R +w ${PLOTDIR}
     fi
     cd ${PLOTDIR}
     root -b -q -l allMillePede.C "pixelPositionChange.C+(\"${HEREIAM}/$TREEFILE1\", \"${HEREIAM}/$TREEFILE2\")"


### PR DESCRIPTION
latest bot [changes](https://github.com/cms-sw/cms-bot/pull/1955/files) make sure that unit test do not generate any data in cmssw/src tree. This is done by dropping the write permissions from the cmssw/src during the PR tests. Whitgh new bot changes the unit test  `test_PixelBaryCentreTool` fails as it can not generate files in the copied `Alignment/MillePedeAlignmentAlgorithm/macros` directory. This PR proposes that tests make sure that the copied directory has write permissions. 