### PR TITLE
Add "one loose" showers from EMTF and "two loose showers in different sectors" from uGMT to L1Tntuples

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonShowerProducer.cc
@@ -82,7 +82,7 @@ void L1TMuonShowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
       if (shower.isOneTightInTime()) {
         isOneTightInTime = true;
       }
-      // two loos in different sectors
+      // two loose in different sectors
       if (shower.isOneLooseInTime()) {
         if (foundOneLoose) {
           isTwoLooseDifferentSectorsInTime = true;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -131,6 +131,7 @@ namespace L1Analysis {
       muonShowerOneNominal.clear();
       muonShowerOneTight.clear();
       muonShowerTwoLoose.clear();
+      muonShowerTwoLooseDiffSectors.clear();
 
       nSums = 0;
       sumType.clear();
@@ -224,6 +225,7 @@ namespace L1Analysis {
     std::vector<short int> muonShowerOneNominal;
     std::vector<short int> muonShowerOneTight;
     std::vector<short int> muonShowerTwoLoose;
+    std::vector<short int> muonShowerTwoLooseDiffSectors;
 
     unsigned short int nSums;
     std::vector<short int> sumType;

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuonShowerDataFormat.h
@@ -15,6 +15,7 @@ namespace L1Analysis {
       tfMuonShowerBx.clear();
       tfMuonShowerOneNominal.clear();
       tfMuonShowerOneTight.clear();
+      tfMuonShowerOneLoose.clear();
       tfMuonShowerTwoLoose.clear();
       tfMuonShowerEndcap.clear();
       tfMuonShowerSector.clear();
@@ -24,6 +25,7 @@ namespace L1Analysis {
     std::vector<short int> tfMuonShowerBx;
     std::vector<short int> tfMuonShowerOneNominal;
     std::vector<short int> tfMuonShowerOneTight;
+    std::vector<short int> tfMuonShowerOneLoose;
     std::vector<short int> tfMuonShowerTwoLoose;
     std::vector<short int> tfMuonShowerEndcap;
     std::vector<short int> tfMuonShowerSector;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -133,6 +133,7 @@ void L1Analysis::L1AnalysisL1Upgrade::SetMuonShower(const l1t::MuonShowerBxColle
         l1upgrade_.muonShowerOneNominal.push_back(it->isOneNominalInTime());
         l1upgrade_.muonShowerOneTight.push_back(it->isOneTightInTime());
         l1upgrade_.muonShowerTwoLoose.push_back(it->isTwoLooseInTime());
+        l1upgrade_.muonShowerTwoLooseDiffSectors.push_back(it->isTwoLooseDiffSectorsInTime());
         l1upgrade_.nMuonShowers++;
       }
     }

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuonShower.cc
@@ -16,6 +16,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuonShower::SetTfMuonShower(const l1t::Reg
         l1upgradetfmuonshower_.tfMuonShowerSector.push_back(it->processor() + 1);
         l1upgradetfmuonshower_.tfMuonShowerOneNominal.push_back(it->isOneNominalInTime());
         l1upgradetfmuonshower_.tfMuonShowerOneTight.push_back(it->isOneTightInTime());
+        l1upgradetfmuonshower_.tfMuonShowerOneLoose.push_back(it->isOneLooseInTime());
         l1upgradetfmuonshower_.tfMuonShowerTwoLoose.push_back(it->isTwoLooseInTime());
         l1upgradetfmuonshower_.nTfMuonShowers++;
       }


### PR DESCRIPTION
#### PR description:

This PR adds the newly added "one loose" showers that are produced at the EMTF level and the "two loose in different sectors" produced in the uGMT to the L1TNtuples.

(mostly for @elfontan, but this might also be useful for @eyigitba)

#### PR validation:

Ran with command `cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=data_def.py -n 10000 --no_output --era=Run3 --data --conditions=124X_dataRun3_Prompt_v4  --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --filein=/store/data/Commissioning2023/Cosmics/RAW/v2/000/365/300/00000/0bee10f0-6e0c-4efd-9ab5-c58993f0b709.root --fileout=HMT_Cosmics_L1Ntuple.root` (provided by @elfontan, thanks for that!). Looking at the resulting NTuple I saw one loose shower from EMTF in every event (this was somewhat surprising to me, but the code is quite straightforward and I'm not sure how loose the thresholds are.. ), I saw two loose showers in different sectors for about 42% of events.
