### PR TITLE
get rid of `gROOT->Reset()` in GeometryComparisonPlotter.cc

### DIFF
--- a/Alignment/OfflineValidation/src/GeometryComparisonPlotter.cc
+++ b/Alignment/OfflineValidation/src/GeometryComparisonPlotter.cc
@@ -154,8 +154,6 @@ GeometryComparisonPlotter::GeometryComparisonPlotter(TString tree_file_name,
 #endif
 
   // style
-  gROOT->Reset();
-
   data->SetMarkerSize(0.5);
   data->SetMarkerStyle(6);
 


### PR DESCRIPTION
#### PR description:

Title says it all, addresses https://github.com/cms-sw/cmssw/issues/41270#issuecomment-1497991926

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A