### PR TITLE
Add ap_data type to Phase 2 GMT output for GT interface

### DIFF
--- a/DataFormats/L1TMuonPhase2/interface/Constants.h
+++ b/DataFormats/L1TMuonPhase2/interface/Constants.h
@@ -54,7 +54,7 @@ namespace Phase2L1GMT {
   // Bitwidth for standalone muons to CL1 and GT
   const int BITSSAZ0 = 5;
   const int BITSSAD0 = 7;
-  const int BITSSAQUALITY = 4;
+  const int BITSSAQUAL = 4;
 
   // Bitwidth for dataformat to GT
   const int BITSGTPT = 16;
@@ -62,14 +62,24 @@ namespace Phase2L1GMT {
   const int BITSGTETA = 14;
   const int BITSGTZ0 = 10;
   const int BITSGTD0 = 10;
-  const int BITSGTQUALITY = 8;
+  const int BITSGTQUAL = 8;
   const int BITSGTISO = 4;
+  const int BITSGTBETA = 4;
+
+  // Bitwidth for Tau->3mu object
+  const int BITSTMPT = 8;
+  const int BITSTMPHI = 8;
+  const int BITSTMETA = 8;
+  const int BITSTMMASS2 = 8;
+  const int BITSTMTYPE = 6;
+  const int BITSTMIDX = 4;
+  const int BITSTMQUAL = 4;
 
   const float maxCurv_ = 0.00855;  // 2 GeV pT Rinv is in cm
   const float maxPhi_ = 1.026;     // relative to the center of the sector
   const float maxTanl_ = 8.0;
-  const float maxZ0_ = 30.;
-  const float maxD0_ = 15.4;
+  const float maxZ0_ = 25.6;
+  const float maxD0_ = 15.36;
   // Updated barrelLimit according to Karol, https://indico.cern.ch/event/1113802/#1-phase2-gmt-performance-and-i
   const int barrelLimit0_ = 1.4 / 0.00076699039 / 8;
   const int barrelLimit1_ = 1.1 / 0.00076699039 / 8;
@@ -81,12 +91,32 @@ namespace Phase2L1GMT {
   const float LSBpt = 0.03125;
   const float LSBphi = 2. * M_PI / pow(2, BITSPHI);
   const float LSBeta = 2. * M_PI / pow(2, BITSETA);
-  const float LSBGTz0 = 2. * maxZ0_ / pow(2, BITSZ0);
-  const float LSBGTd0 = 2. * maxD0_ / pow(2, BITSD0);
-  const float LSBSAz0 = 1.875;
-  const float LSBSAd0 = 3.85;
+  const float LSBGTz0 = 0.05;  // 0.5mm, in sync with GTT and Correlator
+  const float LSBGTd0 = 0.03;  // from GT interface doc
+  const float LSBSAz0 = 1.6;   // 0.05 * 32 cm, with range +- 25.6
+  const float LSBSAd0 = 3.84;  // 0.03 * 128 cm, with range +- 245.76
 
   typedef ap_uint<64> wordtype;
+  typedef ap_uint<1> valid_gt_t;          //valid
+  typedef ap_uint<1> q_gt_t;              //charge
+  typedef ap_uint<BITSGTPT> pt_gt_t;      //pt        of tracker muon
+  typedef ap_int<BITSGTPHI> phi_gt_t;     //phi       of tracker muon
+  typedef ap_int<BITSGTETA> eta_gt_t;     //eta       of tracker muon
+  typedef ap_int<BITSGTZ0> z0_gt_t;       //z0        of tracker muon
+  typedef ap_int<BITSGTD0> d0_gt_t;       //d0        of tracker muon
+  typedef ap_uint<BITSGTISO> iso_gt_t;    //isolation of tracker muon
+  typedef ap_uint<BITSGTBETA> beta_gt_t;  //beta      of tracker muon
+  typedef ap_uint<BITSGTQUAL> qual_gt_t;  //quality   of tracker muon
+
+  //Standalone muon datatype
+  typedef ap_uint<1> valid_sa_t;          //valid
+  typedef ap_uint<BITSGTPT> pt_sa_t;      //pt      of standalone muon
+  typedef ap_int<BITSGTPHI> phi_sa_t;     //phi     of standalone muon
+  typedef ap_int<BITSGTETA> eta_sa_t;     //eta     of standalone muon
+  typedef ap_int<BITSSAZ0> z0_sa_t;       //z0      of standalone muon
+  typedef ap_int<BITSSAD0> d0_sa_t;       //d0      of standalone muon
+  typedef ap_uint<1> q_sa_t;              //charge  of standalone muon
+  typedef ap_uint<BITSSAQUAL> qual_sa_t;  //quality of standalone muon
 
   inline uint64_t twos_complement(long long int v, uint bits) {
     uint64_t mask = (1 << bits) - 1;

--- a/DataFormats/L1TMuonPhase2/interface/SAMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/SAMuon.h
@@ -31,6 +31,16 @@ namespace l1t {
     const uint hwBeta() const { return hwBeta_; }
     void setBeta(uint beta) { hwBeta_ = beta; }
 
+    // For GT, returning ap_ type
+    const Phase2L1GMT::valid_sa_t apValid() const { return Phase2L1GMT::valid_sa_t(hwPt() > 0); };
+    const Phase2L1GMT::pt_sa_t apPt() const { return Phase2L1GMT::pt_sa_t(hwPt()); };
+    const Phase2L1GMT::phi_sa_t apPhi() const { return Phase2L1GMT::phi_sa_t(hwPhi()); };
+    const Phase2L1GMT::eta_sa_t apEta() const { return Phase2L1GMT::eta_sa_t(hwEta()); };
+    const Phase2L1GMT::z0_sa_t apZ0() const { return Phase2L1GMT::z0_sa_t(hwZ0()); };
+    const Phase2L1GMT::d0_sa_t apD0() const { return Phase2L1GMT::d0_sa_t(hwD0()); };
+    const Phase2L1GMT::q_sa_t apCharge() const { return Phase2L1GMT::q_sa_t(hwCharge()); };
+    const Phase2L1GMT::qual_sa_t apQual() const { return Phase2L1GMT::qual_sa_t(hwQual()); };
+
     // For HLT
     const double phZ0() const { return Phase2L1GMT::LSBSAz0 * hwZ0(); }
     const double phD0() const { return Phase2L1GMT::LSBSAd0 * hwD0(); }

--- a/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
+++ b/DataFormats/L1TMuonPhase2/interface/TrackerMuon.h
@@ -32,7 +32,7 @@ namespace l1t {
     ~TrackerMuon() override;
 
     const edm::Ptr<L1TTTrackType>& trkPtr() const { return trkPtr_; }
-    const edm::Ref<l1t::RegionalMuonCandBxCollection>& muonRef() const { return muRef_; }
+    const std::vector<l1t::RegionalMuonCandRef>& muonRef() const { return muRef_; }
 
     const bool hwCharge() const { return hwCharge_; }
     const int hwZ0() const { return hwZ0_; }
@@ -41,9 +41,21 @@ namespace l1t {
     const int hwIsoSumAp() const { return hwIsoSumAp_; }
     const uint hwBeta() const { return hwBeta_; }
     void setBeta(uint beta) { hwBeta_ = beta; }
-    void setMuonRef(const edm::Ref<l1t::RegionalMuonCandBxCollection>& p) { muRef_ = p; }
+    void setMuonRef(const std::vector<l1t::RegionalMuonCandRef>& p) { muRef_ = p; }
     void setHwIsoSum(int isoSum) { hwIsoSum_ = isoSum; }
     void setHwIsoSumAp(int isoSum) { hwIsoSumAp_ = isoSum; }
+
+    // For GT, returning ap_ type
+    const Phase2L1GMT::valid_gt_t apValid() const { return Phase2L1GMT::valid_gt_t(hwPt() > 0); };
+    const Phase2L1GMT::pt_gt_t apPt() const { return Phase2L1GMT::pt_gt_t(hwPt()); };
+    const Phase2L1GMT::phi_gt_t apPhi() const { return Phase2L1GMT::phi_gt_t(hwPhi()); };
+    const Phase2L1GMT::eta_gt_t apEta() const { return Phase2L1GMT::eta_gt_t(hwEta()); };
+    const Phase2L1GMT::z0_gt_t apZ0() const { return Phase2L1GMT::z0_gt_t(hwZ0()); };
+    const Phase2L1GMT::d0_gt_t apD0() const { return Phase2L1GMT::d0_gt_t(hwD0()); };
+    const Phase2L1GMT::q_gt_t apCharge() const { return Phase2L1GMT::q_gt_t(hwCharge()); };
+    const Phase2L1GMT::qual_gt_t apQual() const { return Phase2L1GMT::qual_gt_t(hwQual()); };
+    const Phase2L1GMT::iso_gt_t apIso() const { return Phase2L1GMT::iso_gt_t(hwIso()); };
+    const Phase2L1GMT::beta_gt_t apBeta() const { return Phase2L1GMT::beta_gt_t(hwBeta()); };
 
     // For HLT
     const double phZ0() const { return Phase2L1GMT::LSBGTz0 * hwZ0(); }
@@ -76,7 +88,7 @@ namespace l1t {
     //Store the eneryg sum for isolation with ap_type
     int hwIsoSumAp_;
 
-    edm::Ref<l1t::RegionalMuonCandBxCollection> muRef_;
+    std::vector<l1t::RegionalMuonCandRef> muRef_;
     MuonStubRefVector stubs_;
   };
 }  // namespace l1t

--- a/DataFormats/L1TMuonPhase2/src/classes_def.xml
+++ b/DataFormats/L1TMuonPhase2/src/classes_def.xml
@@ -8,8 +8,8 @@
  <class name="edm::Wrapper<std::vector<l1t::MuonStub > >"/>
  <class name="edm::Ref<l1t::MuonStubCollection>" splitLevel="0"/>
 
- <class name="l1t::TrackerMuon" ClassVersion="3">
-   <version ClassVersion="3" checksum="2397458791"/>
+ <class name="l1t::TrackerMuon" ClassVersion="4">
+   <version ClassVersion="4" checksum="3437073036"/>
  </class>
  <class name="std::vector<l1t::TrackerMuon>"/>
  <class name="edm::Wrapper<std::vector<l1t::TrackerMuon > >"/>

--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTSAMuonProducer.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTSAMuonProducer.cc
@@ -127,17 +127,17 @@ void Phase2L1TGMTSAMuonProducer::produce(edm::Event& iEvent, const edm::EventSet
 //  Description:
 // ===========================================================================
 SAMuon Phase2L1TGMTSAMuonProducer::Convertl1tMuon(const l1t::Muon& mu, const int bx_) {
-  ap_uint<BITSSAQUALITY> qual = mu.hwQual();
+  qual_sa_t qual = mu.hwQual();
   int charge = mu.charge() > 0 ? 0 : 1;
 
-  ap_uint<BITSPT> pt = round(mu.pt() / LSBpt);
-  ap_int<BITSPHI> phi = round(mu.phi() / LSBphi);
-  ap_int<BITSETA> eta = round(mu.eta() / LSBeta);
+  pt_sa_t pt = round(mu.pt() / LSBpt);
+  phi_sa_t phi = round(mu.phi() / LSBphi);
+  eta_sa_t eta = round(mu.eta() / LSBeta);
   // FIXME: Below are not well defined in phase1 GMT
   // Using the version from Correlator for now
-  ap_int<BITSSAZ0> z0 = 0;  // No tracks info in Phase 1
+  z0_sa_t z0 = 0;  // No tracks info in Phase 1
   // Use 2 bits with LSB = 30cm for BMTF and 25cm for EMTF currently, but subjet to change
-  ap_int<BITSSAD0> d0 = mu.hwDXY();
+  d0_sa_t d0 = mu.hwDXY();
 
   int bstart = 0;
   wordtype word(0);
@@ -148,7 +148,7 @@ SAMuon Phase2L1TGMTSAMuonProducer::Convertl1tMuon(const l1t::Muon& mu, const int
   bstart = wordconcat<wordtype>(word, bstart, z0, BITSSAZ0);
   bstart = wordconcat<wordtype>(word, bstart, d0, BITSSAD0);
   bstart = wordconcat<wordtype>(word, bstart, charge, 1);
-  bstart = wordconcat<wordtype>(word, bstart, qual, BITSSAQUALITY);
+  bstart = wordconcat<wordtype>(word, bstart, qual, BITSSAQUAL);
 
   SAMuon samuon(mu, charge, pt.to_uint(), eta.to_int(), phi.to_int(), z0.to_int(), d0.to_int(), qual.to_uint());
   samuon.setWord(word);

--- a/L1Trigger/Phase2L1GMT/plugins/TrackMuonMatchAlgorithm.h
+++ b/L1Trigger/Phase2L1GMT/plugins/TrackMuonMatchAlgorithm.h
@@ -105,7 +105,7 @@ namespace Phase2L1GMT {
         if (out.size() == maximum)
           break;
         l1t::TrackerMuon muon(mu.trkPtr(), mu.charge(), mu.pt(), mu.eta(), mu.phi(), mu.z0(), mu.d0(), mu.quality());
-        //muon.setMuonRef(mu.muonRef());
+        muon.setMuonRef(mu.muonRef());
         for (const auto& stub : mu.stubs())
           muon.addStub(stub);
         out.push_back(muon);
@@ -131,9 +131,9 @@ namespace Phase2L1GMT {
 
         bstart = 0;
         bstart = wordconcat<wordtype>(word2, bstart, mu.hwCharge(), 1);
-        bstart = wordconcat<wordtype>(word2, bstart, mu.hwQual(), BITSGTQUALITY);
+        bstart = wordconcat<wordtype>(word2, bstart, mu.hwQual(), BITSGTQUAL);
         bstart = wordconcat<wordtype>(word2, bstart, mu.hwIso(), BITSGTISO);
-        bstart = wordconcat<wordtype>(word2, bstart, mu.hwBeta(), BITSMUONBETA);
+        bstart = wordconcat<wordtype>(word2, bstart, mu.hwBeta(), BITSGTBETA);
 
         std::array<uint64_t, 2> wordout = {{word1, word2}};
         mu.setWord(wordout);

--- a/L1Trigger/Phase2L1GMT/python/gmt_cfi.py
+++ b/L1Trigger/Phase2L1GMT/python/gmt_cfi.py
@@ -70,7 +70,7 @@ l1tGMTMuons = cms.EDProducer('Phase2L1TGMTProducer',
                        RelIsoThresholdM = cms.double(0.05),
                        RelIsoThresholdT = cms.double(0.01),
                        verbose       = cms.int32(0),
-                       IsodumpForHLS = cms.int32(1),
+                       IsodumpForHLS = cms.int32(0),
                      ),
                     tauto3mu = cms.PSet()
 

--- a/L1Trigger/Phase2L1GMT/test/runGMT.py
+++ b/L1Trigger/Phase2L1GMT/test/runGMT.py
@@ -115,30 +115,10 @@ process.dtTriggerPhase2PrimitiveDigis.dump = False
 process.dtTriggerPhase2PrimitiveDigis.scenario = 0
 
 process.load("L1Trigger.Phase2L1GMT.gmt_cff")
-process.l1tGMTMuons.trackMatching.verbose=1
-process.l1tGMTMuons.verbose=0
-process.l1tGMTMuons.trackConverter.verbose=0
-
-
-
-#process.schedule = cms.Schedule(process.L1TrackTrigger_step,process.pL1TMuonTPS,process.endjob_step,process.e) # Adding MuonTPS
-
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)
 process.L1TrackTrigger_step = cms.Path(process.L1TrackTrigger)
-#process.pL1TkPhotonsCrystal = cms.Path(process.L1TkPhotonsCrystal)
-#process.pL1TkIsoElectronsCrystal = cms.Path(process.L1TkIsoElectronsCrystal)
-#process.pL1TkElectronsLooseCrystal = cms.Path(process.L1TkElectronsLooseCrystal)
-#process.pL1TkElectronsLooseHGC = cms.Path(process.L1TkElectronsLooseHGC)
-#process.pL1TkElectronsHGC = cms.Path(process.L1TkElectronsHGC)
-process.pL1TkMuon = cms.Path(process.L1TkMuons+process.L1TkMuonsTP)
-#process.pL1TkElectronsEllipticMatchHGC = cms.Path(process.L1TkElectronsEllipticMatchHGC)
-#process.pL1TkElectronsCrystal = cms.Path(process.L1TkElectronsCrystal)
-#process.pL1TkPhotonsHGC = cms.Path(process.L1TkPhotonsHGC)
-#process.pL1TkIsoElectronsHGC = cms.Path(process.L1TkIsoElectronsHGC)
-#process.pL1TkElectronsEllipticMatchCrystal = cms.Path(process.L1TkElectronsEllipticMatchCrystal)
-#process.L1simulation_step = cms.Path(process.SimL1Emulator)
 process.testpath=cms.Path(process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis*process.phase2GMT)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)


### PR DESCRIPTION
#### PR description:

1. Added the ap_data type in the Phase2 GMT output dataformat, as requested by the GT group.
2. Update the GMT Z0/D0 LSB 
