### PR TITLE
Run3-gex158D Replace std::cout with edm::LogVerbatim in Geometry/MuonNumbering

### DIFF
--- a/Geometry/MuonNumbering/src/DTNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/DTNumberingScheme.cc
@@ -51,21 +51,15 @@ int DTNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) const {
   //   // however allows for 0 in wire, layer, superlayer!!!)
   //
   //   if ((wire_id < 1) || (wire_id > 100)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "wire id out of range: ";
-  //     std::cout << wire_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: wire id out of range: " << wire_id;
   //   }
 
   //   if ((layer_id < 1) || (layer_id > 4)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "layer id out of range: ";
-  //     std::cout << layer_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: layer id out of range: " << layer_id;
   //   }
 
   //   if ((superlayer_id < 1) || (superlayer_id > 3)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "super-layer id out of range: ";
-  //     std::cout << superlayer_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: super-layer id out of range: " << superlayer_id;
   //   }
 
   return getDetId(num);
@@ -84,21 +78,15 @@ int DTNumberingScheme::getDetId(const MuonBaseNumber& num) const {
 
   // These ranges are enforced by DTWireId
   //   if ((sector_id < 1) || (sector_id > 14)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "sector id out of range: ";
-  //     std::cout << sector_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: sector id out of range: " << sector_id;
   //   }
 
   //   if ((station_id < 1) || (station_id > 4)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "station id out of range: ";
-  //     std::cout << station_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: station id out of range: " << station_id;
   //   }
 
   //   if ((wheel_id < -2) || (wheel_id > 2)) {
-  //     std::cout << "DTNumberingScheme: ";
-  //     std::cout << "wheel id out of range: ";
-  //     std::cout << wheel_id <<std::endl;
+  //     edm::LogVerbatim("MuonNumbering") << "DTNumberingScheme: wheel id out of range: " << wheel_id;
   //   }
 
   DTWireId id(wheel_id, station_id, sector_id, superlayer_id, layer_id, wire_id);

--- a/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
@@ -104,8 +104,9 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) const 
 
           plane_id = 2;
           // }
-
-          //          std::cout<<" KONTROLA w RPCNumberingScheme: eta_id: "<<eta_id<<", plane_tag: "<<plane_tag<<", plane_id: "<<plane_id<<std::endl;
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("MuonNumbering") <<" KONTROLA w RPCNumberingScheme: eta_id: " << eta_id << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
+#endif
         } else if (plane_tag == 4) {
           //          if(copyno == 1) {
           // if(eta_id == 4 || eta_id == 8) {
@@ -113,7 +114,9 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) const 
           //} else {
           plane_id = 6;
           //}
