### PR TITLE
(13_0_X) updated HMT loose thresholds backport

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/showerParams.py
@@ -43,21 +43,21 @@ showerPSet = cms.PSet(
 	## 10000 means to disable cathode HMT for this chamber type
         showerThresholds = cms.vuint32(
             # ME1/1
-            100, 100, 100,
+            80, 100, 100,
             # ME1/2
             10000, 10000, 10000,
             # ME1/3
             10000, 10000, 10000,
             # ME2/1
-            17, 33, 35,
+            14, 33, 35,
             # ME2/2
             10000, 10000, 10000,
             # ME3/1
-            15, 31, 33,
+            12, 31, 33,
             # ME3/2
             10000, 10000, 10000,
             # ME4/1
-            17, 34, 36,
+            14, 34, 36,
             # ME4/2
             10000, 10000, 10000
         ),
@@ -72,23 +72,23 @@ showerPSet = cms.PSet(
         ## {loose, nominal, tight} thresholds for hit counters
         showerThresholds = cms.vuint32(
             # ME1/1
-            140, 140, 140,
+            112, 140, 140,
             # ME1/2
-            140, 140, 140,
+            112, 140, 140,
             # ME1/3
-            14, 14, 18,
+            7, 14, 18,
             # ME2/1
-            28, 56, 58,
+            23, 56, 58,
             # ME2/2
-            28, 28, 32,
+            8, 28, 32,
             # ME3/1
-            26, 55, 57,
+            21, 55, 57,
             # ME3/2
-            26, 26, 34,
+            7, 26, 34,
             # ME4/1
-            31, 62, 64,
+            25, 62, 64,
             # ME4/2
-            13, 27, 31
+            11, 27, 31
         ),
         showerNumTBins = cms.uint32(1),# 1BX for anode HMT
         minLayersCentralTBin = cms.uint32(5),


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/41192

Update HMT loose shower thresholds to values corresponding to 2023 data taking, needed for 2023 run preparation.

Need to backport to CMSSW_13_0_X to be able to test the new loose HMT shower configuration at p5, which is a completely new functionality. The information is propagated through the different subsystems (CSC->EMTF->uGMT->uGT), up to build the new L1 seed.