### PR TITLE
Switch to std::chrono::steady_clock [13_0]

### DIFF
--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -99,7 +99,7 @@ namespace edm::storage {
 
     protected:
       Counter& m_counter;
-      std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
+      std::chrono::time_point<std::chrono::steady_clock> m_start;
     };
 
     class StorageClassToken {

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -101,13 +101,12 @@ StorageAccount::Counter& StorageAccount::counter(StorageClassToken token, Operat
   return opstats[static_cast<int>(operation)];
 }
 
-StorageAccount::Stamp::Stamp(Counter& counter)
-    : m_counter(counter), m_start(std::chrono::high_resolution_clock::now()) {
+StorageAccount::Stamp::Stamp(Counter& counter) : m_counter(counter), m_start(std::chrono::steady_clock::now()) {
   m_counter.attempts++;
 }
 
 void StorageAccount::Stamp::tick(uint64_t amount, int64_t count) const {
-  std::chrono::nanoseconds elapsed_ns = std::chrono::high_resolution_clock::now() - m_start;
+  std::chrono::nanoseconds elapsed_ns = std::chrono::steady_clock::now() - m_start;
   uint64_t elapsed = elapsed_ns.count();
   m_counter.successes++;
 

--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -335,8 +335,8 @@ IOSize XrdFile::readv(IOPosBuffer *into, IOSize n) {
     assert(last_idx < idx);
     last_idx = idx;
   }
-  std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
-  start = std::chrono::high_resolution_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> start, end;
+  start = std::chrono::steady_clock::now();
 
   // If there are multiple readv calls, wait until all return until looking
   // at the results of any.  This guarantees that all readv's have finished
@@ -384,7 +384,7 @@ IOSize XrdFile::readv(IOPosBuffer *into, IOSize n) {
     }
     final_result += result;
   }
-  end = std::chrono::high_resolution_clock::now();
+  end = std::chrono::steady_clock::now();
 
   edm::LogVerbatim("XrdAdaptorInternal")
       << "[" << m_op_count.fetch_add(1) << "] Time for readv: "

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -158,9 +158,9 @@ void XrdSiteStatistics::finishRead(XrdReadStatistics const &readStats) {
 }
 
 XrdReadStatistics::XrdReadStatistics(std::shared_ptr<XrdSiteStatistics> parent, IOSize size, size_t count)
-    : m_size(size), m_count(count), m_parent(parent), m_start(std::chrono::high_resolution_clock::now()) {}
+    : m_size(size), m_count(count), m_parent(parent), m_start(std::chrono::steady_clock::now()) {}
 
 uint64_t XrdReadStatistics::elapsedNS() const {
-  std::chrono::time_point<std::chrono::high_resolution_clock> end = std::chrono::high_resolution_clock::now();
+  std::chrono::time_point<std::chrono::steady_clock> end = std::chrono::steady_clock::now();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(end - m_start).count();
 }

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -118,7 +118,7 @@ namespace XrdAdaptor {
     size_t m_size;
     edm::storage::IOSize m_count;
     edm::propagate_const<std::shared_ptr<XrdSiteStatistics>> m_parent;
-    std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
+    std::chrono::time_point<std::chrono::steady_clock> m_start;
   };
 
 }  // namespace XrdAdaptor


### PR DESCRIPTION
#### PR description:

cppreference.com strongly suggests to not use high_resolution_clock, especially for timing differences as that clock is not guaranteed to always be monotonically increasing. One should use steady_clock for timing differences.

#### PR validation:

Code compiles

backport of #41291