### PR TITLE
add GPU RelVals using 2023 HLT menu

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -25,7 +25,18 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 
-# mc 2021   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+# mc 2022   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+
+# mc 2023   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
@@ -36,6 +47,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 numWFIB = [
+           # 2018
            10842.502, 10842.503, 10842.504,
            10842.506, 10842.507, 10842.508,
            10824.502, 10824.503, 10824.504,
@@ -46,6 +58,8 @@ numWFIB = [
            10824.586, 10824.587, # 10824.528,
            10824.592, 10824.593,
            10824.596, 10824.597,
+
+           # 2022
            11650.502, 11650.503, 11650.504,
            11650.506, 11650.507, 11650.508,
            11634.502, 11634.503, 11634.504,
@@ -56,6 +70,18 @@ numWFIB = [
            11634.586, 11634.587, # 11634.528,
            11634.592, 11634.593,
            11634.596, 11634.597,
+
+           # 2023
+           12450.502, 12450.503, 12450.504,
+           12450.506, 12450.507, 12450.508,
+           12434.502, 12434.503, 12434.504,
+           12434.506, 12434.507, 12434.508,
+           12434.512, 12434.513, 12434.514,
+           12434.522, 12434.523, 12434.524,
+           12434.582, 12434.583,
+           12434.586, 12434.587,
+           12434.592, 12434.593,
+           12434.596, 12434.597,
         ]
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue
@@ -72,3 +98,10 @@ workflows[136.888512] = ['RunJetHT2018DecalGPU',['RunJetHT2018D','HLTDR2_2018','
 workflows[136.885522] = ['',['RunHLTPhy2018D','HLTDR2_2018','RECODR2_2018reHLT_HCALOnlyGPU','HARVEST2018_HCALOnly']]
 workflows[136.888522] = ['RunJetHT2018DhcalGPU',['RunJetHT2018D','HLTDR2_2018','RECODR2_2018reHLT_HCALOnlyGPU','HARVEST2018_HCALOnly']]
 
+# data 2023 Patatrack pixel-only triplets:   RunJetMET2022D on GPU (optional)
+#           Patatrack ECAL-only:             RunJetMET2022D on GPU (optional)
+#           Patatrack HCAL-only:             RunJetMET2022D on GPU (optional)
+
+workflows[140.065506] = ['Run3-2023_JetMET2022D_RecoPixelOnlyTripletsGPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU','HARVESTRUN3_pixelTrackingOnly']]
+workflows[140.065512] = ['Run3-2023_JetMET2022D_RecoECALOnlyGPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_ECALOnlyGPU','HARVESTRUN3_ECALOnly']]
+workflows[140.065522] = ['Run3-2023_JetMET2022D_RecoHCALOnlyGPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_HCALOnlyGPU','HARVESTRUN3_HCALOnly']]

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -494,6 +494,11 @@ workflows[140.067] = ['',['RunEGamma2022D','HLTDR3_2023','RECONANORUN3_reHLT','H
 workflows[140.068] = ['',['RunTau2022D','HLTDR3_2023','RECONANORUN3_reHLT','HARVESTRUN3']]
 workflows[140.069] = ['',['RunMuonEG2022D','HLTDR3_2023','RECONANORUN3_reHLT','HARVESTRUN3']]
 
+### run3-2023 (2022 data) - Pixel-only (triplets), ECAL-only and HCAL-only
+workflows[140.065505] = ['Run3-2023_JetMET2022D_RecoPixelOnlyTripletsCPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_Patatrack_PixelOnlyTripletsCPU','HARVESTRUN3_pixelTrackingOnly']]
+workflows[140.065511] = ['Run3-2023_JetMET2022D_RecoECALOnlyCPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_ECALOnlyCPU','HARVESTRUN3_ECALOnly']]
+workflows[140.065521] = ['Run3-2023_JetMET2022D_RecoHCALOnlyCPU',['RunJetMET2022D','HLTDR3_2023','RECODR3_reHLT_HCALOnlyCPU','HARVESTRUN3_HCALOnly']]
+
 ### run3 (2023) skims ###
 workflows[140.104] = ['',['RunZeroBias2022D','HLTDR3_2023','RECONANORUN3_reHLT','SKIMZEROBIASRUN3_reHLT']]
 workflows[140.105] = ['',['RunBTagMu2022D','HLTDR3_2023','RECONANORUN3_reHLT','SKIMBTAGMURUN3_reHLT']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2763,7 +2763,6 @@ steps['RECODR2_2018reHLT_Patatrack_PixelOnlyCPU']=merge([step3_pixel_ntuplet_cpu
 steps['RECODR2_2018reHLT_Patatrack_PixelOnlyGPU']=merge([step3_pixel_ntuplet_gpu, steps['RECODR2_2018reHLT_Prompt_pixelTrackingOnly']])
 steps['RECODR2_2018reHLT_Patatrack_PixelOnlyTripletsCPU']=merge([step3_pixel_ntuplet_cpu, step3_pixel_triplets, steps['RECODR2_2018reHLT_Prompt_pixelTrackingOnly']])
 steps['RECODR2_2018reHLT_Patatrack_PixelOnlyTripletsGPU']=merge([step3_pixel_ntuplet_gpu, step3_pixel_triplets, steps['RECODR2_2018reHLT_Prompt_pixelTrackingOnly']])
-
 steps['RECODR2_2018reHLT_ECALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,DQM:@ecalOnly'},steps['RECODR2_2018reHLT_Prompt']])
 steps['RECODR2_2018reHLT_ECALOnlyGPU']=merge([step3_gpu, steps['RECODR2_2018reHLT_ECALOnlyCPU']])
 steps['RECODR2_2018reHLT_HCALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,DQM:@hcalOnly+@hcal2Only'},steps['RECODR2_2018reHLT_Prompt']])
