### PR TITLE
add track algo and originalAlgo to PackedCandidates

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -837,6 +837,12 @@ namespace pat {
     /// Return first hit from HitPattern for tracks with high level details
     uint16_t firstHit() const { return firstHit_; }
 
+    /// Set/get track algo
+    void setTrkAlgo(uint8_t algo) { trkAlgo_ = algo; }
+    void setTrkOriginalAlgo(uint8_t algo) { trkOriginalAlgo_ = algo; }
+    uint8_t trkAlgo() const { return trkAlgo_; }
+    uint8_t trkOriginalAlgo() const { return trkOriginalAlgo_; }
+
     void setMuonID(bool isStandAlone, bool isGlobal) {
       int16_t muonFlags = isStandAlone | (2 * isGlobal);
       qualityFlags_ = (qualityFlags_ & ~muonFlagsMask) | ((muonFlags << muonFlagsShift) & muonFlagsMask);
@@ -1110,6 +1116,10 @@ namespace pat {
 
     /// details (hit pattern) of the first hit on track
     uint16_t firstHit_;
+
+    /// track algorithm details
+    uint8_t trkAlgo_ = 0;
+    uint8_t trkOriginalAlgo_ = 0;
 
     /// check overlap with another Candidate
     bool overlap(const reco::Candidate &) const override;

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -221,7 +221,9 @@ namespace pat {
           normalizedChi2_(iOther.normalizedChi2_),
           covarianceVersion_(iOther.covarianceVersion_),
           covarianceSchema_(iOther.covarianceSchema_),
-          firstHit_(iOther.firstHit_) {}
+          firstHit_(iOther.firstHit_),
+          trkAlgo_(iOther.trkAlgo_),
+          trkOriginalAlgo_(iOther.trkOriginalAlgo_) {}
 
     PackedCandidate(PackedCandidate &&iOther)
         : packedPt_(iOther.packedPt_),
@@ -262,7 +264,9 @@ namespace pat {
           normalizedChi2_(iOther.normalizedChi2_),
           covarianceVersion_(iOther.covarianceVersion_),
           covarianceSchema_(iOther.covarianceSchema_),
-          firstHit_(iOther.firstHit_) {}
+          firstHit_(iOther.firstHit_),
+          trkAlgo_(iOther.trkAlgo_),
+          trkOriginalAlgo_(iOther.trkOriginalAlgo_) {}
 
     PackedCandidate &operator=(const PackedCandidate &iOther) {
       if (this == &iOther) {
@@ -339,6 +343,8 @@ namespace pat {
       covarianceVersion_ = iOther.covarianceVersion_;
       covarianceSchema_ = iOther.covarianceSchema_;
       firstHit_ = iOther.firstHit_;
+      trkAlgo_ = iOther.trkAlgo_;
+      trkOriginalAlgo_ = iOther.trkOriginalAlgo_;
       return *this;
     }
 
@@ -385,6 +391,8 @@ namespace pat {
       covarianceVersion_ = iOther.covarianceVersion_;
       covarianceSchema_ = iOther.covarianceSchema_;
       firstHit_ = iOther.firstHit_;
+      trkAlgo_ = iOther.trkAlgo_;
+      trkOriginalAlgo_ = iOther.trkOriginalAlgo_;
       return *this;
     }
 

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -222,8 +222,7 @@ namespace pat {
           covarianceVersion_(iOther.covarianceVersion_),
           covarianceSchema_(iOther.covarianceSchema_),
           firstHit_(iOther.firstHit_),
-          trkAlgo_(iOther.trkAlgo_),
-          trkOriginalAlgo_(iOther.trkOriginalAlgo_) {}
+          trkAlgoPacked_(iOther.trkAlgoPacked_) {}
 
     PackedCandidate(PackedCandidate &&iOther)
         : packedPt_(iOther.packedPt_),
@@ -265,8 +264,7 @@ namespace pat {
           covarianceVersion_(iOther.covarianceVersion_),
           covarianceSchema_(iOther.covarianceSchema_),
           firstHit_(iOther.firstHit_),
-          trkAlgo_(iOther.trkAlgo_),
-          trkOriginalAlgo_(iOther.trkOriginalAlgo_) {}
+          trkAlgoPacked_(iOther.trkAlgoPacked_) {}
 
     PackedCandidate &operator=(const PackedCandidate &iOther) {
       if (this == &iOther) {
@@ -343,8 +341,7 @@ namespace pat {
       covarianceVersion_ = iOther.covarianceVersion_;
       covarianceSchema_ = iOther.covarianceSchema_;
       firstHit_ = iOther.firstHit_;
-      trkAlgo_ = iOther.trkAlgo_;
-      trkOriginalAlgo_ = iOther.trkOriginalAlgo_;
+      trkAlgoPacked_ = iOther.trkAlgoPacked_;
       return *this;
     }
 
@@ -391,8 +388,7 @@ namespace pat {
       covarianceVersion_ = iOther.covarianceVersion_;
       covarianceSchema_ = iOther.covarianceSchema_;
       firstHit_ = iOther.firstHit_;
-      trkAlgo_ = iOther.trkAlgo_;
-      trkOriginalAlgo_ = iOther.trkOriginalAlgo_;
+      trkAlgoPacked_ = iOther.trkAlgoPacked_;
       return *this;
     }
 
@@ -846,10 +842,13 @@ namespace pat {
     uint16_t firstHit() const { return firstHit_; }
 
     /// Set/get track algo
-    void setTrkAlgo(uint8_t algo) { trkAlgo_ = algo; }
-    void setTrkOriginalAlgo(uint8_t algo) { trkOriginalAlgo_ = algo; }
-    uint8_t trkAlgo() const { return trkAlgo_; }
-    uint8_t trkOriginalAlgo() const { return trkOriginalAlgo_; }
+    void setTrkAlgo(uint8_t algo, uint8_t original) {
+      trkAlgoPacked_ = algo | ((algo == original ? 0 : original) << 8);
+    }
+    uint8_t trkAlgo() const { return trkAlgoPacked_ & 0xff; }
+    uint8_t trkOriginalAlgo() const {
+      return (trkAlgoPacked_ & 0xff00) == 0 ? trkAlgo() : ((trkAlgoPacked_ >> 8) & 0xff);
+    }
 
     void setMuonID(bool isStandAlone, bool isGlobal) {
       int16_t muonFlags = isStandAlone | (2 * isGlobal);
@@ -1126,8 +1125,7 @@ namespace pat {
     uint16_t firstHit_;
 
     /// track algorithm details
-    uint8_t trkAlgo_ = 0;
-    uint8_t trkOriginalAlgo_ = 0;
+    uint16_t trkAlgoPacked_ = 0;
 
     /// check overlap with another Candidate
     bool overlap(const reco::Candidate &) const override;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -333,7 +333,8 @@
   <class name="pat::PackedCandidate::PackedCovariance" ClassVersion="3">
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
-  <class name="pat::PackedCandidate" ClassVersion="34">
+  <class name="pat::PackedCandidate" ClassVersion="35">
+   <version ClassVersion="35" checksum="3383258297"/>
    <version ClassVersion="34" checksum="3953181632"/>
    <version ClassVersion="33" checksum="1092680546"/>
    <version ClassVersion="32" checksum="926869123"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -334,7 +334,7 @@
    <version ClassVersion="3" checksum="3320406063"/>
   </class>
   <class name="pat::PackedCandidate" ClassVersion="35">
-   <version ClassVersion="35" checksum="3383258297"/>
+   <version ClassVersion="35" checksum="2065846728"/>
    <version ClassVersion="34" checksum="3953181632"/>
    <version ClassVersion="33" checksum="1092680546"/>
    <version ClassVersion="32" checksum="926869123"/>

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -312,8 +312,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
   cands.back().setCovarianceVersion(covarianceVersion_);
   cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
-    cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()));
-    cands.back().setTrkOriginalAlgo(static_cast<uint8_t>(trk->originalAlgo()));
+    cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()), static_cast<uint8_t>(trk->originalAlgo()));
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);
     } else {

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -311,9 +311,9 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
   cands.back().setTrackHighPurity(trk->quality(reco::TrackBase::highPurity));
   cands.back().setCovarianceVersion(covarianceVersion_);
   cands.back().setLostInnerHits(lostHits);
-  cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()));
-  cands.back().setTrkOriginalAlgo(static_cast<uint8_t>(trk->originalAlgo()));
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
+    cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()));
+    cands.back().setTrkOriginalAlgo(static_cast<uint8_t>(trk->originalAlgo()));
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);
     } else {

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -311,6 +311,8 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
   cands.back().setTrackHighPurity(trk->quality(reco::TrackBase::highPurity));
   cands.back().setCovarianceVersion(covarianceVersion_);
   cands.back().setLostInnerHits(lostHits);
+  cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()));
+  cands.back().setTrkOriginalAlgo(static_cast<uint8_t>(trk->originalAlgo()));
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -290,6 +290,8 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
       }
       // properties of the best track
       outPtrP->back().setLostInnerHits(lostHits);
+      outPtrP->back().setTrkAlgo(static_cast<uint8_t>(ctrack->algo()));
+      outPtrP->back().setTrkOriginalAlgo(static_cast<uint8_t>(ctrack->originalAlgo()));
       if (outPtrP->back().pt() > minPtForTrackProperties_ || outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
           whiteList.find(ic) != whiteList.end() ||
           (cand.trackRef().isNonnull() && whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -293,8 +293,7 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
       if (outPtrP->back().pt() > minPtForTrackProperties_ || outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
           whiteList.find(ic) != whiteList.end() ||
           (cand.trackRef().isNonnull() && whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
-        outPtrP->back().setTrkAlgo(static_cast<uint8_t>(ctrack->algo()));
-        outPtrP->back().setTrkOriginalAlgo(static_cast<uint8_t>(ctrack->originalAlgo()));
+        outPtrP->back().setTrkAlgo(static_cast<uint8_t>(ctrack->algo()), static_cast<uint8_t>(ctrack->originalAlgo()));
         outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
         if (abs(outPtrP->back().pdgId()) == 22) {
           outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[4], covarianceVersion_);

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -290,11 +290,11 @@ void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event &iEvent,
       }
       // properties of the best track
       outPtrP->back().setLostInnerHits(lostHits);
-      outPtrP->back().setTrkAlgo(static_cast<uint8_t>(ctrack->algo()));
-      outPtrP->back().setTrkOriginalAlgo(static_cast<uint8_t>(ctrack->originalAlgo()));
       if (outPtrP->back().pt() > minPtForTrackProperties_ || outPtrP->back().ptTrk() > minPtForTrackProperties_ ||
           whiteList.find(ic) != whiteList.end() ||
           (cand.trackRef().isNonnull() && whiteListTk.find(cand.trackRef()) != whiteListTk.end())) {
+        outPtrP->back().setTrkAlgo(static_cast<uint8_t>(ctrack->algo()));
+        outPtrP->back().setTrkOriginalAlgo(static_cast<uint8_t>(ctrack->originalAlgo()));
         outPtrP->back().setFirstHit(ctrack->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
         if (abs(outPtrP->back().pdgId()) == 22) {
           outPtrP->back().setTrackProperties(*ctrack, covariancePackingSchemas_[4], covarianceVersion_);

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -647,8 +647,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
           } else
             lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
           candidate.setLostInnerHits(lostHits);
-          candidate.setTrkAlgo(static_cast<uint8_t>(track->algo()));
-          candidate.setTrkOriginalAlgo(static_cast<uint8_t>(track->originalAlgo()));
+          candidate.setTrkAlgo(static_cast<uint8_t>(track->algo()), static_cast<uint8_t>(track->originalAlgo()));
 
           if (useTrackProperties(reco_cand) or
               std::find(whiteListSV.begin(), whiteListSV.end(), icand) != whiteListSV.end() or

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -647,6 +647,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
           } else
             lostHits = (nlost == 1 ? pat::PackedCandidate::oneLostInnerHit : pat::PackedCandidate::moreLostInnerHits);
           candidate.setLostInnerHits(lostHits);
+          candidate.setTrkAlgo(static_cast<uint8_t>(track->algo()));
+          candidate.setTrkOriginalAlgo(static_cast<uint8_t>(track->originalAlgo()));
 
           if (useTrackProperties(reco_cand) or
               std::find(whiteListSV.begin(), whiteListSV.end(), icand) != whiteListSV.end() or


### PR DESCRIPTION
This PR adds track algo and originalAlgo to PackedCandidates as `uint8_t` data members; the values are filled with the same selections as other track properties (mainly driven by `pt> minPtForTrackProp`, the cut is at 0.95 GeV)

The primary use case so far is in the tag-and-probe measurements of tracking performance where general and muon tracking iterations need to be separated and the analysis is forced to use AOD, while a switch to miniAOD should be possible.

More use cases can arise for improved track quality selection and lower level debugging in miniAOD.

Tested in CMSSW_13_0_0_pre4 on `/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-RECO/PU_130X_mcRun3_2022_realistic_v2-v2/00000/{08b3cb94-2a3e-42c8-9374-46b4264dbef7.root,1a2b2a1d-133a-435c-b275-a4e3b651e71c.root,50823067-81cd-459a-baf7-aabc7851cce5.root,902c1d68-aa8e-49ea-94df-228edecdd3e9.root}` with 4000 events running PAT step (step4 from wf 11834.21).

- the sum of all products (using `edmEventSize`) compressed size increases by 238 B/ev or 0.27%
- The `packedPFCandidates` collection size increases by 0.5% or 205 B/event (from 43.3 kiB/ev)

This was proposed to XPOG in the [Jan 25 meeting](https://indico.cern.ch/event/1232579/?note=222311#6-pog-roundtable) (before the code was implemented and consequently before the file size measurements mentioned above)
