### PR TITLE
[ALCA-RECONSTRUCTION] Various fixes/improvements for unit test

### DIFF
--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -9,11 +9,7 @@
   <lib name="NtupleHelper"/>
 </bin>
 
-<environment>
-  <bin file="testReadWriteBSFromDB.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoVertex/BeamSpotProducer/test testReadWriteBSFromDB.sh"/>
-  </bin>
-</environment>
+<test name="testReadWriteBSFromDB" command="testReadWriteBSFromDB.sh"/>
 
 <bin file="testBeamSpotAnalyzer.cc">
   <use name="FWCore/TestProcessor"/>

--- a/RecoVertex/BeamSpotProducer/test/testReadWriteBSFromDB.cpp
+++ b/RecoVertex/BeamSpotProducer/test/testReadWriteBSFromDB.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/RecoVertex/BeamSpotProducer/test/testReadWriteBSFromDB.sh
+++ b/RecoVertex/BeamSpotProducer/test/testReadWriteBSFromDB.sh
@@ -10,6 +10,6 @@ if test -f "EarlyCollision.db"; then
 fi
 
 # test write
-cmsRun ${LOCAL_TEST_DIR}/write2DB.py inputFile=${LOCAL_TEST_DIR}/EarlyCollision.txt || die "Failure running write2DB.py" $? 
+cmsRun ${SCRAM_TEST_PATH}/write2DB.py inputFile=${SCRAM_TEST_PATH}/EarlyCollision.txt || die "Failure running write2DB.py" $?
 # test read
-cmsRun ${LOCAL_TEST_DIR}/readDB.py unitTest=True inputFile=${PWD}/EarlyCollision.db || die "Failure running readDB.py" $? 
+cmsRun ${SCRAM_TEST_PATH}/readDB.py unitTest=True inputFile=${PWD}/EarlyCollision.db || die "Failure running readDB.py" $?


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.