### PR TITLE
(13_1_X) streamer format padding

### DIFF
--- a/CalibCalorimetry/EcalLaserSorting/test/RunStreamer.sh
+++ b/CalibCalorimetry/EcalLaserSorting/test/RunStreamer.sh
@@ -10,6 +10,13 @@ echo "LOCAL_TEST_DIR = $SCRAM_TEST_PATH"
 RC=0
 
 mkdir inDir
+cmsRun ${SCRAM_TEST_PATH}/streamOutPadding_cfg.py > outp 2>&1 || die "cmsRun streamOutPadding_cfg.py" $?
+cp teststreamfile.dat teststreamfile.padding
+mv teststreamfile.dat inDir/
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > inp  2>&1 || die "cmsRun streamIn_cfg.py" $?
+rm -rf inDir
+
+mkdir inDir
 cmsRun ${SCRAM_TEST_PATH}/streamOut_cfg.py > out 2>&1 || die "cmsRun streamOut_cfg.py" $?
 cp teststreamfile.dat teststreamfile.original
 mv teststreamfile.dat inDir
@@ -36,6 +43,10 @@ ANS_OUT_SIZE=`grep -c CHECKSUM out`
 ANS_OUT=`grep CHECKSUM out`
 ANS_IN=`grep CHECKSUM in`
 
+ANS_OUTP_SIZE=`grep -c CHECKSUM outp`
+ANS_OUTP=`grep CHECKSUM outp`
+ANS_INP=`grep CHECKSUM inp`
+
 if [ "${ANS_OUT_SIZE}" == "0" ]
 then
     echo "New Stream Test Failed (out was not created)"
@@ -43,6 +54,18 @@ then
 fi
 
 if [ "${ANS_OUT}" != "${ANS_IN}" ]
+then
+    echo "New Stream Test Failed (out!=in)"
+    RC=1
+fi
+
+if [ "${ANS_OUTP_SIZE}" == "0" ]
+then
+    echo "New Stream Test Failed (out was not created)"
+    RC=1
+fi
+
+if [ "${ANS_OUTP}" != "${ANS_INP}" ]
 then
     echo "New Stream Test Failed (out!=in)"
     RC=1

--- a/CalibCalorimetry/EcalLaserSorting/test/streamOutPadding_cfg.py
+++ b/CalibCalorimetry/EcalLaserSorting/test/streamOutPadding_cfg.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('compAlgo',
+                  'ZLIB', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Compression Algorithm")
+
+options.parseArguments()
+
+
+process = cms.Process("HLT")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(50)
+)
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint64(10123456789)
+)
+
+process.m1 = cms.EDProducer("StreamThingProducer",
+    instance_count = cms.int32(5),
+    array_size = cms.int32(2)
+)
+
+process.m2 = cms.EDProducer("NonProducer")
+
+process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
+    product_to_get = cms.string('m1')
+)
+
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('teststreamfile.dat'),
+    padding = cms.untracked.uint32(4096),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    compression_algorithm = cms.untracked.string(options.compAlgo),
+    max_event_size = cms.untracked.int32(7000000)
+)
+
+process.p1 = cms.Path(process.m1*process.a1*process.m2)
+process.end = cms.EndPath(process.out)

--- a/DQMServices/StreamerIO/test/RunStreamer.sh
+++ b/DQMServices/StreamerIO/test/RunStreamer.sh
@@ -9,7 +9,20 @@ echo "LOCAL_TEST_DIR = $SCRAM_TEST_PATH"
 
 RC=0
 
+rm -rf run000001
 mkdir run000001
+
+#test checksum with padded format
+echo "{\"data\" :[10,10, \"teststreamfile.dat\"]}" >  run000001/run1_ls1_test.jsn
+cmsRun ${SCRAM_TEST_PATH}/streamOutPadding_cfg.py > outp 2>&1 || die "cmsRun streamOutPadding_cfg.py" $?
+mv teststreamfile.dat run000001/teststreamfile.dat
+cmsRun ${SCRAM_TEST_PATH}/streamOutAlt_cfg.py  > outAlt 2>&1 || die "cmsRun streamOutAlt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/streamOutExt_cfg.py  > outExt 2>&1 || die "cmsRun streamOutExt_cfg.py" $?
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > inp  2>&1 || die "cmsRun streamIn_cfg.py" $?
+
+rm -rf run000001
+mkdir run000001
+
 #the initial json file to read
 echo "{\"data\" :[10,10, \"teststreamfile.dat\"]}" >  run000001/run1_ls1_test.jsn
 cmsRun ${SCRAM_TEST_PATH}/streamOut_cfg.py > out 2>&1 || die "cmsRun streamOut_cfg.py" $?
