### PR TITLE
[SIMULATION] Various fixes/improvements for unit test

### DIFF
--- a/SimG4Core/DD4hepGeometry/test/BuildFile.xml
+++ b/SimG4Core/DD4hepGeometry/test/BuildFile.xml
@@ -1,10 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="dd4hep-geant4"/>
 <use name="DetectorDescription/DDCMS"/>
-<bin file="dummyMain.cpp" name="DD4hepGeometryTestDriver">
-  <use name="FWCore/Utilities"/>
-  <flags TEST_RUNNER_ARGS="/bin/bash SimG4Core/DD4hepGeometry/test runTest.sh"/>
-</bin>
+<test name="DD4hepGeometryTestDriver" command="runTest.sh"/>
 
 <library name="DD4hepGeometryTestPlugins" file="plugins/*.cc">
   <use name="SimG4Core/DD4hepGeometry"/>

--- a/SimG4Core/DD4hepGeometry/test/dummyMain.cpp
+++ b/SimG4Core/DD4hepGeometry/test/dummyMain.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/SimG4Core/DD4hepGeometry/test/runTest.sh
+++ b/SimG4Core/DD4hepGeometry/test/runTest.sh
@@ -2,12 +2,12 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-F1=${LOCAL_TEST_DIR}/python/testG4Geometry.py
-F2=${LOCAL_TEST_DIR}/python/testG4Regions.py
+F1=${SCRAM_TEST_PATH}/python/testG4Geometry.py
+F2=${SCRAM_TEST_PATH}/python/testG4Regions.py
 
 echo " testing SimG4Core/DD4hepGeometry"
 
-export tmpdir=${LOCAL_TMP_DIR:-/tmp}
+export tmpdir=${PWD}
 echo "===== Test \"cmsRun testG4Geometry.py\" ===="
 (cmsRun $F1) || die "Failure using cmsRun $F1" $?
 echo "===== Test \"cmsRun testG4Regions.py\" ===="


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.