### PR TITLE
[GEM] DataFormat Bugfix - remove unused bits from VFat dataformat - backport of #41384

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMVFAT.h
+++ b/DataFormats/GEMDigi/interface/GEMVFAT.h
@@ -16,7 +16,8 @@ public:
       // is half-full, so it's like a warning
       uint64_t vc : 1;   /// VFAT CRC Error
       uint64_t : 7;      // unused
-      uint64_t pos : 8;  // VFAT position on chamber, 5 used in GE11 but more is needed for phase2
+      uint64_t pos : 5;  // VFAT position on chamber, 5 used in GE11 but more is needed for phase2
+      uint64_t : 3;      // unused
     };
     // v2 dataformat
     struct {


### PR DESCRIPTION
#### PR description:
Urgent bugfix for GEM dataformat needed for current FW.
VFat position uses 5 bits but was set to 8 since the other 3 was unused.
However, this creates invalid vfats in current data due to the unused bits not always being 0.
This was found from http://cmsonline.cern.ch/cms-elog/1178749.

#### PR validation:
Tested with wf 11611.0

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
backport of #41384

@watson-ij @yeckang 