### PR TITLE
[Backport] Adding the new muon track finder index and three eta cuts features in the GT emulator

### DIFF
--- a/L1Trigger/L1TGlobal/interface/CaloTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CaloTemplate.h
@@ -74,6 +74,8 @@ public:
     unsigned int etaWindow1Upper;
     unsigned int etaWindow2Lower;
     unsigned int etaWindow2Upper;
+    unsigned int etaWindow3Lower;
+    unsigned int etaWindow3Upper;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/interface/CaloTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/CaloTemplate.h
@@ -15,10 +15,11 @@
 
  * \new features: R. Cavanaugh
  *          - added LUT bit for LLP displaced jets
- *            Note: Calo Trig considers the DISP bit part of the 
- *                  quality word, but uGT firmware considers the 
+ *            Note: Calo Trig considers the DISP bit part of the
+ *                  quality word, but uGT firmware considers the
  *                  DISP bit to be distinct from the quality word.
- *
+ * \new features: Bernhard Arnold, Elisa Fontanesi                                                          
+ *                - added etaWindows for the checkRangeEta function: it allows to use up to five eta cuts in L1 algorithms
  * $Date$
  * $Revision$
  *
@@ -57,6 +58,11 @@ public:
   CaloTemplate& operator=(const CaloTemplate&);
 
 public:
