### PR TITLE
Add temporary failure element to Framework Job Report

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -430,6 +430,7 @@ namespace edm {
     void temporarilyCloseXML();
     edm::propagate_const<std::unique_ptr<JobReportImpl>> impl_;
     std::mutex write_mutex;
+    bool errorLogged_ = false;
   };
 
   std::ostream& operator<<(std::ostream& os, JobReport::InputFile const& f);

--- a/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport-timing_t.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport-timing_t.xml
@@ -8,4 +8,5 @@
 
 <GeneratorInfo>
 </GeneratorInfo>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/FrameworkJobReport.xml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/job_report.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/job_report.xml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u10_job_report.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/u10_job_report.xml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u14_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u14_job_report.mxml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u16_job_report.mmxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u16_job_report.mmxml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u1_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u1_job_report.mxml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u1d_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u1d_job_report.mxml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u27FJR.xml
+++ b/FWCore/MessageService/test/unit_test_outputs/u27FJR.xml
@@ -10,4 +10,5 @@
   <LogSystem_LogAbsolute  Value="0" />
   <LogWarnng_LogPrint  Value="0" />
 </MessageSummary>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/MessageService/test/unit_test_outputs/u7_job_report.mxml
+++ b/FWCore/MessageService/test/unit_test_outputs/u7_job_report.mxml
@@ -1,2 +1,3 @@
 <FrameworkJobReport>
+<!--                                                            -->
 </FrameworkJobReport>

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -72,6 +72,8 @@ namespace edm {
 
       EventGenerationFailure = 8501,
 
+      UnexpectedJobTermination = 8901,
+
       CaughtSignal = 9000
     };
 

--- a/FWCore/Utilities/src/EDMException.cc
+++ b/FWCore/Utilities/src/EDMException.cc
@@ -46,6 +46,7 @@ namespace edm {
                                                               FILLENTRY(UnavailableAccelerator),
                                                               FILLENTRY(ExternalFailure),
                                                               FILLENTRY(EventGenerationFailure),
+                                                              FILLENTRY(UnexpectedJobTermination),
                                                               FILLENTRY(CaughtSignal)};
     static const std::string kUnknownCode("unknownCode");
   }  // namespace errors

--- a/IOPool/Common/test/proper_RLfjr_output
+++ b/IOPool/Common/test/proper_RLfjr_output
@@ -81,4 +81,5 @@
 <ReadBranches>
 </ReadBranches>
 
+<!--                                                            -->
 </FrameworkJobReport>

--- a/IOPool/Common/test/proper_Rfjr_output
+++ b/IOPool/Common/test/proper_Rfjr_output
@@ -77,4 +77,5 @@
 <ReadBranches>
 </ReadBranches>
 
+<!--                                                            -->
 </FrameworkJobReport>

--- a/IOPool/Common/test/proper_fjr_output
+++ b/IOPool/Common/test/proper_fjr_output
@@ -83,4 +83,5 @@
 <Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35"/>
 </ReadBranches>
 
+<!--                                                            -->
 </FrameworkJobReport>

--- a/IOPool/Common/test/proper_fjrx_output
+++ b/IOPool/Common/test/proper_fjrx_output
@@ -92,4 +92,5 @@
 <Branch Name="edmtestThings_Thing__TESTPROD." ReadCount="35"/>
 </ReadBranches>
 
+<!--                                                            -->
 </FrameworkJobReport>

--- a/IOPool/Common/test/proper_fjrx_second_output
+++ b/IOPool/Common/test/proper_fjrx_second_output
@@ -80,4 +80,5 @@
 </Input>
 </Inputs>
 </File>
+<!--                                                            -->
 </FrameworkJobReport>


### PR DESCRIPTION

#### PR description:

Until the job report finishes, we add a FrameworkError element to denote that if the job suddenly ends the error will be present. When job completes successfully or with another error, that temporary element is not written. 

The new error was added to edm::errors.

#### PR validation:

Code compiles and framework unit tests pass.