### PR TITLE
GetterOfProducts for output modules, use in DQMRootOutputModule

### DIFF
--- a/FWCore/Framework/interface/OutputModuleCore.h
+++ b/FWCore/Framework/interface/OutputModuleCore.h
@@ -20,6 +20,7 @@
 
 // system include files
 #include <array>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -28,6 +29,7 @@
 #include <set>
 
 // user include files
+#include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
@@ -112,6 +114,10 @@ namespace edm {
 
       const ModuleDescription& moduleDescription() const { return moduleDescription_; }
 
+      void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+        callWhenNewProductsRegistered_ = func;
+      }
+
     protected:
       ModuleDescription const& description() const;
 
@@ -190,6 +196,8 @@ namespace edm {
 
       OutputProcessBlockHelper outputProcessBlockHelper_;
 
+      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+
       //------------------------------------------------------------------
       // private member functions
       //------------------------------------------------------------------
@@ -207,7 +215,7 @@ namespace edm {
       /// Tell the OutputModule that is must end the current file.
       void doCloseFile();
 
-      void registerProductsAndCallbacks(OutputModuleCore const*, ProductRegistry const*) {}
+      void registerProductsAndCallbacks(OutputModuleCore const*, ProductRegistry*);
 
       bool needToRunSelection() const;
       std::vector<ProductResolverIndexAndSkipBit> productsUsedBySelection() const;

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -71,8 +71,6 @@ namespace edm {
     private:
       std::string workerType() const { return "WorkerT<edm::global::OutputModuleBase>"; }
 
-      void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
-
       virtual void preallocStreams(unsigned int) {}
       virtual void preallocate(PreallocationConfiguration const&) {}
       virtual void doBeginStream_(StreamID) {}

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -77,8 +77,6 @@ namespace edm {
 
       std::string workerType() const { return "WorkerT<edm::limited::OutputModuleBase>"; }
 
-      void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
-
       virtual void preallocStreams(unsigned int) {}
       virtual void preallocate(PreallocationConfiguration const&) {}
       virtual void doBeginStream_(StreamID) {}

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -79,8 +79,6 @@ namespace edm {
 
       std::string workerType() const { return "WorkerT<edm::one::OutputModuleBase>"; }
 
-      void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
-
       virtual void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                 ModuleCallingContext const& iModuleCallingContext,
                                                 Principal const& iPrincipal) const {}

--- a/FWCore/Framework/src/OutputModuleCore.cc
+++ b/FWCore/Framework/src/OutputModuleCore.cc
@@ -23,6 +23,7 @@
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/EventForOutput.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/src/insertSelectedProcesses.h"
@@ -255,6 +256,15 @@ namespace edm {
     }
 
     void OutputModuleCore::doEndJob() { endJob(); }
+
+    void OutputModuleCore::registerProductsAndCallbacks(OutputModuleCore const*, ProductRegistry* reg) {
+      if (callWhenNewProductsRegistered_) {
+        reg->callForEachBranch(callWhenNewProductsRegistered_);
+
+        Service<ConstProductRegistry> regService;
+        regService->watchProductAdditions(callWhenNewProductsRegistered_);
+      }
+    }
 
     bool OutputModuleCore::needToRunSelection() const { return !wantAllEvents_; }
 

--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
     <use name="FWCore/Utilities"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,ThingSource.cc,ThingExtSource.cc,ThingWithMergeProducer.cc,TestGetterOfProducts.cc,PutOrMergeTestSource.cc,TestGetByLabelAnalyzer.cc,ThingAnalyzer.cc"
+  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,ThingSource.cc,ThingExtSource.cc,ThingWithMergeProducer.cc,TestGetterOfProducts.cc,PutOrMergeTestSource.cc,TestGetByLabelAnalyzer.cc,ThingAnalyzer.cc,TestOutputWithGetterOfProducts.cc,TestOutputWithGetterOfProductsGlobal.cc,TestOutputWithGetterOfProductsLimited.cc"
       name="FWCoreIntegrationTestWithThing">
       <flags EDM_PLUGIN="1"/>
       <use name="FWCore/Framework"/>

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProducts.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProducts.cc
@@ -1,0 +1,141 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      TestOutputWithGetterOfProducts
+//
+/**\class edm::TestOutputWithGetterOfProducts
+
+  Description: Test GetterOfProducts with OutputModule
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  26 April 2023
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/Framework/interface/TypeMatch.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <vector>
+
+namespace edm {
+
+  class TestOutputWithGetterOfProducts : public one::OutputModule<RunCache<int>, LuminosityBlockCache<int>> {
+  public:
+    explicit TestOutputWithGetterOfProducts(ParameterSet const&);
+    static void fillDescriptions(ConfigurationDescriptions&);
+
+  private:
+    void write(EventForOutput const&) override;
+    void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
+    void writeRun(RunForOutput const&) override;
+
+    std::shared_ptr<int> globalBeginRun(RunForOutput const&) const override;
+    void globalEndRun(RunForOutput const&) override;
+
+    std::shared_ptr<int> globalBeginLuminosityBlock(LuminosityBlockForOutput const&) const override;
+    void globalEndLuminosityBlock(LuminosityBlockForOutput const&) override;
+    void endJob() override;
+
+    int sumThings(std::vector<Handle<edmtest::ThingCollection>> const& collections) const;
+
+    unsigned int sum_ = 0;
+    unsigned int expectedSum_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsRun_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsLumi_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsEvent_;
+  };
+
+  TestOutputWithGetterOfProducts::TestOutputWithGetterOfProducts(ParameterSet const& pset)
+      : one::OutputModuleBase(pset),
+        one::OutputModule<RunCache<int>, LuminosityBlockCache<int>>(pset),
+        expectedSum_(pset.getUntrackedParameter<unsigned int>("expectedSum")),
+        getterOfProductsRun_(TypeMatch(), this, InRun),
+        getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
+        getterOfProductsEvent_(edm::TypeMatch(), this) {
+    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+      getterOfProductsRun_(bd);
+      getterOfProductsLumi_(bd);
+      getterOfProductsEvent_(bd);
+    });
+  }
+
+  void TestOutputWithGetterOfProducts::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    OutputModule::fillDescription(desc);
+    desc.addUntracked<unsigned int>("expectedSum", 0);
+    descriptions.addDefault(desc);
+  }
+
+  void TestOutputWithGetterOfProducts::write(EventForOutput const& event) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsEvent_.fillHandles(event, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProducts::writeLuminosityBlock(LuminosityBlockForOutput const& lumi) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProducts::writeRun(RunForOutput const& run) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProducts::globalBeginRun(RunForOutput const& run) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProducts::globalEndRun(RunForOutput const& run) {
+    sum_ += *runCache(run.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProducts::globalBeginLuminosityBlock(
+      LuminosityBlockForOutput const& lumi) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProducts::globalEndLuminosityBlock(LuminosityBlockForOutput const& lumi) {
+    sum_ += *luminosityBlockCache(lumi.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProducts::endJob() {
+    if (expectedSum_ != 0 && expectedSum_ != sum_) {
+      throw cms::Exception("TestFailure") << "TestOutputWithGetterOfProducts::endJob, sum = " << sum_
+                                          << " which is not equal to the expected value " << expectedSum_;
+    }
+  }
+
+  int TestOutputWithGetterOfProducts::sumThings(std::vector<Handle<edmtest::ThingCollection>> const& collections) const {
+    int sum = 0;
+    for (auto const& collection : collections) {
+      for (auto const& thing : *collection) {
+        sum += thing.a;
+      }
+    }
+    return sum;
+  }
+}  // namespace edm
+
+using edm::TestOutputWithGetterOfProducts;
+DEFINE_FWK_MODULE(TestOutputWithGetterOfProducts);

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProductsGlobal.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProductsGlobal.cc
@@ -1,0 +1,143 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      TestOutputWithGetterOfProductsGlobal
+//
+/**\class edm::TestOutputWithGetterOfProductsGlobal
+
+  Description: Test GetterOfProducts with OutputModule
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  26 April 2023
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/OutputModule.h"
+#include "FWCore/Framework/interface/TypeMatch.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <atomic>
+#include <vector>
+
+namespace edm {
+
+  class TestOutputWithGetterOfProductsGlobal : public global::OutputModule<RunCache<int>, LuminosityBlockCache<int>> {
+  public:
+    explicit TestOutputWithGetterOfProductsGlobal(ParameterSet const&);
+    static void fillDescriptions(ConfigurationDescriptions&);
+
+  private:
+    void write(EventForOutput const&) override;
+    void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
+    void writeRun(RunForOutput const&) override;
+
+    std::shared_ptr<int> globalBeginRun(RunForOutput const&) const override;
+    void globalEndRun(RunForOutput const&) const override;
+
+    std::shared_ptr<int> globalBeginLuminosityBlock(LuminosityBlockForOutput const&) const override;
+    void globalEndLuminosityBlock(LuminosityBlockForOutput const&) const override;
+    void endJob() override;
+
+    int sumThings(std::vector<Handle<edmtest::ThingCollection>> const& collections) const;
+
+    mutable std::atomic<unsigned int> sum_ = 0;
+    unsigned int expectedSum_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsRun_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsLumi_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsEvent_;
+  };
+
+  TestOutputWithGetterOfProductsGlobal::TestOutputWithGetterOfProductsGlobal(ParameterSet const& pset)
+      : global::OutputModuleBase(pset),
+        global::OutputModule<RunCache<int>, LuminosityBlockCache<int>>(pset),
+        expectedSum_(pset.getUntrackedParameter<unsigned int>("expectedSum")),
+        getterOfProductsRun_(TypeMatch(), this, InRun),
+        getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
+        getterOfProductsEvent_(edm::TypeMatch(), this) {
+    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+      getterOfProductsRun_(bd);
+      getterOfProductsLumi_(bd);
+      getterOfProductsEvent_(bd);
+    });
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    OutputModule::fillDescription(desc);
+    desc.addUntracked<unsigned int>("expectedSum", 0);
+    descriptions.addDefault(desc);
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::write(EventForOutput const& event) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsEvent_.fillHandles(event, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::writeLuminosityBlock(LuminosityBlockForOutput const& lumi) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::writeRun(RunForOutput const& run) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProductsGlobal::globalBeginRun(RunForOutput const& run) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::globalEndRun(RunForOutput const& run) const {
+    sum_ += *runCache(run.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProductsGlobal::globalBeginLuminosityBlock(
+      LuminosityBlockForOutput const& lumi) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::globalEndLuminosityBlock(LuminosityBlockForOutput const& lumi) const {
+    sum_ += *luminosityBlockCache(lumi.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsGlobal::endJob() {
+    if (expectedSum_ != 0 && expectedSum_ != sum_.load()) {
+      throw cms::Exception("TestFailure") << "TestOutputWithGetterOfProductsGlobal::endJob, sum = " << sum_.load()
+                                          << " which is not equal to the expected value " << expectedSum_;
+    }
+  }
+
+  int TestOutputWithGetterOfProductsGlobal::sumThings(
+      std::vector<Handle<edmtest::ThingCollection>> const& collections) const {
+    int sum = 0;
+    for (auto const& collection : collections) {
+      for (auto const& thing : *collection) {
+        sum += thing.a;
+      }
+    }
+    return sum;
+  }
+}  // namespace edm
+
+using edm::TestOutputWithGetterOfProductsGlobal;
+DEFINE_FWK_MODULE(TestOutputWithGetterOfProductsGlobal);

--- a/FWCore/Integration/plugins/TestOutputWithGetterOfProductsLimited.cc
+++ b/FWCore/Integration/plugins/TestOutputWithGetterOfProductsLimited.cc
@@ -1,0 +1,143 @@
+// -*- C++ -*-
+//
+// Package:    FWCore/Integration
+// Class:      TestOutputWithGetterOfProductsLimited
+//
+/**\class edm::TestOutputWithGetterOfProductsLimited
+
+  Description: Test GetterOfProducts with OutputModule
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  26 April 2023
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/limited/OutputModule.h"
+#include "FWCore/Framework/interface/TypeMatch.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <atomic>
+#include <vector>
+
+namespace edm {
+
+  class TestOutputWithGetterOfProductsLimited : public limited::OutputModule<RunCache<int>, LuminosityBlockCache<int>> {
+  public:
+    explicit TestOutputWithGetterOfProductsLimited(ParameterSet const&);
+    static void fillDescriptions(ConfigurationDescriptions&);
+
+  private:
+    void write(EventForOutput const&) override;
+    void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
+    void writeRun(RunForOutput const&) override;
+
+    std::shared_ptr<int> globalBeginRun(RunForOutput const&) const override;
+    void globalEndRun(RunForOutput const&) const override;
+
+    std::shared_ptr<int> globalBeginLuminosityBlock(LuminosityBlockForOutput const&) const override;
+    void globalEndLuminosityBlock(LuminosityBlockForOutput const&) const override;
+    void endJob() override;
+
+    int sumThings(std::vector<Handle<edmtest::ThingCollection>> const& collections) const;
+
+    mutable std::atomic<unsigned int> sum_ = 0;
+    unsigned int expectedSum_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsRun_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsLumi_;
+    GetterOfProducts<edmtest::ThingCollection> getterOfProductsEvent_;
+  };
+
+  TestOutputWithGetterOfProductsLimited::TestOutputWithGetterOfProductsLimited(ParameterSet const& pset)
+      : limited::OutputModuleBase(pset),
+        limited::OutputModule<RunCache<int>, LuminosityBlockCache<int>>(pset),
+        expectedSum_(pset.getUntrackedParameter<unsigned int>("expectedSum")),
+        getterOfProductsRun_(TypeMatch(), this, InRun),
+        getterOfProductsLumi_(edm::TypeMatch(), this, InLumi),
+        getterOfProductsEvent_(edm::TypeMatch(), this) {
+    callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
+      getterOfProductsRun_(bd);
+      getterOfProductsLumi_(bd);
+      getterOfProductsEvent_(bd);
+    });
+  }
+
+  void TestOutputWithGetterOfProductsLimited::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    OutputModule::fillDescription(desc);
+    desc.addUntracked<unsigned int>("expectedSum", 0);
+    descriptions.addDefault(desc);
+  }
+
+  void TestOutputWithGetterOfProductsLimited::write(EventForOutput const& event) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsEvent_.fillHandles(event, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsLimited::writeLuminosityBlock(LuminosityBlockForOutput const& lumi) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsLimited::writeRun(RunForOutput const& run) {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProductsLimited::globalBeginRun(RunForOutput const& run) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProductsLimited::globalEndRun(RunForOutput const& run) const {
+    sum_ += *runCache(run.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsRun_.fillHandles(run, handles);
+    sum_ += sumThings(handles);
+  }
+
+  std::shared_ptr<int> TestOutputWithGetterOfProductsLimited::globalBeginLuminosityBlock(
+      LuminosityBlockForOutput const& lumi) const {
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    return std::make_shared<int>(sumThings(handles));
+  }
+
+  void TestOutputWithGetterOfProductsLimited::globalEndLuminosityBlock(LuminosityBlockForOutput const& lumi) const {
+    sum_ += *luminosityBlockCache(lumi.index());
+    std::vector<Handle<edmtest::ThingCollection>> handles;
+    getterOfProductsLumi_.fillHandles(lumi, handles);
+    sum_ += sumThings(handles);
+  }
+
+  void TestOutputWithGetterOfProductsLimited::endJob() {
+    if (expectedSum_ != 0 && expectedSum_ != sum_.load()) {
+      throw cms::Exception("TestFailure") << "TestOutputWithGetterOfProductsLimited::endJob, sum = " << sum_.load()
+                                          << " which is not equal to the expected value " << expectedSum_;
+    }
+  }
+
+  int TestOutputWithGetterOfProductsLimited::sumThings(
+      std::vector<Handle<edmtest::ThingCollection>> const& collections) const {
+    int sum = 0;
+    for (auto const& collection : collections) {
+      for (auto const& thing : *collection) {
+        sum += thing.a;
+      }
+    }
+    return sum;
+  }
+}  // namespace edm
+
+using edm::TestOutputWithGetterOfProductsLimited;
+DEFINE_FWK_MODULE(TestOutputWithGetterOfProductsLimited);

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -52,4 +52,7 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
   echo "testGetByWithEmptyRun_cfg.py"
   cmsRun -p ${LOCAL_TEST_DIR}/testGetByWithEmptyRun_cfg.py || die "cmsRun testGetByWithEmptyRun_cfg.py" $?
 
+  echo "testGetterOfProductsWithOutputModule_cfg.py"
+  cmsRun -p ${LOCAL_TEST_DIR}/testGetterOfProductsWithOutputModule_cfg.py || die "cmsRun testGetterOfProductsWithOutputModule_cfg.py" $?
+
 exit 0

--- a/FWCore/Integration/test/testGetterOfProductsWithOutputModule_cfg.py
+++ b/FWCore/Integration/test/testGetterOfProductsWithOutputModule_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 3
+
+process.thing = cms.EDProducer("ThingProducer",
+    nThings = cms.int32(4)
+)
+
+process.testOne = cms.OutputModule("TestOutputWithGetterOfProducts",
+    # 6 in one ThingCollection (0 + 1 + 2 + 3)
+    # 6 * (3 writeEvent + 1 writeLumi * 2 (begin + end) + 1 writeRun * 2 (begin + end)) = 42 for writes
+    # 6 * (1 endLumi * 2 (begin + end) + 1 endRun * 2 (begin + end)) = 24 for end transitions
+    # 6 * (1 beginLumi * 1 (begin) + 1 beginRun * 2 (begin)) = 12 for begin transitions
+    # 42 + 24 + 12 = 78
+    expectedSum = cms.untracked.uint32(78)
+)
+
+process.testGlobal = cms.OutputModule("TestOutputWithGetterOfProductsGlobal",
+    # 6 in one ThingCollection (0 + 1 + 2 + 3)
+    # 6 * (3 writeEvent + 1 writeLumi * 2 (begin + end) + 1 writeRun * 2 (begin + end)) = 42 for writes
+    # 6 * (1 endLumi * 2 (begin + end) + 1 endRun * 2 (begin + end)) = 24 for end transitions
+    # 6 * (1 beginLumi * 1 (begin) + 1 beginRun * 2 (begin)) = 12 for begin transitions
+    # 42 + 24 + 12 = 78
+    expectedSum = cms.untracked.uint32(78)
+)
+
+process.testLimited = cms.OutputModule("TestOutputWithGetterOfProductsLimited",
+    # 6 in one ThingCollection (0 + 1 + 2 + 3)
+    # 6 * (3 writeEvent + 1 writeLumi * 2 (begin + end) + 1 writeRun * 2 (begin + end)) = 42 for writes
+    # 6 * (1 endLumi * 2 (begin + end) + 1 endRun * 2 (begin + end)) = 24 for end transitions
+    # 6 * (1 beginLumi * 1 (begin) + 1 beginRun * 2 (begin)) = 12 for begin transitions
+    # 42 + 24 + 12 = 78
+    expectedSum = cms.untracked.uint32(78)
+)
+
+process.path = cms.Path(process.thing)
+
+process.endPath = cms.EndPath(process.testOne * process.testGlobal * process.testLimited)


### PR DESCRIPTION
#### PR description:

Extends support for GetterOfProducts to output modules and uses that instead of consumesMany in DQMRootOutputModule. DQMRootOutputModule is the last module using consumesMany in CMSSW outside of Core unit tests and finishing the consumesMany migration was the initial motivation for this work. Even without that motivation, it is a good thing that output modules now support GetterOfProducts in the same way as producers, filter and analyzers.

#### PR validation:

This includes a new unit test using GetterOfProducts to read products in a one, a limited and a global output module.
 