### PR TITLE
improve unit test `testCreateRandomMisalignment`

### DIFF
--- a/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
+++ b/Alignment/TrackerAlignment/test/Misalignments/createRandomlyMisalignedGeometry_Phase2_cfg.py
@@ -55,23 +55,7 @@ process.trackerGeometry.applyAlignment = True
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '') # using realistic Phase 2 geom
-process.GlobalTag.toGet = cms.VPSet(
-    cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-             tag = cms.string("Alignments"),
-             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
-         ),
-    cms.PSet(record = cms.string("TrackerAlignmentErrorExtendedRcd"),
-             tag = cms.string("AlignmentErrorsExtended"),
-             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
-         ),
-    cms.PSet(record = cms.string("TrackerSurfaceDeformationRcd"),
-             tag = cms.string("AlignmentSurfaceDeformations"),
-             connect = cms.string('sqlite_file:/afs/cern.ch/user/m/musich/public/forSandra/tracker_alignment_phase2_D88130X_mcRun4_realistic_v2.db')
-         )
-)
-
 print("Using global tag:", process.GlobalTag.globaltag.value())
-
 
 ###################################################################
 # This uses the object from the tag and applies the misalignment scenario on top of that object

--- a/Alignment/TrackerAlignment/test/testCreateRandomMisalignment.sh
+++ b/Alignment/TrackerAlignment/test/testCreateRandomMisalignment.sh
@@ -1,8 +1,9 @@
-#! /bin/bash
+#!/bin/bash
 
+function die { echo $1: status $2 ; exit $2; }
 folder=$CMSSW_BASE/src/Alignment/TrackerAlignment/test/Misalignments
 
 for a in $(ls $folder); do
-    echo "running " ${a}
-    cmsRun $folder/${a}
+    echo "running unit test: " ${a}
+    cmsRun $folder/${a} || die "Failure running ${a}" $?
 done 


### PR DESCRIPTION
#### PR description:

resolves https://github.com/cms-sw/cmssw/issues/41280. After https://github.com/cms-sw/cmssw/pull/41075 is no longer needed to specify details of local sqlite files for the unit test, since they are already included in the (symbolic) global tag. 
Also improved the test in order to not fail quietly in case of issues.

#### PR validation:

`scram b runtests` runs successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

