### PR TITLE
[13_0_X] Add loose bits to uGMT muon shower DQM plots

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h
@@ -23,11 +23,21 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  enum variables { BXRANGEGOOD = 1, BXRANGEBAD, NSHOWERGOOD, NSHOWERBAD, SHOWERALL, SHOWERGOOD, NOMINALBAD, TIGHTBAD };
-  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT };
-  int numSummaryBins_{TIGHTBAD};
-  int numErrBins_{RTIGHT};
-  bool incBin_[RTIGHT + 1];
+  enum variables {
+    BXRANGEGOOD = 1,
+    BXRANGEBAD,
+    NSHOWERGOOD,
+    NSHOWERBAD,
+    SHOWERALL,
+    SHOWERGOOD,
+    NOMINALBAD,
+    TIGHTBAD,
+    LOOSEBAD
+  };
+  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT, RLOOSE };
+  int numSummaryBins_{LOOSEBAD};
+  int numErrBins_{RLOOSE};
+  bool incBin_[RLOOSE + 1];
 
   edm::EDGetTokenT<l1t::MuonShowerBxCollection> showerToken1_;
   edm::EDGetTokenT<l1t::MuonShowerBxCollection> showerToken2_;
@@ -50,6 +60,7 @@ private:
   MonitorElement* showerColl2nShowers_;
   MonitorElement* showerColl2ShowerTypeVsBX_;
 
+  static constexpr unsigned IDX_LOOSE_SHOWER{3};
   static constexpr unsigned IDX_TIGHT_SHOWER{2};
   static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h
@@ -23,12 +23,22 @@ protected:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
-  enum variables { BXRANGEGOOD = 1, BXRANGEBAD, NSHOWERGOOD, NSHOWERBAD, SHOWERALL, SHOWERGOOD, NOMINALBAD, TIGHTBAD };
-  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT };
+  enum variables {
+    BXRANGEGOOD = 1,
+    BXRANGEBAD,
+    NSHOWERGOOD,
+    NSHOWERBAD,
+    SHOWERALL,
+    SHOWERGOOD,
+    NOMINALBAD,
+    TIGHTBAD,
+    LOOSEBAD
+  };
+  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT, RLOOSE };
   enum tfs { EMTFNEGBIN = 1, EMTFPOSBIN };
-  int numSummaryBins_{TIGHTBAD};
-  int numErrBins_{RTIGHT};
-  bool incBin_[RTIGHT + 1];
+  int numSummaryBins_{LOOSEBAD};
+  int numErrBins_{RLOOSE};
+  bool incBin_[RLOOSE + 1];
 
   edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerToken1_;
   edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerToken2_;
@@ -55,6 +65,7 @@ private:
   MonitorElement* showerColl2ShowerTypeVsBX_;
   MonitorElement* showerColl2ProcessorVsBX_;
 
+  static constexpr unsigned IDX_LOOSE_SHOWER{3};
   static constexpr unsigned IDX_TIGHT_SHOWER{2};
   static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -203,6 +203,7 @@ private:
   MonitorElement* ugmtMuMuDPhiEneg;
   MonitorElement* ugmtMuMuDREneg;
 
+  static constexpr unsigned IDX_LOOSE_SHOWER{3};
   static constexpr unsigned IDX_TIGHT_SHOWER{2};
   static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };

--- a/DQM/L1TMonitor/src/L1TStage2MuonShowerComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonShowerComp.cc
@@ -56,6 +56,7 @@ void L1TStage2MuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker, const e
   summary_->setBinLabel(SHOWERGOOD, "# matching showers", 1);
   summary_->setBinLabel(NOMINALBAD, "nominal shower mismatch", 1);
   summary_->setBinLabel(TIGHTBAD, "tight shower mismatch", 1);