-          //          std::cout<<" KONTROLA w RPCNumberingScheme: eta_id: "<<eta_id<<", plane_tag: "<<plane_tag<<", plane_id: "<<plane_id<<std::endl;
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("MuonNumbering") << " KONTROLA w RPCNumberingScheme: eta_id: " << eta_id << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
+#endif
         } else if (plane_tag == 5) {
           plane_id = 3;
         } else {

--- a/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
+++ b/Geometry/MuonNumbering/src/RPCNumberingScheme.cc
@@ -105,7 +105,8 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) const 
           plane_id = 2;
           // }
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("MuonNumbering") <<" KONTROLA w RPCNumberingScheme: eta_id: " << eta_id << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
+          edm::LogVerbatim("MuonNumbering") << " KONTROLA w RPCNumberingScheme: eta_id: " << eta_id
+                                            << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
 #endif
         } else if (plane_tag == 4) {
           //          if(copyno == 1) {
@@ -115,7 +116,8 @@ int RPCNumberingScheme::baseNumberToUnitNumber(const MuonBaseNumber& num) const 
           plane_id = 6;
           //}
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("MuonNumbering") << " KONTROLA w RPCNumberingScheme: eta_id: " << eta_id << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
+          edm::LogVerbatim("MuonNumbering") << " KONTROLA w RPCNumberingScheme: eta_id: " << eta_id
+                                            << ", plane_tag: " << plane_tag << ", plane_id: " << plane_id;
 #endif
         } else if (plane_tag == 5) {
           plane_id = 3;

--- a/Geometry/MuonNumbering/test/MuonGeometryConstantsTester.cc
+++ b/Geometry/MuonNumbering/test/MuonGeometryConstantsTester.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
@@ -29,13 +29,13 @@ void MuonGeometryConstantsTester::analyze(const edm::Event&, const edm::EventSet
   const auto& par = iS.getData(token_);
   const MuonGeometryConstants* parMuon = &par;
   if (parMuon != nullptr) {
-    std::cout << "\n\nMuonDDDConstants found with " << parMuon->size() << " contents\n";
+    edm::LogVerbatim("MuonNumbering") << "\n\nMuonDDDConstants found with " << parMuon->size() << " contents";
     for (unsigned int k = 0; k < parMuon->size(); ++k) {
       auto entry = parMuon->getEntry(k);
-      std::cout << " [" << k << "] " << entry.first << " = " << entry.second << std::endl;
+      edm::LogVerbatim("MuonNumbering") << " [" << k << "] " << entry.first << " = " << entry.second;
     }
   } else {
-    std::cout << "\n\nMuonDDDConstants not found in Event Setup\n";
+    edm::LogVerbatim("MuonNumbering") << "\n\nMuonDDDConstants not found in Event Setup";
   }
 }
 

--- a/Geometry/MuonNumbering/test/MuonNumberingTester.cc
+++ b/Geometry/MuonNumbering/test/MuonNumberingTester.cc
@@ -28,8 +28,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
 #include "DetectorDescription/Core/interface/DDSpecifics.h"
@@ -42,7 +43,7 @@
 class MuonNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit MuonNumberingTester(const edm::ParameterSet&);
-  ~MuonNumberingTester() override;
+  ~MuonNumberingTester() override = default;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -57,20 +58,18 @@ MuonNumberingTester::MuonNumberingTester(const edm::ParameterSet& iConfig)
     : tokDDD_{esConsumes<DDCompactView, IdealGeometryRecord>(edm::ESInputTag{})},
       tokMuon_{esConsumes<MuonDDDConstants, MuonNumberingRecord>(edm::ESInputTag{})} {}
 
-MuonNumberingTester::~MuonNumberingTester() {}
-
 // ------------ method called to produce the data  ------------
 void MuonNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  std::cout << "Here I am " << std::endl;
+  edm::LogVerbatim("MuonNumbering") << "Here I am ";
 
   const auto& pDD = iSetup.getData(tokDDD_);
   const auto& pMNDC = iSetup.getData(tokMuon_);
 
   try {
     DDExpandedView epv(pDD);
-    std::cout << " without firstchild or next... epv.logicalPart() =" << epv.logicalPart() << std::endl;
+    edm::LogVerbatim("MuonNumbering") << " without firstchild or next... epv.logicalPart() =" << epv.logicalPart();
   } catch (const DDLogicalPart& iException) {
     throw cms::Exception("Geometry") << "DDORAReader::readDB caught a DDLogicalPart exception: \"" << iException
                                      << "\"";
@@ -79,15 +78,15 @@ void MuonNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetu
   } catch (std::exception& e) {
     throw cms::Exception("Geometry") << "DDORAReader::readDB caught std::exception: \"" << e.what() << "\"";
   } catch (...) {
-    throw cms::Exception("Geometry") << "DDORAReader::readDB caught UNKNOWN!!! exception." << std::endl;
+    throw cms::Exception("Geometry") << "DDORAReader::readDB caught UNKNOWN!!! exception.";
   }
-  std::cout << "set the toFind string to \"level\"" << std::endl;
+  edm::LogVerbatim("MuonNumbering") << "set the toFind string to \"level\"";
   std::string toFind("level");
-  std::cout << "about to de-reference the edm::ESHandle<MuonDDDConstants> pMNDC" << std::endl;
+  edm::LogVerbatim("MuonNumbering") << "about to de-reference the edm::ESHandle<MuonDDDConstants> pMNDC";
   const MuonDDDConstants mdc(pMNDC);
-  std::cout << "about to getValue( toFind )" << std::endl;
+  edm::LogVerbatim("MuonNumbering") << "about to getValue( toFind )";
   int level = mdc.getValue(toFind);
-  std::cout << "level = " << level << std::endl;
+  edm::LogVerbatim("MuonNumbering") << "level = " << level;
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

Replace std::cout with edm::LogVerbatim in Geometry/MuonNumbering

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special