### PR TITLE
[13_0_X] Update FG HF thresholds to 2022 PbPb

### DIFF
--- a/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
+++ b/CalibCalorimetry/CaloTPG/python/CaloTPGTranscoder_cfi.py
@@ -1,16 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-tpScales = cms.PSet(
-    HF=cms.PSet(
-        NCTShift=cms.int32(1),
-        RCTShift=cms.int32(3),
-    ),
-    HBHE=cms.PSet(
-        LSBQIE8=cms.double(1/8.),
-        LSBQIE11=cms.double(1/16.),
-        LSBQIE11Overlap=cms.double(1/8.),
-    )
-)
+from CalibCalorimetry.CaloTPG.tpScales_cff import tpScales
 
 CaloTPGTranscoder = cms.ESProducer("CaloTPGTranscoderULUTs",
     hcalLUT1 = cms.FileInPath('CalibCalorimetry/CaloTPG/data/outputLUTtranscoder_physics.dat'),
@@ -26,3 +16,6 @@ CaloTPGTranscoder = cms.ESProducer("CaloTPGTranscoderULUTs",
     RCTLSB = cms.double(0.25),
     tpScales = tpScales,
 )
+
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(CaloTPGTranscoder, linearLUTs=True)

--- a/CalibCalorimetry/CaloTPG/python/tpScales_cff.py
+++ b/CalibCalorimetry/CaloTPG/python/tpScales_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+tpScales = cms.PSet(
+    HF=cms.PSet(
+        NCTShift=cms.int32(1),
+        RCTShift=cms.int32(3),
+    ),
+    HBHE=cms.PSet(
+        LSBQIE8=cms.double(1/8.),
+        LSBQIE11=cms.double(1/16.),
+        LSBQIE11Overlap=cms.double(1/8.),
+    )
+)
+
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toModify(tpScales.HF, NCTShift=2)
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(tpScales.HBHE, LSBQIE11Overlap=1/16.)

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -4,12 +4,10 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-
-from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cfi import *
-from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import *
-from CalibCalorimetry.HcalPlugins.Hcal_PCCUpdate_cff import *
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cfi import simHcalTriggerPrimitiveDigis
+from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import CaloTPGTranscoder
+from CalibCalorimetry.CaloTPG.tpScales_cff import tpScales
+from CalibCalorimetry.HcalPlugins.Hcal_PCCUpdate_cff import PCCUpdate
 
 HcalTPGCoderULUT = cms.ESProducer("HcalTPGCoderULUT",
     read_Ascii_LUTs = cms.bool(False),
@@ -34,8 +32,11 @@ HcalTPGCoderULUT = cms.ESProducer("HcalTPGCoderULUT",
 
 HcalTrigTowerGeometryESProducer = cms.ESProducer("HcalTrigTowerGeometryESProducer")
 
-run2_HCAL_2018.toModify(CaloTPGTranscoder, linearLUTs=cms.bool(True))
-run2_HCAL_2018.toModify(HcalTPGCoderULUT, linearLUTs=cms.bool(True))
-run3_common.toModify(HcalTPGCoderULUT, applyFixPCC=cms.bool(True))
-pp_on_AA.toModify(CaloTPGTranscoder, FG_HF_thresholds = cms.vuint32(15, 19))
-pp_on_AA.toModify(HcalTPGCoderULUT, FG_HF_thresholds = cms.vuint32(15, 19))
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+run2_HCAL_2018.toModify(HcalTPGCoderULUT, linearLUTs=True)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [15, 19])
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 19])

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,10 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi import tpScales
-from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
-from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
+from CalibCalorimetry.CaloTPG.tpScales_cff import tpScales
 
 LSParameter =cms.untracked.PSet(
 HcalFeatureHFEMBit= cms.bool(False),
@@ -93,13 +89,18 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     tpScales = tpScales,
 )
 
-run2_HE_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHE=cms.bool(True))
-run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis, 
-                      upgradeHF=cms.bool(True),
-                      numberOfSamplesHF = cms.int32(2),
-                      numberOfPresamplesHF = cms.int32(1)
+from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
+run2_HE_2017.toModify(simHcalTriggerPrimitiveDigis, upgradeHE=True)
+
+from Configuration.Eras.Modifier_run2_HF_2017_cff import run2_HF_2017
+run2_HF_2017.toModify(simHcalTriggerPrimitiveDigis,
+                      upgradeHF=True,
+                      numberOfSamplesHF = 2,
+                      numberOfPresamplesHF = 1
 )
-run2_HF_2017.toModify(tpScales.HF, NCTShift=cms.int32(2))
-run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=cms.bool(True))
-run3_common.toModify(simHcalTriggerPrimitiveDigis, applySaturationFix=cms.bool(True))
-run3_HB.toModify(tpScales.HBHE, LSBQIE11Overlap=cms.double(1/16.))
+
+from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+run3_HB.toModify(simHcalTriggerPrimitiveDigis, upgradeHB=True)
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(simHcalTriggerPrimitiveDigis, applySaturationFix=True)


### PR DESCRIPTION
#### PR description:

This PR updates the values of the HF thresholds in the HCAL TP emulator with those used during the 2022 PbPb run (as documented in https://its.cern.ch/jira/browse/CMSLITDPG-1078 ).

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/41239
