### PR TITLE
L1T Offline DQM: Switching to puppi jets for L1T jets offline DQM

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -79,7 +79,7 @@ completeSelection = 'et > 30 && (' + ' || '.join([centralJetSelection, withinTra
 
 goodPFJetsForL1T = cms.EDFilter(
     "PFJetSelector",
-    src=cms.InputTag("ak4PFJetsCHS"),
+    src=cms.InputTag("ak4PFJetsPuppi"),
     cut=cms.string(completeSelection),
     filter=cms.bool(True),
 )


### PR DESCRIPTION
#### PR description:

Moving to ```ak4PFJetsPuppi``` as the input for Et/Jet plots within the L1T offline DQM.

#### PR validation:
Tested using:

```
cmsDriver.py step2 --conditions 124X_dataRun3_Prompt_v4 --data --datatier RECO,DQMIO --era Run3 --eventcontent RECO,DQM --filein root://cms-xrd-global.cern.ch//store/data/Run2022C/Muon/RAW/v1/000/356/615/00000/0041feb7-2ed3-4051-a6e2-367e278c983b.root --fileout file:step2.root --nStreams 2 --nThreads 8 --no_exec --number 1000 --process RECO --python_filename step_2L1T_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM:@L1TMuon


cmsDriver.py step3 --conditions 124X_dataRun3_Prompt_v4 --data --era Run3 --filein file:step2_inDQM.root --fileout file:step3.root --filetype DQM --nStreams 2 --no_exec --number 1000 --python_filename step_3_cfg.py --scenario pp --step HARVESTING:DQMHarvestL1TMuon
```
