### PR TITLE
L1 nano: 13_0_X backport

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -106,6 +106,9 @@ steps['MuonEG2022MINIAOD12.4'] = {'INPUT':InputInfo(location='STD',ls=run3_lumis
 steps['NANO_data12.4']=merge([{'--era':'Run3,run3_nanoAOD_124',
                                '--conditions':'auto:run3_data'},
                               _NANO_data])
+#prompt nano test
+steps['NANO_data12.4_prompt']=merge([{'--customise' : 'PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize', '-n' : '1000'},
+                                     steps['NANO_data12.4']])
 
 ##12.6 workflows
 steps['TTBarMINIAOD12.6'] = {'INPUT':InputInfo(location='STD',ls=run3_lumis,
@@ -134,6 +137,8 @@ workflows[2500.401] = ['NANOmc122Xrun3', ['TTbarMINIAOD12.2','NANO_mc12.2', 'HRV
 #12.4 input
 workflows[2500.501] = ['NANOmc124Xrun3', ['TTbarMINIAOD12.4','NANO_mc12.4', 'HRV_NANO_mc']]
 workflows[2500.511] = ['NANOdata124Xrun3', ['MuonEG2022MINIAOD12.4','NANO_data12.4', 'HRV_NANO_data']]
+workflows[2500.5111] = ['NANOdata124Xrun3', ['MuonEG2022MINIAOD12.4','NANO_data12.4_prompt', 'HRV_NANO_data']]
+
 
 ################
 #12.6 workflows

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -360,6 +360,7 @@ public:
         cut_(params.getParameter<std::string>("cut"), true),
         minBX_(params.getParameter<int>("minBX")),
         maxBX_(params.getParameter<int>("maxBX")),
+        alwaysWriteBXValue_(params.getParameter<bool>("alwaysWriteBXValue")),
         bxVarName_("bx") {
     edm::ParameterSet const &varsPSet = params.getParameter<edm::ParameterSet>("variables");
     auto varNames = varsPSet.getParameterNamesForType<edm::ParameterSet>();
@@ -378,6 +379,7 @@ public:
         "define the maximum length of the input collection to put in the branch");
     desc.add<int>("minBX", -2)->setComment("min bx (inclusive) to include");
     desc.add<int>("maxBX", 2)->setComment("max bx (inclusive) to include");
+    desc.add<bool>("alwaysWriteBXValue",true)->setComment("always write the bx number (event  when only one bx can be present, ie minBX==maxBX)");
     descriptions.addWithDefaultLabel(desc);
   }
 
@@ -404,7 +406,9 @@ public:
     auto out = std::make_unique<nanoaod::FlatTable>(selObjs.size(), this->name_, false, this->extension_);
     for (const auto &var : this->vars_)
       var->fill(selObjs, *out);
-    out->template addColumn<int>(bxVarName_, selObjBXs, "BX of the L1 candidate");
+    if(alwaysWriteBXValue_ || minBX_!=maxBX_){
+      out->template addColumn<int16_t>(bxVarName_, selObjBXs, "BX of the L1 candidate");
+    }
     return out;
   }
 
@@ -413,6 +417,7 @@ protected:
   const StringCutObjectSelector<T> cut_;
   const int minBX_;
   const int maxBX_;
+  const bool alwaysWriteBXValue_;
   const std::string bxVarName_;
 };
 

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -379,7 +379,8 @@ public:
         "define the maximum length of the input collection to put in the branch");
     desc.add<int>("minBX", -2)->setComment("min bx (inclusive) to include");
     desc.add<int>("maxBX", 2)->setComment("max bx (inclusive) to include");
-    desc.add<bool>("alwaysWriteBXValue",true)->setComment("always write the bx number (event  when only one bx can be present, ie minBX==maxBX)");
+    desc.add<bool>("alwaysWriteBXValue", true)
+        ->setComment("always write the bx number (event  when only one bx can be present, ie minBX==maxBX)");
     descriptions.addWithDefaultLabel(desc);
   }
 
@@ -406,7 +407,7 @@ public:
     auto out = std::make_unique<nanoaod::FlatTable>(selObjs.size(), this->name_, false, this->extension_);
     for (const auto &var : this->vars_)
       var->fill(selObjs, *out);
-    if(alwaysWriteBXValue_ || minBX_!=maxBX_){
+    if (alwaysWriteBXValue_ || minBX_ != maxBX_) {
       out->template addColumn<int16_t>(bxVarName_, selObjBXs, "BX of the L1 candidate");
     }
     return out;

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -10,6 +10,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/NanoAOD/interface/FlatTable.h"
 #include "Utilities/General/interface/ClassName.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
@@ -347,6 +348,57 @@ protected:
   typedef ValueMapVariable<T, int, int16_t> Int16ExtVar;
   typedef ValueMapVariable<T, int, uint16_t> UInt16ExtVar;
   std::vector<std::unique_ptr<ExtVariable<T>>> extvars_;
+};
+
+template <typename T>
+class BXVectorSimpleFlatTableProducer : public SimpleFlatTableProducerBase<T, BXVector<T>> {
+public:
+  BXVectorSimpleFlatTableProducer(edm::ParameterSet const &params)
+      : SimpleFlatTableProducerBase<T, BXVector<T>>(params),
+        maxLen_(params.existsAs<unsigned int>("maxLen") ? params.getParameter<unsigned int>("maxLen")
+                                                        : std::numeric_limits<unsigned int>::max()),
+        cut_(params.getParameter<std::string>("cut"), true),
+        minBX_(params.getParameter<int>("minBX")),
+        maxBX_(params.getParameter<int>("maxBX")),
+        bxVarName_("bx") {
+    edm::ParameterSet const &varsPSet = params.getParameter<edm::ParameterSet>("variables");
+    auto varNames = varsPSet.getParameterNamesForType<edm::ParameterSet>();
+    if (std::find(varNames.begin(), varNames.end(), bxVarName_) != varNames.end()) {
+      throw cms::Exception("Configuration",
+                           "BXVectorSimpleFlatTableProducer already defines the " + bxVarName_ +
+                               "internally and thus you should not specify it yourself");
+    }
+  }
+  std::unique_ptr<nanoaod::FlatTable> fillTable(const edm::Event &iEvent,
+                                                const edm::Handle<BXVector<T>> &prod) const override {
+    std::vector<const T *> selObjs;
+    std::vector<int> selObjBXs;
+    if (prod.isValid() || !(this->skipNonExistingSrc_)) {
+      for (int bx = minBX_; bx <= maxBX_; bx++) {
+        for (size_t objNr = 0, nrObjs = prod->size(bx); objNr < nrObjs; ++objNr) {
+          const auto &obj = prod->at(bx, objNr);
+          if (cut_(obj)) {
+            selObjs.push_back(&obj);
+            selObjBXs.push_back(bx);
+          }
+          if (selObjs.size() >= maxLen_)
+            break;
+        }
+      }
+    }
+    auto out = std::make_unique<nanoaod::FlatTable>(selObjs.size(), this->name_, false, this->extension_);
+    for (const auto &var : this->vars_)
+      var->fill(selObjs, *out);
+    out->template addColumn<int>(bxVarName_, selObjBXs, "BX of the L1 candidate");
+    return out;
+  }
+
+protected:
+  const unsigned int maxLen_;
+  const StringCutObjectSelector<T> cut_;
+  const int minBX_;
+  const int maxBX_;
+  const std::string bxVarName_;
 };
 
 template <typename T>

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -369,12 +369,27 @@ public:
                                "internally and thus you should not specify it yourself");
     }
   }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc = SimpleFlatTableProducerBase<T, BXVector<T>>::baseDescriptions();
