### PR TITLE
Add Wf `*.81` for BPH DQM

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -52,6 +52,7 @@ The offsets currently in use are:
 * 0.601: HLT as separate step
 * 0.7: trackingMkFit modifier
 * 0.8: BPH Parking (Run-2)
+* 0.81: Running also HeavyFlavor DQM
 * 0.9: Vector hits
 * 0.12: Neutron background
 * 0.13: MLPF algorithm
@@ -84,3 +85,4 @@ The offsets currently in use are:
 * 0.9001: Sonic Triton
 * 0.278: Weighted Vertexing in Blocks
 * 0.279: Weighted Vertexing in Blocks and tracking only wf
+

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1756,6 +1756,34 @@ upgradeWFs['ParkingBPH'] = UpgradeWorkflow_ParkingBPH(
     offset = 0.8,
 )
 
+## Wf to add Heavy Flavor DQM to whichever DQM is already there
+class UpgradeWorkflow_HeavyFlavor(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        self.__frags = ["B0","Psi2S","Bu","Bd","Xi","Bs"]
+        thisStep = stepDict[step][k]["-s"]
+        if "Reco" in step:
+            if "DQM:" in thisStep:
+                #print(thisStep.replace("DQM:","DQM:@heavyFlavor+"))
+                stepDict[stepName][k] = merge([{'-s': thisStep.replace("DQM:","DQM:@heavyFlavor+")}, stepDict[step][k]])
+                #print(k)
+            elif "DQM" in thisStep:
+                stepDict[stepName][k] = merge([{'-s': thisStep.replace("DQM","DQM:@heavyFlavor")}, stepDict[step][k]])
+            else:
+                stepDict[stepName][k] = merge([{'-s': thisStep + ",DQM:@heavyFlavor"}, stepDict[step][k]])
+                
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return any(frag in fragment for frag in self.__frags)
+
+upgradeWFs['HeavyFlavor'] = UpgradeWorkflow_HeavyFlavor(
+    steps = [
+        'Reco',
+        'RecoNano'
+    ],
+    PU = [],
+    suffix = '_HeavyFlavor',
+    offset = 0.81,
+)
+
 class UpgradeWorkflow_JMENano(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Nano' in step:


### PR DESCRIPTION
#### PR description:

This PR adds a new set of wfs with offset `*.81` to enable running the BPH specific DQM (introduced by https://github.com/cms-sw/cmssw/pull/38540) for a subset of fragments.

#### PR validation:

Run, e.g, `runTheMatrix.py -w upgrade -l 12944.81 -t8` and checked that the `heavyFlavor` DQM histograms are there.