+  summary_->setBinLabel(LOOSEBAD, "loose shower mismatch", 1);
 
   errorSummaryNum_ = ibooker.book1D("errorSummaryNum",
                                     summaryTitle_.c_str(),
@@ -67,6 +68,7 @@ void L1TStage2MuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker, const e
   errorSummaryNum_->setBinLabel(RSHOWER, "mismatching showers", 1);
   errorSummaryNum_->setBinLabel(RNOMINAL, "nominal shower mismatch", 1);
   errorSummaryNum_->setBinLabel(RTIGHT, "tight shower mismatch", 1);
+  errorSummaryNum_->setBinLabel(RLOOSE, "loose shower mismatch", 1);
 
   // Change the label for those bins that will be ignored
   for (int i = 1; i <= errorSummaryNum_->getNbinsX(); i++) {
@@ -100,13 +102,14 @@ void L1TStage2MuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker, const e
                                               7,
                                               -3.5,
                                               3.5,
-                                              2,
+                                              3,
                                               1,
-                                              3);
+                                              4);
   showerColl1ShowerTypeVsBX_->setAxisTitle("BX", 1);
   showerColl1ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
-  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_LOOSE_SHOWER, "TwoLoose", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
 
   showerColl2BxRange_ =
       ibooker.book1D("showerBxRangeColl2", (showerColl2Title_ + " mismatching BX range").c_str(), 11, -5.5, 5.5);
@@ -119,13 +122,14 @@ void L1TStage2MuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker, const e
                                               7,
                                               -3.5,
                                               3.5,
-                                              2,
+                                              3,
                                               1,
-                                              3);
+                                              4);
   showerColl2ShowerTypeVsBX_->setAxisTitle("BX", 1);
   showerColl2ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
-  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_LOOSE_SHOWER, "TwoLoose", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
 }
 
 void L1TStage2MuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
@@ -184,6 +188,9 @@ void L1TStage2MuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup
           if (showerIt1->isOneTightInTime()) {
             showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
           }
+          if (showerIt1->isTwoLooseDiffSectorsInTime()) {
+            showerColl1ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
+          }
         }
       } else {
         showerIt2 = showerBxColl2->begin(iBx) + showerBxColl1->size(iBx);
@@ -193,6 +200,9 @@ void L1TStage2MuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup
           }
           if (showerIt2->isOneTightInTime()) {
             showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+          if (showerIt2->isTwoLooseDiffSectorsInTime()) {
+            showerColl2ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
           }
         }
       }
@@ -238,12 +248,18 @@ void L1TStage2MuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup
         if (showerIt1->isOneTightInTime()) {
           showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
         }
+        if (showerIt1->isTwoLooseDiffSectorsInTime()) {
+          showerColl1ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
+        }
 
         if (showerIt2->isOneNominalInTime()) {
           showerColl2ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
         }
         if (showerIt2->isOneTightInTime()) {
           showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+        if (showerIt2->isTwoLooseDiffSectorsInTime()) {
+          showerColl2ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
         }
       } else {
         summary_->Fill(SHOWERGOOD);

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonShowerComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonShowerComp.cc
@@ -60,6 +60,7 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
   summary_->setBinLabel(SHOWERGOOD, "# matching showers", 1);
   summary_->setBinLabel(NOMINALBAD, "nominal shower mismatch", 1);
   summary_->setBinLabel(TIGHTBAD, "tight shower mismatch", 1);
+  summary_->setBinLabel(LOOSEBAD, "loose shower mismatch", 1);
 
   errorSummaryNum_ = ibooker.book1D("errorSummaryNum",
                                     summaryTitle_.c_str(),
@@ -71,6 +72,7 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
   errorSummaryNum_->setBinLabel(RSHOWER, "mismatching showers", 1);
   errorSummaryNum_->setBinLabel(RNOMINAL, "nominal shower mismatch", 1);
   errorSummaryNum_->setBinLabel(RTIGHT, "tight shower mismatch", 1);
+  errorSummaryNum_->setBinLabel(RLOOSE, "loose shower mismatch", 1);
 
   // Change the label for those bins that will be ignored
   for (int i = 1; i <= errorSummaryNum_->getNbinsX(); i++) {
@@ -105,9 +107,9 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
                      12,
                      1,
                      13,
-                     2,
+                     3,
                      1,
-                     3);
+                     4);
   showerColl1ShowerTypeVsProcessor_->setAxisTitle("Processor", 1);
   showerColl1ShowerTypeVsProcessor_->setBinLabel(12, "+6", 1);
   showerColl1ShowerTypeVsProcessor_->setBinLabel(11, "+5", 1);
@@ -122,20 +124,22 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
   showerColl1ShowerTypeVsProcessor_->setBinLabel(2, "-2", 1);
   showerColl1ShowerTypeVsProcessor_->setBinLabel(1, "-1", 1);
   showerColl1ShowerTypeVsProcessor_->setAxisTitle("Shower type", 2);
-  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_LOOSE_SHOWER, "OneLoose", 2);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
   showerColl1ShowerTypeVsBX_ = ibooker.book2D("showerColl1ShowerTypeVsBX",
                                               showerColl1Title_ + " mismatching shower type occupancy per BX",
                                               7,
                                               -3.5,
                                               3.5,
-                                              2,
+                                              3,
                                               1,
-                                              3);
+                                              4);
   showerColl1ShowerTypeVsBX_->setAxisTitle("BX", 1);
   showerColl1ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
