### PR TITLE
Added skimming filter for disappearing muons [10_6_X Backport]

### DIFF
--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -22,20 +22,22 @@
 #include <memory>
 
 // user include filter
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 //
 // class declaration
@@ -48,28 +50,28 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+
   bool passTriggers(const edm::Event& iEvent,
-                    edm::EDGetToken m_trigResultsToken,
+                    const edm::TriggerResults& results,
                     std::vector<std::string> m_muonPathsToPass);
-  double getTrackIsolation(const edm::Event&,
-                           edm::Handle<reco::VertexCollection> vtxHandle,
-                           std::vector<reco::Track>::const_iterator& iTrack);
+
+  bool findTrackInVertices(const reco::TrackRef& tkToMatch,
+                           const reco::VertexCollection& vertices,
+                           unsigned int& vtxIndex,
+                           unsigned int& trackIndex);
+
+  double getTrackIsolation(const reco::TrackRef& tkToMatch, const reco::VertexCollection& vertices);
   double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
 
   // ----------member data ---------------------------
-
-  const edm::EDGetToken recoMuonToken_;
-  const edm::EDGetToken standaloneMuonToken_;
-  const edm::EDGetTokenT<std::vector<reco::Track>> trackCollectionToken_;
-  const edm::EDGetTokenT<std::vector<reco::Vertex>> primaryVerticesToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> recoMuonToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> standaloneMuonToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> trackCollectionToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> primaryVerticesToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
   const edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
-  const edm::EDGetToken genParticleToken_;
-  const edm::EDGetToken genInfoToken_;
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   const std::vector<std::string> muonPathsToPass_;

