### PR TITLE
[GEOMETRY-UPGRADE] Various fixes/improvements for unit test

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
+++ b/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
@@ -40,14 +40,8 @@
     <use name="RecoTracker/TransientTrackingRecHit"/>
   </library>
 
-  <bin name="testPhase2PixelNtuple" file="testPhase2PixelNtuple.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash SLHCUpgradeSimulations/Geometry/test phase2_digi_reco_pixelntuple.sh "/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="testPhase2PixelNtuple" command="phase2_digi_reco_pixelntuple.sh"/>
 
-  <bin name="testPhase2SkimmedGeometry" file="testPhase2SkimmedGeometry.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash SLHCUpgradeSimulations/Geometry/test phase2_skimmed_geometry.sh "/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="testPhase2SkimmedGeometry" command="phase2_skimmed_geometry.sh"/>
 
 </environment>

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple.sh
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple.sh
@@ -3,4 +3,4 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-(cmsRun ${LOCAL_TEST_DIR}/phase2_digi_reco_pixelntuple_cfg.py 0) || die 'Failure running cmsRun phase2_digi_reco_pixelntuple_cfg.py 0' $?
+(cmsRun ${SCRAM_TEST_PATH}/phase2_digi_reco_pixelntuple_cfg.py 0) || die 'Failure running cmsRun phase2_digi_reco_pixelntuple_cfg.py 0' $?

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_skimmed_geometry.sh
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_skimmed_geometry.sh
@@ -3,4 +3,4 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-(cmsRun ${LOCAL_TEST_DIR}/writeFile_phase2_cfg.py 0) || die 'Failure running cmsRun writeFile_phase2_cfg.py 0' $?
+(cmsRun ${SCRAM_TEST_PATH}/writeFile_phase2_cfg.py 0) || die 'Failure running cmsRun writeFile_phase2_cfg.py 0' $?

--- a/SLHCUpgradeSimulations/Geometry/test/testPhase2PixelNtuple.cpp
+++ b/SLHCUpgradeSimulations/Geometry/test/testPhase2PixelNtuple.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/SLHCUpgradeSimulations/Geometry/test/testPhase2SkimmedGeometry.cpp
+++ b/SLHCUpgradeSimulations/Geometry/test/testPhase2SkimmedGeometry.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.