### PR TITLE
Revert "[13_0_X] Update muon shower data formats for 2023 running"

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -21,7 +21,6 @@ namespace l1t {
                        bool oneNominalOutOfTime = false,
                        bool twoLooseInTime = false,
                        bool twoLooseOutOfTime = false,
-                       bool oneLooseInTime = false,
                        bool oneTightInTime = false,
                        bool oneTightOutOfTime = false);
 
@@ -33,7 +32,6 @@ namespace l1t {
     void setOneTightOutOfTime(const bool bit) { isOneTightOutOfTime_ = bit; }
     void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
     void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
-    void setOneLooseInTime(const bool bit) { isOneLooseInTime_ = bit; }
 
     /// Set the processor ID, track-finder type. From these two, the link is set
     void setTFIdentifiers(int processor, tftype trackFinder);
@@ -45,7 +43,6 @@ namespace l1t {
     bool isOneTightOutOfTime() const { return isOneTightOutOfTime_; }
     bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
     bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
-    bool isOneLooseInTime() const { return isOneLooseInTime_; }
 
     /// Get link on which the MicroGMT receives the candidate
     const int link() const { return link_; };
@@ -66,7 +63,6 @@ namespace l1t {
     bool isOneTightOutOfTime_;
     bool isTwoLooseInTime_;
     bool isTwoLooseOutOfTime_;
-    bool isOneLooseInTime_;
     int link_;
     int processor_;
     tftype trackFinder_;

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -4,7 +4,6 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
                                             bool oneNominalOutOfTime,
                                             bool twoLooseInTime,
                                             bool twoLooseOutOfTime,
-                                            bool oneLooseInTime,
                                             bool oneTightInTime,
                                             bool oneTightOutOfTime)
     : isOneNominalInTime_(oneNominalInTime),
@@ -13,7 +12,6 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
       isOneTightOutOfTime_(oneTightOutOfTime),
       isTwoLooseInTime_(twoLooseInTime),
       isTwoLooseOutOfTime_(twoLooseOutOfTime),
-      isOneLooseInTime_(oneLooseInTime),
       link_(0),
       processor_(0),
       trackFinder_(l1t::tftype::bmtf) {}
@@ -43,10 +41,10 @@ void l1t::RegionalMuonShower::setTFIdentifiers(int processor, tftype trackFinder
 }
 
 bool l1t::RegionalMuonShower::isValid() const {
-  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_ or isOneLooseInTime_);
+  return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_);
 }
 
 bool l1t::RegionalMuonShower::operator==(const l1t::RegionalMuonShower& rhs) const {
   return (isTwoLooseInTime_ == rhs.isTwoLooseInTime() and isOneNominalInTime_ == rhs.isOneNominalInTime() and
-          isOneTightInTime_ == rhs.isOneTightInTime() and isOneLooseInTime_ == rhs.isOneLooseInTime());
+          isOneTightInTime_ == rhs.isOneTightInTime());
 }

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -14,8 +14,7 @@
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
-  <class name="l1t::RegionalMuonShower" ClassVersion="13">
-   <version ClassVersion="13" checksum="420598270"/>
+  <class name="l1t::RegionalMuonShower" ClassVersion="12">
     <version ClassVersion="12" checksum="1591048325"/>
     <version ClassVersion="11" checksum="376206249"/>
     <version ClassVersion="10" checksum="3501434665"/>

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -32,46 +32,47 @@ namespace l1t {
                bool twoLooseInTime = false,
                bool twoLooseOutOfTime = false,
                bool oneTightInTime = false,
-               bool oneTightOutOfTime = false,
-               bool twoLooseDiffSectorsIntime = false);
+               bool oneTightOutOfTime = false);
 
     ~MuonShower() override;
 
     /*
-     * We currently have three valid cases:
-     * - 1 nominal shower (baseline trigger for physics at Run-3)
-     * - 1 tight shower (backup trigger)
-     * - 2 loose showers in different sectors (to extend the physics reach)
-     *
-     * uGT receives shower information on five bits:
-     * - 2 bits for in-time showers (mus0, mus1 in UTM)
-     * - 2 bits for out-of-time showers (musOutOfTime0, musOutOfTime1 in UTM)
-     * - 1 bit for the newly added two loose showers in different sectors (mus2 in UTM)
-     * Disclaimer: The notion of "in time" and "out of time" showers is outdated, as there
-     * are no plans for out of time showers anymore, however the naming has been kept here
-     * to avoid confusion with the way things have been named from the start.
-     *
-     * The mapping as it is currently understood is:
-     * - 1 nominal shower -> mus0
-     * - 1 tight shower -> mus1
-     * - 2 loose showers in differnt sectors -> mus2
-     */
+      In CMSSW we consider 3 valid cases:
+      - 1 nominal shower (baseline trigger for physics at Run-3)
+      - 1 tight shower (backup trigger)
+      - 2 loose showers (to extend the physics reach)
+
+      In the uGT and UTM library, the hadronic shower trigger data is split
+      over 4 bits: 2 for in-time trigger data, 2 for out-of-time trigger data
+      - mus0, mus1 for in-time
+      - musOutOfTime0, musOutOfTime1 for out-of-time
+
+      The mapping for Run-3 startup is as follows:
+      - 1 nominal shower -> 0b01 (mus0)
+      - 1 tight shower -> 0b10 (mus1)
+
+      The 2 loose showers case would be mapped onto musOutOfTime0 and musOutOfTime1 later during Run-3
+    */
 
     void setOneNominalInTime(const bool bit) { oneNominalInTime_ = bit; }
     void setOneTightInTime(const bool bit) { oneTightInTime_ = bit; }
