### PR TITLE
[RECONSTRUCTION] Various fixes/improvements for unit test

### DIFF
--- a/JetMETCorrections/Modules/test/BuildFile.xml
+++ b/JetMETCorrections/Modules/test/BuildFile.xml
@@ -1,4 +1,1 @@
-<bin name="TestJetMETCorrectionsModulesJetResolutionObject" file="TestDriver.cc">
-  <flags TEST_RUNNER_ARGS="/bin/bash JetMETCorrections/Modules/test test_jetresolution.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="TestJetMETCorrectionsModulesJetResolutionObject" command="test_jetresolution.sh"/>

--- a/JetMETCorrections/Modules/test/TestDriver.cc
+++ b/JetMETCorrections/Modules/test/TestDriver.cc
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/JetMETCorrections/Modules/test/test_jetresolution.sh
+++ b/JetMETCorrections/Modules/test/test_jetresolution.sh
@@ -3,5 +3,5 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-F1=${LOCAL_TEST_DIR}/JetResolutionDemo_cfg.py
+F1=${SCRAM_TEST_PATH}/JetResolutionDemo_cfg.py
 (cmsRun $F1 ) || die "Failure using $F1" $?

--- a/MagneticField/Engine/test/BuildFile.xml
+++ b/MagneticField/Engine/test/BuildFile.xml
@@ -12,7 +12,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin file="regressionTestHelper.cpp" name="MagneticFieldEngineTestDriver">
-  <use name="FWCore/Utilities"/>
-  <flags TEST_RUNNER_ARGS="/bin/bash MagneticField/Engine/test runTest.sh"/>
-</bin>
+<test name="MagneticFieldEngineTestDriver" command="runTest.sh"/>

--- a/MagneticField/Engine/test/regressionTestHelper.cpp
+++ b/MagneticField/Engine/test/regressionTestHelper.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/MagneticField/Engine/test/runTest.sh
+++ b/MagneticField/Engine/test/runTest.sh
@@ -7,33 +7,33 @@ echo "===== Test MF map regressions  ===="
 #Note: Only the most relevant tests are left uncommented since the full set is highly redundant and time consuming.
 
 #Run II, 3.8T
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DDD)      || die "MF regression failure, from xml, DDD, 3.8T" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB)          || die "MF regression failure, from DB, DDD, 3.8T" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DD4hep)          || die "MF regression failure, from xml, DD4hep, 3.8T" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB_DD4hep)   || die "MF regression failure, from DB, DD4hep, 3.8T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DDD)      || die "MF regression failure, from xml, DDD, 3.8T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB)          || die "MF regression failure, from DB, DDD, 3.8T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DD4hep)          || die "MF regression failure, from xml, DD4hep, 3.8T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB_DD4hep)   || die "MF regression failure, from DB, DD4hep, 3.8T" $?
 
 #Run I, 3.8T
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DDD era=RunI)      || die "MF regression failure, from xml, DDD, 3.8T RunI" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB era=RunI)          || die "MF regression failure, from DB, DDD, 3.8T RunI" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DD4hep era=RunI)          || die "MF regression failure, from xml, DD4hep, 3.8T RunI" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB_DD4hep era=RunI)   || die "MF regression failure, from DB, DD4hep, 3.8T RunI" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DDD era=RunI)      || die "MF regression failure, from xml, DDD, 3.8T RunI" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB era=RunI)          || die "MF regression failure, from DB, DDD, 3.8T RunI" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DD4hep era=RunI)          || die "MF regression failure, from xml, DD4hep, 3.8T RunI" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB_DD4hep era=RunI)   || die "MF regression failure, from DB, DD4hep, 3.8T RunI" $?
 
 #Run II, 3.5T
 export CURRENT=16730
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 3.5T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 3.5T" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DD4hep current=$CURRENT)        || die "MF regression failure, from xml, DD4hep, 3.5T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB_DD4hep current=$CURRENT)  || die "MF regression failure, from DB, DD4hep, 3.5T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 3.5T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 3.5T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DD4hep current=$CURRENT)        || die "MF regression failure, from xml, DD4hep, 3.5T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB_DD4hep current=$CURRENT)  || die "MF regression failure, from DB, DD4hep, 3.5T" $?
 
 #Run II, 3T
 export CURRENT=14340
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 3T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 3T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DD4hep current=$CURRENT)        || die "MF regression failure, from xml, DD4hep, 3T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB_DD4hep current=$CURRENT)  || die "MF regression failure, from DB, DD4hep, 3T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 3T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 3T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DD4hep current=$CURRENT)        || die "MF regression failure, from xml, DD4hep, 3T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB_DD4hep current=$CURRENT)  || die "MF regression failure, from DB, DD4hep, 3T" $?
 
 #Run II, 2T
 export CURRENT=9500
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 2T" $?
-#(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 2T" $?
-(cmsRun ${LOCAL_TEST_DIR}/regression.py producerType=fromDB_DD4hep current=$CURRENT) || die "MF regression failure, from DB, DD4hep, 2T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=static_DDD current=$CURRENT)    || die "MF regression failure, from xml, DDD, 2T" $?
+#(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB current=$CURRENT)        || die "MF regression failure, from DB, DDD, 2T" $?
+(cmsRun ${SCRAM_TEST_PATH}/regression.py producerType=fromDB_DD4hep current=$CURRENT) || die "MF regression failure, from DB, DD4hep, 2T" $?

