### PR TITLE
Add upper cut on jet time to `HLTJetTimingFilter` [`13_0_X`]

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTJetTimingFilter.h
+++ b/HLTrigger/JetMET/plugins/HLTJetTimingFilter.h
@@ -37,6 +37,7 @@ private:
   // Thresholds for selection
   const unsigned int minJets_;
   const double jetTimeThresh_;
+  const double jetMaxTimeThresh_;
   const double jetEcalEtForTimingThresh_;
   const unsigned int jetCellsForTimingThresh_;
   const double minPt_;
@@ -54,6 +55,7 @@ HLTJetTimingFilter<T>::HLTJetTimingFilter(const edm::ParameterSet& iConfig)
           consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("jetEcalEtForTiming"))},
       minJets_{iConfig.getParameter<unsigned int>("minJets")},
       jetTimeThresh_{iConfig.getParameter<double>("jetTimeThresh")},
+      jetMaxTimeThresh_{iConfig.getParameter<double>("jetMaxTimeThresh")},
       jetEcalEtForTimingThresh_{iConfig.getParameter<double>("jetEcalEtForTimingThresh")},
       jetCellsForTimingThresh_{iConfig.getParameter<unsigned int>("jetCellsForTimingThresh")},
       minPt_{iConfig.getParameter<double>("minJetPt")} {}
@@ -74,7 +76,7 @@ bool HLTJetTimingFilter<T>::hltFilter(edm::Event& iEvent,
   for (auto iterJet = jets->begin(); iterJet != jets->end(); ++iterJet) {
     edm::Ref<std::vector<T>> const caloJetRef(jets, std::distance(jets->begin(), iterJet));
     if (iterJet->pt() > minPt_ and jetTimes[caloJetRef] > jetTimeThresh_ and
-        jetEcalEtForTiming[caloJetRef] > jetEcalEtForTimingThresh_ and
+        jetTimes[caloJetRef] < jetMaxTimeThresh_ and jetEcalEtForTiming[caloJetRef] > jetEcalEtForTimingThresh_ and
         jetCellsForTiming[caloJetRef] > jetCellsForTimingThresh_) {
       // add caloJetRef to the event
       filterproduct.addObject(trigger::TriggerJet, caloJetRef);
@@ -97,6 +99,7 @@ void HLTJetTimingFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& des
                           edm::InputTag("hltDisplacedHLTCaloJetCollectionProducerMidPtTiming", "jetEcalEtForTiming"));
   desc.add<unsigned int>("minJets", 1);
   desc.add<double>("jetTimeThresh", 1.);
+  desc.add<double>("jetMaxTimeThresh", 999999);
   desc.add<unsigned int>("jetCellsForTimingThresh", 5);
   desc.add<double>("jetEcalEtForTimingThresh", 10.);
   desc.add<double>("minJetPt", 40.);


### PR DESCRIPTION
backport of #41177

Attn: @ssantpur

#### PR description:

From the description of #41089:

> This PR allows for more flexibility in choosing the timing thresholds for the delayed jet and delayed E/gamma triggers, this does not effect any existing triggers or their rates. The modification is to enable triggering on the negative timing region that can target beam halo and satellite collisions, and allow for maximum timing to be specified in the positive timing side to enable some delayed jet triggers to be added to parking dataset.

#### PR validation:

From the description of #41089:

> I ran over HLTPhysics using Run2022G dataset and saw no change in the rates.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41177

Development of Run-3 HLT menus for 2023 data-taking and Run-3 MC.