### PR TITLE
[Backport][GEM][Bug Fix] GEMAMC runType is not used in the latest data format

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -40,7 +40,7 @@ public:
     // Last BC in AMC13 is different to TCDS, AMC, and VFAT
     error.badBC = !((amc13->bunchCrossing() == amc.bunchCrossing()) ||
                     (amc13->bunchCrossing() == 0 && amc.bunchCrossing() == GEMAMC13::lastBC));
-    error.badRunType = amc.runType() != 0x1;
+    error.badRunType = (amc.runType() != 0x1 and amc.formatVer() == 0);
     // Last OC in AMC13 is different to TCDS, AMC, and VFAT
     if (amc.formatVer() == 0)
       error.badOC =


### PR DESCRIPTION
#### PR description:

* The GEM raw data format has been updated last year. (#38062)
* runType in GEM AMC was valid in the old data format. But in the new data format, we didn't assign any bits for it.
* Recently, we realized that the GEMAMCStatus arose an error because of the unused bits in the new version of format.
* This PR fix the issue.
* We expect small changes from the unpacked GEM digi. And the changes will propagate to GEM local reconstruction results.
* Backport to CMSSW_13_0_X is needed for 2023 data taking.

#### PR validation:

* The code format has applied with `scram build code-format` and tested with `scram build code-checks`.
* The branch has tested with `runTheMatrix.py` scenarios which is using 2022 data.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* The original PR is #41444