+    desc.add<std::string>("cut", "")->setComment("selection on the main input collection (but selection can not be bx based)");
+    desc.addOptional<unsigned int>("maxLen")->setComment(
+							 "define the maximum length of the input collection to put in the branch");
+    desc.add<int>("minBX",-2)->setComment("min bx (inclusive) to include");
+    desc.add<int>("maxBX",2)->setComment("max bx (inclusive) to include");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
   std::unique_ptr<nanoaod::FlatTable> fillTable(const edm::Event &iEvent,
                                                 const edm::Handle<BXVector<T>> &prod) const override {
+
     std::vector<const T *> selObjs;
     std::vector<int> selObjBXs;
+
     if (prod.isValid() || !(this->skipNonExistingSrc_)) {
-      for (int bx = minBX_; bx <= maxBX_; bx++) {
+      const int minBX = std::max(minBX_,prod->getFirstBX());
+      const int maxBX = std::min(maxBX_,prod->getLastBX());
+      for (int bx = minBX; bx <= maxBX; bx++) {
         for (size_t objNr = 0, nrObjs = prod->size(bx); objNr < nrObjs; ++objNr) {
           const auto &obj = prod->at(bx, objNr);
           if (cut_(obj)) {

--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -372,23 +372,23 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
     edm::ParameterSetDescription desc = SimpleFlatTableProducerBase<T, BXVector<T>>::baseDescriptions();
-    desc.add<std::string>("cut", "")->setComment("selection on the main input collection (but selection can not be bx based)");
+    desc.add<std::string>("cut", "")->setComment(
+        "selection on the main input collection (but selection can not be bx based)");
     desc.addOptional<unsigned int>("maxLen")->setComment(
-							 "define the maximum length of the input collection to put in the branch");
-    desc.add<int>("minBX",-2)->setComment("min bx (inclusive) to include");
-    desc.add<int>("maxBX",2)->setComment("max bx (inclusive) to include");
+        "define the maximum length of the input collection to put in the branch");
+    desc.add<int>("minBX", -2)->setComment("min bx (inclusive) to include");
+    desc.add<int>("maxBX", 2)->setComment("max bx (inclusive) to include");
     descriptions.addWithDefaultLabel(desc);
   }
 
   std::unique_ptr<nanoaod::FlatTable> fillTable(const edm::Event &iEvent,
                                                 const edm::Handle<BXVector<T>> &prod) const override {
-
     std::vector<const T *> selObjs;
     std::vector<int> selObjBXs;
 
     if (prod.isValid() || !(this->skipNonExistingSrc_)) {
-      const int minBX = std::max(minBX_,prod->getFirstBX());
-      const int maxBX = std::min(maxBX_,prod->getLastBX());
+      const int minBX = std::max(minBX_, prod->getFirstBX());
+      const int maxBX = std::min(maxBX_, prod->getLastBX());
       for (int bx = minBX; bx <= maxBX; bx++) {
         for (size_t objNr = 0, nrObjs = prod->size(bx); objNr < nrObjs; ++objNr) {
           const auto &obj = prod->at(bx, objNr);

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -24,6 +24,21 @@ typedef EventSingletonSimpleFlatTableProducer<math::XYZPointF> SimpleXYZPointFla
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 typedef EventSingletonSimpleFlatTableProducer<reco::BeamSpot> SimpleBeamspotFlatTableProducer;
 
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::EGamma> SimpleTriggerL1EGFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Jet.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Jet> SimpleTriggerL1JetFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Tau.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Tau> SimpleTriggerL1TauFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Muon> SimpleTriggerL1MuonFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::EtSum> SimpleTriggerL1EtSumFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
@@ -33,3 +48,8 @@ DEFINE_FWK_MODULE(SimpleProtonTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleLocalTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleXYZPointFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleBeamspotFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1MuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -2,24 +2,30 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 
-precision=10
-
+l1_float_precision_=12
+print("l1pre",l1_float_precision_)
 l1PtVars = cms.PSet(
-    pt  = Var("pt",  float, precision=precision),
-    phi = Var("phi", float, precision=precision),
+    pt  = Var("pt",  float, precision=l1_float_precision_),
+    phi = Var("phi", float, precision=l1_float_precision_),
 )
 l1P3Vars = cms.PSet(
     l1PtVars,
-    eta = Var("eta", float, precision=precision),
+    eta = Var("eta", float, precision=l1_float_precision_),
 )
 
 l1ObjVars = cms.PSet(
     l1P3Vars,
-    hwPt = Var("hwPt()",int,doc="hardware pt"),
-    hwEta = Var("hwEta()",int,doc="hardware eta"),
-    hwPhi = Var("hwPhi()",int,doc="hardware phi"),
-    hwQual = Var("hwQual()",int,doc="hardware qual"),
-    hwIso = Var("hwIso()",int,doc="hardware iso")
+    hwPt = Var("hwPt()","int16",doc="hardware pt"),
+    hwEta = Var("hwEta()","int16",doc="hardware eta"),
+    hwPhi = Var("hwPhi()","int16",doc="hardware phi"),
+    hwQual = Var("hwQual()","int16",doc="hardware qual"),
+    hwIso = Var("hwIso()","int16",doc="hardware iso")
+)
+
+l1CaloObjVars = cms.PSet(
+    l1ObjVars,
+    towerIEta = Var("towerIEta()","int16",doc="the ieta of the tower"),
+    towerIPhi = Var("towerIPhi()","int16",doc="the iphi of the tower"),
 )
 
 l1JetReducedVars = cms.PSet(
@@ -32,22 +38,22 @@ l1EtSumReducedVars = cms.PSet(
 )
 l1EGReducedVars = cms.PSet(
     l1P3Vars,
-    hwIso = Var("hwIso()",int,doc="hardware iso")
+    hwIso = Var("hwIso()","int16",doc="hardware iso")
 )
 
 l1TauReducedVars = cms.PSet(
     l1P3Vars,
-    hwIso = Var("hwIso()",int,doc="hardware iso")
+    hwIso = Var("hwIso()","int16",doc="hardware iso")
 )
 
 l1MuonReducedVars = cms.PSet(
     l1P3Vars,
     hwQual = Var("hwQual()",int,doc="hardware qual"),
-    hwCharge = Var("hwCharge()",int,doc="hardware charge"), 
-    etaAtVtx = Var("etaAtVtx()",float,precision=precision,doc="eta estimated at the vertex"),
-    phiAtVtx = Var("phiAtVtx()",float,precision=precision,doc="phi estimated at the vertex"),
-    ptUnconstrained = Var("ptUnconstrained()",float,precision=precision,doc="pt when not constrained to the beamspot"),
-    hwDXY = Var("hwDXY()",int,doc="hardware impact parameter"),
+    hwCharge = Var("hwCharge()","int16",doc="hardware charge"), 
+    etaAtVtx = Var("etaAtVtx()",float,precision=l1_float_precision_,doc="eta estimated at the vertex"),
+    phiAtVtx = Var("phiAtVtx()",float,precision=l1_float_precision_,doc="phi estimated at the vertex"),
+    ptUnconstrained = Var("ptUnconstrained()",float,precision=l1_float_precision_,doc="pt when not constrained to the beamspot"),
+    hwDXY = Var("hwDXY()","int16",doc="hardware impact parameter"),
 )
 
 l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
@@ -59,21 +65,21 @@ l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
     doc = cms.string(""),
     extension = cms.bool(False), 
     variables = cms.PSet(l1ObjVars,
-                         hwCharge = Var("hwCharge()",int,doc=""),
-                         hwChargeValid = Var("hwChargeValid()",int,doc=""),
-                         tfMuonIndex = Var("tfMuonIndex()",int,doc=""),
-                         hwTag = Var("hwTag()",int,doc=""),
-                         hwEtaAtVtx = Var("hwEtaAtVtx()",int,doc="hardware eta estimated at the vertex"),
-                         hwPhiAtVtx = Var("hwPhiAtVtx()",int,doc="hardware phi estimated at the vertex"),
+                         hwCharge = Var("hwCharge()","int16",doc="Charge (can be 0 if the charge measurement was not valid)"),
+                         hwChargeValid = Var("hwChargeValid()","int16",doc=""),
+                         tfMuonIndex = Var("tfMuonIndex()","uint16",doc="Index of muon at the uGMT input. 3 indices per link/sector/wedge. EMTF+ are 0-17, OMTF+ are 18-35, BMTF are 36-71, OMTF- are 72-89, EMTF- are 90-107"),
+                         hwTag = Var("hwTag()","int16",doc="not in L1 ntuples"),
+                         hwEtaAtVtx = Var("hwEtaAtVtx()","int16",doc="hardware eta estimated at the vertex"),
+                         hwPhiAtVtx = Var("hwPhiAtVtx()","int16",doc="hardware phi estimated at the vertex"),
                          etaAtVtx = Var("etaAtVtx()",float,doc="eta estimated at the vertex"),
                          phiAtVtx = Var("phiAtVtx()",float,doc="phi estimated at the vertex"),
-                         hwIsoSum = Var("hwIsoSum()",int,doc="hardware iso sum"),
-                         hwDPhiExtra = Var("hwDPhiExtra()",int,doc=""),
-                         hwDEtaExtra = Var("hwDEtaExtra()",int,doc=""),
-                         hwRank = Var("hwRank()",int,doc=""),
-                         hwPtUnconstrained = Var("hwPtUnconstrained()",int,doc=""),
+                         hwIsoSum = Var("hwIsoSum()","int16",doc="not in L1 ntuples"),
+                         hwDPhiExtra = Var("hwDPhiExtra()","int16",doc="Delta between Pseudo-rapidity at the muon system and the projected coordinate at the vertex in HW unit (for future l1t-integration-tag"),
+                         hwDEtaExtra = Var("hwDEtaExtra()","int16",doc="Delta between Azimuth at the muon system and the projected coordinate at the vertex in HW unit (for future l1t-integration-tag)"),
+                         hwRank = Var("hwRank()","int16",doc="not in L1Ntuples"),
+                         hwPtUnconstrained = Var("hwPtUnconstrained()","int16",doc=""),
                          ptUnconstrained = Var("ptUnconstrained()",float,doc=""),
-                         hwDXY = Var("hwDXY()",int,doc=""),
+                         hwDXY = Var("hwDXY()","uint16",doc=""),
                      )
 )
 
@@ -86,16 +92,14 @@ l1JetTable = cms.EDProducer("SimpleTriggerL1JetFlatTableProducer",
     name= cms.string("L1Jet"),
     doc = cms.string(""),
     extension = cms.bool(False),
-    variables = cms.PSet(l1ObjVars,
-                         towerIEta = Var("towerIEta()",int,doc="the ieta of the tower"),
-                         towerIPhi = Var("towerIPhi()",int,doc="the iphi of the tower"),
-                         rawEt = Var("rawEt()",int,doc="raw (uncalibrated) et"),
-                         seedEt = Var("seedEt()",int,doc="et of the seed"),
-                         puEt = Var("puEt()",int,doc="pile up et "),
-                         puDonutEt0 = Var("puDonutEt(0)",int,doc=""),
-                         puDonutEt1 = Var("puDonutEt(1)",int,doc=""),
-                         puDonutEt2 = Var("puDonutEt(2)",int,doc=""),
-                         puDonutEt3 = Var("puDonutEt(3)",int,doc=""),
+    variables = cms.PSet(l1CaloObjVars,
+                         rawEt = Var("rawEt()","int16",doc="raw (uncalibrated) et"),
+                         seedEt = Var("seedEt()","int16",doc="et of the seed"),
+                         puEt = Var("puEt()","int16",doc="pile up et "),
+                         puDonutEt0 = Var("puDonutEt(0)","int16",doc=""),
+                         puDonutEt1 = Var("puDonutEt(1)","int16",doc=""),
+                         puDonutEt2 = Var("puDonutEt(2)","int16",doc=""),
+                         puDonutEt3 = Var("puDonutEt(3)","int16",doc=""),
                      )
 )
 
@@ -107,14 +111,12 @@ l1TauTable = cms.EDProducer("SimpleTriggerL1TauFlatTableProducer",
     name= cms.string("L1Tau"),
     doc = cms.string(""),
     extension = cms.bool(False), # this is the main table for L1 EGs
-    variables = cms.PSet(l1ObjVars,
-                         towerIEta = Var("towerIEta()",int,doc="the ieta of the tower"),
-                         towerIPhi = Var("towerIPhi()",int,doc="the iphi of the tower"),
-                         rawEt = Var("rawEt()",int,doc="raw Et of tau"),
-                         isoEt = Var("isoEt()",int,doc="raw isolation sum - cluster sum"),
-                         nTT = Var("nTT()",int,doc=" nr towers above threshold"),
-                         hasEM = Var("hasEM()",int,doc="has an em component"),
-                         isMerged = Var("isMerged()",int,doc="is merged"),
+    variables = cms.PSet(l1CaloObjVars,
+                         rawEt = Var("rawEt()","int16",doc="raw Et of tau"),
+                         isoEt = Var("isoEt()","int16",doc="raw isolation sum - cluster sum"),
+                         nTT = Var("nTT()","int16",doc=" nr towers above threshold"),
+                         hasEM = Var("hasEM()",bool,doc="has an em component"),
+                         isMerged = Var("isMerged()",bool,doc="is merged"),
 
                      )
 )
@@ -142,15 +144,13 @@ l1EGTable = cms.EDProducer("SimpleTriggerL1EGFlatTableProducer",
     name= cms.string("L1EG"),
     doc = cms.string(""),
     extension = cms.bool(False), 
-    variables = cms.PSet(l1ObjVars,
-                         towerIEta = Var("towerIEta()",int,doc="tower ieta"),
-                         towerIPhi = Var("towerIPhi()",int,doc="tower iphi"),
-                         rawEt = Var("rawEt()",int,doc="raw et"),
-                         isoEt = Var("isoEt()",int,doc="iso et"),
-                         footprintEt = Var("footprintEt()",int,doc=" footprint et"),
-                         nTT = Var("nTT()",int,doc="nr trig towers"),
-                         shape = Var("shape()",int,doc="shape"),
-                         towerHoE = Var("towerHoE()",int,doc="tower H/E"),
+    variables = cms.PSet(l1CaloObjVars,
+                         rawEt = Var("rawEt()","int16",doc="raw et"),
+                         isoEt = Var("isoEt()","int16",doc="iso et"),
+                         footprintEt = Var("footprintEt()","int16",doc=" footprint et"),
+                         nTT = Var("nTT()","int16",doc="nr trig towers"),
+                         shape = Var("shape()","int16",doc="shape"),
+                         towerHoE = Var("towerHoE()","int16",doc="tower H/E"),
                      )
 )
 

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -3,7 +3,7 @@ from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 
 l1_float_precision_=12
-print("l1pre",l1_float_precision_)
+
 l1PtVars = cms.PSet(
     pt  = Var("pt",  float, precision=l1_float_precision_),
     phi = Var("phi", float, precision=l1_float_precision_),

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -2,13 +2,15 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 
+precision=10
+
 l1PtVars = cms.PSet(
-    pt  = Var("pt",  float, precision=10),
-    phi = Var("phi", float, precision=10),
+    pt  = Var("pt",  float, precision=precision),
+    phi = Var("phi", float, precision=precision),
 )
 l1P3Vars = cms.PSet(
     l1PtVars,
-    eta = Var("eta", float, precision=10),
+    eta = Var("eta", float, precision=precision),
 )
 
 l1ObjVars = cms.PSet(
@@ -41,11 +43,11 @@ l1TauReducedVars = cms.PSet(
 l1MuonReducedVars = cms.PSet(
     l1P3Vars,
     hwQual = Var("hwQual()",int,doc="hardware qual"),
-    hwCharge = Var("hwCharge()",int,doc=""), 
-    etaAtVtx = Var("etaAtVtx()",float,doc=""),
-    phiAtVtx = Var("phiAtVtx()",float,doc=""),
-    ptUnconstrained = Var("ptUnconstrained()",float,doc=""),
-    hwDXY = Var("hwDXY()",int,doc=""),
+    hwCharge = Var("hwCharge()",int,doc="hardware charge"), 
+    etaAtVtx = Var("etaAtVtx()",float,precision=precision,doc="eta estimated at the vertex"),
+    phiAtVtx = Var("phiAtVtx()",float,precision=precision,doc="phi estimated at the vertex"),
+    ptUnconstrained = Var("ptUnconstrained()",float,precision=precision,doc="pt when not constrained to the beamspot"),
+    hwDXY = Var("hwDXY()",int,doc="hardware impact parameter"),
 )
 
 l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
@@ -61,11 +63,11 @@ l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
                          hwChargeValid = Var("hwChargeValid()",int,doc=""),
                          tfMuonIndex = Var("tfMuonIndex()",int,doc=""),
                          hwTag = Var("hwTag()",int,doc=""),
-                         hwEtaAtVtx = Var("hwEtaAtVtx()",int,doc=""),
-                         hwPhiAtVtx = Var("hwPhiAtVtx()",int,doc=""),
-                         etaAtVtx = Var("etaAtVtx()",float,doc=""),
-                         phiAtVtx = Var("phiAtVtx()",float,doc=""),
-                         hwIsoSum = Var("hwIsoSum()",int,doc=""),
+                         hwEtaAtVtx = Var("hwEtaAtVtx()",int,doc="hardware eta estimated at the vertex"),
+                         hwPhiAtVtx = Var("hwPhiAtVtx()",int,doc="hardware phi estimated at the vertex"),
+                         etaAtVtx = Var("etaAtVtx()",float,doc="eta estimated at the vertex"),
+                         phiAtVtx = Var("phiAtVtx()",float,doc="phi estimated at the vertex"),
+                         hwIsoSum = Var("hwIsoSum()",int,doc="hardware iso sum"),
                          hwDPhiExtra = Var("hwDPhiExtra()",int,doc=""),
                          hwDEtaExtra = Var("hwDEtaExtra()",int,doc=""),
                          hwRank = Var("hwRank()",int,doc=""),
@@ -85,11 +87,11 @@ l1JetTable = cms.EDProducer("SimpleTriggerL1JetFlatTableProducer",
     doc = cms.string(""),
     extension = cms.bool(False),
     variables = cms.PSet(l1ObjVars,
-                         towerIEta = Var("towerIEta()",int,doc=""),
-                         towerIPhi = Var("towerIPhi()",int,doc=""),
-                         rawEt = Var("rawEt()",int,doc=""),
-                         seedEt = Var("seedEt()",int,doc=""),
-                         puEt = Var("puEt()",int,doc=""),
+                         towerIEta = Var("towerIEta()",int,doc="the ieta of the tower"),
+                         towerIPhi = Var("towerIPhi()",int,doc="the iphi of the tower"),
+                         rawEt = Var("rawEt()",int,doc="raw (uncalibrated) et"),
+                         seedEt = Var("seedEt()",int,doc="et of the seed"),
+                         puEt = Var("puEt()",int,doc="pile up et "),
                          puDonutEt0 = Var("puDonutEt(0)",int,doc=""),
                          puDonutEt1 = Var("puDonutEt(1)",int,doc=""),
                          puDonutEt2 = Var("puDonutEt(2)",int,doc=""),
@@ -106,13 +108,13 @@ l1TauTable = cms.EDProducer("SimpleTriggerL1TauFlatTableProducer",
     doc = cms.string(""),
     extension = cms.bool(False), # this is the main table for L1 EGs
     variables = cms.PSet(l1ObjVars,
-                         towerIEta = Var("towerIEta()",int,doc=""),
-                         towerIPhi = Var("towerIPhi()",int,doc=""),
-                         rawEt = Var("rawEt()",int,doc=""),
-                         isoEt = Var("isoEt()",int,doc=""),
-                         nTT = Var("nTT()",int,doc=""),                         
-                         hasEM = Var("hasEM()",int,doc=""),
-                         isMerged = Var("isMerged()",int,doc=""),
+                         towerIEta = Var("towerIEta()",int,doc="the ieta of the tower"),
+                         towerIPhi = Var("towerIPhi()",int,doc="the iphi of the tower"),
+                         rawEt = Var("rawEt()",int,doc="raw Et of tau"),
+                         isoEt = Var("isoEt()",int,doc="raw isolation sum - cluster sum"),
+                         nTT = Var("nTT()",int,doc=" nr towers above threshold"),
+                         hasEM = Var("hasEM()",int,doc="has an em component"),
+                         isMerged = Var("isMerged()",int,doc="is merged"),
 
                      )
 )
@@ -128,7 +130,7 @@ l1EtSumTable = cms.EDProducer("SimpleTriggerL1EtSumFlatTableProducer",
     variables = cms.PSet(l1PtVars,
                          hwPt = Var("hwPt()",int,doc="hardware pt"),
                          hwPhi = Var("hwPhi()",int,doc="hardware phi"),
-                         etSumType = Var("getType()",int,doc=""),
+                         etSumType = Var("getType()",int,doc="the type of the ET Sum (https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1Trigger/interface/EtSum.h#L27-L56)"),
                      )
 )
 
@@ -167,18 +169,6 @@ def setL1NanoToReduced(process):
     process.l1TauTable.variables = cms.PSet(l1TauReducedVars)
     process.l1EtSumTable.variables = cms.PSet(l1EtSumReducedVars)
    
-    #restrict bx
-    process.l1EGTable.minBX = 0
-    process.l1EGTable.maxBX = 0
-    process.l1MuTable.minBX = 0
-    process.l1MuTable.maxBX = 0
-    process.l1JetTable.minBX = 0 
-    process.l1JetTable.maxBX = 0
-    process.l1TauTable.minBX = 0 
-    process.l1TauTable.maxBX = 0
-    process.l1EtSumTable.minBX = 0 
-    process.l1EtSumTable.maxBX = 0
-    
     #apply cuts
     process.l1EGTable.cut="pt>=10"
     process.l1TauTable.cut="pt>=24"

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -20,6 +20,31 @@ l1ObjVars = cms.PSet(
     hwIso = Var("hwIso()",int,doc="hardware iso")
 )
 
+l1JetReducedVars = cms.PSet(
+    l1P3Vars
+)
+
+l1EtSumReducedVars = cms.PSet(
+    l1PtVars
+)
+l1EGReducedVars = cms.PSet(
+    l1P3Vars,
+    hwIso = Var("hwIso()",int,doc="hardware iso")
+)
+
+l1TauReducedVars = cms.PSet(
+    l1P3Vars,
+    hwIso = Var("hwIso()",int,doc="hardware iso")
+)
+
+l1MuonReducedVars = cms.PSet(
+    hwQual = Var("hwQual()",int,doc="hardware qual"),
+    hwCharge = Var("hwCharge()",int,doc=""), 
+    etaAtVtx = Var("etaAtVtx()",float,doc=""),
+    phiAtVtx = Var("phiAtVtx()",float,doc=""),
+    ptUnconstrained = Var("ptUnconstrained()",float,doc=""),
+    hwDXY = Var("hwDXY()",int,doc=""),
+)
 
 l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
     src = cms.InputTag("gmtStage2Digis","Muon"),
@@ -28,7 +53,7 @@ l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
     cut = cms.string(""), 
     name= cms.string("L1Mu"),
     doc = cms.string(""),
-    extension = cms.bool(False), # this is the main table for L1 EGs
+    extension = cms.bool(False), 
     variables = cms.PSet(l1ObjVars,
                          hwCharge = Var("hwCharge()",int,doc=""),
                          hwChargeValid = Var("hwChargeValid()",int,doc=""),
@@ -56,7 +81,7 @@ l1JetTable = cms.EDProducer("SimpleTriggerL1JetFlatTableProducer",
     cut = cms.string(""), 
     name= cms.string("L1Jet"),
     doc = cms.string(""),
-    extension = cms.bool(False), # this is the main table for L1 EGs
+    extension = cms.bool(False),
     variables = cms.PSet(l1ObjVars,
                          towerIEta = Var("towerIEta()",int,doc=""),
                          towerIPhi = Var("towerIPhi()",int,doc=""),
@@ -97,7 +122,7 @@ l1EtSumTable = cms.EDProducer("SimpleTriggerL1EtSumFlatTableProducer",
     cut = cms.string(""), 
     name= cms.string("L1EtSum"),
     doc = cms.string(""),
-    extension = cms.bool(False), # this is the main table for L1 EGs
+    extension = cms.bool(False), 
     variables = cms.PSet(l1PtVars,
                          hwPt = Var("hwPt()",int,doc="hardware pt"),
                          hwPhi = Var("hwPhi()",int,doc="hardware phi"),
@@ -112,7 +137,7 @@ l1EGTable = cms.EDProducer("SimpleTriggerL1EGFlatTableProducer",
     cut = cms.string(""), 
     name= cms.string("L1EG"),
     doc = cms.string(""),
-    extension = cms.bool(False), # this is the main table for L1 EGs
+    extension = cms.bool(False), 
     variables = cms.PSet(l1ObjVars,
                          towerIEta = Var("towerIEta()",int,doc="tower ieta"),
                          towerIPhi = Var("towerIPhi()",int,doc="tower iphi"),
@@ -134,10 +159,11 @@ def setL1NanoToReduced(process):
     """
     #reduce the variables to the core variables
     #note et sum variables are already reduced
-    process.l1EGTable.variables = cms.PSet(l1ObjVars)
-    process.l1MuTable.variables = cms.PSet(l1ObjVars)
-    process.l1JetTable.variables = cms.PSet(l1ObjVars)
-    process.l1TauTable.variables = cms.PSet(l1ObjVars)
+    process.l1EGTable.variables = cms.PSet(l1EGReducedVars)
+    process.l1MuTable.variables = cms.PSet(l1MuonReducedVars)
+    process.l1JetTable.variables = cms.PSet(l1JetReducedVars)
+    process.l1TauTable.variables = cms.PSet(l1TauReducedVars)
+    process.l1EtSumTable.variables = cms.PSet(l1EtSumReducedVars)
    
     #restrict bx
     process.l1EGTable.minBX = 0
@@ -152,9 +178,11 @@ def setL1NanoToReduced(process):
     process.l1EtSumTable.maxBX = 0
     
     #apply cuts
-    process.l1EGTable.cut="hwPt>=10"
-    process.l1TauTable.cut="hwPt>=50"
-    process.l1JetTable.cut="hwPt>=100"
+    process.l1EGTable.cut="pt>=10"
+    process.l1TauTable.cut="pt>=24"
+    process.l1JetTable.cut="pt>=30"
+    process.l1MuTable.cut="pt>=3 && hwQual>=8"
+    process.l1EtSumTable.cut="(getType==8 || getType==1)"
     
     
     return process

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -1,0 +1,119 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+from PhysicsTools.NanoAOD.common_cff import *
+
+l1ObjVars = cms.PSet(
+    P3Vars, 
+    hwPt = Var("hwPt()",int,doc="hardware pt"),
+    hwEta = Var("hwEta()",int,doc="hardware eta"),
+    hwPhi = Var("hwPhi()",int,doc="hardware phi"),
+    hwQual = Var("hwQual()",int,doc="hardware qual"),
+    hwIso = Var("hwIso()",int,doc="hardware iso")
+)
+
+
+l1MuTable = cms.EDProducer("SimpleTriggerL1MuonFlatTableProducer",
+    src = cms.InputTag("gmtStage2Digis","Muon"),
+    minBX = cms.int32(-2),
+    maxBX = cms.int32(2),                           
+    cut = cms.string(""), 
+    name= cms.string("L1Mu"),
+    doc = cms.string(""),
+    extension = cms.bool(False), # this is the main table for L1 EGs
+    variables = cms.PSet(l1ObjVars,
+                         hwCharge = Var("hwCharge()",int,doc=""),
+                         hwChargeValid = Var("hwChargeValid()",int,doc=""),
+                         tfMuonIndex = Var("tfMuonIndex()",int,doc=""),
+                         hwTag = Var("hwTag()",int,doc=""),
+                         hwEtaAtVtx = Var("hwEtaAtVtx()",int,doc=""),
+                         hwPhiAtVtx = Var("hwPhiAtVtx()",int,doc=""),
+                         etaAtVtx = Var("etaAtVtx()",float,doc=""),
+                         phiAtVtx = Var("phiAtVtx()",float,doc=""),
+                         hwIsoSum = Var("hwIsoSum()",int,doc=""),
+                         hwDPhiExtra = Var("hwDPhiExtra()",int,doc=""),
+                         hwDEtaExtra = Var("hwDEtaExtra()",int,doc=""),
+                         hwRank = Var("hwRank()",int,doc=""),
+                         hwPtUnconstrained = Var("hwPtUnconstrained()",int,doc=""),
+                         ptUnconstrained = Var("ptUnconstrained()",float,doc=""),
+                         hwDXY = Var("hwDXY()",int,doc=""),
+                     )
+)
+
+
+l1JetTable = cms.EDProducer("SimpleTriggerL1JetFlatTableProducer",
+    src = cms.InputTag("caloStage2Digis","Jet"),
+    minBX = cms.int32(-2),
+    maxBX = cms.int32(2),                           
+    cut = cms.string(""), 
+    name= cms.string("L1Jet"),
+    doc = cms.string(""),
+    extension = cms.bool(False), # this is the main table for L1 EGs
+    variables = cms.PSet(l1ObjVars,
+                         towerIEta = Var("towerIEta()",int,doc=""),
+                         towerIPhi = Var("towerIPhi()",int,doc=""),
+                         rawEt = Var("rawEt()",int,doc=""),
+                         seedEt = Var("seedEt()",int,doc=""),
+                         puEt = Var("puEt()",int,doc=""),
+                         puDonutEt0 = Var("puDonutEt(0)",int,doc=""),
+                         puDonutEt1 = Var("puDonutEt(1)",int,doc=""),
+                         puDonutEt2 = Var("puDonutEt(2)",int,doc=""),
+                         puDonutEt3 = Var("puDonutEt(3)",int,doc=""),
+                     )
+)
+
+l1TauTable = cms.EDProducer("SimpleTriggerL1TauFlatTableProducer",
+    src = cms.InputTag("caloStage2Digis","Tau"),
+    minBX = cms.int32(-2),
+    maxBX = cms.int32(2),                           
+    cut = cms.string(""), 
+    name= cms.string("L1Tau"),
+    doc = cms.string(""),
+    extension = cms.bool(False), # this is the main table for L1 EGs
+    variables = cms.PSet(l1ObjVars,
+                         towerIEta = Var("towerIEta()",int,doc=""),
+                         towerIPhi = Var("towerIPhi()",int,doc=""),
+                         rawEt = Var("rawEt()",int,doc=""),
+                         isoEt = Var("isoEt()",int,doc=""),
+                         nTT = Var("nTT()",int,doc=""),                         
+                         hasEM = Var("hasEM()",int,doc=""),
+                         isMerged = Var("isMerged()",int,doc=""),
+
+                     )
+)
+
+l1EtSumTable = cms.EDProducer("SimpleTriggerL1EtSumFlatTableProducer",
+    src = cms.InputTag("caloStage2Digis","EtSum"),
+    minBX = cms.int32(-2),
+    maxBX = cms.int32(2),                           
+    cut = cms.string(""), 
+    name= cms.string("L1EtSum"),
+    doc = cms.string(""),
+    extension = cms.bool(False), # this is the main table for L1 EGs
+    variables = cms.PSet(PTVars,
+                         hwPt = Var("hwPt()",int,doc="hardware pt"),
+                         hwPhi = Var("hwPhi()",int,doc="hardware phi"),
+                         etSumType = Var("getType()",int,doc=""),
+                     )
+)
+
+l1EGTable = cms.EDProducer("SimpleTriggerL1EGFlatTableProducer",
+    src = cms.InputTag("caloStage2Digis","EGamma"),
+    minBX = cms.int32(-2),
+    maxBX = cms.int32(2),                           
+    cut = cms.string(""), 
+    name= cms.string("L1EG"),
+    doc = cms.string(""),
+    extension = cms.bool(False), # this is the main table for L1 EGs
+    variables = cms.PSet(l1ObjVars,
+                         towerIEta = Var("towerIEta()",int,doc="tower ieta"),
+                         towerIPhi = Var("towerIPhi()",int,doc="tower iphi"),
+                         rawEt = Var("rawEt()",int,doc="raw et"),
+                         isoEt = Var("isoEt()",int,doc="iso et"),
+                         footprintEt = Var("footprintEt()",int,doc=" footprint et"),
+                         nTT = Var("nTT()",int,doc="nr trig towers"),
+                         shape = Var("shape()",int,doc="shape"),
+                         towerHoE = Var("towerHoE()",int,doc="tower H/E"),
+                     )
+)
+
+l1TablesTask = cms.Task(l1EGTable,l1EtSumTable,l1TauTable,l1JetTable,l1MuTable)

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -2,8 +2,17 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 
+l1PtVars = cms.PSet(
+    pt  = Var("pt",  float, precision=5),
+    phi = Var("phi", float, precision=5),
+)
+l1P3Vars = cms.PSet(
+    l1PtVars,
+    eta = Var("eta", float, precision=5),
+)
+
 l1ObjVars = cms.PSet(
-    P3Vars, 
+    l1P3Vars,
     hwPt = Var("hwPt()",int,doc="hardware pt"),
     hwEta = Var("hwEta()",int,doc="hardware eta"),
     hwPhi = Var("hwPhi()",int,doc="hardware phi"),
@@ -89,7 +98,7 @@ l1EtSumTable = cms.EDProducer("SimpleTriggerL1EtSumFlatTableProducer",
     name= cms.string("L1EtSum"),
     doc = cms.string(""),
     extension = cms.bool(False), # this is the main table for L1 EGs
-    variables = cms.PSet(PTVars,
+    variables = cms.PSet(l1PtVars,
                          hwPt = Var("hwPt()",int,doc="hardware pt"),
                          hwPhi = Var("hwPhi()",int,doc="hardware phi"),
                          etSumType = Var("getType()",int,doc=""),
@@ -117,3 +126,35 @@ l1EGTable = cms.EDProducer("SimpleTriggerL1EGFlatTableProducer",
 )
 
 l1TablesTask = cms.Task(l1EGTable,l1EtSumTable,l1TauTable,l1JetTable,l1MuTable)
+
+def setL1NanoToReduced(process):
+    """
+    sets the L1 objects only have reduced information which is necessary 
+    for central nano
+    """
+    #reduce the variables to the core variables
+    #note et sum variables are already reduced
+    process.l1EGTable.variables = cms.PSet(l1ObjVars)
+    process.l1MuTable.variables = cms.PSet(l1ObjVars)
+    process.l1JetTable.variables = cms.PSet(l1ObjVars)
+    process.l1TauTable.variables = cms.PSet(l1ObjVars)
+   
+    #restrict bx
+    process.l1EGTable.minBX = 0
+    process.l1EGTable.maxBX = 0
+    process.l1MuTable.minBX = 0
+    process.l1MuTable.maxBX = 0
+    process.l1JetTable.minBX = 0 
+    process.l1JetTable.maxBX = 0
+    process.l1TauTable.minBX = 0 
+    process.l1TauTable.maxBX = 0
+    process.l1EtSumTable.minBX = 0 
+    process.l1EtSumTable.maxBX = 0
+    
+    #apply cuts
+    process.l1EGTable.cut="hwPt>=10"
+    process.l1TauTable.cut="hwPt>=50"
+    process.l1JetTable.cut="hwPt>=100"
+    
+    
+    return process

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -25,7 +25,8 @@ l1JetReducedVars = cms.PSet(
 )
 
 l1EtSumReducedVars = cms.PSet(
-    l1PtVars
+    l1PtVars,
+    etSumType = Var("getType()",int,doc="et sum type"),
 )
 l1EGReducedVars = cms.PSet(
     l1P3Vars,
@@ -38,6 +39,7 @@ l1TauReducedVars = cms.PSet(
 )
 
 l1MuonReducedVars = cms.PSet(
+    l1P3Vars,
     hwQual = Var("hwQual()",int,doc="hardware qual"),
     hwCharge = Var("hwCharge()",int,doc=""), 
     etaAtVtx = Var("etaAtVtx()",float,doc=""),

--- a/PhysicsTools/NanoAOD/python/l1trig_cff.py
+++ b/PhysicsTools/NanoAOD/python/l1trig_cff.py
@@ -3,12 +3,12 @@ from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 
 l1PtVars = cms.PSet(
-    pt  = Var("pt",  float, precision=5),
-    phi = Var("phi", float, precision=5),
+    pt  = Var("pt",  float, precision=10),
+    phi = Var("phi", float, precision=10),
 )
 l1P3Vars = cms.PSet(
     l1PtVars,
-    eta = Var("eta", float, precision=5),
+    eta = Var("eta", float, precision=10),
 )
 
 l1ObjVars = cms.PSet(
@@ -182,7 +182,6 @@ def setL1NanoToReduced(process):
     process.l1TauTable.cut="pt>=24"
     process.l1JetTable.cut="pt>=30"
     process.l1MuTable.cut="pt>=3 && hwQual>=8"
-    process.l1EtSumTable.cut="(getType==8 || getType==1)"
-    
+    process.l1EtSumTable.cut="(getType==8 || getType==1 || getType==2 || getType==3)"
     
     return process

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -27,6 +27,7 @@ from PhysicsTools.NanoAOD.protons_cff import *
 from PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff import *
 from PhysicsTools.NanoAOD.fsrPhotons_cff import *
 from PhysicsTools.NanoAOD.softActivity_cff import *
+from PhysicsTools.NanoAOD.l1trig_cff import *
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
     strings = cms.PSet(
@@ -209,4 +210,8 @@ def nanoWmassGenCustomize(process):
     process.genParticleTable.variables.phi.precision=cms.string(phiPrecision)
     etaPrecision="{} ? {} : {}".format(pdgSelection, CandVars.eta.precision.value(), genParticleTable.variables.eta.precision.value())
     process.genParticleTable.variables.eta.precision=cms.string(etaPrecision)
+    return process
+
+def nanoL1TrigObjCustomize(process):
+    process.nanoTableTaskCommon.add(process.l1TablesTask)
     return process

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -214,4 +214,9 @@ def nanoWmassGenCustomize(process):
 
 def nanoL1TrigObjCustomize(process):
     process.nanoTableTaskCommon.add(process.l1TablesTask)
+    process = setL1NanoToReduced(process)
+    return process
+
+def nanoL1TrigObjCustomizeFull(process):
+    process.nanoTableTaskCommon.add(process.l1TablesTask)
     return process


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/40663 which  adds L1 information to NanoAOD. 

It is necessary to backport to be able to run as prompt nano this year. 

#### PR validation:

Validation is covered in the original PR
https://github.com/cms-sw/cmssw/pull/40663  (its the exact same branch, merges in both 13_0_X and 13_1_X)




