### PR TITLE
Enforce cms python types in configurations

### DIFF
--- a/FWCore/Framework/test/run_wrongOptionsType.sh
+++ b/FWCore/Framework/test/run_wrongOptionsType.sh
@@ -7,4 +7,3 @@ function die { echo $1: status $2 ; echo === Log file === ; cat ${3:-/dev/null} 
 
 cmsRun ${SCRAM_TEST_PATH}/test_wrongOptionsType_cfg.py -- --name=${NAME} --value="$VALUE" > ${NAME}.log 2>&1 && die "cmsRun for ${NAME} succeeded, should have failed" 1 ${NAME}.log
 grep -E "(The type in the configuration is incorrect)|(ValueError type of .* is expected to be .* but declared as)" ${NAME}.log > /dev/null || die "cmsRun for ${NAME} failed for other reason than incorrect configuration type" $? ${NAME}.log
-

--- a/FWCore/Framework/test/test_wrongOptionsType_cfg.py
+++ b/FWCore/Framework/test/test_wrongOptionsType_cfg.py
@@ -17,5 +17,6 @@ process = cms.Process("TEST")
 process.source = cms.Source("EmptySource")
 
 process.maxEvents.input = 2
-
+#avoid type check in python to force check in C++
+delattr(process.options, args.name)
 setattr(process.options, args.name, eval(str(args.value)))

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -150,8 +150,8 @@ class Process(object):
         self.__isStrict = False
         self.__dict__['_Process__modifiers'] = Mods
         self.__dict__['_Process__accelerators'] = {}
-        self.options = Process.defaultOptions_()
-        self.maxEvents = Process.defaultMaxEvents_()
+        self.__injectValidValue('options', Process.defaultOptions_())
+        self.__injectValidValue('maxEvents', Process.defaultMaxEvents_())
         self.maxLuminosityBlocks = Process.defaultMaxLuminosityBlocks_()
         # intentionally not cloned to ensure that everyone taking
         # MessageLogger still via
@@ -422,9 +422,9 @@ class Process(object):
         if not name.replace('_','').isalnum():
             raise ValueError('The label '+name+' contains forbiden characters')
 
-        if name == 'options' and hasattr(self,name):
+        if name == 'options':
             value = self.__updateOptions(value)
-        if name == 'maxEvents' and hasattr(self,name):
+        if name == 'maxEvents':
             value = self.__updateMaxEvents(value)
 
         # private variable exempt from all this
@@ -557,6 +557,10 @@ class Process(object):
                 self._replaceInScheduleDirectly(name, newValue)
 
             self._delattrFromSetattr(name)
+        self.__injectValidValue(name, value, newValue)
+    def __injectValidValue(self, name, value, newValue = None):
+        if newValue is None:
+            newValue = value
         self.__dict__[name]=newValue
         if isinstance(newValue,_Labelable):
             self.__setObjectLabel(newValue, name)
@@ -3600,6 +3604,10 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
                              numberOfThreads =2)
             self.assertEqual(p.options.numberOfThreads.value(),2)
             self.assertEqual(p.options.numberOfStreams.value(),2)
+            del p.options
+            self.assertRaises(TypeError, setattr, p, 'options', untracked.PSet(numberOfThreads = int32(-1)))
+            p.options = untracked.PSet(numberOfThreads = untracked.uint32(4))
+            self.assertEqual(p.options.numberOfThreads.value(), 4)
 
         def testMaxEvents(self):
             p = Process("Test")
@@ -3614,7 +3622,10 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p = Process("Test")
             p.maxEvents = untracked.PSet(input = untracked.int32(5))
             self.assertEqual(p.maxEvents.input.value(), 5)
-
+            del p.maxEvents
+            self.assertRaises(TypeError, setattr, p, 'maxEvents', untracked.PSet(input = untracked.uint32(1)))
+            p.maxEvents = untracked.PSet(input = untracked.int32(1))
+            self.assertEqual(p.maxEvents.input.value(), 1)
         
         def testExamples(self):
             p = Process("Test")

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -422,9 +422,9 @@ class Process(object):
         if not name.replace('_','').isalnum():
             raise ValueError('The label '+name+' contains forbiden characters')
 
-        if name == 'options':
+        if name == 'options' and hasattr(self,name):
             value = self.__updateOptions(value)
-        if name == 'maxEvents':
+        if name == 'maxEvents' and hasattr(self,name):
             value = self.__updateMaxEvents(value)
 
         # private variable exempt from all this

