### PR TITLE
Add CMSHepEmTrackingManager

### DIFF
--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h
@@ -28,6 +28,7 @@ private:
   G4double fSafetyFactor;
   G4double fLambdaLimit;
   G4MscStepLimitType fStepLimitType;
+  bool fG4HepEmActive;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/interface/CMSHepEmTrackingManager.h
+++ b/SimG4Core/PhysicsLists/interface/CMSHepEmTrackingManager.h
@@ -1,0 +1,26 @@
+#ifndef SimG4Core_PhysicsLists_CMSHepEmTrackingManager_h
+#define SimG4Core_PhysicsLists_CMSHepEmTrackingManager_h
+
+#include "G4Version.hh"
+#if G4VERSION_NUMBER >= 1100
+
+#include "G4HepEmTrackingManager.hh"
+
+class CMSHepEmTrackingManager final : public G4HepEmTrackingManager {
+public:
+  CMSHepEmTrackingManager(G4double highEnergyLimit);
+  ~CMSHepEmTrackingManager();
+
+  void BuildPhysicsTable(const G4ParticleDefinition &) override;
+
+  void PreparePhysicsTable(const G4ParticleDefinition &) override;
+
+  void HandOverOneTrack(G4Track *aTrack) override;
+
+private:
+  G4double fHighEnergyLimit;
+};
+
+#endif
+
+#endif

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -1,4 +1,5 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysics.h"
+#include "SimG4Core/PhysicsLists/interface/CMSHepEmTrackingManager.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4SystemOfUnits.hh"
@@ -76,6 +77,7 @@ CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver, const edm::ParameterSet& p
   double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
   param->SetLowestElectronEnergy(tcut);
   param->SetLowestMuHadEnergy(tcut);
+  fG4HepEmActive = p.getParameter<bool>("G4HepEmActive");
 }
 
 void CMSEmStandardPhysics::ConstructParticle() {
@@ -276,6 +278,14 @@ void CMSEmStandardPhysics::ConstructProcess() {
   ph->RegisterProcess(new G4eBremsstrahlung(), particle);
   ph->RegisterProcess(new G4eplusAnnihilation(), particle);
   ph->RegisterProcess(ss, particle);
+
+#if G4VERSION_NUMBER >= 1110
+  if (fG4HepEmActive) {
+    auto* hepEmTM = new CMSHepEmTrackingManager(highEnergyLimit);
+    G4Electron::Electron()->SetTrackingManager(hepEmTM);
+    G4Positron::Positron()->SetTrackingManager(hepEmTM);
+  }
+#endif
 
   // generic ion
   particle = G4GenericIon::GenericIon();

--- a/SimG4Core/PhysicsLists/src/CMSHepEmTrackingManager.cc
+++ b/SimG4Core/PhysicsLists/src/CMSHepEmTrackingManager.cc
@@ -1,0 +1,67 @@
+#include "G4Version.hh"
+#if G4VERSION_NUMBER >= 1100
+
+#include "SimG4Core/PhysicsLists/interface/CMSHepEmTrackingManager.h"
+
+#include "G4EventManager.hh"
+#include "G4ProcessManager.hh"
+#include "G4StackManager.hh"
+#include "G4TrackingManager.hh"
+
+CMSHepEmTrackingManager::CMSHepEmTrackingManager(G4double highEnergyLimit) : fHighEnergyLimit(highEnergyLimit) {}
+
+CMSHepEmTrackingManager::~CMSHepEmTrackingManager() = default;
+
+void CMSHepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition& part) {
+  G4HepEmTrackingManager::BuildPhysicsTable(part);
+
+  G4ProcessManager* pManager = part.GetProcessManager();
+  G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
+
+  G4ProcessVector* pVector = pManager->GetProcessList();
+  for (std::size_t j = 0; j < pVector->size(); ++j) {
+    if (pManagerShadow == pManager) {
+      (*pVector)[j]->BuildPhysicsTable(part);
+    } else {
+      (*pVector)[j]->BuildWorkerPhysicsTable(part);
+    }
+  }
+}
+
+void CMSHepEmTrackingManager::PreparePhysicsTable(const G4ParticleDefinition& part) {
+  G4HepEmTrackingManager::PreparePhysicsTable(part);
+
+  G4ProcessManager* pManager = part.GetProcessManager();
+  G4ProcessManager* pManagerShadow = part.GetMasterProcessManager();
+
+  G4ProcessVector* pVector = pManager->GetProcessList();
+  for (std::size_t j = 0; j < pVector->size(); ++j) {
+    if (pManagerShadow == pManager) {
+      (*pVector)[j]->PreparePhysicsTable(part);
+    } else {
+      (*pVector)[j]->PrepareWorkerPhysicsTable(part);
+    }
+  }
+}
+
+void CMSHepEmTrackingManager::HandOverOneTrack(G4Track* aTrack) {
+  if (aTrack->GetKineticEnergy() < fHighEnergyLimit) {
+    // Fully track with G4HepEm.
+    G4HepEmTrackingManager::HandOverOneTrack(aTrack);
+  } else {
+    // Track with the Geant4 kernel and all registered processes.
+    G4EventManager* eventManager = G4EventManager::GetEventManager();
+    G4TrackingManager* trackManager = eventManager->GetTrackingManager();
+
+    trackManager->ProcessOneTrack(aTrack);
+    if (aTrack->GetTrackStatus() != fStopAndKill) {
+      G4Exception("CMSHepEmTrackingManager::HandOverOneTrack", "NotStopped", FatalException, "track was not stopped");
+    }
+
+    G4TrackVector* secondaries = trackManager->GimmeSecondaries();
+    eventManager->StackTracks(secondaries);
+    delete aTrack;
+  }
+}
+
+#endif


### PR DESCRIPTION
#### PR description:

If `G4HepEmActive`, use a specialized tracking manager to track electrons and positrons with less than 100 MeV using G4HepEm.

#### PR validation:

Not turned on by default; simulated 1000 ttbar events with `G4HepEmActive`, no crashes.