### PR TITLE
[13_0_X] Pixel Alpaka Migration: Modification to Existing Modules [I]

### DIFF
--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -290,6 +290,7 @@ namespace pixelTopology {
     using tindex_type = uint32_t;  // for tuples
     using cindex_type = uint32_t;  // for cells
 
+    static constexpr uint32_t maxNumberOfHits = 256 * 1024;
     static constexpr uint32_t maxCellNeighbors = 64;
     static constexpr uint32_t maxCellTracks = 302;
     static constexpr uint32_t maxHitsOnTrack = 15;
@@ -382,6 +383,7 @@ namespace pixelTopology {
     using tindex_type = uint16_t;  // for tuples
     using cindex_type = uint32_t;  // for cells
 
+    static constexpr uint32_t maxNumberOfHits = 48 * 1024;
     static constexpr uint32_t maxCellNeighbors = 36;
     static constexpr uint32_t maxCellTracks = 48;
     static constexpr uint32_t maxHitsOnTrack = 10;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -31,7 +31,6 @@
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 
 #include "storeTracks.h"
-#include "CUDADataFormats/Common/interface/HostProduct.h"
 
 #include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousHost.h"
 #include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousDevice.h"

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAStructures.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAStructures.h
@@ -1,5 +1,5 @@
-#ifndef CUDADataFormats_TrackerGeometry_CAStructures_h
-#define CUDADataFormats_TrackerGeometry_CAStructures_h
+#ifndef RecoPixelVertexing_PixelTriplets_CAStructures_h
+#define RecoPixelVertexing_PixelTriplets_CAStructures_h
 
 #include "HeterogeneousCore/CUDAUtilities/interface/SimpleVector.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/VecArray.h"


### PR DESCRIPTION
#### PR description:

This PR stems from #41117 and it's the 1st of a series of smaller PRs for `13_0_X`.  

This is It includes the changes to pre-existing modules or headers (`BuildFile`s not included here).
A single real change to include the max number of hits in the the topologies. 

A backport of #41282.

This will change depending on https://github.com/cms-sw/cmssw/pull/41223.
 
#### PR validation:

It compiles. Running base tests. No regression expected.
