### PR TITLE
"SCALLumi" histos renamed as "OnlineLumi"

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -497,9 +497,9 @@ namespace tadqm {
     unsigned int good_vertices_;
     unsigned int bx_;
     float pixel_lumi_;
-    float scal_lumi_;
-    enum monQuantity { VsPU, VsBX, VsPIXELLUMI, VsSCALLUMI, END };
-    std::string monName[monQuantity::END] = {"", "VsBX", "VsPIXELLUMI", "VsSCALLUMI"};
+    float online_lumi_;
+    enum monQuantity { VsPU, VsBX, VsPIXELLUMI, VsOnlineLUMI, END };
+    std::string monName[monQuantity::END] = {"", "VsBX", "VsPIXELLUMI", "VsOnlineLUMI"};
 
     std::string histname;  //for naming the histograms according to algorithm used
   };

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -72,7 +72,7 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig)
       good_vertices_(0),
       bx_(0),
       pixel_lumi_(0.),
-      scal_lumi_(0.) {
+      online_lumi_(0.) {
   initHistos();
   TopFolder_ = iConfig.getParameter<std::string>("FolderName");
 }
@@ -203,12 +203,12 @@ void TrackAnalyzer::initHisto(DQMStore::IBooker& ibooker,
   if (doEffFromHitPatternVsBX_ || doAllPlots_)
     bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsBX", false);
   if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
-    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI", false);
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsOnlineLUMI", false);
   //  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsPIXELLUMI");
   if (doEffFromHitPatternVsPU_ || doAllPlots_)
     bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "", true);
   if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
-    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsSCALLUMI", true);
+    bookHistosForEfficiencyFromHitPatter(ibooker, iSetup, "VsOnlineLUMI", true);
 
   // book tracker specific related histograms
   // ---------------------------------------------------------------------------------//
@@ -1122,15 +1122,15 @@ void TrackAnalyzer::setLumi(const edm::Event& iEvent, const edm::EventSetup& iSe
     edm::Handle<LumiScalersCollection> lumiScalers = iEvent.getHandle(lumiscalersToken_);
     if (lumiScalers.isValid() && !lumiScalers->empty()) {
       LumiScalersCollection::const_iterator scalit = lumiScalers->begin();
-      scal_lumi_ = scalit->instantLumi();
+      online_lumi_ = scalit->instantLumi();
     } else
-      scal_lumi_ = -1;
+      online_lumi_ = -1;
   } else {
     edm::Handle<OnlineLuminosityRecord> metaData = iEvent.getHandle(metaDataToken_);
     if (metaData.isValid())
-      scal_lumi_ = metaData->instLumi();
+      online_lumi_ = metaData->instLumi();
     else
-      scal_lumi_ = -1;
+      online_lumi_ = -1;
   }
 
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters = iEvent.getHandle(pixelClustersToken_);
@@ -1235,12 +1235,12 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   if (doEffFromHitPatternVsBX_ || doAllPlots_)
     fillHistosForEfficiencyFromHitPatter(track, "VsBX", float(bx_), false);
   if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
-    fillHistosForEfficiencyFromHitPatter(track, "VsSCALLUMI", scal_lumi_, false);
+    fillHistosForEfficiencyFromHitPatter(track, "VsOnlineLUMI", online_lumi_, false);
   //  if (doEffFromHitPatternVsLUMI_ || doAllPlots_) fillHistosForEfficiencyFromHitPatter(track,"VsPIXELLUMI", pixel_lumi_           );
   if (doEffFromHitPatternVsPU_ || doAllPlots_)
     fillHistosForEfficiencyFromHitPatter(track, "", float(good_vertices_), true);
   if (doEffFromHitPatternVsLUMI_ || doAllPlots_)
-    fillHistosForEfficiencyFromHitPatter(track, "VsSCALLUMI", scal_lumi_, true);
+    fillHistosForEfficiencyFromHitPatter(track, "VsOnlineLUMI", online_lumi_, true);
 
   if (doGeneralPropertiesPlots_ || doAllPlots_) {
     // fitting


### PR DESCRIPTION
#### PR description:
Minimal changes. Changed the name of some histograms (and variables) that reported erroneously the nomenclature "SCAL", which is no longer used. "Online" is used instead.

#### PR validation:

Run the matrix to test the correctness of the names, Everything went good.
