### PR TITLE
Include HcalPFCuts Rcd and update SiPixel Dynamic Inefficiency tags in MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '131X_mcRun1_design_v1',
+    'run1_design'                  : '131X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '131X_mcRun1_realistic_v1',
+    'run1_mc'                      : '131X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '131X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'                   : '131X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '131X_mcRun2_startup_v1',
+    'run2_mc_50ns'                 : '131X_mcRun2_startup_v2',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '131X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'             : '131X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '131X_mcRun2_design_v1',
+    'run2_design'                  : '131X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '131X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'              : '131X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '131X_mcRun2_asymptotic_v1',
+    'run2_mc'                      : '131X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '131X_mcRun2cosmics_asymptotic_deco_v1',
+    'run2_mc_cosmics'              : '131X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '131X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'                   : '131X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '131X_mcRun2_pA_v1',
+    'run2_mc_pa'                   : '131X_mcRun2_pA_v2',
     # GlobalTag for Run2 data reprocessing
     'run2_data'                    : '124X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
@@ -40,53 +40,53 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-03-16 19:00:00 (UTC)
     'run3_data'                    : '130X_dataRun3_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '131X_mc2017_design_v1',
+    'phase1_2017_design'           : '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '131X_mc2017_realistic_v1',
+    'phase1_2017_realistic'        : '131X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '131X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'          : '131X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '131X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak'     : '131X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '131X_upgrade2018_design_v1',
+    'phase1_2018_design'           : '131X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '131X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'        : '131X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '131X_upgrade2018_realistic_RD_v1',
+    'phase1_2018_realistic_rd'     : '131X_upgrade2018_realistic_RD_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '131X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi'     : '131X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '131X_upgrade2018_realistic_HEfail_v2',
+    'phase1_2018_realistic_HEfail' : '131X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '131X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'          : '131X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '131X_mcRun3_2022_design_v1',
+    'phase1_2022_design'           : '131X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v2',
+    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v2',
+    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v2',
+    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v1',
+    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v4',
+    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v3',
+    'phase1_2023_design'           : '131X_mcRun3_2023_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v3',
+    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v3',
+    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v6',
+    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v1',
+    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '131X_mcRun4_realistic_v2'
+    'phase2_realistic'             : '131X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR:
- Integrates the `HcalPFCuts` record in all the MC GTs introduced in https://github.com/cms-sw/cmssw/pull/41128 by updating the 
  - Run1 and Run2 GTs with tag `HcalPFCuts_2016_v1.0_mc`
  - 2017 GTs with tag `HcalPFCuts_2017_v1.0_mc`
  - 2018 GTs with tag `HcalPFCuts_2018_v1.0_mc`
  - 2022 GTs with tag `HcalPFCuts_2022_v1.0_mc`
  - 2023, 2024 and Phase2 GTs with tag `HcalPFCuts_2023_V1.0_mc`
  as requested in this [CMS Talk post](https://cms-talk.web.cern.ch/t/mc-newly-created-hcalpfcuts-mc-tags-submitted-to-13-1-x-mc-queues/22585)[1]. 
- In addition, it also updates the latest SiPixel dynamic Inefficincy tag `SiPixelDynamicInefficiency_phase1_2023_v2_fix2` in the Phase1 2022, 2023 and 2024 GTs requested in this [CMS Talk post](https://cms-talk.web.cern.ch/t/request-creation-of-a-gt-with-preliminary-pixel-dynamic-inefficiency-settings/20385/15) [2].

[1] https://cms-talk.web.cern.ch/t/mc-newly-created-hcalpfcuts-mc-tags-submitted-to-13-1-x-mc-queues/22585
[2] https://cms-talk.web.cern.ch/t/request-creation-of-a-gt-with-preliminary-pixel-dynamic-inefficiency-settings/20385/15


**GT Differences with the last ones are here**:
- **Run1 Design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun1_design_v1/131X_mcRun1_design_v2

- **Run1 Realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun1_realistic_v1/131X_mcRun1_realistic_v2

- **Run1 HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun1_HeavyIon_v1/131X_mcRun1_HeavyIon_v2

- **Run2 Startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_startup_v1/131X_mcRun2_startup_v2

- **Run2 l1stage1**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_asymptotic_l1stage1_v1/131X_mcRun2_asymptotic_l1stage1_v2

- **Run2 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_design_v1/131X_mcRun2_design_v2

- **Run2 pre VFP**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_asymptotic_preVFP_v1/131X_mcRun2_asymptotic_preVFP_v2

- **Run2 Asymptotic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_asymptotic_v1/131X_mcRun2_asymptotic_v2

- **Run2 MC cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2cosmics_asymptotic_deco_v1/131X_mcRun2cosmics_asymptotic_deco_v2

- **Run2 MC HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_HeavyIon_v1/131X_mcRun2_HeavyIon_v2

- **Run2 MC pA**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun2_pA_v1/131X_mcRun2_pA_v2

- **Phase1 2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mc2017_design_v1/131X_mc2017_design_v2

- **Phase1 2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mc2017_realistic_v1/131X_mc2017_realistic_v2

- **Phase1 2017 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mc2017cosmics_realistic_deco_v1/131X_mc2017cosmics_realistic_deco_v2

- **Phase1 2017 cosmics peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mc2017cosmics_realistic_peak_v1/131X_mc2017cosmics_realistic_peak_v2

- **Phase1 2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018_design_v1/131X_upgrade2018_design_v2

- **Phase1 2018 realistic**   
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018_realistic_v1/131X_upgrade2018_realistic_v2

- **Phase1 2018 realistic RD**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018_realistic_RD_v1/131X_upgrade2018_realistic_RD_v2

- **Phase1 2018 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018_realistic_HI_v1/131X_upgrade2018_realistic_HI_v2

- **Phase1 2018 realistic HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018_realistic_HEfail_v2/131X_upgrade2018_realistic_HEfail_v3

- **Phase1 2018 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018cosmics_realistic_deco_v1/131X_upgrade2018cosmics_realistic_deco_v2

- **Phase1 2018 cosmics peak**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_upgrade2018cosmics_realistic_peak_v2/131X_upgrade2018cosmics_realistic_peak_v3

- **Phase1 2022 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_design_v1/131X_mcRun3_2022_design_v2

- **Phase1 2022 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_v2/131X_mcRun3_2022_realistic_v3

- **Phase1 2022 realistic postEE**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_postEE_v2/131X_mcRun3_2022_realistic_postEE_v3

- **Phase1 2022 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_realistic_deco_v2/131X_mcRun3_2022cosmics_realistic_deco_v3

- **Phase1 2022 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_design_deco_v1/131X_mcRun3_2022cosmics_design_deco_v2

- **Phase1 2022 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v4/131X_mcRun3_2022_realistic_HI_v5

- **Phase1 2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v3/131X_mcRun3_2023_design_v4

- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v3/131X_mcRun3_2023_realistic_v4

- **Phase1 2023 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v3/131X_mcRun3_2023cosmics_realistic_deco_v4

- **Phase1 2023 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v3/131X_mcRun3_2023cosmics_design_deco_v4

- **Phase1 2023 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v6/131X_mcRun3_2023_realistic_HI_v7

- **Phase1 2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2024_realistic_v1/131X_mcRun3_2024_realistic_v2

- **Phase2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun4_realistic_v2/131X_mcRun4_realistic_v3

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 5.1,8.0,9.0,25.0,101.0,140.0,50200.0,7.22,145.0,281.0,1325.516,11634.0,7.23,159.0,12434.0,12834.0,7.24,160.1 -j 8 --ibeos -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport, but a partial backport with the SiPixel Dynamic Inefficiency GT updates will be followed up.
