### PR TITLE
Move leftover PoolDBOutputService modules to use kSharedResource

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -2,21 +2,20 @@
 #define CalibTracker_SiStripESProducer_DummyCondDBWriter_h
 
 // user include files
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-
 #include <string>
 
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
 template <typename TObject, typename TObjectO, typename TRecord>
-class DummyCondDBWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+class DummyCondDBWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit DummyCondDBWriter(const edm::ParameterSet& iConfig);
   ~DummyCondDBWriter() override;
@@ -35,13 +34,14 @@ DummyCondDBWriter<TObject, TObjectO, TRecord>::DummyCondDBWriter(const edm::Para
     : iConfig_(iConfig),
       token_(esConsumes<edm::Transition::EndRun>(
           edm::ESInputTag{"", iConfig.getUntrackedParameter<std::string>("label", "")})) {
+  usesResource(cond::service::PoolDBOutputService::kSharedResource);
   edm::LogInfo("DummyCondDBWriter") << "DummyCondDBWriter constructor for typename " << typeid(TObject).name()
-                                    << " and record " << typeid(TRecord).name() << std::endl;
+                                    << " and record " << typeid(TRecord).name();
 }
 
 template <typename TObject, typename TObjectO, typename TRecord>
 DummyCondDBWriter<TObject, TObjectO, TRecord>::~DummyCondDBWriter() {
-  edm::LogInfo("DummyCondDBWriter") << "DummyCondDBWriter::~DummyCondDBWriter()" << std::endl;
+  edm::LogInfo("DummyCondDBWriter") << "DummyCondDBWriter::~DummyCondDBWriter()";
 }
 
 template <typename TObject, typename TObjectO, typename TRecord>
@@ -49,8 +49,8 @@ void DummyCondDBWriter<TObject, TObjectO, TRecord>::endRun(const edm::Run& run, 
   std::string rcdName = iConfig_.getParameter<std::string>("record");
 
   if (!watcher_.check(es)) {
-    edm::LogInfo("DummyCondDBWriter") << "not needed to store objects with Record " << rcdName << " at run "
-                                      << run.run() << std::endl;
+    edm::LogInfo("DummyCondDBWriter") << "Not needed to store objects with Record " << rcdName << " at run "
+                                      << run.run();
     return;
   }
 
@@ -70,7 +70,7 @@ void DummyCondDBWriter<TObject, TObjectO, TRecord>::endRun(const edm::Run& run, 
 
     dbservice->writeOneIOV(*obj, Time_, rcdName);
   } else {
-    edm::LogError("SiStripFedCablingBuilder") << "Service is unavailable" << std::endl;
+    edm::LogError("DummyCondDBWriter") << "Service is unavailable";
   }
 }
 

--- a/CondTools/Hcal/interface/BoostIODBWriter.h
+++ b/CondTools/Hcal/interface/BoostIODBWriter.h
@@ -24,24 +24,20 @@
 #include <memory>
 #include <cassert>
 
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/Serialization/interface/eos/portable_iarchive.hpp"
-
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/Utilities/interface/Exception.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 //
 // class declaration
 //
 template <class DataType>
-class BoostIODBWriter : public edm::one::EDAnalyzer<> {
+class BoostIODBWriter : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   typedef DataType data_type;
 
@@ -57,7 +53,9 @@ private:
 
 template <class DataType>
 BoostIODBWriter<DataType>::BoostIODBWriter(const edm::ParameterSet& ps)
-    : inputFile_(ps.getParameter<std::string>("inputFile")), record_(ps.getParameter<std::string>("record")) {}
+    : inputFile_(ps.getParameter<std::string>("inputFile")), record_(ps.getParameter<std::string>("record")) {
+  usesResource(cond::service::PoolDBOutputService::kSharedResource);
+}
 
 template <class DataType>
 void BoostIODBWriter<DataType>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
#### PR description:

Last piece to resolve https://github.com/cms-sw/cmssw/issues/18340, `BoostIODBWriter<>`, and `DummyCondDBWriter<>` are now using `SharedResources` for accessing the DB. 

A few cosmetics changes: 
 * fixing how `LogInfo()` should work (which to me actually seems like it should have been `LogDebug()`, but I didnt change to that)
 * Alpha order the include statements

#### PR validation:

code compiles, unit tests `scram b runtests` pass

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport is needed