### PR TITLE
Add tau decay-mode to genTauJets as status

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -11,10 +11,26 @@
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 #include "PhysicsTools/HepMCCandAlgos/interface/GenParticlesHelper.h"
+#include "PhysicsTools/JetMCUtils/interface/JetMCTag.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
 
 using namespace std;
 using namespace edm;
 using namespace reco;
+
+namespace {
+  //Map to convert names of decay modes to integer codes
+  const std::map<std::string, int> decayModeStringToCodeMap = {{"null", PFTau::kNull},
+                                                               {"oneProng0Pi0", PFTau::kOneProng0PiZero},
+                                                               {"oneProng1Pi0", PFTau::kOneProng1PiZero},
+                                                               {"oneProng2Pi0", PFTau::kOneProng2PiZero},
+                                                               {"threeProng0Pi0", PFTau::kThreeProng0PiZero},
+                                                               {"threeProng1Pi0", PFTau::kThreeProng1PiZero},
+                                                               {"electron", PFTau::kRareDecayMode + 1},
+                                                               {"muon", PFTau::kRareDecayMode + 2},
+                                                               {"rare", PFTau::kRareDecayMode},
+                                                               {"tau", PFTau::kNull - 1}};
+}  // namespace
 
 TauGenJetProducer::TauGenJetProducer(const edm::ParameterSet& iConfig)
     : tokenGenParticles_(consumes<GenParticleCollection>(iConfig.getParameter<InputTag>("GenParticles"))),
@@ -39,7 +55,6 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
     // look for all status 1 (stable) descendents
     GenParticleRefVector descendents;
     findDescendents(*iTau, descendents, 1);
-
     if (descendents.empty()) {
       edm::LogWarning("NoTauDaughters") << "Tau p4: " << (*iTau)->p4() << " vtx: " << (*iTau)->vertex()
                                         << " has no daughters";
@@ -51,6 +66,7 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
       constituents.push_back(refToPtr(*iTau));
       GenJet jet((*iTau)->p4(), vertex, specific, constituents);
       jet.setCharge((*iTau)->charge());
+      jet.setStatus(decayModeStringToCodeMap.at("tau"));
       pOutVisTaus->emplace_back(std::move(jet));
       continue;
     }
@@ -101,6 +117,12 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
                                          << " # descendents: " << constituents.size() << "\n";
 
     jet.setCharge(charge);
+    // determine tau decay mode and set it as jet status
+    if (auto search = decayModeStringToCodeMap.find(JetMCTagUtils::genTauDecayMode(jet));
+        search != decayModeStringToCodeMap.end())
+      jet.setStatus(search->second);
+    else
+      jet.setStatus(decayModeStringToCodeMap.at("null"));
     pOutVisTaus->push_back(jet);
   }
   iEvent.put(std::move(pOutVisTaus));

--- a/PhysicsTools/JetMCUtils/src/JetMCTag.cc
+++ b/PhysicsTools/JetMCUtils/src/JetMCTag.cc
@@ -70,6 +70,7 @@ bool JetMCTagUtils::decayFromCHadron(const Candidate &c) {
 std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
   int numElectrons = 0;
   int numMuons = 0;
+  int numTaus = 0;
   int numChargedHadrons = 0;
   int numNeutralHadrons = 0;
   int numPhotons = 0;
@@ -89,6 +90,9 @@ std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
       case 13:
         numMuons++;
         break;
+      case 15:
+        numTaus++;
+        break;
       default: {
         if ((*daughter)->charge() != 0)
           numChargedHadrons++;
@@ -102,6 +106,8 @@ std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
     return std::string("electron");
   else if (numMuons == 1)
     return std::string("muon");
+  else if (numTaus == 1)  //MB: a tau undecayed by generator or an intermediate state used to generate radiations
+    return std::string("tau");
 
   switch (numChargedHadrons) {
     case 1:


### PR DESCRIPTION
#### PR description:
This PR adds a decay-mode of a genTau to a genTauJet built for the genTau as a status of the genTauJet. The decay-mode is as returned by `PhysicsTools/JetMCUtils/src/JetMCTag.cc` with value converted to an integer as defined in the enum in `DataFormats/TauReco/interface/PFTau.h` (Tau POG standard). In case of an undecayed genTau the status is negative and can be used to filter out corresponding genTauJet.
The `PhysicsTools/JetMCUtils/src/JetMCTag.cc` tool was modified to deal correctly with genTauJets for undecayed genTaus where the genTau is its unique constituent. Namely, in this case the "tau" decay-mode is returned.
This PR is a followup for #41064 and implements promise from https://github.com/cms-sw/cmssw/pull/41064#issuecomment-1472227706.

#### PR validation:

PR tested successfully with wf 10024.0 ("TTbar_13+2017")
