### PR TITLE
[CORE] [LLVM14] Apply clang-tidy and clang-format changes

### DIFF
--- a/FWCore/FWLite/bin/storageSizeForBranch.cc
+++ b/FWCore/FWLite/bin/storageSizeForBranch.cc
@@ -45,11 +45,10 @@ int main(int argc, char* argv[]) try {
       "file"
       "\nAllowed options";
   boost::program_options::options_description desc(descString);
-  desc.add_options()(kHelpCommandOpt, "show this help message")(
-      kEntryNumberCommandOpt,
-      boost::program_options::value<int>(),
-      "read branch from the given entry value (default 0)")(kBranchNameOpt, "name of branch")(kFileNameOpt,
-                                                                                              "name of file");
+  desc.add_options()(kHelpCommandOpt, "show this help message")(kEntryNumberCommandOpt,
+                                                                boost::program_options::value<int>(),
+                                                                "read branch from the given entry value (default 0)")(
+      kBranchNameOpt, "name of branch")(kFileNameOpt, "name of file");
 
   boost::program_options::positional_options_description p;
   p.add(kBranchNameOpt, 1);

--- a/FWCore/Framework/test/statemachine_t.cc
+++ b/FWCore/Framework/test/statemachine_t.cc
@@ -20,11 +20,9 @@ int main(int argc, char* argv[]) try {
   std::string outputFile;
   boost::program_options::options_description desc("Allowed options");
   desc.add_options()("help,h", "produce help message")(
-      "inputFile,i",
-      boost::program_options::value<std::string>(&inputFile)
-          ->default_value(""))("outputFile,o",
-                               boost::program_options::value<std::string>(&outputFile)
-                                   ->default_value("statemachine_test_output.txt"));
+      "inputFile,i", boost::program_options::value<std::string>(&inputFile)->default_value(""))(
+      "outputFile,o",
+      boost::program_options::value<std::string>(&outputFile)->default_value("statemachine_test_output.txt"));
   boost::program_options::variables_map vm;
   boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
   boost::program_options::notify(vm);

--- a/FWCore/Integration/bin/interprocess.cc
+++ b/FWCore/Integration/bin/interprocess.cc
@@ -66,9 +66,8 @@ int main(int argc, char* argv[]) {
   boost::program_options::options_description desc(descString);
 
   desc.add_options()(kHelpCommandOpt, "produce help message")(
-      kMemoryNameCommandOpt,
-      boost::program_options::value<std::string>(),
-      "memory name")(kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
 
   boost::program_options::positional_options_description p;
   p.add(kMemoryNameOpt, 1);

--- a/FWCore/Integration/bin/interprocess_random.cc
+++ b/FWCore/Integration/bin/interprocess_random.cc
@@ -58,9 +58,8 @@ int main(int argc, char* argv[]) {
   boost::program_options::options_description desc(descString);
 
   desc.add_options()(kHelpCommandOpt, "produce help message")(
-      kMemoryNameCommandOpt,
-      boost::program_options::value<std::string>(),
-      "memory name")(kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
+      kMemoryNameCommandOpt, boost::program_options::value<std::string>(), "memory name")(
+      kUniqueIDCommandOpt, boost::program_options::value<std::string>(), "unique id");
 
   boost::program_options::positional_options_description p;
   p.add(kMemoryNameOpt, 1);

--- a/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
+++ b/FWCore/Integration/plugins/ProducerWithPSetDesc.cc
@@ -323,7 +323,7 @@ namespace edmtest {
 
     assert(vpset.size() == 2U);
 
-    edm::ParameterSet pset0 = vpset[0];
+    const edm::ParameterSet& pset0 = vpset[0];
     assert(pset0.getParameter<unsigned>("Drinks") == 5U);
     assert(pset0.getUntrackedParameter<unsigned>("uDrinks") == 5U);
     assert(pset0.getParameter<unsigned>("oDrinks") == 11U);
@@ -332,7 +332,7 @@ namespace edmtest {
     assert(pset0.exists("ndouDrinks") == false);
     // assert(pset0.getUntrackedParameter<unsigned>("ndouDrinks") == 5);
 
-    edm::ParameterSet pset1 = vpset[1];
+    const edm::ParameterSet& pset1 = vpset[1];
     assert(pset1.getParameter<unsigned>("Drinks") == 5U);
     assert(pset1.getUntrackedParameter<unsigned>("uDrinks") == 5U);
     assert(pset1.getParameter<unsigned>("oDrinks") == 11U);

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerPluginFactory.h
@@ -32,7 +32,7 @@ namespace edm {
 
 #define DEFINE_FWK_PSET_DESC_FILLER_IMPL(type, name, postfix)                                                     \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::ParameterSetDescriptionFiller<type> > \
-      EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
+  EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
 //NOTE: Can't do the below since this appears on the same line as another factory and w'ed have two variables with the same name
 //DEFINE_EDM_PLUGIN (edm::ParameterSetDescriptionFillerPluginFactory,type,#type)
 
@@ -42,20 +42,20 @@ namespace edm {
 
 #define DEFINE_DESC_FILLER_FOR_SERVICES(pluginName, serviceType)                                                        \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForServices<serviceType> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(#pluginName)
+  EDM_PLUGIN_SYM(s_filler, __LINE__)(#pluginName)
 
 #define DEFINE_DESC_FILLER_FOR_ESSOURCES_IMPL(type, name)                                                         \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESSources<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
+  EDM_PLUGIN_SYM(s_filler, __LINE__)(name)
 #define DEFINE_DESC_FILLER_FOR_ESSOURCES(type) DEFINE_DESC_FILLER_FOR_ESSOURCES_IMPL(type, #type)
 
 #define DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, name, postfix)                                                \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForESProducers<type> > \
-      EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
+  EDM_PLUGIN_SYM(s_filler##postfix, __LINE__)(name)
 #define DEFINE_DESC_FILLER_FOR_ESPRODUCERS(type) DEFINE_DESC_FILLER_FOR_ESPRODUCERS_IMPL(type, #type, _0)
 
 #define DEFINE_DESC_FILLER_FOR_EDLOOPERS(type)                                                                    \
   static const edm::ParameterSetDescriptionFillerPluginFactory::PMaker<edm::DescriptionFillerForEDLoopers<type> > \
-      EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
+  EDM_PLUGIN_SYM(s_filler, __LINE__)(#type)
 
 #endif

--- a/FWCore/PluginManager/bin/dump.cc
+++ b/FWCore/PluginManager/bin/dump.cc
@@ -26,10 +26,9 @@ int main(int argc, char** argv) {
   descString += " [options]";
   descString += "\nAllowed options";
   options_description desc(descString);
-  desc.add_options()(kHelpCommandOpt, "produce help message")(
-      kFilesCommandOpt,
-      "list the file from which a plugin will come")(kAllFilesCommandOpt,
-                                                     "list all the files to which a plugin is registered")
+  desc.add_options()(kHelpCommandOpt, "produce help message")(kFilesCommandOpt,
+                                                              "list the file from which a plugin will come")(
+      kAllFilesCommandOpt, "list all the files to which a plugin is registered")
       //(kAllCommandOpt,"when no paths given, try to update caches for all known directories [default is to only scan the first directory]")
       ;
 

--- a/FWCore/Utilities/interface/propagate_const.h
+++ b/FWCore/Utilities/interface/propagate_const.h
@@ -65,7 +65,7 @@ namespace edm {
     constexpr element_type const* operator->() const { return this->get(); }
     constexpr element_type const& operator*() const { return *m_value; }
 
-    constexpr operator element_type const *() const { return this->get(); }
+    constexpr operator element_type const*() const { return this->get(); }
 
     // ---------- member functions ---------------------------
     constexpr element_type* get() { return to_raw_pointer(m_value); }

--- a/FWCore/Utilities/interface/propagate_const_array.h
+++ b/FWCore/Utilities/interface/propagate_const_array.h
@@ -103,7 +103,7 @@ namespace edm {
     constexpr element_type const* get() const { return &m_value[0]; }
     constexpr element_type const& operator[](std::ptrdiff_t pos) const { return m_value[pos]; }
 
-    constexpr operator element_type const *() const { return this->get(); }
+    constexpr operator element_type const*() const { return this->get(); }
 
     // ---------- member functions ---------------------------
     constexpr element_type* get() { return &m_value[0]; }


### PR DESCRIPTION
code-checks/format changes needed due to llvm 14.0.6 integration.