### PR TITLE
[ALCA] Various fixes/improvements for unit test

### DIFF
--- a/CalibTracker/SiPixelESProducers/test/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/test/BuildFile.xml
@@ -9,9 +9,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<environment>
-  <bin file="testSiPixelFakeLorentzAngleESSource.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiPixelESProducers/test testSiPixelFakeLorentzAngleESSource.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-</environment>
+<test name="testSiPixelFakeLorentzAngleESSource" command="testSiPixelFakeLorentzAngleESSource.sh"/>

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.cpp
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.sh
+++ b/CalibTracker/SiPixelESProducers/test/testSiPixelFakeLorentzAngleESSource.sh
@@ -5,13 +5,13 @@ function die { echo $1: status $2 ; exit $2; }
 echo "TESTING Fake Pixel Conditions Sources ..."
 
 printf "TESTING SiPixelFakeLorentzAngleESSource (BPix) ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isBPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (BPix)" $? 
+cmsRun ${SCRAM_TEST_PATH}/testSiPixelFakeLorentzAngleESSource_cfg.py isBPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (BPix)" $?
 
 printf "TESTING SiPixelFakeLorentzAngleESSource (FPix) ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isFPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (FPix)" $? 
+cmsRun ${SCRAM_TEST_PATH}/testSiPixelFakeLorentzAngleESSource_cfg.py isFPix=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (FPix)" $?
 
 printf "TESTING SiPixelFakeLorentzAngleESSource (By Module) ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isByModule=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (By Module)" $? 
+cmsRun ${SCRAM_TEST_PATH}/testSiPixelFakeLorentzAngleESSource_cfg.py isByModule=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (By Module)" $?
 
 printf "TESTING SiPixelFakeLorentzAngleESSource (Phase-2) ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/testSiPixelFakeLorentzAngleESSource_cfg.py isPhase2=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (Phase-2) " $? 
+cmsRun ${SCRAM_TEST_PATH}/testSiPixelFakeLorentzAngleESSource_cfg.py isPhase2=True  || die "Failure testing SiPixelFakeLorentzAngleESSource (Phase-2) " $?

--- a/CalibTracker/SiStripChannelGain/test/BuildFile.xml
+++ b/CalibTracker/SiStripChannelGain/test/BuildFile.xml
@@ -1,15 +1,9 @@
 <environment>
-  <bin name="testSSTGainPCL_fromRECO" file="testSSTGain_PCL_FromRECO.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromRECO.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="testSSTGainPCL_fromRECO" command="testSSTGain_PCL_FromRECO.sh"/>
   <bin name="checkMultiRunHarvestingOutput" file="checkMultiRunHarvesting.cpp">
     <flags PRE_TEST="testSSTGainPCL_fromRECO"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
   </bin>
