### PR TITLE
Fix for nanoGEN jets

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -88,8 +88,8 @@ def customizeNanoGEN(process):
     process.patJetPartonsNano.particles = "genParticles"
     process.particleLevel.src = "generatorSmeared"
 
-    process.genJetTable.src = "ak4GenJets"
-    process.genJetAK8Table.src = "ak8GenJets"
+    process.genJetTable.src = "ak4GenJetsNoNu"
+    process.genJetAK8Table.src = "ak8GenJetsNoNu"
     process.tauGenJetsForNano.GenParticles = "genParticles"
     process.genVisTaus.srcGenParticles = "genParticles"
 


### PR DESCRIPTION
# PR description
This PR includes a minimal change in the configuration file that is used for producing NanoGEN format: `PhysicsTools/NanoAOD/python/nanogen_cff.py`.

# Additional information
This issue has been known for some time, but it was never fixed and included in the master branch up until know. Everything regarding this issue is discussed in [1] and [2].

I'm adding @kdlong in the thread (since he is the one that told me the issue) just in case there's any other detail I might be leaving out. The changes to the central code should have 0 impact (just change the object that is used for computing generation jets), but the physics impact should be quite relevant specially for those analyses that use NanoGEN information for comparing generation jets between nanoGEN and nanoAOD. 

# References
[1]: https://cms-talk.web.cern.ch/t/question-concerning-ttw-production-using-mg33x-pythia8-3/17491/7
[2]: https://cms-talk.web.cern.ch/t/various-comments-regarding-mostly-nanoaod/4642

