### PR TITLE
Re-enable unit tests for ASAN build

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,6 +1,3 @@
-<ifrelease name="_ASAN_">
-  <flags NO_TEST_PREFIX="1"/>
-</ifrelease>
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -9,11 +9,12 @@
   <use name="FWCore/Framework"/>
 </library>
 
+<test name="TestFWCoreServicesDriver_sitelocalconfig" command="test_sitelocalconfig.sh"/>
+<test name="TestFWCoreServicesDriver_zombiekiller"    command="test_zombiekiller.sh"/>
+<test name="TestFWCoreServicesDriver_cpu"             command="test_cpu.sh"/>
+
 <ifrelease name="!_ASAN_">
-  <test name="TestFWCoreServicesDriver_sitelocalconfig" command="test_sitelocalconfig.sh"/>
   <test name="TestFWCoreServicesDriver_resource"        command="test_resource.sh"/>
-  <test name="TestFWCoreServicesDriver_zombiekiller"    command="test_zombiekiller.sh"/>
-  <test name="TestFWCoreServicesDriver_cpu"             command="test_cpu.sh"/>
 </ifrelease>
 
 <bin file="test_catch2_*.cc" name="testFWCoreServicesCatch2">

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -1,6 +1,3 @@
-<ifrelease name="_ASAN_|_UBSAN_">
-  <flags NO_TEST_PREFIX="1"/>
-</ifrelease>
 <test name="TestHeterogeneousCoreSonicTritonProducerCPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} CPU"/>
 <test name="TestHeterogeneousCoreSonicTritonProducerGPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} GPU"/>
 <library file="*.cc" name="testHeterogenousCoreSonicTriton">

--- a/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
+++ b/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
@@ -9,8 +9,4 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<test name="DRNTest" command="runtests.sh">
-  <ifrelease name="_ASAN_|_UBSAN_">
-    <flags NO_TEST_PREFIX="1"/>
-  </ifrelease>
-</test>
+<test name="DRNTest" command="runtests.sh"/>


### PR DESCRIPTION
Some unit tests were disabled for `ASAN` IBs as they hang due to `libasan.so` and some system commands issues (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589 and https://sourceware.org/bugzilla/show_bug.cgi?id=27653) specially `ps` command. With change https://github.com/cms-sw/cms-bot/pull/1963, now bot overrides selected system commands and allows these tests to run in ASAN IBs.

This should only be merged after https://github.com/cms-sw/cms-bot/pull/1963