### PR TITLE
introduce `SiStripNoisesAndBadCompsChecker`

### DIFF
--- a/CondTools/SiStrip/plugins/SiStripNoisesAndBadCompsChecker.cc
+++ b/CondTools/SiStrip/plugins/SiStripNoisesAndBadCompsChecker.cc
@@ -1,0 +1,134 @@
+// system includes
+#include <iostream>
+#include <fstream>
+
+// user includes
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h" /* for STRIPS_PER_APV*/
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+class SiStripNoisesAndBadCompsChecker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit SiStripNoisesAndBadCompsChecker(const edm::ParameterSet& iConfig);
+
+  ~SiStripNoisesAndBadCompsChecker() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const bool writePayload_;
+  const edm::FileInPath fp_;
+  const uint32_t printdebug_;
+  const edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
+  const edm::ESGetToken<SiStripBadStrip, SiStripBadChannelRcd> deadChannelToken_;
+
+  const std::string k_Name_ = "SiStripNoisesAndBadCompsChecker";
+  const std::string k_Record_ = "SiStripNoisesRcd";
+};
+
+SiStripNoisesAndBadCompsChecker::SiStripNoisesAndBadCompsChecker(const edm::ParameterSet& iConfig)
+    : writePayload_(iConfig.getUntrackedParameter<bool>("writePayload", true)),
+      fp_(iConfig.getUntrackedParameter<edm::FileInPath>("file",
+                                                         edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile))),
+      printdebug_(iConfig.getUntrackedParameter<uint32_t>("printDebug", std::numeric_limits<unsigned int>::max())),
+      noiseToken_(esConsumes()),
+      deadChannelToken_(esConsumes()) {
+  usesResource(cond::service::PoolDBOutputService::kSharedResource);
+}
+
+void SiStripNoisesAndBadCompsChecker::analyze(const edm::Event& evt, const edm::EventSetup& iSetup) {
+  SiStripNoises obj; /* this is the output object */
+
+  unsigned int count{0};
+
+  const auto& reader = SiStripDetInfoFileReader::read(fp_.fullPath());
+  const auto& DetInfos = reader.getAllData();
+
+  auto const& deadChannel = iSetup.getData(deadChannelToken_);
+  auto const& noise = iSetup.getData(noiseToken_);
+
+  for (const auto& it : DetInfos) {
+    const auto& nAPVs = it.second.nApvs;
+
+    SiStripNoises::Range detNoiseRange = noise.getRange(it.first);
+
+    // fill in the information about the dead channels
+    SiStripBadStrip::Range detBadStripRange = deadChannel.getRange(it.first);
+    std::vector<bool> badChannels;
+    badChannels.clear();
+    badChannels.insert(badChannels.begin(), sistrip::STRIPS_PER_APV * nAPVs, false);
+    for (SiStripBadStrip::ContainerIterator it2 = detBadStripRange.first; it2 != detBadStripRange.second; ++it2) {
+      SiStripBadStrip::data fs = deadChannel.decode(*it2);
+      for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip) {
+        badChannels[strip] = true;
+      }
+    }
+
+    SiStripNoises::InputVector theSiStripVector;
+    for (int strip = 0; strip < sistrip::STRIPS_PER_APV * nAPVs; ++strip) {
+      const auto& theNoise = noise.getNoise(strip, detNoiseRange);
+      if (!badChannels[strip]) {
+        try {
+          noise.verify(strip, detNoiseRange);
+        } catch (cms::Exception& e) {
+          if (count < printdebug_) {
+            edm::LogPrint(k_Name_) << "WARNING: out-of-range "
+                                   << " detid: " << it.first << " strip: " << strip << " noise:" << theNoise;
+          }
+          count++;
+        }
+      }  // is strip is not masked
+      obj.setData(theNoise, theSiStripVector);
+    }  // loop on the strips
+
+    if (!obj.put(it.first, theSiStripVector))
+      edm::LogError(k_Name_) << "[SiStripNoisesAndBadCompsChecker::analyze] detid already exists";
+  }  // loop on the detids
+  edm::LogPrint(k_Name_) << "Found " << count << " strips in out-of-bounds!";
+
+  if (writePayload_) {
+    edm::LogInfo(k_Name_) << "Will write an updated fixed payload";
+
+    //And now write sistripnoises data in DB
+    edm::Service<cond::service::PoolDBOutputService> mydbservice;
+
+    if (mydbservice.isAvailable()) {
+      if (mydbservice->isNewTagRequest("SiStripNoisesRcd")) {
+        mydbservice->createOneIOV<SiStripNoises>(obj, mydbservice->beginOfTime(), k_Record_);
+      } else {
+        mydbservice->appendOneIOV<SiStripNoises>(obj, mydbservice->currentTime(), k_Record_);
+      }
+    } else {
+      edm::LogError("SiStripNoisesBuilder") << "Service is unavailable, will not write any output";
+    }
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SiStripNoisesAndBadCompsChecker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.setComment(
+      "Given a certain Global Tag, checks that the all the unmasked strips, do have a noise within the payload range");
+  desc.addUntracked<bool>("writePayload", true);
+  desc.addUntracked<edm::FileInPath>("file", edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile));
+  desc.addUntracked<uint32_t>("printDebug", std::numeric_limits<unsigned int>::max());
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(SiStripNoisesAndBadCompsChecker);

