### PR TITLE
Added new cms::errors::ExternalFailure exception [13_0]

### DIFF
--- a/FWCore/Integration/plugins/TestInterProcessProd.cc
+++ b/FWCore/Integration/plugins/TestInterProcessProd.cc
@@ -63,7 +63,7 @@ namespace testinter {
               iTransitionID)) {
         std::cout << id_ << " FAILED waiting for external process" << std::endl;
         externalFailed_ = true;
-        throw cms::Exception("ExternalFailed");
+        throw edm::Exception(edm::errors::ExternalFailure);
       }
       return value;
     }

--- a/FWCore/Integration/plugins/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/plugins/TestInterProcessRandomProd.cc
@@ -75,7 +75,7 @@ namespace testinter {
               iTransitionID)) {
         std::cout << id_ << " FAILED waiting for external process" << std::endl;
         externalFailed_ = true;
-        throw cms::Exception("ExternalFailed");
+        throw edm::Exception(edm::errors::ExternalFailure);
       }
       return value;
     }

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -29,7 +29,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"
-#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/SharedMemory/interface/BufferInfo.h"
 
 // forward declarations
@@ -63,7 +63,7 @@ namespace edm::shared_memory {
       if (not wait(lock)) {
         //std::cout << id_ << " FAILED waiting for external process" << std::endl;
         *stop_ = true;
-        throw cms::Exception("ExternalFailed")
+        throw edm::Exception(edm::errors::ExternalFailure)
             << "Failed waiting for external process while setting up the process. Timed out after " << maxWaitInSeconds_
             << " seconds.";
       } else {
@@ -87,7 +87,7 @@ namespace edm::shared_memory {
         if (not wait(lock)) {
           if (not iRetry()) {
             *stop_ = true;
-            throw cms::Exception("ExternalFailed")
+            throw edm::Exception(edm::errors::ExternalFailure)
                 << "Failed waiting for external process while setting up the process. Timed out after "
                 << maxWaitInSeconds_ << " seconds with " << retryCount << " retries.";
           }

--- a/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
+++ b/FWCore/SharedMemory/test/test_channels_startupTimeout.cc
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
       retValue = controller(argc, argv, 5);
     }
   } catch (cms::Exception const& iException) {
-    if (iException.category() != "ExternalFailed") {
+    if (iException.category() != "ExternalFailure") {
       throw;
     } else {
       std::cout << "expected failure occurred\n";

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -68,6 +68,7 @@ namespace edm {
       FileNameInconsistentWithGUID = 8034,
 
       UnavailableAccelerator = 8035,
+      ExternalFailure = 8036,
 
       EventGenerationFailure = 8501,
 

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -44,6 +44,7 @@ namespace edm {
                                                               FILLENTRY(FileWriteError),
                                                               FILLENTRY(FileNameInconsistentWithGUID),
                                                               FILLENTRY(UnavailableAccelerator),
+                                                              FILLENTRY(ExternalFailure),
                                                               FILLENTRY(EventGenerationFailure),
                                                               FILLENTRY(CaughtSignal)};
     static const std::string kUnknownCode("unknownCode");


### PR DESCRIPTION
#### PR description:

In order to allow a unique return code in the case of a failure in the SharedMemory package we added a new error code.

#### PR validation:

Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

back port of #41074