### PR TITLE
[13.0.X] Re-adding cosmic track collection ALCARECOTkAlCosmicsCosmicTF0T

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -156,6 +156,7 @@ def getSequence(process, collection,
                 "minimumHits": 10,
                 })
     elif collection in ("ALCARECOTkAlCosmicsCTF0T",
+                        "ALCARECOTkAlCosmicsCosmicTF0T",
                         "ALCARECOTkAlCosmicsInCollisions"):
         isCosmics = True
         options["TrackSelector"]["HighPurity"] = {} # drop high purity cut


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41369

#### PR description:

This PR has a single commit:
   * re-adding ALCARECOTkAlCosmicsCosmicTF0T track collection from https://github.com/cms-sw/cmssw/pull/35694