### PR TITLE
[106X] Silence SiStripDAQ_O2O_test failure in 10_6_X only

### DIFF
--- a/CondTools/SiStrip/test/BuildFile.xml
+++ b/CondTools/SiStrip/test/BuildFile.xml
@@ -3,5 +3,7 @@
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>
   <test name="SiStripDCS_O2O_test" command="testSiStripDCSO2O.sh"/>
+<!-- silence the unit test failure since 10_6_X is not using O2Os
   <test name="SiStripDAQ_O2O_test" command="testSiStripDAQO2O.sh"/>
+-->
 </architecture>


### PR DESCRIPTION
#### PR description:

See issue https://github.com/cms-sw/cmssw/issues/41358
Given that 10_6_X is not using O2Os , I just silence the problem.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport only PR