@@ -2845,6 +2844,15 @@ steps['RECODR3_reHLT_MinBiasOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,ALC
 steps['RECODR3_reHLT_ZBOffline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias+EcalESAlign+HcalCalIsoTrkProducerFilter,DQM:@rerecoZeroBias+@ExtraHLT+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_reHLT']])
 steps['RECODR3_reHLT_HLTPhysics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,ALCA:TkAlMinBias+HcalCalIterativePhiSym+HcalCalIsoTrkProducerFilter+HcalCalHO+HcalCalHBHEMuonProducerFilter,DQM:@commonReduced+@miniAODDQM','--procModifiers':'siPixelQualityRawToDigi'},steps['RECODR3_reHLT']])
 steps['RECODR3_reHLT_AlCaTkCosmics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXONoBPTXSkim,PAT,ALCA:TkAlCosmicsInCollisions,DQM:@standardDQM+@miniAODDQM'},steps['RECODR3_reHLT']])
+steps['RECODR3_reHLT_pixelTrackingOnly']=merge([{'-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,DQM:@pixelTrackingOnlyDQM'},steps['RECODR3_reHLT']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyCPU']=merge([step3_pixel_ntuplet_cpu, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyGPU']=merge([step3_pixel_ntuplet_gpu, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsCPU']=merge([step3_pixel_ntuplet_cpu, step3_pixel_triplets, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU']=merge([step3_pixel_ntuplet_gpu, step3_pixel_triplets, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_ECALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,DQM:@ecalOnly'},steps['RECODR3_reHLT']])
+steps['RECODR3_reHLT_ECALOnlyGPU']=merge([step3_gpu, steps['RECODR3_reHLT_ECALOnlyCPU']])
+steps['RECODR3_reHLT_HCALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,DQM:@hcalOnly+@hcal2Only'},steps['RECODR3_reHLT']])
+steps['RECODR3_reHLT_HCALOnlyGPU']=merge([step3_gpu, steps['RECODR3_reHLT_HCALOnlyCPU']])
 
 steps['RECONANORUN3_reHLT']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['RECODR3_reHLT']])
 steps['RECOCOSMRUN3_reHLT']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L1Reco,RECO,DQM','--datatier':'RECO,DQMIO','--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT']])
