### PR TITLE
fix `RecoTracker/Pixel*` subsystems header file inclusions guards to comply with cmssw rule 4.1

### DIFF
--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterData.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterData.h
@@ -1,5 +1,5 @@
-#ifndef _ClusterData_h_
-#define _ClusterData_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ClusterData_h
+#define RecoTracker_PixelLowPtUtilities_ClusterData_h
 
 #include "FWCore/Utilities/interface/VecArray.h"
 #include <utility>

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShape.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShape.h
@@ -1,5 +1,5 @@
-#ifndef _ClusterShape_h_
-#define _ClusterShape_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ClusterShape_h
+#define RecoTracker_PixelLowPtUtilities_ClusterShape_h
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h
@@ -1,5 +1,5 @@
-#ifndef _ClusterShapeHitFilter_h_
-#define _ClusterShapeHitFilter_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ClusterShapeHitFilter_h
+#define RecoTracker_PixelLowPtUtilities_ClusterShapeHitFilter_h
 
 #include "TrackingTools/TrajectoryFiltering/interface/TrajectoryFilter.h"
 

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
@@ -1,5 +1,5 @@
-#ifndef _ClusterShapeTrackFilter_h_
-#define _ClusterShapeTrackFilter_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ClusterShapeTrackFilter_h
+#define RecoTracker_PixelLowPtUtilities_ClusterShapeTrackFilter_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h"
 

--- a/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ClusterShapeTrajectoryFilter.h
@@ -1,5 +1,5 @@
-#ifndef _ClusterShapeTrajectoryFilter_h_
-#define _ClusterShapeTrajectoryFilter_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ClusterShapeTrajectoryFilter_h
+#define RecoTracker_PixelLowPtUtilities_ClusterShapeTrajectoryFilter_h
 
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"

--- a/RecoTracker/PixelLowPtUtilities/interface/HitInfo.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/HitInfo.h
@@ -1,5 +1,5 @@
-#ifndef _HitInfo_h_
-#define _HitInfo_h_
+#ifndef RecoTracker_PixelLowPtUtilities_HitInfo_h
+#define RecoTracker_PixelLowPtUtilities_HitInfo_h
 
 class DetId;
 class TrackingRecHit;

--- a/RecoTracker/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/LowPtClusterShapeSeedComparitor.h
@@ -1,5 +1,5 @@
-#ifndef _LowPtClusterShapeSeedComparitor_h_
-#define _LowPtClusterShapeSeedComparitor_h_
+#ifndef RecoTracker_PixelLowPtUtilities_LowPtClusterShapeSeedComparitor_h
+#define RecoTracker_PixelLowPtUtilities_LowPtClusterShapeSeedComparitor_h
 
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"

