### PR TITLE
Remove the const_cast from SiStripFedCablingFakeESSource

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.cc
@@ -95,15 +95,13 @@ SiStripFedCabling* SiStripFedCablingFakeESSource::make(const SiStripFedCablingRc
   bool insufficient = false;
   Feds::const_iterator ifed = feds.begin();
   uint16_t fed_ch = 0;
-  for (std::vector<SiStripFecCrate>::const_iterator icrate = fec_cabling->crates().begin();
+  for (std::vector<SiStripFecCrate>::iterator icrate = fec_cabling->crates().begin();
        icrate != fec_cabling->crates().end();
        icrate++) {
-    for (std::vector<SiStripFec>::const_iterator ifec = icrate->fecs().begin(); ifec != icrate->fecs().end(); ifec++) {
-      for (std::vector<SiStripRing>::const_iterator iring = ifec->rings().begin(); iring != ifec->rings().end();
-           iring++) {
-        for (std::vector<SiStripCcu>::const_iterator iccu = iring->ccus().begin(); iccu != iring->ccus().end();
-             iccu++) {
-          for (std::vector<SiStripModule>::const_iterator imod = iccu->modules().begin(); imod != iccu->modules().end();
+    for (std::vector<SiStripFec>::iterator ifec = icrate->fecs().begin(); ifec != icrate->fecs().end(); ifec++) {
+      for (std::vector<SiStripRing>::iterator iring = ifec->rings().begin(); iring != ifec->rings().end(); iring++) {
+        for (std::vector<SiStripCcu>::iterator iccu = iring->ccus().begin(); iccu != iring->ccus().end(); iccu++) {
+          for (std::vector<SiStripModule>::iterator imod = iccu->modules().begin(); imod != iccu->modules().end();
                imod++) {
             if (populateAllFeds) {
               for (uint16_t ipair = 0; ipair < imod->nApvPairs(); ipair++) {
@@ -121,7 +119,7 @@ SiStripFedCabling* SiStripFedCablingFakeESSource::make(const SiStripFedCablingRc
                                                       (*ifed) % 16 + 2,  // FED slot starts from 2
                                                       *ifed,
                                                       fed_ch);
-                const_cast<SiStripModule&>(*imod).fedCh(addr.first, fed_channel);
+                imod->fedCh(addr.first, fed_channel);
                 ifed++;
               }
             } else {
@@ -134,12 +132,12 @@ SiStripFedCabling* SiStripFedCablingFakeESSource::make(const SiStripFedCablingRc
                 fed_ch = 0;
               }  // move to next FED
               for (uint16_t ipair = 0; ipair < imod->nApvPairs(); ipair++) {
-                std::pair<uint16_t, uint16_t> addr = imod->activeApvPair((*imod).lldChannel(ipair));
+                std::pair<uint16_t, uint16_t> addr = imod->activeApvPair(imod->lldChannel(ipair));
                 SiStripModule::FedChannel fed_channel((*ifed) / 16 + 1,  // 16 FEDs per crate, numbering starts from 1
                                                       (*ifed) % 16 + 2,  // FED slot starts from 2
                                                       (*ifed),
                                                       fed_ch);
-                const_cast<SiStripModule&>(*imod).fedCh(addr.first, fed_channel);
+                imod->fedCh(addr.first, fed_channel);
                 fed_ch++;
               }
             }


### PR DESCRIPTION
#### PR description:

The SA reported that the 

/CalibTracker/SiStripESProducers/plugins/fake/SiStripFedCablingFakeESSource.cc
has a const_cast which is not thread safe
https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-480837/31402/llvm-analysis/report-69c66f.html#EndPath

This PR (by Marco) resolves that.

#### PR validation:

Payload produced by [SiStripFedCablingBuilder_cfg.py](https://github.com/cms-sw/cmssw/blob/088f8b102d2dcee3f16ce566889ba40a780dd29d/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py) has the same content as before the PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport is needed.