### PR TITLE
fix peak mode SiStrip noise payload in 2018 cosmics simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -60,7 +60,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
     'phase1_2018_cosmics'          : '131X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '131X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/41108

#### PR description:

In DBG IBs, the function `SiStripNoises::getNoise` verifies that the strip for which the noise is asked lies in the `SiStripNoises::Range` of that DetId:

https://github.com/cms-sw/cmssw/blob/9a025419bef333a60931fca76f257fb79d45b767/CondFormats/SiStripObjects/interface/SiStripNoises.h#L73-L78

definition of `SiStripNoises::verify`

https://github.com/cms-sw/cmssw/blob/9a025419bef333a60931fca76f257fb79d45b767/CondFormats/SiStripObjects/src/SiStripNoises.cc#L68-L72

if that's not verified, the code will throw an exception.
In normal builds if that doesn't happen, there is no exception thrown, though of course the used event setup data might be wrong.
This PR proposes a new peak mode noise payload that ensures that all per-strip noise data complies with the `verify` requirement.
@cms-sw/alca-l2 I propose here a candidate, please let me know if you prefer to transform it upfront into a full-fledged Global Tag, I can then subsequently pick it up here.

#### PR validation:

run successfully `runTheMatrix.py -l 7.4`

For reference here's a comparison of the bugged payload (`SiStripNoise_PeakMode_2018_Minus20C_v0_mc`) vs the fixed one (`SiStripNoise_PeakMode_2018_Minus20C_v0_mc_fixed`)

![image](https://user-images.githubusercontent.com/5082376/226657046-ba684598-c5ee-4b34-94b2-176c5fa49774.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A