-  <bin name="testSSTGainPCL_fromCalibTree" file="testSSTGain_PCL_FromCalibTree.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripChannelGain/test testSSTGain_PCL_FromCalibTree.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
+  <test name="testSSTGainPCL_fromCalibTree" command="testSSTGain_PCL_FromCalibTree.sh"/>
 </environment>

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromCalibTree.cpp
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromCalibTree.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromCalibTree.sh
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromCalibTree.sh
@@ -8,8 +8,8 @@ COMMMAND=`xrdfs root://eoscms.cern.ch// locate ${REMOTE}/${FILE}`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
-    (cmsRun ${LOCAL_TEST_DIR}/Gains_CT_step1.py firstRun=${RUN} lastRun=${RUN} inputFiles=root://eoscms.cern.ch//$REMOTE/$FILE outputFile=PromptCalibProdSiStripGainsFromTree.root) || die 'Failure running cmsRun Gains_CT_step1.py firstRun=${RUN} lastRun=${RUN} inputFiles=root://eoscms.cern.ch//$REMOTE/$FILE outputFile=PromptCalibProdSiStripGainsFromTree.root' $?
-    (cmsRun ${LOCAL_TEST_DIR}/Gains_CT_step2.py inputFiles=file:PromptCalibProdSiStripGainsFromTree.root DQMOutput=True) || die 'Failure running cmsRun Gains_CT_step2.py inputFiles=file:PromptCalibProdSiStripGainsFromTree.root DQMOutput=True' $?
+    (cmsRun ${SCRAM_TEST_PATH}/Gains_CT_step1.py firstRun=${RUN} lastRun=${RUN} inputFiles=root://eoscms.cern.ch//$REMOTE/$FILE outputFile=PromptCalibProdSiStripGainsFromTree.root) || die 'Failure running cmsRun Gains_CT_step1.py firstRun=${RUN} lastRun=${RUN} inputFiles=root://eoscms.cern.ch//$REMOTE/$FILE outputFile=PromptCalibProdSiStripGainsFromTree.root' $?
+    (cmsRun ${SCRAM_TEST_PATH}/Gains_CT_step2.py inputFiles=file:PromptCalibProdSiStripGainsFromTree.root DQMOutput=True) || die 'Failure running cmsRun Gains_CT_step2.py inputFiles=file:PromptCalibProdSiStripGainsFromTree.root DQMOutput=True' $?
 else
   die "SKIPPING test, file ${FILE} not found" 0
 fi

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.cpp
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_PCL_FromRECO.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py era=A) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=A' $?
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_PCL_FromRECO_cfg.py era=B) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=B' $?
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_HARVEST_FromRECO.py 0) || die 'Failure running cmsRun testSSTGain_HARVEST_FromRECO.py 0' $?
-(cmsRun ${LOCAL_TEST_DIR}/testSSTGain_MultiRun_ALCAHARVEST.py globalTag=auto:run3_data_express) || die 'Failure running cmsRun testSSTGain_MultiRun_ALCAHARVEST.py 0' $?
+(cmsRun ${SCRAM_TEST_PATH}/testSSTGain_PCL_FromRECO_cfg.py era=A) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=A' $?
+(cmsRun ${SCRAM_TEST_PATH}/testSSTGain_PCL_FromRECO_cfg.py era=B) || die 'Failure running cmsRun testSSTGain_PCL_FromRECO_cfg.py era=B' $?
+(cmsRun ${SCRAM_TEST_PATH}/testSSTGain_HARVEST_FromRECO.py 0) || die 'Failure running cmsRun testSSTGain_HARVEST_FromRECO.py 0' $?
+(cmsRun ${SCRAM_TEST_PATH}/testSSTGain_MultiRun_ALCAHARVEST.py globalTag=auto:run3_data_express) || die 'Failure running cmsRun testSSTGain_MultiRun_ALCAHARVEST.py 0' $?

--- a/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/test/BuildFile.xml
@@ -1,4 +1,1 @@
-<bin name="testSiStripHitEfficiency" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripHitEfficiency/test test_SiStripHitEfficiency.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="testSiStripHitEfficiency" command="test_SiStripHitEfficiency.sh"/>

--- a/CalibTracker/SiStripHitEfficiency/test/TestDriver.cpp
+++ b/CalibTracker/SiStripHitEfficiency/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiStripHitEfficiency/test/test_SiStripHitEfficiency.sh
+++ b/CalibTracker/SiStripHitEfficiency/test/test_SiStripHitEfficiency.sh
@@ -7,12 +7,12 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
 fi
 
 echo -e "Testing SiStripHitEfficencyWorker \n\n"
-cmsRun ${LOCAL_TEST_DIR}/testHitEffWorker.py isUnitTest=True || die 'failed running testHitEffWorker.py' $?
+cmsRun ${SCRAM_TEST_PATH}/testHitEffWorker.py isUnitTest=True || die 'failed running testHitEffWorker.py' $?
 
 echo -e "Testing SiStripHitEfficencyHarvester \n\n"
