### PR TITLE
Add an option in InitRootHandlers to disable automatic class parsing

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -132,6 +132,7 @@ namespace edm {
       bool resetErrHandler_;
       bool loadAllDictionaries_;
       bool autoLibraryLoader_;
+      bool autoClassParser_;
       bool interactiveDebug_;
       std::shared_ptr<const void> sigBusHandler_;
       std::shared_ptr<const void> sigSegvHandler_;
@@ -771,6 +772,7 @@ namespace edm {
           resetErrHandler_(pset.getUntrackedParameter<bool>("ResetRootErrHandler")),
           loadAllDictionaries_(pset.getUntrackedParameter<bool>("LoadAllDictionaries")),
           autoLibraryLoader_(loadAllDictionaries_ or pset.getUntrackedParameter<bool>("AutoLibraryLoader")),
+          autoClassParser_(pset.getUntrackedParameter<bool>("AutoClassParser")),
           interactiveDebug_(pset.getUntrackedParameter<bool>("InteractiveDebug")) {
       stackTracePause_ = pset.getUntrackedParameter<int>("StackTracePauseTime");
 
@@ -835,6 +837,9 @@ namespace edm {
       if (autoLibraryLoader_) {
         gInterpreter->SetClassAutoloading(1);
       }
+
+      // Enable/disable automatic parsing of headers
+      gInterpreter->SetClassAutoparsing(autoClassParser_);
 
       // Set ROOT parameters.
       TTree::SetMaxTreeSize(kMaxLong64);
@@ -902,6 +907,10 @@ namespace edm {
               "If True, ROOT messages (e.g. errors, warnings) are handled by this service, rather than by ROOT.");
       desc.addUntracked<bool>("AutoLibraryLoader", true)
           ->setComment("If True, enables automatic loading of data dictionaries.");
+      desc.addUntracked<bool>("AutoClassParser", true)
+          ->setComment(
+              "If True, enables automatic parsing of class headers for dictionaries when pre-built dictionaries are "
+              "missing.");
       desc.addUntracked<bool>("LoadAllDictionaries", false)->setComment("If True, loads all ROOT dictionaries.");
       desc.addUntracked<bool>("EnableIMT", true)->setComment("If True, calls ROOT::EnableImplicitMT().");
       desc.addUntracked<bool>("AbortOnSignal", true)


### PR DESCRIPTION
#### PR description:

In the CUDA-to-Alpaka code migration it has happened a few times that a necessary ROOT dictionary has been missing, but the error message is along
```
In file included from DataFormatsSiPixelDigiSoACudaAsync_xr dictionary payload:75:
In file included from ./DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h:5:
In file included from /cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/alpaka.hpp:28:
In file included from /cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/acc/AccGpuCudaRt.hpp:14:
In file included from /cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp:21:
In file included from /cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp:23:
In file included from /cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/core/Cuda.hpp:14:
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/core/CudaHipCommon.hpp:26:18: remark: could not acquire lock file for module 'cuda': failed to create unique file /cvmfs/cms.cern.ch/slc7_amd64_gcc11/lcg/root/6.26.11-4495a4f41e988b20bdba1ccedda069c3/lib/cuda.pcm.lock-bf417c89: Read-only file system [-Rmodule-build]
#        include <cuda_runtime.h>
                 ^
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/core/CudaHipCommon.hpp:26:18: remark: building module 'cuda' as '/cvmfs/cms.cern.ch/slc7_amd64_gcc11/lcg/root/6.26.11-4495a4f41e988b20bdba1ccedda069c3/lib/cuda.pcm' [-Rmodule-build]
error: unable to open output file '/cvmfs/cms.cern.ch/slc7_amd64_gcc11/lcg/root/6.26.11-4495a4f41e988b20bdba1ccedda069c3/lib/cuda.pcm': 'Read-only file system'
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/core/CudaHipCommon.hpp:26:18: remark: finished building module 'cuda' [-Rmodule-build]
/cvmfs/cms.cern.ch/slc7_amd64_gcc11/external/alpaka/develop-20230215-1b72c1c284fb9ec0aa4ade70e3a15b56/include/alpaka/core/CudaHipCommon.hpp:26:18: fatal error: could not build module 'cuda'
#        include <cuda_runtime.h>
         ~~~~~~~~^
----- Begin Fatal Exception 14-Apr-2023 00:30:34 CEST-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=SiPixelRawToCluster@alpaka label='siPixelRawToCluster'
   Additional Info:
      [a] Fatal Root Error: @SUB=TInterpreter::AutoParse
Error parsing payload code for class edm::DeviceProduct with content:

#line 1 "DataFormatsSiPixelDigiSoACudaAsync_xr dictionary payload"

```
which isn't very helpful to figure out which dictionary is missing.

This PR adds a configuration option to `InitRootHandlers` to disable the automatic header parsing, in which case the framework reports a useful error message along
```
----- Begin Fatal Exception 14-Apr-2023 00:38:42 CEST-----------------------
An exception of category 'DictionaryNotFound' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=SiPixelRawToCluster@alpaka label='siPixelRawToCluster'
   [2] Calling ProductRegistryHelper::addToRegistry, checking dictionaries for produced types
Exception Message:
No data dictionary found for the following classes:

  edm::DeviceProduct<SiPixelClustersDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt> > >
  edm::DeviceProduct<SiPixelDigiErrorsDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt> > >
  edm::Wrapper<edm::DeviceProduct<SiPixelClustersDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt> > > >
  edm::Wrapper<edm::DeviceProduct<SiPixelDigiErrorsDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt> > > >

Most likely each dictionary was never generated, but it may
<snip>
```

Eventually I'd like to understand if it would make sense for us to disable the header parsing by default (we want to compile the dictionaries beforehand, and the header parsing has given us trouble in the past).

#### PR validation:

Checked with a reproducer that the reported error is useful as described above.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 13_0_X to aid future Alpaka module use there.