### PR TITLE
Run3-gex158C Replace std::cout with edm::LogVerbatim in Geometry/HcalEventSetup and Geometry/HcalTestBeamData. Also, add some missing files needed for testing

### DIFF
--- a/Geometry/HcalEventSetup/python/HcalDDDGeometry_cfi.py
+++ b/Geometry/HcalEventSetup/python/HcalDDDGeometry_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Ideal geometry, needed for simulation
+from Geometry.CMSCommonData.hcalOnlyGeometryXML_cfi import *
+from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
+
+
+

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -32,7 +32,7 @@ HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
       m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " << m_restrictions
-            << " MergePosition: " << m_mergePosition;
+                               << " MergePosition: " << m_mergePosition;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
 #endif
 }
@@ -54,7 +54,7 @@ HcalTopologyIdealEP::ReturnType HcalTopologyIdealEP::produce(const HcalRecNumber
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
-            << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
+                               << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
   edm::LogInfo("HCAL") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
                        << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
 #endif

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -24,15 +24,15 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-//#define DebugLog
+//#define EDM_ML_DEBUG
 
 HcalTopologyIdealEP::HcalTopologyIdealEP(const edm::ParameterSet& conf)
     : m_hdcToken{setWhatProduced(this, &HcalTopologyIdealEP::produce).consumes<HcalDDDRecConstants>(edm::ESInputTag{})},
       m_restrictions(conf.getUntrackedParameter<std::string>("Exclude")),
       m_mergePosition(conf.getUntrackedParameter<bool>("MergePosition")) {
-#ifdef DebugLog
-  std::cout << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " << m_restrictions
-            << " MergePosition: " << m_mergePosition << std::endl;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalTopologyIdealEP::HcalTopologyIdealEP with Exclude: " << m_restrictions
+            << " MergePosition: " << m_mergePosition;
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::HcalTopologyIdealEP";
 #endif
 }
@@ -46,15 +46,15 @@ void HcalTopologyIdealEP::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 // ------------ method called to produce the data  ------------
 HcalTopologyIdealEP::ReturnType HcalTopologyIdealEP::produce(const HcalRecNumberingRecord& iRecord) {
-#ifdef DebugLog
-  std::cout << "HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)" << std::endl;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)";
   edm::LogInfo("HCAL") << "HcalTopologyIdealEP::produce(const HcalGeometryRecord& iRecord)";
 #endif
   const HcalDDDRecConstants& hdc = iRecord.get(m_hdcToken);
 
-#ifdef DebugLog
-  std::cout << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
-            << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2) << std::endl;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HCalGeom") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
+            << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
   edm::LogInfo("HCAL") << "mode = " << hdc.getTopoMode() << ", maxDepthHB = " << hdc.getMaxDepth(0)
                        << ", maxDepthHE = " << hdc.getMaxDepth(1) << ", maxDepthHF = " << hdc.getMaxDepth(2);
 #endif

--- a/Geometry/HcalEventSetup/test/runTestHcalDDDGeometry_cfg.py
+++ b/Geometry/HcalEventSetup/test/runTestHcalDDDGeometry_cfg.py
@@ -7,23 +7,9 @@ process.load("Geometry.HcalEventSetup.hcalTopologyIdeal_cfi")
 
 #process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    categories = cms.untracked.vstring('HCalGeom'),
-    debugModules = cms.untracked.vstring('*'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        ),
-        DEBUG = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        HCalGeom = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
-    )
-)
+process.load('FWCore.MessageService.MessageLogger_cfi')
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.HCalGeom=dict()
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10)

--- a/Geometry/HcalTestBeamData/data/dd4hep/cms-test-ddTB2006-algorithm.xml
+++ b/Geometry/HcalTestBeamData/data/dd4hep/cms-test-ddTB2006-algorithm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+<!-- 
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_materials/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_materials/>
+    <debug_visattr/>
+-->
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <IncludeSection>
+    <Include ref="Geometry/CMSCommonData/data/materials.xml"/> 
+    <Include ref="Geometry/CMSCommonData/data/rotations.xml"/> 
+    <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06BeamLine.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06Ecal.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcalCable.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2006/TBHcalBarrel.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcalEndcap.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06HcalOuter.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06Sens.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06SimNumbering.xml"/> 
+    <Include ref="Geometry/EcalSimData/data/ebsens.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06ProdCuts.xml"/> 
+    <Include ref="Geometry/EcalSimData/data/EBProdCuts.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06Util.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/hcalRecNumbering.xml"/>
+    <Include ref="Geometry/HcalTestBeamData/data/world.xml"/>
+  </IncludeSection>
+  
+</DDDefinition>
+
+
+

