### PR TITLE
Added option to trigger on loose HMT showers in EMTF

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -7,7 +7,7 @@
   CSC shower and send a trigger to the uGMT. In a possible extension, the
   EMTF shower sector processor can also trigger on two loose showers - to
   enhance the sensitivity to long-lived particles that produce multiple
-  showers, instead of a single showers.
+  showers, instead of a single shower.
  */
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -7,7 +7,7 @@
   CSC shower and send a trigger to the uGMT. In a possible extension, the
   EMTF shower sector processor can also trigger on two loose showers - to
   enhance the sensitivity to long-lived particles that produce multiple
-  smaller showers, instead of a single large shower.
+  showers, instead of a single showers.
  */
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,15 +34,14 @@ private:
   bool is_in_sector_csc(int tp_endcap, int tp_sector) const;
 
   int verbose_, endcap_, sector_;
+  // loose shower trigger for physics
+  bool enableOneLooseShower_;
   // nominal trigger for physics
   bool enableOneNominalShower_;
   // backup trigger
   bool enableOneTightShower_;
   // trigger to extend the physics reach
   bool enableTwoLooseShowers_;
-  unsigned nNominalShowers_;
-  unsigned nTightShowers_;
-  unsigned nLooseShowers_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -41,12 +41,10 @@ void L1TMuonEndCapShowerProducer::produce(edm::Event& iEvent, const edm::EventSe
 void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   // these are different shower selections that can be enabled
+  desc.add<bool>("enableOneLooseShower", true);
   desc.add<bool>("enableOneNominalShowers", true);
   desc.add<bool>("enableOneTightShowers", true);
   desc.add<bool>("enableTwoLooseShowers", false);
-  desc.add<unsigned>("nLooseShowers", 2);
-  desc.add<unsigned>("nNominalShowers", 1);
-  desc.add<unsigned>("nTightShowers", 1);
   desc.add<edm::InputTag>("CSCShowerInput", edm::InputTag("simCscTriggerPrimitiveDigis"));
   descriptions.add("simEmtfShowersDef", desc);
   descriptions.setComment("This is the generic cfi file for the EMTF shower producer");

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -42,8 +42,8 @@ void L1TMuonEndCapShowerProducer::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   // these are different shower selections that can be enabled
   desc.add<bool>("enableOneLooseShower", true);
-  desc.add<bool>("enableOneNominalShowers", true);
-  desc.add<bool>("enableOneTightShowers", true);
+  desc.add<bool>("enableOneNominalShower", true);
+  desc.add<bool>("enableOneTightShower", true);
   desc.add<bool>("enableTwoLooseShowers", false);
   desc.add<edm::InputTag>("CSCShowerInput", edm::InputTag("simCscTriggerPrimitiveDigis"));
   descriptions.add("simEmtfShowersDef", desc);

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
@@ -7,7 +7,7 @@
   in the endcap muon system.
 
   The logic is executed in the SectorProcessorShower class. Multiple options
-  are defined: "OneNominal", "TwoLoose"
+  are defined: "OneLoose", "TwoLoose", "OneNominal", "OneTight" 
  */
 
 // system include files

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -10,8 +10,8 @@ void SectorProcessorShower::configure(const edm::ParameterSet& pset, int endcap,
 
   enableOneLooseShower_ = pset.getParameter<bool>("enableOneLooseShower");
   enableTwoLooseShowers_ = pset.getParameter<bool>("enableTwoLooseShowers");
-  enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShowers");
-  enableOneTightShower_ = pset.getParameter<bool>("enableOneTightShowers");
+  enableOneNominalShower_ = pset.getParameter<bool>("enableOneNominalShower");
+  enableOneTightShower_ = pset.getParameter<bool>("enableOneTightShower");
 }
 
 void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,


### PR DESCRIPTION
#### PR description:

Starting from 2023 we will trigger on loose showers in EMTF. This information will be used in uGMT to build the `TwoLooseDiffSectorInTime` trigger.

I also cleaned the configurable parameters `nLooseShowers_`, `nNominalShowers_`, and `nTightShowers_`. The number of showers is already indicated in the boolean name and these configurables don't really add any configuration options. i.e the condition for `hasOneNominalInTime` should always be one or more showers.

The data format changes were done in https://github.com/cms-sw/cmssw/pull/40890 and uGMT logic update is done in https://github.com/cms-sw/cmssw/pull/41042

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by producing ntuples which had expected amount of loose showers. 

Also ran `runTheMatrix.py -l limited -i all --ibeos` with no failures. 

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/41185

<!-- Please delete the text above after you verified all points of the checklist  -->
