### PR TITLE
TkAl Payload Inspector: fix bug in computation of barycenters per partition and improve graphical display

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -883,6 +883,17 @@ namespace AlignmentPI {
   };
 
   /*--------------------------------------------------------------------*/
+  inline void TkAlBarycenters::init()
+  /*--------------------------------------------------------------------*/
+  {
+    // empty all maps
+    Xbarycenters.clear();
+    Ybarycenters.clear();
+    Zbarycenters.clear();
+    nmodules.clear();
+  }
+
+  /*--------------------------------------------------------------------*/
   inline GlobalPoint TkAlBarycenters::getPartitionAvg(AlignmentPI::PARTITION p)
   /*--------------------------------------------------------------------*/
   {
@@ -895,10 +906,8 @@ namespace AlignmentPI {
                                                   const std::map<AlignmentPI::coordinate, float>& GPR)
   /*--------------------------------------------------------------------*/
   {
-    // zero in the n. modules per partition...
-    for (const auto& p : PARTITIONS) {
-      nmodules[p] = 0.;
-    }
+    // clear all data members;
+    init();
 
     for (const auto& ali : input) {
       if (DetId(ali.rawId()).det() != DetId::Tracker) {

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -693,6 +693,7 @@ namespace {
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
+      const auto &tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<Alignments> payload = fetchPayload(std::get<1>(iov));
       unsigned int run = std::get<0>(iov);
 
@@ -794,8 +795,8 @@ namespace {
       TLatex t1;
       t1.SetNDC();
       t1.SetTextAlign(26);
-      t1.SetTextSize(0.05);
-      t1.DrawLatex(0.5, 0.96, Form("Tracker Alignment Barycenters, IOV %i", run));
+      t1.SetTextSize(0.045);
+      t1.DrawLatex(0.5, 0.96, Form("TkAl Barycenters, Tag: #color[4]{%s}, IOV #color[4]{%i}", tagname.c_str(), run));
       t1.SetTextSize(0.025);
 
       std::string fileName(m_imageFileName);


### PR DESCRIPTION
#### PR description:

Title says it all, correcting a bug when repeatedly computing the barycenters, clean the data members of `TkAlBarycenters` before recomputing. 
Profited of the PR to introduce some small graphical improvement in the displayed layout

#### PR validation:

Run privately the following command:

```
getPayloadData.py --plugin pluginTrackerAlignment_PayloadInspector --plot plot_TrackerAlignmentBarycenters --tag TrackerAlignment_CRAFT23_v0 --input_params '{}' --time_type Run --iovs '{"start_iov": "1", "end_iov": "1"}' --db Prod --test ;
```
and obtained the following plot:

![image](https://user-images.githubusercontent.com/5082376/230382980-25e713bb-9699-4856-9cbc-5e299c355949.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A