### PR TITLE
PPS diamond mapping fix for 2023 run

### DIFF
--- a/CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml
+++ b/CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml
@@ -45,18 +45,18 @@
           <diamond_channel id="11"        hw_id="0x10F"           FEDId="583"             GOHId="1"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">
-          <diamond_channel id="0"         hw_id="0x116"           FEDId="589"             GOHId="0"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x111"           FEDId="589"             GOHId="0"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x117"           FEDId="589"             GOHId="0"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x11D"           FEDId="589"             GOHId="0"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x11A"           FEDId="589"             GOHId="0"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x112"           FEDId="589"             GOHId="0"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x114"           FEDId="589"             GOHId="0"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x11C"           FEDId="589"             GOHId="0"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x11B"           FEDId="589"             GOHId="0"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x113"           FEDId="589"             GOHId="0"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x119"           FEDId="589"             GOHId="0"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x11F"           FEDId="589"             GOHId="0"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x116"           FEDId="589"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x111"           FEDId="589"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x117"           FEDId="589"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x11D"           FEDId="589"             GOHId="3"               IdxInFiber="13"/>
+          <diamond_channel id="4"         hw_id="0x11A"           FEDId="589"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x112"           FEDId="589"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x114"           FEDId="589"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x11C"           FEDId="589"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x11B"           FEDId="589"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x113"           FEDId="589"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x119"           FEDId="589"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x11F"           FEDId="589"             GOHId="3"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>    

--- a/DQM/CTPPS/python/totemRPDQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemRPDQMSource_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 totemRPDQMSource = DQMEDAnalyzer('TotemRPDQMSource',
-    tagStatus = cms.InputTag("totemRPRawToDigi", "TrackingStrip"),
+    tagStatus = cms.untracked.InputTag("totemRPRawToDigi", "TrackingStrip"),
     tagDigi = cms.untracked.InputTag("totemRPRawToDigi", "TrackingStrip"),
     tagCluster = cms.untracked.InputTag("totemRPClusterProducer"),
     tagRecHit = cms.untracked.InputTag("totemRPRecHitProducer"),


### PR DESCRIPTION
#### PR description:

This PR updates the XML mappings for PPS diamond detectors for 2023 run campaign.
The change follows recently discovered hardware issue, related to bad fiber input connector in the NEW OptoRX installed to cope with the new high trigger rate foreseen. Backward compatibility is sustained.

During tests of this PR we discovered as well that on of the parameters in the PPS DQM module was not marked as untracked.
This was probably a leftover from a  migration campaign done in https://github.com/cms-sw/cmssw/pull/38907
Appropriate change comes as well with this PR.

See as well related https://github.com/cms-sw/cmssw/pull/40763

#### PR validation:

This PR was validated with relvals 136.793, 1043 and 1044 (which run PPS reconstruction).
The reconstruction of Run 2 and 2022 data seems not affected.
New XML is parsed properly, I ran cmsRun CalibPPS/ESProducers/test/test_totemDAQMappingESSourceXML_cfg.py to parse XML and print its content on the console.
We ran the tests of unpacker on dataset(run 364968) taken after hardware intervention. The raw2digi step produced expected results.
We do not have proper 2023 data taken with new cabling, so full-scale reconstruction tests are not possible yet.