### PR TITLE
Add protection to avoid crash in `lowPtGsfEleGsfTracks`

### DIFF
--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -12,12 +12,11 @@
 
 TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSurface& tsos,
                                                       const TrackingRecHit& aRecHit) const {
-
   if (!tsos.isValid()) {
     edm::LogError("GsfMultiStateUpdator") << "Trying to update trajectory state with invalid TSOS! ";
     return TrajectoryStateOnSurface();
   }
-  
+
   GetComponents comps(tsos);
   auto const& predictedComponents = comps();
   if (predictedComponents.empty()) {

--- a/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
+++ b/TrackingTools/GsfTracking/src/GsfMultiStateUpdator.cc
@@ -12,6 +12,12 @@
 
 TrajectoryStateOnSurface GsfMultiStateUpdator::update(const TrajectoryStateOnSurface& tsos,
                                                       const TrackingRecHit& aRecHit) const {
+
+  if (!tsos.isValid()) {
+    edm::LogError("GsfMultiStateUpdator") << "Trying to update trajectory state with invalid TSOS! ";
+    return TrajectoryStateOnSurface();
+  }
+  
   GetComponents comps(tsos);
   auto const& predictedComponents = comps();
   if (predictedComponents.empty()) {


### PR DESCRIPTION
#### PR description:
This PR is to fix a GSF crash in prompt-reco, as reported in https://github.com/cms-sw/cmssw/issues/41442
Thanks to @mmusich for providing this fix.

#### PR validation:
`runTheMatrix.py -l 12434.0` ran fine.
Also, checked with 1k MC events that electron reconstruction is otherwise not effected and physics results are identical after this change (see https://github.com/cms-sw/cmssw/issues/41442#issuecomment-1526071451)

A backport to 13_0_X is needed.