@@ -28,31 +41,19 @@ rm run000001/run000001_ls0000_EoR.jsn
 mv teststreamfile_ext.dat run000001/teststreamfile_ext.dat
 timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamInExt_cfg.py  > ext  2>&1 || die "cmsRun streamInExt_cfg.py" $?
 
-echo "{\"data\" :[10,10, \"teststreamfile.dat\"]}" >  run000001/run1_ls1_test.jsn
-cmsRun ${SCRAM_TEST_PATH}/streamOutPadding_cfg.py > outPadding 2>&1 || die "cmsRun streamOutPadding_cfg.py" $?
-mv teststreamfile_padding.dat run000001/teststreamfile.dat
-timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > inPadding  2>&1 || die "cmsRun streamIn_cfg.py" $?
-
-
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in
 
 ANS_OUT_SIZE=`grep -c CHECKSUM out`
-ANS_OUT_PADD_SIZE=`grep -c CHECKSUM outPadding`
 ANS_OUT=`grep CHECKSUM out`
-ANS_OUT_PADD=`grep CHECKSUM outPadding`
 ANS_IN=`grep CHECKSUM in`
-ANS_IN_PADD=`grep CHECKSUM inPadding`
+ANS_OUTP_SIZE=`grep -c CHECKSUM outp`
+ANS_OUTP=`grep CHECKSUM outp`
+ANS_INP=`grep CHECKSUM inp`
 
 if [ "${ANS_OUT_SIZE}" == "0" ]
 then
     echo "New Stream Test Failed (out was not created)"
-    RC=1
-fi
-
-if [ "${ANS_OUT_PADD_SIZE}" == "0" ]
-then
-    echo "New Padded Stream Test Failed (out was not created)"
     RC=1
 fi
 
@@ -62,9 +63,15 @@ then
     RC=1
 fi
 
-if [ "${ANS_OUT_PADD}" != "${ANS_IN_PADD}" ]
+if [ "${ANS_OUTP_SIZE}" == "0" ]
 then
-    echo "New Padded Stream Test Failed (out!=in)"
+    echo "New Stream Padded Test Failed (out was not created)"
+    RC=1
+fi
+
+if [ "${ANS_OUTP}" != "${ANS_INP}" ]
+then
+    echo "New Stream Padded Test Failed (out!=in)"
     RC=1
 fi
 

--- a/DQMServices/StreamerIO/test/RunStreamer.sh
+++ b/DQMServices/StreamerIO/test/RunStreamer.sh
@@ -28,16 +28,31 @@ rm run000001/run000001_ls0000_EoR.jsn
 mv teststreamfile_ext.dat run000001/teststreamfile_ext.dat
 timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamInExt_cfg.py  > ext  2>&1 || die "cmsRun streamInExt_cfg.py" $?
 
+echo "{\"data\" :[10,10, \"teststreamfile.dat\"]}" >  run000001/run1_ls1_test.jsn
+cmsRun ${SCRAM_TEST_PATH}/streamOutPadding_cfg.py > outPadding 2>&1 || die "cmsRun streamOutPadding_cfg.py" $?
+mv teststreamfile_padding.dat run000001/teststreamfile.dat
+timeout --signal SIGTERM 180 cmsRun ${SCRAM_TEST_PATH}/streamIn_cfg.py  > inPadding  2>&1 || die "cmsRun streamIn_cfg.py" $?
+
+
 # echo "CHECKSUM = 1" > out
 # echo "CHECKSUM = 1" > in
 
 ANS_OUT_SIZE=`grep -c CHECKSUM out`
+ANS_OUT_PADD_SIZE=`grep -c CHECKSUM outPadding`
 ANS_OUT=`grep CHECKSUM out`