--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -1,0 +1,103 @@
+// -*- C++ -*-
+//
+// Package:    Skimming/DisappearingMuonsSkimming
+// Class:      DisappearingMuonsSkimming
+//
+/**\class DisappearingMuonsSkimming DisappearingMuonsSkimming.cc Skimming/DisappearingMuonsSkimming/plugins/DisappearingMuonsSkimming.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Michael Revering
+//         Created:  Tie, 31 Jan 2023 21:22:23 GMT
+//
+//
+#ifndef Configuration_Skimming_DisappearingMuonsSkimming_h
+#define Configuration_Skimming_DisappearingMuonsSkimming_h
+
+// system include files
+#include <memory>
+
+// user include filter
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+//
+// class declaration
+//
+
+class DisappearingMuonsSkimming : public edm::one::EDFilter<> {
+public:
+  explicit DisappearingMuonsSkimming(const edm::ParameterSet&);
+  ~DisappearingMuonsSkimming() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+  bool passTriggers(const edm::Event& iEvent,
+                    edm::EDGetToken m_trigResultsToken,
+                    std::vector<std::string> m_muonPathsToPass);
+  double getTrackIsolation(const edm::Event&,
+                           edm::Handle<reco::VertexCollection> vtxHandle,
+                           std::vector<reco::Track>::const_iterator& iTrack);
+  double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
+
+  // ----------member data ---------------------------
+
+  const edm::EDGetToken recoMuonToken_;
+  const edm::EDGetToken standaloneMuonToken_;
+  const edm::EDGetTokenT<std::vector<reco::Track>> trackCollectionToken_;
+  const edm::EDGetTokenT<std::vector<reco::Vertex>> primaryVerticesToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
+  const edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
+  const edm::EDGetToken genParticleToken_;
+  const edm::EDGetToken genInfoToken_;
+  const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  const std::vector<std::string> muonPathsToPass_;
+
+  //options
+  const double minMuPt_;
+  const double maxMuEta_;
+  const double minTrackEta_;
+  const double maxTrackEta_;
+  const double minTrackPt_;
+  const double maxTransDCA_;
+  const double maxLongDCA_;
+  const double maxVtxChi_;
+  const double minInvMass_;
+  const double maxInvMass_;
+  const double trackIsoConesize_;
+  const double trackIsoInnerCone_;
+  const double ecalIsoConesize_;
+  const double minEcalHitE_;
+  const double maxTrackIso_;
+  const double maxEcalIso_;
+  const double minSigInvMass_;
+  const double maxSigInvMass_;
+  const double minStandaloneDr_;
+  const double maxStandaloneDE_;
+  const bool keepOffPeak_;
+  const bool keepSameSign_;
+  const bool keepTotalRegion_;
+  const bool keepPartialRegion_;
+};
+#endif

--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -54,7 +54,7 @@ private:
 
   bool passTriggers(const edm::Event& iEvent,
                     const edm::TriggerResults& results,
-                    std::vector<std::string> m_muonPathsToPass);
+                    const std::vector<std::string>& m_muonPathsToPass);
 
   bool findTrackInVertices(const reco::TrackRef& tkToMatch,
                            const reco::VertexCollection& vertices,
@@ -62,7 +62,7 @@ private:
                            unsigned int& trackIndex);
 
   double getTrackIsolation(const reco::TrackRef& tkToMatch, const reco::VertexCollection& vertices);
-  double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
+  double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack& track);
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<reco::MuonCollection> recoMuonToken_;

--- a/Configuration/Skimming/python/PDWG_EXODisappMuon_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappMuon_cff.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
+
+from Configuration.EventContent.EventContent_cff import AODSIMEventContent
+EXODisappMuonSkimContent = AODSIMEventContent.clone()
+EXODisappMuonSkimContent.outputCommands.append('keep *_hbhereco_*_*')
+EXODisappMuonSkimContent.outputCommands.append('keep *_horeco_*_*')
+EXODisappMuonSkimContent.outputCommands.append('keep *_csc2DRecHits_*_*')
+
+exoDisappMuonsHLT = hlt.hltHighLevel.clone(
+   throw = False,
+   andOr = True,
+   HLTPaths = [
+	"HLT_IsoMu*_v*"
+   ]
+)
+
+from Configuration.Skimming.disappearingMuonsSkimming_cfi import *
+disappMuonsSelection = disappearingMuonsSkimming.clone()
+
+EXODisappMuonSkimSequence = cms.Sequence(
+    exoDisappMuonsHLT+disappMuonsSelection
+)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -271,6 +271,17 @@ SKIMStreamEXODisplacedJet = cms.FilteredStream(
     dataTier = cms.untracked.string('USER')
     )
 
+from Configuration.Skimming.PDWG_EXODisappMuon_cff import *
+EXODisappMuonPath = cms.Path(EXODisappMuonSkimSequence)
+SKIMStreamEXODisappMuon = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXODisappMuon',
+    paths = (EXODisappMuonPath),
+    content = EXODisappMuonSkimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('USER')
+    )
+
 #####################
 # For the Data on Data Mixing in TSG
 from HLTrigger.Configuration.HLT_Fake1_cff import fragment as _fragment

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -257,7 +257,7 @@ bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup
 
 bool DisappearingMuonsSkimming::passTriggers(const edm::Event& iEvent,
                                              const edm::TriggerResults& triggerResults,
-                                             std::vector<std::string> m_muonPathsToPass) {
+                                             const std::vector<std::string>& m_muonPathsToPass) {
   bool passTriggers = false;
   const edm::TriggerNames& trigNames = iEvent.triggerNames(triggerResults);
   for (size_t i = 0; i < trigNames.size(); ++i) {
@@ -343,7 +343,7 @@ double DisappearingMuonsSkimming::getTrackIsolation(const reco::TrackRef& tkToMa
 
 double DisappearingMuonsSkimming::getECALIsolation(const edm::Event& iEvent,
                                                    const edm::EventSetup& iSetup,
-                                                   const reco::TransientTrack track) {
+                                                   const reco::TransientTrack& track) {
   edm::Handle<EcalRecHitCollection> rechitsEE;
   iEvent.getByToken(reducedEndcapRecHitCollectionToken_, rechitsEE);
 

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -409,7 +409,7 @@ void DisappearingMuonsSkimming::fillDescriptions(edm::ConfigurationDescriptions&
                                      });
   desc.add<double>("minMuPt", 26);
   desc.add<double>("maxMuEta", 2.4);
-  desc.add<double>("minTrackEta", 0);
+  desc.add<double>("minTrackEta", 1.4);
   desc.add<double>("maxTrackEta", 2.4);
   desc.add<double>("minTrackPt", 20);
   desc.add<double>("maxTransDCA", 0.005);

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -1,0 +1,444 @@
+// -*- C++ -*-
+//
+// Package:    MuMu/DisappearingMuonsSkimming
+// Class:      DisappearingMuonsSkimming
+//
+/**\class DisappearingMuonsSkimming DisappearingMuonsSkimming_AOD.cc MuMu/DisappearingMuonsSkimming/plugins/DisappearingMuonsSkimming_AOD.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Michael Revering
+//         Created:  Mon, 18 Jun 2018 21:22:23 GMT
+//
+//
+// system include files
+#include <memory>
+
+#include "Math/VectorUtil.h"
+// user include files
+#include "Configuration/Skimming/interface/DisappearingMuonsSkimming.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+
+DisappearingMuonsSkimming::DisappearingMuonsSkimming(const edm::ParameterSet& iConfig)
+    : recoMuonToken_(consumes<std::vector<reco::Muon>>(iConfig.getParameter<edm::InputTag>("recoMuons"))),
+      standaloneMuonToken_(consumes<std::vector<reco::Track>>(iConfig.getParameter<edm::InputTag>("StandaloneTracks"))),
+      trackCollectionToken_(consumes<std::vector<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracks"))),
+      primaryVerticesToken_(
+          consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+      reducedEndcapRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EERecHits"))),
+      reducedBarrelRecHitCollectionToken_(
+          consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EBRecHits"))),
+      trigResultsToken_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("TriggerResultsTag"))),
+      transientTrackToken_(
+          esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))),
+      geometryToken_(esConsumes<CaloGeometry, CaloGeometryRecord>(edm::ESInputTag{})),
+      muonPathsToPass_(iConfig.getParameter<std::vector<std::string>>("muonPathsToPass")),
+      minMuPt_(iConfig.getParameter<double>("minMuPt")),
+      maxMuEta_(iConfig.getParameter<double>("maxMuEta")),
+      minTrackEta_(iConfig.getParameter<double>("minTrackEta")),
+      maxTrackEta_(iConfig.getParameter<double>("maxTrackEta")),
+      minTrackPt_(iConfig.getParameter<double>("minTrackPt")),
+      maxTransDCA_(iConfig.getParameter<double>("maxTransDCA")),
+      maxLongDCA_(iConfig.getParameter<double>("maxLongDCA")),
+      maxVtxChi_(iConfig.getParameter<double>("maxVtxChi")),
+      minInvMass_(iConfig.getParameter<double>("minInvMass")),
+      maxInvMass_(iConfig.getParameter<double>("maxInvMass")),
+      trackIsoConesize_(iConfig.getParameter<double>("trackIsoConesize")),
+      trackIsoInnerCone_(iConfig.getParameter<double>("trackIsoInnerCone")),
+      ecalIsoConesize_(iConfig.getParameter<double>("ecalIsoConesize")),
+      minEcalHitE_(iConfig.getParameter<double>("minEcalHitE")),
+      maxTrackIso_(iConfig.getParameter<double>("maxTrackIso")),
+      maxEcalIso_(iConfig.getParameter<double>("maxEcalIso")),
+      minSigInvMass_(iConfig.getParameter<double>("minSigInvMass")),
+      maxSigInvMass_(iConfig.getParameter<double>("maxSigInvMass")),
+      minStandaloneDr_(iConfig.getParameter<double>("minStandaloneDr")),
+      maxStandaloneDE_(iConfig.getParameter<double>("maxStandaloneDE")),
+      keepOffPeak_(iConfig.getParameter<bool>("keepOffPeak")),
+      keepSameSign_(iConfig.getParameter<bool>("keepSameSign")),
+      keepTotalRegion_(iConfig.getParameter<bool>("keepTotalRegion")),
+      keepPartialRegion_(iConfig.getParameter<bool>("keepPartialRegion")) {}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+  using namespace reco;
+
+  bool totalRegion = false;
+  bool sameSign = false;
+  bool offPeak = false;
+  bool partialRegion = false;
+
+  edm::Handle<reco::TrackCollection> staTracks;
+  iEvent.getByToken(standaloneMuonToken_, staTracks);
+  edm::Handle<std::vector<reco::Vertex>> vertices;
+  iEvent.getByToken(primaryVerticesToken_, vertices);
+  edm::Handle<std::vector<reco::Muon>> recoMuons;
+  iEvent.getByToken(recoMuonToken_, recoMuons);
+  edm::Handle<std::vector<reco::Track>> thePATTrackHandle;
+  iEvent.getByToken(trackCollectionToken_, thePATTrackHandle);
+  // this wraps tracks with additional methods that are used in vertex-calculation
+  const TransientTrackBuilder* transientTrackBuilder = &iSetup.getData(transientTrackToken_);
+
+  if (!passTriggers(iEvent, trigResultsToken_, muonPathsToPass_))
+    return false;
+
+  int nMuonTrackCand = 0;
+  float MuonTrackMass = 0.;
+
+  //Looping over the reconstructed Muons
+  for (std::vector<reco::Muon>::const_iterator iMuon = recoMuons->begin(); iMuon != recoMuons->end(); iMuon++) {
+    if (!(iMuon->isPFMuon() && iMuon->isGlobalMuon()))
+      continue;
+    if (!(iMuon->passed(reco::Muon::CutBasedIdTight)))
+      continue;
+    if (!(iMuon->passed(reco::Muon::PFIsoTight)))
+      continue;
+    if (iMuon->pt() < minMuPt_ || fabs(iMuon->eta()) > maxMuEta_)
+      continue;
+
+    //Looping over tracks for any good muon
+    for (std::vector<reco::Track>::const_iterator iTrack = thePATTrackHandle->begin();
+         iTrack != thePATTrackHandle->end();
+         ++iTrack) {
+      if (!iTrack->quality(reco::Track::qualityByName("highPurity")))
+        continue;
+      if (fabs(iTrack->eta()) > maxTrackEta_ || fabs(iTrack->eta()) < minTrackEta_)
+        continue;
+      if (iTrack->pt() < minTrackPt_)
+        continue;
+      //Check if the track belongs to a primary vertex for isolation calculation
+      bool foundtrack = false;
+      GlobalPoint tkVtx;
+      for (unsigned int i = 0; i < vertices->size(); i++) {
+        reco::VertexRef vtx(vertices, i);
+        if (!vtx->isValid()) {
+          continue;
+        }
+        for (unsigned int j = 0; j < vtx->tracksSize(); j++) {
+          double dPt = fabs(vtx->trackRefAt(j)->pt() - iTrack->pt()) / iTrack->pt();
+          //Find the vertex track that is the same as the probe
+          if (dPt < 0.001) {
+            double dR2 = deltaR2(vtx->trackRefAt(j)->eta(), vtx->trackRefAt(j)->phi(), iTrack->eta(), iTrack->phi());
+            if (dR2 < 0.001 * 0.001) {
+              foundtrack = true;
+              GlobalPoint vert(vtx->x(), vtx->y(), vtx->z());
+              tkVtx = vert;
+              break;
+            }
+          }
+        }
+      }
+      if (!foundtrack)
+        continue;
+      reco::TransientTrack tk = transientTrackBuilder->build(*iTrack);
+      TrajectoryStateClosestToPoint traj = tk.trajectoryStateClosestToPoint(tkVtx);
+      double transDCA = traj.perigeeParameters().transverseImpactParameter();
+      double longDCA = traj.perigeeParameters().longitudinalImpactParameter();
+      if (fabs(longDCA) > maxLongDCA_)
+        continue;
+      if (fabs(transDCA) > maxTransDCA_)
+        continue;
+      // make a pair of TransientTracks to feed the vertexer
+      std::vector<reco::TransientTrack> tracksToVertex;
+      tracksToVertex.push_back(transientTrackBuilder->build(*iTrack));
+      tracksToVertex.push_back(transientTrackBuilder->build(iMuon->globalTrack()));
+      // try to fit these two tracks to a common vertex
+      KalmanVertexFitter vertexFitter;
+      CachingVertex<5> fittedVertex = vertexFitter.vertex(tracksToVertex);
+      double vtxChi = 0;
+      // some poor fits will simply fail to find a common vertex
+      if (fittedVertex.isValid() && fittedVertex.totalChiSquared() >= 0. && fittedVertex.degreesOfFreedom() > 0) {
+        // others we can exclude by their poor fit
+        vtxChi = fittedVertex.totalChiSquared() / fittedVertex.degreesOfFreedom();
+
+        if (vtxChi < maxVtxChi_) {
+          // important! evaluate momentum vectors AT THE VERTEX
+          TrajectoryStateClosestToPoint one_TSCP =
+              tracksToVertex[0].trajectoryStateClosestToPoint(fittedVertex.position());
+          TrajectoryStateClosestToPoint two_TSCP =
+              tracksToVertex[1].trajectoryStateClosestToPoint(fittedVertex.position());
+          GlobalVector one_momentum = one_TSCP.momentum();
+          GlobalVector two_momentum = two_TSCP.momentum();
+
+          double total_energy = sqrt(one_momentum.mag2() + 0.106 * 0.106) + sqrt(two_momentum.mag2() + 0.106 * 0.106);
+          double total_px = one_momentum.x() + two_momentum.x();
+          double total_py = one_momentum.y() + two_momentum.y();
+          double total_pz = one_momentum.z() + two_momentum.z();
+          MuonTrackMass = sqrt(pow(total_energy, 2) - pow(total_px, 2) - pow(total_py, 2) - pow(total_pz, 2));
+        } else {
+          continue;
+        }
+      } else {
+        continue;
+      }
+      if (MuonTrackMass < minInvMass_ || MuonTrackMass > maxInvMass_)
+        continue;
+
+      double trackIso = getTrackIsolation(iEvent, vertices, iTrack);
+      //Track iso returns -1 when it fails to find the vertex containing the track (already checked in track selection, but might as well make sure)
+      if (trackIso < 0)
+        continue;
+      double ecalIso = getECALIsolation(iEvent, iSetup, transientTrackBuilder->build(*iTrack));
+      if (trackIso > maxTrackIso_ || ecalIso > maxEcalIso_)
+        continue;
+
+      //A good tag/probe pair has been selected, now check for control or signal regions
+      if (iMuon->charge() == iTrack->charge()) {
+        sameSign = true;
+      }
+
+      //If not same sign CR, need to check standalone muons for signal regions
+      double staMinDr2 = 1000;
+      double staMinDEoverE = -10;
+      if (!staTracks->empty()) {
+        for (reco::TrackCollection::const_iterator staTrack = staTracks->begin(); staTrack != staTracks->end();
+             ++staTrack) {
+          reco::TransientTrack track = transientTrackBuilder->build(*staTrack);
+          double dR2 = deltaR2(track.impactPointTSCP().momentum().eta(),
+                               track.impactPointTSCP().momentum().phi(),
+                               (*iTrack).eta(),
+                               (*iTrack).phi());
+          double staDE = (std::sqrt(track.impactPointTSCP().momentum().mag2()) - (*iTrack).p()) / (*iTrack).p();
+          if (dR2 < staMinDr2) {
+            staMinDr2 = dR2;
+          }
+          //Pick the largest standalone muon within the cone
+          if (dR2 < minStandaloneDr_ * minStandaloneDr_ && staDE > staMinDEoverE) {
+            staMinDEoverE = staDE;
+          }
+        }
+      }
+      if (staMinDr2 > minStandaloneDr_ * minStandaloneDr_) {
+        if (MuonTrackMass < minSigInvMass_ || MuonTrackMass > maxSigInvMass_) {
+          offPeak = true;
+        } else {
+          totalRegion = true;
+        }
+      } else {
+        if (staMinDEoverE < maxStandaloneDE_) {
+          if (MuonTrackMass < minSigInvMass_ || MuonTrackMass > maxSigInvMass_) {
+            offPeak = true;
+          } else {
+            partialRegion = true;
+          }
+        }
+      }
+      nMuonTrackCand++;
+    }
+  }
+
+  if (nMuonTrackCand == 0)
+    return false;
+  bool passes = false;
+  //Pass all same sign CR events
+  if (sameSign && keepSameSign_) {
+    passes = true;
+  }
+  //Pass all total disappearance events
+  else if (totalRegion && keepTotalRegion_) {
+    passes = true;
+  }
+  //Pass all partial disappearkance off-peak events
+  else if (offPeak && keepOffPeak_) {
+    passes = true;
+  }
+  //Pass partial region events that pass minimum standalone muon DE/E.
+  else if (partialRegion && keepPartialRegion_) {
+    passes = true;
+  }
+  return passes;
+}
+
+bool DisappearingMuonsSkimming::passTriggers(const edm::Event& iEvent,
+                                             edm::EDGetToken m_trigResultsToken,
+                                             std::vector<std::string> m_muonPathsToPass) {
+  bool passTriggers = false;
+  edm::Handle<edm::TriggerResults> triggerResults;
+  iEvent.getByToken(m_trigResultsToken, triggerResults);
+  const edm::TriggerNames& trigNames = iEvent.triggerNames(*triggerResults);
+  for (size_t i = 0; i < trigNames.size(); ++i) {
+    const std::string& name = trigNames.triggerName(i);
+    for (auto& pathName : m_muonPathsToPass) {
+      if ((name.find(pathName) != std::string::npos)) {
+        if (triggerResults->accept(i)) {
+          passTriggers = true;
+          break;
+        }
+      }
+    }
+  }
+  return passTriggers;
+}
+
+double DisappearingMuonsSkimming::getTrackIsolation(const edm::Event& iEvent,
+                                                    edm::Handle<reco::VertexCollection> vtxHandle,
+                                                    std::vector<reco::Track>::const_iterator& iTrack) {
+  bool foundtrack = false;
+  unsigned int vtxindex = -1;
+  unsigned int trackindex = -1;
+  double Isolation = 0;
+  for (unsigned int i = 0; i < vtxHandle->size(); i++) {
+    reco::VertexRef vtx(vtxHandle, i);
+    if (!vtx->isValid()) {
+      continue;
+    }
+    for (unsigned int j = 0; j < vtx->tracksSize(); j++) {
+      double dPt = fabs(vtx->trackRefAt(j)->pt() - iTrack->pt()) / iTrack->pt();
+      //Find the vertex track that is the same as the probe
+      if (dPt < 0.001) {
+        double dR2 = deltaR2(vtx->trackRefAt(j)->eta(), vtx->trackRefAt(j)->phi(), iTrack->eta(), iTrack->phi());
+        if (dR2 < 0.001 * 0.001) {
+          vtxindex = i;
+          trackindex = j;
+          foundtrack = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!foundtrack) {
+    return -1;
+  }
+
+  reco::VertexRef primaryVtx(vtxHandle, vtxindex);
+
+  for (unsigned int i = 0; i < primaryVtx->tracksSize(); i++) {
+    if (i == trackindex)
+      continue;
+    reco::TrackBaseRef secondarytrack = primaryVtx->trackRefAt(i);
+    if (deltaR2(iTrack->eta(), iTrack->phi(), secondarytrack->eta(), secondarytrack->phi()) >
+            trackIsoConesize_ * trackIsoConesize_ ||
+        deltaR2(iTrack->eta(), iTrack->phi(), secondarytrack->eta(), secondarytrack->phi()) <
+            trackIsoInnerCone_ * trackIsoInnerCone_)
+      continue;
+    Isolation += secondarytrack->pt();
+  }
+
+  return Isolation / iTrack->pt();
+}
+
+double DisappearingMuonsSkimming::getECALIsolation(const edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup,
+                                                   const reco::TransientTrack track) {
+  edm::Handle<EcalRecHitCollection> rechitsEE;
+  iEvent.getByToken(reducedEndcapRecHitCollectionToken_, rechitsEE);
+
+  edm::Handle<EcalRecHitCollection> rechitsEB;
+  iEvent.getByToken(reducedBarrelRecHitCollectionToken_, rechitsEB);
+
+  const CaloGeometry& caloGeom = iSetup.getData(geometryToken_);
+  TrajectoryStateClosestToPoint t0 = track.impactPointTSCP();
+  double eDR = 0;
+
+  for (EcalRecHitCollection::const_iterator hit = rechitsEE->begin(); hit != rechitsEE->end(); hit++) {
+    const DetId id = (*hit).detid();
+    const GlobalPoint hitPos = caloGeom.getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
+    //Check if hit and track trajectory ar in the same endcap (transient track projects both ways)
+    if ((hitPos.eta() * t0.momentum().eta()) < 0) {
+      continue;
+    }
+    TrajectoryStateClosestToPoint traj = track.trajectoryStateClosestToPoint(hitPos);
+    math::XYZVector idPositionRoot(hitPos.x(), hitPos.y(), hitPos.z());
+    math::XYZVector trajRoot(traj.position().x(), traj.position().y(), traj.position().z());
+    if (deltaR2(idPositionRoot, trajRoot) < ecalIsoConesize_ * ecalIsoConesize_ && (*hit).energy() > minEcalHitE_) {
+      eDR += (*hit).energy();
+    }
+  }
+  for (EcalRecHitCollection::const_iterator hit = rechitsEB->begin(); hit != rechitsEB->end(); hit++) {
+    const DetId id = (*hit).detid();
+    const GlobalPoint hitPos = caloGeom.getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
+    if ((hitPos.eta() * t0.momentum().eta()) < 0) {
+      continue;
+    }
+    TrajectoryStateClosestToPoint traj = track.trajectoryStateClosestToPoint(hitPos);
+    math::XYZVector idPositionRoot(hitPos.x(), hitPos.y(), hitPos.z());
+    math::XYZVector trajRoot(traj.position().x(), traj.position().y(), traj.position().z());
+    if (deltaR2(idPositionRoot, trajRoot) < ecalIsoConesize_ * ecalIsoConesize_ && (*hit).energy() > minEcalHitE_) {
+      eDR += (*hit).energy();
+    }
+  }
+
+  return eDR;
+}
+
+void DisappearingMuonsSkimming::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("recoMuons", edm::InputTag("muons"));
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("StandaloneTracks", edm::InputTag("standAloneMuons"));
+  desc.add<edm::InputTag>("primaryVertices", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("EERecHits", edm::InputTag("reducedEcalRecHitsEE"));
+  desc.add<edm::InputTag>("EBRecHits", edm::InputTag("reducedEcalRecHitsEB"));
+  desc.add<edm::InputTag>("TriggerResultsTag", edm::InputTag("TriggerResults", "", "HLT"));
+  desc.add<std::vector<std::string>>("muonPathsToPass",
+                                     {
+                                         "HLT_IsoMu24_v",
+                                         "HLT_IsoMu27_v",
+                                     });
+  desc.add<double>("minMuPt", 26);
+  desc.add<double>("maxMuEta", 2.4);
+  desc.add<double>("minTrackEta", 0);
+  desc.add<double>("maxTrackEta", 2.4);
+  desc.add<double>("minTrackPt", 20);
+  desc.add<double>("maxTransDCA", 0.005);
+  desc.add<double>("maxLongDCA", 0.05);
+  desc.add<double>("maxVtxChi", 3.0);
+  desc.add<double>("minInvMass", 50);
+  desc.add<double>("maxInvMass", 150);
+  desc.add<double>("trackIsoConesize", 0.3);
+  desc.add<double>("trackIsoInnerCone", 0.01);
+  desc.add<double>("ecalIsoConesize", 0.4);
+  desc.add<double>("minEcalHitE", 0.3);
+  desc.add<double>("maxTrackIso", 0.05);
+  desc.add<double>("maxEcalIso", 10);
+  desc.add<double>("minSigInvMass", 76);
+  desc.add<double>("maxSigInvMass", 106);
+  desc.add<double>("minStandaloneDr", 1.0);
+  desc.add<double>("maxStandaloneDE", -0.5);
+  desc.add<bool>("keepOffPeak", true);
+  desc.add<bool>("keepSameSign", true);
+  desc.add<bool>("keepTotalRegion", true);
+  desc.add<bool>("keepPartialRegion", true);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void DisappearingMuonsSkimming::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void DisappearingMuonsSkimming::endJob() {}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(DisappearingMuonsSkimming);

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -17,38 +17,27 @@
 //
 // system include files
 #include <memory>
-
 #include "Math/VectorUtil.h"
+
 // user include files
 #include "Configuration/Skimming/interface/DisappearingMuonsSkimming.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "FWCore/Common/interface/TriggerNames.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 
 DisappearingMuonsSkimming::DisappearingMuonsSkimming(const edm::ParameterSet& iConfig)
-    : recoMuonToken_(consumes<std::vector<reco::Muon>>(iConfig.getParameter<edm::InputTag>("recoMuons"))),
-      standaloneMuonToken_(consumes<std::vector<reco::Track>>(iConfig.getParameter<edm::InputTag>("StandaloneTracks"))),
-      trackCollectionToken_(consumes<std::vector<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracks"))),
-      primaryVerticesToken_(
-          consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+    : recoMuonToken_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("recoMuons"))),
+      standaloneMuonToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("StandaloneTracks"))),
+      trackCollectionToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+      primaryVerticesToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
       reducedEndcapRecHitCollectionToken_(
           consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EERecHits"))),
       reducedBarrelRecHitCollectionToken_(
@@ -98,80 +87,68 @@ bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup
   bool offPeak = false;
   bool partialRegion = false;
 
-  edm::Handle<reco::TrackCollection> staTracks;
-  iEvent.getByToken(standaloneMuonToken_, staTracks);
-  edm::Handle<std::vector<reco::Vertex>> vertices;
-  iEvent.getByToken(primaryVerticesToken_, vertices);
-  edm::Handle<std::vector<reco::Muon>> recoMuons;
-  iEvent.getByToken(recoMuonToken_, recoMuons);
-  edm::Handle<std::vector<reco::Track>> thePATTrackHandle;
-  iEvent.getByToken(trackCollectionToken_, thePATTrackHandle);
+  const auto& staTracks = iEvent.get(standaloneMuonToken_);
+  const auto& vertices = iEvent.get(primaryVerticesToken_);
+  const auto& recoMuons = iEvent.get(recoMuonToken_);
+  const auto& thePATTracks = iEvent.get(trackCollectionToken_);
+  const auto& triggerResults = iEvent.get(trigResultsToken_);
+
   // this wraps tracks with additional methods that are used in vertex-calculation
   const TransientTrackBuilder* transientTrackBuilder = &iSetup.getData(transientTrackToken_);
 
-  if (!passTriggers(iEvent, trigResultsToken_, muonPathsToPass_))
+  if (!passTriggers(iEvent, triggerResults, muonPathsToPass_))
     return false;
 
   int nMuonTrackCand = 0;
   float MuonTrackMass = 0.;
 
   //Looping over the reconstructed Muons
-  for (std::vector<reco::Muon>::const_iterator iMuon = recoMuons->begin(); iMuon != recoMuons->end(); iMuon++) {
-    if (!(iMuon->isPFMuon() && iMuon->isGlobalMuon()))
+  for (const auto& iMuon : recoMuons) {
+    if (!(iMuon.isPFMuon() && iMuon.isGlobalMuon()))
       continue;
-    if (!(iMuon->passed(reco::Muon::CutBasedIdTight)))
+    if (!(iMuon.passed(reco::Muon::CutBasedIdTight)))
       continue;
-    if (!(iMuon->passed(reco::Muon::PFIsoTight)))
+    if (!(iMuon.passed(reco::Muon::PFIsoTight)))
       continue;
-    if (iMuon->pt() < minMuPt_ || fabs(iMuon->eta()) > maxMuEta_)
+    if (iMuon.pt() < minMuPt_ || std::abs(iMuon.eta()) > maxMuEta_)
       continue;
 
     //Looping over tracks for any good muon
-    for (std::vector<reco::Track>::const_iterator iTrack = thePATTrackHandle->begin();
-         iTrack != thePATTrackHandle->end();
-         ++iTrack) {
-      if (!iTrack->quality(reco::Track::qualityByName("highPurity")))
+    int indx(0);
+    for (const auto& iTrack : thePATTracks) {
+      reco::TrackRef trackRef = reco::TrackRef(&thePATTracks, indx);
+      indx++;
+
+      if (!iTrack.quality(reco::Track::qualityByName("highPurity")))
         continue;
-      if (fabs(iTrack->eta()) > maxTrackEta_ || fabs(iTrack->eta()) < minTrackEta_)
+      if (std::abs(iTrack.eta()) > maxTrackEta_ || std::abs(iTrack.eta()) < minTrackEta_)
         continue;
-      if (iTrack->pt() < minTrackPt_)
+      if (iTrack.pt() < minTrackPt_)
         continue;
       //Check if the track belongs to a primary vertex for isolation calculation
-      bool foundtrack = false;
-      GlobalPoint tkVtx;
-      for (unsigned int i = 0; i < vertices->size(); i++) {
-        reco::VertexRef vtx(vertices, i);
-        if (!vtx->isValid()) {
-          continue;
-        }
-        for (unsigned int j = 0; j < vtx->tracksSize(); j++) {
-          double dPt = fabs(vtx->trackRefAt(j)->pt() - iTrack->pt()) / iTrack->pt();
-          //Find the vertex track that is the same as the probe
-          if (dPt < 0.001) {
-            double dR2 = deltaR2(vtx->trackRefAt(j)->eta(), vtx->trackRefAt(j)->phi(), iTrack->eta(), iTrack->phi());
-            if (dR2 < 0.001 * 0.001) {
-              foundtrack = true;
-              GlobalPoint vert(vtx->x(), vtx->y(), vtx->z());
-              tkVtx = vert;
-              break;
-            }
-          }
-        }
-      }
+
+      unsigned int vtxIndex;
+      unsigned int tkIndex;
+      bool foundtrack = this->findTrackInVertices(trackRef, vertices, vtxIndex, tkIndex);
+
       if (!foundtrack)
         continue;
-      reco::TransientTrack tk = transientTrackBuilder->build(*iTrack);
+
+      reco::VertexRef vtx(&vertices, vtxIndex);
+      GlobalPoint tkVtx = GlobalPoint(vtx->x(), vtx->y(), vtx->z());
+
+      reco::TransientTrack tk = transientTrackBuilder->build(iTrack);
       TrajectoryStateClosestToPoint traj = tk.trajectoryStateClosestToPoint(tkVtx);
       double transDCA = traj.perigeeParameters().transverseImpactParameter();
       double longDCA = traj.perigeeParameters().longitudinalImpactParameter();
-      if (fabs(longDCA) > maxLongDCA_)
+      if (std::abs(longDCA) > maxLongDCA_)
         continue;
-      if (fabs(transDCA) > maxTransDCA_)
+      if (std::abs(transDCA) > maxTransDCA_)
         continue;
       // make a pair of TransientTracks to feed the vertexer
       std::vector<reco::TransientTrack> tracksToVertex;
-      tracksToVertex.push_back(transientTrackBuilder->build(*iTrack));
-      tracksToVertex.push_back(transientTrackBuilder->build(iMuon->globalTrack()));
+      tracksToVertex.push_back(tk);
+      tracksToVertex.push_back(transientTrackBuilder->build(iMuon.globalTrack()));
       // try to fit these two tracks to a common vertex
       KalmanVertexFitter vertexFitter;
       CachingVertex<5> fittedVertex = vertexFitter.vertex(tracksToVertex);
@@ -204,31 +181,30 @@ bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup
       if (MuonTrackMass < minInvMass_ || MuonTrackMass > maxInvMass_)
         continue;
 
-      double trackIso = getTrackIsolation(iEvent, vertices, iTrack);
+      double trackIso = getTrackIsolation(trackRef, vertices);
       //Track iso returns -1 when it fails to find the vertex containing the track (already checked in track selection, but might as well make sure)
       if (trackIso < 0)
         continue;
-      double ecalIso = getECALIsolation(iEvent, iSetup, transientTrackBuilder->build(*iTrack));
+      double ecalIso = getECALIsolation(iEvent, iSetup, transientTrackBuilder->build(iTrack));
       if (trackIso > maxTrackIso_ || ecalIso > maxEcalIso_)
         continue;
 
       //A good tag/probe pair has been selected, now check for control or signal regions
-      if (iMuon->charge() == iTrack->charge()) {
+      if (iMuon.charge() == iTrack.charge()) {
         sameSign = true;
       }
 
       //If not same sign CR, need to check standalone muons for signal regions
       double staMinDr2 = 1000;
       double staMinDEoverE = -10;
-      if (!staTracks->empty()) {
-        for (reco::TrackCollection::const_iterator staTrack = staTracks->begin(); staTrack != staTracks->end();
-             ++staTrack) {
-          reco::TransientTrack track = transientTrackBuilder->build(*staTrack);
+      if (!staTracks.empty()) {
+        for (const auto& staTrack : staTracks) {
+          reco::TransientTrack track = transientTrackBuilder->build(staTrack);
           double dR2 = deltaR2(track.impactPointTSCP().momentum().eta(),
                                track.impactPointTSCP().momentum().phi(),
-                               (*iTrack).eta(),
-                               (*iTrack).phi());
-          double staDE = (std::sqrt(track.impactPointTSCP().momentum().mag2()) - (*iTrack).p()) / (*iTrack).p();
+                               iTrack.eta(),
+                               iTrack.phi());
+          double staDE = (std::sqrt(track.impactPointTSCP().momentum().mag2()) - iTrack.p()) / iTrack.p();
           if (dR2 < staMinDr2) {
             staMinDr2 = dR2;
           }
@@ -280,17 +256,15 @@ bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup
 }
 
 bool DisappearingMuonsSkimming::passTriggers(const edm::Event& iEvent,
-                                             edm::EDGetToken m_trigResultsToken,
+                                             const edm::TriggerResults& triggerResults,
                                              std::vector<std::string> m_muonPathsToPass) {
   bool passTriggers = false;
-  edm::Handle<edm::TriggerResults> triggerResults;
-  iEvent.getByToken(m_trigResultsToken, triggerResults);
-  const edm::TriggerNames& trigNames = iEvent.triggerNames(*triggerResults);
+  const edm::TriggerNames& trigNames = iEvent.triggerNames(triggerResults);
   for (size_t i = 0; i < trigNames.size(); ++i) {
     const std::string& name = trigNames.triggerName(i);
     for (auto& pathName : m_muonPathsToPass) {
       if ((name.find(pathName) != std::string::npos)) {
-        if (triggerResults->accept(i)) {
+        if (triggerResults.accept(i)) {
           passTriggers = true;
           break;
         }
@@ -300,52 +274,71 @@ bool DisappearingMuonsSkimming::passTriggers(const edm::Event& iEvent,
   return passTriggers;
 }
 
-double DisappearingMuonsSkimming::getTrackIsolation(const edm::Event& iEvent,
-                                                    edm::Handle<reco::VertexCollection> vtxHandle,
-                                                    std::vector<reco::Track>::const_iterator& iTrack) {
-  bool foundtrack = false;
-  unsigned int vtxindex = -1;
-  unsigned int trackindex = -1;
-  double Isolation = 0;
-  for (unsigned int i = 0; i < vtxHandle->size(); i++) {
-    reco::VertexRef vtx(vtxHandle, i);
-    if (!vtx->isValid()) {
+bool DisappearingMuonsSkimming::findTrackInVertices(const reco::TrackRef& tkToMatch,
+                                                    const reco::VertexCollection& vertices,
+                                                    unsigned int& vtxIndex,
+                                                    unsigned int& trackIndex) {
+  // initialize indices
+  vtxIndex = -1;
+  trackIndex = -1;
+
+  bool foundtrack{false};
+  unsigned int idx = 0;
+  for (const auto& vtx : vertices) {
+    if (!vtx.isValid()) {
+      idx++;
       continue;
     }
-    for (unsigned int j = 0; j < vtx->tracksSize(); j++) {
-      double dPt = fabs(vtx->trackRefAt(j)->pt() - iTrack->pt()) / iTrack->pt();
-      //Find the vertex track that is the same as the probe
-      if (dPt < 0.001) {
-        double dR2 = deltaR2(vtx->trackRefAt(j)->eta(), vtx->trackRefAt(j)->phi(), iTrack->eta(), iTrack->phi());
-        if (dR2 < 0.001 * 0.001) {
-          vtxindex = i;
-          trackindex = j;
-          foundtrack = true;
-          break;
-        }
-      }
+
+    std::vector<unsigned int> thePVkeys;
+    thePVkeys.reserve(vtx.tracksSize());
+    for (unsigned int i=0; i<vtx.tracksSize(); i++){
+      thePVkeys.push_back(vtx.trackRefAt(i).key());
     }
+
+    auto result = std::find_if(
+        thePVkeys.begin(), thePVkeys.end(), [tkToMatch](const auto& tkRef) { return tkRef == tkToMatch.key(); });
+    if (result != thePVkeys.end()) {
+      foundtrack = true;
+      trackIndex = std::distance(thePVkeys.begin(), result);
+      vtxIndex = idx;
+    }
+    if (foundtrack)
+      break;
+    idx++;
   }
+  return foundtrack;
+}
+
+double DisappearingMuonsSkimming::getTrackIsolation(const reco::TrackRef& tkToMatch,
+                                                    const reco::VertexCollection& vertices) {
+  unsigned int vtxindex;
+  unsigned int trackIndex;
+  bool foundtrack = this->findTrackInVertices(tkToMatch, vertices, vtxindex, trackIndex);
+
+  LogDebug("DisappearingMuonsSkimming") << "getTrackIsolation vtx Index: " << vtxindex
+                                        << " track Index: " << trackIndex;
 
   if (!foundtrack) {
-    return -1;
+    return -1.;
   }
 
-  reco::VertexRef primaryVtx(vtxHandle, vtxindex);
+  reco::VertexRef primaryVtx(&vertices, vtxindex);
 
+  double Isolation = 0;
   for (unsigned int i = 0; i < primaryVtx->tracksSize(); i++) {
-    if (i == trackindex)
+    if (i == trackIndex)
       continue;
     reco::TrackBaseRef secondarytrack = primaryVtx->trackRefAt(i);
-    if (deltaR2(iTrack->eta(), iTrack->phi(), secondarytrack->eta(), secondarytrack->phi()) >
+    if (deltaR2(tkToMatch.get()->eta(), tkToMatch.get()->phi(), secondarytrack->eta(), secondarytrack->phi()) >
             trackIsoConesize_ * trackIsoConesize_ ||
-        deltaR2(iTrack->eta(), iTrack->phi(), secondarytrack->eta(), secondarytrack->phi()) <
+        deltaR2(tkToMatch.get()->eta(), tkToMatch.get()->phi(), secondarytrack->eta(), secondarytrack->phi()) <
             trackIsoInnerCone_ * trackIsoInnerCone_)
       continue;
     Isolation += secondarytrack->pt();
   }
 
-  return Isolation / iTrack->pt();
+  return Isolation / tkToMatch.get()->pt();
 }
 
 double DisappearingMuonsSkimming::getECALIsolation(const edm::Event& iEvent,
@@ -433,12 +426,6 @@ void DisappearingMuonsSkimming::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<bool>("keepPartialRegion", true);
   descriptions.addWithDefaultLabel(desc);
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DisappearingMuonsSkimming::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DisappearingMuonsSkimming::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DisappearingMuonsSkimming);

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -292,7 +292,7 @@ bool DisappearingMuonsSkimming::findTrackInVertices(const reco::TrackRef& tkToMa
 
     std::vector<unsigned int> thePVkeys;
     thePVkeys.reserve(vtx.tracksSize());
-    for (unsigned int i=0; i<vtx.tracksSize(); i++){
+    for (unsigned int i = 0; i < vtx.tracksSize(); i++) {
       thePVkeys.push_back(vtx.trackRefAt(i).key());
     }
 


### PR DESCRIPTION
#### PR description:

Backport of #40666 to CMSSW_10_6_X for run 2 data skimming.
There are three changes with respect to the 13_1_X version:
-The run 2 analysis only uses tracks in the HCAL endcap because of the need for the increased resolution from the SiPMs, so the default minTrackEta is set to 1.4 instead of zero.
- reco::vertex does not have a tracks() method in 10_6_X, so I replaced the loop using it in findTrackInVertices() with an older style one.
- reco::VertexCollection is not included by Vertex.h (or wherever it was found) in 10_6_X, so I included VertexFwd.h to get it instead.

#### PR validation:
I tested the filter using a Run 2 2018 DY MC file to verify that all utilities used in the skim are available in CMSSW_10_6_X.
