### PR TITLE
[13_0_X] Add loose showers to uGMT shower bit vs. BX DQM plot

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h
@@ -52,6 +52,7 @@ private:
   MonitorElement* ugmtEMTFBXvsProcessor;
   MonitorElement* ugmtBXvsLink;
 
+  static constexpr unsigned IDX_LOOSE_SHOWER{3};
   static constexpr unsigned IDX_TIGHT_SHOWER{2};
   static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };

--- a/DQM/L1TMonitor/src/L1TStage2uGMTInputBxDistributions.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTInputBxDistributions.cc
@@ -63,9 +63,10 @@ void L1TStage2uGMTInputBxDistributions::bookHistograms(DQMStore::IBooker& ibooke
       ibooker.setCurrentFolder(monitorDir_ + "/EMTFInput/Muon showers");
 
       ugmtEMTFShowerTypeOccupancyPerBx =
-          ibooker.book2D("ugmtEMTFShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 2, 1, 3);
+          ibooker.book2D("ugmtEMTFShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 3, 1, 4);
       ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("BX", 1);
       ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("Shower type", 2);
+      ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_LOOSE_SHOWER, "Loose", 2);
       ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
       ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
 
@@ -214,6 +215,11 @@ void L1TStage2uGMTInputBxDistributions::analyze(const edm::Event& e, const edm::
             ugmtEMTFShowerSectorOccupancyPerBx->Fill(
                 itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
             ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_TIGHT_SHOWER);
+          }
+          if (shower->isOneLooseInTime()) {
+            ugmtEMTFShowerSectorOccupancyPerBx->Fill(
+                itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_LOOSE_SHOWER);
           }
         }
       }


### PR DESCRIPTION
#### PR description:

This PR adds the loose showers from EMTF to the uGMT shower bit vs. BX DQM plot. (This one plot was forgotten in https://github.com/cms-sw/cmssw/pull/41216.)

#### PR validation:

Ran the usual commands to check formatting etc.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/41448, needed in the P5 DQM to monitor the new loose shower bits.