+ANS_OUT_PADD=`grep CHECKSUM outPadding`
 ANS_IN=`grep CHECKSUM in`
+ANS_IN_PADD=`grep CHECKSUM inPadding`
 
 if [ "${ANS_OUT_SIZE}" == "0" ]
 then
     echo "New Stream Test Failed (out was not created)"
+    RC=1
+fi
+
+if [ "${ANS_OUT_PADD_SIZE}" == "0" ]
+then
+    echo "New Padded Stream Test Failed (out was not created)"
     RC=1
 fi
 
@@ -46,5 +61,12 @@ then
     echo "New Stream Test Failed (out!=in)"
     RC=1
 fi
+
+if [ "${ANS_OUT_PADD}" != "${ANS_IN_PADD}" ]
+then
+    echo "New Padded Stream Test Failed (out!=in)"
+    RC=1
+fi
+
 
 exit ${RC}

--- a/DQMServices/StreamerIO/test/streamOutPadding_cfg.py
+++ b/DQMServices/StreamerIO/test/streamOutPadding_cfg.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('compAlgo',
+                  'ZLIB', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Compression Algorithm")
+
+options.parseArguments()
+
+
+process = cms.Process("HLT")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(50)
+)
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint64(10123456789)
+)
+
+process.m1 = cms.EDProducer("StreamThingProducer",
+    instance_count = cms.int32(5),
+    array_size = cms.int32(2)
+)
+
+process.m2 = cms.EDProducer("NonProducer")
+
+process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
+    product_to_get = cms.string('m1')
+)
+
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string('teststreamfile.dat'),
+    padding = cms.untracked.uint32(4096),
+    compression_level = cms.untracked.int32(1),
+    use_compression = cms.untracked.bool(True),
+    compression_algorithm = cms.untracked.string(options.compAlgo),
+    max_event_size = cms.untracked.int32(7000000)
+)
+
+process.p1 = cms.Path(process.m1*process.a1*process.m2)
+process.end = cms.EndPath(process.out)

--- a/IOPool/Streamer/interface/MsgHeader.h
+++ b/IOPool/Streamer/interface/MsgHeader.h
@@ -27,7 +27,8 @@ struct Header {
     ERROR_EVENT = 14,
     FILE_CLOSE_REQUEST = 15,
     SPARE1 = 16,
-    SPARE2 = 17
+    SPARE2 = 17,
+    PADDING = 255  //reserved for padding
   };
 };
 

