### PR TITLE
Re-inforce time of arrival threshold in aged scenarios

### DIFF
--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigitizerBase.cc
@@ -184,7 +184,7 @@ void HGCDigitizerBase::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& coll,
               : std::floor(cell.thickness * myFEelectronics_->getADCThreshold() / myFEelectronics_->getADClsb());
     }
 
-    //loop over time samples and add noise
+    //loop over time samples, compute toa and add noise
     for (size_t i = 0; i < cell.hit_info[0].size(); i++) {
       double rawCharge(cell.hit_info[0][i]);
 

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -246,9 +246,8 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
   //ToA is in central BX if fired -- std::floor(BX/25.)+9;
   int fireBX = 9;
   //noise fluctuation on charge is added after ToA computation
-  //do not recheck the ToA firing threshold tdcForToAOnset_fC_[thickness-1] not to bias the efficiency
   //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing
-  if (toaColl[fireBX] != 0.f) {
+  if (toaColl[fireBX] != 0.f && chargeColl[fireBX]>tdcForToAOnset_fC_[thickness-1]) {
     timeToA = toaColl[fireBX];
     float sensor_noise = noiseWidth <= 0 ? noise_fC_[thickness - 1] : noiseWidth;
     float noise = jitterNoise_ns_[thickness - 1] * sensor_noise;

--- a/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCFEElectronics.cc
@@ -247,7 +247,7 @@ void HGCFEElectronics<DFr>::runShaperWithToT(DFr& dataFrame,
   int fireBX = 9;
   //noise fluctuation on charge is added after ToA computation
   //to be done properly with realistic ToA shaper and jitter for the moment accounted in the smearing
-  if (toaColl[fireBX] != 0.f && chargeColl[fireBX]>tdcForToAOnset_fC_[thickness-1]) {
+  if (toaColl[fireBX] != 0.f && chargeColl[fireBX] > tdcForToAOnset_fC_[thickness - 1]) {
     timeToA = toaColl[fireBX];
     float sensor_noise = noiseWidth <= 0 ? noise_fC_[thickness - 1] : noiseWidth;
     float noise = jitterNoise_ns_[thickness - 1] * sensor_noise;


### PR DESCRIPTION
#### PR description:

In the HGCAL DPG meeting of 29th March it was reported an incosistent behavior for the efficiency of time of arrival (TOA) when aging is applied [1].
This has been tracked down to a missing condition in the HGCalFEElectronics class requiring the charge deposited to be above the required threshold which this PR patches.

#### PR validation:

The PR has been validated locally using `runTheMatrix.py -w upgrade -l 23234.103` 
The charge spectra of the hits with TOA measurement is shown below. The left plot corresponds to the simhit level charge (before ageing) and the right plot corresponds to the reconstructed charge including noise and ageing. The nominal threshold for TOA measurement is 12 fC. Without the fix all simulated hits with 12 fC will generate TOA, however after ageing they'll correspond to <12 fC which is an unwanted behavior. After the fix one can observe that the sharp threshold is now at 12 fC at reconstruction level and depicts a slow rise at sim hit level.

![qspectra_toa](https://user-images.githubusercontent.com/4624574/228843094-dbd938a4-d792-406d-bbbd-d38a861d8a1a.png)

The TOA efficiency curves are below

![toaeff](https://user-images.githubusercontent.com/4624574/228843096-89d5d467-439d-40d5-89d6-c6d5614b8771.png)

The patch generates a different number of calls to the random number generator and thus a smearing in the digis. This is illustrated below for CE-H, CE-H Si and SiPM-on-tile sections. However the result is expected to be unbiased with respect to previous releases

| Section      | Migration of DIGIs expected after PR |
| ----------- | ----------- |
| CE-E | ![adcperdetid_0](https://user-images.githubusercontent.com/4624574/228843008-74691d9c-6166-4fb3-bcef-54d443ef8f98.png) |
| CE-H Si | ![adcperdetid_1](https://user-images.githubusercontent.com/4624574/228843017-bf74fa7b-8cf5-4f19-a819-a6b2c35b9d99.png) |
| CE-H SiPM-on-tile | ![adcperdetid_2](https://user-images.githubusercontent.com/4624574/228843024-bef6465b-b3df-45e8-8e86-12135ff8a174.png) |

#### References

[1]  https://indico.cern.ch/event/1270358/#2-update-on-toa-studies