### PR TITLE
[13.0.X] Modernize / optimize `DisappearingMuonsSkimming`

### DIFF
--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -49,13 +49,18 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
+
   bool passTriggers(const edm::Event& iEvent,
-                    edm::EDGetToken m_trigResultsToken,
+                    const edm::TriggerResults& results,
                     std::vector<std::string> m_muonPathsToPass);
-  double getTrackIsolation(const edm::Event&, const reco::VertexCollection& vtxHandle, const reco::Track& iTrack);
+
+  bool findTrackInVertices(const reco::TrackRef& tkToMatch,
+                           const reco::VertexCollection& vertices,
+                           unsigned int& vtxIndex,
+                           unsigned int& trackIndex);
+
+  double getTrackIsolation(const reco::TrackRef& tkToMatch, const reco::VertexCollection& vertices);
   double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
 
   // ----------member data ---------------------------

--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -53,7 +53,7 @@ private:
 
   bool passTriggers(const edm::Event& iEvent,
                     const edm::TriggerResults& results,
-                    std::vector<std::string> m_muonPathsToPass);
+                    const std::vector<std::string>& m_muonPathsToPass);
 
   bool findTrackInVertices(const reco::TrackRef& tkToMatch,
                            const reco::VertexCollection& vertices,
@@ -61,7 +61,7 @@ private:
                            unsigned int& trackIndex);
 
   double getTrackIsolation(const reco::TrackRef& tkToMatch, const reco::VertexCollection& vertices);
-  double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
+  double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack& track);
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<reco::MuonCollection> recoMuonToken_;

--- a/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
+++ b/Configuration/Skimming/interface/DisappearingMuonsSkimming.h
@@ -22,19 +22,21 @@
 #include <memory>
 
 // user include filter
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 //
 // class declaration
@@ -53,22 +55,17 @@ private:
   bool passTriggers(const edm::Event& iEvent,
                     edm::EDGetToken m_trigResultsToken,
                     std::vector<std::string> m_muonPathsToPass);
-  double getTrackIsolation(const edm::Event&,
-                           edm::Handle<reco::VertexCollection> vtxHandle,
-                           std::vector<reco::Track>::const_iterator& iTrack);
+  double getTrackIsolation(const edm::Event&, const reco::VertexCollection& vtxHandle, const reco::Track& iTrack);
   double getECALIsolation(const edm::Event&, const edm::EventSetup&, const reco::TransientTrack track);
 
   // ----------member data ---------------------------
-
-  const edm::EDGetToken recoMuonToken_;
-  const edm::EDGetToken standaloneMuonToken_;
-  const edm::EDGetTokenT<std::vector<reco::Track>> trackCollectionToken_;
-  const edm::EDGetTokenT<std::vector<reco::Vertex>> primaryVerticesToken_;
+  const edm::EDGetTokenT<reco::MuonCollection> recoMuonToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> standaloneMuonToken_;
+  const edm::EDGetTokenT<reco::TrackCollection> trackCollectionToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> primaryVerticesToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
   const edm::EDGetTokenT<edm::TriggerResults> trigResultsToken_;
-  const edm::EDGetToken genParticleToken_;
-  const edm::EDGetToken genInfoToken_;
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   const std::vector<std::string> muonPathsToPass_;

--- a/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
+++ b/Configuration/Skimming/src/DisappearingMuonsSkimming.cc
@@ -21,27 +21,17 @@
 
 // user include files
 #include "Configuration/Skimming/interface/DisappearingMuonsSkimming.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/one/EDFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 DisappearingMuonsSkimming::DisappearingMuonsSkimming(const edm::ParameterSet& iConfig)
     : recoMuonToken_(consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("recoMuons"))),
@@ -267,7 +257,7 @@ bool DisappearingMuonsSkimming::filter(edm::Event& iEvent, const edm::EventSetup
 
 bool DisappearingMuonsSkimming::passTriggers(const edm::Event& iEvent,
                                              const edm::TriggerResults& triggerResults,
-                                             std::vector<std::string> m_muonPathsToPass) {
+                                             const std::vector<std::string>& m_muonPathsToPass) {
   bool passTriggers = false;
   const edm::TriggerNames& trigNames = iEvent.triggerNames(triggerResults);
   for (size_t i = 0; i < trigNames.size(); ++i) {
@@ -355,7 +345,7 @@ double DisappearingMuonsSkimming::getTrackIsolation(const reco::TrackRef& tkToMa
 
 double DisappearingMuonsSkimming::getECALIsolation(const edm::Event& iEvent,
                                                    const edm::EventSetup& iSetup,
-                                                   const reco::TransientTrack track) {
+                                                   const reco::TransientTrack& track) {
   edm::Handle<EcalRecHitCollection> rechitsEE;
   iEvent.getByToken(reducedEndcapRecHitCollectionToken_, rechitsEE);
 

--- a/Configuration/Skimming/test/test_DisMuon_cfg.py
+++ b/Configuration/Skimming/test/test_DisMuon_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("testSkimming", Run3)
+
+# Message logger service
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.DisappearingMuonsSkimming=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(100)
+                                   ),                                                      
+    DMRChecker = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    DisappearingMuonsSkimming = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    )
+
+readFiles = cms.untracked.vstring(
+    '/store/relval/CMSSW_13_0_0_pre3/RelValZMM_14/GEN-SIM-RECO/PU_130X_mcRun3_2022_realistic_v2-v1/00000/04f597b5-14d3-44c8-851e-c5f46657d92a.root',
+)   
+
+process.source = cms.Source("PoolSource",fileNames = readFiles)
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32((800)))
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '130X_mcRun3_2022_realistic_v2', '')
+
+process.load("Configuration.Skimming.PDWG_EXODisappMuon_cff")
+# Additional output definition
+process.SKIMStreamEXODisappMuon = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('EXODisappMuonPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('EXODisappMuon')
+        #filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('EXODisappMuon.root'),
+    outputCommands = process.EXODisappMuonSkimContent.outputCommands
+)
+
+process.EXODisappMuonPath = cms.Path(process.EXODisappMuonSkimSequence)
+process.SKIMStreamEXODisappMuonOutPath = cms.EndPath(process.SKIMStreamEXODisappMuon)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.EXODisappMuonPath,process.SKIMStreamEXODisappMuonOutPath)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41225

#### PR description:

I noticed that the code introduced in https://github.com/cms-sw/cmssw/pull/40666 could be optimized in a few places, mostly:
  * do not use track matching in dR / dPt when direct comparison of track references is available
  * use range-based loops
  * modernize access to event collections
  * avoid repeated calculations
  * avoid code duplication
  * use `deltaR2` in lieu of `deltaR`
  
I propose these optimizations here, as well as a test configuration that I have been using to make sure the update code results in exactly the same output as the old one.

#### PR validation:

Run the `Configuration/Skimming/test/test_DisMuon_cfg.py` file introduced here in a vanilla `CMSSW_13_1_X_2023-03-27-1100` release and in this branch and checked that the exact same events are selected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/41225, as request in https://github.com/cms-sw/cmssw/pull/41225#issuecomment-1498725573