### PR TITLE
Remove unnecessary calls to consumesMany in DQMRootOutputModule

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -293,15 +293,7 @@ DQMRootOutputModule::DQMRootOutputModule(edm::ParameterSet const& pset)
       m_presentHistoryIndex(0),
       m_filterOnRun(pset.getUntrackedParameter<unsigned int>("filterOnRun")),
       m_fullNameBufferPtr(&m_fullNameBuffer),
-      m_indicesTree(nullptr) {
-  // Declare dependencies for all Lumi and Run tokens here. In
-  // principle could use the keep statements, but then DQMToken would
-  // have to be made persistent (transient products are ignored),
-  // which would lead to a need to (finally) remove underscores from
-  // DQM module labels.
-  consumesMany<DQMToken, edm::InLumi>();
-  consumesMany<DQMToken, edm::InRun>();
-}
+      m_indicesTree(nullptr) {}
 
 // DQMRootOutputModule::DQMRootOutputModule(const DQMRootOutputModule& rhs)
 // {


### PR DESCRIPTION
#### PR description:

Remove unnecessary calls to consumesMany in DQMRootOutputModule.

DQMTokens are used to order execution of modules when one module
depends on the actions of another module. DQMRootOutputModule
only has write methods. It does not have endRun or endLumi methods
so there is no reason for it to consume endRun or endLumi DQMToken
products. The write methods are already sequenced by the Framework
to execute after endRun or endLumi methods that could produce DQMTokens
are finished.

This was motivated by the migration to remove all consumesMany calls
from CMSSW. That function has been deprecated.

FYI @makortel @Dr15Jones 

#### PR validation:

There should be no change in behavior. No tests were added.
