### PR TITLE
Include Phase2 TkAl Rcds in Phase2 MC GT with T21 tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -86,7 +86,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '131X_mcRun4_realistic_v1'
+    'phase2_realistic'             : '131X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR is a follow up to https://github.com/cms-sw/cmssw/pull/41116. It updates the Phase2 Global Tag (`auto:phase2_realistic`) in autoCond to add the Tracker Alignment Records for Phase2 (earlier we had the Phase1 tags. See https://github.com/cms-sw/cmssw/pull/41072).

The new GT has the following tags which are for the default geometry (i.e. T21 currently)
- `TrackerAlignment_Upgrade2026_T21_design_v0` 
- `TrackerAlignmentErrorsExtended_Upgrade2026_T21_design_v0` 
- `TrackerSurfaceDeformations_Upgrade2026_Zero`

 **The difference with the latest GT is here**:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun4_realistic_v1/131X_mcRun4_realistic_v2

**and the comparison with the GT before the removal of Phase1 TkAl Rcds in https://github.com/cms-sw/cmssw/pull/41072 is** 
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun4_realistic_v3/131X_mcRun4_realistic_v2

#### PR validation:
Tested the GT locally with `runTheMatrix.py -l 23234.0 -j10 --ibeos` which consumes `auto:phase2_realistic_T21`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport. No backport is foreseen.

