### PR TITLE
[13_0_X] Add L1 Stage2 Digis to Cosmics AOD event content

### DIFF
--- a/Configuration/EventContent/python/EventContentCosmics_cff.py
+++ b/Configuration/EventContent/python/EventContentCosmics_cff.py
@@ -132,6 +132,7 @@ AODEventContent.outputCommands.extend(MEtoEDMConverterAOD.outputCommands)
 AODEventContent.outputCommands.extend(EvtScalersAOD.outputCommands)
 AODEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
+AODEventContent.outputCommands.extend(L1TriggerAOD.outputCommands)
 #
 #
 # RAWSIM Data Tier definition

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_Cosmics_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_Cosmics_cff.py
@@ -84,3 +84,17 @@ L1TriggerFEVTDEBUG = cms.PSet(
         'keep LumiSummary_lumiProducer_*_*'       
         )
 )
+
+def _appendStage2Digis(obj):
+    l1Stage2Digis = [
+        'keep *_gtStage2Digis_*_*',
+        'keep *_gmtStage2Digis_*_*',
+        'keep *_caloStage2Digis_*_*',
+        ]
+    obj.outputCommands += l1Stage2Digis
+
+# adding them to all places where we had l1extraParticles
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(L1TriggerRECO, func=_appendStage2Digis)
+stage2L1Trigger.toModify(L1TriggerAOD, func=_appendStage2Digis)
+stage2L1Trigger.toModify(L1TriggerFEVTDEBUG, func=_appendStage2Digis)


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

As discussed in PPDC meeting we want to have L1 objects in Cosmics AOD event content. This PR adds required L1 stage2 digis to cosmics AOD event content.

This will make L1 displaced muon performance studies much easier to perform with cosmics data. 

#### PR validation:

Validated by running reconstruction on cosmics RAW data from 2022 using:

`cmsDriver.py reco -s RAW2DIGI,RECO --data --scenario cosmics --eventcontent AOD --filein /store/data/Run2022G/Cosmics/RAW/v1/000/362/363/00000/887de473-401c-4b6d-a9bb-66a32e35f446.root --fileout testAOD.root --conditions 124X_dataRun3_Prompt_v4 -n 1000 --era=Run3`

I verified that the required digis now exist in the event content after the changes

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of https://github.com/cms-sw/cmssw/pull/41149

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
