### PR TITLE
renew matched lepton ids for every jet

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc
@@ -76,9 +76,6 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
   std::vector<int> vmuIdx3SJ;
   std::vector<int> veleIdx3SJ;
 
-  int ele_pfmatch_index = -1;
-  int mu_pfmatch_index = -1;
-
   // Find leptons in jets
   for (unsigned int ij = 0; ij < nJet; ij++) {
     const pat::Jet &itJet = (*srcJet)[ij];
@@ -91,6 +88,9 @@ void LeptonInJetProducer<T>::produce(edm::StreamID streamID, edm::Event &iEvent,
       fastjet::PseudoJet p(d->px(), d->py(), d->pz(), d->energy());
       lClusterParticles.emplace_back(p);
     }
+
+    int ele_pfmatch_index = -1;
+    int mu_pfmatch_index = -1;
 
     // match to leading and closest electron or muon
     double dRmin(0.8), dRele(999), dRmu(999), dRtmp(999);


### PR DESCRIPTION
#### PR description:

< initially the matched lepton ids are declared only once https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/plugins/LeptonInJetProducer.cc#L79-L80, in the case of that when there is no matched lepton, the previous matched lepton id will be used for the next jet, i.e., two fat jets can match to one lepton which is not correct. >

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of PR https://github.com/cms-sw/cmssw/pull/41325

