### PR TITLE
change input file of `testTriggerEventAnalyzers` unit test

### DIFF
--- a/HLTrigger/HLTcore/test/testTriggerEventAnalyzers.sh
+++ b/HLTrigger/HLTcore/test/testTriggerEventAnalyzers.sh
@@ -7,7 +7,5 @@ function die {
 }
 
 # run test job
-TESTDIR="${LOCALTOP}"/src/HLTrigger/HLTcore/test
-
-cmsRun "${TESTDIR}"/testTriggerEventAnalyzers_cfg.py \
+cmsRun "${SCRAM_TEST_PATH}"/testTriggerEventAnalyzers_cfg.py \
   || die "Failure running testTriggerEventAnalyzers_cfg.py" $?

--- a/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
+++ b/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
@@ -6,7 +6,7 @@ options = VarParsing.VarParsing('analysis')
 options.register('logLevel', 'WARNING', options.multiplicity.singleton, options.varType.string, 'value of MessageLogger.cerr.threshold')
 options.register('globalTag', '125X_mcRun3_2022_realistic_v3', options.multiplicity.singleton, options.varType.string, 'name of GlobalTag')
 options.setDefault('inputFiles', [
-  '/store/relval/CMSSW_12_6_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun3_2022_realistic_v3-v1/2580000/2d96539c-b321-401f-b7b2-51884a5d421f.root',
+  '/store/mc/CMSSW_13_0_0_pre2/RelValWToLNu_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun3_2022_realistic_v5-v2/80000/155dc2cf-2b77-4797-883c-c22d6c065d59.root',
 ])
 options.setDefault('maxEvents', 10)
 options.parseArguments()


### PR DESCRIPTION
#### PR description:

This PR changes the input file of the unit test `testTriggerEventAnalyzers`.

This will make the unit test pass in ASAN builds, and it technically solves #41045 (although the actual solution to that issue requires more work, see #41045).

#### PR validation:

The relevant unit test passes in an ASAN build.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
