### PR TITLE
[ALCA-DB] Various fixes/improvements for unit test

### DIFF
--- a/CondCore/ESSources/test/BuildFile.xml
+++ b/CondCore/ESSources/test/BuildFile.xml
@@ -24,10 +24,7 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin file="TestCondCoreESSources.cpp" name="UnitTestConcurrentIOVsCondCore">
-  <flags TEST_RUNNER_ARGS=" /bin/bash CondCore/ESSources/test TestConcurrentIOVsCondCore.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="UnitTestConcurrentIOVsCondCore" command="TestConcurrentIOVsCondCore.sh"/>
 
 <library file="stubs/LumiTestReadAnalyzer.cc" name="LumiTestReadAnalyzer">
   <flags EDM_PLUGIN="1"/>

--- a/CondCore/ESSources/test/TestConcurrentIOVsCondCore.sh
+++ b/CondCore/ESSources/test/TestConcurrentIOVsCondCore.sh
@@ -2,11 +2,7 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
-pushd ${LOCAL_TMP_DIR}
-
 echo cmsRun TestConcurrentIOVsCondCore_cfg.py
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/TestConcurrentIOVsCondCore_cfg.py || die 'Failed in TestConcurrentIOVsCondCore_cfg.py' $?
+cmsRun --parameter-set ${SCRAM_TEST_PATH}/TestConcurrentIOVsCondCore_cfg.py || die 'Failed in TestConcurrentIOVsCondCore_cfg.py' $?
 grep "TestConcurrentIOVsCondCore: " TestConcurrentIOVsCondCoreCout.log > TestConcurrentIOVsCondCore.log
-diff ${LOCAL_TEST_DIR}/unit_test_outputs/TestConcurrentIOVsCondCore.log TestConcurrentIOVsCondCore.log || die "comparing TestConcurrentIOVsCondCore.log" $?
-
-popd
+diff ${SCRAM_TEST_PATH}/unit_test_outputs/TestConcurrentIOVsCondCore.log TestConcurrentIOVsCondCore.log || die "comparing TestConcurrentIOVsCondCore.log" $?

--- a/CondCore/ESSources/test/TestCondCoreESSources.cpp
+++ b/CondCore/ESSources/test/TestCondCoreESSources.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.