### PR TITLE
Run3-gex158B Replace std::cout with edm::LogVerbatim in Geometry/HGCalGeometry and Geometry/HcalCommonData

### DIFF
--- a/Geometry/HGCalGeometry/plugins/moduleDB.cc
+++ b/Geometry/HGCalGeometry/plugins/moduleDB.cc
@@ -1,3 +1,4 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HGCalGeometry/interface/CaloGeometryDBHGCal.h"
 #include "Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h"
@@ -12,7 +13,7 @@ CaloGeometryDBEP<HGCalGeometry, CaloGeometryDBReader>::produceAligned(
   IVec ivec;
   IVec dins;
 
-  std::cout << "Reading HGCalGeometry " << calogeometryDBEPimpl::nameHGCal << "\n";
+  edm::LogVerbatim("HGCalGeom") << "Reading HGCalGeometry " << calogeometryDBEPimpl::nameHGCal;
   const auto& pG = iRecord.get(geometryToken_);
 
   tvec = pG.getTranslation();

--- a/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
+++ b/Geometry/HcalCommonData/test/HcalParametersAnalyzer.cc
@@ -53,7 +53,7 @@ void HcalParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Ev
   st1 << "\nrhoxHB: ";
   for (const auto& it : pars->rhoxHB)
     st1 << it << ", ";
-  std::cout << "\nzxHB: ";
+  st1 << "\nzxHB: ";
   for (const auto& it : pars->zxHB)
     st1 << it << ", ";
   st1 << "\ndyHB: ";
@@ -70,7 +70,7 @@ void HcalParametersAnalyzer::analyze(const edm::Event& /*iEvent*/, const edm::Ev
     st1 << it << ", ";
   st1 << "\ndyHE: ";
   for (const auto& it : pars->dyHE)
-    std::cout << it << ", ";
+    st1 << it << ", ";
   st1 << "\ndx1HE: ";
   for (const auto& it : pars->dx1HE)
     st1 << it << ", ";


### PR DESCRIPTION
#### PR description:

Replace std::cout with edm::LogVerbatim in Geometry/HGCalGeometry and Geometry/HcalCommonData

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->

Nothing special