### PR TITLE
Fix FastSim PreMixing configuration for Run-3

### DIFF
--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -71,7 +71,7 @@ phase2_tracker.toModify(simAPVsaturation, mixData = None)
 
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-fastSim.toModify(simCastorDigis, mix = None)
+(fastSim & ~run3_common).toModify(simCastorDigis, mix = None)
 fastSim.toModify(simSiPixelDigis, mix = None)
 fastSim.toModify(simSiStripDigis, mix = None)
 fastSim.toModify(simAPVsaturation, mixData = None)


### PR DESCRIPTION
#### PR description:
This PR fixes a double deletion of simCastorDigis from
`run3_common.toModify(simCastorDigis, mix = None) `
and
`fastSim.toModify(simCastorDigis, mix = None)`
in https://github.com/cms-sw/cmssw/blob/master/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py

#### PR validation:
The following cmsDriver works properly,
`cmsDriver.py TTbar_14TeV_TuneCP5_cfi --step GEN,SIM,RECOBEFMIX,DIGI,DATAMIX,L1,DIGI2RAW,L1Reco,RECO --fast --era Run3_FastSim --beamspot Realistic25ns13p6TeVEarly2022Collision --geometry DB:Extended --eventcontent AODSIM --datatier AODSIM --conditions auto:phase1_2022_realistic --mc --pileup_input "file:MinBias_PreMix.root" --procModifiers premix_stage2 --datamix PreMix --fileout file:TTBar_FSPU_2022.root --no_exec --nThreads 8`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This needs a backport to 12_4 (for 2022 FastSim campaign), and other release if need FastSim for Run-3.

FYI: @cms-sw/pdmv-l2 @sbein 