### PR TITLE
HcalDigiDump.cc Migrate consumesMany to GetterOfProducts

### DIFF
--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -1,5 +1,7 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/TypeMatch.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
@@ -16,23 +18,55 @@ public:
   explicit HcalDigiDump(edm::ParameterSet const& conf);
   ~HcalDigiDump() override = default;
   void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+
+private:
+  edm::GetterOfProducts<HBHEDigiCollection> getterOfProducts1_;
+  edm::GetterOfProducts<HODigiCollection> getterOfProducts2_;
+  edm::GetterOfProducts<HFDigiCollection> getterOfProducts3_;
+  edm::GetterOfProducts<ZDCDigiCollection> getterOfProducts4_;
+  edm::GetterOfProducts<CastorDigiCollection> getterOfProducts5_;
+  edm::GetterOfProducts<CastorTrigPrimDigiCollection> getterOfProducts6_;
+  edm::GetterOfProducts<HcalCalibDigiCollection> getterOfProducts7_;
+  edm::GetterOfProducts<HcalTrigPrimDigiCollection> getterOfProducts8_;
+  edm::GetterOfProducts<HOTrigPrimDigiCollection> getterOfProducts9_;
+  edm::GetterOfProducts<HcalHistogramDigiCollection> getterOfProducts10_;
+  edm::GetterOfProducts<HcalTTPDigiCollection> getterOfProducts11_;
+  edm::GetterOfProducts<QIE10DigiCollection> getterOfProducts12_;
+  edm::GetterOfProducts<QIE11DigiCollection> getterOfProducts13_;
+  edm::GetterOfProducts<HcalUMNioDigi> getterOfProducts14_;
 };
 
-HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf) {
-  consumesMany<HBHEDigiCollection>();
-  consumesMany<HODigiCollection>();
-  consumesMany<HFDigiCollection>();
-  consumesMany<ZDCDigiCollection>();
-  consumesMany<CastorDigiCollection>();
-  consumesMany<CastorTrigPrimDigiCollection>();
-  consumesMany<HcalCalibDigiCollection>();
-  consumesMany<HcalTrigPrimDigiCollection>();
-  consumesMany<HOTrigPrimDigiCollection>();
-  consumesMany<HcalHistogramDigiCollection>();
-  consumesMany<HcalTTPDigiCollection>();
-  consumesMany<QIE10DigiCollection>();
-  consumesMany<QIE11DigiCollection>();
-  consumesMany<HcalUMNioDigi>();
+HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf)
+    : getterOfProducts1_(edm::TypeMatch(), this),
+      getterOfProducts2_(edm::TypeMatch(), this),
+      getterOfProducts3_(edm::TypeMatch(), this),
+      getterOfProducts4_(edm::TypeMatch(), this),
+      getterOfProducts5_(edm::TypeMatch(), this),
+      getterOfProducts6_(edm::TypeMatch(), this),
+      getterOfProducts7_(edm::TypeMatch(), this),
+      getterOfProducts8_(edm::TypeMatch(), this),
+      getterOfProducts9_(edm::TypeMatch(), this),
+      getterOfProducts10_(edm::TypeMatch(), this),
+      getterOfProducts11_(edm::TypeMatch(), this),
+      getterOfProducts12_(edm::TypeMatch(), this),
+      getterOfProducts13_(edm::TypeMatch(), this),
+      getterOfProducts14_(edm::TypeMatch(), this) {
+  callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+    getterOfProducts1_(bd);
+    getterOfProducts2_(bd);
+    getterOfProducts3_(bd);
+    getterOfProducts4_(bd);
+    getterOfProducts5_(bd);
+    getterOfProducts6_(bd);
+    getterOfProducts7_(bd);
+    getterOfProducts8_(bd);
+    getterOfProducts9_(bd);
+    getterOfProducts10_(bd);
+    getterOfProducts11_(bd);
+    getterOfProducts12_(bd);
+    getterOfProducts13_(bd);
+    getterOfProducts14_(bd);
+  });
 }
 
 void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
