### PR TITLE
Fix build failure in DBG_X

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -1242,8 +1242,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferHalf) {
@@ -1253,8 +1253,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferThree) {
@@ -1263,8 +1263,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferChopTwo) {
@@ -1278,8 +1278,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferSemi) {
@@ -1293,8 +1293,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferChopTwoM) {
@@ -1308,8 +1308,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferSemi2) {
@@ -1323,8 +1323,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferFive2) {
@@ -1338,8 +1338,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   } else if (part == HGCalTypes::WaferHalf2) {
@@ -1353,8 +1353,8 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
-                                    << dy[np[orient][k]] + offsety[np[orient][k]];
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]
+                                    << ":" << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
   }

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -1242,7 +1242,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -1253,7 +1253,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1263,7 +1263,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1278,7 +1278,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1293,7 +1293,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1308,7 +1308,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1323,7 +1323,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1338,7 +1338,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }
@@ -1353,7 +1353,7 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(
       xy.push_back(std::make_pair((xpos + dx[np[orient][k]] + offsetx[np[orient][k]]),
                                   (ypos + dy[np[orient][k]] + offsety[np[orient][k]])));
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
+      edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]]<< ":"
                                     << dy[np[orient][k]] + offsety[np[orient][k]];
 #endif
     }


### PR DESCRIPTION
#### PR description:

Log file: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_13_1_DBG_X_2023-03-23-2300/Geometry/HGCalCommonData

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc: In static member function 'static std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(int, int, int, double, double, double, double)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1245:118: error: expected ';' before ')' token
  1245 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1256:118: error: expected ';' before ')' token
  1256 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1266:118: error: expected ';' before ')' token
  1266 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1281:118: error: expected ';' before ')' token
  1281 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1296:118: error: expected ';' before ')' token
  1296 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1311:118: error: expected ';' before ')' token
  1311 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1326:118: error: expected ';' before ')' token
  1326 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1341:118: error: expected ';' before ')' token
  1341 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/05d62365f17d9d2cecbb9853ed8b8cf3/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-23-2300/src/Geometry/HGCalCommonData/src/HGCalWaferMask.cc:1356:118: error: expected ';' before ')' token
  1356 |       edm::LogVerbatim("HGCalGeom") << k << ":" << np[orient][k] << ":" << dx[np[orient][k]] + offsetx[np[orient][k]])<< ":"
      |                                                                                                                      ^
      |                                                                                                                      ;
  gmake: *** [tmp/el8_amd64_gcc11/src/Geometry/HGCalCommonData/src/GeometryHGCalCommonData/HGCalWaferMask.cc.o] Error 1
```

#### PR validation:

