### PR TITLE
remove erroneous call to global ROOT reset

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -559,11 +559,6 @@ TrackerMap::~TrackerMap() {
     TmPsu *psu = ipsu->second;
     delete psu;
   }
-
-  gROOT->Reset();
-
-  //for(std::vector<TColor*>::iterator col1=vc.begin();col1!=vc.end();col1++){
-  //     std::cout<<(*col1)<<std::endl;}
 }
 
 void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, std::ofstream *svgfile) {


### PR DESCRIPTION
#### PR description:

The TrackerMap destructor has a call to the ROOT global interpreter Reset() function, which should never be called from compiled code.  Apparently this is only instantiated for `!SiPixelPI::phase::two`, which I guess is why it hasn't bitten us before.  See #41270 for details.

#### PR validation:

Compiles, purely technical fix for what is clearly an error.