### PR TITLE
[ALCA-DB] Various fixes/improvements for unit test

### DIFF
--- a/CondFormats/PCLConfig/test/BuildFile.xml
+++ b/CondFormats/PCLConfig/test/BuildFile.xml
@@ -2,7 +2,4 @@
   <use name="CondFormats/PCLConfig"/>
 </bin>
 
-<bin name="testReadWriteAlignPCLThresholds" file="testDriver.cpp">
-  <flags TEST_RUNNER_ARGS="/bin/bash CondFormats/PCLConfig/test testReadWriteAlignPCLThresholds.sh"/>
-  <use name="FWCore/Utilities"/>
-</bin>
+<test name="testReadWriteAlignPCLThresholds" command="testReadWriteAlignPCLThresholds.sh"/>

--- a/CondFormats/PCLConfig/test/testDriver.cpp
+++ b/CondFormats/PCLConfig/test/testDriver.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CondFormats/PCLConfig/test/testReadWriteAlignPCLThresholds.sh
+++ b/CondFormats/PCLConfig/test/testReadWriteAlignPCLThresholds.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 # test High Granularity
-cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsWriter_cfg.py || die 'failed running AlignPCLThresholdsWriter_cfg.py' $?
-cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsReader_cfg.py || die 'failed running AlignPCLThresholdsReader_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/AlignPCLThresholdsWriter_cfg.py || die 'failed running AlignPCLThresholdsWriter_cfg.py' $?
+cmsRun ${SCRAM_TEST_PATH}/AlignPCLThresholdsReader_cfg.py || die 'failed running AlignPCLThresholdsReader_cfg.py' $?
 
 # test Low Granularity
-(cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsWriter_cfg.py writeLGpayload=True) || die 'failed running AlignPCLThresholdsWriter_cfg.py writeLGpayload=True' $?
-(cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsReader_cfg.py readLGpayload=True) || die 'failed running AlignPCLThresholdsReader_cfg.py readLGpayload=True' $?
+(cmsRun ${SCRAM_TEST_PATH}/AlignPCLThresholdsWriter_cfg.py writeLGpayload=True) || die 'failed running AlignPCLThresholdsWriter_cfg.py writeLGpayload=True' $?
+(cmsRun ${SCRAM_TEST_PATH}/AlignPCLThresholdsReader_cfg.py readLGpayload=True) || die 'failed running AlignPCLThresholdsReader_cfg.py readLGpayload=True' $?

--- a/CondTools/BeamSpot/test/BuildFile.xml
+++ b/CondTools/BeamSpot/test/BuildFile.xml
@@ -1,6 +1,1 @@
-<environment>
-  <bin file="testReadWriteOnlineBSFromDB.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash CondTools/BeamSpot/test testReadWriteOnlineBSFromDB.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-</environment>
+<test name="testReadWriteOnlineBSFromDB" command="testReadWriteOnlineBSFromDB.sh"/>

--- a/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.cpp
+++ b/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.cpp
@@ -1,2 +1,0 @@
-#include "FWCore/Utilities/interface/TestHelper.h"
-RUNTEST()

--- a/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
@@ -18,17 +18,17 @@ cp -pr $CMSSW_BASE/src/CondTools/BeamSpot/data/BeamFitResults_Run306171.txt .
 
 # test write
 printf "TESTING Writing BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure writing payload for BeamSpotOnlineLegacyObjectsRcd" $? 
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure writing payload for BeamSpotOnlineLegacyObjectsRcd" $?
 
 printf "TESTING Writing BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure writing payload for BeamSpotOnlineHLTObjectsRcd" $? 
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure writing payload for BeamSpotOnlineHLTObjectsRcd" $?
 # test read
 
 printf "TESTING Reading BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure reading payload for BeamSpotOnlineLegacyObjectsRcd" $? 
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure reading payload for BeamSpotOnlineLegacyObjectsRcd" $?
 
 printf "TESTING Reading BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure reading payload for BeamSpotOnlineHLTObjectsRcd" $? 
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure reading payload for BeamSpotOnlineHLTObjectsRcd" $?
 
 echo "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
-cmsRun ${LOCAL_TEST_DIR}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?


### PR DESCRIPTION
- Convert unit tests to use `<test ...command="cmd"/>` instead of using `FW unit tests driver`
- Make sure that test can run from its dedicated test directory.