### PR TITLE
L1T: read pt compression bit depth from LUT for JEC

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -692,6 +692,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet>&
     // Calibrate using 3 LUTs: pt and eta compression LUTs, and a multiplicand/addend LUT.
     // The pt and eta are each converted to a compressed scale using individual LUTs
     // pt : 8 -> 4 bits, eta 6 -> 4 bits
+    // **updated** pt : 8 -> 6 bits, eta 6 -> 6 bits (uncompressed)
     // This then forms an address. Using the third LUT, we get a
     // multiplicand & addend, so we can do y = m*x + c on the original
     // (i.e. non-compressed) jet pt.
@@ -714,9 +715,11 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet>&
       if (jetHwPt >= 0x200) {
         jetHwPt = 0x1FF;
       }
+
+      unsigned int ptCompNrBits = params_->jetCompressPtLUT()->nrBitsData();
       unsigned int ptBin = params_->jetCompressPtLUT()->data(jetHwPt >> 1);
       unsigned int etaBin = params_->jetCompressEtaLUT()->data(abs(CaloTools::mpEta(jet->hwEta())));
-      unsigned int compBin = (etaBin << 4) | ptBin;
+      unsigned int compBin = (etaBin << ptCompNrBits) | ptBin;
 
       unsigned int addPlusMult = params_->jetCalibrationLUT()->data(compBin);
       unsigned int multiplier = addPlusMult & 0x3ff;


### PR DESCRIPTION
L1 will soon use finer granularity in the pt compression LUT used to obtain the JEC scale factors. 
This PR removes the hard-coded pt compression data bit depth of 4 and replaces it with the bit depth obtained from the input LUT, to get the address for the JEC LUT in the jet emulator.
This change should be transparent and produce no changes to the L1 jets. This has been checked by re-emulating 2022 data. 

Ran scram build code-format
Passes runTheMatrix.py -l limited -i all --ibeos
(all except 11634.911_TTbar_14TeV+2021_DD4hep  Step2-FAILED)