### PR TITLE
Add `--nEvents` option to `runTheMatrix.py`

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -59,7 +59,7 @@ class MatrixRunner(object):
 
             print('\nPreparing to run %s %s' % (wf.numId, item))
             sys.stdout.flush()
-            current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.nStreams, opt.maxSteps)
+            current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasOptions, opt.jobReports, opt.nThreads, opt.nStreams, opt.maxSteps, opt.nEvents)
             self.threadList.append(current)
             current.start()
             if not dryRun:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -8,7 +8,7 @@ from os.path import exists, basename, join
 from datetime import datetime
 
 class WorkFlowRunner(Thread):
-    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True,dasOptions="",jobReport=False, nThreads=1, nStreams=0, maxSteps=9999):
+    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True,dasOptions="",jobReport=False, nThreads=1, nStreams=0, maxSteps=9999, nEvents=0):
         Thread.__init__(self)
         self.wf = wf
 
@@ -24,6 +24,7 @@ class WorkFlowRunner(Thread):
         self.nThreads=nThreads
         self.nStreams=nStreams
         self.maxSteps=maxSteps
+        self.nEvents=nEvents
         
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
         return
@@ -166,6 +167,11 @@ class WorkFlowRunner(Thread):
                   cmd += ' --nThreads %s' % self.nThreads
                 if (self.nStreams > 0) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):
                   cmd += ' --nStreams %s' % self.nStreams
+                if (self.nEvents > 0):
+                  event_token = " -n "
+                  split = cmd.split(event_token)
+                  pos_cmd = " ".join(split[1].split(" ")[1:])
+                  cmd = split[0] + event_token + '%s ' % self.nEvents + pos_cmd
                 cmd+=closeCmd(istep,self.wf.nameId)            
                 retStep = 0
                 if istep>self.maxSteps:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -154,6 +154,12 @@ if __name__ == '__main__':
                         type=int,
                         default=0)
     
+    parser.add_argument('--nEvents',
+                        help='number of events to process in cmsRun. If 0 will use the standard 10 events.',
+                        dest='nEvents',
+                        type=int,
+                        default=0)
+    
     parser.add_argument('--numberEventsInLuminosityBlock',
                         help='number of events in a luminosity block',
                         dest='numberEventsInLuminosityBlock',


### PR DESCRIPTION
#### PR description:

This PR proposes a solution for those as lazy as me that would like to produce more than `10` events with `runTheMatrix.py` without having to manually edit the configs or use `--command="-n 100"`. It adds a `--nEvents` option for the script to overwrite the standard number of events. It's not really needed , given the `--command` option, but it's slightly cleaner (no double `-n` in the `cmsDriver.py`) and since I had already spent the time needed to have it working I'm making it public to be reviewed. 


#### PR validation:

Tested with a random workflow `runTheMatrix.py -l 12540.0 -w upgrade -t12 --dryRun --nEvents 100` that outputs:

```
Preparing to run 12540.0 Psi2SToJPsiPiPi_14TeV+2023

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py Psi2SToJPsiPiPi_14TeV_TuneCP5_pythia8_cfi  -s GEN,SIM -n 100 --conditions auto:phase1_2023_realistic --beamspot Realistic25ns13p6TeVEarly2022Collision --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --relval 45000,500 --fileout file:step1.root  --nThreads 12 > step1_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2023 --conditions auto:phase1_2023_realistic --datatier GEN-SIM-DIGI-RAW -n 100 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --filein  file:step1.root  --fileout file:step2.root  --nThreads 12 > step2_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2023_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 100 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --filein  file:step2.root  --fileout file:step3.root  --nThreads 12 > step3_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step4  -s HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2023_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 100  --filein file:step3_inDQM.root --fileout file:step4.root  > step4_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias --conditions auto:phase1_2023_realistic --datatier ALCARECO -n 100 --eventcontent ALCARECO --geometry DB:Extended --filein file:step3.root --era Run3 --fileout file:step5.root  --nThreads 12 > step5_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 
12540.0_Psi2SToJPsiPiPi_14TeV+2023 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Apr  4 09:23:58 2023-date Tue Apr  4 09:23:58 2023; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

```

while the original `runTheMatrix.py -l 12540.0 -w upgrade -t12 --dryRun` is untouched:


```
Preparing to run 12540.0 Psi2SToJPsiPiPi_14TeV+2023

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py Psi2SToJPsiPiPi_14TeV_TuneCP5_pythia8_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2023_realistic --beamspot Realistic25ns13p6TeVEarly2022Collision --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --relval 45000,500 --fileout file:step1.root  --nThreads 12 > step1_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2023 --conditions auto:phase1_2023_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --filein  file:step1.root  --fileout file:step2.root  --nThreads 12 > step2_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step3  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2023_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --filein  file:step2.root  --fileout file:step3.root  --nThreads 12 > step3_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step4  -s HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2023_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 100  --filein file:step3_inDQM.root --fileout file:step4.root  > step4_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_Matrix_Events/cmssw/src dryRun for 'cd 12540.0_Psi2SToJPsiPiPi_14TeV+2023
 cmsDriver.py step5  -s ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu+SiStripCalMinBias --conditions auto:phase1_2023_realistic --datatier ALCARECO -n 10 --eventcontent ALCARECO --geometry DB:Extended --filein file:step3.root --era Run3 --fileout file:step5.root  --nThreads 12 > step5_Psi2SToJPsiPiPi_14TeV+2023.log  2>&1
 
12540.0_Psi2SToJPsiPiPi_14TeV+2023 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Tue Apr  4 09:25:20 2023-date Tue Apr  4 09:25:20 2023; exit: 0 0 0 0 0
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```