### PR TITLE
DQM perLS in one shot

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -792,7 +792,6 @@ namespace dqm {
 
       // Book MEs by lumi by default whenever possible.
       bool doSaveByLumi_;
-      //      std::vector<std::string> MEsToSave_;  //just if perLS is ON
 
       // if non-empty, debugTrackME calls will log some information whenever a
       // ME path contains this string.

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -792,11 +792,15 @@ namespace dqm {
 
       // Book MEs by lumi by default whenever possible.
       bool doSaveByLumi_;
-      std::vector<std::string> MEsToSave_;  //just if perLS is ON
+      //      std::vector<std::string> MEsToSave_;  //just if perLS is ON
 
       // if non-empty, debugTrackME calls will log some information whenever a
       // ME path contains this string.
       std::string trackME_;
+
+    public:
+      // Book MEs by lumi from list in DQMServices/Core/python/DQMStore_cfi.py
+      std::vector<std::string> MEsToSave_;  //just if perLS is ON
     };
   }  // namespace implementation
 

--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -139,9 +139,9 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "SiStrip/MechanicalView/MainDiagonal Position",
     "SiStrip/MechanicalView/NumberOfClustersInPixel",
     "SiStrip/MechanicalView/NumberOfClustersInStrip",
-    "Tracking/TrackParameters/GeneralProperties/Chi2oNDF_lumiFlag_GenTk",  #non existing
-    "Tracking/TrackParameters/GeneralProperties/NumberOfRecHitsPerTrack_lumiFlag_GenTk", #non existing
-    "Tracking/TrackParameters/GeneralProperties/NumberOfTracks_lumiFlag_GenTk", #non existing
+    "Tracking/TrackParameters/generalTracks/LSanalysis/Chi2oNDF_lumiFlag_GenTk",  
+    "Tracking/TrackParameters/generalTracks/LSanalysis/NumberOfRecHitsPerTrack_lumiFlag_GenTk", 
+    "Tracking/TrackParameters/generalTracks/LSanalysis/NumberOfTracks_lumiFlag_GenTk", 
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDxyToPV_GenTk",
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDzToPV_GenTk",
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIP3DToPV_GenTk",

--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -148,7 +148,7 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "Tracking/TrackParameters/generalTracks/HitProperties/NumberOfMissingOuterRecHitsPerTrack_GenTk",
     "Tracking/TrackParameters/generalTracks/HitProperties/NumberMORecHitsPerTrackVsPt_GenTk",
     "OfflinePV/offlinePrimaryVertices/tagVtxProb",
-    "OfflinePV/offlinePrimaryVertice/tagType",
+    "OfflinePV/offlinePrimaryVertices/tagType",
     "OfflinePV/Resolution/PV/pull_x",
     "OfflinePV/Resolution/PV/pull_y",
     "OfflinePV/Resolution/PV/pull_z",

--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -139,9 +139,9 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "SiStrip/MechanicalView/MainDiagonal Position",
     "SiStrip/MechanicalView/NumberOfClustersInPixel",
     "SiStrip/MechanicalView/NumberOfClustersInStrip",
