### PR TITLE
[13_0_X] Update SiPixel Dynamic Inefficiency tag in 2022, 2023, 2024 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,27 +64,27 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '130X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v2',
+    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v2',
+    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v2',
+    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '130X_mcRun3_2023_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v6',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v5',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v7',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '130X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:
This PR is a partial backport of https://github.com/cms-sw/cmssw/pull/41327 and it:

- Updates the latest SiPixel dynamic Inefficiency tag 
`SiPixelDynamicInefficiency_phase1_2023_v2_fix2`, Rcd:`SiPixelDynamicInefficiencyRcd`, Label:`-`
in Phase1 2022, 2023 and 2024 MC GTs as requested in this [CMS Talk post](https://cms-talk.web.cern.ch/t/request-creation-of-a-gt-with-preliminary-pixel-dynamic-inefficiency-settings/20385/15) [1]. 

- Apart from that, the 2023 HI realistic GT also includes the following updated spike-killer tags derived from 2022 PbPb test data 
    - `EcalTPGSpike_HI_Run3_12GeV_mc`, Rcd:`EcalTPGSpikeRcd`, Label:`-`
    - `EcalTPGFineGrainStripEE_HI_Run3_sFGVB_7ADC_mc`, Rcd:`EcalTPGFineGrainStripEERcd`, Label:`-`
[(See this CMS Talk post)](https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-realistic-spike-killer-settings-125x-130x-131x/22082/8) [2].

[1] https://cms-talk.web.cern.ch/t/request-creation-of-a-gt-with-preliminary-pixel-dynamic-inefficiency-settings/20385/15
[2] https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-realistic-spike-killer-settings-125x-130x-131x/22082/8

**GT Differences with the last ones are here**:
- **Phase1 2022 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_v2/130X_mcRun3_2022_realistic_v3

- **Phase1 2022 realistic postEE**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_postEE_v2/130X_mcRun3_2022_realistic_postEE_v3

- **Phase1 2022 cosmics realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_realistic_deco_v2/130X_mcRun3_2022cosmics_realistic_deco_v3

- **Phase1 2022 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_v3/130X_mcRun3_2022_realistic_HI_v4

- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v6/130X_mcRun3_2023_realistic_v7

- **Phase1 2023 cosmics realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v5/130X_mcRun3_2023cosmics_realistic_deco_v6

- **Phase1 2023 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v7/130X_mcRun3_2023_realistic_HI_v9

- **Phase1 2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v4/130X_mcRun3_2024_realistic_v5

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 11634.0,7.23,7.24,159.0,12434.0,12834.0 -j 10 --ibeos`


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial Backport of https://github.com/cms-sw/cmssw/pull/41327

