### PR TITLE
adapt Tracker Alignment Payload Inspector for phase-2

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -31,6 +31,7 @@ namespace AlignmentPI {
 
   // size of the phase-I Tracker APE payload (including both SS + DS modules)
   static const unsigned int phase0size = 19876;
+  static const unsigned int phase1size = 20292;
   static const float cmToUm = 10000.f;
   static const float tomRad = 1000.f;
 
@@ -670,7 +671,7 @@ namespace AlignmentPI {
   }
 
   /*--------------------------------------------------------------------*/
-  inline std::string getStringFromPart(AlignmentPI::partitions i)
+  inline std::string getStringFromPart(AlignmentPI::partitions i, bool isPhase2 = false)
   /*--------------------------------------------------------------------*/
   {
     switch (i) {
@@ -679,13 +680,13 @@ namespace AlignmentPI {
       case FPix:
         return "FPix";
       case TIB:
-        return "TIB";
+        return (isPhase2 ? "TIB-invalid" : "TIB");
       case TID:
-        return "TID";
+        return (isPhase2 ? "P2OTEC" : "TID");
       case TOB:
-        return "TOB";
+        return (isPhase2 ? "P2OTB" : "TOB");
       case TEC:
-        return "TEC";
+        return (isPhase2 ? "TEC-invalid" : "TEC");
       default:
         return "should never be here!";
     }
@@ -998,7 +999,7 @@ namespace AlignmentPI {
 
   /*--------------------------------------------------------------------*/
   inline void fillComparisonHistogram(const AlignmentPI::coordinate& coord,
-                                      std::vector<int>& boundaries,
+                                      std::map<int, AlignmentPI::partitions>& boundaries,
                                       const std::vector<AlignTransform>& ref_ali,
                                       const std::vector<AlignTransform>& target_ali,
                                       std::unique_ptr<TH1F>& compare)
@@ -1014,7 +1015,7 @@ namespace AlignmentPI {
         auto thePart = static_cast<AlignmentPI::partitions>(subid);
         if (thePart != currentPart) {
           currentPart = thePart;
-          boundaries.push_back(counter);
+          boundaries.insert({counter, thePart});
         }
 
         CLHEP::HepRotation target_rot(target_ali[i].rotation());
@@ -1074,7 +1075,7 @@ namespace AlignmentPI {
   }
 
   /*--------------------------------------------------------------------*/
-  inline void fillComparisonHistograms(std::vector<int>& boundaries,
+  inline void fillComparisonHistograms(std::map<int, AlignmentPI::partitions>& boundaries,
                                        const std::vector<AlignTransform>& ref_ali,
                                        const std::vector<AlignTransform>& target_ali,
                                        std::unordered_map<AlignmentPI::coordinate, std::unique_ptr<TH1F> >& compare,
@@ -1098,7 +1099,7 @@ namespace AlignmentPI {
 
         if (thePart != currentPart) {
           currentPart = thePart;
-          boundaries.push_back(counter);
+          boundaries.insert({counter, thePart});
         }
 
         CLHEP::HepRotation target_rot(target_ali[i].rotation());


### PR DESCRIPTION
#### PR description:

With the recent increase of activities related to the Phase-2 tracker alignment (see e.g. https://github.com/cms-sw/cmssw/pull/41129 and https://github.com/cms-sw/cmssw/pull/41075), it becomes necessary to support phase-2 payloads in the payload inspector.
This PR offers some generalization in order to do that. 

#### PR validation:

Tested with:

```
getPayloadData.py \
   --plugin pluginTrackerAlignment_PayloadInspector \
   --plot plot_TrackerAlignmentComparatorTwoTags \
   --tag TrackerAlignment_Upgrade2026_T21_design_v0 \
   --tagtwo TrackerAlignment_Phase2_T21_misalignmentTest_FullTracker_v0 \
   --time_type Run \
   --iovs '{"start_iov": "1", "end_iov": "1"}' \
   --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
   --db Prep \
   --test ;

getPayloadData.py \
    --plugin pluginTrackerAlignment_PayloadInspector \
    --plot plot_TrackerAlignmentCompareXTwoTags \
    --tag TrackerAlignment_Upgrade2026_T21_design_v0 \
    --tagtwo TrackerAlignment_Phase2_T21_misalignmentTest_FullTracker_v0 \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prep  \
    --test ;
```

and obtained the following plots:

![image](https://user-images.githubusercontent.com/5082376/226963346-3fbc9a77-7dd4-4c4c-8fe7-39b93a1dd349.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:


N/A
