### PR TITLE
Fix build failures in DBG_X after #41174

### DIFF
--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -44,8 +44,6 @@ void DTGeometryParsFromDD::build(const DDCompactView* cview,
                                  RecoIdealGeometry& rig) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("DTGeometry") << "DTGeometryParsFromDD::build";
-  static const string t0 = "DTGeometryParsFromDD::build";
-  TimeMe timer(t0, true);
 #endif
 
   std::string attribute = "MuStructure";


### PR DESCRIPTION
#### PR description:

Fix build failures in DBG_X after #41174 was merged (@bsunanda ) : 

```
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/fa2a20807dfa5bd1720b9c1e1c7bc4b7/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-30-2300/src/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=110201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_13_1_DBG_X_2023-03-30-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_1_DBG_X_2023-03-30-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/fa2a20807dfa5bd1720b9c1e1c7bc4b7/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-30-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/dd4hep/v01-23x-3637f0613a0d3afea6b636bfbb4ace09/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/pcre/8.43-5dcc901acc02f624b22dd9840b2357e8/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/boost/1.80.0-d560885614912b656cea04440e0ae44f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/bz2lib/1.0.6-2c1f18484cb66c30aba7929f2be5e7d4/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/clhep/2.4.5.1-7e9b1c45d7f5b4361ac787761986b8a2/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gsl/2.6-fcf47bcbedd800ca8386c7e2920fa474/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/libuuid/2.34-0451b31e1b9a58c6aeefab41c18eea34/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/lcg/root/6.26.11-9cfff04c7e738c67c5f012057fa9fe5a/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/tbb/v2021.8.0-b05aa240920b2e90a45b2d4a5dc13536/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/cms/vdt/0.4.3-b2ab7c000c16e419f85e9fb6284d3681/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/xerces-c/3.1.3-96261f23c7d6fbfb7d59be544bd882f3/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/xz/5.2.5-83d0a00b575efd1701e07bedf7977343/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/zlib/1.2.11-3dfb2715f3608466b74431b80eb9d788/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/eigen/82dd3710dac619448f50331c1d6a35da673f764a-9ac4aed18ac60d0189693c592862694d/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/fmt/8.0.1-43b841663c2a0d6622910a1ad66d228d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/md5/1.0.0-e68283f2de2e2e709a0db99db3b53205/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/OpenBLAS/0.3.15-26c67b8b638762cfd2e2bcfc936e3ec7/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/tinyxml2/6.2.0-c2bad61e58f94d6db8f640afbd739be2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -g -O3 -DEDM_ML_DEBUG -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  -MMD -MF tmp/el8_amd64_gcc11/src/Geometry/DTGeometryBuilder/src/GeometryDTGeometryBuilder/DTGeometryParsFromDD.cc.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/fa2a20807dfa5bd1720b9c1e1c7bc4b7/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-30-2300/src/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc -o tmp/el8_amd64_gcc11/src/Geometry/DTGeometryBuilder/src/GeometryDTGeometryBuilder/DTGeometryParsFromDD.cc.o
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/fa2a20807dfa5bd1720b9c1e1c7bc4b7/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-30-2300/src/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc: In member function 'void DTGeometryParsFromDD::build(const DDCompactView*, const MuonGeometryConstants&, RecoIdealGeometry&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/fa2a20807dfa5bd1720b9c1e1c7bc4b7/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_1_DBG_X_2023-03-30-2300/src/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc:48:3: error: 'TimeMe' was not declared in this scope
    48 |   TimeMe timer(t0, true);
      |   ^~~~~~
  gmake: *** [tmp/el8_amd64_gcc11/src/Geometry/DTGeometryBuilder/src/GeometryDTGeometryBuilder/DTGeometryParsFromDD.cc.o] Error 1
```

#### PR validation:

Builds locally

