### PR TITLE
Timing Service now measures time not running a Module

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -885,7 +885,9 @@ namespace edm {
 
     // make the services available
     ServiceRegistry::Operate operate(serviceToken_);
-
+    actReg_->beginProcessingSignal_();
+    auto endSignal = [](ActivityRegistry* iReg) { iReg->endProcessingSignal_(); };
+    std::unique_ptr<ActivityRegistry, decltype(endSignal)> guard(actReg_.get(), endSignal);
     try {
       FilesProcessor fp(fileModeNoMerge_);
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1179,7 +1179,7 @@ namespace edm {
 
     auto status = std::make_shared<RunProcessingStatus>(preallocations_.numberOfStreams(), iHolder);
 
-    chain::first([this, &status, &iSync](auto nextTask) {
+    chain::first([this, &status, iSync](auto nextTask) {
       espController_->runOrQueueEventSetupForInstanceAsync(iSync,
                                                            nextTask,
                                                            status->endIOVWaitingTasks(),
@@ -1188,7 +1188,7 @@ namespace edm {
                                                            actReg_.get(),
                                                            serviceToken_,
                                                            forceESCacheClearOnNewRun_);
-    }) | chain::then([this, status, iSync](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, status](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         if (iException) {
           WaitingTaskHolder copyHolder(nextTask);
@@ -1433,7 +1433,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, iRunStatus, ts](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, iRunStatus](std::exception_ptr const* iException, auto nextTask) {
       if (iException) {
         iRunStatus->setEndingEventSetupSucceeded(false);
         handleEndRunExceptions(*iException, nextTask);
@@ -1633,7 +1633,7 @@ namespace edm {
                                                            queueWhichWaitsForIOVsToFinish_,
                                                            actReg_.get(),
                                                            serviceToken_);
-    }) | chain::then([this, status, iRunStatus, iSync](std::exception_ptr const* iException, auto nextTask) {
+    }) | chain::then([this, status, iRunStatus](std::exception_ptr const* iException, auto nextTask) {
       CMS_SA_ALLOW try {
         //the call to doneWaiting will cause the count to decrement
         if (iException) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1196,7 +1196,6 @@ namespace edm {
           // Finish handling the exception in the task pushed to runQueue_
         }
         ServiceRegistry::Operate operate(serviceToken_);
-        actReg_->postESSyncIOVSignal_.emit(iSync);
 
         runQueue_->pushAndPause(
             *nextTask.group(),
@@ -1440,11 +1439,6 @@ namespace edm {
         handleEndRunExceptions(*iException, nextTask);
       }
       ServiceRegistry::Operate operate(serviceToken_);
-      CMS_SA_ALLOW try { actReg_->postESSyncIOVSignal_.emit(ts); } catch (...) {
-        WaitingTaskHolder copyHolder(nextTask);
-        copyHolder.doneWaiting(std::current_exception());
-      }
-
       streamQueuesInserter_.push(*nextTask.group(), [this, nextTask]() mutable {
         for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
           CMS_SA_ALLOW try {
@@ -1646,9 +1640,6 @@ namespace edm {
           WaitingTaskHolder copyHolder(nextTask);
           copyHolder.doneWaiting(*iException);
         }
-
-        ServiceRegistry::Operate operate(serviceToken_);
-        actReg_->postESSyncIOVSignal_.emit(iSync);
 
         lumiQueue_->pushAndPause(
             *nextTask.group(),

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -119,10 +119,8 @@ namespace edm {
                 // new SyncValue in the call. The async part is just waiting for
                 // the Records to be available which is done after the SyncValue setup.
                 actReg->preESSyncIOVSignal_.emit(iSync);
-                auto postSignal = [&iSync](ActivityRegistry* actReg) {
-                  actReg->postESSyncIOVSignal_.emit(iSync);
-                };
-                std::unique_ptr<ActivityRegistry,decltype(postSignal)> guard(actReg, postSignal);
+                auto postSignal = [&iSync](ActivityRegistry* actReg) { actReg->postESSyncIOVSignal_.emit(iSync); };
+                std::unique_ptr<ActivityRegistry, decltype(postSignal)> guard(actReg, postSignal);
                 eventSetupForInstanceAsync(iSync, task, endIOVWaitingTasks, eventSetupImpls);
               }
               sentry.completedSuccessfully();

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -114,8 +114,17 @@ namespace edm {
                 forceCacheClear();
               }
               SendSourceTerminationSignalIfException sentry(actReg);
-              actReg->preESSyncIOVSignal_.emit(iSync);
-              eventSetupForInstanceAsync(iSync, task, endIOVWaitingTasks, eventSetupImpls);
+              {
+                //all EventSetupRecordIntervalFinders are sequentially set to the
+                // new SyncValue in the call. The async part is just waiting for
+                // the Records to be available which is done after the SyncValue setup.
+                actReg->preESSyncIOVSignal_.emit(iSync);
+                auto postSignal = [&iSync](ActivityRegistry* actReg) {
+                  actReg->postESSyncIOVSignal_.emit(iSync);
+                };
+                std::unique_ptr<ActivityRegistry,decltype(postSignal)> guard(actReg, postSignal);
+                eventSetupForInstanceAsync(iSync, task, endIOVWaitingTasks, eventSetupImpls);
+              }
               sentry.completedSuccessfully();
             } catch (...) {
               task.doneWaiting(std::current_exception());

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -82,6 +82,7 @@ ModuleCallingContext state = Running
 ++++ finished: global begin run 1 : time = 1000000
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
@@ -108,7 +109,6 @@ ModuleCallingContext state = Running
     ProcessContext: TEST d84cfc6bef4d9d1fe04243c166360a06
 
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
@@ -483,6 +483,7 @@ ModuleCallingContext state = Running
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
@@ -513,7 +514,6 @@ ModuleCallingContext state = Running
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
-++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndRun

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -50,13 +50,13 @@
 ++++ finished: global begin run 1 : time = 1000000
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
@@ -147,6 +147,7 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
@@ -157,7 +158,6 @@
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
-++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end run for module: stream = 0 label = 'two' id = 5

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -321,6 +321,7 @@ GlobalContext: transition = BeginRun
 
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -377,7 +378,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
@@ -1198,6 +1198,7 @@ StreamContext: StreamID = 0 transition = Event
 
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1364,7 +1365,6 @@ GlobalContext: transition = WriteLuminosityBlock
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -134,6 +134,7 @@ GlobalContext: transition = BeginRun
 
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -172,7 +173,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
@@ -671,6 +671,7 @@ StreamContext: StreamID = 0 transition = Event
 
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -735,7 +736,6 @@ GlobalContext: transition = WriteLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1086,6 +1086,7 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 2 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 2 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 2 event: 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
@@ -1196,7 +1197,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
-++++ post: EventSetup synchronizing run: 1 lumi: 2 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
@@ -1919,6 +1919,7 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 3 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 3 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 3 event: 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
@@ -2029,7 +2030,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
-++++ post: EventSetup synchronizing run: 1 lumi: 3 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
@@ -2440,6 +2440,7 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
@@ -2550,7 +2551,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
-++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ queuing: EventSetup synchronization run: 2 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 2 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 2 lumi: 0 event: 0
@@ -2744,6 +2744,7 @@
 ++++ finished: global begin run 2 : time = 55000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 2 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
@@ -2762,7 +2763,6 @@
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
-++++ post: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
@@ -3485,6 +3485,7 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 2 event: 0
 ++++ pre: EventSetup synchronizing run: 2 lumi: 2 event: 0
+++++ post: EventSetup synchronizing run: 2 lumi: 2 event: 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
@@ -3595,7 +3596,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
-++++ post: EventSetup synchronizing run: 2 lumi: 2 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
@@ -4318,6 +4318,7 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 3 event: 0
 ++++ pre: EventSetup synchronizing run: 2 lumi: 3 event: 0
+++++ post: EventSetup synchronizing run: 2 lumi: 3 event: 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
@@ -4428,7 +4429,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
-++++ post: EventSetup synchronizing run: 2 lumi: 3 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
@@ -4839,6 +4839,7 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
@@ -4949,7 +4950,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
-++++ post: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
 ++++ queuing: EventSetup synchronization run: 3 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 3 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 3 lumi: 0 event: 0
@@ -5143,6 +5143,7 @@
 ++++ finished: global begin run 3 : time = 105000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 3 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
@@ -5161,7 +5162,6 @@
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
-++++ post: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
@@ -5884,6 +5884,7 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 2 event: 0
 ++++ pre: EventSetup synchronizing run: 3 lumi: 2 event: 0
+++++ post: EventSetup synchronizing run: 3 lumi: 2 event: 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
@@ -5994,7 +5995,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
-++++ post: EventSetup synchronizing run: 3 lumi: 2 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
@@ -6717,6 +6717,7 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 3 event: 0
 ++++ pre: EventSetup synchronizing run: 3 lumi: 3 event: 0
+++++ post: EventSetup synchronizing run: 3 lumi: 3 event: 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
@@ -6827,7 +6828,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
-++++ post: EventSetup synchronizing run: 3 lumi: 3 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
@@ -7238,6 +7238,7 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ pre: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
+++++ post: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
@@ -7348,7 +7349,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
-++++ post: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -327,6 +327,18 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_1(watchPostEndProcessBlock)
 
+    typedef signalslot::Signal<void()> BeginProcessing;
+    /// signal is emitted just before the transitions from the Source will begin to be processed
+    BeginProcessing beginProcessingSignal_;
+    void watchBeginProcessing(BeginProcessing::slot_type const& iSlot) { beginProcessingSignal_.connect(iSlot); }
+    AR_WATCH_USING_METHOD_0(watchBeginProcessing)
+
+    typedef signalslot::Signal<void()> EndProcessing;
+    /// signal is emitted after all work has been done processing all transitions
+    EndProcessing endProcessingSignal_;
+    void watchEndProcessing(EndProcessing::slot_type const& iSlot) { endProcessingSignal_.connect(iSlot); }
+    AR_WATCH_USING_METHOD_0(watchEndProcessing)
+
     typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalBeginRun;
     /// signal is emitted after the Run has been created by the InputSource but before any modules have seen the Run
     PreGlobalBeginRun preGlobalBeginRunSignal_;

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -334,7 +334,7 @@ namespace edm {
     AR_WATCH_USING_METHOD_0(watchBeginProcessing)
 
     typedef signalslot::Signal<void()> EndProcessing;
-    /// signal is emitted after all work has been done processing all transitions
+    /// signal is emitted after all work has been done processing all source transitions
     EndProcessing endProcessingSignal_;
     void watchEndProcessing(EndProcessing::slot_type const& iSlot) { endProcessingSignal_.connect(iSlot); }
     AR_WATCH_USING_METHOD_0(watchEndProcessing)

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -90,6 +90,8 @@ namespace edm {
 
   void ActivityRegistry::connectGlobals(ActivityRegistry& iOther) {
     preallocateSignal_.connect(std::cref(iOther.preallocateSignal_));
+    beginProcessingSignal_.connect(std::cref(iOther.beginProcessingSignal_));
+    endProcessingSignal_.connect(std::cref(iOther.endProcessingSignal_));
     postBeginJobSignal_.connect(std::cref(iOther.postBeginJobSignal_));
     preEndJobSignal_.connect(std::cref(iOther.preEndJobSignal_));
     postEndJobSignal_.connect(std::cref(iOther.postEndJobSignal_));
@@ -327,6 +329,8 @@ namespace edm {
 
   void ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
     copySlotsToFrom(preallocateSignal_, iOther.preallocateSignal_);
+    copySlotsToFrom(beginProcessingSignal_, iOther.beginProcessingSignal_);
+    copySlotsToFrom(endProcessingSignal_, iOther.endProcessingSignal_);
     copySlotsToFrom(preBeginJobSignal_, iOther.preBeginJobSignal_);
     copySlotsToFrom(postBeginJobSignal_, iOther.postBeginJobSignal_);
     copySlotsToFromReverse(preEndJobSignal_, iOther.preEndJobSignal_);

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -57,7 +57,7 @@ namespace edm {
 
     private:
       void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
-      void postBeginProcessBlock(GlobalContext const&);
+      void beginProcessing();
       void postEndJob();
 
       void preEvent(StreamContext const&);
@@ -230,7 +230,7 @@ namespace edm {
           configuredInTopLevelProcess_{false},
           nSubProcesses_{0} {
       iRegistry.watchPreBeginJob(this, &Timing::preBeginJob);
-      iRegistry.watchPostBeginProcessBlock(this, &Timing::postBeginProcessBlock);
+      iRegistry.watchBeginProcessing(this, &Timing::beginProcessing);
       iRegistry.watchPreEndJob([this]() {
         end_loop_time_ = getTime();
         end_loop_cpu_ = getCPU();
@@ -446,7 +446,7 @@ namespace edm {
       }
     }
 
-    void Timing::postBeginProcessBlock(GlobalContext const&) {
+    void Timing::beginProcessing() {
       if (!configuredInTopLevelProcess_) {
         return;
       }

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -57,7 +57,7 @@ namespace edm {
 
     private:
       void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
-      void postBeginJob();
+      void postBeginProcessBlock(GlobalContext const&);
       void postEndJob();
 
       void preEvent(StreamContext const&);
@@ -230,7 +230,7 @@ namespace edm {
           configuredInTopLevelProcess_{false},
           nSubProcesses_{0} {
       iRegistry.watchPreBeginJob(this, &Timing::preBeginJob);
-      iRegistry.watchPostBeginJob(this, &Timing::postBeginJob);
+      iRegistry.watchPostBeginProcessBlock(this, &Timing::postBeginProcessBlock);
       iRegistry.watchPreEndJob([this]() {
         end_loop_time_ = getTime();
         end_loop_cpu_ = getCPU();
@@ -446,7 +446,7 @@ namespace edm {
       }
     }
 
-    void Timing::postBeginJob() {
+    void Timing::postBeginProcessBlock(GlobalContext const&) {
       if (!configuredInTopLevelProcess_) {
         return;
       }

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -107,7 +107,7 @@ namespace edm {
       bool summary_only_;
       bool report_summary_;
       double threshold_;
-      
+
       std::atomic<bool> updating_task_info_ = false;
       CMS_THREAD_GUARD(updating_task_info_) unsigned int num_running_tasks_ = 0;
       CMS_THREAD_GUARD(updating_task_info_) double last_task_change_time_ = 0;
@@ -369,46 +369,46 @@ namespace edm {
       });
       setTaskCallbacks(iRegistry);
     }
-  
+
     void Timing::setTaskCallbacks(ActivityRegistry& iRegistry) {
-      iRegistry.preSourceSignal_.connect([this](auto){addTask();});
-      iRegistry.postSourceSignal_.connect([this](auto){removeTask();});
+      iRegistry.preSourceSignal_.connect([this](auto) { addTask(); });
+      iRegistry.postSourceSignal_.connect([this](auto) { removeTask(); });
 
-      iRegistry.preModuleEventSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleEventSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleEventSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleEventSignal_.connect([this](auto, auto) { removeTask(); });
 
-      iRegistry.preSourceLumiSignal_.connect([this](auto){addTask();});
-      iRegistry.postSourceLumiSignal_.connect([this](auto){removeTask();});
+      iRegistry.preSourceLumiSignal_.connect([this](auto) { addTask(); });
+      iRegistry.postSourceLumiSignal_.connect([this](auto) { removeTask(); });
 
-      iRegistry.preSourceRunSignal_.connect([this](auto){addTask();});
-      iRegistry.postSourceRunSignal_.connect([this](auto){removeTask();});
+      iRegistry.preSourceRunSignal_.connect([this](auto) { addTask(); });
+      iRegistry.postSourceRunSignal_.connect([this](auto) { removeTask(); });
 
-      iRegistry.preEventReadFromSourceSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postEventReadFromSourceSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preEventReadFromSourceSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postEventReadFromSourceSignal_.connect([this](auto, auto) { removeTask(); });
 
-      iRegistry.preModuleStreamBeginRunSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleStreamBeginRunSignal_.connect([this](auto, auto){removeTask();});
-      iRegistry.preModuleStreamEndRunSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleStreamEndRunSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleStreamBeginRunSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleStreamBeginRunSignal_.connect([this](auto, auto) { removeTask(); });
+      iRegistry.preModuleStreamEndRunSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleStreamEndRunSignal_.connect([this](auto, auto) { removeTask(); });
 
-      iRegistry.preModuleStreamBeginLumiSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleStreamBeginLumiSignal_.connect([this](auto, auto){removeTask();});
-      iRegistry.preModuleStreamEndLumiSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleStreamEndLumiSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleStreamBeginLumiSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleStreamBeginLumiSignal_.connect([this](auto, auto) { removeTask(); });
+      iRegistry.preModuleStreamEndLumiSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleStreamEndLumiSignal_.connect([this](auto, auto) { removeTask(); });
 
-      iRegistry.preModuleGlobalBeginRunSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleGlobalBeginRunSignal_.connect([this](auto, auto){removeTask();});
-      iRegistry.preModuleGlobalEndRunSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleGlobalEndRunSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleGlobalBeginRunSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleGlobalBeginRunSignal_.connect([this](auto, auto) { removeTask(); });
+      iRegistry.preModuleGlobalEndRunSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleGlobalEndRunSignal_.connect([this](auto, auto) { removeTask(); });
 
-      iRegistry.preModuleGlobalBeginLumiSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleGlobalBeginLumiSignal_.connect([this](auto, auto){removeTask();});
-      iRegistry.preModuleGlobalEndLumiSignal_.connect([this](auto, auto){addTask();});
-      iRegistry.postModuleGlobalEndLumiSignal_.connect([this](auto, auto){removeTask();});
-      
+      iRegistry.preModuleGlobalBeginLumiSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleGlobalBeginLumiSignal_.connect([this](auto, auto) { removeTask(); });
+      iRegistry.preModuleGlobalEndLumiSignal_.connect([this](auto, auto) { addTask(); });
+      iRegistry.postModuleGlobalEndLumiSignal_.connect([this](auto, auto) { removeTask(); });
+
       //account for any time ESSources spend looking up new IOVs
-      iRegistry.preESSyncIOVSignal_.connect([this](auto const&){addTask();});
-      iRegistry.postESSyncIOVSignal_.connect([this](auto const&){removeTask();});
+      iRegistry.preESSyncIOVSignal_.connect([this](auto const&) { addTask(); });
+      iRegistry.postESSyncIOVSignal_.connect([this](auto const&) { removeTask(); });
     }
 
     Timing::~Timing() {}
@@ -689,14 +689,14 @@ namespace edm {
       }
       return t;
     }
-  
+
     void Timing::runningTasksChanged(bool iMoreTasks) {
       const auto presentTime = getTime();
       bool expected = false;
-      while( not updating_task_info_.compare_exchange_strong(expected, true) ) {
+      while (not updating_task_info_.compare_exchange_strong(expected, true)) {
         expected = false;
       }
-      auto previousNumberOfTasks = iMoreTasks? num_running_tasks_++ : num_running_tasks_--;
+      auto previousNumberOfTasks = iMoreTasks ? num_running_tasks_++ : num_running_tasks_--;
       total_time_without_tasks_ += (nThreads_ - previousNumberOfTasks) * (presentTime - last_task_change_time_);
       last_task_change_time_ = presentTime;
       updating_task_info_ = false;

--- a/FWCore/Services/plugins/Timing.cc
+++ b/FWCore/Services/plugins/Timing.cc
@@ -92,6 +92,11 @@ namespace edm {
 
       double postCommon() const;
 
+      void setTaskCallbacks(ActivityRegistry&);
+      inline void addTask() { runningTasksChanged(true); }
+      inline void removeTask() { runningTasksChanged(false); }
+      void runningTasksChanged(bool iMoreTasks);
+
       double curr_job_time_;               // seconds
       double curr_job_cpu_;                // seconds
       std::atomic<double> extra_job_cpu_;  //seconds
@@ -102,6 +107,11 @@ namespace edm {
       bool summary_only_;
       bool report_summary_;
       double threshold_;
+      
+      std::atomic<bool> updating_task_info_ = false;
+      CMS_THREAD_GUARD(updating_task_info_) unsigned int num_running_tasks_ = 0;
+      CMS_THREAD_GUARD(updating_task_info_) double last_task_change_time_ = 0;
+      CMS_THREAD_GUARD(updating_task_info_) double total_time_without_tasks_ = 0;
       //
       // Min Max and total event times for each Stream.
       //  Used for summary at end of job
@@ -116,7 +126,7 @@ namespace edm {
 
       std::vector<std::unique_ptr<std::atomic<double>>> eventSetupModuleStartTimes_;
       std::vector<std::pair<uintptr_t, eventsetup::EventSetupRecordKey>> eventSetupModuleCallInfo_;
-      std::atomic<double> accumulatedEventSetupModuleTimings_;
+      std::atomic<double> accumulatedEventSetupModuleTimings_ = 0.;
 
       std::vector<std::unique_ptr<std::atomic<unsigned int>>> countSubProcessesPreEvent_;
       std::vector<std::unique_ptr<std::atomic<unsigned int>>> countSubProcessesPostEvent_;
@@ -355,6 +365,41 @@ namespace edm {
           countSubProcessesPostEvent_.emplace_back(std::make_unique<std::atomic<unsigned int>>(0));
         }
       });
+      setTaskCallbacks(iRegistry);
+    }
+  
+    void Timing::setTaskCallbacks(ActivityRegistry& iRegistry) {
+      iRegistry.preSourceSignal_.connect([this](auto){addTask();});
+      iRegistry.postSourceSignal_.connect([this](auto){removeTask();});
+
+      iRegistry.preSourceLumiSignal_.connect([this](auto){addTask();});
+      iRegistry.postSourceLumiSignal_.connect([this](auto){removeTask();});
+
+      iRegistry.preSourceRunSignal_.connect([this](auto){addTask();});
+      iRegistry.postSourceRunSignal_.connect([this](auto){removeTask();});
+
+      iRegistry.preEventReadFromSourceSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postEventReadFromSourceSignal_.connect([this](auto, auto){removeTask();});
+
+      iRegistry.preModuleStreamBeginRunSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleStreamBeginRunSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleStreamEndRunSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleStreamEndRunSignal_.connect([this](auto, auto){removeTask();});
+
+      iRegistry.preModuleStreamBeginLumiSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleStreamBeginLumiSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleStreamEndLumiSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleStreamEndLumiSignal_.connect([this](auto, auto){removeTask();});
+
+      iRegistry.preModuleGlobalBeginRunSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleGlobalBeginRunSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleGlobalEndRunSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleGlobalEndRunSignal_.connect([this](auto, auto){removeTask();});
+
+      iRegistry.preModuleGlobalBeginLumiSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleGlobalBeginLumiSignal_.connect([this](auto, auto){removeTask();});
+      iRegistry.preModuleGlobalEndLumiSignal_.connect([this](auto, auto){addTask();});
+      iRegistry.postModuleGlobalEndLumiSignal_.connect([this](auto, auto){removeTask();});
     }
 
     Timing::~Timing() {}
@@ -394,6 +439,7 @@ namespace edm {
       }
       curr_job_time_ = getTime();
       curr_job_cpu_ = getCPU();
+      last_task_change_time_ = curr_job_time_;
 
       if (not summary_only_) {
         LogImportant("TimeReport") << "TimeReport> Report activated"
@@ -469,6 +515,7 @@ namespace edm {
                                  << " - Total init:  " << total_initialization_time << "\n"
                                  << " - Total job:   " << total_job_time << "\n"
                                  << " - Total EventSetup: " << accumulatedEventSetupModuleTimings_.load() << "\n"
+                                 << " - Total non-task: " << total_time_without_tasks_ << "\n"
                                  << " Event Throughput: " << event_throughput << " ev/s\n"
                                  << " CPU Summary: \n"
                                  << " - Total loop:     " << total_loop_cpu << "\n"
@@ -494,6 +541,7 @@ namespace edm {
         reportData.insert(std::make_pair("TotalJobChildrenCPU", d2str(job_end_children_cpu)));
         reportData.insert(std::make_pair("TotalLoopTime", d2str(total_loop_time)));
         reportData.insert(std::make_pair("TotalEventSetupTime", d2str(accumulatedEventSetupModuleTimings_.load())));
+        reportData.insert(std::make_pair("TotalNonTaskTime", d2str(total_time_without_tasks_)));
         reportData.insert(std::make_pair("TotalLoopCPU", d2str(total_loop_cpu)));
         reportData.insert(std::make_pair("TotalInitTime", d2str(total_initialization_time)));
         reportData.insert(std::make_pair("TotalInitCPU", d2str(total_initialization_cpu)));
@@ -631,6 +679,19 @@ namespace edm {
             << " seconds.";
       }
       return t;
+    }
+  
+    void Timing::runningTasksChanged(bool iMoreTasks) {
+      const auto presentTime = getTime();
+      bool expected = false;
+      while( not updating_task_info_.compare_exchange_strong(expected, true) ) {
+        expected = false;
+      }
+      auto previousNumberOfTasks = iMoreTasks? num_running_tasks_++ : num_running_tasks_--;
+      
+      total_time_without_tasks_ += (nThreads_ - previousNumberOfTasks) * (presentTime - last_task_change_time_);
+      last_task_change_time_ = presentTime;
+      updating_task_info_ = false;
     }
   }  // namespace service
 }  // namespace edm

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -30,3 +30,4 @@
 
 <test name="TestResourceInformationService" command="test_resourceInformationService.sh"/>
 <test name="TestSignalMessages" command="test_signal.sh"/>
+<test name="TestTimingFJR" command="test_Timing.sh"/>

--- a/FWCore/Services/test/test_Timing.sh
+++ b/FWCore/Services/test/test_Timing.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+cmsRun -e ${SCRAM_TEST_PATH}/test_Timing_cfg.py &> test_Timing.log || die "cmsRun test_Timing_cfg.py" $?
+
+NAMES=("AvgEventTime" "EventThroughput" "MaxEventTime" "MinEventTime" "NumberOfStreams" "NumberOfThreads" "TotalEventSetupTime" \
+	 "TotalInitCPU" "TotalInitTime" "TotalJobCPU" "TotalJobChildrenCPU" "TotalJobTime" "TotalLoopCPU" "TotalLoopTime" "TotalNonModuleTime")
+
+grep "Time Summary" test_Timing.log || die "Check for 'Time Summary' message" $?
+grep '<PerformanceSummary Metric="Timing">' FrameworkJobReport.xml || die "Check for Timing group in FJR" $?
+
+for NAME in ${NAMES[@]}; do
+  grep $NAME FrameworkJobReport.xml || die "Check for $NAME in FJR" $?
+done
+exit 0

--- a/FWCore/Services/test/test_Timing_cfg.py
+++ b/FWCore/Services/test/test_Timing_cfg.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.add_(cms.Service("Timing", summaryOnly = cms.untracked.bool(True)))


### PR DESCRIPTION
#### PR description:

The built in timing service now calculates the amount of time all cores are not running a module (i.e. Source, EDProducer, EDFilter, EDAnalyzer, OutputModule, ESModule or ESSource) during the data processing loop. This gets reported in the summary and to the framework job report. Time is summed across all threads.

Additional changes:
- Moved postESSyncIOV signal to run right after ESSources synchronize. This now properly encapsulate the time calling the ESSources.
- Added beginProcessing and endProcessing signals to specify when starting/ending processing of source transitions.

#### PR validation:

Framework unit tests pass.