-    void setTwoLooseDiffSectorsInTime(const bool bit) { twoLooseDiffSectorsInTime_ = bit; }
+    void setMus0(const bool bit) { oneNominalInTime_ = bit; }
+    void setMus1(const bool bit) { oneTightInTime_ = bit; }
     void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
     void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
 
-    bool isOneNominalInTime() const { return oneNominalInTime_; }
-    bool isOneTightInTime() const { return oneTightInTime_; }
-    bool isTwoLooseDiffSectorsInTime() const { return twoLooseDiffSectorsInTime_; }
+    bool mus0() const { return oneNominalInTime_; }
+    bool mus1() const { return oneTightInTime_; }
     bool musOutOfTime0() const { return musOutOfTime0_; }
     bool musOutOfTime1() const { return musOutOfTime1_; }
 
     // at least one bit must be valid
     bool isValid() const;
 
+    // useful members for trigger performance studies
+    // needed at startup Run-3
+    bool isOneNominalInTime() const { return oneNominalInTime_; }
+    bool isOneTightInTime() const { return oneTightInTime_; }
     // to be developed during Run-3
     bool isTwoLooseInTime() const { return false; }
     // these options require more study
@@ -87,7 +88,6 @@ namespace l1t {
     // in time and out-of-time qualities. only 2 bits each.
     bool oneNominalInTime_;
     bool oneTightInTime_;
-    bool twoLooseDiffSectorsInTime_;
     bool musOutOfTime0_;
     bool musOutOfTime1_;
   };

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -5,25 +5,22 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime,
                             bool twoLooseInTime,
                             bool twoLooseOutOfTime,
                             bool oneTightInTime,
-                            bool oneTightOutOfTime,
-                            bool twoLooseDiffSectorsInTime)
+                            bool oneTightOutOfTime)
     : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
       // in this object it makes more sense to the different shower types to
       // the 4 bits, so that the object easily interfaces with the uGT emulator
       oneNominalInTime_(oneNominalInTime),
       oneTightInTime_(oneTightInTime),
-      twoLooseDiffSectorsInTime_(twoLooseDiffSectorsInTime),
       musOutOfTime0_(false),
       musOutOfTime1_(false) {}
 
 l1t::MuonShower::~MuonShower() {}
 
 bool l1t::MuonShower::isValid() const {
-  return oneNominalInTime_ or oneTightInTime_ or twoLooseDiffSectorsInTime_ or musOutOfTime0_ or musOutOfTime1_;
+  return oneNominalInTime_ or oneTightInTime_ or musOutOfTime0_ or musOutOfTime1_;
 }
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
   return (oneNominalInTime_ == rhs.isOneNominalInTime() and oneTightInTime_ == rhs.isOneTightInTime() and
-          musOutOfTime0_ == rhs.musOutOfTime0() and musOutOfTime1_ == rhs.musOutOfTime1() and
-          twoLooseDiffSectorsInTime_ == rhs.isTwoLooseDiffSectorsInTime());
+          musOutOfTime0_ == rhs.musOutOfTime0() and musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -109,8 +109,7 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="13">
-   <version ClassVersion="13" checksum="39793345"/>
+  <class name="l1t::MuonShower" ClassVersion="12">
    <version ClassVersion="12" checksum="2452991184"/>
    <version ClassVersion="11" checksum="3610959089"/>
    <version ClassVersion="10" checksum="3869296059"/>


### PR DESCRIPTION
Reverts cms-sw/cmssw#41198
Just in case the investigations on issue https://github.com/cms-sw/cmssw/issues/41246 suggest to build a new release without this PR.
At the moment this revert PR is only intended to verify that it is still mergeable in 13_0_X, and it can run.