### PR TITLE
Added ShutdownSignal entry to JobReport

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -851,6 +851,9 @@ namespace edm {
     // Look for a shutdown signal
     if (shutdown_flag.load(std::memory_order_acquire)) {
       returnValue = true;
+      edm::LogSystem("ShutdownSignal") << "an external signal was sent to shutdown the job early.";
+      edm::Service<edm::JobReport> jr;
+      jr->reportShutdownSignal();
       returnCode = epSignal;
     }
     return returnValue;

--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -356,6 +356,11 @@ namespace edm {
     void reportError(std::string const& shortDesc, std::string const& longDesc, int const& exitCode);
 
     ///
+    /// Report a unix signal sent to early terminate the job
+    ///
+    void reportShutdownSignal();
+
+    ///
     /// Report Skipped File
     ///
     /// Report that a file has been skipped due to it not being

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -540,6 +540,17 @@ namespace edm {
     }
   }
 
+  void JobReport::reportShutdownSignal() {
+    if (impl_->ost_) {
+      {
+        std::lock_guard<std::mutex> lock(write_mutex);
+        std::ostream& msg = *(impl_->ost_);
+        msg << "<ShutdownSignal/>\n";
+        temporarilyCloseXML();
+      }
+    }
+  }
+
   void JobReport::reportSkippedFile(std::string const& pfn, std::string const& lfn) {
     if (impl_->ost_) {
       std::ostream& msg = *(impl_->ost_);

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -3,6 +3,11 @@
   <use name="FWCore/Framework"/>
 </library>
 
+<library file="SignallingAnalyzer.cc" name="SignallingAnalyzer">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+</library>
+
 <library file="SiteLocalConfigServiceTester.cc SiteLocalConfigServiceCatalogTester.cc" name="SiteLocalConfigUnitTestClient">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Services"/>
@@ -24,3 +29,4 @@
 </bin>
 
 <test name="TestResourceInformationService" command="test_resourceInformationService.sh"/>
+<test name="TestSignalMessages" command="test_signal.sh"/>

--- a/FWCore/Services/test/SignallingAnalyzer.cc
+++ b/FWCore/Services/test/SignallingAnalyzer.cc
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Services/test
+// Class  :     SignallingAnalyzer
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Sat, 22 Mar 2014 23:07:05 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/allowedValues.h"
+#include <csignal>
+
+class SignallingAnalyzer : public edm::global::EDAnalyzer<> {
+public:
+  SignallingAnalyzer(edm::ParameterSet const& iPSet) : m_signal(iPSet.getUntrackedParameter<std::string>("signal")) {}
+
+  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const final {
+    if (m_signal == "INT") {
+      raise(SIGINT);
+    }
+    if (m_signal == "ABRT") {
+      raise(SIGABRT);
+    }
+    if (m_signal == "SEGV") {
+      raise(SIGSEGV);
+    }
+    if (m_signal == "TERM") {
+      raise(SIGTERM);
+    }
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& iConf) {
+    edm::ParameterSetDescription desc;
+    desc.ifValue(edm::ParameterDescription<std::string>("signal", "INT", false),
+                 edm::allowedValues<std::string>("INT", "ABRT", "SEGV", "TERM"))
+        ->setComment("which signal to raise.");
+    iConf.addDefault(desc);
+  }
+
+private:
+  std::string const m_signal;
+};
+
+DEFINE_FWK_MODULE(SignallingAnalyzer);

--- a/FWCore/Services/test/test_signal.sh
+++ b/FWCore/Services/test/test_signal.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+cmsRun -e ${SCRAM_TEST_PATH}/test_signal_cfg.py &> test_signal.log || die "cmsRun test_signal_cfg.py" $?
+
+grep "%MSG-s ShutdownSignal:" test_signal.log || die "Check for shutdown signal message" $?
+grep "<ShutdownSignal/>" FrameworkJobReport.xml || die "Check for signal element in FJR" $?
+
+exit 0

--- a/FWCore/Services/test/test_signal_cfg.py
+++ b/FWCore/Services/test/test_signal_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.signal = cms.EDAnalyzer("SignallingAnalyzer", signal = cms.untracked.string("INT"))
+
+process.p = cms.Path(process.signal)


### PR DESCRIPTION
#### PR description:

If a job was told by an external signal to shutdown early we not record that info into the FrameworkJobReport.
Also added a log message when the signal occurs.

#### PR validation:

Code compiles and framework unit tests pass.