### PR TITLE
New Run3 era for updated HB thresholds in 2023

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
@@ -11,7 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
 
 from Configuration.DataProcessing.Impl.pp import pp
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2023_
+
+Scenario supporting proton collisions for 2023 with updated HCAL Barrel thresholds
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2023
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+    """
+    _ppEra_Run3_2023_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2023
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023.py
@@ -15,7 +15,7 @@ from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
 
 from Configuration.DataProcessing.Impl.pp import pp
 
-class ppEra_Run3(pp):
+class ppEra_Run3_2023(pp):
     def __init__(self):
         pp.__init__(self)
         self.recoSeq=''

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -90,6 +90,11 @@ def customisePostEra_Run3(process):
     customisePostEra_Run2_2018(process)
     return process
 
+def customisePostEra_Run3_2023(process):
+    #start with a repeat of Run3
+    customisePostEra_Run3(process)
+    return process
+
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run3_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+
+Run3_2023 = cms.ModifierChain(Run3, run3_egamma_2023)

--- a/Configuration/Eras/python/Modifier_run3_egamma_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_egamma_2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_egamma_2023 =cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -34,6 +34,7 @@ class Eras (object):
                  'Run2_2018_highBetaStar',
                  'Run2_2018_noMkFit',
                  'Run3',
+                 'Run3_2023',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',
                  'Run3_pp_on_PbPb_approxSiStripClusters',

--- a/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1, _thresholdsHBphase1_2023
 
 egammaHBHERecHit = cms.PSet(
     hbheRecHits = cms.InputTag('hbhereco'),
@@ -8,3 +8,10 @@ egammaHBHERecHit = cms.PSet(
     recHitEThresholdHE = _thresholdsHEphase1,
     maxHcalRecHitSeverity = cms.int32(9),
 )
+
+egammaHBHERecHit_2023 = egammaHBHERecHit.clone(
+    recHitEThresholdHB = _thresholdsHBphase1_2023
+)
+
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+run3_egamma_2023.toReplaceWith(egammaHBHERecHit,egammaHBHERecHit_2023)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -9,6 +9,10 @@ _seedingThresholdsHB = cms.vdouble(1.0, 1.0, 1.0, 1.0)
 _seedingThresholdsHE = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1)
 _seedingThresholdsHBphase1 = cms.vdouble(0.125, 0.25, 0.35, 0.35)
 _seedingThresholdsHEphase1 = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275)
+#updated HB RecHit threshold for 2023
+_thresholdsHBphase1_2023 = cms.vdouble(0.4, 0.3, 0.3, 0.3)
+#updated HB seeding threshold for 2023
+_seedingThresholdsHBphase1_2023 = cms.vdouble(0.6, 0.5, 0.5, 0.5)
 
 
 #### PF CLUSTER HCAL ####
@@ -141,6 +145,19 @@ run3_HB.toModify(particleFlowClusterHBHE,
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
     ),
 )
+
+# offline 2023
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+run3_egamma_2023.toModify(particleFlowClusterHBHE,
+    seedFinder = dict(thresholdsByDetector = {0 : dict(seedingThreshold = _seedingThresholdsHBphase1_2023) } ),
+    initialClusteringStep = dict(thresholdsByDetector = {0 : dict(gatheringThreshold = _thresholdsHBphase1_2023) } ),
+    pfClusterBuilder = dict(
+        recHitEnergyNorms = {0 : dict(recHitEnergyNorm = _thresholdsHBphase1_2023) },
+        positionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2023) } ),
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2023) } ),
+    ),
+)
+
 
 # HCALonly WF
 particleFlowClusterHBHEOnly = particleFlowClusterHBHE.clone(

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -4,6 +4,8 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+#updated HB RecHit threshold for 2023
+_thresholdsHBphase1_2023 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),
@@ -48,6 +50,14 @@ from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(particleFlowClusterHCAL,
     pfClusterBuilder = dict(
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+    ),
+)
+
+# offline 2023
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+run3_egamma_2023.toModify(particleFlowClusterHCAL,
+    pfClusterBuilder = dict(
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2023) } ),
     ),
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -5,7 +5,7 @@ _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
 #updated HB RecHit threshold for 2023
-_thresholdsHBphase1_2023 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
+_thresholdsHBphase1_2023 = cms.vdouble(0.4, 0.3, 0.3, 0.3)
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -4,6 +4,8 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+#updated HB RecHit threshold for 2023
+_thresholdsHBphase1_2023 = cms.vdouble(0.4, 0.3, 0.3, 0.3)
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
@@ -52,6 +54,11 @@ from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HEColla
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1) } ) } ) },
+)
+
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+run3_egamma_2023.toModify(particleFlowRecHitHBHE,
+    producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1_2023) } ) } ) },
 )
 
 # HCALonly WF


### PR DESCRIPTION
#### PR description:
Creating a new era to update HB thresholds. 
This PR is essentially doing similar things as done in https://github.com/cms-sw/cmssw/pull/40689 and https://github.com/cms-sw/cmssw/pull/40756 for 12_6_X. 

#### PR validation:
Checked with `12434.0`

This PR needs to be back-ported to data-taking release 13_0_X.

FYI @cms-sw/hcal-dpg-l2 @cms-sw/pf-l2 @francescobrivio @davidlange6 