### PR TITLE
[13_0_X] Add logic to produce "two loose showers in different sectors" in the MuonShowerProducer

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -61,30 +61,45 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     Showers that arrive out-of-time are also under consideration, but are not
     going be to enabled at startup Run-3. So all showers should be in-time.
    */
-  bool isOneNominalInTime = false;
-  bool isTwoLooseInTime = false;
-  bool isOneTightInTime = false;
+  bool isOneNominalInTime{false};
+  bool isTwoLooseInTime{false};
+  bool isOneTightInTime{false};
+  bool isTwoLooseDifferentSectorsInTime{false};
 
+  bool foundOneLoose{false};
   for (size_t i = 0; i < emtfShowers->size(0); ++i) {
     auto shower = emtfShowers->at(0, i);
     if (shower.isValid()) {
       // nominal
-      if (shower.isOneNominalInTime())
+      if (shower.isOneNominalInTime()) {
         isOneNominalInTime = true;
+      }
       // two loose
-      if (shower.isTwoLooseInTime())
+      if (shower.isTwoLooseInTime()) {
         isTwoLooseInTime = true;
+      }
       // tight
-      if (shower.isOneTightInTime())
+      if (shower.isOneTightInTime()) {
         isOneTightInTime = true;
+      }
+      // two loos in different sectors
+      if (shower.isOneLooseInTime()) {
+        if (foundOneLoose) {
+          isTwoLooseDifferentSectorsInTime = true;
+        } else {
+          foundOneLoose = true;
+        }
+      }
     }
   }
 
   // Check for at least one nominal shower
-  const bool acceptCondition(isOneNominalInTime or isTwoLooseInTime or isOneTightInTime);
+  const bool acceptCondition{isOneNominalInTime or isTwoLooseInTime or isOneTightInTime or
+                             isTwoLooseDifferentSectorsInTime};
 
   if (acceptCondition) {
-    MuonShower outShower(isOneNominalInTime, false, isTwoLooseInTime, false, isOneTightInTime, false);
+    MuonShower outShower(
+        isOneNominalInTime, false, isTwoLooseInTime, false, isOneTightInTime, false, isTwoLooseDifferentSectorsInTime);
     outShowers->push_back(0, outShower);
   }
   iEvent.put(std::move(outShowers));


### PR DESCRIPTION
#### PR description:

From 2023 we should also trigger on two showers from two different sectors. This PR is a backport to add logic to compute this bit in the MuonShowerProducer for the data taking release.

attn @eyigitba, @elfontan

#### PR validation:

No validation (beyond running standard tests) possible as there are no upstream producers for the required data, yet.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #41042
