### PR TITLE
Phase-2 L1T: fix isolation type for GT e/g objects

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -30,7 +30,7 @@ namespace l1gt {
   typedef ap_uint<1> valid_t;
 
   // E/gamma fields
-  typedef ap_fixed<11, 9> iso_t;
+  typedef ap_ufixed<11, 9> iso_t;
   typedef ap_uint<4> egquality_t;
 
   // tau fields


### PR DESCRIPTION
#### PR description:

This is a bug-fix.