-  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_LOOSE_SHOWER, "OneLoose", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
   showerColl1ProcessorVsBX_ = ibooker.book2D("showerColl1ProcessorVsBX",
                                              showerColl1Title_ + " mismatching shower BX occupancy per sector",
                                              7,
@@ -171,9 +175,9 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
                      12,
                      1,
                      13,
-                     2,
+                     3,
                      1,
-                     3);
+                     4);
   showerColl2ShowerTypeVsProcessor_->setAxisTitle("Processor", 1);
   showerColl2ShowerTypeVsProcessor_->setBinLabel(12, "+6", 1);
   showerColl2ShowerTypeVsProcessor_->setBinLabel(11, "+5", 1);
@@ -188,20 +192,22 @@ void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
   showerColl2ShowerTypeVsProcessor_->setBinLabel(2, "-2", 1);
   showerColl2ShowerTypeVsProcessor_->setBinLabel(1, "-1", 1);
   showerColl2ShowerTypeVsProcessor_->setAxisTitle("Shower type", 2);
-  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_LOOSE_SHOWER, "OneLoose", 2);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
   showerColl2ShowerTypeVsBX_ = ibooker.book2D("showerColl2ShowerTypeVsBX",
                                               showerColl2Title_ + " mismatching shower type occupancy per BX",
                                               7,
                                               -3.5,
                                               3.5,
-                                              2,
+                                              3,
                                               1,
-                                              3);
+                                              4);
   showerColl2ShowerTypeVsBX_->setAxisTitle("BX", 1);
   showerColl2ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
-  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "OneLoose", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
   showerColl2ProcessorVsBX_ = ibooker.book2D("showerColl2ProcessorVsBX",
                                              showerColl2Title_ + " mismatching shower BX occupancy per sector",
                                              7,
@@ -287,6 +293,12 @@ void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::Ev
                 showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
             showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
           }
+          if (showerIt1->isOneLooseInTime()) {
+            showerColl1ShowerTypeVsProcessor_->Fill(
+                IDX_LOOSE_SHOWER,
+                showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl1ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
+          }
           showerColl1ProcessorVsBX_->Fill(
               showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
         }
@@ -304,6 +316,12 @@ void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::Ev
                 IDX_TIGHT_SHOWER,
                 showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
             showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+          if (showerIt2->isOneLooseInTime()) {
+            showerColl2ShowerTypeVsProcessor_->Fill(
+                IDX_LOOSE_SHOWER,
+                showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl2ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
           }
           showerColl2ProcessorVsBX_->Fill(
               showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
@@ -339,6 +357,14 @@ void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::Ev
           errorSummaryNum_->Fill(RTIGHT);
         }
       }
+      if (showerIt1->isOneLooseInTime() != showerIt2->isOneLooseInTime()) {
+        showerMismatch = true;
+        summary_->Fill(LOOSEBAD);
+        if (incBin_[RLOOSE]) {
+          showerSelMismatch = true;
+          errorSummaryNum_->Fill(RLOOSE);
+        }
+      }
       if (incBin_[RSHOWER] && showerSelMismatch) {
         errorSummaryNum_->Fill(RSHOWER);
       }
@@ -356,6 +382,12 @@ void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::Ev
               showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
           showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
         }
