### PR TITLE
Update `AlignableTracker` for phase-2 Outer Tracker

### DIFF
--- a/Alignment/TrackerAlignment/interface/AlignableStackDet.h
+++ b/Alignment/TrackerAlignment/interface/AlignableStackDet.h
@@ -1,0 +1,37 @@
+#ifndef Alignment_TrackerAlignment_AlignableStackDet_H
+#define Alignment_TrackerAlignment_AlignableStackDet_H
+
+/** \class AlignableStackDet
+ *  An alignable for StackDets in the Phase-2 Outer Tracker detector, 
+ *  taking care of consistency with AlignableDet components.
+ *
+ *  First implementation March 2022
+ *  \author Marco Musich, U. Pisa / INFN
+ *  $Date: 2022/03/15 13:36:00 $
+ *  $Revision: 1.0 $
+ */
+
+#include "Alignment/CommonAlignment/interface/AlignableDet.h"
+#include "Geometry/CommonDetUnit/interface/StackGeomDet.h"
+
+class AlignTransformErrorExtended;
+class Bounds;
+class StripGeomDetType;
+
+class AlignableStackDet : public AlignableDet {
+public:
+  /// Constructor
+  AlignableStackDet(const StackGeomDet *geomDet);
+  /// reduntantly make destructor virtual
+  ~AlignableStackDet() override = default;
+
+  /// first consistify with component detunits, then call method from AlignableDet
+  Alignments *alignments() const override;
+
+private:
+  /// make alignments consistent with daughters
+  void consistifyAlignments();
+  const Plane theLowerDetSurface;
+};
+
+#endif

--- a/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
+++ b/Alignment/TrackerAlignment/interface/AlignableTrackerBuilder.h
@@ -49,6 +49,9 @@ private:  //==================================================================
   void buildStripDetectorAlignable(
       const GeomDet*, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update = false);
 
+  void buildOuterTrackerDetectorAlignable(
+      const GeomDet*, int subdetId, Alignables& aliDets, Alignables& aliDetUnits, bool update = false);
+
   /// Builds all composite Alignables for the tracker. The hierarchy and
   /// numbers of components are determined in TrackerAlignmentLevelBuilder.
   void buildAlignableComposites(bool update = false);
@@ -56,6 +59,8 @@ private:  //==================================================================
   void buildPixelDetector(AlignableTracker*);
   /// Builds the StripDetector by hand.
   void buildStripDetector(AlignableTracker*);
+  /// Builds the Phase-2 Outer Tracker Detector by hand.
+  void buildOuterTrackerDetector(AlignableTracker*);
 
   //========================== PRIVATE DATA ===================================
   //===========================================================================

--- a/Alignment/TrackerAlignment/python/Scenarios_cff.py
+++ b/Alignment/TrackerAlignment/python/Scenarios_cff.py
@@ -3090,6 +3090,60 @@ MisalignmentScenario10Mu = MisalignmentScenarioSettings.clone(
   ),
 )
 