@@ -3473,7 +3481,10 @@ steps['HARVESTPROMPTRUN3']=merge([{'--data':'', '-s':'HARVESTING:@allForPrompt',
 
 
 steps['HARVESTRUN3']=merge([{'--data':'', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM','--era':'Run3'},steps['HARVESTDRUN3']])
-                                    
+steps['HARVESTRUN3_pixelTrackingOnly'] = merge([ {'-s':'HARVESTING:@pixelTrackingOnlyDQM'}, steps['HARVESTRUN3'] ])
+steps['HARVESTRUN3_ECALOnly'] = merge([ {'-s':'HARVESTING:@ecal'}, steps['HARVESTRUN3'] ])
+steps['HARVESTRUN3_HCALOnly'] = merge([ {'-s':'HARVESTING:@hcalOnly'}, steps['HARVESTRUN3'] ])
+
 #MC
 steps['HARVEST']={'-s':'HARVESTING:validationHarvestingNoHLT+dqmHarvestingFakeHLT',
                    '--conditions':'auto:run1_mc',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -704,11 +704,14 @@ upgradeWFs['photonDRN'].step3 = {
 }
 
 
-# Patatrack workflows:
+# Patatrack workflows (NoPU and PU):
 #   - 2018 conditions, TTbar
-#   - 2018 conditions, Z->mumu,
-#   - 2021 conditions, TTbar
-#   - 2021 conditions, Z->mumu,
+#   - 2018 conditions, Z->mumu
+#   - 2022 conditions (labelled "2021"), TTbar
+#   - 2022 conditions (labelled "2021"), Z->mumu
+#   - 2023 conditions, TTbar
+#   - 2023 conditions, Z->mumu
+#   - 2026D88 conditions, TTbar
 class PatatrackWorkflow(UpgradeWorkflow):
     def __init__(self, digi = {}, reco = {}, harvest = {}, **kwargs):
         # adapt the parameters for the UpgradeWorkflow init method
@@ -756,9 +759,11 @@ class PatatrackWorkflow(UpgradeWorkflow):
         # select only a subset of the workflows
         selected = [
             ('2018' in key and fragment == "TTbar_13"),
-            (('2021' in key or '2023' in key) and fragment == "TTbar_14TeV" and 'FS' not in key),
+            ('2021' in key and fragment == "TTbar_14TeV" and 'FS' not in key),
+            ('2023' in key and fragment == "TTbar_14TeV" and 'FS' not in key),
             ('2018' in key and fragment == "ZMM_13"),
-            (('2021' in key or '2023' in key) and fragment == "ZMM_14" and 'FS' not in key),
+            ('2021' in key and fragment == "ZMM_14" and 'FS' not in key),
+            ('2023' in key and fragment == "ZMM_14" and 'FS' not in key),
             ('2026D88' in key and fragment == "TTbar_14TeV" and "PixelOnly" in self.suffix)
         ]
         result = any(selected) and hasHarvest


### PR DESCRIPTION
#### PR description:

This PR is an attempt to add GPU RelVals making use of the 2023 HLT menu. The goal is to have wfs that run the latest HLT pp menu for 2023 on machines with a GPU.

Workflows are added for both MC and data (using data from 2022), trying to follow the structure of the existing GPU RelVals.

The next step would be to change the default GPU wfs in PR tests ([here](https://github.com/cms-sw/cms-bot/blob/9235c8b33989af8f0ceee9f652f8b763d1ed3b65/cmssw-pr-test-config#L2)) to use 2023 ones.

#### PR validation:

Some of the added workflows pass locally.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

If approved, it should be backported to `CMSSW_13_0_X`.