### PR TITLE
add layer-1 monitoring for new slot-7 cards [13_0_3 P5 DQM test]

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -119,8 +119,8 @@ namespace CaloL1Information {
     dqm::reco::MonitorElement *hcalOccFg1Discrepancy_;
     dqm::reco::MonitorElement *hcalOccFg2Discrepancy_;
     dqm::reco::MonitorElement *hcalOccFg3Discrepancy_;
-    dqm::reco::MonitorElement *hcalOccFg4Discrepancy_;
-    dqm::reco::MonitorElement *hcalOccFg5Discrepancy_;
+    //dqm::reco::MonitorElement *hcalOccFg4Discrepancy_;
+    //dqm::reco::MonitorElement *hcalOccFg5Discrepancy_;
     dqm::reco::MonitorElement *hcalOccRecdFg0_;
     dqm::reco::MonitorElement *hcalOccRecdFg1_;
     dqm::reco::MonitorElement *hcalOccRecdFg2_;
@@ -177,6 +177,8 @@ namespace CaloL1Information {
     dqm::reco::MonitorElement *ecalOccRecdBx3_;
     dqm::reco::MonitorElement *ecalOccRecdBx4_;
     dqm::reco::MonitorElement *ecalOccRecdBx5_;
+
+    dqm::reco::MonitorElement *slot7bit_;
 
     std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> runMismatchList;
   };

--- a/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
+++ b/DQM/L1TMonitor/src/L1TStage2CaloLayer1.cc
@@ -68,6 +68,14 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
   bool caloLayer1OutOfRun{true};
   bool FATevent{false};
   bool additionalFB{false};
+  std::vector<uint32_t> FED1354_slot7_bits;
+  std::vector<uint32_t> FED1356_slot7_bits;
+  std::vector<uint32_t> FED1358_slot7_bits;
+  for (int i = 0; i < 6; i++) {
+    FED1354_slot7_bits.push_back(0);
+    FED1356_slot7_bits.push_back(0);
+    FED1358_slot7_bits.push_back(0);
+  }
   if (fedRawDataCollection.isValid()) {
     caloLayer1OutOfRun = false;
     for (int iFed = 1354; iFed < 1360; iFed += 2) {
@@ -83,16 +91,45 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
         const uint32_t* amcPtr = amcData.dataPtr();
         FATevent = ((amcPtr[5] >> 16) & 0xf) == 5;
         additionalFB = (amcPtr[5] >> 15) & 0x1;
-        int lPhi = amcData.layer1Phi();
-        if (daqData.BXID() != amcData.BXID()) {
-          eventMonitors.bxidErrors_->Fill(lPhi);
+        if (((amcPtr[5] >> 14) & 0x1) == 0) {
+          int lPhi = amcData.layer1Phi();
+          if (daqData.BXID() != amcData.BXID()) {
+            eventMonitors.bxidErrors_->Fill(lPhi);
+          }
+          if (daqData.L1ID() != amcData.L1ID()) {
+            eventMonitors.l1idErrors_->Fill(lPhi);
+          }
+          // AMC payload header has 16 bit orbit number, AMC13 header is full 32
+          if ((daqData.orbitNumber() & 0xFFFF) != amcData.orbitNo()) {
+            eventMonitors.orbitErrors_->Fill(lPhi);
+          }
         }
-        if (daqData.L1ID() != amcData.L1ID()) {
-          eventMonitors.l1idErrors_->Fill(lPhi);
+        if (daqData.nAMCs() == 7 && i == 3) {
+          for (int j = 0; j < 6; j++) {
+            if (iFed == 1354) {
+              FED1354_slot7_bits[j] = amcPtr[j + 6] & 0xFFFFFFFF;
+            } else if (iFed == 1356) {
+              FED1356_slot7_bits[j] = amcPtr[j + 6] & 0xFFFFFFFF;
+            } else {
+              FED1358_slot7_bits[j] = amcPtr[j + 6] & 0xFFFFFFFF;
+            }
+          }
         }
-        // AMC payload header has 16 bit orbit number, AMC13 header is full 32
-        if ((daqData.orbitNumber() & 0xFFFF) != amcData.orbitNo()) {
-          eventMonitors.orbitErrors_->Fill(lPhi);
+      }
+    }
+  }
+
+  if (not caloLayer1OutOfRun) {
+    for (int iword = 0; iword < 6; iword++) {
+      for (int ibit = 0; ibit < 32; ibit++) {
+        if (((FED1354_slot7_bits[iword] >> ibit) & 0x1) == 1) {
+          eventMonitors.slot7bit_->Fill(ibit, iword);
+        }
+        if (((FED1356_slot7_bits[iword] >> ibit) & 0x1) == 1) {
+          eventMonitors.slot7bit_->Fill(ibit, iword + 7);
+        }
+        if (((FED1358_slot7_bits[iword] >> ibit) & 0x1) == 1) {
+          eventMonitors.slot7bit_->Fill(ibit, iword + 14);
         }
       }
     }
@@ -411,8 +448,8 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
     const bool Hfg1Agreement = (abs(ieta) < 29) ? (layer1fg1 == uHTRfg1) : true;
     const bool Hfg2Agreement = (abs(ieta) < 29) ? (layer1fg2 == uHTRfg2) : true;
     const bool Hfg3Agreement = (abs(ieta) < 29) ? (layer1fg3 == uHTRfg3) : true;
-    const bool Hfg4Agreement = (abs(ieta) < 29) ? (layer1fg4 == uHTRfg4) : true;
-    const bool Hfg5Agreement = (abs(ieta) < 29) ? (layer1fg5 == uHTRfg5) : true;
+    //const bool Hfg4Agreement = (abs(ieta) < 29) ? (layer1fg4 == uHTRfg4) : true;
+    //const bool Hfg5Agreement = (abs(ieta) < 29) ? (layer1fg5 == uHTRfg5) : true;
     // Mute fg4 and fg5 for now (reserved bits not used anyway)
     const bool HfgAgreement = (Hfg0Agreement && Hfg1Agreement && Hfg2Agreement && Hfg3Agreement);
 
@@ -476,12 +513,12 @@ void L1TStage2CaloLayer1::dqmAnalyze(const edm::Event& event,
       }
       // fg4-5 are reserved bits and not used
       // so compare here and not stream to mismatch list for now
-      if (not Hfg4Agreement) {
-        eventMonitors.hcalOccFg4Discrepancy_->Fill(ieta, iphi);
-      }
-      if (not Hfg5Agreement) {
-        eventMonitors.hcalOccFg5Discrepancy_->Fill(ieta, iphi);
-      }
+      //if (not Hfg4Agreement) {
+      //  eventMonitors.hcalOccFg4Discrepancy_->Fill(ieta, iphi);
+      //}
+      //if (not Hfg5Agreement) {
+      //  eventMonitors.hcalOccFg5Discrepancy_->Fill(ieta, iphi);
+      //}
       // Fill Fb Occ and compare between layer1 emulated and layer2 data readout
       // FAT events only!!
       if (LLPfb_Expd) {
@@ -643,6 +680,10 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker,
   auto bookHcalOccupancy = [&ibooker](std::string name, std::string title) {
     return ibooker.book2D(name, title + ";iEta;iPhi", 83, -41.5, 41.5, 72, 0.5, 72.5);
   };
+  auto bookSlot7Occupancy = [&ibooker](std::string name, std::string title) {
+    return ibooker.book2D(
+        name, title + ";bit;slot-7 word in FED13(54[0-5],56[7-12],58[14-19])", 32, -0.5, 31.5, 20, -0.5, 19.5);
+  };
 
   ibooker.setCurrentFolder(histFolder_);
 
@@ -656,6 +697,7 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker,
   eventMonitors.hcalLinkError_ = bookHcalOccupancy("hcalLinkError", "HCAL Link Errors");
   eventMonitors.hcalOccupancy_ = bookHcalOccupancy("hcalOccupancy", "HCAL TP Occupancy at Layer1");
   eventMonitors.hcalOccRecdEtWgt_ = bookHcalOccupancy("hcalOccRecdEtWgt", "HCal TP ET-weighted Occupancy at Layer1");
+  eventMonitors.slot7bit_ = bookSlot7Occupancy("slot7bit", "Bit Occupancy of the Three Slot-7 Cards");
 
   ibooker.setCurrentFolder(histFolder_ + "/ECalDetail");
 
@@ -706,10 +748,10 @@ void L1TStage2CaloLayer1::bookHistograms(DQMStore::IBooker& ibooker,
       bookHcalOccupancy("hcalOccFg2Discrepancy", "HCal Fine Grain 2 Discrepancy between uHTR and Layer1");
   eventMonitors.hcalOccFg3Discrepancy_ =
       bookHcalOccupancy("hcalOccFg3Discrepancy", "HCal Fine Grain 3 Discrepancy between uHTR and Layer1");
-  eventMonitors.hcalOccFg4Discrepancy_ =
-      bookHcalOccupancy("hcalOccFg4Discrepancy", "HCal Fine Grain 4 Discrepancy between uHTR and Layer1");
-  eventMonitors.hcalOccFg5Discrepancy_ =
-      bookHcalOccupancy("hcalOccFg5Discrepancy", "HCal Fine Grain 5 Discrepancy between uHTR and Layer1");
+  //eventMonitors.hcalOccFg4Discrepancy_ =
+  //    bookHcalOccupancy("hcalOccFg4Discrepancy", "HCal Fine Grain 4 Discrepancy between uHTR and Layer1");
+  //eventMonitors.hcalOccFg5Discrepancy_ =
+  //    bookHcalOccupancy("hcalOccFg5Discrepancy", "HCal Fine Grain 5 Discrepancy between uHTR and Layer1");
   eventMonitors.hcalOccSentFg0_ = bookHcalOccupancy("hcalOccSentFg0", "HCal Fine Grain 0 Occupancy at uHTR");
   eventMonitors.hcalOccSentFg1_ = bookHcalOccupancy("hcalOccSentFg1", "HCal Fine Grain 1 Occupancy at uHTR");
   eventMonitors.hcalOccSentFg2_ = bookHcalOccupancy("hcalOccSentFg2", "HCal Fine Grain 2 Occupancy at uHTR");

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -186,6 +186,7 @@ namespace l1t {
     unsigned bx_per_l1a_;
     unsigned calo_bxid_;
     unsigned six_hcal_feature_bits_;
+    unsigned slot7_card_;
     amc::Header amcHeader_;
   };
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -25,51 +25,58 @@ namespace l1t {
       //      std::cout << " N_BX calculated " << N_BX << std::endl;
 
       int HCALFB = (block.header().getFlags() >> 15) & 0x1;
+      int slot7card = (block.header().getFlags() >> 14) & 0x1;
 
-      if (N_BX == 1) {
-        if (HCALFB == 0) {
-          UCTCTP7RawData ctp7Data(ptr);
-          makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-          makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-          makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-          makeRegions(ctp7_phi, ctp7Data, res->getRegions());
-        }
-        if (HCALFB == 1) {
-          UCTCTP7RawData_HCALFB ctp7Data_HCALFB(ptr);
-          makeECalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getEcalDigis());
-          makeHCalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
-          makeHFTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
-          makeRegions_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getRegions());
-        }
-      } else if (N_BX == 5) {
-        if (HCALFB == 0) {
-          UCTCTP7RawData5BX ctp7Data5BX(ptr);
-          // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
-          makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigis(), 2);
-          makeHCalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
-          makeHFTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
-          makeRegions5BX(ctp7_phi, ctp7Data5BX, res->getRegions(), 2);
-          for (int i = 0; i < 5; i++) {
-            makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigisBx(i), i);
+      if (slot7card == 0) {
+        if (N_BX == 1) {
+          if (HCALFB == 0) {
+            UCTCTP7RawData ctp7Data(ptr);
+            makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+            makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+            makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+            makeRegions(ctp7_phi, ctp7Data, res->getRegions());
           }
-        }
-        if (HCALFB == 1) {
-          UCTCTP7RawData5BX_HCALFB ctp7Data5BX_HCALFB(ptr);
-          // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
-          makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigis(), 2);
-          makeHCalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
-          makeHFTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
-          makeRegions5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getRegions(), 2);
-          for (int i = 0; i < 5; i++) {
-            makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigisBx(i), i);
+          if (HCALFB == 1) {
+            UCTCTP7RawData_HCALFB ctp7Data_HCALFB(ptr);
+            makeECalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getEcalDigis());
+            makeHCalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
+            makeHFTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
+            makeRegions_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getRegions());
           }
+        } else if (N_BX == 5) {
+          if (HCALFB == 0) {
+            UCTCTP7RawData5BX ctp7Data5BX(ptr);
+            // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+            makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigis(), 2);
+            makeHCalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+            makeHFTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+            makeRegions5BX(ctp7_phi, ctp7Data5BX, res->getRegions(), 2);
+            for (int i = 0; i < 5; i++) {
+              makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigisBx(i), i);
+            }
+          }
+          if (HCALFB == 1) {
+            UCTCTP7RawData5BX_HCALFB ctp7Data5BX_HCALFB(ptr);
+            // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+            makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigis(), 2);
+            makeHCalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
+            makeHFTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
+            makeRegions5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getRegions(), 2);
+            for (int i = 0; i < 5; i++) {
+              makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigisBx(i), i);
+            }
+          }
+        } else {
+          LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX
+                                         << std::endl;
+          return false;
         }
