### PR TITLE
fix some bugs in the TrackerAlignment `DiMuonValidation` code

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -128,17 +128,17 @@ if "conditions" in config["alignment"]:
 ###################################################################
 # The Di Muon Mass Validation module
 ###################################################################
-from Alignment.OfflineValidation.diMuonValidation_cfi.py import diMuonValidation as _diMuonValidation
+from Alignment.OfflineValidation.diMuonValidation_cfi import diMuonValidation as _diMuonValidation
 process.DiMuonMassValidation = _diMuonValidation.clone(
     TkTag = 'TrackRefitter',
     # mu mu mass
     Pair_mass_min   = 80.,
     Pair_mass_max   = 120.,
     Pair_mass_nbins = 80,
-    Pair_etaminpos  = -1,
-    Pair_etamaxpos  = 1,
-    Pair_etaminneg  = -1,
-    Pair_etamaxneg  = 1,
+    Pair_etaminpos  = -2.4,
+    Pair_etamaxpos  = 2.4,
+    Pair_etaminneg  = -2.4,
+    Pair_etamaxneg  = 2.4,
     # cosTheta CS
     Variable_CosThetaCS_xmin  = -1.,
     Variable_CosThetaCS_xmax  =  1.,


### PR DESCRIPTION
#### PR description:

This is a follow up to https://github.com/cms-sw/cmssw/pull/40346 and fixes some miscellaneous problems in the Tracker alignment di-muon validation code:
   * do not use range-based loops to create the candidate, which duplicated the entries in the histograms;
   * fix the pseudo-rapidity range for creating the input histograms
   * fix the inclusion of the auto-generated cfi file in the validation configuration file 

#### PR validation:

Private tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported.
