### PR TITLE
Add default parameter description to L1TCaloLayer1 producer

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -352,10 +352,21 @@ void L1TCaloLayer1::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TCaloLayer1::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
+  //Description set to reflect default present in simCaloStage2Layer1Digis_cfi.py
+  //Currently redundant, but could be adjusted to provide defaults in case additional LUT
+  //checks are added and before other configurations adjust to match.
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
+  desc.add<edm::InputTag>("ecalToken", edm::InputTag("simEcalTriggerPrimitiveDigis"));
+  desc.add<edm::InputTag>("hcalToken", edm::InputTag("simHcalTriggerPrimitiveDigis"));
+  desc.add<bool>("useLSB", true);
+  desc.add<bool>("useCalib", true);
+  desc.add<bool>("useECALLUT", true);
+  desc.add<bool>("useHCALLUT", true);
+  desc.add<bool>("useHFLUT", true);
+  desc.add<bool>("verbose", false);
+  desc.add<bool>("unpackEcalMask", false);
+  desc.add<bool>("unpackHcalMask", false);
+  desc.add<int>("firmwareVersion", 1);
   descriptions.addDefault(desc);
 }
 


### PR DESCRIPTION
### PR description:

This PR provides a description for the L1TCaloLayer1 producer to provide default options as discussed in https://github.com/cms-sw/cmssw/pull/41221. https://github.com/cms-sw/cmssw/pull/41221 may be able to add new HCAL LUT options to the description to smooth over the change of configurations in multiple unit tests not including specific HCAL FB LUT options.

The default parameter description options have been set to the current options provided by the [simCaloStage2Layer1Digis_cfi.py](https://github.com/cms-sw/cmssw/blob/60499d5eac1799b4855d61b7b948a2930278a188/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py) 

https://github.com/cms-sw/cmssw/blob/60499d5eac1799b4855d61b7b948a2930278a188/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Digis_cfi.py#L10-L21

### PR validation:

Code compiles and has had code formatting applied, code checks ran, and passes all unit tests for the L1 branch.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport
