### PR TITLE
Implement return value for ESProducer acquire function

### DIFF
--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -60,7 +60,9 @@ namespace edm {
         return Base::prefetchAsyncImpl(
             [this](auto&& group, auto&& token, auto&& record, auto&& es) {
               constexpr bool emitPostPrefetchingSignal = true;
-              return Base::makeProduceTask(group, token, record, es, emitPostPrefetchingSignal);
+              auto produceFunctor = [this](TRecord const& record) { return (*Base::produceFunction())(record); };
+              return Base::makeProduceTask(
+                  group, token, record, es, emitPostPrefetchingSignal, std::move(produceFunctor));
             },
             std::move(iTask),
             iRecord,

--- a/FWCore/Integration/test/testESProducerUsingAcquire_cfg.py
+++ b/FWCore/Integration/test/testESProducerUsingAcquire_cfg.py
@@ -24,7 +24,7 @@ process.options = dict(
 
 process.emptyESSourceI = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordI"),
-    firstValid = cms.vuint32(1,100),
+    firstValid = cms.vuint32(1),
     iovIsRunNotTime = cms.bool(True)
 )
 
@@ -49,12 +49,14 @@ process.test = cms.EDAnalyzer("ConcurrentIOVAnalyzer",
                               # 9 + 5 (external work increments each of the 5 values by 1) = 14,
                               # runs are always 1, lumi ranges 1-3, 4-5, 6, 7, 8
                               # cacheIdentifier increments by 1 each time 3, 4, 5, 6, 7
-                              expectedESAcquireTestResults = cms.untracked.vint32(0, 0, 0, 14, 20, 24, 27, 30)
+                              expectedESAcquireTestResults = cms.untracked.vint32(0, 0, 0, 14, 20, 24, 27, 30),
+                              expectedUniquePtrTestValue = cms.untracked.int32(102),
+                              expectedOptionalTestValue = cms.untracked.int32(202)
 )
 
 process.emptyESSourceB = cms.ESSource("EmptyESSource",
     recordName = cms.string("ESTestRecordB"),
-    firstValid = cms.vuint32(1,2),
+    firstValid = cms.vuint32(1),
     iovIsRunNotTime = cms.bool(True)
 )
 process.esTestAnalyzerB = cms.EDAnalyzer("ESTestAnalyzerB",


### PR DESCRIPTION
#### PR description:

For ESProducers using the ExternalWork feature, the acquire function now returns a value. The value is moved into the CallbackExernalWork object temporarily. When produce is called, the object is passed in as an argument. The object is moved not copied if that is supported by its type. The type can be anything because it is a template parameter, but we expect the most common types used will be std::unique_ptr, std::shared_ptr, and std::optional. One could just pass any type, for example an int will work. This seemed to be the simplest and most flexible design.

One weakness of the new interface is that it requires some type. Acquire cannot just return void and the produce function must have the 2nd argument. In this case, acquire can just return 0 and the argument to produce can be unused. 

ESProducers not using ExternalWork should not be affected. Their interface does not change.

#### PR validation:

An existing unit test was extended to cover this new case. There is no existing code outside that unit test that uses this new feature. We should see no behavior changes in other tests or production processes.
