### PR TITLE
Added extra Invalid = -1 enum to avoid llvm16 build errors

### DIFF
--- a/CondFormats/L1TObjects/interface/L1GtDefinitions.h
+++ b/CondFormats/L1TObjects/interface/L1GtDefinitions.h
@@ -25,7 +25,7 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h"
 
 /// board types in GT
-enum L1GtBoardType { GTFE, FDL, PSB, GMT, TCS, TIM, BoardNull };
+enum L1GtBoardType { GTFE, FDL, PSB, GMT, TCS, TIM, BoardNull, L1GtBoardTypeInvalid = -1 };
 
 struct L1GtBoardTypeStringToEnum {
   const char* label;
@@ -62,7 +62,8 @@ enum L1GtPsbQuad {
   HfQ,
   BptxQ,
   GtExternalQ,
-  PsbQuadNull
+  PsbQuadNull,
+  L1GtPsbQuadInvalid = -1
 };
 
 struct L1GtPsbQuadStringToEnum {

--- a/DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h
+++ b/DataFormats/L1GlobalTrigger/interface/L1GtDefinitions.h
@@ -19,7 +19,8 @@ enum L1GtConditionType {
   TypeHfRingEtSums,
   TypeBptx,
   TypeExternal,
-  Type2corWithOverlapRemoval
+  Type2corWithOverlapRemoval,
+  L1GtConditionTypeInvalid = -1
 };
 
 /// condition categories
@@ -35,7 +36,8 @@ enum L1GtConditionCategory {
   CondHfRingEtSums,
   CondBptx,
   CondExternal,
-  CondCorrelationWithOverlapRemoval
+  CondCorrelationWithOverlapRemoval,
+  L1GtConditionCategoryInvalid = -1
 };
 
 #endif

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -26,7 +26,7 @@
 
 namespace l1t {
   /// board types in GT
-  enum L1GtBoardType { MP7, BoardNull };
+  enum L1GtBoardType { MP7, BoardNull, L1GtBoardTypeInvalid = -1 };
 
   struct L1GtBoardTypeStringToEnum {
     const char* label;
@@ -78,7 +78,8 @@ namespace l1t {
     TypeAsymEt,
     TypeAsymHt,
     TypeAsymEtHF,
-    TypeAsymHtHF
+    TypeAsymHtHF,
+    GtConditionTypeInvalid = -1
   };
 
   struct GtConditionTypeStringToEnum {
@@ -100,6 +101,7 @@ namespace l1t {
     CondCorrelationWithOverlapRemoval,
     CondCorrelationThreeBody,
     CondMuonShower,
+    GtConditionCategoryInvalid = -1
   };
 
   struct GtConditionCategoryStringToEnum {


### PR DESCRIPTION
I am trying to test [LLVM 16.0.3](https://github.com/cms-sw/cmsdist/pull/8472) for CLANG IBs and there are few build [a] [errors](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-b22fce/32191/build-logs/). Looks like llvm 16 does not like to set `-1` for an enum. ThisPR proposes to add the extra `Invalid = -1` enum value. Local tests with this change and llvm16 passed

[a] 
```
CondFormats/L1TObjects/src/L1GtDefinitions.cc:53:78: error: integer value -1 is outside the valid range of values [0, 7] for this enumeration type [-Wenum-constexpr-conversion]
                                                                    {nullptr, (L1GtBoardType)-1}};
CondFormats/L1TObjects/src/L1GtDefinitions.cc:81:74: error: integer value -1 is outside the valid range of values [0, 31] for this enumeration type [-Wenum-constexpr-conversion]
                                                                {nullptr, (L1GtPsbQuad)-1}};
```
