### PR TITLE
[GENERATORS] Various fixes/improvements for unit test

### DIFF
--- a/GeneratorInterface/EvtGenInterface/test/BuildFile.xml
+++ b/GeneratorInterface/EvtGenInterface/test/BuildFile.xml
@@ -1,6 +1,3 @@
-<bin name="GeneratorInterfaceEvtGenInterfaceTest" file="TestEvtGenInterface.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash GeneratorInterface/EvtGenInterface/test runevtgentests.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="GeneratorInterfaceEvtGenInterfaceTest" command="runevtgentests.sh"/>
 <test name="TestGeneratorInterfaceEvtGenInterface_bplus" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/EvtGenInterface/test/Py8_bplus_evtgen1_cfg.py"/>
 <test name="TestGeneratorInterfaceEvtGenInterface_external_bplus" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/EvtGenInterface/test/external_Py8_bplus_evtgen1_cfg.py"/>

--- a/GeneratorInterface/EvtGenInterface/test/TestEvtGenInterface.cpp
+++ b/GeneratorInterface/EvtGenInterface/test/TestEvtGenInterface.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/GeneratorInterface/EvtGenInterface/test/runevtgentests.sh
+++ b/GeneratorInterface/EvtGenInterface/test/runevtgentests.sh
@@ -3,7 +3,7 @@
 function die { echo $1: status $2 ;  exit $2; }
 
 # list basic test
-cmsRun ${LOCAL_TEST_DIR}/Py8_bplus_evtgen1_cfg.py || die 'Failure using Py8_bplus_evtgen1_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/Py8_bplus_evtgen1_cfg.py || die 'Failure using Py8_bplus_evtgen1_cfg.py' $?
 
 # extra test
-cmsRun ${LOCAL_TEST_DIR}/../plugins/test/Py8_lambadb_evtgen1_Lb2plnuLCSR_cfg.py || die 'Py8_lambadb_evtgen1_Lb2plnuLCSR_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/../plugins/test/Py8_lambadb_evtgen1_Lb2plnuLCSR_cfg.py || die 'Py8_lambadb_evtgen1_Lb2plnuLCSR_cfg.py' $?

--- a/GeneratorInterface/LHEInterface/test/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/test/BuildFile.xml
@@ -4,10 +4,7 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin name="TestGeneratorInterfaceLHEInterfaceFileReading" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS=" /bin/bash GeneratorInterface/LHEInterface/test testMerging.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestGeneratorInterfaceLHEInterfaceFileReading" command="testMerging.sh"/>
 
 <bin file="test_catch2_*.cc" name="testGeneratorInterfaceLHEInterface_TP">
   <use name="FWCore/TestProcessor"/>

--- a/GeneratorInterface/LHEInterface/test/TestDriver.cpp
+++ b/GeneratorInterface/LHEInterface/test/TestDriver.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/GeneratorInterface/LHEInterface/test/testMerging.sh
+++ b/GeneratorInterface/LHEInterface/test/testMerging.sh
@@ -3,18 +3,14 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
-
-F1=${LOCAL_TEST_DIR}/testMerge_cfg.py
-F2=${LOCAL_TEST_DIR}/testNoMerge_cfg.py
+F1=${SCRAM_TEST_PATH}/testMerge_cfg.py
+F2=${SCRAM_TEST_PATH}/testNoMerge_cfg.py
 
 
 (cmsRun $F1) > test_merge.log || die "Failure using $F1" $?
 
-diff ${LOCAL_TEST_DIR}/testMerge.log test_merge.log || die "comparing test_merge.log" $?
+diff ${SCRAM_TEST_PATH}/testMerge.log test_merge.log || die "comparing test_merge.log" $?
 
 
 (cmsRun $F2) > test_no_merge.log || die "Failure using $F2" $?
-diff ${LOCAL_TEST_DIR}/testNoMerge.log test_no_merge.log || die "comparing test_no_merge.log" $?
-
-popd
+diff ${SCRAM_TEST_PATH}/testNoMerge.log test_no_merge.log || die "comparing test_no_merge.log" $?


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.