### PR TITLE
Re-introduce `BeamSpotOnlineProducer` for Phase-2 HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+hltOnlineBeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer",
+    timeThreshold = cms.int32( 48 ),
+    sigmaZThreshold = cms.double( 2.0 ),
+    sigmaXYThreshold = cms.double( 4.0 )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltOnlineBeamSpot_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltOnlineBeamSpot_cfi.py
@@ -1,3 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-hltOnlineBeamSpot = cms.EDProducer("BeamSpotProducer")
+hltOnlineBeamSpot = cms.EDProducer("BeamSpotOnlineProducer",
+                                   useTransientRecord = cms.bool(True),
+                                   changeToCMSCoordinates = cms.bool(False),
+                                   gtEvmLabel = cms.InputTag(""),
+                                   maxRadius = cms.double(2.0),
+                                   maxZ = cms.double(40.0),
+                                   setSigmaZ = cms.double(0.0))

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -55,6 +55,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/highPtTripletStepTra
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/muonSeededTrajectoryCleanerBySharedHits_cfi")
 
 ### Mostly comes from HLT-like configuration, not RECO-like configuration
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltOnlineBeamSpotESProducer_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPBwdElectronPropagator_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator2000_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPChi2ChargeMeasurementEstimator30_cfi")

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -62,7 +62,8 @@ BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
       theMaxZ(iconf.getParameter<double>("maxZ")),
       theSetSigmaZ(iconf.getParameter<double>("setSigmaZ")),
       useTransientRecord_(iconf.getParameter<bool>("useTransientRecord")),
-      scalerToken_(consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
+      scalerToken_(useTransientRecord_ ? edm::EDGetTokenT<BeamSpotOnlineCollection>()
+                                       : consumes<BeamSpotOnlineCollection>(iconf.getParameter<InputTag>("src"))),
       l1GtEvmReadoutRecordToken_(consumes<L1GlobalTriggerEvmReadoutRecord>(iconf.getParameter<InputTag>("gtEvmLabel"))),
       beamToken_(esConsumes<BeamSpotObjects, BeamSpotObjectsRcd>()),
       beamTransientToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd>()),
@@ -79,7 +80,7 @@ void BeamSpotOnlineProducer::fillDescriptions(edm::ConfigurationDescriptions& iD
   ps.add<double>("maxZ", 40.);
   ps.add<double>("setSigmaZ", -1.);
   ps.addUntracked<unsigned int>("beamMode", 11);
-  ps.add<InputTag>("src", InputTag("hltScalersRawToDigi"));
+  ps.addOptional<InputTag>("src", InputTag("hltScalersRawToDigi"))->setComment("SCAL decommissioned after Run 2");
   ps.add<InputTag>("gtEvmLabel", InputTag(""));
   ps.add<double>("maxRadius", 2.0);
   ps.add<bool>("useTransientRecord", false);


### PR DESCRIPTION
#### PR description:

This PR proposes a somewhat alternative approach to deliver the online Beam Spot to the HLT menu in Phase-2 as the one introduced at https://github.com/cms-sw/cmssw/pull/41047.
The goal is to re-align the Phase-2 HLT configuration to be the same as in Run3 (i.e. use `BeamSpotOnlineProducer` instead of `BeamSpotProducer`) this is achieved by means of:
   * adding the `hltOnlineBeamSpotESProducer` (`ESProducer` for the arbitration) to the HLT menu itself;
   * set `useTransientRecord = True` in the `onlineBeamSpot` configuration (in this way one do not need to use scalers input any longer);

As with the proposed configuration the `BeamSpotOnlineProducer` falls back into producing the in the event the content of the DB (`BeamSpotObjectsRcd`) this should not introduce any change in the HLT results.
One of the main objections to use `BeamSpotOnlineProducer` for the phase-2 setup was about the fact that it needs to consume `BeamSpotOnlineCollection` from the SCAL FED (which doesn't exist anymore in >= Run3). I therefore profit of this PR to change `BeamSpotOnlineProducer` in order to not consume it unless  `useTransientRecord` is set to `False`. This and declaring this parameter as optional in the `fillDescription` method of `BeamSpotOnlineProducer` allows to avoid declaring `hltScalersRawToDigi` as input collection.

#### PR validation:

Successfully run:
   * `runTheMatrix.py -l 20834.76`
   * `addOnTests.py`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A