--- a/IOPool/Streamer/interface/StreamerFileIO.h
+++ b/IOPool/Streamer/interface/StreamerFileIO.h
@@ -20,13 +20,14 @@ namespace edm::streamer {
   */
   {
   public:
-    explicit OutputFile(const std::string& name);
+    explicit OutputFile(const std::string& name, uint32 padding = 0);
     /**
       CTOR, takes file path name as argument
      */
     ~OutputFile();
 
-    bool write(const char* ptr, size_t n);
+    bool write(const char* ptr, size_t n, bool doPadding = false);
+    bool writePadding();
 
     std::string fileName() const { return filename_; }
     uint64 current_offset() const { return current_offset_; }
@@ -42,9 +43,11 @@ namespace edm::streamer {
     bool do_adler_;
     uint32 adlera_;
     uint32 adlerb_;
+    uint32 padding_;
 
     edm::propagate_const<std::shared_ptr<std::ofstream>> ost_;
     std::string filename_;
+    std::unique_ptr<char[]> paddingBuf_;
   };
 }  // namespace edm::streamer
 #endif

--- a/IOPool/Streamer/interface/StreamerOutputFile.h
+++ b/IOPool/Streamer/interface/StreamerOutputFile.h
@@ -26,7 +26,7 @@ class StreamerOutputFile
   */
 {
 public:
-  explicit StreamerOutputFile(const std::string& name);
+  explicit StreamerOutputFile(const std::string& name, uint32 padding = 0);
   /**
       CTOR, takes file path name as argument
      */

--- a/IOPool/Streamer/src/StreamerFileIO.cc
+++ b/IOPool/Streamer/src/StreamerFileIO.cc
@@ -1,35 +1,61 @@
 #include "IOPool/Streamer/interface/StreamerFileIO.h"
 #include <fstream>
 #include <iostream>
+#include <cstring>
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Streamer/interface/MsgHeader.h"
 
 namespace edm::streamer {
-  OutputFile::OutputFile(const std::string& name)
+  OutputFile::OutputFile(const std::string& name, uint32 padding)
       : current_offset_(1),
         do_adler_(false),
         adlera_(1),
         adlerb_(0),
+        padding_(padding),
         ost_(new std::ofstream(name.c_str(), std::ios_base::binary | std::ios_base::out)),
         filename_(name) {
     if (!ost_->is_open()) {
       throw cms::Exception("OutputFile", "OutputFile") << "Error Opening Output File: " << name << "\n";
     }
     ost_->rdbuf()->pubsetbuf(nullptr, 0);
+    if (padding_) {
+      paddingBuf_ = std::make_unique<char[]>(padding_);
+      memset(paddingBuf_.get(), Header::PADDING, padding_);
+    }
   }
 
   OutputFile::~OutputFile() { ost_->close(); }
 
-  bool OutputFile::write(const char* ptr, size_t n) {
+  bool OutputFile::write(const char* ptr, size_t n, bool doPadding) {
     ost_->write(ptr, n);
     if (!ost_->fail()) {
       current_offset_ += (uint64)(n);
       if (do_adler_)
         cms::Adler32(ptr, n, adlera_, adlerb_);
+      if (doPadding && padding_) {
+        return writePadding();
+      }
       return false;
     }
     return true;
   }
 
-  void OutputFile::close() { ost_->close(); }
+  bool OutputFile::writePadding() {
+    uint64 mod = ost_->tellp() % padding_;
+    if (mod) {
+      uint32 rem = padding_ - (uint32)(mod % padding_);
+      bool ret = write(paddingBuf_.get(), rem, false);
+      return ret;
+    }
+    return false;
+  }
+
+  void OutputFile::close() {
+    if (padding_)
+      if (writePadding())
+        throw cms::Exception("OutputFile", "OutputFile")
+            << "Error writing padding to the output file: " << filename_ << ": " << std::strerror(errno);
+    ost_->close();
+  }
 }  // namespace edm::streamer

--- a/IOPool/Streamer/src/StreamerFileWriter.cc
+++ b/IOPool/Streamer/src/StreamerFileWriter.cc
@@ -3,7 +3,8 @@
 
 namespace edm {
   StreamerFileWriter::StreamerFileWriter(edm::ParameterSet const& ps)
-      : stream_writer_(new StreamerOutputFile(ps.getUntrackedParameter<std::string>("fileName"))) {}
+      : stream_writer_(new StreamerOutputFile(ps.getUntrackedParameter<std::string>("fileName"),
+                                              ps.getUntrackedParameter<unsigned int>("padding"))) {}
 
   StreamerFileWriter::StreamerFileWriter(std::string const& fileName)
       : stream_writer_(new StreamerOutputFile(fileName)) {}
@@ -34,5 +35,7 @@ namespace edm {
   void StreamerFileWriter::fillDescription(ParameterSetDescription& desc) {
     desc.setComment("Writes events into a streamer output file.");
     desc.addUntracked<std::string>("fileName", "teststreamfile.dat")->setComment("Name of output file.");
+    desc.addUntracked<unsigned int>("padding", 0)
+        ->setComment("For testing: INIT and event block size will be rounded to this size padded with 0xff bytes.");
   }
 }  //namespace edm

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -179,7 +179,7 @@ namespace edm {
 
   void StreamerInputFile::readStartMessage() {
     using namespace edm::storage;
-    IOSize nWant = sizeof(HeaderView);
+    IOSize nWant = sizeof(InitHeader);
     IOSize nGot = readBytes(&headerBuf_[0], nWant, false).first;
     if (nGot != nWant) {
       throw Exception(errors::FileReadError, "StreamerInputFile::readStartMessage")
@@ -202,9 +202,9 @@ namespace edm {
     if (headerBuf_.size() < headerSize)
       headerBuf_.resize(headerSize);
 
-    if (headerSize > sizeof(HeaderView)) {
-      nWant = headerSize - sizeof(HeaderView);
-      auto res = readBytes(&headerBuf_[sizeof(HeaderView)], nWant, true, sizeof(HeaderView));
+    if (headerSize > sizeof(InitHeader)) {
+      nWant = headerSize - sizeof(InitHeader);
+      auto res = readBytes(&headerBuf_[sizeof(InitHeader)], nWant, true, sizeof(InitHeader));
       if (res.first != nWant) {
         throw Exception(errors::FileReadError, "StreamerInputFile::readStartMessage")
             << "Failed reading streamer file, second read in readStartMessage\n";
@@ -270,18 +270,47 @@ namespace edm {
 
     using namespace edm::storage;
     bool eventRead = false;
+    unsigned hdrSkipped = 0;
     while (!eventRead) {
       IOSize nWant = sizeof(EventHeader);
-      IOSize nGot = readBytes(&eventBuf_[0], nWant, false).first;
+      IOSize nGot = readBytes(&eventBuf_[hdrSkipped], nWant - hdrSkipped, false).first + hdrSkipped;
+      while (nGot == nWant) {
+        //allow padding before next event or end of file.
+        //event header starts with code 0 - 17, so 0xff (Header:PADDING) uniquely represents padding
+        bool headerFetched = false;
+        for (size_t i = 0; i < nGot; i++) {
+          if ((unsigned char)eventBuf_[i] != Header::PADDING) {
+            //no padding 0xff
+            if (i != 0) {
+              memmove(&eventBuf_[0], &eventBuf_[i], nGot - i);
+              //read remainder of the header
+              nGot = nGot - i + readBytes(&eventBuf_[nGot - i], i, false).first;
+            }
+            headerFetched = true;
+            break;
+          }
+        }
+        if (headerFetched)
+          break;
+        //read another block
+        nGot = readBytes(&eventBuf_[0], nWant, false).first;
+      }
       if (nGot == 0) {
         // no more data available
         endOfFile_ = true;
         return 0;
       }
       if (nGot != nWant) {
-        throw edm::Exception(errors::FileReadError, "StreamerInputFile::readEventMessage")
-            << "Failed reading streamer file, first read in readEventMessage\n"
-            << "Requested " << nWant << " bytes, read function returned " << nGot << " bytes\n";
+        for (size_t i = 0; i < nGot; i++) {
+          if ((unsigned char)eventBuf_[i] != Header::PADDING)
+            throw edm::Exception(errors::FileReadError, "StreamerInputFile::readEventMessage")
+                << "Failed reading streamer file, first read in readEventMessage\n"
+                << "Requested " << nWant << " bytes, read function returned " << nGot
+                << " bytes, non-padding at offset " << i;
+        }
+        //padded 0xff only
+        endOfFile_ = true;
+        return 0;
       }
       uint32 eventSize;
       {
@@ -289,12 +318,27 @@ namespace edm {
         uint32 code = head.code();
 
         // If it is not an event then something is wrong.
+        eventSize = head.size();
         if (code != Header::EVENT) {
+          if (code == Header::INIT) {
+            edm::LogWarning("StreamerInputFile") << "Found another INIT header in the file. It will be skipped";
+            if (eventSize < sizeof(EventHeader)) {
+              //very unlikely case that EventHeader is larger than total INIT size inserted in the middle of the file
+              hdrSkipped = nGot - eventSize;
+              memmove(&eventBuf_[0], &eventBuf_[eventSize], hdrSkipped);
+              continue;
+            }
+            if (headerBuf_.size() < eventSize)
+              headerBuf_.resize(eventSize);
+            memcpy(&headerBuf_[0], &eventBuf_[0], nGot);
+            readBytes(&headerBuf_[nGot], eventSize, true, nGot);
+            //do not parse this header and proceed to the next event
+            continue;
+          }
           throw Exception(errors::FileReadError, "StreamerInputFile::readEventMessage")
               << "Failed reading streamer file, unknown code in event header\n"
               << "code = " << code << "\n";
         }
-        eventSize = head.size();
       }
       if (eventSize <= sizeof(EventHeader)) {
         throw edm::Exception(errors::FileReadError, "StreamerInputFile::readEventMessage")

--- a/IOPool/Streamer/src/StreamerOutputFile.cc
+++ b/IOPool/Streamer/src/StreamerOutputFile.cc
@@ -3,8 +3,8 @@
 
 StreamerOutputFile::~StreamerOutputFile() {}
 
-StreamerOutputFile::StreamerOutputFile(const std::string& name)
-    : streamerfile_(std::make_shared<edm::streamer::OutputFile>(name)) {
+StreamerOutputFile::StreamerOutputFile(const std::string& name, uint32 padding)
+    : streamerfile_(std::make_shared<edm::streamer::OutputFile>(name, padding)) {
   streamerfile_->set_do_adler(true);
 }
 
@@ -18,7 +18,7 @@ uint64 StreamerOutputFile::write(const EventMsgView& ineview) {
   uint64 offset_to_return = streamerfile_->current_offset();
 
   writeEventHeader(ineview);
-  bool ret = streamerfile_->write((const char*)ineview.eventData(), ineview.size() - ineview.headerSize());
+  bool ret = streamerfile_->write((const char*)ineview.eventData(), ineview.size() - ineview.headerSize(), true);
   if (ret) {
     throw cms::Exception("OutputFile", "write(EventMsgView)")
         << "Error writing streamer event data to " << streamerfile_->fileName() << ".  Possibly the output disk "
@@ -56,7 +56,7 @@ void StreamerOutputFile::write(const InitMsgBuilder& inview) {
 
 void StreamerOutputFile::write(const InitMsgView& inview) {
   writeStart(inview);
-  bool ret = streamerfile_->write((const char*)inview.descData(), inview.size() - inview.headerSize());
+  bool ret = streamerfile_->write((const char*)inview.descData(), inview.size() - inview.headerSize(), true);
   if (ret) {
     throw cms::Exception("OutputFile", "write(InitMsgView)")
         << "Error writing streamer header data to " << streamerfile_->fileName() << ".  Possibly the output disk "

--- a/IOPool/Streamer/test/NewStreamCopy_cfg.py
+++ b/IOPool/Streamer/test/NewStreamCopy_cfg.py
@@ -16,7 +16,8 @@ process.source = cms.Source("PoolSource",
 )
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
-    product_to_get = cms.string('m1')
+    product_to_get = cms.string('m1'),
+    inChecksum = cms.untracked.string('out')
 )
 
 process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',

--- a/IOPool/Streamer/test/NewStreamIn2_cfg.py
+++ b/IOPool/Streamer/test/NewStreamIn2_cfg.py
@@ -14,7 +14,8 @@ process.source = cms.Source("NewEventStreamFileReader",
 )
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
-    product_to_get = cms.string('m1')
+    product_to_get = cms.string('m1'),
+    inChecksum = cms.untracked.string('out')
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/IOPool/Streamer/test/NewStreamInPadding_cfg.py
+++ b/IOPool/Streamer/test/NewStreamInPadding_cfg.py
@@ -1,4 +1,16 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+
+options.register ('inChecksum',
+                  'out', # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Input checksum file")
+
+options.parseArguments()
+
 
 process = cms.Process("TRANSFER")
 
@@ -8,13 +20,13 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring('file:teststreamfile.dat')
+    fileNames = cms.untracked.vstring('file:teststreamfile_padding.dat')
     #firstEvent = cms.untracked.uint64(10123456835)
 )
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
     product_to_get = cms.string('m1'),
-    inChecksum = cms.untracked.string('out')
+    inChecksum = cms.untracked.string(options.inChecksum)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/IOPool/Streamer/test/NewStreamOutPadding_cfg.py
+++ b/IOPool/Streamer/test/NewStreamOutPadding_cfg.py
@@ -36,11 +36,12 @@ process.m2 = cms.EDProducer("NonProducer")
 
 process.a1 = cms.EDAnalyzer("StreamThingAnalyzer",
     product_to_get = cms.string('m1'),
-    outChecksum = cms.untracked.string('out')
+    outChecksum = cms.untracked.string('outPadded')
 )
 
 process.out = cms.OutputModule("EventStreamFileWriter",
-    fileName = cms.untracked.string('teststreamfile.dat'),
+    fileName = cms.untracked.string('teststreamfile_padding.dat'),
+    padding = cms.untracked.uint32(4096),
     compression_level = cms.untracked.int32(1),
     use_compression = cms.untracked.bool(True),
     compression_algorithm = cms.untracked.string(options.compAlgo),

--- a/IOPool/Streamer/test/RunSimple_NewStreamer.sh
+++ b/IOPool/Streamer/test/RunSimple_NewStreamer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function die { echo Failure $1: status $2 ; exit $2 ; }
+function die { echo Failure $1: status $2 ; echo ""; cat log ; exit $2 ; }
 
 if [ -z  $SCRAM_TEST_PATH ]; then
 SCRAM_TEST_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -14,48 +14,28 @@ echo "TEST_COMPRESSION_ALGO = $TEST_COMPRESSION_ALGO"
 
 RC=0
 
-cmsRun ${SCRAM_TEST_PATH}/NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > out 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outAlt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > outExt 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamIn_cfg.py  > in  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamIn2_cfg.py  > in2  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy_cfg.py  > copy  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy2_cfg.py  > copy2  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamInAlt_cfg.py  > alt  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamInExt_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
-cmsRun ${SCRAM_TEST_PATH}/NewStreamInExtBuf_cfg.py  > ext  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
+rm -rf {out,outPadded,log,*.txt,*.dat,*.root}
+
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > log 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutAlt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > log 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > log 2>&1 || die "cmsRun NewStreamOut_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > log 2>&1 || die "cmsRun NewStreamOutExt2_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamOutPadding_cfg.py compAlgo=${TEST_COMPRESSION_ALGO} > log 2>&1 || die "cmsRun NewStreamOutPadding_cfg.py compAlgo=${TEST_COMPRESSION_ALGO}" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamIn_cfg.py  > log  2>&1 || die "cmsRun NewStreamIn_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamIn2_cfg.py  > log  2>&1 || die "cmsRun NewStreamIn2_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy_cfg.py  > log  2>&1 || die "cmsRun NewStreamCopy_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamCopy2_cfg.py  > log  2>&1 || die "cmsRun NewStreamCopy2_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInAlt_cfg.py  > log  2>&1 || die "cmsRun NewStreamInAlt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInExt_cfg.py  > log  2>&1 || die "cmsRun NewStreamInExt_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInExtBuf_cfg.py > log  2>&1 || die "cmsRun NewStreamInExtBuf_cfg.py" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInPadding_cfg.py > log  2>&1 || die "cmsRun NewStreamInPadding_cfg.py (1)" $?
+cmsRun ${SCRAM_TEST_PATH}/NewStreamInPadding_cfg.py inChecksum=outPadded  > log  2>&1 || die "cmsRun NewStreamInPadding_cfg.py (2)" $?
 
 # echo "CHECKSUM = 1" > out
-# echo "CHECKSUM = 1" > in
 
-ANS_OUT_SIZE=`grep -c CHECKSUM out`
-ANS_OUT=`grep CHECKSUM out`
-ANS_IN=`grep CHECKSUM in`
-ANS_IN2=`grep CHECKSUM in2`
-ANS_COPY=`grep CHECKSUM copy`
+if [ ! -s out ]; then
 
-if [ "${ANS_OUT_SIZE}" == "0" ]
-then
-    echo "New Stream Test Failed (out was not created)"
-    RC=1
-fi
-
-if [ "${ANS_OUT}" != "${ANS_IN}" ]
-then
-    echo "New Stream Test Failed (out!=in)"
-    RC=1
-fi
-
-if [ "${ANS_OUT}" != "${ANS_IN2}" ]
-then
-    echo "New Stream Test Failed (out!=in2)"
-    RC=1
-fi
-
-if [ "${ANS_OUT}" != "${ANS_COPY}" ]
-then
-    echo "New Stream Test Failed (copy!=out)"
+    echo "New Stream Test Failed (out was not created or is empty)"
     RC=1
 fi
 

--- a/IOPool/Streamer/test/StreamThingAnalyzer.cc
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.cc
@@ -37,6 +37,8 @@ namespace edmtest_thing {
     //edm::LogInfo("stuff") << "again, ctor completing";
   }
 
+  StreamThingAnalyzer::~StreamThingAnalyzer() { std::cout << "\nSTREAMTHING_CHECKSUM " << total_ << "\n" << std::endl; }
+
   void StreamThingAnalyzer::endJob() {
     edm::LogInfo("StreamThingAnalyzer") << "STREAMTHING_CHECKSUM " << total_;
     if (!outChecksumFile_.empty()) {

--- a/IOPool/Streamer/test/StreamThingAnalyzer.cc
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.cc
@@ -22,6 +22,8 @@ namespace edmtest_thing {
       : name_(ps.getParameter<std::string>("product_to_get")),
         total_(),
         out_("gennums.txt"),
+        inChecksumFile_(ps.getUntrackedParameter<std::string>("inChecksum", "")),
+        outChecksumFile_(ps.getUntrackedParameter<std::string>("outChecksum", "")),
         cnt_(),
         getterUsingLabel_(edm::ModuleLabelMatch(name_), this) {
     callWhenNewProductsRegistered(getterUsingLabel_);
@@ -35,7 +37,22 @@ namespace edmtest_thing {
     //edm::LogInfo("stuff") << "again, ctor completing";
   }
 
-  StreamThingAnalyzer::~StreamThingAnalyzer() { std::cout << "\nSTREAMTHING_CHECKSUM " << total_ << "\n" << std::endl; }
+  void StreamThingAnalyzer::endJob() {
+    edm::LogInfo("StreamThingAnalyzer") << "STREAMTHING_CHECKSUM " << total_;
+    if (!outChecksumFile_.empty()) {
+      edm::LogInfo("StreamThingAnalyzer") << "Writing checksum to " << outChecksumFile_;
+      std::ofstream outChecksum(outChecksumFile_);
+      outChecksum << total_;
+    } else if (!inChecksumFile_.empty()) {
+      edm::LogInfo("StreamThingAnalyzer") << "Reading checksum from " << inChecksumFile_;
+      int totalIn = 0;
+      std::ifstream inChecksum(inChecksumFile_);
+      inChecksum >> totalIn;
+      if (totalIn != total_)
+        throw cms::Exception("StreamThingAnalyzer")
+            << "Checksum mismatch input: " << totalIn << " compared to: " << total_;
+    }
+  }
 
   void StreamThingAnalyzer::analyze(edm::Event const& e, edm::EventSetup const&) {
     typedef std::vector<edm::Handle<WriteThis> > ProdList;

--- a/IOPool/Streamer/test/StreamThingAnalyzer.h
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.h
@@ -21,6 +21,9 @@ namespace edmtest_thing {
   class StreamThingAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit StreamThingAnalyzer(edm::ParameterSet const&);
+
+    ~StreamThingAnalyzer() override;
+
     void endJob() override;
 
     void analyze(edm::Event const& e, edm::EventSetup const& c) override;

--- a/IOPool/Streamer/test/StreamThingAnalyzer.h
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.h
@@ -21,8 +21,7 @@ namespace edmtest_thing {
   class StreamThingAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit StreamThingAnalyzer(edm::ParameterSet const&);
-
-    ~StreamThingAnalyzer() override;
+    void endJob() override;
 
     void analyze(edm::Event const& e, edm::EventSetup const& c) override;
 
@@ -30,6 +29,8 @@ namespace edmtest_thing {
     std::string name_;
     int total_;
     std::ofstream out_;
+    std::string inChecksumFile_;
+    std::string outChecksumFile_;
     int cnt_;
     edm::GetterOfProducts<WriteThis> getterUsingLabel_;
   };


### PR DESCRIPTION
#### PR description:
Adding support for padding in the Streamer format. Padding bytes (0xff) can be appended after the end of each event or INIT message. Intention is to add them at the end of the file (4096-byte blocks) to round the file size so it is compatible with O_DIRECT copy from DAQ RUBUs to Lustre system in hope this will reduce deadtime issues seen recently.

Streamer Input sources will automatically detect padding which will (typically) be appended to streams transferred to Tier-0. Also an option was added to generate files which contain padding after each event or INI object.

Update: DQM and EcalCalibration unit tests were extended with the padded format test as well.

#### PR validation:
Unit test was added to generate and read padded streamer file. In addition it was manually tested with standard merged streamer files in CDAQ, as well as new padded ones that are created in the DAQ test system.