### PR TITLE
[13_0_X] Update GEM geometry in 2023 MC GTs and the HI beamspot in 2023 MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -74,15 +74,15 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v3',
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v4',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v3',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v3',
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v4',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/41202
This PR updates the `130X` 2023 MC Global Tags in `autoCond` with the GEM geometry tags requested in [this CMS Talk post](https://cms-talk.web.cern.ch/t/update-of-gem-geometry-for-2023-data-and-mc/21887) [1]. Also, the 2023 Heavy Ion MC GT is updated with the beamspot tag `BeamSpotObjects_Realistic2022PbPbCollision_v5_mc` as requested in [[2]](https://cms-talk.web.cern.ch/t/request-for-new-run3-hi-mc-gt-realistic-bs-for-13-0-x/21912). 

[1] https://cms-talk.web.cern.ch/t/update-of-gem-geometry-for-2023-data-and-mc/21887
[2] https://cms-talk.web.cern.ch/t/request-for-new-run3-hi-mc-gt-realistic-bs-for-13-0-x/21912

The difference with the last GTs in `autoCond` is here:

- **Phase1 2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_v3/130X_mcRun3_2023_design_v5
- **Phase1 2023 cosmics realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v3/130X_mcRun3_2023cosmics_realistic_deco_v5
- **Phase1 2023 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_v3/130X_mcRun3_2023cosmics_design_deco_v5
- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v4/130X_mcRun3_2023_realistic_v6
- **Phase1 2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v4/130X_mcRun3_2023_realistic_HI_v7

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 160.1, 12434.0 --ibeos -j 16`  which consume `auto:phase1_2023_realistic_hi` and `auto:phase1_2023_realistic` respectively

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial backport of https://github.com/cms-sw/cmssw/pull/41202. No other backport foreseen.
