### PR TITLE
Migrate consumesMany() to edm::GetterOfProducts() in FWCore test code

### DIFF
--- a/FWCore/Framework/test/stubs/TestFilterModule.cc
+++ b/FWCore/Framework/test/stubs/TestFilterModule.cc
@@ -14,6 +14,8 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/ProcessMatch.h"
 
 #include <string>
 #include <iostream>
@@ -42,6 +44,7 @@ namespace edmtest {
     int failed_;
     std::string name_;
     int numbits_;
+    edm::GetterOfProducts<edm::TriggerResults> getter_;
   };
 
   class TestContextAnalyzer : public edm::global::EDAnalyzer<> {
@@ -115,7 +118,8 @@ namespace edmtest {
         failed_(),
         name_(ps.getUntrackedParameter<std::string>("name", "DEFAULT")),
         numbits_(ps.getUntrackedParameter<int>("numbits", -1)) {
-    consumesMany<edm::TriggerResults>();
+    getter_ = edm::GetterOfProducts<edm::TriggerResults>(edm::ProcessMatch("*"), this);
+    callWhenNewProductsRegistered(getter_);
   }
 
   TestResultAnalyzer::~TestResultAnalyzer() {}
@@ -123,7 +127,7 @@ namespace edmtest {
   void TestResultAnalyzer::analyze(edm::Event const& e, edm::EventSetup const&) {
     typedef std::vector<edm::Handle<edm::TriggerResults> > Trig;
     Trig prod;
-    e.getManyByType(prod);
+    getter_.fillHandles(e, prod);
 
     if (prod.size() == 0)
       return;


### PR DESCRIPTION
#### PR description:
Based on PR #40167 .
Migrate GlobalRecHitsAnalyzer away from consumesMany() to use edm::GetterOfProducts().

        modified:   FWCore/Framework/test/stubs/TestFilterModule.cc
        modified:   FWCore/Framework/test/stubs/TestTriggerNames.cc

FWCore/Framework/test/stubs/ToyIntProducers.cc is updated on PR #41054 (https://github.com/cms-sw/cmssw/pull/41054)

#### PR validation:
Tested in CMSSW_13_1_0_pre2, the basic test passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)