### PR TITLE
Update muon shower (un)packers for 2023 running

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -45,8 +45,11 @@ namespace l1t {
       if (fed == 1402) {
         auto gmt_in_packer = static_pointer_cast<l1t::stage2::RegionalMuonGMTPacker>(
             PackerFactory::get()->make("stage2::RegionalMuonGMTPacker"));
+        if (fw >= 0x8000000) {
+          gmt_in_packer->setUseEmtfLooseShowers();
+        }
         if (fw >= 0x7000000) {
-          gmt_in_packer->setUseEmtfShowers();
+          gmt_in_packer->setUseEmtfNominalTightShowers();
         }
         if (fw >= 0x6010000) {
           gmt_in_packer->setUseEmtfDisplacementInfo();
@@ -100,8 +103,11 @@ namespace l1t {
       // input muons on links 36-71
       auto gmt_in_unp = static_pointer_cast<l1t::stage2::RegionalMuonGMTUnpacker>(
           UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker"));
+      if (fw >= 0x8000000) {
+        gmt_in_unp->setUseEmtfLooseShowers();
+      }
       if (fw >= 0x7000000) {
-        gmt_in_unp->setUseEmtfShowers();
+        gmt_in_unp->setUseEmtfNominalTightShowers();
       }
       if (fw >= 0x6010000) {
         gmt_in_unp->setUseEmtfDisplacementInfo();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
@@ -75,7 +75,7 @@ namespace l1t {
         uint32_t mu1_lsw{0};
         uint32_t mu2_lsw{0};
         auto mu{objMap.at(bx).mus.begin()};  // Need to get the first muon of that bx from the object map
-        std::array<uint32_t, 4> showerWords{
+        std::array<std::array<uint32_t, 4>, 2> const showerWords{
             MuonRawDigiTranslator::getPackedShowerDataWords(objMap.at(bx).shower, fedId_, fwId_)};
         // Slightly convoluted logic to account for the Run-3 muon readout record:
         // To make space for displacement information we moved the raw
@@ -99,8 +99,9 @@ namespace l1t {
             mu1_shared_word = mu2_shared_word;
             mu1_lsw = mu2_lsw;
             mu1_msw = mu2_msw;
-            mu1_msw |= showerWords.at(muCtr / 2);  // Shower bits are added only to the first muon of the link.
+            mu1_msw |= showerWords.at(0).at(muCtr / 2);
           } else {
+            mu2_msw |= showerWords.at(1).at(muCtr / 2 - 1);
             payloadMap[blkId].push_back(mu1_shared_word | mu2_shared_word);
             payloadMap[blkId].push_back(mu1_lsw);
             payloadMap[blkId].push_back(mu1_msw);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -84,9 +84,12 @@ namespace l1t {
           shower = muonShowerCollection_->at(bx, 0);
           muonShowerCollection_->erase(bx, 0);
         }
-        if (linkID == 0) {  // OneNominal shower
+        if (linkID ==
+            0) {  // OneNominal and TwoLoose showers are embedded in the first and second muons of the first link
           shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
-        } else if (linkID == 1) {  // OneTight shower
+          shower.setTwoLooseDiffSectorsInTime(
+              l1t::MuonRawDigiTranslator::showerFired(payload[i + 3], fed_, getAlgoVersion()));
+        } else if (linkID == 1) {  // OneTight shower is embedded in the first muon of the second link
           shower.setOneTightInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
         }
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
@@ -12,19 +12,19 @@ namespace l1t {
       GMTObjectMap bmtfObjMap;
       GMTObjectMap omtfObjMap;
       GMTObjectMap emtfObjMap;
-      auto bmtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenBMTF();
-      auto omtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenOMTF();
-      auto emtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenEMTF();
+      auto const bmtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenBMTF();
+      auto const omtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenOMTF();
+      auto const emtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenEMTF();
 
       // First we put the muons in our object map.
-      std::pair<int, int> bmtfMuonBx = getMuons(bmtfObjMap, event, bmtfToken);
-      std::pair<int, int> omtfMuonBx = getMuons(omtfObjMap, event, omtfToken);
-      std::pair<int, int> emtfMuonBx = getMuons(emtfObjMap, event, emtfToken);
+      std::pair<int, int> const bmtfMuonBx = getMuons(bmtfObjMap, event, bmtfToken);
+      std::pair<int, int> const omtfMuonBx = getMuons(omtfObjMap, event, omtfToken);
+      std::pair<int, int> const emtfMuonBx = getMuons(emtfObjMap, event, emtfToken);
 
       // Then the showers (We don't expect to have shower data from BMTF and OMTF -- at the moment, at least)
       std::pair<int, int> emtfMuonShowerBx{0, 0};
-      if (useEmtfShowers_) {
-        auto emtfShowerToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonShowerTokenEMTF();
+      if (useEmtfNominalTightShowers_ || useEmtfLooseShowers_) {
+        auto const emtfShowerToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonShowerTokenEMTF();
         emtfMuonShowerBx = getMuonShowers(emtfObjMap, event, emtfShowerToken);
       }
 
@@ -114,7 +114,8 @@ namespace l1t {
               buf.at(frameIdx++) = msw;
             }
             // Add shower bits to the payload buffer.
-            RegionalMuonRawDigiTranslator::generatePackedShowerPayload(gmtObjects.shower, buf, useEmtfShowers_);
+            RegionalMuonRawDigiTranslator::generatePackedShowerPayload(
+                gmtObjects.shower, buf, useEmtfNominalTightShowers_, useEmtfLooseShowers_);
 
             payloadMap[linkTimes2].insert(
                 payloadMap[linkTimes2].end(), std::move_iterator(buf.begin()), std::move_iterator(buf.end()));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -16,7 +16,8 @@ namespace l1t {
       Blocks pack(const edm::Event&, const PackerTokens*) override;
       void setIsKbmtf() { isKbmtf_ = true; };
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; };
-      void setUseEmtfShowers() { useEmtfShowers_ = true; };
+      void setUseEmtfNominalTightShowers() { useEmtfNominalTightShowers_ = true; };
+      void setUseEmtfLooseShowers() { useEmtfLooseShowers_ = true; };
 
     private:
       struct GMTObjects {
@@ -42,7 +43,8 @@ namespace l1t {
 
       bool isKbmtf_{false};
       bool useEmtfDisplacementInfo_{false};
-      bool useEmtfShowers_{false};
+      bool useEmtfNominalTightShowers_{false};
+      bool useEmtfLooseShowers_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -121,7 +121,7 @@ namespace l1t {
           // Fill RegionalMuonShower objects. For this we need to look at all six words together.
           RegionalMuonShower muShower;
           if (RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
-                  muShower, bxPayload, processor, trackFinder, useEmtfShowers_)) {
+                  muShower, bxPayload, processor, trackFinder, useEmtfNominalTightShowers_, useEmtfLooseShowers_)) {
             regionalMuonShowerCollection->push_back(bx, muShower);
           }
         } else {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -12,7 +12,8 @@ namespace l1t {
       bool unpack(const Block& block, UnpackerCollections* coll) override;
       void setIsKbmtf() { isKbmtf_ = true; }
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; }
-      void setUseEmtfShowers() { useEmtfShowers_ = true; }
+      void setUseEmtfNominalTightShowers() { useEmtfNominalTightShowers_ = true; }
+      void setUseEmtfLooseShowers() { useEmtfLooseShowers_ = true; }
 
     private:
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
@@ -20,7 +21,8 @@ namespace l1t {
 
       bool isKbmtf_{false};
       bool useEmtfDisplacementInfo_{false};
-      bool useEmtfShowers_{false};
+      bool useEmtfNominalTightShowers_{false};
+      bool useEmtfLooseShowers_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
@@ -4,7 +4,7 @@ gmtStage2Raw = cms.EDProducer(
     "L1TDigiToRaw",
     Setup = cms.string("stage2::GMTSetup"),
     InputLabel = cms.InputTag("simGmtStage2Digis"),
-    BMTFInputLabel = cms.InputTag("simBmtfDigis", "BMTF"),
+    BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"),
     OMTFInputLabel = cms.InputTag("simOmtfDigis", "OMTF"),
     EMTFInputLabel = cms.InputTag("simEmtfDigis", "EMTF"),
     ImdInputLabelBMTF = cms.InputTag("simGmtStage2Digis", "imdMuonsBMTF"),
@@ -15,7 +15,7 @@ gmtStage2Raw = cms.EDProducer(
     EMTFShowerInputLabel = cms.InputTag("simEmtfShowers", "EMTF"),
     ShowerInputLabel = cms.InputTag("simGmtShowerDigis"),
     FedId = cms.int32(1402),
-    FWId = cms.uint32(0x3000000), # First used uGMT firmware version
+    FWId = cms.uint32(0x8000000), # Firmware with support for 2loose showers
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -34,4 +34,4 @@ stage2L1Trigger_2018.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simBm
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x7000000))
+stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x8000000))

--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -13,7 +13,7 @@ gtStage2Raw = cms.EDProducer(
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
     EtSumInputTag  = cms.InputTag("simCaloStage2Digis"),
     FedId = cms.int32(1404),
-    FWId = cms.uint32(0x113b),  # FW w/ displaced muon info and hadronic showers.
+    FWId = cms.uint32(0x1150), # FW w/ 2loose hadronic showers.
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -32,4 +32,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x113b)) # FW w/ displaced muon info and hadronic showers.
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x1150)) # FW w/ 2loose hadronic showers.

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -28,7 +28,9 @@ namespace l1t {
                                             int muInBx);
     static void generate64bitDataWord(
         const Muon& mu, uint32_t& raw_data_spare, uint64_t& dataword, int fedId, int fwId, int muInBx);
-    static std::array<uint32_t, 4> getPackedShowerDataWords(const MuonShower& shower, int fedId, int fwId);
+    static std::array<std::array<uint32_t, 4>, 2> getPackedShowerDataWords(const MuonShower& shower,
+                                                                           int fedId,
+                                                                           int fwId);
     static int calcHwEta(const uint32_t& raw, unsigned absEtaShift, unsigned etaSignShift);
 
     static constexpr unsigned ptMask_ = 0x1FF;
@@ -69,6 +71,8 @@ namespace l1t {
     static constexpr int kUgtFwVersionUntilRun3Start = 0x1130;
     static constexpr int kUgmtFwVersionFirstWithShowers = 0x7000000;
     static constexpr int kUgtFwVersionFirstWithShowers = 0x113B;
+    static constexpr int kUgmtFwVersionShowersFrom2023 = 0x8000000;
+    static constexpr int kUgtFwVersionShowersFrom2023 = 0x1150;
 
   private:
     static void fillMuonStableQuantities(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -16,8 +16,12 @@ namespace l1t {
                                      bool useEmtfDisplacementInfo);
     static void fillRegionalMuonCand(
         RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isKbmtf, bool useEmtfDisplacementInfo);
-    static bool fillRegionalMuonShower(
-        RegionalMuonShower& muShower, std::vector<uint32_t> bxPayload, int proc, tftype tf, bool useEmtfShowers);
+    static bool fillRegionalMuonShower(RegionalMuonShower& muShower,
+                                       std::vector<uint32_t> bxPayload,
+                                       int proc,
+                                       tftype tf,
+                                       bool useEmtfNominalTightShowers,
+                                       bool useEmtfLooseShowers);
     static void generatePackedDataWords(const RegionalMuonCand& mu,
                                         uint32_t& raw_data_00_31,
                                         uint32_t& raw_data_32_63,
@@ -25,7 +29,8 @@ namespace l1t {
                                         bool useEmtfDisplacementInfo);
     static void generatePackedShowerPayload(const RegionalMuonShower& shower,
                                             std::array<uint32_t, 6>& payload,
-                                            bool useEmtfShowers);
+                                            bool useEmtfNominalTightShowers,
+                                            bool useEmtfLooseShowers);
     static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isKbmtf, bool useEmtfDisplacementInfo);
     static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
 
@@ -51,11 +56,12 @@ namespace l1t {
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
-    static constexpr unsigned emtfShowerMask_ = 0x1;
-    static constexpr unsigned emtfShowerInTimeFrame_ = 1;
-    static constexpr unsigned emtfShowerOOTFrame_ = 3;
-    static constexpr unsigned emtfShowerOneNominalShift_ = 18;
-    static constexpr unsigned emtfShowerOneTightShift_ = 19;
+    static constexpr unsigned kEmtfShowerMask = 0x1;
+    static constexpr unsigned kEmtfShowerStandardFrame = 1;
+    static constexpr unsigned kEmtfShowerExtendedFrame = 3;
+    static constexpr unsigned kEmtfShowerOneNominalShift = 18;
+    static constexpr unsigned kEmtfShowerOneLooseShift = kEmtfShowerOneNominalShift;
+    static constexpr unsigned kEmtfShowerOneTightShift = 19;
 
     // relative shifts within track address
     static constexpr unsigned bmtfTrAddrSegSelMask_ = 0xF;

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -270,14 +270,18 @@ bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, in
   return false;
 }
 
-std::array<uint32_t, 4> l1t::MuonRawDigiTranslator::getPackedShowerDataWords(const MuonShower& shower,
-                                                                             const int fedId,
-                                                                             const int fwId) {
-  std::array<uint32_t, 4> res{};
+std::array<std::array<uint32_t, 4>, 2> l1t::MuonRawDigiTranslator::getPackedShowerDataWords(const MuonShower& shower,
+                                                                                            const int fedId,
+                                                                                            const int fwId) {
+  std::array<std::array<uint32_t, 4>, 2> res{};
   if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionFirstWithShowers) ||
       (fedId == kUgtFedId && fwId >= kUgtFwVersionFirstWithShowers)) {
-    res.at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
-    res.at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
+    res.at(0).at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
+    res.at(0).at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
+  }
+  if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionShowersFrom2023) ||
+      (fedId == kUgtFedId && fwId >= kUgtFwVersionShowersFrom2023)) {
+    res.at(1).at(0) = shower.isTwoLooseDiffSectorsInTime() ? (1 << showerShift_) : 0;
   }
   return res;
 }


### PR DESCRIPTION
#### PR description:

Added logic to the (un)packers to deal with the new "two loose showers" bit that will be used in 2023. The logic for those changes is gated behind either the firmware version that was extracted from the readout record or by the era. Once this PR is approved I will create a backport for 13_0_X.

attn @eyigitba and @elfontan

#### PR validation:

No validation beyond the standard tests possible while the loose shower logic hasn't been implemented in the upstream systems.
