### PR TITLE
Build genTauJets for undecayed taus and add tau decay-mode to genTauJets [13_0_X]

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -11,10 +11,26 @@
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 #include "PhysicsTools/HepMCCandAlgos/interface/GenParticlesHelper.h"
+#include "PhysicsTools/JetMCUtils/interface/JetMCTag.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
 
 using namespace std;
 using namespace edm;
 using namespace reco;
+
+namespace {
+  //Map to convert names of decay modes to integer codes
+  const std::map<std::string, int> decayModeStringToCodeMap = {{"null", PFTau::kNull},
+                                                               {"oneProng0Pi0", PFTau::kOneProng0PiZero},
+                                                               {"oneProng1Pi0", PFTau::kOneProng1PiZero},
+                                                               {"oneProng2Pi0", PFTau::kOneProng2PiZero},
+                                                               {"threeProng0Pi0", PFTau::kThreeProng0PiZero},
+                                                               {"threeProng1Pi0", PFTau::kThreeProng1PiZero},
+                                                               {"electron", PFTau::kRareDecayMode + 1},
+                                                               {"muon", PFTau::kRareDecayMode + 2},
+                                                               {"rare", PFTau::kRareDecayMode},
+                                                               {"tau", PFTau::kNull - 1}};
+}  // namespace
 
 TauGenJetProducer::TauGenJetProducer(const edm::ParameterSet& iConfig)
     : tokenGenParticles_(consumes<GenParticleCollection>(iConfig.getParameter<InputTag>("GenParticles"))),
@@ -39,7 +55,6 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
     // look for all status 1 (stable) descendents
     GenParticleRefVector descendents;
     findDescendents(*iTau, descendents, 1);
-
     if (descendents.empty()) {
       edm::LogWarning("NoTauDaughters") << "Tau p4: " << (*iTau)->p4() << " vtx: " << (*iTau)->vertex()
                                         << " has no daughters";
@@ -51,6 +66,7 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
       constituents.push_back(refToPtr(*iTau));
       GenJet jet((*iTau)->p4(), vertex, specific, constituents);
       jet.setCharge((*iTau)->charge());
+      jet.setStatus(decayModeStringToCodeMap.at("tau"));
       pOutVisTaus->emplace_back(std::move(jet));
       continue;
     }
@@ -101,6 +117,12 @@ void TauGenJetProducer::produce(edm::StreamID, Event& iEvent, const EventSetup& 
                                          << " # descendents: " << constituents.size() << "\n";
 
     jet.setCharge(charge);
+    // determine tau decay mode and set it as jet status
+    if (auto search = decayModeStringToCodeMap.find(JetMCTagUtils::genTauDecayMode(jet));
+        search != decayModeStringToCodeMap.end())
+      jet.setStatus(search->second);
+    else
+      jet.setStatus(decayModeStringToCodeMap.at("null"));
     pOutVisTaus->push_back(jet);
   }
   iEvent.put(std::move(pOutVisTaus));

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
@@ -31,7 +31,6 @@ public:
 
 private:
   /// Input PFCandidates
-  const edm::InputTag inputTagGenParticles_;
   const edm::EDGetTokenT<reco::GenParticleCollection> tokenGenParticles_;
 
   /// if yes, neutrinos will be included, for debug purposes

--- a/PhysicsTools/JetMCUtils/src/JetMCTag.cc
+++ b/PhysicsTools/JetMCUtils/src/JetMCTag.cc
@@ -70,6 +70,7 @@ bool JetMCTagUtils::decayFromCHadron(const Candidate &c) {
 std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
   int numElectrons = 0;
   int numMuons = 0;
+  int numTaus = 0;
   int numChargedHadrons = 0;
   int numNeutralHadrons = 0;
   int numPhotons = 0;
@@ -89,6 +90,9 @@ std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
       case 13:
         numMuons++;
         break;
+      case 15:
+        numTaus++;
+        break;
       default: {
         if ((*daughter)->charge() != 0)
           numChargedHadrons++;
@@ -102,6 +106,8 @@ std::string JetMCTagUtils::genTauDecayMode(const CompositePtrCandidate &c) {
     return std::string("electron");
   else if (numMuons == 1)
     return std::string("muon");
+  else if (numTaus == 1)  //MB: a tau undecayed by generator or an intermediate state used to generate radiations
+    return std::string("tau");
 
   switch (numChargedHadrons) {
     case 1:


### PR DESCRIPTION
#### PR description:

This PR enables creation of genTauJets for taus which were not decayed by the generator based on the tau's own data. In addition, information on decay-modes of generated taus is added to the genTauJets using the `status` flag. The decay-modes are codded following Tau POG standard (as defined in `DataFormats/TauReco/interface/PFTau.h`), while for undecayed (or others with abnormal decay-mode) taus the status is a negative number.
 
Backport of #41064 & #41092.

#### PR validation:

Validated during integration of original PRs #41064 & #41092, and revalidated with wf's 10024.0 & 148.0

#### Backport PR

It is backport of #41064 & #41092 to production releases of 13_0_X series for 2023.