### PR TITLE
Different Geant4 SteppingActions for Run3 and Phase2

### DIFF
--- a/SimG4Core/Application/interface/CMSSimEventManager.h
+++ b/SimG4Core/Application/interface/CMSSimEventManager.h
@@ -21,7 +21,7 @@ class G4Event;
 class EventAction;
 class StackingAction;
 class TrackingAction;
-class SteppingAction;
+class G4UserSteppingAction;
 class G4SDManager;
 class G4StateManager;
 class G4PrimaryTransformer;
@@ -44,7 +44,7 @@ public:
   void SetUserAction(EventAction* ptr);
   void SetUserAction(StackingAction* ptr);
   void SetUserAction(TrackingAction* ptr);
-  void SetUserAction(SteppingAction* ptr);
+  void SetUserAction(G4UserSteppingAction* ptr);
 
   CMSSimEventManager(const CMSSimEventManager& right) = delete;
   CMSSimEventManager& operator=(const CMSSimEventManager& right) = delete;

--- a/SimG4Core/Application/interface/Phase2SteppingAction.h
+++ b/SimG4Core/Application/interface/Phase2SteppingAction.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+#include "SimG4Core/Application/interface/SteppingTrackStatus.h"
 
 #include "G4LogicalVolume.hh"
 #include "G4Region.hh"
@@ -15,18 +16,6 @@
 #include <vector>
 
 class CMSSteppingVerbose;
