### PR TITLE
Unit test: Do not generate files in top level directory

### DIFF
--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,13 +1,11 @@
 #!/bin/bash -ex
 
-cd ${LOCALTOP}
-curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o ${LOCALTOP}/tmp/GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
-touch ${LOCALTOP}/tmp/GIP8/__init__.py
-export PYTHONPATH="${LOCALTOP}/tmp${PYTHONPATH:+:$PYTHONPATH}"
+curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
+touch GIP8/__init__.py
+export PYTHONPATH="${PWD}${PYTHONPATH:+:$PYTHONPATH}"
 
 cmsDriver.py GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(10)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
 
 sed -i "s/Pythia8GeneratorFilter/Pythia8ConcurrentGeneratorFilter/g" test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
 
 cmsRun test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py
-rm -rf ${LOCALTOP}/tmp/GIP8


### PR DESCRIPTION
This unit tests was running n top level directory and creating log files and python files in `LOCALTOP`. This PR fixes this and allows this test to generate files in its own test directory (which is prepared by scram)