--- a/MagneticField/GeomBuilder/test/BuildFile.xml
+++ b/MagneticField/GeomBuilder/test/BuildFile.xml
@@ -8,7 +8,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin file="dummyMain.cpp" name="MagneticFieldGeomBuilderTestDriver">
-  <use name="FWCore/Utilities"/>
-  <flags TEST_RUNNER_ARGS="/bin/bash MagneticField/GeomBuilder/test runTest.sh"/>
-</bin>
+<test name="MagneticFieldGeomBuilderTestDriver" command="runTest.sh"/>

--- a/MagneticField/GeomBuilder/test/dummyMain.cpp
+++ b/MagneticField/GeomBuilder/test/dummyMain.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/MagneticField/GeomBuilder/test/runTest.sh
+++ b/MagneticField/GeomBuilder/test/runTest.sh
@@ -2,12 +2,12 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-F1=${LOCAL_TEST_DIR}/python/dumpMFGeometry.py
-F2=${LOCAL_TEST_DIR}/python/testMFGeometry.py
+F1=${SCRAM_TEST_PATH}/python/dumpMFGeometry.py
+F2=${SCRAM_TEST_PATH}/python/testMFGeometry.py
 
 echo " testing MagneticField/GeomBuilder"
 
-export tmpdir=${LOCAL_TMP_DIR:-/tmp}
+export tmpdir=${PWD}
 echo "===== Test \"cmsRun dumpMFGeometry.py\" ===="
 (cmsRun $F1) || die "Failure using cmsRun $F1" $?
 echo "===== Test \"cmsRun testMFGeometry.py\" ===="

--- a/PhysicsTools/SelectorUtils/test/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/test/BuildFile.xml
@@ -1,4 +1,1 @@
-<bin file="testPhysicsToolsSelectorUtilsPythonTestsDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash PhysicsTools/SelectorUtils/test runPythonTests.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="testPhysicsToolsSelectorUtilsPythonTestsDriver" command="runPythonTests.sh"/>

--- a/PhysicsTools/SelectorUtils/test/testPhysicsToolsSelectorUtilsPythonTestsDriver.cpp
+++ b/PhysicsTools/SelectorUtils/test/testPhysicsToolsSelectorUtilsPythonTestsDriver.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
+++ b/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
@@ -9,10 +9,8 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<bin name="DRNTest" file="runtestRecoEcalEgammaClusterProducers.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash RecoEcal/EgammaClusterProducers/test runtests.sh"/>
-  <use name="FWCore/Utilities"/>
+<test name="DRNTest" command="runtests.sh">
   <ifrelease name="_ASAN_|_UBSAN_">
     <flags NO_TEST_PREFIX="1"/>
   </ifrelease>
