### PR TITLE
Disable CondToolsLHCInfoNewPopConTest for non-AMD64

### DIFF
--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -5,4 +5,6 @@
 </ifarch>
 <test name="CondToolsRunInfoTest" command="test_runinfo.sh"/>
 <test name="CondToolsLHCInfoTest" command="test_lhcInfo.sh"/>
+<ifarch value="x86_64">
 <test name="CondToolsLHCInfoNewPopConTest" command="test_lhcInfoNewPopCon.sh"/>
+</ifarch>


### PR DESCRIPTION
#### PR description:

The test was introduced in https://github.com/cms-sw/cmssw/pull/40817 and fails for non-amd64 architectures: it connects to Oracle databases, and proprietary libraries for that are only available for amd64.