@@ -52,7 +86,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   std::vector<edm::Handle<HcalUMNioDigi> > umnio;
 
   try {
-    e.getManyByType(hbhe);
+    getterOfProducts1_.fillHandles(e, hbhe);
     std::vector<edm::Handle<HBHEDigiCollection> >::iterator i;
     for (i = hbhe.begin(); i != hbhe.end(); i++) {
       const HBHEDigiCollection& c = *(*i);
@@ -67,7 +101,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(hf);
+    getterOfProducts3_.fillHandles(e, hf);
     std::vector<edm::Handle<HFDigiCollection> >::iterator i;
     for (i = hf.begin(); i != hf.end(); i++) {
       const HFDigiCollection& c = *(*i);
@@ -82,7 +116,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(ho);
+    getterOfProducts2_.fillHandles(e, ho);
     std::vector<edm::Handle<HODigiCollection> >::iterator i;
     for (i = ho.begin(); i != ho.end(); i++) {
       const HODigiCollection& c = *(*i);
@@ -97,7 +131,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(htp);
+    getterOfProducts8_.fillHandles(e, htp);
     std::vector<edm::Handle<HcalTrigPrimDigiCollection> >::iterator i;
     for (i = htp.begin(); i != htp.end(); i++) {
       const HcalTrigPrimDigiCollection& c = *(*i);
@@ -112,7 +146,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(hotp);
+    getterOfProducts9_.fillHandles(e, hotp);
     std::vector<edm::Handle<HOTrigPrimDigiCollection> >::iterator i;
     for (i = hotp.begin(); i != hotp.end(); i++) {
       const HOTrigPrimDigiCollection& c = *(*i);
@@ -127,7 +161,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(hc);
+    getterOfProducts7_.fillHandles(e, hc);
     std::vector<edm::Handle<HcalCalibDigiCollection> >::iterator i;
     for (i = hc.begin(); i != hc.end(); i++) {
       const HcalCalibDigiCollection& c = *(*i);
@@ -141,7 +175,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(zdc);
+    getterOfProducts4_.fillHandles(e, zdc);
     std::vector<edm::Handle<ZDCDigiCollection> >::iterator i;
     for (i = zdc.begin(); i != zdc.end(); i++) {
       const ZDCDigiCollection& c = *(*i);
@@ -155,7 +189,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(castor);
+    getterOfProducts5_.fillHandles(e, castor);
     std::vector<edm::Handle<CastorDigiCollection> >::iterator i;
     for (i = castor.begin(); i != castor.end(); i++) {
       const CastorDigiCollection& c = *(*i);
@@ -169,7 +203,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(castortp);
+    getterOfProducts6_.fillHandles(e, castortp);
     std::vector<edm::Handle<CastorTrigPrimDigiCollection> >::iterator i;
     for (i = castortp.begin(); i != castortp.end(); i++) {
       const CastorTrigPrimDigiCollection& c = *(*i);
@@ -182,7 +216,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(ttp);
+    getterOfProducts11_.fillHandles(e, ttp);
     std::vector<edm::Handle<HcalTTPDigiCollection> >::iterator i;
     for (i = ttp.begin(); i != ttp.end(); i++) {
       const HcalTTPDigiCollection& c = *(*i);
@@ -194,7 +228,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(hh);
+    getterOfProducts10_.fillHandles(e, hh);
     std::vector<edm::Handle<HcalHistogramDigiCollection> >::iterator i;
     for (i = hh.begin(); i != hh.end(); i++) {
       const HcalHistogramDigiCollection& c = *(*i);
@@ -206,7 +240,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(umnio);
+    getterOfProducts14_.fillHandles(e, umnio);
     std::vector<edm::Handle<HcalUMNioDigi> >::iterator i;
     for (i = umnio.begin(); i != umnio.end(); i++) {
       cout << *(*i) << std::endl;
@@ -215,7 +249,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(qie10s);
+    getterOfProducts12_.fillHandles(e, qie10s);
     std::vector<edm::Handle<QIE10DigiCollection> >::iterator i;
     for (i = qie10s.begin(); i != qie10s.end(); i++) {
       const QIE10DigiCollection& c = *(*i);
@@ -227,7 +261,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   }
 
   try {
-    e.getManyByType(qie11s);
+    getterOfProducts13_.fillHandles(e, qie11s);
     std::vector<edm::Handle<QIE11DigiCollection> >::iterator i;
     for (i = qie11s.begin(); i != qie11s.end(); i++) {
       const QIE11DigiCollection& c = *(*i);


### PR DESCRIPTION
#### PR description:

In HcalDigiDump.cc, migrate consumesMany to GetterOfProducts. It should behave the same as before.

#### PR validation:

This module is a utility to print out information to cout, but it is not used for anything else. There are no existing tests. I ran it manually on some data files I generated and it seems to print out information as one would expect.

FYI @makortel 