### PR TITLE
Guard for No Digis for Phase2 and Patatrack `NuGun`

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -47,7 +47,9 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (Patatrack pixel-only: ZMM - on CPU: quadruplets, triplets)
 #        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing))
 #        (ZEE)
+#        (Nu Gun)
 #   2024 (TTbar, TTbar PU, TTbar PU premix)
+
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
            10042.0,10024.0,10025.0,10026.0,10023.0,10224.0,10225.0,10424.0,
            10024.1,10024.2,10024.3,10024.4,10024.5,
@@ -85,7 +87,8 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            12450.501,12450.505,
            14034.0,14234.0,14040.303,
            12446.0,
-           12834.0,13034.0,13034.99,]
+           12461.0,	
+           12834.0,13034.0,13034.99,] 
 
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows:

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -42,6 +42,8 @@ numWFIB.extend([27634.0]) #2026D105
 #CloseByPGun for HGCAL
 numWFIB.extend([24896.0]) #CE_E_Front_120um D98
 numWFIB.extend([24900.0]) #CE_H_Coarse_Scint D98
+# NuGun 
+numWFIB.extend([24861.0]) #Nu Gun 2026D98
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -23,6 +23,8 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling (to be implemented)
 #           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation
 #           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation
+#           Patatrack Single Nu E10 on GPU (optional)
+# mc 2026   Patatrack Single Nu E10 on GPU (optional)
 numWFIB = [
            # 2023
            12450.502, 12450.503, 12450.504,
@@ -35,6 +37,8 @@ numWFIB = [
            12434.586, 12434.587, # 12434.588,
            12434.592, 12434.593,
            12434.596, 12434.597,
+           12461.502, 
+           24861.502
         ]
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -782,10 +782,13 @@ upgradeWFs['photonDRN'].step3 = {
 #   - 2018 conditions, TTbar
 #   - 2018 conditions, Z->mumu
 #   - 2022 conditions (labelled "2021"), TTbar
+#   - 2022 conditions (labelled "2021"), NuGun
 #   - 2022 conditions (labelled "2021"), Z->mumu
 #   - 2023 conditions, TTbar
+#   - 2023 conditions, NuGun
 #   - 2023 conditions, Z->mumu
 #   - 2026 conditions, TTbar
+#   - 2026 conditions, NuGu
 class PatatrackWorkflow(UpgradeWorkflow):
     def __init__(self, digi = {}, reco = {}, mini = {}, harvest = {}, **kwargs):
         # adapt the parameters for the UpgradeWorkflow init method
@@ -843,10 +846,12 @@ class PatatrackWorkflow(UpgradeWorkflow):
             ('2018' in key and fragment == "TTbar_13"),
             ('2021' in key and fragment == "TTbar_14TeV" and 'FS' not in key),
             ('2023' in key and fragment == "TTbar_14TeV" and 'FS' not in key),
+            ('2021' in key and fragment == "NuGun"),
+            ('2023' in key and fragment == "NuGun"),
             ('2018' in key and fragment == "ZMM_13"),
             ('2021' in key and fragment == "ZMM_14" and 'FS' not in key),
             ('2023' in key and fragment == "ZMM_14" and 'FS' not in key),
-            ('2026' in key and fragment == "TTbar_14TeV"),
+            ('2026' in key and (fragment == "TTbar_14TeV" or fragment=="NuGun")),
             (('HI' in key) and 'Hydjet' in fragment and "PixelOnly" in self.suffix )
         ]
         result = any(selected) and hasHarvest


### PR DESCRIPTION
#### PR description:

This PR adds a guard in `SiPixelPhase2DigiToClusterCUDA` when no pixel digi is recorded in Phase2 tracker. Without this guard the subsequent kernels crashes due to non-sensible configuration parameters. In order to monitor these special conditions, the Patatrack workflows are enabled also for `NuGun` fragments.

#### PR validation:

Running `20861.502` (i.e. `NuGun+2026D88_Patatrack_PixelOnlyGPU`). Without the fix the wf crashes with


```
Begin processing the 1st record. Run 1, Event 7, LumiSection 1 on stream 0 at 03-Apr-2023 11:35:31.678 CEST
----- Begin Fatal Exception 03-Apr-2023 11:36:43 CEST-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 7 stream: 0
   [1] Running path 'dqmoffline_step'
   [2] Prefetching for module SiPixelMonitorVertexSoA/'siPixelMonitorVertexSoA'
   [3] Prefetching for module PixelVertexSoAFromCUDA/'pixelVerticesSoA@cuda'
   [4] Prefetching for module PixelVertexProducerCUDAPhase2/'pixelVerticesCUDA'
   [5] Prefetching for module CAHitNtupletCUDAPhase2/'pixelTracksCUDA'
   [6] Prefetching for module SiPixelRecHitCUDAPhase2/'siPixelRecHitsPreSplittingCUDA'
   [7] Calling method for module SiPixelPhase2DigiToClusterCUDA/'siPixelClustersPreSplittingCUDA'
Exception Message:
A std::exception was thrown.

/data/cmsbld/jenkins/workspace/auto-builds/CMSSW_13_1_0_pre2-slc7_amd64_gcc11/build/CMSSW_13_1_0_pre2-build/tmp/BUILDROOT/c7a65d060b20ecc5cac26a602544466e/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_13_1_0_pre2/src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu, line 735:
cudaCheck(cudaGetLastError());
cudaErrorInvalidConfiguration: invalid configuration argument
----- End Fatal Exception -------------------------------------------------
```

No back-port needed.


