### PR TITLE
Move to steady_clock in the framework

### DIFF
--- a/FWCore/Utilities/interface/TimingServiceBase.h
+++ b/FWCore/Utilities/interface/TimingServiceBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <chrono>
 
 // user include files
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -44,10 +45,10 @@ namespace edm {
 
     static void jobStarted();
 
-    static double jobStartTime() { return s_jobStartTime; }
+    static std::chrono::steady_clock::time_point jobStartTime() { return s_jobStartTime; }
 
   private:
-    static double s_jobStartTime;
+    static std::chrono::steady_clock::time_point s_jobStartTime;
   };
 }  // namespace edm
 

--- a/FWCore/Utilities/src/TimingServiceBase.cc
+++ b/FWCore/Utilities/src/TimingServiceBase.cc
@@ -21,15 +21,11 @@ using namespace edm;
 //
 // constants, enums and typedefs
 //
-double TimingServiceBase::s_jobStartTime = 0.0;
+std::chrono::steady_clock::time_point TimingServiceBase::s_jobStartTime;
 
 void TimingServiceBase::jobStarted() {
-  if (0.0 == s_jobStartTime) {
-    struct timeval t;
-    if (gettimeofday(&t, nullptr) < 0) {
-      return;
-    }
-    s_jobStartTime = static_cast<double>(t.tv_sec) + (static_cast<double>(t.tv_usec) * 1E-6);
+  if (0 == s_jobStartTime.time_since_epoch().count()) {
+    s_jobStartTime = std::chrono::steady_clock::now();
   }
 }
 


### PR DESCRIPTION
#### PR description:

For all duration measurements, switch to using the steady_clock.

#### PR validation:

All framework tests pass.