-</bin>
+</test>

--- a/RecoEcal/EgammaClusterProducers/test/runtestRecoEcalEgammaClusterProducers.cpp
+++ b/RecoEcal/EgammaClusterProducers/test/runtestRecoEcalEgammaClusterProducers.cpp
@@ -1,3 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-
-RUNTEST()

--- a/RecoEcal/EgammaClusterProducers/test/runtests.sh
+++ b/RecoEcal/EgammaClusterProducers/test/runtests.sh
@@ -15,4 +15,4 @@ if ! apptainer-check.sh; then
 	exit 0
 fi
 
-cmsRun ${LOCAL_TEST_DIR}/DRNTest_cfg.py || die 'Failure using cmsRun' $?
+cmsRun ${SCRAM_TEST_PATH}/DRNTest_cfg.py || die 'Failure using cmsRun' $?

--- a/RecoTracker/MkFit/test/BuildFile.xml
+++ b/RecoTracker/MkFit/test/BuildFile.xml
@@ -6,8 +6,5 @@
   <use name="RecoTracker/Record"/>
 </library>
 
-<bin file="TestDriver.cpp" name="testDumpMkFitGeometry">
-  <use name="FWCore/Utilities"/>
-  <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/MkFit/test testDumpMkFitGeometry.sh"/>
-</bin>
+<test name="testDumpMkFitGeometry" command="testDumpMkFitGeometry.sh"/>
 

--- a/RecoTracker/MkFit/test/TestDriver.cpp
+++ b/RecoTracker/MkFit/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/RecoTracker/MkFit/test/testDumpMkFitGeometry.sh
+++ b/RecoTracker/MkFit/test/testDumpMkFitGeometry.sh
@@ -7,5 +7,5 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   cd ${SCRAM_TEST_NAME}
 fi
 
-(cmsRun ${LOCAL_TEST_DIR}/dumpMkFitGeometry.py) || die "failed to run dumpMkFitGeometry.py" $?
-(cmsRun ${LOCAL_TEST_DIR}/dumpMkFitGeometryPhase2.py) || die "failed to run dumpMkFitGeometryPhase2.py" $?
+(cmsRun ${SCRAM_TEST_PATH}/dumpMkFitGeometry.py) || die "failed to run dumpMkFitGeometry.py" $?
+(cmsRun ${SCRAM_TEST_PATH}/dumpMkFitGeometryPhase2.py) || die "failed to run dumpMkFitGeometryPhase2.py" $?

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -30,8 +30,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="testMuonTrackRefitting.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoTracker/TrackProducer/test testMuonTrackRefitting.sh"/>
-  </bin>
-</environment>
+<test name="testMuonTrackRefitting" command="testMuonTrackRefitting.sh"/>

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
+++ b/RecoTracker/TrackProducer/test/testMuonTrackRefitting.sh
@@ -6,8 +6,8 @@ echo "TESTING Refitting from Analysis Data-Tier codes ..."
 
 # test AOD
 echo "TESTING refitting from AOD ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/refitFromAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
+cmsRun ${SCRAM_TEST_PATH}/refitFromAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16RECO/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/AODSIM/106X_mcRun2_asymptotic_v13-v2/00000/1D4FBF4B-7B8D-A04F-A108-B1BEB60558FA.root || die "Failure refitting from AOD" $?
 
 # test MINIAOD
 echo "TESTING refitting from MINIAOD ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/refitFromMINIAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root || die "Failure refitting from MINIAOD" $?
+cmsRun ${SCRAM_TEST_PATH}/refitFromMINIAOD.py maxEvents=100 inputFiles=/store/mc/RunIISummer20UL16MiniAOD/DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/MINIAODSIM/106X_mcRun2_asymptotic_v13-v2/00000/01916D91-A314-D947-A420-388891D62FEA.root || die "Failure refitting from MINIAOD" $?


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.