### PR TITLE
Fixed bug. Missing edm::InputTag src default value in fillDescriptions

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEGenericMassFilter.cc
@@ -91,6 +91,7 @@ bool LHEGenericMassFilter::filter(edm::StreamID iID, edm::Event& iEvent, edm::Ev
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void LHEGenericMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("externalLHEProducer"));
   desc.add<int>("NumRequired", 1);
   desc.add<vector<int>>("ParticleID", std::vector<int>{1});
   desc.add<double>("MinMass", 0.0);


### PR DESCRIPTION
PR description:

There is currently a bug that makes the usage of the LHEGenericMassFilter unusable. This is because the `fillDescriptions` method was missing the default value for the `edm::InputTag src` constructor parameter. This PR fixes this bug.


PR validation:

I ran
`scram b runtests`
and
`runTheMatrix.py -l limited -i all --ibeos`
No new code needs to be added for unit tests, test configurations, additions, or updates to the runTheMatrix test workflows as far as I am concerned.