### PR TITLE
[13_0_X] Reverting BeamSpot Legacy DQM client error scale to 1p2

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -329,7 +329,7 @@ process.dqmBeamMonitor.resetPVEveryNLumi = 5 # was 10 for HI
 
 process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
 process.dqmBeamMonitor.PVFitter.minVertexNdf = 10
-process.dqmBeamMonitor.PVFitter.errorScale = 1.0
+process.dqmBeamMonitor.PVFitter.errorScale = 1.2
 
 #----------------------------
 # Pixel tracks/vertices reco


### PR DESCRIPTION
#### PR description:

This PR reverts the value of the error scale of the BeamSpot fit in the DQM Legacy client to 1.2
The error scale is a multiplicative term of the covariance matrix that accounts for under or over estimation of the PV errors.
The value 1.2 was estimated at the beginning of Run 1 operations and never changed since then.
At the beginning of the 2022 data taking at 13p6 TeV the client was constantly crashing due to fit failures. Offline investigations revealed that setting the error scale to 1.0 was curing the issue so we changed the value. Unfortunately we did not investigate the impact on the BeamSpot transverse widths. As you can see in the attachment we get a width of 18 um with error scale 1.2 which is quite far from the expected 10 um that we can get with an error scale of 1.2
We are in contact with Tracker DPG to perform an evaluation of the pixel vertices pulls using the split vertex method but we would to change the value in production before LHC moves to PHYSICS.

These change will affect the BeamSpot used in the HLT and Express reco and not the one in the Prompt reco. 

#### PR validation:

See attached plots. The code itself is unchanged.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. A forward port to 13_1_X will be made soon.

FYI: @mmusich @francescobrivio @gennai - could one of you please launch the test? Thanks!

@cmsdqm : can you please put this PR in production before the next stable beams? Thanks!

<img width="933" alt="2022G_errorScale1p0" src="https://user-images.githubusercontent.com/46677792/234884932-299b192f-5bef-4789-9f72-22357ef34389.png">
<img width="937" alt="2022G_errorScale1p2" src="https://user-images.githubusercontent.com/46677792/234884941-bde06fce-7b2d-4f36-b351-9956c53682d8.png">
