### PR TITLE
cleanup spurious change introduced in PAT photon/muon producer auto fwd-port in 2015

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -309,8 +309,6 @@ void pat::PATMuonProducer::readIsolationLabels(const edm::ParameterSet& iConfig,
       for (; it != ed; ++it, ++key) {
         labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
-      tokens = edm::vector_transform(
-          labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T>>(label.second); });
     }
   }
   tokens = edm::vector_transform(labels, [this](pat::PATMuonProducer::IsolationLabel const& label) {

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -182,9 +182,6 @@ void pat::PATPhotonProducer::readIsolationLabels(const edm::ParameterSet& iConfi
         labels.push_back(std::make_pair(pat::IsolationKeys(key), *it));
       }
     }
-
-    tokens = edm::vector_transform(
-        labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T>>(label.second); });
   }
   tokens = edm::vector_transform(
       labels, [this](IsolationLabel const& label) { return consumes<edm::ValueMap<T>>(label.second); });


### PR DESCRIPTION
partly as a follow up to #41396 I was somewhat non-comprehensively looking at other changes from automatic forward ports

https://github.com/cms-sw/cmssw/commit/2315273a3ba054696c8f7f330192c8468c3177b7#diff-2fdb475ba7d21b78d12e835c8df71fd7a251210fc88ebd4bc8ec6fd2b1dbb2c4L200-L201

was an auto-forward port of #10671 (75X) which in turn was a backport of #11140 (76X; initial version #10620) but there were enough nested merges and differences that the porting got apparently confused