--- a/Geometry/HcalTestBeamData/data/dd4hep/cms-test-ddTB2007-algorithm.xml
+++ b/Geometry/HcalTestBeamData/data/dd4hep/cms-test-ddTB2007-algorithm.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<DDDefinition>
+  <debug>
+<!-- 
+    <debug_shapes/>
+    <debug_includes/>
+    <debug_rotations/>
+    <debug_includes/>
+    <debug_volumes/>
+    <debug_constants/>
+    <debug_materials/>
+    <debug_namespaces/>
+    <debug_placements/>
+    <debug_algorithms/>
+    <debug_materials/>
+    <debug_visattr/>
+-->
+  </debug>
+  
+  <open_geometry/>
+  <close_geometry/>
+
+  <IncludeSection>
+    <Include ref="Geometry/CMSCommonData/data/materials.xml"/> 
+    <Include ref="Geometry/CMSCommonData/data/rotations.xml"/> 
+    <Include ref="Geometry/HcalCommonData/data/hcalrotations.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/TBHcal.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal07BeamLine.xml"/> 
+    <Include ref="Geometry/EcalCommonData/data/eecon.xml"/> 
+    <Include ref="Geometry/EcalCommonData/data/eealgo.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/eehier.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/eefixed.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/eregalgo.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/escon.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/2007/esalgoTB.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcalCable.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcalBarrel.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcalEndcap.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal07HcalOuter.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal07Sens.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06SimNumbering.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal07eeSens.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal07esSens.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06ProdCuts.xml"/> 
+    <Include ref="Geometry/HcalTestBeamData/data/TBHcal06Util.xml"/>
+    <Include ref="Geometry/HcalCommonData/data/hcalRecNumbering.xml"/>
+    <Include ref="Geometry/HcalTestBeamData/data/world.xml"/>
+  </IncludeSection>
+  
+</DDDefinition>

--- a/Geometry/HcalTestBeamData/plugins/HcalTBParameterTester.cc
+++ b/Geometry/HcalTestBeamData/plugins/HcalTBParameterTester.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/HcalTestBeamData/interface/HcalTB02Parameters.h"
 #include "Geometry/HcalTestBeamData/interface/HcalTB06BeamParameters.h"
@@ -13,7 +14,7 @@
 class HcalTBParameterTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HcalTBParameterTester(const edm::ParameterSet&);
-  ~HcalTBParameterTester() override {}
+  ~HcalTBParameterTester() override = default;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -36,19 +37,19 @@ void HcalTBParameterTester::analyze(const edm::Event& iEvent, const edm::EventSe
   if (mode_ == 0) {
     const auto& hcp = iSetup.getData(token1_);
     const auto* php = &hcp;
-    std::cout << "TB02Parameters for " << name_ << "\n";
-    std::cout << "Length map with " << php->lengthMap_.size() << " elements\n";
+    edm::LogVerbatim("HCalGeom") << "TB02Parameters for " << name_;
+    edm::LogVerbatim("HCalGeom") << "Length map with " << php->lengthMap_.size() << " elements";
     std::map<std::string, double>::const_iterator itr = php->lengthMap_.begin();
     int i(0);
     for (; itr != php->lengthMap_.end(); ++itr, ++i)
-      std::cout << "[" << i << "] " << itr->first << " " << itr->second << " mm\n";
+      edm::LogVerbatim("HCalGeom") << "[" << i << "] " << itr->first << " " << itr->second << " mm";
   } else {
     const auto& hcp = iSetup.getData(token2_);
     const auto* php = &hcp;
-    std::cout << "TB06BeamParameters:: Material " << php->material_ << "\n";
-    std::cout << "TB06BeamParameters:: " << php->wchambers_.size() << " wire chambers:\n";
+    edm::LogVerbatim("HCalGeom") << "TB06BeamParameters:: Material " << php->material_;
+    edm::LogVerbatim("HCalGeom") << "TB06BeamParameters:: " << php->wchambers_.size() << " wire chambers:";
     for (unsigned int k = 0; k < php->wchambers_.size(); ++k)
-      std::cout << "[" << k << "] " << php->wchambers_[k] << "\n";
+      edm::LogVerbatim("HCalGeom") << "[" << k << "] " << php->wchambers_[k];
   }
 }
 


### PR DESCRIPTION
#### PR description:

Replace std::cout with edm::LogVerbatim in Geometry/HcalEventSetup and Geometry/HcalTestBeamData. Also, add some missing files needed for testing

#### PR validation:

Use the test scripts in the corresponding test areas

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special