### PR TITLE
Update GlobalAlgBlkUnpacker to throw error in the case of headers received in the wrong order

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GlobalAlgBlkUnpacker.cc
@@ -46,6 +46,13 @@ namespace l1t {
           GlobalAlgBlk talg = GlobalAlgBlk();
           res_->push_back(bx, talg);
         }
+        //If this is not the first block, but the vector is empty, something has gone wrong (corrupted data)
+        else if (res_->isEmpty(bx))
+          throw cms::Exception("InvalidGlobalAlgBlkBxCollection")
+              << "The GlobalAlgBlk unpacker result vector is empty, but is not receiving the first expected header "
+                 "ID! This may be due to corrupted, or poorly formatted events.\n"
+              << "uGTBoard: " << uGTBoard << "\nBX: " << bx << "\nFirst expected block: " << initialBlkID
+              << "\nReceived block: " << block.header().getID();
 
         //fetch
         GlobalAlgBlk alg = res_->at(bx, 0);


### PR DESCRIPTION
### PR description:

This PR has been opened in response to [L1 JIRA ticket 411](https://its.cern.ch/jira/browse/CMSLITOPS-411). HLT has noticed problems regarding the L1TRawToDigi process, which has been tracked to an issue in the GlobalAlgBlk unpacker receiving blocks and header IDs out of order. This causes a bad access/`->at` call,of a following BXVector, which fails somewhat un-informatively. This PR has been opened to produce a more informative failure message in case the initial header ID assumption fails.

@dinyar @kbunkow @missirol @alintulu I figured you would like to be kept in the loop on this.

### PR validation:

All code compiles, has had code-formatting applied, and passes code checks. When testing on error events from [the open JIRA ticket](https://its.cern.ch/jira/browse/CMSLITOPS-411), the cms::exception reports instead of bad vector access errors.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, however a backport may be expected for CMSSW_13_0.