+        if (showerIt1->isOneLooseInTime()) {
+          showerColl1ShowerTypeVsProcessor_->Fill(
+              IDX_LOOSE_SHOWER,
+              showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl1ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
+        }
         showerColl1ProcessorVsBX_->Fill(
             showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
 
@@ -370,6 +402,12 @@ void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::Ev
               IDX_TIGHT_SHOWER,
               showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
           showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+        if (showerIt2->isOneLooseInTime()) {
+          showerColl2ShowerTypeVsProcessor_->Fill(
+              IDX_LOOSE_SHOWER,
+              showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl2ShowerTypeVsBX_->Fill(IDX_LOOSE_SHOWER, iBx);
         }
         showerColl2ProcessorVsBX_->Fill(
             showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -243,7 +243,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       ibooker.setCurrentFolder(monitorDir_ + "/EMTFInput/Muon showers");
 
       ugmtEMTFShowerTypeOccupancyPerSector = ibooker.book2D(
-          "ugmtEMTFShowerTypeOccupancyPerSector", "Shower type occupancy per sector", 12, 1, 13, 2, 1, 3);
+          "ugmtEMTFShowerTypeOccupancyPerSector", "Shower type occupancy per sector", 12, 1, 13, 3, 1, 4);
       ugmtEMTFShowerTypeOccupancyPerSector->setAxisTitle("Processor", 1);
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(12, "+6", 1);
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(11, "+5", 1);
@@ -258,8 +258,9 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(2, "-2", 1);
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(1, "-1", 1);
       ugmtEMTFShowerTypeOccupancyPerSector->setAxisTitle("Shower type", 2);
-      ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-      ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+      ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_LOOSE_SHOWER, "OneLoose", 2);
+      ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+      ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
     }
 
     // inter-TF muon correlations
@@ -510,11 +511,12 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
   if (hadronicShowers_) {
     ugmtMuonShowerTypeOccupancyPerBx =
-        ibooker.book2D("ugmtMuonShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 2, 1, 3);
+        ibooker.book2D("ugmtMuonShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 3, 1, 4);
     ugmtMuonShowerTypeOccupancyPerBx->setAxisTitle("BX", 1);
     ugmtMuonShowerTypeOccupancyPerBx->setAxisTitle("Shower type", 2);
-    ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-    ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+    ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_LOOSE_SHOWER, "TwoLoose", 2);
+    ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_TIGHT_SHOWER, "OneTight", 2);
+    ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "OneNominal", 2);
   }
 
   ugmtMuonBXvshwPt =
@@ -859,6 +861,11 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
                 shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0),
                 IDX_TIGHT_SHOWER);
           }
+          if (shower->isOneLooseInTime()) {
+            ugmtEMTFShowerTypeOccupancyPerSector->Fill(
+                shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0),
+                IDX_LOOSE_SHOWER);
+          }
         }
       }
     }
@@ -1095,6 +1102,9 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
         }
         if (shower->isOneTightInTime()) {
           ugmtMuonShowerTypeOccupancyPerBx->Fill(itBX, IDX_TIGHT_SHOWER);
+        }
+        if (shower->isTwoLooseDiffSectorsInTime()) {
+          ugmtMuonShowerTypeOccupancyPerBx->Fill(itBX, IDX_LOOSE_SHOWER);
         }
       }
     }


### PR DESCRIPTION
#### PR description:

This PR backports the (one|two) loose shower bit to the uGMT DQM for 13_0_X.

attn: @vukasinmilosevic, @eyigitba, @elfontan

#### PR validation:

No validation (beyond running standard tests) possible as there are no upstream producers for the required data, yet.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #41182
