### PR TITLE
[VISUALIZATION] [LLVM14] Apply clang-tidy and clang-format changes

### DIFF
--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -199,9 +199,8 @@ CmsShowMain::CmsShowMain(int argc, char* argv[])
 
   po::options_description tcachedesc("TreeCache");
   tcachedesc.add_options()(kLogTreeCacheOpt, "Log tree cache operations and status")(
-      kSizeTreeCacheOpt,
-      po::value<int>(),
-      "Set size of TTreeCache for data access in MB (default is 50)")(kPrefetchTreeCacheOpt, "Enable prefetching");
+      kSizeTreeCacheOpt, po::value<int>(), "Set size of TTreeCache for data access in MB (default is 50)")(
+      kPrefetchTreeCacheOpt, "Enable prefetching");
 
   po::options_description rnrdesc("Appearance");
   rnrdesc.add_options()(kFreePaletteCommandOpt, "Allow free color selection (requires special configuration!)")(


### PR DESCRIPTION
code-checks/format changes needed due to llvm 14.0.6 integration.