### PR TITLE
[Geom] Avoid unit tests failures in DBG IBs

### DIFF
--- a/DetectorDescription/Core/src/DDCompactViewImpl.cc
+++ b/DetectorDescription/Core/src/DDCompactViewImpl.cc
@@ -10,9 +10,9 @@ DDCompactViewImpl::DDCompactViewImpl(const DDLogicalPart& rootnodedata) : root_(
 DDCompactViewImpl::~DDCompactViewImpl() {
   Graph::adj_list::size_type it = 0;
   if (graph_.size() == 0) {
-    LogDebug("DDCompactViewImpl") << "In destructor, graph is empty.  Root:" << root_ << std::endl;
+    LogDebug("DDCompactViewImpl") << "In destructor, graph is empty." << std::endl;
   } else {
-    LogDebug("DDCompactViewImpl") << "In destructor, graph is NOT empty.  Root:" << root_
+    LogDebug("DDCompactViewImpl") << "In destructor, graph is NOT empty."
                                   << " graph_.size() = " << graph_.size() << std::endl;
     for (; it < graph_.size(); ++it) {
       Graph::edge_range erange = graph_.edges(it);


### PR DESCRIPTION
DBG IBs, couple of unit tests failed with error [a].  This PRs fixes those tests but one should really check why `DDName::ns()` crashes

[a]
```
#5  DDName::ns[abi:cxx11]() const (this=0x1a05d70) at <path>/tbb/v2021.8.0-d98ea1c603fa3368d06780eab09b1de9/include/oneapi/tbb/detail/_concurrent_unordered_base.h:88
#6  DDName::ns[abi:cxx11]() const (this=0x1a05d70) at <cmssw>/src/DetectorDescription/Core/src/DDName.cc:52
#7  0x00002b32dbe04747 in operator<< (os=..., n=...) at <cmssw>/src/DetectorDescription/Core/src/DDName.cc:12
#8  0x00002b32dbe047bc in operator<< (os=..., part=...) at <cmssw>/src/DetectorDescription/Core/src/DDLogicalPart.cc:30
#9  0x00002b32dbe27569 in edm::ErrorObj::opltlt<DDLogicalPart>(DDLogicalPart const&) [clone .isra.0] (this=0x19ab260, t=...) at <cmssw>/src/FWCore/MessageLogger/interface/ErrorObj.icc:28
#10 0x00002b32dbdf9429 in edm::operator<< <DDLogicalPart> (t=..., e=...) at <cmssw>/src/FWCore/MessageLogger/interface/ErrorObj.icc:44
#11 edm::MessageSender::operator<< <DDLogicalPart> (t=..., this=0x7ffd7f6727b0) at <cmssw>/src/FWCore/MessageLogger/interface/MessageSender.h:36
#12 edm::Log<edm::level::Debug, false>::operator<< <DDLogicalPart> (t=..., this=0x7ffd7f6727b0) at <cmssw>/src/FWCore/MessageLogger/interface/MessageLogger.h:83
#13 DDCompactViewImpl::~DDCompactViewImpl (this=<optimized out>, this=<optimized out>) at <cmssw>/src/DetectorDescription/Core/src/DDCompactViewImpl.cc:15
#14 0x00002b32dbdf981a in std::default_delete<DDCompactViewImpl>::operator() (__ptr=0x1982550, this=<optimized out>) at <path>/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/bits/unique_ptr.h:85
#15 std::unique_ptr<DDCompactViewImpl, std::default_delete<DDCompactViewImpl> >::~unique_ptr (this=<optimized out>, this=<optimized out>) at <path>/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/bits/unique_ptr.h:361
#16 DDCompactView::~DDCompactView (this=<optimized out>, this=<optimized out>) at <cmssw>/src/DetectorDescription/Core/src/DDCompactView.cc:52

```