### PR TITLE
Utilities/StaticAnalyzers: skip pybind11 types in non-const global statics check

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -148,7 +148,9 @@ bool clangcms::support::isSafeClassName(const std::string &cname) {
                                                  "class TVirtualMutex",
                                                  "boost::(anonymous namespace)::extents",
                                                  "(anonymous namespace)::_1",
-                                                 "(anonymous namespace)::_2"};
+                                                 "(anonymous namespace)::_2",
+                                                 "struct PyModuleDef",
+                                                 "::pybind11::class module_::module_def"};
 
   for (auto &name : names)
     if (cname.substr(0, name.length()) == name)

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -28,7 +28,7 @@ namespace clangcms {
 
       if (!m_exception.reportGlobalStaticForType(t, DLoc, BR))
         return;
-      if (support::isSafeClassName(t.getCanonicalType().getAsString()))
+      if (support::isSafeClassName(t.getCanonicalType().getAsString()) || support::isSafeClassName(t.getAsString()))
         return;
 
       std::string buf;


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/41107
