### PR TITLE
[13_0_X] Update L1TcaloParams in 2023 HI MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -82,7 +82,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v9',
+    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/41437

This PR updates the 2023 HI MC GT with the following latest `L1TCaloParams` tag:

- `L1TCaloParams_static_HI_2022_v0_06_mc_v1` 
 
as requested in this [CMS Talk post](https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-updated-l1-parameters-for-heavy-ions-for-125x-and-131x/23153) [1]. 


[1] https://cms-talk.web.cern.ch/t/request-for-new-hi-mc-gts-with-updated-l1-parameters-for-heavy-ions-for-125x-and-131x/23153


**GT Differences with the last ones are here**:

- **Phase1 2023 realistic HI**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v9/130X_mcRun3_2023_realistic_HI_v12

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/41437
