### PR TITLE
renew matched lepton ids for every jet

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
@@ -76,9 +76,6 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
   std::vector<int> vmuIdx3SJ;
   std::vector<int> veleIdx3SJ;
 
-  int ele_pfmatch_index = -1;
-  int mu_pfmatch_index = -1;
-
   // Find leptons in jets
   for (unsigned int ij = 0; ij < nJet; ij++) {
     const pat::Jet &itJet = (*srcJet)[ij];
@@ -91,8 +88,8 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
       fastjet::PseudoJet p(d->px(), d->py(), d->pz(), d->energy());
       lClusterParticles.emplace_back(p);
     }
-    ele_pfmatch_index = -1;
-    mu_pfmatch_index = -1;
+    int ele_pfmatch_index = -1;
+    int mu_pfmatch_index = -1;
 
     // match to leading and closest electron or muon
     double dRmin(0.8), dRele(999), dRmu(999), dRtmp(999);

--- a/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
@@ -91,6 +91,8 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
       fastjet::PseudoJet p(d->px(), d->py(), d->pz(), d->energy());
       lClusterParticles.emplace_back(p);
     }
+    ele_pfmatch_index = -1;
+    mu_pfmatch_index = -1;
 
     // match to leading and closest electron or muon
     double dRmin(0.8), dRele(999), dRmu(999), dRtmp(999);


### PR DESCRIPTION
#### PR description:

< initially the matched lepton ids are declared only once https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc#L79-L80, in the case of that when there is no matched lepton, the previous matched lepton id will be used for the next jet, i.e., two fat jets can match to one lepton which is not correct. >

#### PR validation:
<before the modification:
```
Events->Scan("FatJet_electronIdx3SJ:FatJet_pt")
***********************************************
*    Row   * Instance * FatJet_el * FatJet_pt *
***********************************************
*        0 *        0 *         0 *       751 *
*        0 *        1 *         0 *       709 *
*        1 *        0 *        -1 *       958 *
*        1 *        1 *         0 *     598.5 *
*        2 *        0 *        -1 *     849.5 *
*        2 *        1 *        -1 *       835 *
*        2 *        2 *         0 *     240.5 *
*        3 *        0 *         0 *       995 *
*        3 *        1 *        -1 *     932.5 *
*        3 *        2 *        -1 *       335 *
*        4 *        0 *         0 *       751 *
*        4 *        1 *        -1 *     603.5 *
*        4 *        2 *        -1 *       365 *
*        5 *        0 *        -1 *     624.5 *
*        5 *        1 *         0 *       616 *
*        5 *        2 *         0 *   184.125 *
......
```

after the modification:
```
Events->Scan("FatJet_electronIdx3SJ:FatJet_pt")
***********************************************
*    Row   * Instance * FatJet_el * FatJet_pt *
***********************************************
*        0 *        0 *         0 *       751 *
*        0 *        1 *        -1 *       709 *
*        1 *        0 *        -1 *       958 *
*        1 *        1 *         0 *     598.5 *
*        2 *        0 *        -1 *     849.5 *
*        2 *        1 *        -1 *       835 *
*        2 *        2 *         0 *     240.5 *
*        3 *        0 *         0 *       995 *
*        3 *        1 *        -1 *     932.5 *
*        3 *        2 *        -1 *       335 *
*        4 *        0 *         0 *       751 *
*        4 *        1 *        -1 *     603.5 *
*        4 *        2 *        -1 *       365 *
*        5 *        0 *        -1 *     624.5 *
*        5 *        1 *         0 *       616 *
*        5 *        2 *        -1 *   184.125 *
```
>

you see that before modification, for the first event, the first and second fatjet match to the first lepton. similar case in 6th event. (the pt of jet is to confirm other info is not changed )