-    "Tracking/TrackParameters/GeneralProperties/Chi2oNDF_lumiFlag_GenTk",
-    "Tracking/TrackParameters/GeneralProperties/NumberOfRecHitsPerTrack_lumiFlag_GenTk",
-    "Tracking/TrackParameters/GeneralProperties/NumberOfTracks_lumiFlag_GenTk",
+    "Tracking/TrackParameters/GeneralProperties/Chi2oNDF_lumiFlag_GenTk",  #non existing
+    "Tracking/TrackParameters/GeneralProperties/NumberOfRecHitsPerTrack_lumiFlag_GenTk", #non existing
+    "Tracking/TrackParameters/GeneralProperties/NumberOfTracks_lumiFlag_GenTk", #non existing
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDxyToPV_GenTk",
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIPDzToPV_GenTk",
     "Tracking/TrackParameters/highPurityTracks/pt_1/GeneralProperties/SIP3DToPV_GenTk",

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -105,7 +105,7 @@ namespace dqm::implementation {
         for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
              ipath != store_->MEsToSave_.end();
              ++ipath) {
-          if (fullpath == ipath->data()) {
+          if (fullpath == (*ipath)) {
             medata.key_.scope_ = MonitorElementData::Scope::LUMI;
             this->scope_ = MonitorElementData::Scope::LUMI;
             pathInList = true;

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -100,8 +100,8 @@ namespace dqm::implementation {
       medata.key_.path_ = path;
       medata.key_.kind_ = kind;
 
-      bool pathInList = false;
       if (not store_->MEsToSave_.empty()) {
+         bool pathInList = false;
         for (auto& thepath : store_->MEsToSave_) {
           if (fullpath == thepath) {
             medata.key_.scope_ = MonitorElementData::Scope::LUMI;

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -99,15 +99,31 @@ namespace dqm::implementation {
       MonitorElementData medata;
       medata.key_.path_ = path;
       medata.key_.kind_ = kind;
-      medata.key_.scope_ = this->scope_;
+
+      bool pathInList = false;
+      if (not store_->MEsToSave_.empty()) {
+        for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
+             ipath != store_->MEsToSave_.end();
+             ++ipath) {
+          if (fullpath == ipath->data()) {
+            medata.key_.scope_ = MonitorElementData::Scope::LUMI;
+            this->scope_ = MonitorElementData::Scope::LUMI;
+            pathInList = true;
+            break;
+          }
+        }
+        if (not pathInList)
+          medata.key_.scope_ = this->scope_;
+      } else
+        medata.key_.scope_ = this->scope_;
 
       // will be (0,0) ( = prototype) in the common case.
       // This branching is for harvesting, where we have run/lumi in the booker.
-      if (this->scope_ == MonitorElementData::Scope::JOB) {
+      if (medata.key_.scope_ == MonitorElementData::Scope::JOB) {
         medata.key_.id_ = edm::LuminosityBlockID();
-      } else if (this->scope_ == MonitorElementData::Scope::RUN) {
+      } else if (medata.key_.scope_ == MonitorElementData::Scope::RUN) {
         medata.key_.id_ = edm::LuminosityBlockID(this->runlumi_.run(), 0);
-      } else if (this->scope_ == MonitorElementData::Scope::LUMI) {
+      } else if (medata.key_.scope_ == MonitorElementData::Scope::LUMI) {
         // In the messy case of legacy-booking a LUMI ME in beginRun (or
         // similar), where we don't have a valid lumi number yet, make sure to
         // book a prototype instead.

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -101,7 +101,7 @@ namespace dqm::implementation {
       medata.key_.kind_ = kind;
 
       if (not store_->MEsToSave_.empty()) {
-         bool pathInList = false;
+        bool pathInList = false;
         for (auto& thepath : store_->MEsToSave_) {
           if (fullpath == thepath) {
             medata.key_.scope_ = MonitorElementData::Scope::LUMI;

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -107,7 +107,6 @@ namespace dqm::implementation {
              ++ipath) {
           if (fullpath == (*ipath)) {
             medata.key_.scope_ = MonitorElementData::Scope::LUMI;
-            this->scope_ = MonitorElementData::Scope::LUMI;
             pathInList = true;
             break;
           }

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -102,10 +102,8 @@ namespace dqm::implementation {
 
       bool pathInList = false;
       if (not store_->MEsToSave_.empty()) {
-        for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
-             ipath != store_->MEsToSave_.end();
-             ++ipath) {
-          if (fullpath == (*ipath)) {
+        for (auto& thepath : store_->MEsToSave_) {
+          if (fullpath == thepath) {
             medata.key_.scope_ = MonitorElementData::Scope::LUMI;
             pathInList = true;
             break;


### PR DESCRIPTION
#### PR description:
DQMIO data tier is saved perRun basis up to now, while perLS mode was activated in the so called nanoDQMIO format which is described here:
https://twiki.cern.ch/twiki/bin/view/CMS/PerLsDQMIO

This implied running RECO-DQM steps twice, one perRun and one perLS. This PR attempts to create the output in one shot to reduce computing resource needs, by enabling perLS mode for the list of (needed) MEs requested by DPG/POGs in [1].

These changes result in an (expected) increase of the DQMIO data tier (usual perRun MEs + additional dedicated perLS MEs) but maintaining at the same time (plain root) DQM format (to be uploaded to DQM GUI) after HARVESTING identical (up to rounding errors).

With this single shot mode, there will only be one output file, with both per-run and per-lumi histograms in it (depending on the ME). For the per-lumi MEs, no per-run results will be present, but that is fine, the harvesting job will make per-run histograms from the per-lumi ones. The Harvesting Job will see per-lumi histograms (which only matters if there is endLumi code, which is rare outside online), and save per-Job histograms in the end (which will be full runs for the usual Harvesting jobs). The plain ROOT file should be the same, up to rounding errors, which the DQM BinByBin tool may detect in this PR.

Needless to say that, future updates of the list of MEs in file [1], will chnage the content of per LS MEs to be saved in the future. 

#### PR validation:
Uisng file: /store/data/Run2022G/Muon/RAW/v1/000/362/596/00000/6e355fc9-e4e9-478a-9ce4-d3b6c1d6135e.root from /Muon/Run2022G  which contains 8 LS from run 362596, I performed standard RECO and DQM with command in [2]:

- Checked MEs from [1] are created in a per LS basis (identified one typo in [1] and 3 MEs from Tracking POG which apparently do not exist in this run[3], so I flagged them in [1] file)

- Checked DQMIO output does not explode (average increase is 72kB per LS with the current version of [1]). Indeed, standard DQM workflow already contains 1366 MEs in perLS mode by default (used by DPGs and POGs to created plots vs LS in DQM GUI), out of which 14 are again requested in [1]. 

- Hence, we are adding   only 148 new MEs in per LS to the standard DQMIO data tier, which acocunt for 578545 extra bytes / 8 LSs = 72318 bytes = 72.3 kB  per LS.  An increase totally acceptable bearing in mind that DQMIO datasets are small (order of of dozens of GB) compared to the rest of CMS datasets in DAS[4]

- The total numbers of MEs in default DQMIO for a given run and in the new version after this PR iare the following:
Default (before):
Run 362596, 72672 MEs       (per Run MEs)
Run 362596, Lumi 31-38, 1514 MEs   (per LS MEs)

After this PR:
Run 362596, 72820 MEs      (per Run MEs)
Run 362596, Lumi 31-38, 1366 MEs   (per LS MEs)

and the type composition is detailed in [5]

- Checked that DQM Harvesting works out of the box taking as input the new DQMIO with mixed per Run and per LS MEs:
https://tinyurl.com/27pmw76f    (differences in the bin by bin tool ONLY for process time in DQM modules)

- runTheMatrix.py -l limited -t 8   works

[1] DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py 

[2] cmsDriver.py step2 --conditions 124X_dataRun3_v10 --data --datatier DQMIO --era Run3 --eventcontent DQM --filein file:/eos/cms/store/data/Run2022B/SingleMuon/RAW/v1/000/355/094/00000/1ed76311-a4df-4699-885e-965087521f03.root --fileout file:step2.root --nStreams 2 --nThreads 8 --no_exec --number 10 --process RECO --python_filename step_2_nano_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM

[3] https://tinyurl.com/2oy3k7vc    does not contain the following MEs: 
Tracking/TrackParameters/GeneralProperties/Chi2oNDF_lumiFlag_GenTk
Tracking/TrackParameters/GeneralProperties/NumberOfRecHitsPerTrack_lumiFlag_GenTk
Tracking/TrackParameters/GeneralProperties/NumberOfTracks_lumiFlag_GenTk
requested in [1]

[4] https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=size+dataset%3D%2FMuon%2FRun2022G-PromptReco-v1%2FDQMIO

[5] Before (default DQM) and now (after this PR) perLS ME composition:
+--------+------+------------+-----------+------------------+----------+
|  Run   | Lumi | FirstIndex | LastIndex |       Type       | ME Count |
+--------+------+------------+-----------+------------------+----------+
| 362596 |  31  |     0      |    984    |    3 (TH1Fs)     |   985    |
| 362596 |  31  |     0      |     19    |    5 (TH1Ds)     |    20    |
| 362596 |  31  |     0      |     38    |    6 (TH2Fs)     |    39    |
| 362596 |  31  |     0      |    265    |  10 (TProfiles)  |   266    |
| 362596 |  31  |     0      |     55    | 11 (TProfile2Ds) |    56    |
+--------+------+------------+-----------+------------------+----------+
|  Run   | Lumi | FirstIndex | LastIndex |       Type       | ME Count |
+--------+------+------------+-----------+------------------+----------+
| 362596 |  31  |     0      |     0     |     0 (Ints)     |    1     |
| 362596 |  31  |     0      |    1109   |    3 (TH1Fs)     |   1110   |
| 362596 |  31  |     0      |     19    |    5 (TH1Ds)     |    20    |
| 362596 |  31  |     0      |     60    |    6 (TH2Fs)     |    61    |
| 362596 |  31  |     0      |    265    |  10 (TProfiles)  |   266    |
| 362596 |  31  |     0      |     55    | 11 (TProfile2Ds) |    56    |

Used dqmiodumpmetadata.py , dqmiodumpindices.py and dqmiolistmes.py scripts for these checks