### PR TITLE
Update Run-3 HI GTs to include ECAL spike-killers

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -72,7 +72,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '131X_mcRun3_2023_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
@@ -82,7 +82,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v5',
+    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

As requested in https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-realistic-spike-killer-settings-125x-130x-131x/22082/7 this PR updates the Run-3 HI GTs to include ECAL spike-killers. The diffs are
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v3/131X_mcRun3_2022_realistic_HI_v4
 * https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v5/131X_mcRun3_2023_realistic_HI_v6

#### PR validation:
Run wf `160.1` 


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 13_0_X for the 2023 HI MC campaign and to 12_5_X for the 2022 HI  HI MC campaign