### PR TITLE
[DBG] Fix compilation warnings

### DIFF
--- a/Geometry/HGCalTBCommonData/plugins/HGCalTBNumberingInitialization.cc
+++ b/Geometry/HGCalTBCommonData/plugins/HGCalTBNumberingInitialization.cc
@@ -26,8 +26,6 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBParameters.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#define EDM_ML_DEBUG
-
 class HGCalTBNumberingInitialization : public edm::ESProducer {
 public:
   HGCalTBNumberingInitialization(const edm::ParameterSet&);

--- a/Geometry/HGCalTBCommonData/plugins/HGCalTBNumberingInitialization.cc
+++ b/Geometry/HGCalTBCommonData/plugins/HGCalTBNumberingInitialization.cc
@@ -26,6 +26,8 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBParameters.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
+//#define EDM_ML_DEBUG
+
 class HGCalTBNumberingInitialization : public edm::ESProducer {
 public:
   HGCalTBNumberingInitialization(const edm::ParameterSet&);
@@ -42,9 +44,7 @@ private:
 
 HGCalTBNumberingInitialization::HGCalTBNumberingInitialization(const edm::ParameterSet& iConfig) {
   name_ = iConfig.getUntrackedParameter<std::string>("name");
-#ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "HGCalTBNumberingInitialization for " << name_;
-#endif
   auto cc = setWhatProduced(this, name_);
   hgParToken_ = cc.consumes<HGCalTBParameters>(edm::ESInputTag{"", name_});
 }

--- a/Geometry/HGCalTBCommonData/plugins/HGCalTBParametersESModule.cc
+++ b/Geometry/HGCalTBCommonData/plugins/HGCalTBParametersESModule.cc
@@ -11,6 +11,8 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBParametersFromDD.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
+//#define EDM_ML_DEBUG
+
 class HGCalTBParametersESModule : public edm::ESProducer {
 public:
   HGCalTBParametersESModule(const edm::ParameterSet&);

--- a/Geometry/HGCalTBCommonData/plugins/HGCalTBParametersESModule.cc
+++ b/Geometry/HGCalTBCommonData/plugins/HGCalTBParametersESModule.cc
@@ -11,8 +11,6 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBParametersFromDD.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#define EDM_ML_DEBUG
-
 class HGCalTBParametersESModule : public edm::ESProducer {
 public:
   HGCalTBParametersESModule(const edm::ParameterSet&);


### PR DESCRIPTION
Remove explicit `#define EDM_ML_DEBUG` defines which are not only generating compiltion warnings for DBG IBs ( where `EDM_ML_DEBUG`  is set by `scram`) but it also prints the edm debug messages for production.