### PR TITLE
Use start time of cmsRun in CondorStatusService

### DIFF
--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -209,8 +209,6 @@ void CondorStatusService::beginPost() {
     ss_max_lumis << maxLumis;
     updateChirp("MaxLumis", ss_max_lumis.str());
   }
-
-  m_beginJob = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   update();
 }
 
@@ -234,6 +232,10 @@ void CondorStatusService::firstUpdate() {
   updateChirp("MaxLumis", "-1");
   updateChirp("Done", "false");
   updateChirpQuoted("Guid", edm::processGUID().toString());
+  m_beginJob = TimingServiceBase::jobStartTime();
+  if (m_beginJob == 0.) {
+    m_beginJob = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  }
 }
 
 void CondorStatusService::secondUpdate() {


### PR DESCRIPTION
#### PR description:

Use the information in the timing service to get the start time of cmsRun and use that time to calculate job duration.

Previously the time as of the begin job transition was used but this misses all the initialization time. As the CPU time reported is for the job as a whole this change now allows for better CPU efficiency calculations.

#### PR validation:

Code compiles.