### PR TITLE
Change ECAL Presample RMS threshold

### DIFF
--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -8,7 +8,7 @@ expectedMean = 200.0
 toleranceLow = 25.0
 toleranceHigh = 40.0
 toleranceHighFwd = 100.0
-toleranceRMS = 3.0
+toleranceRMS = 6.0
 toleranceRMSFwd = 6.0
 
 ecalPresampleClient = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

This PR changes the RMS threshold in ECAL Presample quality and removes the many red spots in the plot.

#### PR validation:

PR validated by running the Ecal dqm client and the plot looks as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the master PR. Backport is made to 13_0_X used in production: https://github.com/cms-sw/cmssw/pull/41439