-cmsRun ${LOCAL_TEST_DIR}/testHitEffHarvester.py isUnitTest=True || die 'failed running testHitEffHarvester.py' $?
+cmsRun ${SCRAM_TEST_PATH}/testHitEffHarvester.py isUnitTest=True || die 'failed running testHitEffHarvester.py' $?
 
 echo -e " testing tSiStripHitEffFromCalibTree \n\n"
-cmsRun ${LOCAL_TEST_DIR}/testSiStripHitEffFromCalibTree_cfg.py inputFiles=HitEffTree.root runNumber=325172 || die 'failed running testSiStripHitEffFromCalibTree_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/testSiStripHitEffFromCalibTree_cfg.py inputFiles=HitEffTree.root runNumber=325172 || die 'failed running testSiStripHitEffFromCalibTree_cfg.py' $?
 
 echo -e "Done with the tests!"

--- a/CalibTracker/SiStripHitResolution/test/BuildFile.xml
+++ b/CalibTracker/SiStripHitResolution/test/BuildFile.xml
@@ -1,4 +1,1 @@
-<bin name="testSiStripHitResolution" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripHitResolution/test test_SiStripHitResolution.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="testSiStripHitResolution" command="test_SiStripHitResolution.sh"/>

--- a/CalibTracker/SiStripHitResolution/test/TestDriver.cpp
+++ b/CalibTracker/SiStripHitResolution/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiStripHitResolution/test/test_SiStripHitResolution.sh
+++ b/CalibTracker/SiStripHitResolution/test/test_SiStripHitResolution.sh
@@ -7,20 +7,20 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
 fi
 
 echo -e "Testing SiStripHitEfficencyWorker \n\n"
-cmsRun ${LOCAL_TEST_DIR}/SiStripHitResol_test.py isUnitTest=True || die 'failed running SiStripHitResol_test.py' $?
+cmsRun ${SCRAM_TEST_PATH}/SiStripHitResol_test.py isUnitTest=True || die 'failed running SiStripHitResol_test.py' $?
 
 echo -e "Testing CPEanconfig.py \n\n"
-cmsRun ${LOCAL_TEST_DIR}/CPEanconfig.py isUnitTest=True || die 'failed running CPEanconfig.py' $?
+cmsRun ${SCRAM_TEST_PATH}/CPEanconfig.py isUnitTest=True || die 'failed running CPEanconfig.py' $?
 
 echo -e "Testing SiStripHitResolutionFromCalibTree_cfg.py \n\n"
-cmsRun ${LOCAL_TEST_DIR}/SiStripHitResolutionFromCalibTree_cfg.py || die 'failed running SiStripHitResolutionFromCalibTree_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/SiStripHitResolutionFromCalibTree_cfg.py || die 'failed running SiStripHitResolutionFromCalibTree_cfg.py' $?
 
 ### To be implemented
 
 #echo -e "Testing SiStripHitEfficencyHarvester \n\n"
-#cmsRun ${LOCAL_TEST_DIR}/testHitEffHarvester.py isUnitTest=True || die 'failed running testHitEffHarvester.py' $?
+#cmsRun ${SCRAM_TEST_PATH}/testHitEffHarvester.py isUnitTest=True || die 'failed running testHitEffHarvester.py' $?
 
 #echo -e " testing tSiStripHitEffFromCalibTree \n\n"
-#cmsRun ${LOCAL_TEST_DIR}/testSiStripHitEffFromCalibTree_cfg.py inputFiles=HitEffTree.root runNumber=325172 || die 'failed running testSiStripHitEffFromCalibTree_cfg.py' $?
+#cmsRun ${SCRAM_TEST_PATH}/testSiStripHitEffFromCalibTree_cfg.py inputFiles=HitEffTree.root runNumber=325172 || die 'failed running testSiStripHitEffFromCalibTree_cfg.py' $?
 
 echo -e "Done with the tests!"

