### PR TITLE
Backport of fix to NanoGENJets

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -88,8 +88,8 @@ def customizeNanoGEN(process):
     process.patJetPartonsNano.particles = "genParticles"
     process.particleLevel.src = "generatorSmeared"
 
-    process.genJetTable.src = "ak4GenJets"
-    process.genJetAK8Table.src = "ak8GenJets"
+    process.genJetTable.src = "ak4GenJetsNoNu"
+    process.genJetAK8Table.src = "ak8GenJetsNoNu"
     process.tauGenJetsForNano.GenParticles = "genParticles"
     process.genVisTaus.srcGenParticles = "genParticles"
 


### PR DESCRIPTION
Backport of [41163](https://github.com/cms-sw/cmssw/pull/41163). Description of the original PR can be found below. @swertz  suggested that it would be good to have this fix in CMSSW_13_X just in case people compares nanoGEN jets from nanoAODv12 with nanoGEN produced with this release. 

PR description
This PR includes a minimal change in the configuration file that is used for producing NanoGEN format: PhysicsTools/NanoAOD/python/nanogen_cff.py.

Additional information
This issue has been known for some time, but it was never fixed and included in the master branch up until know. Everything regarding this issue is discussed in [1](https://cms-talk.web.cern.ch/t/question-concerning-ttw-production-using-mg33x-pythia8-3/17491/7) and [2](https://cms-talk.web.cern.ch/t/various-comments-regarding-mostly-nanoaod/4642).

