### PR TITLE
Add missing dictionaries in DataFormats/CTPPSReco

### DIFF
--- a/DataFormats/CTPPSReco/src/classes_def.xml
+++ b/DataFormats/CTPPSReco/src/classes_def.xml
@@ -60,8 +60,11 @@
   <class name="std::vector<edm::DetSet<TotemRPLocalTrack> >"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack>"/>
   <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack>>"/>
+  <class name="TotemRPLocalTrack::FittedRecHit" ClassVersion="3">
+    <version ClassVersion="3" checksum="839012906"/>
+  </class>
+  <class name="edm::DetSet<TotemRPLocalTrack::FittedRecHit>"/>
   <class name="edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>"/>
-  <class name="edm::Wrapper<edm::DetSetVector<TotemRPLocalTrack::FittedRecHit>>"/>
   <class name="std::vector<edm::DetSet<TotemRPLocalTrack::FittedRecHit> >"/>
   <class name="std::vector<TotemRPLocalTrack::FittedRecHit>"/>
 
@@ -187,8 +190,11 @@
   <class name="edm::DetSetVector<CTPPSPixelFittedRecHit>"/>
   <class name="edm::Wrapper<edm::DetSetVector<CTPPSPixelFittedRecHit>>"/>
   <class name="std::vector<edm::DetSet<CTPPSPixelFittedRecHit> >"/>
+  <class name="edm::DetSet<CTPPSPixelFittedRecHit>"/>
   <class name="std::vector<CTPPSPixelFittedRecHit>"/>
-  <class name="CTPPSPixelFittedRecHit"/>
+  <class name="CTPPSPixelFittedRecHit" ClassVersion="10">
+    <version ClassVersion="10" checksum="2285724696"/>
+  </class>
 
 <!-- common objects -->
 


### PR DESCRIPTION
#### PR description:

Disabling ROOT automatic class header parsing in #41344 revealed some dictionaries that are missing in `DataFormats/CTPPSReco` , this PR adds them.

#### PR validation:

With #41344 workflow 136.8311 step 2 runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

If there is any evolution for these classes that is foreseen to be backported to 13_0_X, this PR would be good to be backported as well.
