### PR TITLE
Add DD4hep Phase2 wf in short,IB matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -15,7 +15,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #2026 WFs to run in IB (TTbar)
 numWFIB = []
 numWFIB.extend([20034.0]) #2026D86
-numWFIB.extend([20834.0,20834.911,20834.103]) #2026D88 DDD XML, DD4hep XML, aging
+numWFIB.extend([20834.0]) #2026D88
 numWFIB.extend([21061.97]) #2026D88 premixing stage1 (NuGun+PU)
 numWFIB.extend([20834.5,20834.9,20834.501,20834.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([21034.99,21034.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
@@ -33,7 +33,7 @@ numWFIB.extend([23634.21,23834.21,23834.9921]) #2026D95 prodlike, prodlike PU, p
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0]) #2026D98
-numWFIB.extend([25234.0]) #2026D99
+numWFIB.extend([25234.0,25234.911]) #2026D99 DDD XML, DD4hep XML
 
 #Additional sample for short matrix and IB
 #CloseByPGun for HGCAL

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,8 +97,8 @@ if __name__ == '__main__':
                      13234.0, #2021 ttbar fastsim
                      13434.0, #2021 ttbar PU fastsim
                      12434.0, #2023 ttbar
-                     23634.0, #2026D95 ttbar (2023 new baseline)
-                     #23634.911, #2026D95 ttbar DD4hep XML
+                     23634.0, #2026D95 ttbar (Phase-2 baseline)
+                     23634.911, #2026D95 ttbar DD4hep XML
                      23834.999, #2026D95 ttbar premixing stage1+stage2, PU50
                      23696.0, #CE_E_Front_120um D95
                      23700.0, #CE_H_Coarse_Scint D95


### PR DESCRIPTION
#### PR description:
From [SIM meeting (31 March)](https://indico.cern.ch/event/1269959/), DD4hep and DDD should give the same geometry (except for few versions of geometries with EB supermodules). This PR is to enable D95 (current baseline) DD4hep wf in the short matrix, and add D99 (next baseline) DD4hep wf to IB for the regular test. I use this PR to clean a bit D88 workflows in IB.

#### PR validation:
Test with 23634.911, 25234.911.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Note a backport, and no need of backport