+  struct Window {
+    unsigned int lower;
+    unsigned int upper;
+  };
+
   /// typedef for a single object template
   struct ObjectParameter {
     unsigned int etLowThreshold;
@@ -70,12 +76,7 @@ public:
     unsigned int qualityLUT;
     unsigned int displacedLUT;  // Added for LLP Jets
 
-    unsigned int etaWindow1Lower;
-    unsigned int etaWindow1Upper;
-    unsigned int etaWindow2Lower;
-    unsigned int etaWindow2Upper;
-    unsigned int etaWindow3Lower;
-    unsigned int etaWindow3Upper;
+    std::vector<Window> etaWindows;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -117,6 +117,8 @@ namespace l1t {
                              const Type1& W1endR,
                              const Type1& W2beginR,
                              const Type1& W2endR,
+                             const Type1& W3beginR,
+                             const Type1& W3endR,
                              const unsigned int nEtaBits) const;
 
     /// check if a value is in a given range and outside of a veto range
@@ -144,8 +146,7 @@ namespace l1t {
 
     /// check if a value is in a given range
     template <class Type1>
-    const bool checkRangeTfMuonIndex(const unsigned int bitNumber,
-                                     const std::vector<Type1>& windows) const;
+    const bool checkRangeTfMuonIndex(const unsigned int bitNumber, const std::vector<Type1>& windows) const;
 
   protected:
     /// maximum number of objects received for the evaluation of the condition
@@ -242,7 +243,7 @@ namespace l1t {
                            << "\n\t indexLo = " << indexLo << "\n\t indexHi = " << indexHi << "\n\t index = " << index
                            << std::endl;
 
-    // set condtion to false if indexLo > indexHi
+    // set condition to false if indexLo > indexHi
     if (indexLo > indexHi) {
       return false;
     }
@@ -286,8 +287,10 @@ namespace l1t {
                                                 const Type1& W1endR,
                                                 const Type1& W2beginR,
                                                 const Type1& W2endR,
+                                                const Type1& W3beginR,
+                                                const Type1& W3endR,
                                                 const unsigned int nEtaBits) const {
-    // set condtion to true if beginR==endR = default -1
+    // set condition to true if beginR==endR = default -1
     if (W1beginR == W1endR && W1beginR == (Type1)-1) {
       return true;
     }
@@ -347,7 +350,35 @@ namespace l1t {
                            << "\n\t passWindow2 = " << passWindow2
                            << "\n\t pass W1 || W2 = " << (passWindow1 || passWindow2) << std::endl;
 
-    if (passWindow1 || passWindow2) {
+    if (W3beginR == W2endR && W3beginR == (Type1)-1) {
+      return passWindow2;
+    }
+
+    unsigned int W3diff1 = W3endR - W3beginR;
+    unsigned int W3diff2 = bitNumber - W3beginR;
+    unsigned int W3diff3 = W3endR - bitNumber;
+
+    bool W3cond1 = ((W3diff1 >> nEtaBits) & 1) ? false : true;
+    bool W3cond2 = ((W3diff2 >> nEtaBits) & 1) ? false : true;
+    bool W3cond3 = ((W3diff3 >> nEtaBits) & 1) ? false : true;
+
+    bool passWindow3 = false;
+    if (W3cond1 && (W3cond2 && W3cond3))
+      passWindow3 = true;
+    else if (!W3cond1 && (W3cond2 || W3cond3))
+      passWindow3 = true;
+    else {
+      passWindow3 = false;
+    }
+
+    LogDebug("l1t|Global") << "\n\t W3beginR = " << W3beginR << "\n\t W3endR   = " << W3endR
+                           << "\n\t W3diff1 = " << W3diff1 << "\n\t W3cond1 = " << W3cond1
+                           << "\n\t W3diff2 = " << W3diff2 << "\n\t W3cond2 = " << W3cond2
+                           << "\n\t W3diff3 = " << W3diff3 << "\n\t W3cond3 = " << W3cond3
+                           << "\n\t passWindow3 = " << passWindow3
+                           << "\n\t pass W1 || W2 |W3| = " << (passWindow1 || passWindow2 || passWindow3) << std::endl;
+
+    if (passWindow1 || passWindow2 || passWindow3) {
       return true;
     } else {
       return false;
@@ -361,7 +392,7 @@ namespace l1t {
                                                 const Type1& W1endR,
                                                 const Type1& W2beginR,
                                                 const Type1& W2endR) const {
-    // set condtion to true if beginR==endR = default -1
+    // set condition to true if beginR==endR = default -1
     if (W1beginR == W1endR && W1beginR == (Type1)-1) {
       return true;
     }
@@ -430,7 +461,7 @@ namespace l1t {
                                                      const Type1& lowerR,
                                                      const Type1& upperR,
                                                      const unsigned int nEtaBits) const {
-    /*   // set condtion to true if beginR==endR = default -1 */
+    /*   // set condition to true if beginR==endR = default -1 */
     /*   if( beginR==endR && beginR==-1 ){ */
     /*     return true; */
     /*   } */

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -142,6 +142,11 @@ namespace l1t {
                                   const Type1& lowerR,
                                   const Type1& upperR) const;
 
+    /// check if a value is in a given range
+    template <class Type1>
+    const bool checkRangeTfMuonIndex(const unsigned int bitNumber,
+                                     const std::vector<Type1>& windows) const;
+
   protected:
     /// maximum number of objects received for the evaluation of the condition
     /// usually retrieved from event setup
@@ -502,6 +507,22 @@ namespace l1t {
     else {
       return false;
     }
+  }
+
+  template <class Type1>
+  const bool ConditionEvaluation::checkRangeTfMuonIndex(const unsigned int value,
+                                                        const std::vector<Type1>& windows) const {
+    if (windows.empty()) {
+      return true;
+    }
+
+    for (const auto& window : windows) {
+      if ((window.lower <= value) and (value <= window.upper)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
+++ b/L1Trigger/L1TGlobal/interface/ConditionEvaluation.h
@@ -11,8 +11,12 @@
  *    <TODO: enter implementation details>
  *
  * \author: Vasile Mihai Ghete   - HEPHY Vienna
- *          Vladimir Rekovic - extend for indexing
  *
+ * \new features: Vladimir Rekovic                                                          
+ *                - extend for indexing
+ * \new features: Bernhard Arnold, Elisa Fontanesi                                                          
+ *                - extended for muon track finder index feature (used for Run 3 muon monitoring seeds)             
+ *                - checkRangeEta function allows to use up to five eta cuts in L1 algorithms 
  *
  */
 
@@ -93,7 +97,7 @@ namespace l1t {
 
     /// check if a value is greater than a threshold or
     /// greater-or-equal depending on the value of the condGEqValue flag
-    /// Added by Rick Cavanaugh for Displaced Muons:
+    /// Added for Displaced Muons:
     ///       Above checkThreshold fails when value overflows or threshold window is invalid
     ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
     template <class Type1, class Type2>
@@ -110,18 +114,15 @@ namespace l1t {
     template <class Type1>
     const bool checkBit(const Type1& mask, const unsigned int bitNumber) const;
 
-    /// check if a value is in a given range and outside of a veto range
+    /// check if a value is in a given eta range and outside of a veto range
+    ///        Up to five eta cuts are allowed in L1 algorithms.
+    ///        Three eta cuts are used for the DoubleMu seeds with upt requirement implemented for Run 3 (2023)
     template <class Type1>
     const bool checkRangeEta(const unsigned int bitNumber,
-                             const Type1& W1beginR,
-                             const Type1& W1endR,
-                             const Type1& W2beginR,
-                             const Type1& W2endR,
-                             const Type1& W3beginR,
-                             const Type1& W3endR,
+                             const std::vector<Type1>& windows,
                              const unsigned int nEtaBits) const;
 
-    /// check if a value is in a given range and outside of a veto range
+    /// check if a value is in a given phi range and outside of a veto range
     template <class Type1>
     const bool checkRangePhi(const unsigned int bitNumber,
                              const Type1& W1beginR,
@@ -129,7 +130,7 @@ namespace l1t {
                              const Type1& W2beginR,
                              const Type1& W2endR) const;
 
-    /// check if a value is in a given range
+    /// check if a value is in a given deltaEta range
     template <class Type1>
     const bool checkRangeDeltaEta(const unsigned int obj1Eta,
                                   const unsigned int obj2Eta,
@@ -137,14 +138,14 @@ namespace l1t {
                                   const Type1& upperR,
                                   const unsigned int nEtaBits) const;
 
-    /// check if a value is in a given range
+    /// check if a value is in a given deltaPhi range
     template <class Type1>
     const bool checkRangeDeltaPhi(const unsigned int obj1Phi,
                                   const unsigned int obj2Phi,
                                   const Type1& lowerR,
                                   const Type1& upperR) const;
 
-    /// check if a value is in a given range
+    /// check if a value is in a given muon track finder index range
     template <class Type1>
     const bool checkRangeTfMuonIndex(const unsigned int bitNumber, const std::vector<Type1>& windows) const;
 
@@ -203,7 +204,7 @@ namespace l1t {
 
   // check if a value is greater than a threshold or
   // greater-or-equal depending on the value of the condGEqValue flag
-  /// Added by Rick Cavanaugh for Displaced Muons:
+  /// Added for Displaced Muons:
   ///       Above checkThreshold fails when value overflows or threshold window is invalid
   ///       Below checkUnconstrainedPt allows value to overflow and only evaluates cut if threshold window is valid
   template <class Type1, class Type2>
@@ -234,7 +235,7 @@ namespace l1t {
       return true;
   }
 
-  // check if a index in a given range
+  // check if a index in a given index range
   template <class Type1>
   const bool ConditionEvaluation::checkIndex(const Type1& indexLo,
                                              const Type1& indexHi,
@@ -280,112 +281,53 @@ namespace l1t {
     return (mask & oneBit);
   }
 
-  /// check if a value is in a given range and outside of a veto range
+  /// check if a value is in a given eta range and outside of a veto range
+  ///        Up to five eta cuts are allowed in L1 algorithms.
+  ///        Three eta cuts are used for the DoubleMu seeds with upt requirement implemented for Run 3 (2023)
   template <class Type1>
   const bool ConditionEvaluation::checkRangeEta(const unsigned int bitNumber,
-                                                const Type1& W1beginR,
-                                                const Type1& W1endR,
-                                                const Type1& W2beginR,
-                                                const Type1& W2endR,
-                                                const Type1& W3beginR,
-                                                const Type1& W3endR,
+                                                const std::vector<Type1>& windows,
                                                 const unsigned int nEtaBits) const {
-    // set condition to true if beginR==endR = default -1
-    if (W1beginR == W1endR && W1beginR == (Type1)-1) {
+    if (windows.empty()) {
       return true;
     }
 
-    unsigned int W1diff1 = W1endR - W1beginR;
-    unsigned int W1diff2 = bitNumber - W1beginR;
-    unsigned int W1diff3 = W1endR - bitNumber;
+    for (const auto& window : windows) {
+      const unsigned int diff1 = window.upper - window.lower;
+      const unsigned int diff2 = bitNumber - window.lower;
+      const unsigned int diff3 = window.upper - bitNumber;
 
-    bool W1cond1 = ((W1diff1 >> nEtaBits) & 1) ? false : true;
-    bool W1cond2 = ((W1diff2 >> nEtaBits) & 1) ? false : true;
-    bool W1cond3 = ((W1diff3 >> nEtaBits) & 1) ? false : true;
+      const bool cond1 = ((diff1 >> nEtaBits) & 1) ? false : true;
+      const bool cond2 = ((diff2 >> nEtaBits) & 1) ? false : true;
+      const bool cond3 = ((diff3 >> nEtaBits) & 1) ? false : true;
 
-    // check if value is in range
-    // for begin <= end takes [begin, end]
-    // for begin >= end takes [begin, end] over zero angle!
-    bool passWindow1 = false;
-    if (W1cond1 && (W1cond2 && W1cond3))
-      passWindow1 = true;
-    else if (!W1cond1 && (W1cond2 || W1cond3))
-      passWindow1 = true;
-    else {
-      passWindow1 = false;
+      // check if value is in range
+      // for begin <= end takes [begin, end]
+      // for begin >= end takes [begin, end] over zero angle!
+      bool passWindow = false;
+      if (cond1 && (cond2 && cond3))
+        passWindow = true;
+      else if (!cond1 && (cond2 || cond3))
+        passWindow = true;
+      else
+        passWindow = false;
+
+      LogDebug("l1t|Global") << "\n l1t::ConditionEvaluation"
+                             << "\n\t bitNumber = " << bitNumber << "\n\t window.lower = " << window.lower
+                             << "\n\t window.upper = " << window.upper << "\n\t diff1 = " << diff1
+                             << "\n\t cond1 = " << cond1 << "\n\t diff2 = " << diff2 << "\n\t cond2 = " << cond2
+                             << "\n\t diff3 = " << diff3 << "\n\t cond3 = " << cond3
+                             << "\n\t passWindow = " << passWindow << std::endl;
+
+      if (passWindow) {
+        return true;
+      }
     }
 
-    LogDebug("l1t|Global") << "\n l1t::ConditionEvaluation"
-                           << "\n\t bitNumber = " << bitNumber << "\n\t W1beginR = " << W1beginR
-                           << "\n\t W1endR   = " << W1endR << "\n\t W1diff1 = " << W1diff1
-                           << "\n\t W1cond1 = " << W1cond1 << "\n\t W1diff2 = " << W1diff2
-                           << "\n\t W1cond2 = " << W1cond2 << "\n\t W1diff3 = " << W1diff3
-                           << "\n\t W1cond3 = " << W1cond3 << "\n\t passWindow1 = " << passWindow1 << std::endl;
-
-    if (W2beginR == W2endR && W2beginR == (Type1)-1) {
-      return passWindow1;
-    }
-
-    unsigned int W2diff1 = W2endR - W2beginR;
-    unsigned int W2diff2 = bitNumber - W2beginR;
-    unsigned int W2diff3 = W2endR - bitNumber;
-
-    bool W2cond1 = ((W2diff1 >> nEtaBits) & 1) ? false : true;
-    bool W2cond2 = ((W2diff2 >> nEtaBits) & 1) ? false : true;
-    bool W2cond3 = ((W2diff3 >> nEtaBits) & 1) ? false : true;
-
-    bool passWindow2 = false;
-    if (W2cond1 && (W2cond2 && W2cond3))
-      passWindow2 = true;
-    else if (!W2cond1 && (W2cond2 || W2cond3))
-      passWindow2 = true;
-    else {
-      passWindow2 = false;
-    }
-
-    LogDebug("l1t|Global") << "\n\t W2beginR = " << W2beginR << "\n\t W2endR   = " << W2endR
-                           << "\n\t W2diff1 = " << W2diff1 << "\n\t W2cond1 = " << W2cond1
-                           << "\n\t W2diff2 = " << W2diff2 << "\n\t W2cond2 = " << W2cond2
-                           << "\n\t W2diff3 = " << W2diff3 << "\n\t W2cond3 = " << W2cond3
-                           << "\n\t passWindow2 = " << passWindow2
-                           << "\n\t pass W1 || W2 = " << (passWindow1 || passWindow2) << std::endl;
-
-    if (W3beginR == W2endR && W3beginR == (Type1)-1) {
-      return passWindow2;
-    }
-
-    unsigned int W3diff1 = W3endR - W3beginR;
-    unsigned int W3diff2 = bitNumber - W3beginR;
-    unsigned int W3diff3 = W3endR - bitNumber;
-
-    bool W3cond1 = ((W3diff1 >> nEtaBits) & 1) ? false : true;
-    bool W3cond2 = ((W3diff2 >> nEtaBits) & 1) ? false : true;
-    bool W3cond3 = ((W3diff3 >> nEtaBits) & 1) ? false : true;
-
-    bool passWindow3 = false;
-    if (W3cond1 && (W3cond2 && W3cond3))
-      passWindow3 = true;
-    else if (!W3cond1 && (W3cond2 || W3cond3))
-      passWindow3 = true;
-    else {
-      passWindow3 = false;
-    }
-
-    LogDebug("l1t|Global") << "\n\t W3beginR = " << W3beginR << "\n\t W3endR   = " << W3endR
-                           << "\n\t W3diff1 = " << W3diff1 << "\n\t W3cond1 = " << W3cond1
-                           << "\n\t W3diff2 = " << W3diff2 << "\n\t W3cond2 = " << W3cond2
-                           << "\n\t W3diff3 = " << W3diff3 << "\n\t W3cond3 = " << W3cond3
-                           << "\n\t passWindow3 = " << passWindow3
-                           << "\n\t pass W1 || W2 |W3| = " << (passWindow1 || passWindow2 || passWindow3) << std::endl;
-
-    if (passWindow1 || passWindow2 || passWindow3) {
-      return true;
-    } else {
-      return false;
-    }
+    return false;
   }
 
-  /// check if a value is in a given range and outside of a veto range
+  /// check if a value is in a given phi range and outside of a veto range
   template <class Type1>
   const bool ConditionEvaluation::checkRangePhi(const unsigned int bitNumber,
                                                 const Type1& W1beginR,
@@ -550,6 +492,9 @@ namespace l1t {
     for (const auto& window : windows) {
       if ((window.lower <= value) and (value <= window.upper)) {
         return true;
+        LogDebug("l1t|Global") << "\n l1t::ConditionEvaluation"
+                               << "\n\t window.lower = " << window.lower << "\n\t window.upper = " << window.upper
+                               << "Passed TfMuonIndex window" << std::endl;
       }
     }
 

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -51,6 +51,11 @@ public:
   MuonTemplate& operator=(const MuonTemplate&);
 
 public:
+  struct Window {
+    unsigned int lower;
+    unsigned int upper;
+  };
+
   // typedef for a single object template
   struct ObjectParameter {
     unsigned int unconstrainedPtHigh;
@@ -82,6 +87,8 @@ public:
     unsigned int phiWindow1Upper;
     unsigned int phiWindow2Lower;
     unsigned int phiWindow2Upper;
+
+    std::vector<Window> tfMuonIndexWindows;
   };
 
   // typedef for correlation parameters

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -82,6 +82,8 @@ public:
     unsigned int etaWindow1Upper;
     unsigned int etaWindow2Lower;
     unsigned int etaWindow2Upper;
+    unsigned int etaWindow3Lower;
+    unsigned int etaWindow3Upper;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/interface/MuonTemplate.h
+++ b/L1Trigger/L1TGlobal/interface/MuonTemplate.h
@@ -11,8 +11,12 @@
  *    <TODO: enter implementation details>
  *
  * \author: Vasile Mihai Ghete - HEPHY Vienna
- *          Vladimir Rekovic - extend for indexing
- *
+ *          
+ * \new features: Vladimir Rekovic
+ *                - extend for indexing
+ * \new features: Bernhard Arnold, Elisa Fontanesi                                                   
+ *                - added etaWindows for the checkRangeEta function: it allows to use up to five eta cuts in L1 algorithms 
+ *                - extended for muon track finder index feature (used for Run 3 muon monitoring seeds)                   
  * $Date$
  * $Revision$
  *
@@ -78,12 +82,7 @@ public:
 
     int charge;
 
-    unsigned int etaWindow1Lower;
-    unsigned int etaWindow1Upper;
-    unsigned int etaWindow2Lower;
-    unsigned int etaWindow2Upper;
-    unsigned int etaWindow3Lower;
-    unsigned int etaWindow3Upper;
+    std::vector<Window> etaWindows;
 
     unsigned int phiWindow1Lower;
     unsigned int phiWindow1Upper;

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -861,6 +861,7 @@ namespace l1t {
     packedVal |= ((cms_uint64_t)(mu->hwCharge() & 0x1) << 34);            // & 0x1)   <<29);
     packedVal |= ((cms_uint64_t)(mu->hwQual() & 0xf) << 19);              // & 0xf)   <<30);
     packedVal |= ((cms_uint64_t)(mu->hwIso() & 0x3) << 32);               // & 0x3)   <<34);
+    packedVal |= ((cms_uint64_t)(mu->tfMuonIndex() & 0x7f) << 36);
 
     //    if (false) {  // for debugging purposes
     //      std::cout << "----------------------" << std::endl;

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1152,6 +1152,8 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     int qualityLUT = 0xFFFF;       //default is to ignore unless specified.
 
     const std::vector<esCut>& cuts = object.getCuts();
+    std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
     for (size_t kk = 0; kk < cuts.size(); kk++) {
       const esCut& cut = cuts.at(kk);
 
@@ -1226,6 +1228,14 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
           isolationLUT = l1tstr2int(cut.getData());
 
         } break;
+
+        case esCutType::Index: {
+          tfMuonIndexWindows.push_back({
+            cut.getMinimum().index,
+            cut.getMaximum().index
+          });
+        } break;
+
         default:
           break;
       }  //end switch
@@ -1263,6 +1273,8 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     objParameter[cnt].charge = charge;
     objParameter[cnt].qualityLUT = qualityLUT;
     objParameter[cnt].isolationLUT = isolationLUT;
+
+    objParameter[cnt].tfMuonIndexWindows = tfMuonIndexWindows;
 
     cnt++;
   }  //end loop over objects
@@ -1384,6 +1396,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   int qualityLUT = 0xFFFF;  //default is to ignore unless specified.
 
   const std::vector<esCut>& cuts = corrMu->getCuts();
+  std::vector<MuonTemplate::Window> tfMuonIndexWindows;
+
   for (size_t kk = 0; kk < cuts.size(); kk++) {
     const esCut& cut = cuts.at(kk);
 
@@ -1458,6 +1472,14 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
         isolationLUT = l1tstr2int(cut.getData());
 
       } break;
+
+      case esCutType::Index: {
+        tfMuonIndexWindows.push_back({
+          cut.getMinimum().index,
+          cut.getMaximum().index
+        });
+      } break;
+
       default:
         break;
     }  //end switch
@@ -1495,6 +1517,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   objParameter[0].charge = charge;
   objParameter[0].qualityLUT = qualityLUT;
   objParameter[0].isolationLUT = isolationLUT;
+
+  objParameter[0].tfMuonIndexWindows = tfMuonIndexWindows;
 
   // object types - all muons
   std::vector<GlobalObject> objType(nrObj, gtMu);

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -1142,8 +1142,11 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     int lowerThresholdInd = 0;
     int upperIndexInd = -1;
     int lowerIndexInd = 0;
+    // Up to five eta cuts can be implemented: at the moment three eta cuts are used only for muons (upt seeds for Run 3)
     int cntEta = 0;
-    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
+    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1;
+    unsigned int etaWindow2Lower = -1, etaWindow2Upper = -1;
+    unsigned int etaWindow3Lower = -1, etaWindow3Upper = -1;
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
     int isolationLUT = 0xF;        //default is to ignore unless specified.
@@ -1186,6 +1189,9 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
           } else if (cntEta == 1) {
             etaWindow2Lower = cut.getMinimum().index;
             etaWindow2Upper = cut.getMaximum().index;
+          } else if (cntEta == 2) {
+            etaWindow3Lower = cut.getMinimum().index;
+            etaWindow3Upper = cut.getMaximum().index;
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
@@ -1230,10 +1236,7 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
         } break;
 
         case esCutType::Index: {
-          tfMuonIndexWindows.push_back({
-            cut.getMinimum().index,
-            cut.getMaximum().index
-          });
+          tfMuonIndexWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
         } break;
 
         default:
@@ -1259,6 +1262,8 @@ bool l1t::TriggerMenuParser::parseMuon(tmeventsetup::esCondition condMu, unsigne
     objParameter[cnt].etaWindow1Upper = etaWindow1Upper;
     objParameter[cnt].etaWindow2Lower = etaWindow2Lower;
     objParameter[cnt].etaWindow2Upper = etaWindow2Upper;
+    objParameter[cnt].etaWindow3Lower = etaWindow3Lower;
+    objParameter[cnt].etaWindow3Upper = etaWindow3Upper;
 
     objParameter[cnt].phiWindow1Lower = phiWindow1Lower;
     objParameter[cnt].phiWindow1Upper = phiWindow1Upper;
@@ -1387,8 +1392,11 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   int lowerThresholdInd = 0;
   int upperIndexInd = -1;
   int lowerIndexInd = 0;
+  // Up to five eta cuts can be implemented: at the moment three eta cuts are used only for muons (upt seeds for Run 3)
   int cntEta = 0;
-  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
+  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1;
+  unsigned int etaWindow2Lower = -1, etaWindow2Upper = -1;
+  unsigned int etaWindow3Lower = -1, etaWindow3Upper = -1;
   int cntPhi = 0;
   unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
   int isolationLUT = 0xF;   //default is to ignore unless specified.
@@ -1430,6 +1438,9 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
         } else if (cntEta == 1) {
           etaWindow2Lower = cut.getMinimum().index;
           etaWindow2Upper = cut.getMaximum().index;
+        } else if (cntEta == 2) {
+          etaWindow3Lower = cut.getMinimum().index;
+          etaWindow3Upper = cut.getMaximum().index;
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for muon-condition (" << particle << ")" << std::endl;
@@ -1474,10 +1485,7 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
       } break;
 
       case esCutType::Index: {
-        tfMuonIndexWindows.push_back({
-          cut.getMinimum().index,
-          cut.getMaximum().index
-        });
+        tfMuonIndexWindows.push_back({cut.getMinimum().index, cut.getMaximum().index});
       } break;
 
       default:
@@ -1487,11 +1495,11 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   }  //end loop over cuts
 
   // Set the parameter cuts
-  objParameter[0].unconstrainedPtHigh = upperUnconstrainedPtInd;  // Added for displacd muons
-  objParameter[0].unconstrainedPtLow = lowerUnconstrainedPtInd;   // Added for displacd muons
-  objParameter[0].impactParameterHigh = upperImpactParameterInd;  // Added for displacd muons
-  objParameter[0].impactParameterLow = lowerImpactParameterInd;   // Added for displacd muons
-  objParameter[0].impactParameterLUT = impactParameterLUT;        // Added for displacd muons
+  objParameter[0].unconstrainedPtHigh = upperUnconstrainedPtInd;  // Added for displaced muons
+  objParameter[0].unconstrainedPtLow = lowerUnconstrainedPtInd;   // Added for displaced muons
+  objParameter[0].impactParameterHigh = upperImpactParameterInd;  // Added for displaced muons
+  objParameter[0].impactParameterLow = lowerImpactParameterInd;   // Added for displaced muons
+  objParameter[0].impactParameterLUT = impactParameterLUT;        // Added for displaced muons
 
   objParameter[0].ptHighThreshold = upperThresholdInd;
   objParameter[0].ptLowThreshold = lowerThresholdInd;
@@ -1503,6 +1511,8 @@ bool l1t::TriggerMenuParser::parseMuonCorr(const tmeventsetup::esObject* corrMu,
   objParameter[0].etaWindow1Upper = etaWindow1Upper;
   objParameter[0].etaWindow2Lower = etaWindow2Lower;
   objParameter[0].etaWindow2Upper = etaWindow2Upper;
+  objParameter[0].etaWindow3Lower = etaWindow3Lower;
+  objParameter[0].etaWindow3Upper = etaWindow3Upper;
 
   objParameter[0].phiWindow1Lower = phiWindow1Lower;
   objParameter[0].phiWindow1Upper = phiWindow1Upper;
@@ -1787,8 +1797,11 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
     int lowerThresholdInd = 0;
     int upperIndexInd = -1;
     int lowerIndexInd = 0;
+    // Up to five eta cuts can be implemented: at the moment three eta cuts are used only for muons (upt seeds for Run 3)
     int cntEta = 0;
-    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
+    unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1;
+    unsigned int etaWindow2Lower = -1, etaWindow2Upper = -1;
+    unsigned int etaWindow3Lower = -1, etaWindow3Upper = -1;
     int cntPhi = 0;
     unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
     int isolationLUT = 0xF;  //default is to ignore isolation unless specified.
@@ -1817,6 +1830,9 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
           } else if (cntEta == 1) {
             etaWindow2Lower = cut.getMinimum().index;
             etaWindow2Upper = cut.getMaximum().index;
+          } else if (cntEta == 2) {
+            etaWindow3Lower = cut.getMinimum().index;
+            etaWindow3Upper = cut.getMaximum().index;
           } else {
             edm::LogError("TriggerMenuParser")
                 << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;
@@ -1874,6 +1890,8 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
     objParameter[cnt].etaWindow1Upper = etaWindow1Upper;
     objParameter[cnt].etaWindow2Lower = etaWindow2Lower;
     objParameter[cnt].etaWindow2Upper = etaWindow2Upper;
+    objParameter[cnt].etaWindow3Lower = etaWindow3Lower;
+    objParameter[cnt].etaWindow3Upper = etaWindow3Upper;
     objParameter[cnt].phiWindow1Lower = phiWindow1Lower;
     objParameter[cnt].phiWindow1Upper = phiWindow1Upper;
     objParameter[cnt].phiWindow2Lower = phiWindow2Lower;
@@ -1890,6 +1908,8 @@ bool l1t::TriggerMenuParser::parseCalo(tmeventsetup::esCondition condCalo, unsig
                                   << objParameter[cnt].etaWindow1Lower << " / 0x" << objParameter[cnt].etaWindow1Upper
                                   << "\n      etaWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
                                   << objParameter[cnt].etaWindow2Lower << " / 0x" << objParameter[cnt].etaWindow2Upper
+                                  << "\n      etaWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
+                                  << objParameter[cnt].etaWindow3Lower << " / 0x" << objParameter[cnt].etaWindow3Upper
                                   << "\n      phiWindow Lower / Upper for calo object " << cnt << " = 0x"
                                   << objParameter[cnt].phiWindow1Lower << " / 0x" << objParameter[cnt].phiWindow1Upper
                                   << "\n      phiWindowVeto Lower / Upper for calo object " << cnt << " = 0x"
@@ -2022,8 +2042,11 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
   int lowerThresholdInd = 0;
   int upperIndexInd = -1;
   int lowerIndexInd = 0;
+  // Up to five eta cuts can be implemented: at the moment three eta cuts are used only for muons (upt seeds for Run 3)
   int cntEta = 0;
-  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1, etaWindow2Lower = -1, etaWindow2Upper = -1;
+  unsigned int etaWindow1Lower = -1, etaWindow1Upper = -1;
+  unsigned int etaWindow2Lower = -1, etaWindow2Upper = -1;
+  unsigned int etaWindow3Lower = -1, etaWindow3Upper = -1;
   int cntPhi = 0;
   unsigned int phiWindow1Lower = -1, phiWindow1Upper = -1, phiWindow2Lower = -1, phiWindow2Upper = -1;
   int isolationLUT = 0xF;  //default is to ignore isolation unless specified.
@@ -2052,6 +2075,9 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
         } else if (cntEta == 1) {
           etaWindow2Lower = cut.getMinimum().index;
           etaWindow2Upper = cut.getMaximum().index;
+        } else if (cntEta == 2) {
+          etaWindow3Lower = cut.getMinimum().index;
+          etaWindow3Upper = cut.getMaximum().index;
         } else {
           edm::LogError("TriggerMenuParser")
               << "Too Many Eta Cuts for calo-condition (" << particle << ")" << std::endl;
@@ -2109,6 +2135,8 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
   objParameter[0].etaWindow1Upper = etaWindow1Upper;
   objParameter[0].etaWindow2Lower = etaWindow2Lower;
   objParameter[0].etaWindow2Upper = etaWindow2Upper;
+  objParameter[0].etaWindow3Lower = etaWindow3Lower;
+  objParameter[0].etaWindow3Upper = etaWindow3Upper;
   objParameter[0].phiWindow1Lower = phiWindow1Lower;
   objParameter[0].phiWindow1Upper = phiWindow1Upper;
   objParameter[0].phiWindow2Lower = phiWindow2Lower;
@@ -2125,7 +2153,10 @@ bool l1t::TriggerMenuParser::parseCaloCorr(const tmeventsetup::esObject* corrCal
                                 << objParameter[0].etaWindow1Upper
                                 << "\n      etaWindowVeto Lower / Upper for calo object "
                                 << " = 0x" << objParameter[0].etaWindow2Lower << " / 0x"
-                                << objParameter[0].etaWindow2Upper << "\n      phiWindow Lower / Upper for calo object "
+                                << objParameter[0].etaWindow2Upper
+                                << "\n      etaWindowVeto Lower / Upper for calo object "
+                                << " = 0x" << objParameter[0].etaWindow3Lower << " / 0x"
+                                << objParameter[0].etaWindow3Upper << "\n      phiWindow Lower / Upper for calo object "
                                 << " = 0x" << objParameter[0].phiWindow1Lower << " / 0x"
                                 << objParameter[0].phiWindow1Upper
                                 << "\n      phiWindowVeto Lower / Upper for calo object "

--- a/L1Trigger/L1TGlobal/src/CaloCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CaloCondition.cc
@@ -495,6 +495,8 @@ const bool l1t::CaloCondition::checkObjectParameter(const int iCondition,
                      objPar.etaWindow1Upper,
                      objPar.etaWindow2Lower,
                      objPar.etaWindow2Upper,
+                     objPar.etaWindow3Lower,
+                     objPar.etaWindow3Upper,
                      7)) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
     return false;

--- a/L1Trigger/L1TGlobal/src/CaloCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CaloCondition.cc
@@ -490,14 +490,7 @@ const bool l1t::CaloCondition::checkObjectParameter(const int iCondition,
   }
 
   // check eta
-  if (!checkRangeEta(cand.hwEta(),
-                     objPar.etaWindow1Lower,
-                     objPar.etaWindow1Upper,
-                     objPar.etaWindow2Lower,
-                     objPar.etaWindow2Upper,
-                     objPar.etaWindow3Lower,
-                     objPar.etaWindow3Upper,
-                     7)) {
+  if (!checkRangeEta(cand.hwEta(), objPar.etaWindows, 7)) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
     return false;
   }

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -435,15 +435,8 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
   }
 
   // check eta
-  if (!checkRangeEta(cand.hwEtaAtVtx(),
-                     objPar.etaWindow1Lower,
-                     objPar.etaWindow1Upper,
-                     objPar.etaWindow2Lower,
-                     objPar.etaWindow2Upper,
-                     objPar.etaWindow3Lower,
-                     objPar.etaWindow3Upper,
-                     8)) {
-    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
+  if (!checkRangeEta(cand.hwEtaAtVtx(), objPar.etaWindows, 8)) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRangeEta" << std::endl;
     return false;
   }
 
@@ -491,7 +484,7 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
 
   // check muon TF index
   if (!checkRangeTfMuonIndex(cand.tfMuonIndex(), objPar.tfMuonIndexWindows)) {
-    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(tfMuonIndex)" << std::endl;
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRangeTfMuonIndex" << std::endl;
     return false;
   }
 

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -440,6 +440,8 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
                      objPar.etaWindow1Upper,
                      objPar.etaWindow2Lower,
                      objPar.etaWindow2Upper,
+                     objPar.etaWindow3Lower,
+                     objPar.etaWindow3Upper,
                      8)) {
     LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(eta)" << std::endl;
     return false;

--- a/L1Trigger/L1TGlobal/src/MuCondition.cc
+++ b/L1Trigger/L1TGlobal/src/MuCondition.cc
@@ -487,6 +487,12 @@ const bool l1t::MuCondition::checkObjectParameter(const int iCondition,
     return false;
   }
 
+  // check muon TF index
+  if (!checkRangeTfMuonIndex(cand.tfMuonIndex(), objPar.tfMuonIndexWindows)) {
+    LogDebug("L1TGlobal") << "\t\t l1t::Candidate failed checkRange(tfMuonIndex)" << std::endl;
+    return false;
+  }
+
   // A number of values is required to trigger (at least one).
   // "Don't care" means that all values are allowed.
   // Qual = 000 means then NO MUON (GTL module)

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -101,12 +101,17 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    phiWindow1Upper   =" << std::hex << m_objectParameter[i].phiWindow1Upper << std::endl;
     myCout << "    phiWindow2Lower   =" << std::hex << m_objectParameter[i].phiWindow2Lower << std::endl;
     myCout << "    phiWindow2Upper   =" << std::hex << m_objectParameter[i].phiWindow2Upper << std::endl;
-    myCout << "    etaWindow1Lower   =" << std::hex << m_objectParameter[i].etaWindow1Lower << std::endl;
-    myCout << "    etaWindow1Upper   =" << std::hex << m_objectParameter[i].etaWindow1Upper << std::endl;
-    myCout << "    etaWindow2Lower   =" << std::hex << m_objectParameter[i].etaWindow2Lower << std::endl;
-    myCout << "    etaWindow2Upper   =" << std::hex << m_objectParameter[i].etaWindow2Upper << std::endl;
-    myCout << "    etaWindow3Lower   =" << std::hex << m_objectParameter[i].etaWindow3Lower << std::endl;
-    myCout << "    etaWindow3Upper   =" << std::hex << m_objectParameter[i].etaWindow3Upper << std::endl;
+
+    size_t etaWindowIndex = 1;
+    for (const auto& window : m_objectParameter[i].etaWindows) {
+      //myCout << "    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower << std::endl;
+      //myCout << "    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper << std::endl;
+      std::cout << " # MUON TEMPLATE:    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower
+                << std::endl;
+      std::cout << " # MUON TEMPLATE:    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper
+                << std::endl;
+      ++etaWindowIndex;
+    }
   }
 
   if (wsc()) {

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -91,12 +91,6 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    qualityLUT        = " << std::hex << m_objectParameter[i].qualityLUT << std::endl;
     myCout << "    isolationLUT      = " << std::hex << m_objectParameter[i].isolationLUT << std::endl;
     myCout << "    impactParameterLUT= " << std::hex << m_objectParameter[i].impactParameterLUT << std::endl;
-    //       myCout << "    etaRange          = "
-    //       << std::hex << m_objectParameter[i].etaRange << std::endl;
-    //       myCout << "    phiHigh           = "
-    //       << std::hex << m_objectParameter[i].phiHigh << std::endl;
-    //       myCout << "    phiLow            = "
-    //        << std::hex << m_objectParameter[i].phiLow << std::endl;
     myCout << "    phiWindow1Lower   =" << std::hex << m_objectParameter[i].phiWindow1Lower << std::endl;
     myCout << "    phiWindow1Upper   =" << std::hex << m_objectParameter[i].phiWindow1Upper << std::endl;
     myCout << "    phiWindow2Lower   =" << std::hex << m_objectParameter[i].phiWindow2Lower << std::endl;
@@ -104,12 +98,8 @@ void MuonTemplate::print(std::ostream& myCout) const {
 
     size_t etaWindowIndex = 1;
     for (const auto& window : m_objectParameter[i].etaWindows) {
-      //myCout << "    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower << std::endl;
-      //myCout << "    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper << std::endl;
-      std::cout << " # MUON TEMPLATE:    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower
-                << std::endl;
-      std::cout << " # MUON TEMPLATE:    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper
-                << std::endl;
+      myCout << "    etaWindows[" << etaWindowIndex << "].lower =" << std::hex << window.lower << std::endl;
+      myCout << "    etaWindows[" << etaWindowIndex << "].upper =" << std::hex << window.upper << std::endl;
       ++etaWindowIndex;
     }
   }

--- a/L1Trigger/L1TGlobal/src/MuonTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/MuonTemplate.cc
@@ -105,6 +105,8 @@ void MuonTemplate::print(std::ostream& myCout) const {
     myCout << "    etaWindow1Upper   =" << std::hex << m_objectParameter[i].etaWindow1Upper << std::endl;
     myCout << "    etaWindow2Lower   =" << std::hex << m_objectParameter[i].etaWindow2Lower << std::endl;
     myCout << "    etaWindow2Upper   =" << std::hex << m_objectParameter[i].etaWindow2Upper << std::endl;
+    myCout << "    etaWindow3Lower   =" << std::hex << m_objectParameter[i].etaWindow3Lower << std::endl;
+    myCout << "    etaWindow3Upper   =" << std::hex << m_objectParameter[i].etaWindow3Upper << std::endl;
   }
 
   if (wsc()) {

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -79,11 +79,11 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        # TTbar CMSSW_12X samples
-        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/04b2f8e0-57d6-449c-aa9f-a416c9926f31.root",
-        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/12bfbbc7-60fe-44c9-8f04-daa8c7b61406.root",
-        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/198e5a8c-8f06-4688-ae0d-5cc51b1eef46.root",
-        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/2e6c92bb-4997-4232-8475-04a668d8d163.root",
+        # TTbar CMSSW_13X samples
+        "/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v2-v1/00000/03acba5e-3c92-48ac-8a9f-f1a64e366586.root",
+        "/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v2-v1/00000/0d7ef730-93b6-4802-940c-6e671e273ed9.root",
+        "/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v2-v1/00000/1c2f6a11-ab8f-4aaf-89f2-745435227846.root",
+        "/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v2-v1/00000/2bd89da6-765e-42dd-bbdc-5a2d343d3086.root"
 	),
     skipEvents = cms.untracked.uint32(skip)
     )
@@ -204,7 +204,7 @@ process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
 
-xmlMenu="L1Menu_Collisions2022_v1_1_0.xml"
+xmlMenu="L1Menu_Collisions2023_v1_0_1.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 
@@ -227,6 +227,7 @@ process.load('L1Trigger.L1TGlobal.simGtStage2Digis_cfi')
 process.simGtStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
 process.simGtStage2Digis.MuonInputTag = cms.InputTag("gtInput")
+process.simGtStage2Digis.MuonShowerInputTag = cms.InputTag("gtStage2Digis", "MuonShower")
 process.simGtStage2Digis.EGammaInputTag = cms.InputTag("gtInput")
 process.simGtStage2Digis.TauInputTag = cms.InputTag("gtInput")
 process.simGtStage2Digis.JetInputTag = cms.InputTag("gtInput")
@@ -284,6 +285,7 @@ process.gtStage2Raw.TauInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.JetInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.EtSumInputTag = cms.InputTag("gtInput")
 process.gtStage2Raw.MuonInputTag = cms.InputTag("gtInput")
+process.gtStage2Raw.MuonShowerInputTag = cms.InputTag("gtInput")
 
 process.load('EventFilter.L1TRawToDigi.gtStage2Digis_cfi')
 process.newGtStage2Digis = process.gtStage2Digis.clone()
@@ -300,7 +302,8 @@ process.dumpRaw = cms.EDAnalyzer(
 
 process.newDumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
                 egInputTag    = cms.InputTag("newGtStage2Digis","EGamma"),
-		muInputTag    = cms.InputTag("newGtStage2Digis","Muon"),
+                muInputTag    = cms.InputTag("newGtStage2Digis","Muon"),
+                muShowerInputTag    = cms.InputTag("newGtStage2Digis","MuonShower"),
 		tauInputTag   = cms.InputTag("newGtStage2Digis","Tau"),
 		jetInputTag   = cms.InputTag("newGtStage2Digis","Jet"),
 		etsumInputTag = cms.InputTag("newGtStage2Digis","EtSum"),


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/41312.
These updates are needed for the deployment of the Run L1 menu [L1Menu_Collisions2023_v1_0_1](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/development/L1Menu_Collisions2023_v1_0_1) in view of the first stable beams at 13.6 TeV or soon after.

This PR includes two updates of the GT emulator accorging to the latest version of the utm library v0.11.2 (see details in [CMSLITDPG-1104](https://its.cern.ch/jira/browse/CMSLITDPG-1104)) and developments of the L1 menu for Run 3:
* Usage of three eta cuts (up to five cuts are allowed) in the design of the muon algorithms with the upt requirement. The check on the eta range is now implemented as a function checking a vector of eta windows to handle the five cuts in a easier way.
* New track finder index feature for muons in the uGT emulator needed for the update of the 2023 L1 menu as detailed in [CMSLITDPG-1075](https://its.cern.ch/jira/browse/CMSLITDPG-1075)). Note that the missing muon index data is also included in the GtRecordDumper, needed to produce a test vector as input to the firmware validation. The bits assigned to muon index in the muon object are 36..42 (see Table 6 in the uGT firmware documentation - [scales_inputs_2_ugt.pdf](https://github.com/cms-l1-globaltrigger/mp7_ugt_legacy/blob/master/doc/scales_inputs_2_ugt/pdf/scales_inputs_2_ugt.pdf)). Thank you @arnobaer and Herbert for the work!

#### PR validation:
Basic tests performed successfully starting from CMSSW_13_0_X_2023-04-06-1100
> cmsrel CMSSW_13_0_X_2023-04-06-1100
> cd CMSSW_13_0_X_2023-04-06-1100/src
> cmsenv
> git cms-addpkg L1Trigger/L1TGlobal 
> git cms-addpkg L1Trigger/Configuration
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests 
> scram build code-checks
> scram build code-format

A cross-check of the countings of each trigger bit in the new firmware and in the updated emulator showed a perfect match.

Basic cmsDriver command for L1Ntuple production successfully tested:
> cmsDriver.py l1Ntuple -s RAW2DIGI --python_filename=test.py -n 1000 --no_output --era=Run3 --data --conditions=124X_dataRun3_Prompt_v4  --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --filein=/store/data/Run2022F/EphemeralZeroBias0/RAW/v1/000/361/468/00000/52351179-2329-47d8-bffc-a01833bb1704.root --fileout=L1Ntuple.root

Note that the temporary release CMSSW_13_0_X_2023-04-06-1100 is not available anymore, so that final tests have been performed in CMSSW_13_0_X_2023-04-15-1100.