--- a/CalibTracker/SiStripQuality/test/BuildFile.xml
+++ b/CalibTracker/SiStripQuality/test/BuildFile.xml
@@ -1,9 +1,2 @@
-<bin name="test_SiStripQualityStatistics" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripQuality/test test_SiStripQualityStatistics.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
-
-<bin name="test_makeMergedBadComponentsWithFedErr" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash CalibTracker/SiStripQuality/test test_makeMergedBadComponentsWithFedErr.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="test_SiStripQualityStatistics" command="test_SiStripQualityStatistics.sh"/>
+<test name="test_makeMergedBadComponentsWithFedErr" command="test_makeMergedBadComponentsWithFedErr.sh"/>

--- a/CalibTracker/SiStripQuality/test/TestDriver.cpp
+++ b/CalibTracker/SiStripQuality/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CalibTracker/SiStripQuality/test/test_SiStripQualityStatistics.sh
+++ b/CalibTracker/SiStripQuality/test/test_SiStripQualityStatistics.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
-(cmsRun ${LOCAL_TEST_DIR}/test_SiStripQualityStatistics_cfg.py) || die 'Failure running cmsRun test_SiStripQualityStatistics_cfg.py' $?
+(cmsRun ${SCRAM_TEST_PATH}/test_SiStripQualityStatistics_cfg.py) || die 'Failure running cmsRun test_SiStripQualityStatistics_cfg.py' $?

--- a/CalibTracker/SiStripQuality/test/test_makeMergedBadComponentsWithFedErr.sh
+++ b/CalibTracker/SiStripQuality/test/test_makeMergedBadComponentsWithFedErr.sh
@@ -5,9 +5,9 @@ dqmFile="/eos/cms/store/group/comm_dqm/DQMGUI_data/Run2018/ZeroBias/R0003191xx/D
 if [ ! -f "${dqmFile}" ]; then
   die "SKIPPING test, file ${dqmFile} not found" 0
 fi
-runStartTime=$( (python "${LOCAL_TEST_DIR}/cfg/getRunStartTime.py" "${run}" | tail -n1 ) || die "Failed to get run start time" $? )
+runStartTime=$( (python "${SCRAM_TEST_PATH}/cfg/getRunStartTime.py" "${run}" | tail -n1 ) || die "Failed to get run start time" $? )
 echo "DEBUG: Run ${run} started at ${runStartTime}"
-(cmsRun "${LOCAL_TEST_DIR}/cfg/makeMergeBadComponentPayload_example_cfg.py" globalTag=auto:run3_data_prompt runNumber="${run}"  runStartTime="${runStartTime}" dqmFile="${dqmFile}" dbfile="test.db" outputTag="TestBadComponents" ) || die "Failure running cmsRun makeMergeBadComponentPayload_example_cfg.py" $?
+(cmsRun "${SCRAM_TEST_PATH}/cfg/makeMergeBadComponentPayload_example_cfg.py" globalTag=auto:run3_data_prompt runNumber="${run}"  runStartTime="${runStartTime}" dqmFile="${dqmFile}" dbfile="test.db" outputTag="TestBadComponents" ) || die "Failure running cmsRun makeMergeBadComponentPayload_example_cfg.py" $?
 # get the hash
 plEntryLn=$( (conddb --db sqlite_file:test.db list TestBadComponents | grep SiStripBadStrip) || die "Failed to get payload" $? )
 read -a plEntryLn_split <<< "${plEntryLn}"

--- a/Calibration/PPSAlCaRecoProducer/test/BuildFile.xml
+++ b/Calibration/PPSAlCaRecoProducer/test/BuildFile.xml
@@ -1,18 +1,8 @@
-<bin name="testExpressPPSAlCaRecoProducer" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Calibration/PPSAlCaRecoProducer/test test_express_AlCaRecoProducer.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
-<bin name="testExpressPPSAlCaRecoOutput" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Calibration/PPSAlCaRecoProducer/test test_express_PPSAlCaReco_output.sh"/>
+<test name="testExpressPPSAlCaRecoProducer" command="test_express_AlCaRecoProducer.sh"/>
+<test name="testExpressPPSAlCaRecoOutput" command="test_express_PPSAlCaReco_output.sh">
   <flags PRE_TEST="testExpressPPSAlCaRecoProducer"/>
