### PR TITLE
Update L1TCaloParams in 2022 and 2023 HI MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -72,7 +72,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v5',
+    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '131X_mcRun3_2023_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
@@ -82,7 +82,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v7',
+    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:
This PR updates the 2022 and 2023 realsitic HI MC GTs with the following latest `L1TCaloParams` tags, respectively:

- `L1TCaloParams_static_HI_2022_v0_05_mc_v1`
- `L1TCaloParams_static_HI_2022_v0_06_mc_v1` 
 
as requested in this [CMS Talk post](https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-updated-l1-parameters-for-heavy-ions-for-125x-and-131x/23153) [1]. 


[1] https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-updated-l1-parameters-for-heavy-ions-for-125x-and-131x/23153


**GT Differences with the last ones are here**:

- **Phase1 2022 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v5/131X_mcRun3_2022_realistic_HI_v7

- **Phase1 2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v7/131X_mcRun3_2023_realistic_HI_v9

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 159.1,160.1 -j 10 --ibeos` which consume `auto:phase1_2022_realistic_hi` and `auto:phase1_2023_realistic_hi` keys

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. A backport will be followed up in 130X for 2023 HI MC GT.