### PR TITLE
[SIMULATION] Various fixes/improvements for unit test

### DIFF
--- a/SimGeneral/PreMixingModule/test/BuildFile.xml
+++ b/SimGeneral/PreMixingModule/test/BuildFile.xml
@@ -7,7 +7,4 @@
   <use name="SimDataFormats/PileupSummaryInfo"/>
 </library>
 
-<bin file="runtestSimGeneralPreMixingModule.cpp" name="runtestSimGeneralPreMixingModule">
-  <flags TEST_RUNNER_ARGS=" /bin/bash SimGeneral/PreMixingModule/test run_testPremixPileupAdjustment.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="runtestSimGeneralPreMixingModule" command="run_testPremixPileupAdjustment.sh"/>

--- a/SimGeneral/PreMixingModule/test/run_testPremixPileupAdjustment.sh
+++ b/SimGeneral/PreMixingModule/test/run_testPremixPileupAdjustment.sh
@@ -2,20 +2,14 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-pushd ${LOCAL_TMP_DIR}
-
   echo "*************************************************"
   echo "Produce a fake MinBias event library"
-  cmsRun ${LOCAL_TEST_DIR}/testFakeMinBias_cfg.py || die "cmsRun testFakeMinBias_cfg.py" $?
+  cmsRun ${SCRAM_TEST_PATH}/testFakeMinBias_cfg.py || die "cmsRun testFakeMinBias_cfg.py" $?
 
   echo "*************************************************"
   echo "Produce a fake pileup library (premix stage1)"
-  cmsRun ${LOCAL_TEST_DIR}/testPremixStage1_cfg.py || die "cmsRun testPremixStage1_cfg.py" $?
+  cmsRun ${SCRAM_TEST_PATH}/testPremixStage1_cfg.py || die "cmsRun testPremixStage1_cfg.py" $?
 
   echo "*************************************************"
   echo "Test premixing by adjusting the pileup"
-  cmsRun ${LOCAL_TEST_DIR}/testPremixStage2_cfg.py || die "cmsRun testPremixStage2_cfg.py" $?
-
-popd
-
-exit 0
+  cmsRun ${SCRAM_TEST_PATH}/testPremixStage2_cfg.py || die "cmsRun testPremixStage2_cfg.py" $?

--- a/SimGeneral/PreMixingModule/test/runtestSimGeneralPreMixingModule.cpp
+++ b/SimGeneral/PreMixingModule/test/runtestSimGeneralPreMixingModule.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.