+        return true;
       } else {
-        LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
-        return false;
+        // slot-7 card payload data have 6 32-bit words only
+        // we read from FED raw data collection for DQM directly
+        return true;
       }
-
-      return true;
     }
 
     void CaloLayer1Unpacker::makeECalTPGs(uint32_t lPhi,

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -212,6 +212,7 @@ namespace l1t {
     calo_bxid_ = *data_ & 0xfff;
     capId_ = 0;
     six_hcal_feature_bits_ = (*data_ >> 15) & 0x1;
+    slot7_card_ = (*data_ >> 14) & 0x1;
     if (bx_per_l1a_ > 1) {
       edm::LogInfo("L1T") << "CTP7 block with multiple bunch crossings:" << bx_per_l1a_;
     }
@@ -226,8 +227,9 @@ namespace l1t {
     // CTP7 header contains number of BX in payload and the bunch crossing ID
     // Not sure how to map to generic BlockHeader variables, so just packing
     // it all in flags variable
-    unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff) | ((six_hcal_feature_bits_ & 0x1) << 15);
-    unsigned blockSize = (192 + (int)six_hcal_feature_bits_ * 28) * (int)bx_per_l1a_;
+    unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff) | ((six_hcal_feature_bits_ & 0x1) << 15) |
+                          ((slot7_card_ & 0x1) << 14);
+    unsigned blockSize = (slot7_card_ == 1) ? 6 : ((192 + (int)six_hcal_feature_bits_ * 28) * (int)bx_per_l1a_);
     return BlockHeader(blockId, blockSize, capId_, blockFlags, CTP7);
   }
 


### PR DESCRIPTION
#### PR description:
This PR modifies Calo-Layer1 unpacker to adapt the additions of a new CTP7 card in slot-7 in each of the three layer-1 crates (FEDs 1354, 1356, 1358), where each card sends the same payload header and trailer as all other existing calo cards, but with a fixed payload data size of 6 32-bit words, regardless of normal or FAT events being sent. New monitoring elements are added to layer-1 DQM for the 3x6x32 bits. The modification is done in such a way that it works before and after the card addition (current firmware and new firmware not yet uploaded).

Note that the monitoring elements for HCAL FB4-5 are commented out, we will put them back once HCAL fixes them (FB4-5 are reserved bits and not used for LLP, but they are sending unphysical data there which layer-1 could not read out, causing discrepancies seen when comparing them).

#### PR validation:
Validated by running offline DQM on past commissioning runs, it works as expected for current production firmware. It needs to be tested with new firmware not yet deployed at P5.