### PR TITLE
Improved options handling for TensorFlow sessions

### DIFF
--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -12,21 +12,14 @@
 
 namespace tensorflow {
 
-  void setLogging(const std::string& level) { setenv("TF_CPP_MIN_LOG_LEVEL", level.c_str(), 0); }
-
-  void setThreading(SessionOptions& sessionOptions, int nThreads) {
+  void Options::setThreading(int nThreads) {
+    _nThreads = nThreads;
     // set number of threads used for intra and inter operation communication
-    sessionOptions.config.set_intra_op_parallelism_threads(nThreads);
-    sessionOptions.config.set_inter_op_parallelism_threads(nThreads);
+    _options.config.set_intra_op_parallelism_threads(nThreads);
+    _options.config.set_inter_op_parallelism_threads(nThreads);
   }
 
-  void setThreading(SessionOptions& sessionOptions, int nThreads, const std::string& singleThreadPool) {
-    edm::LogInfo("PhysicsTools/TensorFlow") << "setting the thread pool via tensorflow::setThreading() is deprecated";
-
-    setThreading(sessionOptions, nThreads);
-  }
-
-  void setBackend(SessionOptions& sessionOptions, Backend backend) {
+  void Options::setBackend(Backend backend) {
     /*
      * The TensorFlow backend configures the available devices using options provided in the sessionOptions proto.
      * // Options from https://github.com/tensorflow/tensorflow/blob/c53dab9fbc9de4ea8b1df59041a5ffd3987328c3/tensorflow/core/protobuf/config.proto
@@ -43,17 +36,17 @@ namespace tensorflow {
     edm::Service<edm::ResourceInformation> ri;
     if (backend == Backend::cpu) {
       // disable GPU usage
-      (*sessionOptions.config.mutable_device_count())["GPU"] = 0;
-      sessionOptions.config.mutable_gpu_options()->set_visible_device_list("");
+      (*_options.config.mutable_device_count())["GPU"] = 0;
+      _options.config.mutable_gpu_options()->set_visible_device_list("");
     }
     // NVidia GPU
     else if (backend == Backend::cuda) {
       if (not ri->nvidiaDriverVersion().empty()) {
         // Take only the first GPU in the CUDA_VISIBLE_DEVICE list
-        (*sessionOptions.config.mutable_device_count())["GPU"] = 1;
-        sessionOptions.config.mutable_gpu_options()->set_visible_device_list("0");
+        (*_options.config.mutable_device_count())["GPU"] = 1;
+        _options.config.mutable_gpu_options()->set_visible_device_list("0");
         // Do not allocate all the memory on the GPU at the beginning.
-        sessionOptions.config.mutable_gpu_options()->set_allow_growth(true);
+        _options.config.mutable_gpu_options()->set_allow_growth(true);
       } else {
         edm::Exception ex(edm::errors::UnavailableAccelerator);
         ex << "Cuda backend requested, but no NVIDIA GPU available in the job";
@@ -73,26 +66,41 @@ namespace tensorflow {
       // Check if a Nvidia GPU is availabl
       if (not ri->nvidiaDriverVersion().empty()) {
         // Take only the first GPU in the CUDA_VISIBLE_DEVICE list
-        (*sessionOptions.config.mutable_device_count())["GPU"] = 1;
-        sessionOptions.config.mutable_gpu_options()->set_visible_device_list("0");
+        (*_options.config.mutable_device_count())["GPU"] = 1;
+        _options.config.mutable_gpu_options()->set_visible_device_list("0");
         // Do not allocate all the memory on the GPU at the beginning.
-        sessionOptions.config.mutable_gpu_options()->set_allow_growth(true);
+        _options.config.mutable_gpu_options()->set_allow_growth(true);
       } else {
         // Just CPU support
-        (*sessionOptions.config.mutable_device_count())["GPU"] = 0;
-        sessionOptions.config.mutable_gpu_options()->set_visible_device_list("");
+        (*_options.config.mutable_device_count())["GPU"] = 0;
+        _options.config.mutable_gpu_options()->set_visible_device_list("");
       }
     }
   }
 
-  MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag, SessionOptions& sessionOptions) {
+  void setLogging(const std::string& level) {
+    /*
+     * 0 = all messages are logged (default behavior)
+     * 1 = INFO messages are not printed
+     * 2 = INFO and WARNING messages are not printed
+     * 3 = INFO, WARNING, and ERROR messages are not printed
+     */
+    setenv("TF_CPP_MIN_LOG_LEVEL", level.c_str(), 0);
+  }
+
+  MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag) {
+    Options default_options{};
+    return loadMetaGraphDef(exportDir, tag, default_options);
+  }
+
+  MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag, Options& options) {
     // objects to load the graph
     Status status;
     RunOptions runOptions;
     SavedModelBundle bundle;
 
     // load the model
-    status = LoadSavedModel(sessionOptions, runOptions, exportDir, {tag}, &bundle);
+    status = LoadSavedModel(options.getSessionOptions(), runOptions, exportDir, {tag}, &bundle);
     if (!status.ok()) {
       throw cms::Exception("InvalidMetaGraphDef")
           << "error while loading metaGraphDef from '" << exportDir << "': " << status.ToString();
@@ -102,27 +110,11 @@ namespace tensorflow {
     return new MetaGraphDef(bundle.meta_graph_def);
   }
 
-  MetaGraphDef* loadMetaGraph(const std::string& exportDir, const std::string& tag, SessionOptions& sessionOptions) {
+  MetaGraphDef* loadMetaGraph(const std::string& exportDir, const std::string& tag, Options& options) {
     edm::LogInfo("PhysicsTools/TensorFlow")
         << "tensorflow::loadMetaGraph() is deprecated, use tensorflow::loadMetaGraphDef() instead";
 
-    return loadMetaGraphDef(exportDir, tag, sessionOptions);
-  }
-
-  MetaGraphDef* loadMetaGraphDef(const std::string& exportDir, const std::string& tag, Backend backend, int nThreads) {
-    // create session options and set thread options
-    SessionOptions sessionOptions;
-    setThreading(sessionOptions, nThreads);
-    setBackend(sessionOptions, backend);
-
-    return loadMetaGraphDef(exportDir, tag, sessionOptions);
-  }
-
-  MetaGraphDef* loadMetaGraph(const std::string& exportDir, const std::string& tag, Backend backend, int nThreads) {
-    edm::LogInfo("PhysicsTools/TensorFlow")
-        << "tensorflow::loadMetaGraph() is deprecated, use tensorflow::loadMetaGraphDef() instead";
-
-    return loadMetaGraphDef(exportDir, tag, backend, nThreads);
+    return loadMetaGraphDef(exportDir, tag, options);
   }
 
   GraphDef* loadGraphDef(const std::string& pbFile) {
@@ -142,13 +134,18 @@ namespace tensorflow {
     return graphDef;
   }
 
-  Session* createSession(SessionOptions& sessionOptions) {
+  Session* createSession() {
+    Options default_options{};
+    return createSession(default_options);
+  }
+
+  Session* createSession(Options& options) {
     // objects to create the session
     Status status;
 
     // create a new, empty session
     Session* session = nullptr;
-    status = NewSession(sessionOptions, &session);
+    status = NewSession(options.getSessionOptions(), &session);
     if (!status.ok()) {
       throw cms::Exception("InvalidSession") << "error while creating session: " << status.ToString();
     }
@@ -156,18 +153,7 @@ namespace tensorflow {
     return session;
   }
 
-  Session* createSession(Backend backend, int nThreads) {
-    // create session options and set thread options
-    SessionOptions sessionOptions;
-    setThreading(sessionOptions, nThreads);
-    setBackend(sessionOptions, backend);
-
-    return createSession(sessionOptions);
-  }
-
-  Session* createSession(const MetaGraphDef* metaGraphDef,
-                         const std::string& exportDir,
-                         SessionOptions& sessionOptions) {
+  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, Options& options) {
     // check for valid pointer
     if (metaGraphDef == nullptr) {
       throw cms::Exception("InvalidMetaGraphDef") << "error while creating session: metaGraphDef is nullptr";
@@ -178,7 +164,7 @@ namespace tensorflow {
       throw cms::Exception("InvalidMetaGraphDef") << "error while creating session: graphDef has no nodes";
     }
 
-    Session* session = createSession(sessionOptions);
+    Session* session = createSession(options);
 
     // add the graph def from the meta graph
     Status status;
@@ -214,16 +200,12 @@ namespace tensorflow {
     return session;
   }
 
-  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, Backend backend, int nThreads) {
-    // create session options and set thread options
-    SessionOptions sessionOptions;
-    setThreading(sessionOptions, nThreads);
-    setBackend(sessionOptions, backend);
-
-    return createSession(metaGraphDef, exportDir, sessionOptions);
+  Session* createSession(const GraphDef* graphDef) {
+    Options default_options{};
+    return createSession(graphDef, default_options);
   }
 
-  Session* createSession(const GraphDef* graphDef, SessionOptions& sessionOptions) {
+  Session* createSession(const GraphDef* graphDef, Options& options) {
     // check for valid pointer
     if (graphDef == nullptr) {
       throw cms::Exception("InvalidGraphDef") << "error while creating session: graphDef is nullptr";
@@ -235,7 +217,7 @@ namespace tensorflow {
     }
 
     // create a new, empty session
-    Session* session = createSession(sessionOptions);
+    Session* session = createSession(options);
 
     // add the graph def
     Status status;
@@ -247,15 +229,6 @@ namespace tensorflow {
     }
 
     return session;
-  }
-
-  Session* createSession(const GraphDef* graphDef, Backend backend, int nThreads) {
-    // create session options and set thread options
-    SessionOptions sessionOptions;
-    setThreading(sessionOptions, nThreads);
-    setBackend(sessionOptions, backend);
-
-    return createSession(graphDef, sessionOptions);
   }
 
   bool closeSession(Session*& session) {

--- a/PhysicsTools/TensorFlow/test/testConstSession.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSession.cc
@@ -33,12 +33,12 @@ void testConstSession::test() {
   tensorflow::Backend backend = tensorflow::Backend::cpu;
 
   // load the graph
-  tensorflow::setLogging();
+  tensorflow::Options options{backend};
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  const tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  const tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // example evaluation

--- a/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testConstSessionCUDA.cc
@@ -55,11 +55,13 @@ process.add_(cms.Service('CUDAService'))
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
   tensorflow::setLogging();
+  tensorflow::Options options{backend};
+
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  const tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  const tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // example evaluation

--- a/PhysicsTools/TensorFlow/test/testGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoading.cc
@@ -33,16 +33,16 @@ void testGraphLoading::test() {
   tensorflow::Backend backend = tensorflow::Backend::cpu;
 
   // load the graph
-  tensorflow::setLogging();
+  tensorflow::Options options{backend};
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testGraphLoadingCUDA.cc
@@ -55,15 +55,16 @@ process.add_(cms.Service('CUDAService'))
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
   tensorflow::setLogging();
+  tensorflow::Options options{backend};
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testHelloWorld.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorld.cc
@@ -36,13 +36,13 @@ void testHelloWorld::test() {
 
   // object to load and run the graph / session
   tensorflow::Status status;
-  tensorflow::SessionOptions sessionOptions;
-  tensorflow::setBackend(sessionOptions, backend);
+  tensorflow::Options options{backend};
+  tensorflow::setLogging();
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;
 
   // load everything
-  status = tensorflow::LoadSavedModel(sessionOptions, runOptions, modelDir, {"serve"}, &bundle);
+  status = tensorflow::LoadSavedModel(options.getSessionOptions(), runOptions, modelDir, {"serve"}, &bundle);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     return;

--- a/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testHelloWorldCUDA.cc
@@ -56,14 +56,14 @@ process.add_(cms.Service('CUDAService'))
 
   // object to load and run the graph / session
   tensorflow::Status status;
-  tensorflow::SessionOptions sessionOptions;
-  tensorflow::setBackend(sessionOptions, backend);
+  tensorflow::Options options{backend};
+  tensorflow::setLogging("0");
   tensorflow::RunOptions runOptions;
   tensorflow::SavedModelBundle bundle;
 
   // load everything
   std::string modelDir = dataPath_ + "/simplegraph";
-  status = tensorflow::LoadSavedModel(sessionOptions, runOptions, modelDir, {"serve"}, &bundle);
+  status = tensorflow::LoadSavedModel(options.getSessionOptions(), runOptions, modelDir, {"serve"}, &bundle);
   if (!status.ok()) {
     std::cout << status.ToString() << std::endl;
     return;

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoading.cc
@@ -33,20 +33,20 @@ void testMetaGraphLoading::test() {
   tensorflow::Backend backend = tensorflow::Backend::cpu;
 
   // load the graph
-  tensorflow::setLogging();
+  tensorflow::Options options{backend};
   tensorflow::MetaGraphDef* metaGraphDef = tensorflow::loadMetaGraphDef(exportDir);
   CPPUNIT_ASSERT(metaGraphDef != nullptr);
 
   // create a new, empty session
-  tensorflow::Session* session1 = tensorflow::createSession(backend);
+  tensorflow::Session* session1 = tensorflow::createSession(options);
   CPPUNIT_ASSERT(session1 != nullptr);
 
   // create a new session, using the meta graph
-  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir, backend);
+  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir, options);
   CPPUNIT_ASSERT(session2 != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir, options), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testMetaGraphLoadingCUDA.cc
@@ -55,19 +55,20 @@ process.add_(cms.Service('CUDAService'))
   // load the graph
   std::string exportDir = dataPath_ + "/simplegraph";
   tensorflow::setLogging();
+  tensorflow::Options options{backend};
   tensorflow::MetaGraphDef* metaGraphDef = tensorflow::loadMetaGraphDef(exportDir);
   CPPUNIT_ASSERT(metaGraphDef != nullptr);
 
   // create a new, empty session
-  tensorflow::Session* session1 = tensorflow::createSession(backend);
+  tensorflow::Session* session1 = tensorflow::createSession(options);
   CPPUNIT_ASSERT(session1 != nullptr);
 
   // create a new session, using the meta graph
-  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir, backend);
+  tensorflow::Session* session2 = tensorflow::createSession(metaGraphDef, exportDir, options);
   CPPUNIT_ASSERT(session2 != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, exportDir, options), cms::Exception);
 
   // example evaluation
   tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 10});

--- a/PhysicsTools/TensorFlow/test/testSessionCache.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCache.cc
@@ -30,11 +30,10 @@ void testSessionCache::test() {
 
   std::cout << "Testing CPU backend" << std::endl;
   tensorflow::Backend backend = tensorflow::Backend::cpu;
-
-  tensorflow::setLogging();
+  tensorflow::Options options{backend};
 
   // load the graph and the session
-  tensorflow::SessionCache cache(pbFile, backend);
+  tensorflow::SessionCache cache(pbFile, options);
   CPPUNIT_ASSERT(cache.graph.load() != nullptr);
   CPPUNIT_ASSERT(cache.session.load() != nullptr);
 

--- a/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testSessionCacheCUDA.cc
@@ -54,7 +54,11 @@ process.add_(cms.Service('CUDAService'))
   // load the graph and the session
   std::string pbFile = dataPath_ + "/constantgraph.pb";
   tensorflow::setLogging();
-  tensorflow::SessionCache cache(pbFile, backend);
+  tensorflow::Options options{backend};
+
+  // load the graph and the session
+  tensorflow::SessionCache cache(pbFile, options);
+
   CPPUNIT_ASSERT(cache.graph.load() != nullptr);
   CPPUNIT_ASSERT(cache.session.load() != nullptr);
 

--- a/PhysicsTools/TensorFlow/test/testThreadPools.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPools.cc
@@ -31,18 +31,19 @@ void testGraphLoading::test() {
 
   std::cout << "Testing CPU backend" << std::endl;
   tensorflow::Backend backend = tensorflow::Backend::cpu;
+  tensorflow::Options options{backend};
 
   // initialize the TBB threadpool
   int nThreads = 4;
   tensorflow::TBBThreadPool::instance(nThreads);
+  options.setThreading(nThreads);
 
   // load the graph
-  tensorflow::setLogging();
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // prepare inputs
@@ -69,7 +70,7 @@ void testGraphLoading::test() {
   CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
   // tensorflow defaut pool using a new session
-  tensorflow::Session* session2 = tensorflow::createSession(graphDef, backend, nThreads);
+  tensorflow::Session* session2 = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
   outputs.clear();
   tensorflow::run(session2, {{"input", input}, {"scale", scale}}, {"output"}, &outputs, "tensorflow");

--- a/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testThreadPoolsCUDA.cc
@@ -51,10 +51,12 @@ process.add_(cms.Service('CUDAService'))
 
   std::cout << "Testing CUDA backend" << std::endl;
   tensorflow::Backend backend = tensorflow::Backend::cuda;
+  tensorflow::Options options{backend};
 
   // initialize the TBB threadpool
   int nThreads = 4;
   tensorflow::TBBThreadPool::instance(nThreads);
+  options.setThreading(nThreads);
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
@@ -63,7 +65,7 @@ process.add_(cms.Service('CUDAService'))
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // prepare inputs
@@ -90,7 +92,7 @@ process.add_(cms.Service('CUDAService'))
   CPPUNIT_ASSERT(outputs[0].matrix<float>()(0, 0) == 46.);
 
   // tensorflow defaut pool using a new session
-  tensorflow::Session* session2 = tensorflow::createSession(graphDef, backend, nThreads);
+  tensorflow::Session* session2 = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
   outputs.clear();
   tensorflow::run(session2, {{"input", input}, {"scale", scale}}, {"output"}, &outputs, "tensorflow");

--- a/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevices.cc
@@ -32,18 +32,18 @@ std::string testVisibleDevices::pyScript() const { return "createconstantgraph.p
 void testVisibleDevices::test() {
   std::string pbFile = dataPath_ + "/constantgraph.pb";
   tensorflow::Backend backend = tensorflow::Backend::cpu;
+  tensorflow::Options options{backend};
 
   // load the graph
-  tensorflow::setLogging();
   tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   std::vector<tensorflow::DeviceAttributes> response;
   tensorflow::Status status = session->ListDevices(&response);

--- a/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
+++ b/PhysicsTools/TensorFlow/test/testVisibleDevicesCUDA.cc
@@ -54,6 +54,8 @@ process.add_(cms.Service('CUDAService'))
 
   std::cout << "Testing CUDA backend" << std::endl;
   tensorflow::Backend backend = tensorflow::Backend::cuda;
+  tensorflow::Options options{backend};
+  tensorflow::setLogging("0");
 
   // load the graph
   std::string pbFile = dataPath_ + "/constantgraph.pb";
@@ -62,11 +64,11 @@ process.add_(cms.Service('CUDAService'))
   CPPUNIT_ASSERT(graphDef != nullptr);
 
   // create a new session and add the graphDef
-  tensorflow::Session* session = tensorflow::createSession(graphDef, backend);
+  tensorflow::Session* session = tensorflow::createSession(graphDef, options);
   CPPUNIT_ASSERT(session != nullptr);
 
   // check for exception
-  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, backend), cms::Exception);
+  CPPUNIT_ASSERT_THROW(tensorflow::createSession(nullptr, options), cms::Exception);
 
   std::vector<tensorflow::DeviceAttributes> response;
   tensorflow::Status status = session->ListDevices(&response);
@@ -74,11 +76,11 @@ process.add_(cms.Service('CUDAService'))
 
   // If a single device is found, we assume that it's the CPU.
   // You can check that name if you want to make sure that this is the case
-  std::cout << "Available devices: " << response.size() << std::endl;
-  CPPUNIT_ASSERT(response.size() == 2);
   for (unsigned int i = 0; i < response.size(); ++i) {
     std::cout << i << " " << response[i].name() << " type: " << response[i].device_type() << std::endl;
   }
+  std::cout << "Available devices: " << response.size() << std::endl;
+  CPPUNIT_ASSERT(response.size() == 2);
 
   // cleanup
   CPPUNIT_ASSERT(tensorflow::closeSession(session));

--- a/RecoTauTag/RecoTau/src/DeepTauBase.cc
+++ b/RecoTauTag/RecoTau/src/DeepTauBase.cc
@@ -214,10 +214,8 @@ namespace deep_tau {
 
   DeepTauCache::DeepTauCache(const std::map<std::string, std::string>& graph_names, bool mem_mapped) {
     for (const auto& graph_entry : graph_names) {
-      tensorflow::SessionOptions options;
-      tensorflow::setThreading(options, 1);
-      // To be parametrized from the python config
-      tensorflow::setBackend(options, tensorflow::Backend::cpu);
+      // Backend : to be parametrized from the python config
+      tensorflow::Options options{tensorflow::Backend::cpu};
 
       const std::string& entry_name = graph_entry.first;
       const std::string& graph_file = graph_entry.second;
@@ -239,9 +237,9 @@ namespace deep_tau {
           throw cms::Exception("DeepTauCache: unable to load graph from ") << graph_file << ". \n"
                                                                            << load_graph_status.ToString();
 
-        options.config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(
+        options.getSessionOptions().config.mutable_graph_options()->mutable_optimizer_options()->set_opt_level(
             ::tensorflow::OptimizerOptions::L0);
-        options.env = memmappedEnv_.at(entry_name).get();
+        options.getSessionOptions().env = memmappedEnv_.at(entry_name).get();
 
         sessions_[entry_name] = tensorflow::createSession(graphs_.at(entry_name).get(), options);
 


### PR DESCRIPTION
#### PR description:

This PR is a follow up from PR #40551,  https://github.com/cms-sw/cmssw/pull/40551#issuecomment-1427687134.

The PR improves the handling of the TF interface options by creating a new struct: 

```
Options {
    int _nThreads;
    Backend _backend;
    SessionOptions _options;
}
```

This change allows to have always a well defined default backend for TF sessions created with default options.
Moreover it simplifies the multiple overloaded functions  for TF graph loading and session creation.

We will try to make the interface to ONNX more  similar to the TF one in a separate PR,  as in https://github.com/cms-sw/cmssw/pull/39402

#### PR validation:

Technical PR: no changes on the reconstruction output are expected.

@riga @yongbinfeng 
