### PR TITLE
Update GEM geometry in 2023 MC GTs and L1 HI menu tag in 2022/2023 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -72,17 +72,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v2',
+    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v1',
+    'phase1_2023_design'           : '131X_mcRun3_2023_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v1',
+    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v1',
+    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v1',
+    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v2',
+    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:
This PR updates the 2023 MC Global Tags in `autoCond` with the GEM geometry tags requested in [this CMS Talk post](https://cms-talk.web.cern.ch/t/update-of-gem-geometry-for-2023-data-and-mc/21887) [1]. In addition, the 2022 and 2023 HI MC GTs are also updated with the L1 menu tag `L1Menu_CollisionsHeavyIons2022_v1_1_0-d1_xml` requested in [[2]](https://cms-talk.web.cern.ch/t/request-to-include-the-hi-l1-menu-in-the-run3-hi-mc-gt/21665/2)

[1] https://cms-talk.web.cern.ch/t/update-of-gem-geometry-for-2023-data-and-mc/21887
[2] https://cms-talk.web.cern.ch/t/request-to-include-the-hi-l1-menu-in-the-run3-hi-mc-gt/21665

The difference with the last GTs in `autoCond` is here:

- **Phase1 2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v1/131X_mcRun3_2023_design_v3
- **Phase1 2023 cosmics realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v1/131X_mcRun3_2023cosmics_realistic_deco_v3
- **Phase1 2023 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v1/131X_mcRun3_2023cosmics_design_deco_v3
- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v1/131X_mcRun3_2023_realistic_v3
- **Phase1 2023 realsitic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v2/131X_mcRun3_2023_realistic_HI_v5
- **Phase1 2022 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v2/131X_mcRun3_2022_realistic_HI_v3

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 160.1, 12434.0 --ibeos -j 16`  which consume `auto:phase1_2023_realistic_hi` and `auto:phase1_2023_realistic` respectively

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport, but the GEM geometry updates will be backported in `130X` GTs, which is the baseline release for 2023 MC production