--- a/CondTools/SiStrip/test/SiStripNoisesAndBadCompsChecker_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoisesAndBadCompsChecker_cfg.py
@@ -1,0 +1,96 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import copy 
+
+process = cms.Process("Demo")
+
+#prepare options
+
+options = VarParsing.VarParsing("analysis")
+
+options.register ('globalTag',
+                  "auto:phase1_2018_cosmics_peak",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "GlobalTag")
+
+options.register ('runNumber',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "run number")
+
+options.register ('writePayload',
+                  True,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.bool,            # string, int, or float
+                  "write out payload")
+
+options.parseArguments()
+
+
+##
+## MessageLogger
+##
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripNoisesAndBadCompsChecker=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable    = cms.untracked.bool(True),
+    enableStatistics = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripNoisesAndBadCompsChecker = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+
+##
+## Conditions
+##
+process.load("Configuration.Geometry.GeometryRecoDB_cff") # Ideal geometry and interface 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+
+print("Using Global Tag:", process.GlobalTag.globaltag._value)
+
+##
+## Empty Source
+##
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            )
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+##
+## DB Output
+##
+if(options.writePayload) :
+    process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                              BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                              DBParameters = cms.PSet(authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')),
+                                              timetype = cms.untracked.string('runnumber'),
+                                              connect = cms.string('sqlite_file:SiStripNoise_PeakMode_2018_Minus20C_v0_mc_fixed.db'),
+                                              toPut = cms.VPSet(cms.PSet(record = cms.string('SiStripNoisesRcd'),
+                                                                         tag = cms.string('SiStripNoise_PeakMode_2018_Minus20C_v0_mc_fixed')
+                                                                     )
+                                                            )
+                                          )
+
+##
+## Analyzer
+##
+process.demo = cms.EDAnalyzer('SiStripNoisesAndBadCompsChecker',
+                              writePayload = cms.untracked.bool(options.writePayload),
+                              printDebug = cms.untracked.uint32(100),
+                              file = cms.untracked.FileInPath('CalibTracker/SiStripCommon/data/SiStripDetInfo.dat'))
+
+##
+## Parh
+##
+process.p = cms.Path(process.demo)


### PR DESCRIPTION
#### PR description:

As requested at https://github.com/cms-sw/cmssw/pull/41120#issuecomment-1479613523, introduce a new plugin  `SiStripNoisesAndBadCompsChecker` that  given a certain Global Tag, checks that the all the unmasked strips (as per input `SiStripBadStrip` records), do have a noise within the DetId range, to avoid leading to the issue solved in #41120.

#### PR validation:

Private tests, running the configuration file added here.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A