-
-enum TrackStatus {
-  sAlive = 0,
-  sKilledByProcess = 1,
-  sDeadRegion = 2,
-  sOutOfTime = 3,
-  sLowEnergy = 4,
-  sLowEnergyInVacuum = 5,
-  sEnergyDepNaN = 6,
-  sVeryForward = 7,
-  sNumberOfSteps = 8
-};
 
 class Phase2SteppingAction : public G4UserSteppingAction {
 public:

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -77,12 +77,16 @@ public:
   // need a non-const pointer. Thread-safety is handled inside Geant4.
   inline PhysicsList* physicsListForWorker() const { return m_physicsList.get(); }
 
+  inline bool isPhase2() const { return m_isPhase2; }
+
 private:
   void terminateRun();
 
   void checkVoxels();
 
   void setupVoxels();
+
+  void runForPhase2();
 
   G4MTRunManagerKernel* m_kernel;
 
@@ -100,6 +104,7 @@ private:
   bool m_StorePhysicsTables;
   bool m_RestorePhysicsTables;
   bool m_check;
+  bool m_isPhase2{false};
   edm::ParameterSet m_pPhysics;
   edm::ParameterSet m_pRunAction;
   edm::ParameterSet m_g4overlap;

--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -35,6 +35,7 @@ class RunAction;
 class EventAction;
 class TrackingAction;
 class SteppingAction;
+class Phase2SteppingAction;
 class CMSSteppingVerbose;
 class CMSSimEventManager;
 class G4Field;
@@ -63,6 +64,7 @@ public:
   void Connect(EventAction*);
   void Connect(TrackingAction*);
   void Connect(SteppingAction*);
+  void Connect(Phase2SteppingAction*);
 
   SimTrackManager* GetSimTrackManager();
   std::vector<SensitiveTkDetector*>& sensTkDetectors();
@@ -99,6 +101,7 @@ private:
   bool m_LHCTransport{false};
   bool m_dumpMF{false};
   bool m_endOfRun{false};
+  bool m_isPhase2{false};
 
   const int m_thread_index{-1};
 

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
+#include "SimG4Core/Application/interface/SteppingTrackStatus.h"
 
 #include "G4LogicalVolume.hh"
 #include "G4Region.hh"
@@ -15,18 +16,6 @@
 #include <vector>
 
 class CMSSteppingVerbose;
-
-enum TrackStatus {
-  sAlive = 0,
-  sKilledByProcess = 1,
-  sDeadRegion = 2,
-  sOutOfTime = 3,
-  sLowEnergy = 4,
-  sLowEnergyInVacuum = 5,
-  sEnergyDepNaN = 6,
-  sVeryForward = 7,
-  sNumberOfSteps = 8
-};
 
 class SteppingAction : public G4UserSteppingAction {
 public:
@@ -48,7 +37,6 @@ private:
 
   const G4VPhysicalVolume* tracker{nullptr};
   const G4VPhysicalVolume* calo{nullptr};
-  const G4VPhysicalVolume* btl{nullptr};
   const CMSSteppingVerbose* steppingVerbose;
   double theCriticalEnergyForVacuum;
   double theCriticalDensity;

--- a/SimG4Core/Application/interface/SteppingTrackStatus.h
+++ b/SimG4Core/Application/interface/SteppingTrackStatus.h
@@ -1,0 +1,16 @@
+#ifndef SimG4Core_SteppingTrackStatus_H
+#define SimG4Core_SteppingTrackStatus_H
+
+enum TrackStatus {
+  sAlive = 0,
+  sKilledByProcess = 1,
+  sDeadRegion = 2,
+  sOutOfTime = 3,
+  sLowEnergy = 4,
+  sLowEnergyInVacuum = 5,
+  sEnergyDepNaN = 6,
+  sVeryForward = 7,
+  sNumberOfSteps = 8
+};
+
+#endif

--- a/SimG4Core/Application/src/CMSSimEventManager.cc
+++ b/SimG4Core/Application/src/CMSSimEventManager.cc
@@ -3,7 +3,6 @@
 #include "SimG4Core/Application/interface/EventAction.h"
 #include "SimG4Core/Application/interface/StackingAction.h"
 #include "SimG4Core/Application/interface/TrackingAction.h"
-#include "SimG4Core/Application/interface/SteppingAction.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -14,6 +13,7 @@
 #include "G4PrimaryTransformer.hh"
 #include "G4TrackingManager.hh"
 #include "G4TrackStatus.hh"
+#include "G4UserSteppingAction.hh"
 
 #include "G4SDManager.hh"
 #include "G4StateManager.hh"
@@ -107,6 +107,6 @@ void CMSSimEventManager::SetUserAction(TrackingAction* ptr) {
   m_defTrackManager->SetUserAction((G4UserTrackingAction*)ptr);
 }
 
-void CMSSimEventManager::SetUserAction(SteppingAction* ptr) {
-  m_defTrackManager->SetUserAction((G4UserSteppingAction*)ptr);
+void CMSSimEventManager::SetUserAction(G4UserSteppingAction* ptr) {
+  m_defTrackManager->SetUserAction(ptr);
 }

--- a/SimG4Core/Application/src/CMSSimEventManager.cc
+++ b/SimG4Core/Application/src/CMSSimEventManager.cc
@@ -107,6 +107,4 @@ void CMSSimEventManager::SetUserAction(TrackingAction* ptr) {
   m_defTrackManager->SetUserAction((G4UserTrackingAction*)ptr);
 }
 
-void CMSSimEventManager::SetUserAction(G4UserSteppingAction* ptr) {
-  m_defTrackManager->SetUserAction(ptr);
-}
+void CMSSimEventManager::SetUserAction(G4UserSteppingAction* ptr) { m_defTrackManager->SetUserAction(ptr); }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -250,6 +250,7 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
 
   // G4Region dump file name
   auto regionFile = m_p.getUntrackedParameter<std::string>("FileNameRegions", "");
+  runForPhase2();  
 
   // Geometry checks
   if (m_check || !regionFile.empty()) {
@@ -356,4 +357,17 @@ void RunManagerMT::setupVoxels() {
   }
   edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMT: default voxel density=" << density << "; number of regions with special density " << nr;
+}
+
+void RunManagerMT::runForPhase2() {
+  const G4RegionStore* regStore = G4RegionStore::GetInstance();
+  for(auto & r : *regStore) {
+    const G4String& name = r->GetName();
+    if(name == "HGCalRegion" ||
+       name == "FastTimerRegionETL" ||
+       name == "FastTimerRegionBTL") {
+      m_isPhase2 = true;
+      break;
+    }
+  }
 }

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -250,7 +250,7 @@ void RunManagerMT::initG4(const DDCompactView* pDD,
 
   // G4Region dump file name
   auto regionFile = m_p.getUntrackedParameter<std::string>("FileNameRegions", "");
-  runForPhase2();  
+  runForPhase2();
 
   // Geometry checks
   if (m_check || !regionFile.empty()) {
@@ -361,11 +361,9 @@ void RunManagerMT::setupVoxels() {
 
 void RunManagerMT::runForPhase2() {
   const G4RegionStore* regStore = G4RegionStore::GetInstance();
-  for(auto & r : *regStore) {
+  for (auto& r : *regStore) {
     const G4String& name = r->GetName();
-    if(name == "HGCalRegion" ||
-       name == "FastTimerRegionETL" ||
-       name == "FastTimerRegionBTL") {
+    if (name == "HGCalRegion" || name == "FastTimerRegionETL" || name == "FastTimerRegionBTL") {
       m_isPhase2 = true;
       break;
     }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -420,7 +420,7 @@ void RunManagerMTWorker::initializeUserActions() {
 
   // different stepping actions for Run2,3 and Phase2
   G4UserSteppingAction* userSteppingAction;
-  if(m_isPhase2) {
+  if (m_isPhase2) {
     auto ptr = new Phase2SteppingAction(m_sVerbose.get(), m_pSteppingAction, m_hasWatchers);
     Connect(ptr);
     userSteppingAction = (G4UserSteppingAction*)ptr;

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -158,39 +158,10 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
       }
     }
   }
-  // check transition tracker/btl and tracker/calo
+  // check transition tracker/calo
   bool isKilled = false;
   if (sAlive == tstat || sVeryForward == tstat) {
-    // store TrackInformation about transition from one envelope to another
-    if (preStep->GetPhysicalVolume() == tracker && postStep->GetPhysicalVolume() == btl) {
-      // store transition tracker -> BTL only for tracks entering BTL for the first time
-      TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
-      if (!trkinfo->isFromTtoBTL() && !trkinfo->isFromBTLtoT()) {
-        trkinfo->setFromTtoBTL();
-        trkinfo->setIdAtBTLentrance(theTrack->GetTrackID());
-#ifdef DebugLog
-        LogDebug("SimG4CoreApplication") << "Setting flag for Tracker -> BTL " << trkinfo->isFromTtoBTL()
-                                         << " IdAtBTLentrance = " << trkinfo->idAtBTLentrance();
-#endif
-      } else {
-        trkinfo->setBTLlooper();
-        trkinfo->setIdAtBTLentrance(theTrack->GetTrackID());
-#ifdef DebugLog
-        LogDebug("SimG4CoreApplication") << "Setting flag for BTL looper " << trkinfo->isBTLlooper();
-        trkinfo->Print();
-#endif
-      }
-    } else if (preStep->GetPhysicalVolume() == btl && postStep->GetPhysicalVolume() == tracker) {
-      // store transition BTL -> tracker
-      TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
-      if (!trkinfo->isFromBTLtoT()) {
-        trkinfo->setFromBTLtoT();
-#ifdef DebugLog
-        LogDebug("SimG4CoreApplication") << "Setting flag for BTL -> Tracker " << trkinfo->isFromBTLtoT();
-#endif
-      }
-    } else if (preStep->GetPhysicalVolume() == tracker && postStep->GetPhysicalVolume() == calo) {
-      // store transition tracker -> calo
+    if (preStep->GetPhysicalVolume() == tracker && postStep->GetPhysicalVolume() == calo) {
       TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
       if (!trkinfo->crossedBoundary()) {
         trkinfo->setCrossedBoundary(theTrack);
@@ -233,14 +204,12 @@ bool SteppingAction::initPointer() {
       tracker = pvcite;
     } else if (pvname == "CALO" || pvname == "caloBase:CALO_1") {
       calo = pvcite;
-    } else if (pvname == "BarrelTimingLayer" || pvname == "btl:BarrelTimingLayer_1") {
-      btl = pvcite;
     }
-    if (tracker && calo && btl)
+    if (tracker && calo)
       break;
   }
   edm::LogVerbatim("SimG4CoreApplication")
-      << "SteppingAction: pointer for Tracker " << tracker << " and for Calo " << calo << " and for BTL " << btl;
+      << "SteppingAction: pointer for Tracker " << tracker << " and for Calo " << calo;
 
   const G4LogicalVolumeStore* lvs = G4LogicalVolumeStore::GetInstance();
   if (numberEkins > 0) {


### PR DESCRIPTION
#### PR description:
Recent development for Phase-2 MC truth handling (https://indico.cern.ch/event/1275985/) demonstrate that Geant4 SteppingAction logic in the case of Run2 or Run3 is slightly different from Phase2, because of existence of MTD and HGCal new detectors. This code is called at each simulation step for each track, in this PR we introduce usage of different classes for these two cases. No change of results in any WF is expected.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

