### PR TITLE
Adding 2Loose HMT showers in the GT emulator

### DIFF
--- a/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonShowerTemplate.h
@@ -47,6 +47,7 @@ public:
   struct ObjectParameter {
     bool MuonShower0;
     bool MuonShower1;
+    bool MuonShower2;
     bool MuonShowerOutOfTime0;
     bool MuonShowerOutOfTime1;
   };

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -308,6 +308,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
 
         } else if (condition.getType() == esConditionType::MuonShower0 ||
                    condition.getType() == esConditionType::MuonShower1 ||
+                   condition.getType() == esConditionType::MuonShower2 ||
                    condition.getType() == esConditionType::MuonShowerOutOfTime0 ||
                    condition.getType() == esConditionType::MuonShowerOutOfTime1) {
           parseMuonShower(condition, chipNr, false);
@@ -1571,6 +1572,8 @@ bool l1t::TriggerMenuParser::parseMuonShower(L1TUtmCondition condMu, unsigned in
     objParameter[0].MuonShower0 = true;
   } else if (condMu.getType() == esConditionType::MuonShower1) {
     objParameter[0].MuonShower1 = true;
+  } else if (condMu.getType() == esConditionType::MuonShower2) {
+    objParameter[0].MuonShower2 = true;
   } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime0) {
     objParameter[0].MuonShowerOutOfTime0 = true;
   } else if (condMu.getType() == esConditionType::MuonShowerOutOfTime1) {

--- a/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerCondition.cc
@@ -7,14 +7,16 @@
  * Implementation:                                                                                                     
  *    This condition class checks for the presente of a valid muon shower in the event.                                                                  
  *    If present, according to the condition parsed by the xml menu 
- *    (four possibilities for the first Run 3 implementation: MuonShower0, MuonShower1, MuonShowerOutOfTime0, MuonShowerOutOfTime1)
- *    the corresponding boolean flag is checked (isOneNominalInTime, isOneTightInTime, musOutOfTime0, musOutOfTime1).   
+ *    (five possibilities for the 2023 Run 3 implementation: MuonShower0, MuonShower1, MuonShower2, MuonShowerOutOfTime0, MuonShowerOutOfTime1)
+ *    the corresponding boolean flag is checked (isOneNominalInTime, isOneTightInTime, isTwoLooseDiffSectorsInTime, musOutOfTime0, musOutOfTime1).   
  *    If it is set to 1, the condition is satisfied and the object  is saved.
- *    Note that for the start of Run 3 only two cases are considered in the menu: Nominal and Tight muon showers.  
+ *    Note that for the start of Run 3 only two cases were considered in the menu: Nominal and Tight muon showers,  
+ *    an additional case is added for the 2023 data-taking: TwoLooseDiffSectors muon showers.
  *  
  * \author: S. Dildick (2021) - Rice University                                                    
  *         
  * \fixes by: E. Fontanesi, E. Yigitbasi, A. Loeliger (2023)                                                                                                
+ * \adding TwoLooseDiffSectors HMT: E. Fontanesi                                                                                                
  *         
  */
 
@@ -177,12 +179,14 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
 
   LogDebug("L1TGlobal") << "\n MuonShowerTemplate::ObjectParameter (utm objects, checking which condition is parsed): "
                         << std::hex << "\n\t MuonShower0 = 0x " << objPar.MuonShower0 << "\n\t MuonShower1 = 0x "
-                        << objPar.MuonShower1 << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
+                        << objPar.MuonShower1 << "\n\t MuonShower2 = 0x " << objPar.MuonShower2
+                        << "\n\t MuonShowerOutOfTime0 = 0x " << objPar.MuonShowerOutOfTime0
                         << "\n\t MuonShowerOutOfTime1 = 0x " << objPar.MuonShowerOutOfTime1 << std::endl;
 
   LogDebug("L1TGlobal") << "\n l1t::MuonShower (uGT emulator bits): "
                         << "\n\t MuonShower0: isOneNominalInTime() = " << cand.isOneNominalInTime()
                         << "\n\t MuonShower1: isOneTightInTime() = " << cand.isOneTightInTime()
+                        << "\n\t MuonShower2: isTwoLooseDiffSectorsInTime() = " << cand.isTwoLooseDiffSectorsInTime()
                         << "\n\t MuonShowerOutOfTime0: musOutOfTime0() = " << cand.musOutOfTime0()
                         << "\n\t MuonShowerOutOfTime1: musOutOfTime1() = " << cand.musOutOfTime1() << std::endl;
 
@@ -194,6 +198,11 @@ const bool l1t::MuonShowerCondition::checkObjectParameter(const int iCondition,
   // Check oneTightInTime
   if (cand.isOneTightInTime() != objPar.MuonShower1) {
     LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower1 requirement" << std::endl;
+    return false;
+  }
+  // Check twoLooseInTime
+  if (cand.isTwoLooseDiffSectorsInTime() != objPar.MuonShower2) {
+    LogDebug("L1TGlobal") << "\t\t MuonShower failed MuonShower2 requirement" << std::endl;
     return false;
   }
   if (cand.musOutOfTime0() != objPar.MuonShowerOutOfTime0) {

--- a/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonShowerTemplate.cc
@@ -54,6 +54,7 @@ void MuonShowerTemplate::print(std::ostream& myCout) const {
     myCout << "  Template for object " << i << " [ hex ]" << std::endl;
     myCout << "    MuonShower0   = " << std::hex << m_objectParameter[i].MuonShower0 << std::endl;
     myCout << "    MuonShower1   = " << std::hex << m_objectParameter[i].MuonShower1 << std::endl;
+    myCout << "    MuonShower2   = " << std::hex << m_objectParameter[i].MuonShower2 << std::endl;
     myCout << "    MuonShowerOutOfTime0   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime0 << std::endl;
     myCout << "    MuonShowerOutOfTime1   = " << std::hex << m_objectParameter[i].MuonShowerOutOfTime1 << std::endl;
   }


### PR DESCRIPTION
#### PR description:
Update of the Global Trigger emulator for 2Loose HMT seeds (targeting the 2023 L1 menu).
It relies on the new utm library v0.11.2 recently integrated: https://github.com/cms-sw/cmsdist/pull/8386.

This PR includes also an update of the GlobalBoard code to check the HMT condition for all BXs (see the discussion in https://github.com/cms-l1t-offline/cmssw/issues/1071). It should complete the fix of DQM issues at uGT with HMT observed during 2022. 

Backport to CMSSW_13_0_X: https://github.com/cms-sw/cmssw/pull/41249.

[cc: @dinyar @eyigitba @fmanteca]

#### PR validation:
Basic tests performed successfully starting from CMSSW_13_1_X_2023-03-28-1100
> cmsrel CMSSW_13_1_X_2023-03-28-1100
> cd CMSSW_13_1_X_2023-03-28-1100/src
> cmsenv
> git cms-addpkg L1Trigger/L1TGlobal 
> git cms-addpkg L1Trigger/Configuration
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests 
> scram build code-checks
> scram build code-format

Changes for the L1Ntuples have been included as well: https://github.com/cms-sw/cmssw/pull/41233.
A L1Ntuple [1] has been produced emulating a new menu [2] including the 2LooseHMT seed with the following recipe:

`cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=data_def.py -n 10000 --no_output --era=Run3 --data --conditions=124X_dataRun3_Prompt_v4  --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --filein=/store/data/Commissioning2023/Cosmics/RAW/v2/000/365/300/00000/0bee10f0-6e0c-4efd-9ab5-c58993f0b709.root  --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --fileout=HMT_test_L1Ntuple.root`
Note that the file `L1Trigger/Configuration/python/customiseUtils.py` has to be modify to use the new menu.

The output of the `uGTEmuTree` has been checked and includes countings for all the three HMT seeds:

> L1_TwoMuShower_Loose (Bit 69): 98
> L1_SingleMuShower_Nominal (Bit 101): 153
> L1_SingleMuShower_Tight (Bit 102):  89
> 

As discussed in [HMT](https://github.com/cms-l1t-offline/cmssw/issues/1080), at the moment all HMT rates are high and the reason is under investigation. Anyway, the uGT updates can be considered validated. 

[1] _/afs/cern.ch/work/e/elfontan/public/L1MenuTeamWork/HMT_test_L1Ntuple.root_
[2]  _/afs/cern.ch/work/e/elfontan/public/L1MenuTeamWork/L1TMenu_test_HMT.xml_ (Bit 69)
