### PR TITLE
Backport (update) option to override GEN decays with FastSim decays

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -287,7 +287,8 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
         LogDebug(MESSAGECATEGORY) << "Decaying particle...";
         std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-        decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+        if (useFastSimsDecayer) 
+            decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
         LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
         particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
         continue;
@@ -499,7 +500,8 @@ FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
   if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
     LogDebug(MESSAGECATEGORY) << "Decaying particle...";
     std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-    decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+    if (useFastSimsDecayer) 
+        decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
     LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
     particleManager->addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
   }


### PR DESCRIPTION
#### PR description:

The backport https://github.com/cms-sw/cmssw/pull/39022 was missing two key lines that were in the HEAD, which this PR corrects for. These changes are needed to achieve better agreement between FastSim and FullSim for Standard Model production, e.g., ttbar, for Run 2 UL productions.

#### PR validation:
