### PR TITLE
[DAQ] Various fixes/improvements for unit test

### DIFF
--- a/EventFilter/Utilities/test/BuildFile.xml
+++ b/EventFilter/Utilities/test/BuildFile.xml
@@ -10,9 +10,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="RunBUFU_t.cpp" name="BUFU_TEST">
-    <flags TEST_RUNNER_ARGS="/bin/bash EventFilter/Utilities/test RunBUFU.sh"/>
-  </bin>
-
-</environment>
+<test name="BUFU_TEST" command="RunBUFU.sh"/>

--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -13,21 +13,15 @@ if [ ! -z $1 ]; then
   fi
 fi
 
-if [ -z  $LOCAL_TEST_DIR ]; then
-LOCAL_TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -z  ${SCRAM_TEST_PATH} ]; then
+SCRAM_TEST_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 fi
-echo "LOCAL_TEST_DIR = $LOCAL_TEST_DIR"
-
-if [ -z  $LOCAL_TMP_DIR ]; then
-LOCAL_TMP_DIR="/tmp"
-fi
-
-cd $LOCAL_TEST_DIR
+echo "SCRAM_TEST_PATH = ${SCRAM_TEST_PATH}"
 
 RC=0
 P=$$
 PREFIX=results_${USER}${P}
-OUTDIR=${LOCAL_TMP_DIR}/${PREFIX}
+OUTDIR=${PWD}/${PREFIX}
 
 echo "OUT_TMP_DIR = $OUTDIR"
 

--- a/EventFilter/Utilities/test/RunBUFU_t.cpp
+++ b/EventFilter/Utilities/test/RunBUFU_t.cpp
@@ -1,8 +1,0 @@
-//------------------------------------------------------------
-//
-// Driver for shell scripts.
-//
-//------------------------------------------------------------
-
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.