### PR TITLE
[DBG] fix compilation error for dbg IBs

### DIFF
--- a/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalTimeDigiProducer.cc
@@ -49,10 +49,6 @@ void EcalTimeDigiProducer::initializeEvent(edm::Event const &event, edm::EventSe
     m_ComponentShapes->setEventSetup(eventSetup);
     m_BarrelDigitizer->setEventSetup(eventSetup);
   }
-#ifdef EDM_ML_DEBUG
-  if (m_componentWaveform)
-    m_ComponentShapes->test();
-#endif
 }
 
 void EcalTimeDigiProducer::accumulateCaloHits(HitsHandle const &ebHandle, int bunchCrossing) {


### PR DESCRIPTION
Fix the DBG compilation error. `ComponentShapeCollection` does not have `test()` member function. This was introduced in https://github.com/cms-sw/cmssw/pull/40855 