+MisalignmentScenario10MuPhase2 = MisalignmentScenarioSettings.clone(
+  setError = cms.bool(False),
+  scale = cms.double(0.01), # shifts in 100um
+
+  P2PXBHalfBarrels = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+  P2OTBHalfBarrels = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+  P2PXECEndcaps = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+  P2OTECEndcaps = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+)
+
+MisalignmentScenario10MuPixelPhase2 = MisalignmentScenarioSettings.clone(
+  setError = cms.bool(False),
+  scale = cms.double(0.01), # shifts in 100um
+
+  P2PXBHalfBarrels = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+  P2PXECEndcaps = cms.PSet(
+    DetUnits = cms.PSet(
+      dYlocal = cms.double(0.1),
+      dXlocal = cms.double(0.1),
+    ),
+  ),
+
+)
+
 MisalignmentScenario100Mu = MisalignmentScenarioSettings.clone(
   setError = cms.bool(False),
   scale = cms.double(0.01), # shifts in 100um

--- a/Alignment/TrackerAlignment/src/AlignableStackDet.cc
+++ b/Alignment/TrackerAlignment/src/AlignableStackDet.cc
@@ -1,0 +1,54 @@
+/* 
+ *  $Date: 2011/09/05 16:59:07 $
+ *  $Revision: 1.9 $
+ */
+
+#include "Alignment/CommonAlignment/interface/AlignableSurface.h"
+#include "Alignment/TrackerAlignment/interface/AlignableStackDet.h"
+#include "CondFormats/Alignment/interface/AlignTransformErrorExtended.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/AlignmentPositionError.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
+#include "DataFormats/GeometrySurface/interface/BoundPlane.h"
+#include "DataFormats/GeometrySurface/interface/Bounds.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "Geometry/CommonDetUnit/interface/StackGeomDet.h"
+#include <cmath>
+
+AlignableStackDet::AlignableStackDet(const StackGeomDet* stackedDet)
+    : AlignableDet(stackedDet, true),  // true: adding DetUnits
+      theLowerDetSurface(stackedDet->lowerDet()->surface()) {
+  // check order lower/upper
+  const Alignables units(this->components());
+  if (units.size() != 2 || stackedDet->lowerDet()->geographicalId() != units[0]->geomDetId() ||
+      stackedDet->upperDet()->geographicalId() != units[1]->geomDetId()) {
+    throw cms::Exception("LogicError") << "[AlignableStackDet] "
+                                       << "Either != 2 components or "
+                                       << "upper/lower in wrong order for consistifyAlignments.";
+  }
+}
+
+//__________________________________________________________________________________________________
+Alignments* AlignableStackDet::alignments() const {
+  const_cast<AlignableStackDet*>(this)->consistifyAlignments();
+  return this->AlignableDet::alignments();
+}
+
+//__________________________________________________________________________________________________
+void AlignableStackDet::consistifyAlignments() {
+  // Now we have all to calculate new position and rotation via PlaneBuilderForGluedDet.
+  const PositionType oldPos(theSurface.position());  // From old surface for keeping...
+  const RotationType oldRot(theSurface.rotation());  // ...track of changes.
+
+  // The plane is *not* built in the middle, but on the Lower surface
+  // see usage in  Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+  theSurface = AlignableSurface(theLowerDetSurface);
+
+  // But do not forget to keep track of movements/rotations:
+  const GlobalVector movement(theSurface.position().basicVector() - oldPos.basicVector());
+  // Seems to be correct down to delta angles 4.*1e-8:
+  const RotationType rotation(oldRot.multiplyInverse(theSurface.rotation()));
+  this->addDisplacement(movement);
+  this->addRotation(rotation);
+}

--- a/Alignment/TrackerAlignment/test/BuildFile.xml
+++ b/Alignment/TrackerAlignment/test/BuildFile.xml
@@ -26,3 +26,4 @@
 
 <test name="test_PixelBaryCentreTool" command="pixelPositions.sh"/>
 <test name="test_ProduceSystematicMisalignment" command="testProduceAllMisalignments.sh"/>
+<test name="test_CreateRandomMisalignment" command="testCreateRandomMisalignment.sh"/>

--- a/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
+++ b/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
@@ -1,0 +1,158 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import copy, sys, os
+
+process = cms.Process("Misaligner")
+
+###################################################################
+# Setup 'standard' options
+###################################################################
+options = VarParsing.VarParsing()
+
+options.register('myScenario',
+                 "MisalignmentScenario10MuPixelPhase2", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "scenario to apply")
+
+options.register('mySigma',
+                 -1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.float, # string, int, or float
+                 "sigma for random misalignment in um")
+
+options.register('inputDB',
+                 None, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input database file to override GT (optional)")
+
+options.parseArguments()
+
+###################################################################
+# Message logger service
+###################################################################
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('INFO'),
+    default = cms.untracked.PSet(
+        limit = cms.untracked.int32(10000000)
+    )
+)
+# replace MessageLogger.debugModules = { "*" }
+# service = Tracer {}
+
+###################################################################
+# Ideal geometry producer and standard includes
+###################################################################
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.trackerGeometry.applyAlignment = True
+
+###################################################################
+# Just state the Global Tag (and pick some run)
+###################################################################
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '') # using realistic Phase 2 geom
+process.GlobalTag.toGet = cms.VPSet(
+    cms.PSet(record = cms.string("TrackerAlignmentRcd"),
+             tag = cms.string("Alignments"),
+             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
+         ),
+    cms.PSet(record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+             tag = cms.string("AlignmentErrorsExtended"),
+             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
+         ),
+    cms.PSet(record = cms.string("TrackerSurfaceDeformationRcd"),
+             tag = cms.string("AlignmentSurfaceDeformations"),
+             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
+         )
+)
+
+print("Using global tag:", process.GlobalTag.globaltag.value())
+
+
+###################################################################
+# This uses the object from the tag and applies the misalignment scenario on top of that object
+###################################################################
+process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")
+process.AlignmentProducer.doMisalignmentScenario=True
+process.AlignmentProducer.applyDbAlignment=True
+process.AlignmentProducer.checkDbAlignmentValidity=False #otherwise error thrown for IOV dependent GTs
+import Alignment.TrackerAlignment.Scenarios_cff as scenarios
+
+if hasattr(scenarios, options.myScenario):
+    print("Using scenario:", options.myScenario)
+    print("    with sigma:", options.mySigma)
+    print()
+    process.AlignmentProducer.MisalignmentScenario = getattr(scenarios, options.myScenario)
+else:
+    print("----- Begin Fatal Exception -----------------------------------------------")
+    print("Unrecognized",options.myScenario,"misalignment scenario !!!!")
+    print("Aborting cmsRun now, please check your input")
+    print("----- End Fatal Exception -------------------------------------------------")
+    sys.exit(1)
+
+sigma = options.mySigma
+if sigma > 0:
+    process.AlignmentProducer.MisalignmentScenario.scale = cms.double(0.0001*sigma) # shifts are in cm
+
+# if options.inputDB is not None:
+#     print("EXTENDING THE GLOBAL TAG!!!!")
+#     process.GlobalTag.toGet.extend([
+#             cms.PSet(
+#                 connect = cms.string("sqlite_file:"+options.inputDB),
+#                 record = cms.string("TrackerAlignmentRcd"),
+#                 tag = cms.string("Alignments")
+#                 ),
+#             cms.PSet(
+#                 connect = cms.string("sqlite_file:"+options.inputDB),
+#                 record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+#                 tag = cms.string("AlignmentErrorsExtended")
+#                 )
+#             ])
+
+process.AlignmentProducer.saveToDB=True
+process.AlignmentProducer.saveApeToDB=True
+
+###################################################################
+# Output name
+###################################################################
+outputfilename = None
+scenariolabel = str(options.myScenario)
+if sigma > 0:
+    scenariolabel = scenariolabel+str(sigma)
+outputfilename = "geometry_"+str(scenariolabel)+"__from_"
+if options.inputDB is None:
+    outputfilename += process.GlobalTag.globaltag.value()+".db"
+else:
+    outputfilename += options.inputDB
+
+###################################################################
+# Source
+###################################################################
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+###################################################################
+# Database output service
+###################################################################
+from CondCore.CondDB.CondDB_cfi import *
+process.PoolDBOutputService = cms.Service(
+    "PoolDBOutputService",
+    CondDB,
+    timetype = cms.untracked.string("runnumber"),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string("TrackerAlignmentRcd"),
+            tag = cms.string("Alignments")
+            ),
+        cms.PSet(
+            record = cms.string("TrackerAlignmentErrorExtendedRcd"),
+            tag = cms.string("AlignmentErrorsExtended")
+            ),
+        )
+    )
+process.PoolDBOutputService.connect = "sqlite_file:"+outputfilename
+process.PoolDBOutputService.DBParameters.messageLevel = 2