-  <use name="FWCore/Utilities"/>
-</bin>
-<bin name="testPromptPPSAlCaRecoProducer" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Calibration/PPSAlCaRecoProducer/test test_prompt_AlCaRecoProducer.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
-<bin name="testPromptPPSAlCaRecoOutput" file="TestDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash Calibration/PPSAlCaRecoProducer/test test_prompt_PPSAlCaReco_output.sh"/>
+</test>
+<test name="testPromptPPSAlCaRecoProducer" command="test_prompt_AlCaRecoProducer.sh"/>
+<test name="testPromptPPSAlCaRecoOutput" command="test_prompt_PPSAlCaReco_output.sh">
   <flags PRE_TEST="testPromptPPSAlCaRecoProducer"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+</test>

--- a/Calibration/PPSAlCaRecoProducer/test/TestDriver.cpp
+++ b/Calibration/PPSAlCaRecoProducer/test/TestDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/Calibration/PPSAlCaRecoProducer/test/test_express_AlCaRecoProducer.sh
+++ b/Calibration/PPSAlCaRecoProducer/test/test_express_AlCaRecoProducer.sh
@@ -11,7 +11,7 @@ COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $INPUTFILE`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
-    echo "Using file ${INPUTFILE}. Running in ${LOCAL_TEST_DIR}."
+    echo "Using file ${INPUTFILE}. Running in ${SCRAM_TEST_PATH}."
     (cmsDriver.py testExpressPPSAlCaRecoProducer -s ALCAPRODUCER:PPSCalMaxTracks,ENDJOB \
     --process ALCARECO \
     --scenario pp \

--- a/Calibration/PPSAlCaRecoProducer/test/test_express_PPSAlCaReco_output.sh
+++ b/Calibration/PPSAlCaRecoProducer/test/test_express_PPSAlCaReco_output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
-(cmsRun ${LOCAL_TEST_DIR}/test_express_PPSAlCaReco_output.py) || die 'failed running test_express_PPSAlCaReco_output.py' $?
+(cmsRun ${SCRAM_TEST_PATH}/test_express_PPSAlCaReco_output.py) || die 'failed running test_express_PPSAlCaReco_output.py' $?

--- a/Calibration/PPSAlCaRecoProducer/test/test_prompt_AlCaRecoProducer.sh
+++ b/Calibration/PPSAlCaRecoProducer/test/test_prompt_AlCaRecoProducer.sh
@@ -11,7 +11,7 @@ COMMMAND=`xrdfs cms-xrd-global.cern.ch locate $INPUTFILE`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
-    echo "Using file ${INPUTFILE}. Running in ${LOCAL_TEST_DIR}."
+    echo "Using file ${INPUTFILE}. Running in ${SCRAM_TEST_PATH}."
     # note we currently use `auto:run3_data_express` GT
     # the correct GT (auto:run3_data_prompt) doesn't have LHCInfo record for run 322022 which corresponds to our face ALCARAW file
     (cmsDriver.py testPromptPPSAlCaRecoProducer -s ALCAPRODUCER:PPSCalMaxTracks,ENDJOB \

--- a/Calibration/PPSAlCaRecoProducer/test/test_prompt_PPSAlCaReco_output.sh
+++ b/Calibration/PPSAlCaRecoProducer/test/test_prompt_PPSAlCaReco_output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
-(cmsRun ${LOCAL_TEST_DIR}/test_prompt_PPSAlCaReco_output.py) || die 'failed running test_prompt_PPSAlCaReco_output.py' $?
+(cmsRun ${SCRAM_TEST_PATH}/test_prompt_PPSAlCaReco_output.py) || die 'failed running test_prompt_PPSAlCaReco_output.py' $?


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.