### PR TITLE
Remove `12450.*` wfs (2023, ZMuMu) from GPU RelVals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -36,9 +36,7 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 
-# mc 2023   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+# mc 2023   Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
@@ -72,8 +70,6 @@ numWFIB = [
            11634.596, 11634.597,
 
            # 2023
-           12450.502, 12450.503, 12450.504,
-           12450.506, 12450.507, 12450.508,
            12434.502, 12434.503, 12434.504,
            12434.506, 12434.507, 12434.508,
            12434.512, 12434.513, 12434.514,


### PR DESCRIPTION
#### PR description:

#41354 added Run-3 wfs with 2023 conditions to the list of GPU RelVals.

After that PR was merged, the `12450.*` wfs failed in the relevant IB (i.e. `CMSSW_13_1_GPU_X_2023-04-21-2300`), likely because the corresponding GEN-SIM input sample does not exist (see https://github.com/cms-sw/cmssw/pull/41354#issuecomment-1518589878).

This PR disables those GPU RelVals to avoid IB failures, until the situation is clarified.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

If accepted, this PR will be backported in #41371.