### PR TITLE
Fix several unit test post-merge of #41075

### DIFF
--- a/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
+++ b/Alignment/OfflineValidation/test/testPrimaryVertexRelatedValidations_cfg.py
@@ -118,7 +118,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, ('auto:phase2_realistic' if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
+process.GlobalTag = GlobalTag(process.GlobalTag, ('auto:phase2_realistic_T21' if options.isPhase2 else 'auto:phase1_2022_realistic'), '')
 
 if _allFromGT:
      print("############ testPVValidation_cfg.py: msg%-i: All is taken from GT")

--- a/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectUploader_Phase2_cfg.py
@@ -46,7 +46,7 @@ options.register('TemplateFilePath',
 				 opts.VarParsing.varType.string,
 				 'Location of template files')
 options.register('GlobalTag',
-				 'auto:phase2_realistic',
+				 'auto:phase2_realistic_T21', # as needed by the unit test
 				 opts.VarParsing.multiplicity.singleton,
 				 opts.VarParsing.varType.string,
 				 'Global tag for this run')

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectUploader_Phase2_cfg.py
@@ -46,7 +46,7 @@ options.register('TemplateFilePath',
     			 opts.VarParsing.varType.string,
     			 'Location of template files')
 options.register('GlobalTag',
-    			 'auto:phase2_realistic',
+                         'auto:phase2_realistic',
     			 opts.VarParsing.multiplicity.singleton,
     			 opts.VarParsing.varType.string,
     			 'Global tag for this run')

--- a/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
+++ b/RecoTracker/MkFit/test/dumpMkFitGeometryPhase2.py
@@ -14,9 +14,8 @@ process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['phase2_realistic']
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase2_realistic_T21", '')
 
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.MkFitGeometryESProducer = dict(limit=-1)

--- a/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/listIds_PhaseII.py
@@ -23,6 +23,7 @@ if options.fromDB :
    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 else:
    process.load('Configuration.Geometry.GeometryExtended2026D92Reco_cff')
+   process.trackerGeometry.applyAlignment = False # needed to avoid to pass the Global Position Record
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
 


### PR DESCRIPTION
#### PR description:

After #41075 I noticed several unit tests started failing in CMSSW_13_1_X_2023-03-20-2300, see [cmssw dashboard](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc11/www/mon/13.1-mon-23/CMSSW_13_1_X_2023-03-20-2300?utests). The failures are all due to the missing `Tracker*Rcd` records in the base phase-2 Global Tag key in autoCond (`auto:phase2_realistic`). For the moment I just redirect the tests to use one of the geometry-flavoured keys, but eventually also the base one could use the records relative to the default geometry (T21, at the time of writing).

#### PR validation:

Run `scram b runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