--- a/RecoTracker/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -1,5 +1,5 @@
-#ifndef _PixelTripletLowPtGenerator_h_
-#define _PixelTripletLowPtGenerator_h_
+#ifndef RecoTracker_PixelLowPtUtilities_PixelTripletLowPtGenerator_h
+#define RecoTracker_PixelLowPtUtilities_PixelTripletLowPtGenerator_h
 
 /** A HitTripletGenerator from HitPairGenerator and vector of
     Layers. The HitPairGenerator provides a set of hit pairs.

--- a/RecoTracker/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/StripSubClusterShapeTrajectoryFilter.h
@@ -1,5 +1,5 @@
-#ifndef _StripSubClusterShapeTrajectoryFilter_h_
-#define _StripSubClusterShapeTrajectoryFilter_h_
+#ifndef RecoTracker_PixelLowPtUtilities_StripSubClusterShapeTrajectoryFilter_h
+#define RecoTracker_PixelLowPtUtilities_StripSubClusterShapeTrajectoryFilter_h
 
 #include <vector>
 #include <unordered_map>

--- a/RecoTracker/PixelLowPtUtilities/interface/ThirdHitPrediction.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/ThirdHitPrediction.h
@@ -1,5 +1,5 @@
-#ifndef _ThirdHitPrediction_h_
-#define _ThirdHitPrediction_h_
+#ifndef RecoTracker_PixelLowPtUtilities_ThirdHitPrediction_h
+#define RecoTracker_PixelLowPtUtilities_ThirdHitPrediction_h
 
 /** predicts a range in r-z for the position of third hit.
  *  the predicted reange is defined by stright line extrapolation/interpolation

--- a/RecoTracker/PixelLowPtUtilities/interface/TrackCleaner.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/TrackCleaner.h
@@ -1,5 +1,5 @@
-#ifndef _TrackCleaner_h_
-#define _TrackCleaner_h_
+#ifndef RecoTracker_PixelLowPtUtilities_TrackCleaner_h
+#define RecoTracker_PixelLowPtUtilities_TrackCleaner_h
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoTracker/PixelLowPtUtilities/interface/TrackFitter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/TrackFitter.h
@@ -1,5 +1,5 @@
-#ifndef TrackFitter_H
-#define TrackFitter_H
+#ifndef RecoTracker_PixelLowPtUtilities_TrackFitter_h
+#define RecoTracker_PixelLowPtUtilities_TrackFitter_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"

--- a/RecoTracker/PixelLowPtUtilities/interface/TripletFilter.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/TripletFilter.h
@@ -1,5 +1,5 @@
-#ifndef _TripletFilter_h_
-#define _TripletFilter_h_
+#ifndef RecoTracker_PixelLowPtUtilities_TripletFilter_h
+#define RecoTracker_PixelLowPtUtilities_TripletFilter_h
 
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"

--- a/RecoTracker/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
+++ b/RecoTracker/PixelLowPtUtilities/plugins/PixelVertexProducerClusters.h
@@ -1,5 +1,5 @@
-#ifndef PixelVertexProducerClusters_H
-#define PixelVertexProducerClusters_H
+#ifndef RecoTracker_PixelLowPtUtilities_plugins_PixelVertexProducerClusters_h
+#define RecoTracker_PixelLowPtUtilities_plugins_PixelVertexProducerClusters_h
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"

--- a/RecoTracker/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
+++ b/RecoTracker/PixelLowPtUtilities/plugins/PixelVertexProducerMedian.h
@@ -1,5 +1,5 @@
-#ifndef PixelVertexProducerMedian_H
-#define PixelVertexProducerMedian_H
+#ifndef RecoTracker_PixelLowPtUtilities_plugins_PixelVertexProducerMedian_h
+#define RecoTracker_PixelLowPtUtilities_plugins_PixelVertexProducerMedian_h
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTracker/PixelLowPtUtilities/plugins/TrackListCombiner.h
+++ b/RecoTracker/PixelLowPtUtilities/plugins/TrackListCombiner.h
@@ -1,5 +1,5 @@
-#ifndef TrackListCombiner_H
-#define TrackListCombiner_H
+#ifndef RecoTracker_PixelLowPtUtilities_plugins_TrackListCombiner_h
+#define RecoTracker_PixelLowPtUtilities_plugins_TrackListCombiner_h
 
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTracker/PixelSeeding/interface/CACut.h
+++ b/RecoTracker/PixelSeeding/interface/CACut.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_interface_CACut_h
-#define RecoPixelVertexing_PixelTriplets_interface_CACut_h
+#ifndef RecoTracker_PixelSeeding_CACut_h
+#define RecoTracker_PixelSeeding_CACut_h
 // -*- C++ -*-
 // //
 // // Package:    RecoTracker/PixelSeeding

--- a/RecoTracker/PixelSeeding/interface/CAGraph.h
+++ b/RecoTracker/PixelSeeding/interface/CAGraph.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
-#define RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
+#ifndef RecoTracker_PixelSeeding_CAGraph_h
+#define RecoTracker_PixelSeeding_CAGraph_h
 
 #include <array>
 #include <string>
@@ -61,4 +61,4 @@ struct CAGraph {
   std::vector<int> theRootLayers;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_interface_CAGraph_h
+#endif  // RecoTracker_PixelSeeding_CAGraph_h

--- a/RecoTracker/PixelSeeding/interface/CAHitQuadrupletGenerator.h
+++ b/RecoTracker/PixelSeeding/interface/CAHitQuadrupletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITQUADRUPLETGENERATOR_H
+#ifndef RecoTracker_PixelSeeding_CAHitQuadrupletGenerator_h
+#define RecoTracker_PixelSeeding_CAHitQuadrupletGenerator_h
 
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"

--- a/RecoTracker/PixelSeeding/interface/CAHitTripletGenerator.h
+++ b/RecoTracker/PixelSeeding/interface/CAHitTripletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITTRIPLETGENERATOR_H
-#define RECOPIXELVERTEXING_PIXELTRIPLETS_CAHITTRIPLETGENERATOR_H
+#ifndef RecoTracker_PixelSeeding_CAHitTripletGenerator_h
+#define RecoTracker_PixelSeeding_CAHitTripletGenerator_h
 
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitorFactory.h"
 #include "RecoTracker/TkSeedingLayers/interface/SeedComparitor.h"

--- a/RecoTracker/PixelSeeding/interface/CircleEq.h
+++ b/RecoTracker/PixelSeeding/interface/CircleEq.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexingPixelTripletsCircleEq_H
-#define RecoPixelVertexingPixelTripletsCircleEq_H
+#ifndef RecoTracker_PixelSeeding_CircleEq_h
+#define RecoTracker_PixelSeeding_CircleEq_h
 /**
 | 1) circle is parameterized as:                                              |
 |    C*[(X-Xp)**2+(Y-Yp)**2] - 2*alpha*(X-Xp) - 2*beta*(Y-Yp) = 0             |

--- a/RecoTracker/PixelSeeding/interface/CosmicHitTripletGenerator.h
+++ b/RecoTracker/PixelSeeding/interface/CosmicHitTripletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef CosmicHitTripletGenerator_H
-#define CosmicHitTripletGenerator_H
+#ifndef RecoTracker_PixelSeeding_CosmicHitTripletGenerator_h
+#define RecoTracker_PixelSeeding_CosmicHitTripletGenerator_h
 
 #include <vector>
 #include "RecoTracker/PixelSeeding/interface/OrderedHitTriplets.h"

--- a/RecoTracker/PixelSeeding/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
+++ b/RecoTracker/PixelSeeding/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
@@ -1,5 +1,5 @@
-#ifndef CosmicHitTripletGeneratorFromLayerTriplet_h
-#define CosmicHitTripletGeneratorFromLayerTriplet_h
+#ifndef RecoTracker_PixelSeeding_CosmicHitTripletGeneratorFromLayerTriplet_h
+#define RecoTracker_PixelSeeding_CosmicHitTripletGeneratorFromLayerTriplet_h
 
 #include "RecoTracker/PixelSeeding/interface/OrderedHitTriplets.h"
 #include "RecoTracker/TkHitPairs/interface/LayerWithHits.h"

--- a/RecoTracker/PixelSeeding/interface/CosmicLayerTriplets.h
+++ b/RecoTracker/PixelSeeding/interface/CosmicLayerTriplets.h
@@ -1,5 +1,5 @@
-#ifndef CosmicLayerTriplets_H
-#define CosmicLayerTriplets_H
+#ifndef RecoTracker_PixelSeeding_CosmicLayerTriplets_h
+#define RecoTracker_PixelSeeding_CosmicLayerTriplets_h
 
 /** \class CosmicLayerTriplets
  * find all (resonable) pairs of pixel layers

--- a/RecoTracker/PixelSeeding/interface/HitTripletEDProducerT.h
+++ b/RecoTracker/PixelSeeding/interface/HitTripletEDProducerT.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_HitTripletEDProducerT_H
-#define RecoPixelVertexing_PixelTriplets_HitTripletEDProducerT_H
+#ifndef RecoTracker_PixelSeeding_HitTripletEDProducerT_h
+#define RecoTracker_PixelSeeding_HitTripletEDProducerT_h
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"

--- a/RecoTracker/PixelSeeding/interface/HitTripletGenerator.h
+++ b/RecoTracker/PixelSeeding/interface/HitTripletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef HitTripletGenerator_H
-#define HitTripletGenerator_H
+#ifndef RecoTracker_PixelSeeding_HitTripletGenerator_h
+#define RecoTracker_PixelSeeding_HitTripletGenerator_h
 
 /** abstract interface for generators of hit triplets pairs
  *  compatible with a TrackingRegion.

--- a/RecoTracker/PixelSeeding/interface/HitTripletGeneratorFromPairAndLayers.h
+++ b/RecoTracker/PixelSeeding/interface/HitTripletGeneratorFromPairAndLayers.h
@@ -1,5 +1,5 @@
-#ifndef HitTripletGeneratorFromPairAndLayers_H
-#define HitTripletGeneratorFromPairAndLayers_H
+#ifndef RecoTracker_PixelSeeding_HitTripletGeneratorFromPairAndLayers_h
+#define RecoTracker_PixelSeeding_HitTripletGeneratorFromPairAndLayers_h
 
 /** A HitTripletGenerator from HitPairGenerator and vector of
     Layers. The HitPairGenerator provides a set of hit pairs.

--- a/RecoTracker/PixelSeeding/interface/HitTripletGeneratorFromPairAndLayersFactory.h
+++ b/RecoTracker/PixelSeeding/interface/HitTripletGeneratorFromPairAndLayersFactory.h
@@ -1,5 +1,5 @@
-#ifndef PixelTriplets_HitTripletGeneratorFromPairAndLayersFactory_H
-#define PixelTriplets_HitTripletGeneratorFromPairAndLayersFactory_H
+#ifndef RecoTracker_PixelSeeding_HitTripletGeneratorFromPairAndLayersFactory_h
+#define RecoTracker_PixelSeeding_HitTripletGeneratorFromPairAndLayersFactory_h
 
 #include "RecoTracker/PixelSeeding/interface/HitTripletGeneratorFromPairAndLayers.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/RecoTracker/PixelSeeding/interface/IntermediateHitTriplets.h
+++ b/RecoTracker/PixelSeeding/interface/IntermediateHitTriplets.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_IntermediateHitTriplets_h
-#define RecoPixelVertexing_PixelTriplets_IntermediateHitTriplets_h
+#ifndef RecoTracker_PixelSeeding_IntermediateHitTriplets_h
+#define RecoTracker_PixelSeeding_IntermediateHitTriplets_h
 
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"

--- a/RecoTracker/PixelSeeding/interface/LayerTriplets.h
+++ b/RecoTracker/PixelSeeding/interface/LayerTriplets.h
@@ -1,5 +1,5 @@
-#ifndef LayerTriplets_H
-#define LayerTriplets_H
+#ifndef RecoTracker_PixelSeeding_LayerTriplets_h
+#define RecoTracker_PixelSeeding_LayerTriplets_h
 
 /** A class grouping pixel layers in pairs and associating a vector
     of layers to each layer pair. The layer pair is used to generate

--- a/RecoTracker/PixelSeeding/interface/OrderedHitSeeds.h
+++ b/RecoTracker/PixelSeeding/interface/OrderedHitSeeds.h
@@ -1,5 +1,5 @@
-#ifndef OrderedHitSeeds_H
-#define OrderedHitSeeds_H
+#ifndef RecoTracker_PixelSeeding_OrderedHitSeeds_h
+#define RecoTracker_PixelSeeding_OrderedHitSeeds_h
 
 #include <vector>
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"

--- a/RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h
+++ b/RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h
@@ -1,5 +1,5 @@
-#ifndef OrderedHitTriplet_H
-#define OrderedHitTriplet_H
+#ifndef RecoTracker_PixelSeeding_OrderedHitTriplet_h
+#define RecoTracker_PixelSeeding_OrderedHitTriplet_h
 
 /** \class OrderedHitTriplet 
  * Associate 3 RecHits into hit triplet of InnerHit,MiddleHit,OuterHit

--- a/RecoTracker/PixelSeeding/interface/OrderedHitTriplets.h
+++ b/RecoTracker/PixelSeeding/interface/OrderedHitTriplets.h
@@ -1,5 +1,5 @@
-#ifndef OrderedHitTriplets_H
-#define OrderedHitTriplets_H
+#ifndef RecoTracker_PixelSeeding_OrderedHitTriplets_h
+#define RecoTracker_PixelSeeding_OrderedHitTriplets_h
 
 #include <vector>
 #include "RecoTracker/PixelSeeding/interface/OrderedHitTriplet.h"

--- a/RecoTracker/PixelSeeding/interface/ThirdHitPredictionFromCircle.h
+++ b/RecoTracker/PixelSeeding/interface/ThirdHitPredictionFromCircle.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitPredictionFromCircle_H
-#define ThirdHitPredictionFromCircle_H
+#ifndef RecoTracker_PixelSeeding_ThirdHitPredictionFromCircle_h
+#define RecoTracker_PixelSeeding_ThirdHitPredictionFromCircle_h
 
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"

--- a/RecoTracker/PixelSeeding/interface/ThirdHitRZPrediction.h
+++ b/RecoTracker/PixelSeeding/interface/ThirdHitRZPrediction.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitRZPrediction_H
-#define ThirdHitRZPrediction_H
+#ifndef RecoTracker_PixelSeeding_ThirdHitRZPrediction_h
+#define RecoTracker_PixelSeeding_ThirdHitRZPrediction_h
 
 /** predicts a range in r-z for the position of third hit.
  *  the predicted reange is defined by the template argument, which

--- a/RecoTracker/PixelSeeding/interface/ThirdHitRZPredictionBase.h
+++ b/RecoTracker/PixelSeeding/interface/ThirdHitRZPredictionBase.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitRZPredictionBase_H
-#define ThirdHitRZPredictionBase_H
+#ifndef RecoTracker_PixelSeeding_ThirdHitRZPredictionBase_h
+#define RecoTracker_PixelSeeding_ThirdHitRZPredictionBase_h
 
 /** predicts a range in r-z for the position of third hit.
  *  The is the base class with common code, the actual implementation

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorKernels.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorKernels_h
-#define RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorKernels_h
+#ifndef RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorKernels_h
+#define RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorKernels_h
 
 // #define GPU_DEBUG
 
@@ -336,4 +336,4 @@ public:
   static void printCounters(Counters const* counters);
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorKernels_h
+#endif  // RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorKernels_h

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.h
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorOnGPU_h
-#define RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorOnGPU_h
+#ifndef RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorOnGPU_h
+#define RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorOnGPU_h
 
 #include <cuda_runtime.h>
 
@@ -79,4 +79,4 @@ private:
   Counters* m_counters = nullptr;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_CAHitNtupletGeneratorOnGPU_h
+#endif  // RecoTracker_PixelSeeding_plugins_CAHitNtupletGeneratorOnGPU_h

--- a/RecoTracker/PixelSeeding/plugins/CAStructures.h
+++ b/RecoTracker/PixelSeeding/plugins/CAStructures.h
@@ -1,5 +1,5 @@
-#ifndef CUDADataFormats_TrackerGeometry_CAStructures_h
-#define CUDADataFormats_TrackerGeometry_CAStructures_h
+#ifndef RecoTracker_PixelSeeding_plugins_CAStructures_h
+#define RecoTracker_PixelSeeding_plugins_CAStructures_h
 
 #include "HeterogeneousCore/CUDAUtilities/interface/SimpleVector.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/VecArray.h"

--- a/RecoTracker/PixelSeeding/plugins/CombinedHitTripletGenerator.h
+++ b/RecoTracker/PixelSeeding/plugins/CombinedHitTripletGenerator.h
@@ -1,5 +1,5 @@
-#ifndef CombinedHitTripletGenerator_H
-#define CombinedHitTripletGenerator_H
+#ifndef RecoTracker_PixelSeeding_plugins_CombinedHitTripletGenerator_h
+#define RecoTracker_PixelSeeding_plugins_CombinedHitTripletGenerator_h
 
 /** A HitTripletGenerator consisting of a set of 
  *  triplet generators of type HitTripletGeneratorFromPairAndLayers

--- a/RecoTracker/PixelSeeding/plugins/GPUCACell.h
+++ b/RecoTracker/PixelSeeding/plugins/GPUCACell.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_GPUCACellT_h
-#define RecoPixelVertexing_PixelTriplets_plugins_GPUCACellT_h
+#ifndef RecoTracker_PixelSeeding_plugins_GPUCACell_h
+#define RecoTracker_PixelSeeding_plugins_GPUCACell_h
 
 //
 // Author: Felice Pantaleo, CERN
@@ -387,4 +387,4 @@ private:
   hindex_type theFishboneId;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_GPUCACellT_h
+#endif  // RecoTracker_PixelSeeding_plugins_GPUCACell_h

--- a/RecoTracker/PixelSeeding/plugins/HelixFitOnGPU.h
+++ b/RecoTracker/PixelSeeding/plugins/HelixFitOnGPU.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_HelixFitOnGPU_h
-#define RecoPixelVertexing_PixelTriplets_plugins_HelixFitOnGPU_h
+#ifndef RecoTracker_PixelSeeding_plugins_HelixFitOnGPU_h
+#define RecoTracker_PixelSeeding_plugins_HelixFitOnGPU_h
 
 #include "CUDADataFormats/Track/interface/PixelTrackUtilities.h"
 #include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHitsUtilities.h"
@@ -81,4 +81,4 @@ private:
   const bool fitNas4_;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_HelixFitOnGPU_h
+#endif  // RecoTracker_PixelSeeding_plugins_HelixFitOnGPU_h

--- a/RecoTracker/PixelSeeding/plugins/MatchedHitRZCorrectionFromBending.h
+++ b/RecoTracker/PixelSeeding/plugins/MatchedHitRZCorrectionFromBending.h
@@ -1,5 +1,5 @@
-#ifndef MatchedHitRZCorrectionFromBending_H
-#define MatchedHitRZCorrectionFromBending_H
+#ifndef RecoTracker_PixelSeeding_plugins_MatchedHitRZCorrectionFromBending_h
+#define RecoTracker_PixelSeeding_plugins_MatchedHitRZCorrectionFromBending_h
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
@@ -44,4 +44,4 @@ private:
   FixupFn rFixup, zFixup;
 };
 
-#endif  // MatchedHitRZCorrectionFromBending_H
+#endif  // RecoTracker_PixelSeeding_plugins_MatchedHitRZCorrectionFromBending_h

--- a/RecoTracker/PixelSeeding/plugins/PixelTripletHLTGenerator.h
+++ b/RecoTracker/PixelSeeding/plugins/PixelTripletHLTGenerator.h
@@ -1,5 +1,5 @@
-#ifndef PixelTripletHLTGenerator_H
-#define PixelTripletHLTGenerator_H
+#ifndef RecoTracker_PixelSeeding_plugins_PixelTripletHLTGenerator_h
+#define RecoTracker_PixelSeeding_plugins_PixelTripletHLTGenerator_h
 
 /** A HitTripletGenerator from HitPairGenerator and vector of
     Layers. The HitPairGenerator provides a set of hit pairs.

--- a/RecoTracker/PixelSeeding/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoTracker/PixelSeeding/plugins/PixelTripletLargeTipGenerator.h
@@ -1,5 +1,5 @@
-#ifndef PixelTripletLargeTipGenerator_H
-#define PixelTripletLargeTipGenerator_H
+#ifndef RecoTracker_PixelSeeding_plugins_PixelTripletLargeTipGenerator_h
+#define RecoTracker_PixelSeeding_plugins_PixelTripletLargeTipGenerator_h
 
 /** A HitTripletGenerator from HitPairGenerator and vector of
     Layers. The HitPairGenerator provides a set of hit pairs.

--- a/RecoTracker/PixelSeeding/plugins/PixelTripletNoTipGenerator.h
+++ b/RecoTracker/PixelSeeding/plugins/PixelTripletNoTipGenerator.h
@@ -1,5 +1,5 @@
-#ifndef PixelTripletNoTipGenerator_H
-#define PixelTripletNoTipGenerator_H
+#ifndef RecoTracker_PixelSeeding_plugins_PixelTripletNoTipGenerator_h
+#define RecoTracker_PixelSeeding_plugins_PixelTripletNoTipGenerator_h
 
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/RecoTracker/PixelSeeding/plugins/ThirdHitCorrection.h
+++ b/RecoTracker/PixelSeeding/plugins/ThirdHitCorrection.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_ThirdHitCorrection_H
-#define RecoPixelVertexing_PixelTriplets_ThirdHitCorrection_H
+#ifndef RecoTracker_PixelSeeding_plugins_ThirdHitCorrection_h
+#define RecoTracker_PixelSeeding_plugins_ThirdHitCorrection_h
 
 #include "RecoTracker/TkMSParametrization/interface/LongitudinalBendingCorrection.h"
 #include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisation.h"

--- a/RecoTracker/PixelSeeding/plugins/ThirdHitPredictionFromInvLine.h
+++ b/RecoTracker/PixelSeeding/plugins/ThirdHitPredictionFromInvLine.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitPredictionFromInvLine_H
-#define ThirdHitPredictionFromInvLine_H
+#ifndef RecoTracker_PixelSeeding_plugins_ThirdHitPredictionFromInvLine_h
+#define RecoTracker_PixelSeeding_plugins_ThirdHitPredictionFromInvLine_h
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
 #include "DataFormats/GeometrySurface/interface/TkRotation.h"

--- a/RecoTracker/PixelSeeding/plugins/ThirdHitPredictionFromInvParabola.h
+++ b/RecoTracker/PixelSeeding/plugins/ThirdHitPredictionFromInvParabola.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitPredictionFromInvParabola_H
-#define ThirdHitPredictionFromInvParabola_H
+#ifndef RecoTracker_PixelSeeding_plugins_ThirdHitPredictionFromInvParabola_h
+#define RecoTracker_PixelSeeding_plugins_ThirdHitPredictionFromInvParabola_h
 
 /** Check phi compatibility of a hit with a track
     constrained by a hit pair and TrackingRegion kinematical constraints.

--- a/RecoTracker/PixelSeeding/plugins/ThirdHitZPrediction.h
+++ b/RecoTracker/PixelSeeding/plugins/ThirdHitZPrediction.h
@@ -1,5 +1,5 @@
-#ifndef ThirdHitZPrediction_H
-#define ThirdHitZPrediction_H
+#ifndef RecoTracker_PixelSeeding_plugins_ThirdHitZPrediction_h
+#define RecoTracker_PixelSeeding_plugins_ThirdHitZPrediction_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"

--- a/RecoTracker/PixelSeeding/plugins/gpuFishbone.h
+++ b/RecoTracker/PixelSeeding/plugins/gpuFishbone.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_gpuFishbone_h
-#define RecoPixelVertexing_PixelTriplets_plugins_gpuFishbone_h
+#ifndef RecoTracker_PixelSeeding_plugins_gpuFishbone_h
+#define RecoTracker_PixelSeeding_plugins_gpuFishbone_h
 
 #include <algorithm>
 #include <cmath>
@@ -116,4 +116,4 @@ namespace gpuPixelDoublets {
 
 }  // namespace gpuPixelDoublets
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_gpuFishbone_h
+#endif  // RecoTracker_PixelSeeding_plugins_gpuFishbone_h

--- a/RecoTracker/PixelSeeding/plugins/gpuPixelDoublets.h
+++ b/RecoTracker/PixelSeeding/plugins/gpuPixelDoublets.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoublets_h
-#define RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoublets_h
+#ifndef RecoTracker_PixelSeeding_plugins_gpuPixelDoublets_h
+#define RecoTracker_PixelSeeding_plugins_gpuPixelDoublets_h
 
 #include "RecoTracker/PixelSeeding/plugins/gpuPixelDoubletsAlgos.h"
 
@@ -54,4 +54,4 @@ namespace gpuPixelDoublets {
 
 }  // namespace gpuPixelDoublets
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoublets_h
+#endif  // RecoTracker_PixelSeeding_plugins_gpuPixelDoublets_h

--- a/RecoTracker/PixelSeeding/plugins/gpuPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/gpuPixelDoubletsAlgos.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoubletsAlgos_h
-#define RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoubletsAlgos_h
+#ifndef RecoTracker_PixelSeeding_plugins_gpuPixelDoubletsAlgos_h
+#define RecoTracker_PixelSeeding_plugins_gpuPixelDoubletsAlgos_h
 
 #include <algorithm>
 #include <cmath>
@@ -281,4 +281,4 @@ namespace gpuPixelDoublets {
 
 }  // namespace gpuPixelDoublets
 
-#endif  // RecoPixelVertexing_PixelTriplets_plugins_gpuPixelDoubletsAlgos_h
+#endif  // RecoTracker_PixelSeeding_plugins_gpuPixelDoubletsAlgos_h

--- a/RecoTracker/PixelSeeding/src/CACell.h
+++ b/RecoTracker/PixelSeeding/src/CACell.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_src_CACell_h
-#define RecoPixelVertexing_PixelTriplets_src_CACell_h
+#ifndef RecoTracker_PixelSeeding_src_CACell_h
+#define RecoTracker_PixelSeeding_src_CACell_h
 
 #include <array>
 #include <cmath>
@@ -288,4 +288,4 @@ private:
   const float theInnerZ;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_src_CACell_h
+#endif  // RecoTracker_PixelSeeding_src_CACell_h

--- a/RecoTracker/PixelSeeding/src/CellularAutomaton.h
+++ b/RecoTracker/PixelSeeding/src/CellularAutomaton.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
-#define RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
+#ifndef RecoTracker_PixelSeeding_src_CellularAutomaton_h
+#define RecoTracker_PixelSeeding_src_CellularAutomaton_h
 
 #include <array>
 
@@ -37,4 +37,4 @@ private:
   std::vector<std::vector<CACell*> > theNtuplets;
 };
 
-#endif  // RecoPixelVertexing_PixelTriplets_src_CellularAutomaton_h
+#endif  // RecoTracker_PixelSeeding_src_CellularAutomaton_h

--- a/RecoTracker/PixelTrackFitting/interface/BrokenLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/BrokenLine.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_BrokenLine_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_BrokenLine_h
+#ifndef RecoTracker_PixelTrackFitting_BrokenLine_h
+#define RecoTracker_PixelTrackFitting_BrokenLine_h
 
 #include <Eigen/Eigenvalues>
 
@@ -616,4 +616,4 @@ namespace brokenline {
 
 }  // namespace brokenline
 
-#endif  // RecoPixelVertexing_PixelTrackFitting_interface_BrokenLine_h
+#endif  // RecoTracker_PixelTrackFitting_BrokenLine_h

--- a/RecoTracker/PixelTrackFitting/interface/CircleFromThreePoints.h
+++ b/RecoTracker/PixelTrackFitting/interface/CircleFromThreePoints.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
+#ifndef RecoTracker_PixelTrackFitting_CircleFromThreePoints_h
+#define RecoTracker_PixelTrackFitting_CircleFromThreePoints_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
@@ -56,4 +56,4 @@ private:
   void init(const Vector2D& b, const Vector2D& c, const Vector2D& offset, double precision);
 };
 
-#endif  // RecoPixelVertexing_PixelTrackFitting_interface_CircleFromThreePoints_h
+#endif  // RecoTracker_PixelTrackFitting_CircleFromThreePoints_h

--- a/RecoTracker/PixelTrackFitting/interface/FitResult.h
+++ b/RecoTracker/PixelTrackFitting/interface/FitResult.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_FitResult_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_FitResult_h
+#ifndef RecoTracker_PixelTrackFitting_FitResult_h
+#define RecoTracker_PixelTrackFitting_FitResult_h
 
 #include <cmath>
 #include <cstdint>

--- a/RecoTracker/PixelTrackFitting/interface/FitUtils.h
+++ b/RecoTracker/PixelTrackFitting/interface/FitUtils.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_FitUtils_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_FitUtils_h
+#ifndef RecoTracker_PixelTrackFitting_FitUtils_h
+#define RecoTracker_PixelTrackFitting_FitUtils_h
 
 #include "DataFormats/Math/interface/choleskyInversion.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h"
@@ -240,4 +240,4 @@ namespace riemannFit {
 
 }  // namespace riemannFit
 
-#endif  // RecoPixelVertexing_PixelTrackFitting_interface_FitUtils_h
+#endif  // RecoTracker_PixelTrackFitting_FitUtils_h

--- a/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
+++ b/RecoTracker/PixelTrackFitting/interface/KFBasedPixelFitter.h
@@ -1,5 +1,5 @@
-#ifndef KFBasedPixelFitter_H
-#define KFBasedPixelFitter_H
+#ifndef RecoTracker_PixelTrackFitting_KFBasedPixelFitter_h
+#define RecoTracker_PixelTrackFitting_KFBasedPixelFitter_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/RecoTracker/PixelTrackFitting/interface/PixelFitter.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelFitter.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelFitter_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelFitter_H
+#ifndef RecoTracker_PixelTrackFitting_PixelFitter_h
+#define RecoTracker_PixelTrackFitting_PixelFitter_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelFitterBase_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelFitterBase_H
+#ifndef RecoTracker_PixelTrackFitting_PixelFitterBase_h
+#define RecoTracker_PixelTrackFitting_PixelFitterBase_h
 
 #include "DataFormats/TrackReco/interface/Track.h"
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelFitterByConformalMappingAndLine.h
@@ -1,5 +1,5 @@
-#ifndef PixelFitterByConformalMappingAndLine_H
-#define PixelFitterByConformalMappingAndLine_H
+#ifndef RecoTracker_PixelTrackFitting_PixelFitterByConformalMappingAndLine_h
+#define RecoTracker_PixelTrackFitting_PixelFitterByConformalMappingAndLine_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"

--- a/RecoTracker/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelFitterByHelixProjections.h
@@ -1,5 +1,5 @@
-#ifndef PixelFitterByHelixProjections_H
-#define PixelFitterByHelixProjections_H
+#ifndef RecoTracker_PixelTrackFitting_PixelFitterByHelixProjections_h
+#define RecoTracker_PixelTrackFitting_PixelFitterByHelixProjections_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelFitterBase.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"

--- a/RecoTracker/PixelTrackFitting/interface/PixelNtupletsFitter.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelNtupletsFitter.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_PixelNtupletsFitter_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_PixelNtupletsFitter_h
+#ifndef RecoTracker_PixelTrackFitting_PixelNtupletsFitter_h
+#define RecoTracker_PixelTrackFitting_PixelNtupletsFitter_h
 
 #include <vector>
 
@@ -22,4 +22,4 @@ private:
   bool useRiemannFit_;
 };
 
-#endif  // RecoPixelVertexing_PixelTrackFitting_interface_PixelNtupletsFitter_h
+#endif  // RecoTracker_PixelTrackFitting_PixelNtupletsFitter_h

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackBuilder.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackBuilder.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackBuilder_H
-#define PixelTrackBuilder_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackBuilder_h
+#define RecoTracker_PixelTrackFitting_PixelTrackBuilder_h
 
 #include <vector>
 #include <string>

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackCleaner.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackCleaner.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_PixelTrackCleaner_H
-#define PixelTrackFitting_PixelTrackCleaner_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackCleaner_h
+#define RecoTracker_PixelTrackFitting_PixelTrackCleaner_h
 
 /**
 class PixelTrackCleaner:

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackCleanerBySharedHits.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_PixelTrackCleanerBySharedHits_H
-#define PixelTrackFitting_PixelTrackCleanerBySharedHits_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackCleanerBySharedHits_h
+#define RecoTracker_PixelTrackFitting_PixelTrackCleanerBySharedHits_h
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelTrackCleanerWrapper_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelTrackCleanerWrapper_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackCleanerWrapper_h
+#define RecoTracker_PixelTrackFitting_PixelTrackCleanerWrapper_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelTrackCleaner.h"
 #include "RecoTracker/PixelTrackFitting/interface/TracksWithHits.h"

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackErrorParam.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackErrorParam.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_PixelTrackErrorParam_H
-#define PixelTrackFitting_PixelTrackErrorParam_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackErrorParam_h
+#define RecoTracker_PixelTrackFitting_PixelTrackErrorParam_h
 #include <cmath>
 
 class PixelTrackErrorParam {

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackFilter.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackFilter.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelTrackFilter_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelTrackFilter_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackFilter_h
+#define RecoTracker_PixelTrackFitting_PixelTrackFilter_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h"
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelTrackFilterBase_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelTrackFilterBase_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
+#define RecoTracker_PixelTrackFitting_PixelTrackFilterBase_h
 
 namespace reco {
   class Track;

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_PixelTrackFilterByKinematics_H
-#define PixelTrackFitting_PixelTrackFilterByKinematics_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackFilterByKinematics_h
+#define RecoTracker_PixelTrackFitting_PixelTrackFilterByKinematics_h
 
 #include "RecoTracker/PixelTrackFitting/interface/PixelTrackFilterBase.h"
 

--- a/RecoTracker/PixelTrackFitting/interface/PixelTrackReconstruction.h
+++ b/RecoTracker/PixelTrackFitting/interface/PixelTrackReconstruction.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_PixelTrackReconstruction_H
-#define RecoPixelVertexing_PixelTrackFitting_PixelTrackReconstruction_H
+#ifndef RecoTracker_PixelTrackFitting_PixelTrackReconstruction_h
+#define RecoTracker_PixelTrackFitting_PixelTrackReconstruction_h
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"

--- a/RecoTracker/PixelTrackFitting/interface/RZLine.h
+++ b/RecoTracker/PixelTrackFitting/interface/RZLine.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_RZLine_H
-#define PixelTrackFitting_RZLine_H
+#ifndef RecoTracker_PixelTrackFitting_RZLine_h
+#define RecoTracker_PixelTrackFitting_RZLine_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"

--- a/RecoTracker/PixelTrackFitting/interface/RiemannFit.h
+++ b/RecoTracker/PixelTrackFitting/interface/RiemannFit.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelTrackFitting_interface_RiemannFit_h
-#define RecoPixelVertexing_PixelTrackFitting_interface_RiemannFit_h
+#ifndef RecoTracker_PixelTrackFitting_RiemannFit_h
+#define RecoTracker_PixelTrackFitting_RiemannFit_h
 
 #include "RecoTracker/PixelTrackFitting/interface/FitUtils.h"
 
@@ -1005,4 +1005,4 @@ namespace riemannFit {
 
 }  // namespace riemannFit
 
-#endif  // RecoPixelVertexing_PixelTrackFitting_interface_RiemannFit_h
+#endif  // RecoTracker_PixelTrackFitting_RiemannFit_h

--- a/RecoTracker/PixelTrackFitting/interface/TracksWithHits.h
+++ b/RecoTracker/PixelTrackFitting/interface/TracksWithHits.h
@@ -1,5 +1,5 @@
-#ifndef PixelTrackFitting_TracksWithHits_H
-#define PixelTrackFitting_TracksWithHits_H
+#ifndef RecoTracker_PixelTrackFitting_TracksWithHits_h
+#define RecoTracker_PixelTrackFitting_TracksWithHits_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"

--- a/RecoTracker/PixelTrackFitting/plugins/storeTracks.h
+++ b/RecoTracker/PixelTrackFitting/plugins/storeTracks.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexingPixelTrackFittingStoreTracks_H
-#define RecoPixelVertexingPixelTrackFittingStoreTracks_H
+#ifndef RecoTracker_PixelTrackFitting_plugins_storeTracks_h
+#define RecoTracker_PixelTrackFitting_plugins_storeTracks_h
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/RecoTracker/PixelTrackFitting/src/ConformalMappingFit.h
+++ b/RecoTracker/PixelTrackFitting/src/ConformalMappingFit.h
@@ -1,5 +1,5 @@
-#ifndef ConformalMappingFit_H
-#define ConformalMappingFit_H
+#ifndef RecoTracker_PixelTrackFitting_src_ConformalMappingFit_h
+#define RecoTracker_PixelTrackFitting_src_ConformalMappingFit_h
 
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"

--- a/RecoTracker/PixelTrackFitting/src/ParabolaFit.h
+++ b/RecoTracker/PixelTrackFitting/src/ParabolaFit.h
@@ -1,5 +1,5 @@
-#ifndef ParabolaFit_H
-#define ParabolaFit_H
+#ifndef RecoTracker_PixelTrackFitting_src_ParabolaFit_h
+#define RecoTracker_PixelTrackFitting_src_ParabolaFit_h
 
 #include <vector>
 

--- a/RecoTracker/PixelTrackFitting/test/test_common.h
+++ b/RecoTracker/PixelTrackFitting/test/test_common.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing__PixelTrackFitting__test_common_h
-#define RecoPixelVertexing__PixelTrackFitting__test_common_h
+#ifndef RecoTracker_PixelTrackFitting_test_test_common_h
+#define RecoTracker_PixelTrackFitting_test_test_common_h
 
 #include <algorithm>
 #include <cassert>

--- a/RecoTracker/PixelVertexFinding/interface/Cluster1DCleaner.h
+++ b/RecoTracker/PixelVertexFinding/interface/Cluster1DCleaner.h
@@ -1,5 +1,5 @@
-#ifndef _Cluster1DCleaner_H_
-#define _Cluster1DCleaner_H_
+#ifndef RecoTracker_PixelVertexFinding_Cluster1DCleaner_h
+#define RecoTracker_PixelVertexFinding_Cluster1DCleaner_h
 
 #include "CommonTools/Clustering1D/interface/Cluster1D.h"
 

--- a/RecoTracker/PixelVertexFinding/interface/Cluster1DMerger.h
+++ b/RecoTracker/PixelVertexFinding/interface/Cluster1DMerger.h
@@ -1,5 +1,5 @@
-#ifndef _Cluster1DMerger_H_
-#define _Cluster1DMerger_H_
+#ifndef RecoTracker_PixelVertexFinding_Cluster1DMerger_h
+#define RecoTracker_PixelVertexFinding_Cluster1DMerger_h
 
 #include "CommonTools/Clustering1D/interface/Cluster1D.h"
 #include "CommonTools/Clustering1D/interface/WeightEstimator.h"

--- a/RecoTracker/PixelVertexFinding/interface/DivisiveClusterizer1D.h
+++ b/RecoTracker/PixelVertexFinding/interface/DivisiveClusterizer1D.h
@@ -1,5 +1,5 @@
-#ifndef _DivisiveClusterizer1D_H_
-#define _DivisiveClusterizer1D_H_
+#ifndef RecoTracker_PixelVertexFinding_DivisiveClusterizer1D_h
+#define RecoTracker_PixelVertexFinding_DivisiveClusterizer1D_h
 
 #include "CommonTools/Clustering1D/interface/Clusterizer1D.h"
 //#include "CommonTools/Clustering1D/interface/Cluster1DMerger.h"

--- a/RecoTracker/PixelVertexFinding/interface/DivisiveVertexFinder.h
+++ b/RecoTracker/PixelVertexFinding/interface/DivisiveVertexFinder.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_DivisiveVertexFinder_h
-#define RecoPixelVertexing_DivisiveVertexFinder_h
+#ifndef RecoTracker_PixelVertexFinding_DivisiveVertexFinder_h
+#define RecoTracker_PixelVertexFinding_DivisiveVertexFinder_h
 /** \class DivisiveVertexFinder DivisiveVertexFinder.h RecoTracker/PixelVertexFinding/interface/DivisiveVertexFinder.h 
 
  Description: Fits a primary vertex in 1D (z) using the "divisive method"

--- a/RecoTracker/PixelVertexFinding/interface/FindPeakFastPV.h
+++ b/RecoTracker/PixelVertexFinding/interface/FindPeakFastPV.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_FindPeakFastPV_h
-#define RecoPixelVertexing_FindPeakFastPV_h
+#ifndef RecoTracker_PixelVertexFinding_FindPeakFastPV_h
+#define RecoTracker_PixelVertexFinding_FindPeakFastPV_h
 /** \class FindPeakFastPV FindPeakFastPV.h RecoTracker/PixelVertexFinding/FindPeakFastPV.h 
  * Given *zProjections* and *zWeights* find the peak of width *m_zClusterWidth*. 
  * Use only values with *zWeights*>*m_weightCut*. 

--- a/RecoTracker/PixelVertexFinding/interface/PVCluster.h
+++ b/RecoTracker/PixelVertexFinding/interface/PVCluster.h
@@ -1,5 +1,5 @@
-#ifndef PixelVertexFinding_PVCluster_h
-#define PixelVertexFinding_PVCluster_h
+#ifndef RecoTracker_PixelVertexFinding_PVCluster_h
+#define RecoTracker_PixelVertexFinding_PVCluster_h
 /** \class PVCluster PVCluster.h RecoTracker/PixelVertexFinding/PVCluster.h 
  * A simple collection of tracks that represents a physical clustering
  * of charged particles, ie a vertex, in one dimension.  This

--- a/RecoTracker/PixelVertexFinding/interface/PVClusterComparer.h
+++ b/RecoTracker/PixelVertexFinding/interface/PVClusterComparer.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PVClusterComparer_h
-#define RecoPixelVertexing_PVClusterComparer_h
+#ifndef RecoTracker_PixelVertexFinding_PVClusterComparer_h
+#define RecoTracker_PixelVertexFinding_PVClusterComparer_h
 /** \class PVClusterComparer PVClusterComparer.h
  * RecoTracker/PixelVertexFinding/PVClusterComparer.h  
  * This helper class is used to sort the collection of vertexes by

--- a/RecoTracker/PixelVertexFinding/interface/PVPositionBuilder.h
+++ b/RecoTracker/PixelVertexFinding/interface/PVPositionBuilder.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PVPositionBuilder_h
-#define RecoPixelVertexing_PVPositionBuilder_h
+#ifndef RecoTracker_PixelVertexFinding_PVPositionBuilder_h
+#define RecoTracker_PixelVertexFinding_PVPositionBuilder_h
 /** \class PVPositionBuilder PVPositionBuilder.h RecoTracker/PixelVertexFinding/PVPositionBuilder.h 
  * This helper class calculates the average Z position of a collection of
  * tracks.  You have the option of calculating the straight average,

--- a/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceSoADevice.h
+++ b/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceSoADevice.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpaceSoADevice_h
-#define RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpaceSoADevice_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceSoADevice_h
+#define RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceSoADevice_h
 
 #include "CUDADataFormats/Common/interface/PortableDeviceCollection.h"
 #include "CUDADataFormats/Vertex/interface/ZVertexUtilities.h"

--- a/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceSoAHost.h
+++ b/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceSoAHost.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpaceSoAHost_h
-#define RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpaceSoAHost_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceSoAHost_h
+#define RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceSoAHost_h
 
 #include "CUDADataFormats/Common/interface/PortableHostCollection.h"
 #include "CUDADataFormats/Vertex/interface/ZVertexUtilities.h"

--- a/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceUtilities.h
+++ b/RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceUtilities.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpace_h
-#define RecoPixelVertexing_PixelVertexFinding_PixelVertexWorkSpace_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceUtilities_h
+#define RecoTracker_PixelVertexFinding_plugins_PixelVertexWorkSpaceUtilities_h
 
 #include <cuda_runtime.h>
 #include "DataFormats/SoATemplate/interface/SoALayout.h"

--- a/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksByDensity.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksByDensity.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h
 
 #include <algorithm>
 #include <cmath>
@@ -234,4 +234,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksByDensity_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksDBSCAN.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksDBSCAN.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h
 
 #include <algorithm>
 #include <cmath>
@@ -240,4 +240,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksDBSCAN_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksIterative.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuClusterTracksIterative.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksIterative_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksIterative_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksIterative_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksIterative_h
 
 #include <algorithm>
 #include <cmath>
@@ -211,4 +211,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuClusterTracksIterative_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuClusterTracksIterative_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuFitVertices.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuFitVertices.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuFitVertices_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuFitVertices_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuFitVertices_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuFitVertices_h
 
 #include <algorithm>
 #include <cmath>
@@ -107,4 +107,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuFitVertices_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuFitVertices_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuSortByPt2.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuSortByPt2.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuSortByPt2_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuSortByPt2_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuSortByPt2_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuSortByPt2_h
 
 #include <algorithm>
 #include <cmath>
@@ -70,4 +70,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuSortByPt2_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuSortByPt2_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuSplitVertices.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuSplitVertices.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuSplitVertices_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuSplitVertices_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuSplitVertices_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuSplitVertices_h
 
 #include <algorithm>
 #include <cmath>
@@ -138,4 +138,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuSplitVertices_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuSplitVertices_h

--- a/RecoTracker/PixelVertexFinding/plugins/gpuVertexFinder.h
+++ b/RecoTracker/PixelVertexFinding/plugins/gpuVertexFinder.h
@@ -1,5 +1,5 @@
-#ifndef RecoPixelVertexing_PixelVertexFinding_plugins_gpuVertexFinder_h
-#define RecoPixelVertexing_PixelVertexFinding_plugins_gpuVertexFinder_h
+#ifndef RecoTracker_PixelVertexFinding_plugins_gpuVertexFinder_h
+#define RecoTracker_PixelVertexFinding_plugins_gpuVertexFinder_h
 
 #include <cstddef>
 #include <cstdint>
@@ -64,4 +64,4 @@ namespace gpuVertexFinder {
 
 }  // namespace gpuVertexFinder
 
-#endif  // RecoPixelVertexing_PixelVertexFinding_plugins_gpuVertexFinder_h
+#endif  // RecoTracker_PixelVertexFinding_plugins_gpuVertexFinder_h


### PR DESCRIPTION
#### PR description:

Title says it all, addresses second part of the https://github.com/cms-sw/cmssw/pull/41058#issuecomment-1473531611 , to comply with http://cms-sw.github.io/cms_coding_rules.html#4--technical-coding-rules-1

#### PR validation:

`cmssw` compiles.
Technical, no regressions expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A