### PR TITLE
[RECONSTRUCTION-XPOG] Various fixes/improvements for unit test

### DIFF
--- a/PhysicsTools/PatAlgos/test/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/test/BuildFile.xml
@@ -8,10 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="runtestPhysicsToolsPatAlgos.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash PhysicsTools/PatAlgos/test runtests.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-
-</environment>
+<test name="runtestPhysicsToolsPatAlgos" command="runtests.sh"/>

--- a/PhysicsTools/PatAlgos/test/runtestPhysicsToolsPatAlgos.cpp
+++ b/PhysicsTools/PatAlgos/test/runtestPhysicsToolsPatAlgos.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -10,47 +10,47 @@ do
     fi
 done
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_standard_cfg.py || die 'Failure using patTuple_standard_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_standard_cfg.py || die 'Failure using patTuple_standard_cfg.py' $?
 
 # FIXME: event content broken in only available data RelVal
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_data_cfg.py || die 'Failure using patTuple_data_cfg.py' $? # Recent input RelVals currently not reachable (from CERN)
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_data_cfg.py || die 'Failure using patTuple_data_cfg.py' $? # Recent input RelVals currently not reachable (from CERN)
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_PF2PAT_cfg.py || die 'Failure using patTuple_PF2PAT_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_PF2PAT_cfg.py || die 'Failure using patTuple_PF2PAT_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_PATandPF2PAT_cfg.py || die 'Failure using patTuple_PATandPF2PAT_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_PATandPF2PAT_cfg.py || die 'Failure using patTuple_PATandPF2PAT_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addDecayInFlight_cfg.py || die 'Failure using patTuple_addDecayInFlight_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addDecayInFlight_cfg.py || die 'Failure using patTuple_addDecayInFlight_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addBTagging_cfg.py || die 'Failure using patTuple_addBTagging_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addBTagging_cfg.py || die 'Failure using patTuple_addBTagging_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addJets_cfg.py || die 'Failure using patTuple_addJets_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addJets_cfg.py || die 'Failure using patTuple_addJets_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addTracks_cfg.py || die 'Failure using patTuple_addTracks_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addTracks_cfg.py || die 'Failure using patTuple_addTracks_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addTriggerInfo_cfg.py || die 'Failure using patTuple_addTriggerInfo_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addTriggerInfo_cfg.py || die 'Failure using patTuple_addTriggerInfo_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_addVertexInfo_cfg.py || die 'Failure using patTuple_addVertexInfo_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_addVertexInfo_cfg.py || die 'Failure using patTuple_addVertexInfo_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_fastsim_cfg.py || die 'Failure using patTuple_fastsim_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_fastsim_cfg.py || die 'Failure using patTuple_fastsim_cfg.py' $?
 
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_topSelection_cfg.py || die 'Failure using patTuple_topSelection_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_topSelection_cfg.py || die 'Failure using patTuple_topSelection_cfg.py' $?
 
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_userData_cfg.py || die 'Failure using patTuple_userData_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_userData_cfg.py || die 'Failure using patTuple_userData_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_updateMet_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateMet_fromMiniAOD_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_updateMet_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateMet_fromMiniAOD_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/patTuple_updateJets_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateJets_fromMiniAOD_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/patTuple_updateJets_fromMiniAOD_cfg.py || die 'Failure using patTuple_updateJets_fromMiniAOD_cfg.py' $?
 
 #---- disabled while the release is still open and changes to AOD event content are still allowed
-#cmsRun ${LOCAL_TEST_DIR}/patMiniAOD_standard_cfg.py || die 'Failure using patMiniAOD_standard_cfg.py' $?
+#cmsRun ${SCRAM_TEST_PATH}/patMiniAOD_standard_cfg.py || die 'Failure using patMiniAOD_standard_cfg.py' $?
 
 # Not needed in IBs
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyElectrons_cfg.py || die 'Failure using patTuple_onlyElectrons_cfg.py' $?
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyJets_cfg.py || die 'Failure using patTuple_onlyJets_cfg.py' $?
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyMET_cfg.py || die 'Failure using patTuple_onlyMET_cfg.py' $?
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyMuons_cfg.py || die 'Failure using patTuple_onlyMuons_cfg.py' $?
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyPhotons_cfg.py || die 'Failure using patTuple_onlyPhotons_cfg.py' $?
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyTaus_cfg.py || die 'Failure using patTuple_onlyTaus_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyElectrons_cfg.py || die 'Failure using patTuple_onlyElectrons_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyJets_cfg.py || die 'Failure using patTuple_onlyJets_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyMET_cfg.py || die 'Failure using patTuple_onlyMET_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyMuons_cfg.py || die 'Failure using patTuple_onlyMuons_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyPhotons_cfg.py || die 'Failure using patTuple_onlyPhotons_cfg.py' $?
+# cmsRun ${SCRAM_TEST_PATH}/patTuple_onlyTaus_cfg.py || die 'Failure using patTuple_onlyTaus_cfg.py' $?
 


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.