### PR TITLE
Add an option to disable automatic class parsing in InitRootHandlers during module construction

### DIFF
--- a/FWCore/Reflection/interface/SetClassParsing.h
+++ b/FWCore/Reflection/interface/SetClassParsing.h
@@ -1,0 +1,36 @@
+#ifndef FWCore_Reflection_interface_SetClassParsing_h
+#define FWCore_Reflection_interface_SetClassParsing_h
+
+#include "TInterpreter.h"
+
+#include <atomic>
+#include <cassert>
+
+namespace edm {
+  /**
+   * An instance of this class can be used to temporarily enable or
+   * disable ROOT class parsing. The destructor restores the state.
+   *
+   * Because this class modifies the global state of ROOT, it must
+   * not be used in concurrent context.
+   */
+  class SetClassParsing {
+  public:
+    SetClassParsing(bool enable) {
+      bool expected = false;
+      const bool used_concurrently_but_shouldnt = active_.compare_exchange_strong(expected, true);
+      assert(used_concurrently_but_shouldnt);
+      previous_ = gInterpreter->SetClassAutoparsing(enable);
+    }
+    ~SetClassParsing() {
+      gInterpreter->SetClassAutoparsing(previous_);
+      active_ = false;
+    }
+
+  private:
+    int previous_;
+    static std::atomic<bool> active_;  // to detect if the class is used in concurrent context
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Reflection/src/SetClassParsing.cc
+++ b/FWCore/Reflection/src/SetClassParsing.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Reflection/interface/SetClassParsing.h"
+
+namespace edm {
+  std::atomic<bool> SetClassParsing::active_ = false;
+}

--- a/IOPool/TFileAdaptor/BuildFile.xml
+++ b/IOPool/TFileAdaptor/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/Reflection"/>
 <use name="FWCore/Catalog"/>
 <use name="rootcore"/>
 <export>

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Reflection/interface/SetClassParsing.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
@@ -196,6 +197,16 @@ TFileAdaptor::TFileAdaptor(edm::ParameterSet const& pset, edm::ActivityRegistry&
     addType(mgr, "^root:", 1);  // See comments in addType
   if (!native("root"))
     addType(mgr, "^[x]?root:", 1);  // See comments in addType
+
+  // Make sure the TStorageFactoryFile can be loaded regardless of the header auto-parsing setting
+  {
+    edm::SetClassParsing guard(true);
+    if (auto cl = TClass::GetClass("TStorageFactoryFile")) {
+      cl->GetClassInfo();
+    } else {
+      throw cms::Exception("TFileAdaptor") << "Unable to obtain TClass for TStorageFactoryFile";
+    }
+  }
 }
 
 void TFileAdaptor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

~~This PR builds on https://github.com/cms-sw/cmssw/pull/41343 by disabling the automatic header parsing by default. I primarily want to see the impact on tests (wouldn't be surprised if some dictionaries were missing). If we decide to merge this PR, maybe the earliest convenient moment would be early 13_2_X.~~

This PR adds a configuration option to `InitRootHandlers` to disable the automatic header parsing. For more context see the description of https://github.com/cms-sw/cmssw/pull/41343 . Known not to work with multiple threads and cutParser/expressionParser (noted in the help message of the configuration option)

#### PR validation:

None