--- a/FWCore/ParameterSet/python/MassReplace.py
+++ b/FWCore/ParameterSet/python/MassReplace.py
@@ -173,9 +173,12 @@ if __name__=="__main__":
                                        ),
             )
             p.op = cms.EDProducer("op", src = cms.optional.InputTag, unset = cms.optional.InputTag, vsrc = cms.optional.VInputTag, vunset = cms.optional.VInputTag)
+            p.op2 = cms.EDProducer("op2", src = cms.optional.InputTag, unset = cms.optional.InputTag, vsrc = cms.optional.VInputTag, vunset = cms.optional.VInputTag)
             p.op.src="b"
-            p.op.vsrc=cms.VInputTag("b")
-            p.s = cms.Sequence(p.a*p.b*p.c*p.sp*p.op)
+            p.op.vsrc = ["b"]
+            p.op2.src=cms.InputTag("b")
+            p.op2.vsrc = cms.VInputTag("b")
+            p.s = cms.Sequence(p.a*p.b*p.c*p.sp*p.op*p.op2)
             massSearchReplaceAnyInputTag(p.s, cms.InputTag("b"), cms.InputTag("new"))
             self.assertNotEqual(cms.InputTag("new"), p.b.src)
             self.assertEqual(cms.InputTag("new"), p.c.src)
@@ -210,6 +213,8 @@ if __name__=="__main__":
             self.assertEqual(cms.untracked.InputTag("new"), p.sp.test2.nested.usrc)
             self.assertEqual(cms.InputTag("new"), p.op.src)
             self.assertEqual(cms.InputTag("new"), p.op.vsrc[0])
+            self.assertEqual(cms.InputTag("new"), p.op2.src)
+            self.assertEqual(cms.InputTag("new"), p.op2.vsrc[0])
 
         def testMassReplaceInputTag(self):
             process1 = cms.Process("test")

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -584,7 +584,7 @@ class _ValidatingListBase(list):
         super(_ValidatingListBase,self).__init__(arg)
         if 0 != len(args):
             raise SyntaxError("named arguments ("+','.join([x for x in args])+") passsed to "+str(type(self)))
-        if not self._isValid(iter(self)):
+        if not type(self)._isValid(iter(self)):
             raise TypeError("wrong types ("+','.join([str(type(value)) for value in iter(self)])+
                             ") added to "+str(type(self)))
     def __setitem__(self,key,value):
@@ -595,12 +595,13 @@ class _ValidatingListBase(list):
             if not self._itemIsValid(value):
                 raise TypeError("can not insert the type "+str(type(value))+" in container "+self._labelIfAny())
         super(_ValidatingListBase,self).__setitem__(key,value)
-    def _isValid(self,seq):
+    @classmethod
+    def _isValid(cls,seq):
         # see if strings get reinterpreted as lists
         if isinstance(seq, str):
             return False
         for item in seq:
-            if not self._itemIsValid(item):
+            if not cls._itemIsValid(item):
                 return False
         return True
     def _itemFromArgument(self, x):
@@ -758,7 +759,8 @@ if __name__ == "__main__":
 
     import unittest
     class TestList(_ValidatingParameterListBase):
-        def _itemIsValid(self,item):
+        @classmethod
+        def _itemIsValid(cls,item):
             return True
     class testMixins(unittest.TestCase):
         def testListConstruction(self):

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -85,7 +85,7 @@ class _ParameterTypeBase(object):
         self._isFrozen = True
     def isCompatibleCMSType(self,aType):
         return isinstance(self,aType)
-    def _returnTypeWithValue(self, valueWithType):
+    def _checkAndReturnValueWithType(self, valueWithType):
         if isinstance(valueWithType, type(self)):
             return valueWithType
         raise TypeError("Attempted to assign type {from_} to type {to}".format(from_ = str(type(valueWithType)), to = str(type(self))) )
@@ -282,7 +282,7 @@ class _Parameterizable(object):
         else:
             # handle the case where users just replace with a value, a = 12, rather than a = cms.int32(12)
             if isinstance(value,_ParameterTypeBase):
-                self.__dict__[name] = self.__dict__[name]._returnTypeWithValue(value)
+                self.__dict__[name] = self.__dict__[name]._checkAndReturnValueWithType(value)
             else:
                 self.__dict__[name].setValue(value)
             self._isModified = True

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -47,7 +47,7 @@ class _ProxyParameter(_ParameterTypeBase):
         if not _ParameterTypeBase.isTracked(self):
             v = untracked(v)
         self.__dict__["_ProxyParameter__value"] = v
-    def _returnTypeWithValue(self, valueWithType):
+    def _checkAndReturnValueWithType(self, valueWithType):
         if isinstance(valueWithType, type(self)):
             return valueWithType
         if isinstance(self.__type, type):
