### PR TITLE
Phase2-gex158A Replace cout with edm::Logverbatim in Geometry/GlobalTrackingGeometryBuilder

### DIFF
--- a/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/GlobalTrackingGeometryTest.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
@@ -30,7 +31,7 @@
 class GlobalTrackingGeometryTest : public edm::one::EDAnalyzer<> {
 public:
   explicit GlobalTrackingGeometryTest(const edm::ParameterSet&);
-  ~GlobalTrackingGeometryTest() override;
+  ~GlobalTrackingGeometryTest() override = default;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -52,8 +53,6 @@ GlobalTrackingGeometryTest::GlobalTrackingGeometryTest(const edm::ParameterSet& 
     : my_name("GlobalTrackingGeometryTest"),
       geometryToken_{esConsumes<GlobalTrackingGeometry, GlobalTrackingGeometryRecord>(edm::ESInputTag{})} {}
 
-GlobalTrackingGeometryTest::~GlobalTrackingGeometryTest() {}
-
 void GlobalTrackingGeometryTest::analyzeCSC(const GlobalTrackingGeometry* geo, const CSCGeometry* cscGeometry) {
   for (auto& detUnit : cscGeometry->detUnits()) {
     const DetId detId(detUnit->geographicalId());
@@ -62,7 +61,7 @@ void GlobalTrackingGeometryTest::analyzeCSC(const GlobalTrackingGeometry* geo, c
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "CSC detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "CSC detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : cscGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -71,7 +70,7 @@ void GlobalTrackingGeometryTest::analyzeCSC(const GlobalTrackingGeometry* geo, c
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "CSC det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "CSC det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyzeDT(const GlobalTrackingGeometry* geo, const DTGeometry* dtGeometry) {
@@ -82,7 +81,7 @@ void GlobalTrackingGeometryTest::analyzeDT(const GlobalTrackingGeometry* geo, co
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "DT detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "DT detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : dtGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -91,7 +90,7 @@ void GlobalTrackingGeometryTest::analyzeDT(const GlobalTrackingGeometry* geo, co
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "DT det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "DT det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyzeRPC(const GlobalTrackingGeometry* geo, const RPCGeometry* rpcGeometry) {
@@ -102,7 +101,7 @@ void GlobalTrackingGeometryTest::analyzeRPC(const GlobalTrackingGeometry* geo, c
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "RPC detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "RPC detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : rpcGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -111,7 +110,7 @@ void GlobalTrackingGeometryTest::analyzeRPC(const GlobalTrackingGeometry* geo, c
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "RPC det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "RPC det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyzeGEM(const GlobalTrackingGeometry* geo, const GEMGeometry* gemGeometry) {
@@ -122,7 +121,7 @@ void GlobalTrackingGeometryTest::analyzeGEM(const GlobalTrackingGeometry* geo, c
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "GEM detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "GEM detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : gemGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -131,7 +130,7 @@ void GlobalTrackingGeometryTest::analyzeGEM(const GlobalTrackingGeometry* geo, c
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "GEM det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "GEM det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyzeMTD(const GlobalTrackingGeometry* geo, const MTDGeometry* mtdGeometry) {
@@ -142,7 +141,7 @@ void GlobalTrackingGeometryTest::analyzeMTD(const GlobalTrackingGeometry* geo, c
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "MTD detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "MTD detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : mtdGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -151,7 +150,7 @@ void GlobalTrackingGeometryTest::analyzeMTD(const GlobalTrackingGeometry* geo, c
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "MTD det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "MTD det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyzeTracker(const GlobalTrackingGeometry* geo, const TrackerGeometry* tkGeometry) {
@@ -162,7 +161,7 @@ void GlobalTrackingGeometryTest::analyzeTracker(const GlobalTrackingGeometry* ge
     const GeomDetUnit* gdu(geo->idToDetUnit(detId));
     assert(gdu == detUnit);
   }
-  std::cout << "Tracker detUnit: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "Tracker detUnit: GlobalTrackingGeometry succesfully tested.";
 
   for (auto& det : tkGeometry->dets()) {
     const DetId detId(det->geographicalId());
@@ -171,72 +170,66 @@ void GlobalTrackingGeometryTest::analyzeTracker(const GlobalTrackingGeometry* ge
     const GeomDet* gd(geo->idToDet(detId));
     assert(gd == det);
   }
-  std::cout << "Tracker det: GlobalTrackingGeometry succesfully tested." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << "Tracker det: GlobalTrackingGeometry succesfully tested.";
 }
 
 void GlobalTrackingGeometryTest::analyze(const edm::Event& /*iEvent*/, const edm::EventSetup& iSetup) {
-  std::cout << myName() << ": Analyzer..." << std::endl;
+  edm::LogVerbatim("GlobalTracking") << myName() << ": Analyzer...";
 
   const auto& geo = iSetup.getData(geometryToken_);
 
   DetId detId1(DetId::Tracker, 0);
   const TrackerGeometry* trackerGeometry = nullptr;
-  std::cout << "Pointer to Tracker Geometry: ";
   try {
     trackerGeometry = (const TrackerGeometry*)geo.slaveGeometry(detId1);
-    std::cout << trackerGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to Tracker Geometry: " << trackerGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to Tracker Geometry: N/A";
   }
 
   DetId detId6(DetId::Forward, 1);
   const MTDGeometry* mtdGeometry = nullptr;
-  std::cout << "Pointer to MTD Geometry: ";
   try {
     mtdGeometry = (const MTDGeometry*)geo.slaveGeometry(detId6);
-    std::cout << mtdGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to MTD Geometry: " << mtdGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to MTD Geometry: N/A";
   }
 
   DetId detId2(DetId::Muon, 1);
   const DTGeometry* dtGeometry = nullptr;
-  std::cout << "Pointer to DT Geometry: ";
   try {
     dtGeometry = (const DTGeometry*)geo.slaveGeometry(detId2);
-    std::cout << dtGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to DT Geometry: " << dtGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to DT Geometry: N/A";
   }
 
   DetId detId3(DetId::Muon, 2);
   const CSCGeometry* cscGeometry = nullptr;
-  std::cout << "Pointer to CSC Geometry: ";
   try {
     cscGeometry = (const CSCGeometry*)geo.slaveGeometry(detId3);
-    std::cout << cscGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to CSC Geometry: " << cscGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to CSC Geometry: N/A";
   }
 
   DetId detId4(DetId::Muon, 3);
   const RPCGeometry* rpcGeometry = nullptr;
-  std::cout << "Pointer to RPC Geometry: ";
   try {
     rpcGeometry = (const RPCGeometry*)geo.slaveGeometry(detId4);
-    std::cout << rpcGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to RPC Geometry: " << rpcGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to RPC Geometry: N/A";
   }
 
   DetId detId5(DetId::Muon, 4);
   const GEMGeometry* gemGeometry = nullptr;
-  std::cout << "Pointer to GEM Geometry: ";
   try {
     gemGeometry = (const GEMGeometry*)geo.slaveGeometry(detId5);
-    std::cout << gemGeometry << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to GEM Geometry: " << gemGeometry;
   } catch (...) {
-    std::cout << "N/A" << std::endl;
+    edm::LogVerbatim("GlobalTracking") << "Pointer to GEM Geometry: N/A";
   }
 
   if (cscGeometry)

--- a/Geometry/GlobalTrackingGeometryBuilder/test/testGlobalTrackingGeometry_cfg.py
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/testGlobalTrackingGeometry_cfg.py
@@ -1,21 +1,21 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process("Demo")
-process.load('Configuration.Geometry.GeometryExtended2023D24_cff')
-process.load('Configuration.Geometry.GeometryExtended2023D24Reco_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process = cms.Process("Demo",Phase2C17I13M9)
+process.load('Configuration.Geometry.GeometryExtended2026D99Reco_cff')
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.GlobalTracking=dict()
 
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T25', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 process.source = cms.Source("EmptySource")
-
-process.MessageLogger = cms.Service("MessageLogger")
 
 process.test = cms.EDAnalyzer("GlobalTrackingGeometryTest")
 


### PR DESCRIPTION
#### PR description:

Replace cout with edm::Logverbatim in Geometry/GlobalTrackingGeometryBuilder

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special