### PR TITLE
Have ExternalGeneratorFilter throw an generator specific exception [13_0]

### DIFF
--- a/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
+++ b/GeneratorInterface/Core/plugins/ExternalGeneratorFilter.cc
@@ -77,8 +77,9 @@ namespace externalgen {
       if (not channel_.doTransition(
               [&value, &iDeserializer]() { value = iDeserializer.deserialize(); }, iTrans, iTransitionID)) {
         externalFailed_ = true;
-        throw cms::Exception("ExternalFailed") << "failed waiting for external process " << channel_.uniqueID()
-                                               << ". Timed out after " << channel_.maxWaitInSeconds() << " seconds.";
+        throw edm::Exception(edm::errors::EventGenerationFailure)
+            << "failed waiting for external process " << channel_.uniqueID() << ". Timed out after "
+            << channel_.maxWaitInSeconds() << " seconds.";
       }
       return value;
     }


### PR DESCRIPTION

#### PR description:

Looking at log files from failed jobs showed that the external failures at event time where all caused by the generators being run in the external process. Throwing a generator specific exception will cause cmsRun to exit with a specific code which will help evaluate failures in the production system.

#### PR validation:

Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #41073