@@ -153,12 +153,12 @@ class _ObsoleteParameter(_OptionalParameter):
         return 'obsolete'
 
 class _AllowedParameterTypes(object):
-    def __init__(self, *args, **kargs):
+    def __init__(self, *args, default=None):
         self.__dict__['_AllowedParameterTypes__types'] = args
         self.__dict__['_default'] = None
         self.__dict__['__name__'] = self.dumpPython()
-        if len(kargs):
-            self.__dict__['_default'] = self._setValueWithType(kargs['default'])
+        if default is not None:
+            self.__dict__['_default'] = self._setValueWithType(default)
     def dumpPython(self, options=PrintOptions()):
         specialImportRegistry.registerUse(self)
         return "allowed("+','.join( ("cms."+t.__name__ for t in self.__types))+')'
@@ -1961,7 +1961,7 @@ if __name__ == "__main__":
             self.assertEqual(p1.dumpPython(),'cms.PSet(\n    foo = cms.PSet(\n        a = cms.int32(5)\n    ),\n    allowAnyLabel_=cms.required.PSetTemplate(\n        a = cms.required.int32\n    )\n)')
             self.assertEqual(p1.foo.a.value(), 5)
             p1 = PSet(anInt = required.int32)
-            self.assertRaises(TypeError, lambda : setattr(p1,'anInt', uint32(2)))
+            self.assertRaises(TypeError, setattr, p1,'anInt', uint32(2))
 
         def testOptional(self):
             p1 = PSet(anInt = optional.int32)

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -61,6 +61,25 @@ class _ProxyParameter(_ParameterTypeBase):
             if not name.startswith('_'):
                  raise AttributeError("%r object has no attribute %r" % (self.__class__.__name__, name))
             return object.__setattr__(self, name, value)
+    #support container like behavior
+    def __iter__(self):
+        v =self.__dict__.get('_ProxyParameter__value', None)
+        if v is not None:
+            return v.__iter__()
+        else:
+            raise TypeError("'_OptionalParameter' object is not iterable")
+    def __setitem__(self, key, value):
+        v =self.__dict__.get('_ProxyParameter__value', None)
+        if v is not None:
+            return v.__setitem__(key,value)
+        else:
+            raise TypeError("'_OptionalParameter' object does not support item assignment")
+    def __getitem__(self, key):
+        v =self.__dict__.get('_ProxyParameter__value', None)
+        if v is not None:
+            return v.__getitem__(key)
+        else:
+            raise TypeError("'_OptionalParameter' object is not subscriptable")
     def __bool__(self):
         v = self.__dict__.get('_ProxyParameter__value',None)
         return _builtin_bool(v)
@@ -140,6 +159,13 @@ class _AllowedParameterTypes(object):
         if chosenType is None:
             raise RuntimeError("Cannot convert "+str(value)+" to 'allowed' type")
         return chosenType(value)
+    def _setValueWithType(self, valueWithType):
+        for t in self.__types:
+            if isinstance(valueWithType, t):
+                return valueWithType
+        raise TypeError("type {bad} is not one of 'allowed' types {types}".format(bad=str(type(valueWithType)), types = ",".join( (str(t) for t in self__types))) )
+            
+
 
 class _PSetTemplate(object):
     def __init__(self, *args, **kargs):

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -77,7 +77,7 @@ patMuons = cms.EDProducer("PATMuonProducer",
     # mc matching
     addGenMatch   = cms.bool(True),
     embedGenMatch = cms.bool(True),
-    genParticleMatch = cms.InputTag("muonMatch"), ## particles source to be used for the matching
+    genParticleMatch = cms.required.allowed(cms.InputTag, cms.VInputTag, default = cms.InputTag("muonMatch")), ## particles source to be used for the matching
 
     # efficiencies
     addEfficiencies = cms.bool(False),

--- a/Validation/Configuration/python/ECALHCAL.py
+++ b/Validation/Configuration/python/ECALHCAL.py
@@ -24,7 +24,7 @@ def customise(process):
 
     # use directly the generator output, no Hector
 
-    process.g4SimHits.Generator.HepMCProductLabel = cms.string('generatorSmeared')
+    process.g4SimHits.Generator.HepMCProductLabel = 'generatorSmeared'
 
     # modify the content
 


### PR DESCRIPTION
#### PR description:

- when assigning a parameter in python using an explicit type, require that existing value's type matches new type
- fixed problem where _ProxyParameter was not forwarding container methods to set value

#### PR validation:

Framework unit tests pass.