### PR TITLE
Remove unneeded header includes from DQM/CTPPS plugins

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -6,7 +6,6 @@
  *
  ****************************************************************************/
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -9,7 +9,6 @@
 *
 ****************************************************************************/
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -7,7 +7,6 @@
  *
  *******************************************/
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -191,7 +191,7 @@ void CTPPSRandomDQMSource::analyze(edm::Event const &event, edm::EventSetup cons
 
 void CTPPSRandomDQMSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer"));
+  desc.add<edm::InputTag>("tagRPixDigi", edm::InputTag("ctppsPixelDigisAlCaRecoProducer", ""));
   desc.addUntracked<std::string>("folderName", "PPSRANDOM/RandomPixel");
   desc.addUntracked<unsigned int>("RPStatusWord", 0x8008);
   descriptions.add("ctppsRandomDQMSource", desc);

--- a/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSRandomDQMSource.cc
@@ -6,7 +6,6 @@
  *
  *******************************************/
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -18,13 +17,9 @@
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 
-#include "CondFormats/PPSObjects/interface/CTPPSPixelIndices.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h"
-#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h"
-#include "DataFormats/CTPPSReco/interface/CTPPSPixelCluster.h"
-#include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
 
 #include <string>
 

--- a/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsRandomDQMSource_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-
-ctppsRandomDQMSource = DQMEDAnalyzer('CTPPSRandomDQMSource',
-    tagRPixDigi = cms.InputTag("ctppsPixelDigisAlCaRecoProducer", ""),
-    folderName = cms.untracked.string("PPSRANDOM/RandomPixel"),
-    RPStatusWord = cms.untracked.uint32(0x8008) # rpots in readout:220_fr_hr; 210_fr_hr
-)


### PR DESCRIPTION
#### PR description:

As a follow up of #40895, a few unnecessary header includes are removed from the newly added plugins, in order to reduce unnecessary dependencies

Added also the removal of explicit ctppsRandomDQMSource_cfi.py, as suggested by @AndreaBellora , because it is already created automatically by the `fillDescriptions` method of the plugin

@AndreaBellora FYI

#### PR validation:

It builds