--- a/Alignment/TrackerAlignment/test/testCreateRandomMisalignment.sh
+++ b/Alignment/TrackerAlignment/test/testCreateRandomMisalignment.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+folder=$CMSSW_BASE/src/Alignment/TrackerAlignment/test/Misalignments
+
+for a in $(ls $folder); do
+    echo "running " ${a}
+    cmsRun $folder/${a}
+done 


### PR DESCRIPTION
#### PR description:

The goal of this PR is to introduce the necessary changes in order to be able to construct the `AlignableTracker` geometry tree in the case of the phase-2 Tracker detector.
For that purpose I introduce a new class `AlignableStackDet` to deal with the Stack detectors (PS and SS modules) of the Phase-2 Outer Tracker and use it in the new method `AlignableTrackerBuilder::buildOuterTrackerDetector`.
I also add a test file to create random misalignment scenarios starting from the D88 (T21) and a couple of misalignment scenarios for Phase2. 

**This PR is still draft, pending some more refined validation from the alignment group**. 
I would nevertheless profit of the central testing infrastructure to make sure this doesn't create issues in the existing workflows.

#### PR validation:

Relies on the augmented unit tests introduced in this PR:

```
scram b runtests_test_CreateRandomMisalignment
```

runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

For the moment no backport is foreseen, might happen at a later time.

cc:
@consuegs @henriettepetersen 