### PR TITLE
Renamed ParticleNet paths and reduced threshold on AK8 pT

### DIFF
--- a/DQMOffline/Trigger/python/ParticleNetAK8HbbTagClient_cfi.py
+++ b/DQMOffline/Trigger/python/ParticleNetAK8HbbTagClient_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 particleNetAK8HbbTagEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs    = cms.untracked.vstring("HLT/HIG/PNETAK8/HLT_IsoMu50_AK8PFJet230_SoftDropMass40_PFAK8ParticleNetBB0p35_or_HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet230_SoftDropMass40/"),
+    subDirs    = cms.untracked.vstring("HLT/HIG/PNETAK8/HLT_IsoMu50_AK8PFJet220_SDMass40_PFAK8PNetBB0p35_or_HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet220_SDMass40/"),
     verbose    = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution = cms.vstring(),
     efficiency = cms.vstring(

--- a/DQMOffline/Trigger/python/ParticleNetAK8HbbTagMonitoring_cfi.py
+++ b/DQMOffline/Trigger/python/ParticleNetAK8HbbTagMonitoring_cfi.py
@@ -4,7 +4,7 @@ from DQMOffline.Trigger.ParticleNetJetTagMonitor_cfi import ParticleNetJetTagMon
 
 particleNetAK8HbbTagMonitoring = _particleNetJetTagMonitor.clone(
     ## general options
-    FolderName = "HLT/HIG/PNETAK8/HLT_IsoMu50_AK8PFJet230_SoftDropMass40_PFAK8ParticleNetBB0p35_or_HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet230_SoftDropMass40/",
+    FolderName = "HLT/HIG/PNETAK8/HLT_IsoMu50_AK8PFJet220_SDMass40_PFAK8PNetBB0p35_or_HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet220_SDMass40/",
     requireValidHLTPaths = True,
     requireHLTOfflineJetMatching = True,
     ## objects
@@ -84,8 +84,8 @@ particleNetAK8HbbTagMonitoring = _particleNetJetTagMonitor.clone(
     jet2PNETscoreTransBinning2d = [],
     ## trigger for numerator and denominator
     numGenericTriggerEvent = dict(
-        hltPaths      = ["HLT_IsoMu50_AK8PFJet230_SoftDropMass40_PFAK8ParticleNetBB0p35_v*",
-                         "HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet230_SoftDropMass40_PFAK8ParticleNetBB0p35_v*"],
+        hltPaths      = ["HLT_IsoMu50_AK8PFJet220_SDMass40_PFAK8PNetBB0p35_v*",
+                         "HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet220_SDMass40_PFAK8PNetBB0p35_v*"],
         andOr         = False,
         andOrHlt      = True,
         #hltInputTag   = "TriggerResults::reHLT", ## when testing in the DQM workflow (https://twiki.cern.ch/twiki/bin/viewauth/CMS/HLTValidationAndDQM)
@@ -98,8 +98,8 @@ particleNetAK8HbbTagMonitoring = _particleNetJetTagMonitor.clone(
         verbosityLevel = 1,
     ),
     denGenericTriggerEvent = dict(
-        hltPaths      = ["HLT_IsoMu50_AK8PFJet230_SoftDropMass40_v*",
-                         "HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet230_SoftDropMass40_v*",
+        hltPaths      = ["HLT_IsoMu50_AK8PFJet220_SDMass40_v*",
+                         "HLT_Ele50_CaloIdVT_GsfTrkIdT_AK8PFJet220_SDMass40_v*",
                      ],
         andOr         = False,
         andOrHlt      = True,


### PR DESCRIPTION
#### PR description:

This PR just includes renaming of the PartlcleNet monitoring paths as discussed in JIRA: [CMSHLT-2684](https://its.cern.ch/jira/browse/CMSHLT-2684)
No other changes made.

#### PR validation:

Passed runTheMatrix tests.