### PR TITLE
Improve thread efficiency of CSCTriggerPrimitivesProducer

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -53,7 +53,7 @@ public:
                        unsigned sector,
                        unsigned subsector,
                        unsigned chamber,
-                       const edm::ParameterSet& conf);
+                       CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~CSCAnodeLCTProcessor() override = default;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -12,13 +12,45 @@
 
 class CSCBaseboard {
 public:
+  struct Parameters {
+    Parameters(edm::ParameterSet const& conf);
+
+    edm::ParameterSet const& conf() const { return *conf_; }
+
+    edm::ParameterSet const& commonParams() const { return commonParams_; }
+    edm::ParameterSet const& showerParams() const { return showerParams_; }
+    edm::ParameterSet const& tmbParams() const { return tmbParams_; }
+    edm::ParameterSet const& alctParams() const { return alctParams_; }
+    edm::ParameterSet const& clctParams() const { return clctParams_; }
+
+    void chooseParams(std::string_view tmb, std::string_view alct, std::string_view clct);
+
+  private:
+    edm::ParameterSet const* conf_;
+
+    // Parameters common for all boards
+    edm::ParameterSet const commonParams_;
+
+    // Shower Trigger parameters:
+    edm::ParameterSet const showerParams_;
+
+    // Motherboard parameters:
+    edm::ParameterSet tmbParams_;
+
+    // ALCT Processor parameters:
+    edm::ParameterSet alctParams_;
+
+    // CLCT Processor parameters:
+    edm::ParameterSet clctParams_;
+
+    std::string tmbName_;
+    std::string alctName_;
+    std::string clctName_;
+  };
+
   /** Normal constructor. */
-  CSCBaseboard(unsigned endcap,
-               unsigned station,
-               unsigned sector,
-               unsigned subsector,
-               unsigned chamber,
-               const edm::ParameterSet& conf);
+  CSCBaseboard(
+      unsigned endcap, unsigned station, unsigned sector, unsigned subsector, unsigned chamber, Parameters& conf);
 
   /** Constructor for use during testing. */
   CSCBaseboard();
@@ -70,21 +102,6 @@ protected:
 
   const CSCGeometry* cscGeometry_;
   const CSCChamber* cscChamber_;
-
-  // Parameters common for all boards
-  edm::ParameterSet commonParams_;
-
-  // Motherboard parameters:
-  edm::ParameterSet tmbParams_;
-
-  // ALCT Processor parameters:
-  edm::ParameterSet alctParams_;
-
-  // CLCT Processor parameters:
-  edm::ParameterSet clctParams_;
-
-  // Shower Trigger parameters:
-  edm::ParameterSet showerParams_;
 
   // chamber name, e.g. ME+1/1/9
   std::string theCSCName_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -49,7 +49,7 @@ public:
                          unsigned sector,
                          unsigned subsector,
                          unsigned chamber,
-                         const edm::ParameterSet& conf);
+                         CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~CSCCathodeLCTProcessor() override = default;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -28,7 +28,7 @@ public:
                     unsigned sector,
                     unsigned subsector,
                     unsigned chamber,
-                    const edm::ParameterSet& conf);
+                    CSCBaseboard::Parameters& conf);
 
   ~CSCGEMMotherboard() override;
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -55,7 +55,7 @@ public:
                  unsigned sector,
                  unsigned subsector,
                  unsigned chamber,
-                 const edm::ParameterSet& conf);
+                 CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~CSCMotherboard() override = default;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeAnodeLCTProcessor.h
@@ -21,7 +21,7 @@ public:
                               unsigned sector,
                               unsigned subsector,
                               unsigned chamber,
-                              const edm::ParameterSet& conf);
+                              CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~CSCUpgradeAnodeLCTProcessor() override{};

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
@@ -29,7 +29,7 @@ public:
                                 unsigned sector,
                                 unsigned subsector,
                                 unsigned chamber,
-                                const edm::ParameterSet& conf);
+                                CSCBaseboard::Parameters& conf);
 
 private:
   /* Phase2 version. Check all half-strip pattern envelopes simultaneously,

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
@@ -62,7 +62,7 @@ public:
                        unsigned sector,
                        unsigned subsector,
                        unsigned chamber,
-                       const edm::ParameterSet& conf);
+                       CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~LCTQualityAssignment() override {}

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityControl.h
@@ -27,7 +27,7 @@ public:
                     unsigned sector,
                     unsigned subsector,
                     unsigned chamber,
-                    const edm::ParameterSet& conf);
+                    CSCBaseboard::Parameters& conf);
 
   /** Default destructor. */
   ~LCTQualityControl() override = default;

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -1,6 +1,3 @@
-#ifndef L1Trigger_CSCTriggerPrimitives_CSCTriggerPrimitivesProducer_h
-#define L1Trigger_CSCTriggerPrimitives_CSCTriggerPrimitivesProducer_h
-
 /** \class CSCTriggerPrimitivesProducer
  *
  * Implementation of the local Level-1 Cathode Strip Chamber trigger.
@@ -27,9 +24,11 @@
  */
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/limited/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -56,19 +55,19 @@
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 
 // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
-class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<> {
+class CSCTriggerPrimitivesProducer : public edm::limited::EDProducer<> {
 public:
   explicit CSCTriggerPrimitivesProducer(const edm::ParameterSet&);
   ~CSCTriggerPrimitivesProducer() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  // master configuration
-  edm::ParameterSet config_;
-
   // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
-  std::unique_ptr<CSCTriggerPrimitivesBuilder> builder_;
+  std::vector<std::unique_ptr<CSCTriggerPrimitivesBuilder>> builders_;
+  mutable std::vector<std::atomic<bool>> usedBuilders_;
 
   // input tags for input collections
   edm::InputTag compDigiProducer_;
@@ -86,6 +85,8 @@ private:
   edm::ESGetToken<CSCL1TPLookupTableME11ILT, CSCL1TPLookupTableME11ILTRcd> pLookupTableME11ILTToken_;
   edm::ESGetToken<CSCL1TPLookupTableME21ILT, CSCL1TPLookupTableME21ILTRcd> pLookupTableME21ILTToken_;
   edm::ESGetToken<CSCDBL1TPParameters, CSCDBL1TPParametersRcd> confToken_;
+
+  std::unique_ptr<CSCBadChambers const> dummyBadChambers_;
   // switch to force the use of parameters from config file rather then from DB
   bool debugParameters_;
 
@@ -109,11 +110,8 @@ private:
   bool runME21ILT_;
 };
 
-#endif
-
-CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterSet& conf) {
-  config_ = conf;
-
+CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterSet& conf)
+    : edm::limited::EDProducerBase(conf), edm::limited::EDProducer<>(conf) {
   // if false, parameters will be read in from DB using EventSetup mechanism
   // else will use all parameters from the config file
   debugParameters_ = conf.getParameter<bool>("debugParameters");
@@ -123,13 +121,18 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   gemPadDigiClusterProducer_ = conf.getParameter<edm::InputTag>("GEMPadDigiClusterProducer");
 
   checkBadChambers_ = conf.getParameter<bool>("checkBadChambers");
+  if (not checkBadChambers_) {
+    dummyBadChambers_ = std::make_unique<CSCBadChambers>();
+  } else {
+    pBadChambersToken_ = esConsumes<CSCBadChambers, CSCBadChambersRcd>();
+  }
 
   keepCLCTPreTriggers_ = conf.getParameter<bool>("keepCLCTPreTriggers");
   keepALCTPreTriggers_ = conf.getParameter<bool>("keepALCTPreTriggers");
   keepShowers_ = conf.getParameter<bool>("keepShowers");
 
   // check whether you need to run the integrated local triggers
-  const edm::ParameterSet commonParam(conf.getParameter<edm::ParameterSet>("commonParam"));
+  const edm::ParameterSet& commonParam = conf.getParameter<edm::ParameterSet>("commonParam");
   runCCLUT_TMB_ = commonParam.getParameter<bool>("runCCLUT_TMB");
   runCCLUT_OTMB_ = commonParam.getParameter<bool>("runCCLUT_OTMB");
   runCCLUT_ = runCCLUT_TMB_ or runCCLUT_OTMB_;
@@ -140,12 +143,12 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
 
   wire_token_ = consumes<CSCWireDigiCollection>(wireDigiProducer_);
   comp_token_ = consumes<CSCComparatorDigiCollection>(compDigiProducer_);
-  if (runILT_)
+  if (runILT_) {
     gem_pad_cluster_token_ = consumes<GEMPadDigiClusterCollection>(gemPadDigiClusterProducer_);
+    gemToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
+  }
 
   cscToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
-  gemToken_ = esConsumes<GEMGeometry, MuonGeometryRecord>();
-  pBadChambersToken_ = esConsumes<CSCBadChambers, CSCBadChambersRcd>();
   // consume lookup tables only when flags are set
   if (runCCLUT_)
     pLookupTableCCLUTToken_ = esConsumes<CSCL1TPLookupTableCCLUT, CSCL1TPLookupTableCCLUTRcd>();
@@ -153,7 +156,8 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
     pLookupTableME11ILTToken_ = esConsumes<CSCL1TPLookupTableME11ILT, CSCL1TPLookupTableME11ILTRcd>();
   if (runME21ILT_)
     pLookupTableME21ILTToken_ = esConsumes<CSCL1TPLookupTableME21ILT, CSCL1TPLookupTableME21ILTRcd>();
-  confToken_ = esConsumes<CSCDBL1TPParameters, CSCDBL1TPParametersRcd>();
+  if (not debugParameters_)
+    confToken_ = esConsumes<CSCDBL1TPParameters, CSCDBL1TPParametersRcd>();
 
   // register what this produces
   produces<CSCALCTDigiCollection>();
@@ -175,29 +179,57 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   if (runILT_) {
     produces<GEMCoPadDigiCollection>();
   }
-  // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
-  builder_ = std::make_unique<CSCTriggerPrimitivesBuilder>(config_);
+  auto n = concurrencyLimit();
+  builders_.reserve(n);
+  //usedBuilders_.reserve(n);
+  usedBuilders_ = std::vector<std::atomic<bool>>(n);
+  for (auto i = 0U; i < n; ++i) {
+    // temporarily switch to a "one" module with a CSCTriggerPrimitivesBuilder data member
+    builders_.emplace_back(std::make_unique<CSCTriggerPrimitivesBuilder>(conf));
+  }
+}
+
+void CSCTriggerPrimitivesProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.addUntracked<unsigned int>("concurrencyLimit", 1);
+
+  desc.setAllowAnything();
+  descriptions.addDefault(desc);
 }
 
 CSCTriggerPrimitivesProducer::~CSCTriggerPrimitivesProducer() {}
 
-void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
+void CSCTriggerPrimitivesProducer::produce(edm::StreamID, edm::Event& ev, const edm::EventSetup& setup) const {
+  unsigned int builderIndex = 0;
+  for (auto& used : usedBuilders_) {
+    bool expected = false;
+    if (used.compare_exchange_strong(expected, true)) {
+      break;
+    } else {
+      ++builderIndex;
+    }
+  }
+  assert(builderIndex < usedBuilders_.size());
+  auto* builder = builders_[builderIndex].get();
+
+  //make sure usedBuilders_[builderIndex] = false is done even if have an exception
+  auto reset = [](std::atomic<bool>* iValue) { *iValue = false; };
+  std::unique_ptr<std::atomic<bool>, decltype(reset)> usedGuard(&usedBuilders_[builderIndex], reset);
+
   // get the csc geometry
-  builder_->setCSCGeometry(&setup.getData(cscToken_));
+  builder->setCSCGeometry(&setup.getData(cscToken_));
 
   // get the gem geometry if it's there
-  edm::ESHandle<GEMGeometry> h_gem = setup.getHandle(gemToken_);
   if (runILT_) {
+    edm::ESHandle<GEMGeometry> h_gem = setup.getHandle(gemToken_);
     if (h_gem.isValid()) {
-      builder_->setGEMGeometry(&*h_gem);
+      builder->setGEMGeometry(&*h_gem);
     } else {
       edm::LogWarning("CSCTriggerPrimitivesProducer|NoGEMGeometry")
           << "GEM geometry is unavailable. Running CSC-only trigger algorithm. +++\n";
     }
   }
-
-  // Find conditions data for bad chambers.
-  edm::ESHandle<CSCBadChambers> pBadChambers = setup.getHandle(pBadChambersToken_);
 
   if (runCCLUT_) {
     edm::ESHandle<CSCL1TPLookupTableCCLUT> conf = setup.getHandle(pLookupTableCCLUTToken_);
@@ -206,7 +238,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
           << "Failed to find a CSCL1TPLookupTableCCLUTRcd in EventSetup with runCCLUT_ on";
       return;
     }
-    builder_->setESLookupTables(conf.product());
+    builder->setESLookupTables(conf.product());
   }
 
   if (runME11ILT_) {
@@ -216,7 +248,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
           << "Failed to find a CSCL1TPLookupTableME11ILTRcd in EventSetup with runME11ILT_ on";
       return;
     }
-    builder_->setESLookupTables(conf.product());
+    builder->setESLookupTables(conf.product());
   }
 
   if (runME21ILT_) {
@@ -226,7 +258,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
           << "Failed to find a CSCL1TPLookupTableME21ILTRcd in EventSetup with runME21ILT_ on";
       return;
     }
-    builder_->setESLookupTables(conf.product());
+    builder->setESLookupTables(conf.product());
   }
 
   // If !debugParameters then get config parameters using EventSetup mechanism.
@@ -240,7 +272,7 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
           << "+++ Cannot continue emulation without these parameters +++\n";
       return;
     }
-    builder_->setConfigParameters(conf.product());
+    builder->setConfigParameters(conf.product());
   }
 
   // Get the collections of comparator & wire digis from event.
@@ -298,24 +330,28 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev, const edm::EventSetup
 
   // Fill output collections if valid input collections are available.
   if (wireDigis.isValid() && compDigis.isValid()) {
-    const CSCBadChambers* temp = checkBadChambers_ ? pBadChambers.product() : new CSCBadChambers;
-    builder_->build(temp,
-                    wireDigis.product(),
-                    compDigis.product(),
-                    gemPadClusters,
-                    *oc_alct,
-                    *oc_clct,
-                    *oc_alctpretrigger,
-                    *oc_clctpretrigger,
-                    *oc_pretrig,
-                    *oc_lct,
-                    *oc_sorted_lct,
-                    *oc_shower_anode,
-                    *oc_shower_cathode,
-                    *oc_shower,
-                    *oc_gemcopad);
-    if (!checkBadChambers_)
-      delete temp;
+    const CSCBadChambers* temp = nullptr;
+    if (checkBadChambers_) {
+      // Find conditions data for bad chambers.
+      temp = &setup.getData(pBadChambersToken_);
+    } else {
+      temp = dummyBadChambers_.get();
+    }
+    builder->build(temp,
+                   wireDigis.product(),
+                   compDigis.product(),
+                   gemPadClusters,
+                   *oc_alct,
+                   *oc_clct,
+                   *oc_alctpretrigger,
+                   *oc_clctpretrigger,
+                   *oc_pretrig,
+                   *oc_lct,
+                   *oc_sorted_lct,
+                   *oc_shower_anode,
+                   *oc_shower_cathode,
+                   *oc_shower,
+                   *oc_gemcopad);
   }
 
   // Put collections in event.

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -22,43 +22,43 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap,
                                            unsigned sector,
                                            unsigned subsector,
                                            unsigned chamber,
-                                           const edm::ParameterSet& conf)
+                                           CSCBaseboard::Parameters& conf)
     : CSCBaseboard(endcap, station, sector, subsector, chamber, conf) {
   static std::atomic<bool> config_dumped{false};
 
   // ALCT configuration parameters.
-  fifo_tbins = alctParams_.getParameter<unsigned int>("alctFifoTbins");
-  fifo_pretrig = alctParams_.getParameter<unsigned int>("alctFifoPretrig");
-  drift_delay = alctParams_.getParameter<unsigned int>("alctDriftDelay");
-  nplanes_hit_pretrig = alctParams_.getParameter<unsigned int>("alctNplanesHitPretrig");
-  nplanes_hit_pattern = alctParams_.getParameter<unsigned int>("alctNplanesHitPattern");
-  nplanes_hit_accel_pretrig = alctParams_.getParameter<unsigned int>("alctNplanesHitAccelPretrig");
-  nplanes_hit_accel_pattern = alctParams_.getParameter<unsigned int>("alctNplanesHitAccelPattern");
-  trig_mode = alctParams_.getParameter<unsigned int>("alctTrigMode");
-  accel_mode = alctParams_.getParameter<unsigned int>("alctAccelMode");
-  l1a_window_width = alctParams_.getParameter<unsigned int>("alctL1aWindowWidth");
+  fifo_tbins = conf.alctParams().getParameter<unsigned int>("alctFifoTbins");
+  fifo_pretrig = conf.alctParams().getParameter<unsigned int>("alctFifoPretrig");
+  drift_delay = conf.alctParams().getParameter<unsigned int>("alctDriftDelay");
+  nplanes_hit_pretrig = conf.alctParams().getParameter<unsigned int>("alctNplanesHitPretrig");
+  nplanes_hit_pattern = conf.alctParams().getParameter<unsigned int>("alctNplanesHitPattern");
+  nplanes_hit_accel_pretrig = conf.alctParams().getParameter<unsigned int>("alctNplanesHitAccelPretrig");
+  nplanes_hit_accel_pattern = conf.alctParams().getParameter<unsigned int>("alctNplanesHitAccelPattern");
+  trig_mode = conf.alctParams().getParameter<unsigned int>("alctTrigMode");
+  accel_mode = conf.alctParams().getParameter<unsigned int>("alctAccelMode");
+  l1a_window_width = conf.alctParams().getParameter<unsigned int>("alctL1aWindowWidth");
 
-  hit_persist = alctParams_.getParameter<unsigned int>("alctHitPersist");
+  hit_persist = conf.alctParams().getParameter<unsigned int>("alctHitPersist");
 
   // Verbosity level, set to 0 (no print) by default.
-  infoV = alctParams_.getParameter<int>("verbosity");
+  infoV = conf.alctParams().getParameter<int>("verbosity");
 
   // separate handle for early time bins
-  early_tbins = alctParams_.getParameter<int>("alctEarlyTbins");
+  early_tbins = conf.alctParams().getParameter<int>("alctEarlyTbins");
   if (early_tbins < 0)
     early_tbins = fifo_pretrig - CSCConstants::ALCT_EMUL_TIME_OFFSET;
 
   // delta BX time depth for ghostCancellationLogic
-  ghost_cancellation_bx_depth = alctParams_.getParameter<int>("alctGhostCancellationBxDepth");
+  ghost_cancellation_bx_depth = conf.alctParams().getParameter<int>("alctGhostCancellationBxDepth");
 
   // whether to consider ALCT candidates' qualities while doing ghostCancellationLogic on +-1 wire groups
-  ghost_cancellation_side_quality = alctParams_.getParameter<bool>("alctGhostCancellationSideQuality");
+  ghost_cancellation_side_quality = conf.alctParams().getParameter<bool>("alctGhostCancellationSideQuality");
 
   // deadtime clocks after pretrigger (extra in addition to drift_delay)
-  pretrig_extra_deadtime = alctParams_.getParameter<unsigned int>("alctPretrigDeadtime");
+  pretrig_extra_deadtime = conf.alctParams().getParameter<unsigned int>("alctPretrigDeadtime");
 
   // whether to use narrow pattern mask for the rings close to the beam
-  narrow_mask_r1 = alctParams_.getParameter<bool>("alctNarrowMaskForR1");
+  narrow_mask_r1 = conf.alctParams().getParameter<bool>("alctNarrowMaskForR1");
 
   // Check and print configuration parameters.
   checkConfigParameters();
@@ -73,7 +73,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap,
   // whether to calculate bx as corrected_bx instead of pretrigger one
   use_corrected_bx = false;
   if (runPhase2_) {
-    use_corrected_bx = alctParams_.getParameter<bool>("alctUseCorrectedBx");
+    use_corrected_bx = conf.alctParams().getParameter<bool>("alctUseCorrectedBx");
   }
 
   // Load appropriate pattern mask.
@@ -82,7 +82,7 @@ CSCAnodeLCTProcessor::CSCAnodeLCTProcessor(unsigned endcap,
   // quality control of stubs
   qualityControl_ = std::make_unique<LCTQualityControl>(endcap, station, sector, subsector, chamber, conf);
 
-  const auto& shower = showerParams_.getParameterSet("anodeShower");
+  const auto& shower = conf.showerParams().getParameterSet("anodeShower");
   thresholds_ = shower.getParameter<std::vector<unsigned>>("showerThresholds");
   showerNumTBins_ = shower.getParameter<unsigned>("showerNumTBins");
   minLayersCentralTBin_ = shower.getParameter<unsigned>("minLayersCentralTBin");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -1,11 +1,27 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h"
 
-CSCBaseboard::CSCBaseboard(unsigned endcap,
-                           unsigned station,
-                           unsigned sector,
-                           unsigned subsector,
-                           unsigned chamber,
-                           const edm::ParameterSet& conf)
+CSCBaseboard::Parameters::Parameters(const edm::ParameterSet& conf)
+    : conf_(&conf),
+      commonParams_(conf.getParameter<edm::ParameterSet>("commonParam")),
+      showerParams_(conf.getParameterSet("showerParam")){};
+
+void CSCBaseboard::Parameters::chooseParams(std::string_view tmb, std::string_view alct, std::string_view clct) {
+  if (tmbName_ != tmb) {
+    tmbParams_ = conf_->getParameter<edm::ParameterSet>(std::string(tmb));
+    tmbName_ = tmb;
+  }
+  if (alctName_ != alct) {
+    alctParams_ = conf_->getParameter<edm::ParameterSet>(std::string(alct));
+    alctName_ = alct;
+  }
+  if (clctName_ != clct) {
+    clctParams_ = conf_->getParameter<edm::ParameterSet>(std::string(clct));
+    clctName_ = clct;
+  }
+}
+
+CSCBaseboard::CSCBaseboard(
+    unsigned endcap, unsigned station, unsigned sector, unsigned subsector, unsigned chamber, Parameters& conf)
     : theEndcap(endcap), theStation(station), theSector(sector), theSubsector(subsector), theTrigChamber(chamber) {
   theRegion = (theEndcap == 1) ? 1 : -1;
 
@@ -26,38 +42,34 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
   const bool hasOTMB(isME11_ or isME21_ or isME31_ or isME41_);
   cscId_ = CSCDetId(theEndcap, theStation, theRing, theChamber, 0);
 
-  commonParams_ = conf.getParameter<edm::ParameterSet>("commonParam");
-
-  showerParams_ = conf.getParameterSet("showerParam");
-
   theCSCName_ = CSCDetId::chamberName(theEndcap, theStation, theRing, theChamber);
 
-  runPhase2_ = commonParams_.getParameter<bool>("runPhase2");
+  runPhase2_ = conf.commonParams().getParameter<bool>("runPhase2");
 
-  enableAlctPhase2_ = commonParams_.getParameter<bool>("enableAlctPhase2");
+  enableAlctPhase2_ = conf.commonParams().getParameter<bool>("enableAlctPhase2");
 
-  disableME1a_ = commonParams_.getParameter<bool>("disableME1a");
+  disableME1a_ = conf.commonParams().getParameter<bool>("disableME1a");
 
-  gangedME1a_ = commonParams_.getParameter<bool>("gangedME1a");
+  gangedME1a_ = conf.commonParams().getParameter<bool>("gangedME1a");
 
-  runME11Up_ = commonParams_.getParameter<bool>("runME11Up");
-  runME21Up_ = commonParams_.getParameter<bool>("runME21Up");
-  runME31Up_ = commonParams_.getParameter<bool>("runME31Up");
-  runME41Up_ = commonParams_.getParameter<bool>("runME41Up");
+  runME11Up_ = conf.commonParams().getParameter<bool>("runME11Up");
+  runME21Up_ = conf.commonParams().getParameter<bool>("runME21Up");
+  runME31Up_ = conf.commonParams().getParameter<bool>("runME31Up");
+  runME41Up_ = conf.commonParams().getParameter<bool>("runME41Up");
 
-  runME11ILT_ = commonParams_.getParameter<bool>("runME11ILT");
-  runME21ILT_ = commonParams_.getParameter<bool>("runME21ILT");
+  runME11ILT_ = conf.commonParams().getParameter<bool>("runME11ILT");
+  runME21ILT_ = conf.commonParams().getParameter<bool>("runME21ILT");
 
-  run3_ = commonParams_.getParameter<bool>("run3");
-  runCCLUT_TMB_ = commonParams_.getParameter<bool>("runCCLUT_TMB");
-  runCCLUT_OTMB_ = commonParams_.getParameter<bool>("runCCLUT_OTMB");
+  run3_ = conf.commonParams().getParameter<bool>("run3");
+  runCCLUT_TMB_ = conf.commonParams().getParameter<bool>("runCCLUT_TMB");
+  runCCLUT_OTMB_ = conf.commonParams().getParameter<bool>("runCCLUT_OTMB");
   // check if CCLUT should be on in this chamber
   runCCLUT_ = (hasTMB and runCCLUT_TMB_) or (hasOTMB and runCCLUT_OTMB_);
 
   // general case
-  tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbPhase1");
-  alctParams_ = conf.getParameter<edm::ParameterSet>("alctPhase1");
-  clctParams_ = conf.getParameter<edm::ParameterSet>("clctPhase1");
+  std::string_view tmbParams = "tmbPhase1";
+  std::string_view alctParams = "alctPhase1";
+  std::string_view clctParams = "clctPhase1";
 
   const bool upgradeME11 = runPhase2_ and isME11_ and runME11Up_;
   const bool upgradeME21 = runPhase2_ and isME21_ and runME21Up_;
@@ -66,27 +78,28 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
   const bool upgradeME = upgradeME11 or upgradeME21 or upgradeME31 or upgradeME41;
 
   if (upgradeME) {
-    tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbPhase2");
-    clctParams_ = conf.getParameter<edm::ParameterSet>("clctPhase2");
+    tmbParams = "tmbPhase2";
+    clctParams = "clctPhase2";
     // upgrade ME1/1
     if (upgradeME11) {
       // do not run the Phase-2 ALCT for Run-3
       if (enableAlctPhase2_) {
-        alctParams_ = conf.getParameter<edm::ParameterSet>("alctPhase2");
+        alctParams = "alctPhase2";
       }
 
       if (runME11ILT_) {
-        tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbPhase2GE11");
-        clctParams_ = conf.getParameter<edm::ParameterSet>("clctPhase2GEM");
+        tmbParams = "tmbPhase2GE11";
+        clctParams = "clctPhase2GEM";
       }
     }
     // upgrade ME2/1
     if (upgradeME21 and runME21ILT_) {
-      tmbParams_ = conf.getParameter<edm::ParameterSet>("tmbPhase2GE21");
-      clctParams_ = conf.getParameter<edm::ParameterSet>("clctPhase2GEM");
-      alctParams_ = conf.getParameter<edm::ParameterSet>("alctPhase2GEM");
+      tmbParams = "tmbPhase2GE21";
+      clctParams = "clctPhase2GEM";
+      alctParams = "alctPhase2GEM";
     }
   }
+  conf.chooseParams(tmbParams, alctParams, clctParams);
 }
 
 CSCBaseboard::CSCBaseboard() : theEndcap(1), theStation(1), theSector(1), theSubsector(1), theTrigChamber(1) {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -23,32 +23,32 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
                                                unsigned sector,
                                                unsigned subsector,
                                                unsigned chamber,
-                                               const edm::ParameterSet& conf)
+                                               CSCBaseboard::Parameters& conf)
     : CSCBaseboard(endcap, station, sector, subsector, chamber, conf) {
   static std::atomic<bool> config_dumped{false};
 
   // CLCT configuration parameters.
-  fifo_tbins = clctParams_.getParameter<unsigned int>("clctFifoTbins");
-  hit_persist = clctParams_.getParameter<unsigned int>("clctHitPersist");
-  drift_delay = clctParams_.getParameter<unsigned int>("clctDriftDelay");
-  nplanes_hit_pretrig = clctParams_.getParameter<unsigned int>("clctNplanesHitPretrig");
-  nplanes_hit_pattern = clctParams_.getParameter<unsigned int>("clctNplanesHitPattern");
+  fifo_tbins = conf.clctParams().getParameter<unsigned int>("clctFifoTbins");
+  hit_persist = conf.clctParams().getParameter<unsigned int>("clctHitPersist");
+  drift_delay = conf.clctParams().getParameter<unsigned int>("clctDriftDelay");
+  nplanes_hit_pretrig = conf.clctParams().getParameter<unsigned int>("clctNplanesHitPretrig");
+  nplanes_hit_pattern = conf.clctParams().getParameter<unsigned int>("clctNplanesHitPattern");
 
   // Not used yet.
-  fifo_pretrig = clctParams_.getParameter<unsigned int>("clctFifoPretrig");
+  fifo_pretrig = conf.clctParams().getParameter<unsigned int>("clctFifoPretrig");
 
-  pid_thresh_pretrig = clctParams_.getParameter<unsigned int>("clctPidThreshPretrig");
-  min_separation = clctParams_.getParameter<unsigned int>("clctMinSeparation");
+  pid_thresh_pretrig = conf.clctParams().getParameter<unsigned int>("clctPidThreshPretrig");
+  min_separation = conf.clctParams().getParameter<unsigned int>("clctMinSeparation");
 
-  start_bx_shift = clctParams_.getParameter<int>("clctStartBxShift");
+  start_bx_shift = conf.clctParams().getParameter<int>("clctStartBxShift");
 
-  localShowerZone = clctParams_.getParameter<int>("clctLocalShowerZone");
+  localShowerZone = conf.clctParams().getParameter<int>("clctLocalShowerZone");
 
-  localShowerThresh = clctParams_.getParameter<int>("clctLocalShowerThresh");
+  localShowerThresh = conf.clctParams().getParameter<int>("clctLocalShowerThresh");
 
   // Motherboard parameters: common for all configurations.
   tmb_l1a_window_size =  // Common to CLCT and TMB
-      tmbParams_.getParameter<unsigned int>("tmbL1aWindowSize");
+      conf.tmbParams().getParameter<unsigned int>("tmbL1aWindowSize");
 
   /*
     In Summer 2021 the CLCT readout function was updated so that the
@@ -56,15 +56,15 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     time BX7. In the past the window was based on early_tbins and late_tbins.
     The parameter is kept, but is not used.
   */
-  early_tbins = tmbParams_.getParameter<int>("tmbEarlyTbins");
+  early_tbins = conf.tmbParams().getParameter<int>("tmbEarlyTbins");
   if (early_tbins < 0)
     early_tbins = fifo_pretrig - CSCConstants::CLCT_EMUL_TIME_OFFSET;
 
   // wether to readout only the earliest two LCTs in readout window
-  readout_earliest_2 = tmbParams_.getParameter<bool>("tmbReadoutEarliest2");
+  readout_earliest_2 = conf.tmbParams().getParameter<bool>("tmbReadoutEarliest2");
 
   // Verbosity level, set to 0 (no print) by default.
-  infoV = clctParams_.getParameter<int>("verbosity");
+  infoV = conf.clctParams().getParameter<int>("verbosity");
 
   // Do not exclude pattern 0 and 1 when the Run-3 patterns are enabled!!
   // Valid Run-3 patterns are 0,1,2,3,4
@@ -96,12 +96,12 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   if (runCCLUT_) {
     clct_pattern_ = CSCPatternBank::clct_pattern_run3_;
     // comparator code lookup table algorithm for Phase-2
-    cclut_ = std::make_unique<ComparatorCodeLUT>(conf);
+    cclut_ = std::make_unique<ComparatorCodeLUT>(conf.conf());
   } else {
     clct_pattern_ = CSCPatternBank::clct_pattern_legacy_;
   }
 
-  const auto& shower = showerParams_.getParameterSet("cathodeShower");
+  const auto& shower = conf.showerParams().getParameterSet("cathodeShower");
   thresholds_ = shower.getParameter<std::vector<unsigned>>("showerThresholds");
   showerNumTBins_ = shower.getParameter<unsigned>("showerNumTBins");
   minLayersCentralTBin_ = shower.getParameter<unsigned>("minLayersCentralTBin");

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -6,21 +6,21 @@ CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
                                      unsigned sector,
                                      unsigned subsector,
                                      unsigned chamber,
-                                     const edm::ParameterSet& conf)
+                                     CSCBaseboard::Parameters& conf)
     : CSCMotherboard(endcap, station, sector, subsector, chamber, conf),
-      drop_low_quality_alct_(tmbParams_.getParameter<bool>("dropLowQualityALCTs")),
-      drop_low_quality_clct_(tmbParams_.getParameter<bool>("dropLowQualityCLCTs")),
-      build_lct_from_alct_gem_(tmbParams_.getParameter<bool>("buildLCTfromALCTandGEM")),
-      build_lct_from_clct_gem_(tmbParams_.getParameter<bool>("buildLCTfromCLCTandGEM")) {
+      drop_low_quality_alct_(conf.tmbParams().getParameter<bool>("dropLowQualityALCTs")),
+      drop_low_quality_clct_(conf.tmbParams().getParameter<bool>("dropLowQualityCLCTs")),
+      build_lct_from_alct_gem_(conf.tmbParams().getParameter<bool>("buildLCTfromALCTandGEM")),
+      build_lct_from_clct_gem_(conf.tmbParams().getParameter<bool>("buildLCTfromCLCTandGEM")) {
   // case for ME1/1
   if (isME11_) {
-    drop_low_quality_clct_me1a_ = tmbParams_.getParameter<bool>("dropLowQualityCLCTs_ME1a");
+    drop_low_quality_clct_me1a_ = conf.tmbParams().getParameter<bool>("dropLowQualityCLCTs_ME1a");
   }
 
-  alct_gem_bx_window_size_ = tmbParams_.getParameter<unsigned>("windowBXALCTGEM");
-  clct_gem_bx_window_size_ = tmbParams_.getParameter<unsigned>("windowBXCLCTGEM");
+  alct_gem_bx_window_size_ = conf.tmbParams().getParameter<unsigned>("windowBXALCTGEM");
+  clct_gem_bx_window_size_ = conf.tmbParams().getParameter<unsigned>("windowBXCLCTGEM");
 
-  assign_gem_csc_bending_ = tmbParams_.getParameter<bool>("assignGEMCSCBending");
+  assign_gem_csc_bending_ = conf.tmbParams().getParameter<bool>("assignGEMCSCBending");
   qualityAssignment_->setGEMCSCBending(assign_gem_csc_bending_);
 
   // These LogErrors are sanity checks and should not be printed
@@ -35,9 +35,9 @@ CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
   // super chamber has layer=0!
   gemId = GEMDetId(theRegion, 1, theStation, 0, theChamber, 0).rawId();
 
-  clusterProc_ = std::make_shared<GEMClusterProcessor>(theRegion, theStation, theChamber, conf);
+  clusterProc_ = std::make_shared<GEMClusterProcessor>(theRegion, theStation, theChamber, conf.conf());
 
-  cscGEMMatcher_ = std::make_unique<CSCGEMMatcher>(theRegion, theStation, theChamber, tmbParams_, conf);
+  cscGEMMatcher_ = std::make_unique<CSCGEMMatcher>(theRegion, theStation, theChamber, conf.tmbParams(), conf.conf());
 }
 
 CSCGEMMotherboard::~CSCGEMMotherboard() {}

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -15,32 +15,32 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
                                unsigned sector,
                                unsigned subsector,
                                unsigned chamber,
-                               const edm::ParameterSet& conf)
+                               CSCBaseboard::Parameters& conf)
     : CSCBaseboard(endcap, station, sector, subsector, chamber, conf) {
   // Normal constructor.  -JM
   // Pass ALCT, CLCT, and common parameters on to ALCT and CLCT processors.
   static std::atomic<bool> config_dumped{false};
 
-  mpc_block_me1a = tmbParams_.getParameter<unsigned int>("mpcBlockMe1a");
-  alct_trig_enable = tmbParams_.getParameter<unsigned int>("alctTrigEnable");
-  clct_trig_enable = tmbParams_.getParameter<unsigned int>("clctTrigEnable");
-  match_trig_enable = tmbParams_.getParameter<unsigned int>("matchTrigEnable");
-  match_trig_window_size = tmbParams_.getParameter<unsigned int>("matchTrigWindowSize");
+  mpc_block_me1a = conf.tmbParams().getParameter<unsigned int>("mpcBlockMe1a");
+  alct_trig_enable = conf.tmbParams().getParameter<unsigned int>("alctTrigEnable");
+  clct_trig_enable = conf.tmbParams().getParameter<unsigned int>("clctTrigEnable");
+  match_trig_enable = conf.tmbParams().getParameter<unsigned int>("matchTrigEnable");
+  match_trig_window_size = conf.tmbParams().getParameter<unsigned int>("matchTrigWindowSize");
   tmb_l1a_window_size =  // Common to CLCT and TMB
-      tmbParams_.getParameter<unsigned int>("tmbL1aWindowSize");
+      conf.tmbParams().getParameter<unsigned int>("tmbL1aWindowSize");
 
   // configuration handle for number of early time bins
-  early_tbins = tmbParams_.getParameter<int>("tmbEarlyTbins");
+  early_tbins = conf.tmbParams().getParameter<int>("tmbEarlyTbins");
 
   // whether to not reuse CLCTs that were used by previous matching ALCTs
-  drop_used_clcts = tmbParams_.getParameter<bool>("tmbDropUsedClcts");
+  drop_used_clcts = conf.tmbParams().getParameter<bool>("tmbDropUsedClcts");
 
   // whether to readout only the earliest two LCTs in readout window
-  readout_earliest_2 = tmbParams_.getParameter<bool>("tmbReadoutEarliest2");
+  readout_earliest_2 = conf.tmbParams().getParameter<bool>("tmbReadoutEarliest2");
 
-  match_earliest_clct_only_ = tmbParams_.getParameter<bool>("matchEarliestClctOnly");
+  match_earliest_clct_only_ = conf.tmbParams().getParameter<bool>("matchEarliestClctOnly");
 
-  infoV = tmbParams_.getParameter<int>("verbosity");
+  infoV = conf.tmbParams().getParameter<int>("verbosity");
 
   alctProc = std::make_unique<CSCAnodeLCTProcessor>(endcap, station, sector, subsector, chamber, conf);
   clctProc = std::make_unique<CSCCathodeLCTProcessor>(endcap, station, sector, subsector, chamber, conf);
@@ -55,10 +55,10 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
   allLCTs_.setMatchTrigWindowSize(match_trig_window_size);
 
   // get the preferred CLCT BX match array
-  preferred_bx_match_ = tmbParams_.getParameter<std::vector<int>>("preferredBxMatch");
+  preferred_bx_match_ = conf.tmbParams().getParameter<std::vector<int>>("preferredBxMatch");
 
   // sort CLCT only by bx or by quality+bending for  ALCT-CLCT match
-  sort_clct_bx_ = tmbParams_.getParameter<bool>("sortClctBx");
+  sort_clct_bx_ = conf.tmbParams().getParameter<bool>("sortClctBx");
 
   // quality assignment
   qualityAssignment_ = std::make_unique<LCTQualityAssignment>(endcap, station, sector, subsector, chamber, conf);
@@ -67,7 +67,7 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
   qualityControl_ = std::make_unique<LCTQualityControl>(endcap, station, sector, subsector, chamber, conf);
 
   // shower-trigger source
-  showerSource_ = showerParams_.getParameter<std::vector<unsigned>>("source");
+  showerSource_ = conf.showerParams().getParameter<std::vector<unsigned>>("source");
 
   unsigned csc_idx = CSCDetId::iChamberType(theStation, theRing) - 2;
   thisShowerSource_ = showerSource_[csc_idx];
@@ -86,9 +86,9 @@ CSCMotherboard::CSCMotherboard(unsigned endcap,
   }
 
   // set up helper class to check if ALCT and CLCT cross
-  ignoreAlctCrossClct_ = tmbParams_.getParameter<bool>("ignoreAlctCrossClct");
+  ignoreAlctCrossClct_ = conf.tmbParams().getParameter<bool>("ignoreAlctCrossClct");
   if (!ignoreAlctCrossClct_) {
-    cscOverlap_ = std::make_unique<CSCALCTCrossCLCT>(endcap, station, theRing, ignoreAlctCrossClct_, conf);
+    cscOverlap_ = std::make_unique<CSCALCTCrossCLCT>(endcap, station, theRing, ignoreAlctCrossClct_, conf.conf());
   }
 }
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -34,6 +34,7 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
   runME21ILT_ = commonParams.getParameter<bool>("runME21ILT");
 
   // Initializing boards.
+  CSCBaseboard::Parameters baseparams(conf);
   for (int endc = min_endcap; endc <= max_endcap; endc++) {
     for (int stat = min_station; stat <= max_station; stat++) {
       int numsubs = ((stat == 1) ? max_subsector : 1);
@@ -60,11 +61,11 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
             // GE1/1-ME1/1 integrated local trigger or GE2/1-ME2/1 integrated local trigger
             if (upgradeGE11 or upgradeGE21)
               tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1] =
-                  std::make_unique<CSCGEMMotherboard>(endc, stat, sect, subs, cham, conf);
+                  std::make_unique<CSCGEMMotherboard>(endc, stat, sect, subs, cham, baseparams);
             // default case
             else
               tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1] =
-                  std::make_unique<CSCMotherboard>(endc, stat, sect, subs, cham, conf);
+                  std::make_unique<CSCMotherboard>(endc, stat, sect, subs, cham, baseparams);
           }
         }
         // Init MPC

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeAnodeLCTProcessor.cc
@@ -5,7 +5,7 @@ CSCUpgradeAnodeLCTProcessor::CSCUpgradeAnodeLCTProcessor(unsigned endcap,
                                                          unsigned sector,
                                                          unsigned subsector,
                                                          unsigned chamber,
-                                                         const edm::ParameterSet& conf)
+                                                         CSCBaseboard::Parameters& conf)
     : CSCAnodeLCTProcessor(endcap, station, sector, subsector, chamber, conf) {
   if (!runPhase2_)
     edm::LogError("CSCUpgradeAnodeLCTProcessor|ConfigError")

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -7,18 +7,18 @@ CSCUpgradeCathodeLCTProcessor::CSCUpgradeCathodeLCTProcessor(unsigned endcap,
                                                              unsigned sector,
                                                              unsigned subsector,
                                                              unsigned chamber,
-                                                             const edm::ParameterSet& conf)
+                                                             CSCBaseboard::Parameters& conf)
     : CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, conf) {
   if (!runPhase2_)
     edm::LogError("CSCUpgradeCathodeLCTProcessor|ConfigError")
         << "+++ Upgrade CSCUpgradeCathodeLCTProcessor constructed while runPhase2_ is not set! +++\n";
 
   // use of localized dead-time zones
-  use_dead_time_zoning_ = clctParams_.getParameter<bool>("useDeadTimeZoning");
-  clct_state_machine_zone_ = clctParams_.getParameter<unsigned int>("clctStateMachineZone");
+  use_dead_time_zoning_ = conf.clctParams().getParameter<bool>("useDeadTimeZoning");
+  clct_state_machine_zone_ = conf.clctParams().getParameter<unsigned int>("clctStateMachineZone");
 
   // how far away may trigger happen from pretrigger
-  pretrig_trig_zone_ = clctParams_.getParameter<unsigned int>("clctPretriggerTriggerZone");
+  pretrig_trig_zone_ = conf.clctParams().getParameter<unsigned int>("clctPretriggerTriggerZone");
 }
 
 // --------------------------------------------------------------------------

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
@@ -5,7 +5,7 @@ LCTQualityAssignment::LCTQualityAssignment(unsigned endcap,
                                            unsigned sector,
                                            unsigned subsector,
                                            unsigned chamber,
-                                           const edm::ParameterSet& conf)
+                                           CSCBaseboard::Parameters& conf)
     : CSCBaseboard(endcap, station, sector, subsector, chamber, conf) {
   // at least one integrated local trigger is running
   runILT_ = (isME11_ and runME11ILT_) or (isME21_ and runME21ILT_);

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
@@ -8,9 +8,9 @@ LCTQualityControl::LCTQualityControl(unsigned endcap,
                                      unsigned sector,
                                      unsigned subsector,
                                      unsigned chamber,
-                                     const edm::ParameterSet& conf)
+                                     CSCBaseboard::Parameters& conf)
     : CSCBaseboard(endcap, station, sector, subsector, chamber, conf) {
-  nplanes_clct_hit_pattern = clctParams_.getParameter<unsigned int>("clctNplanesHitPattern");
+  nplanes_clct_hit_pattern = conf.clctParams().getParameter<unsigned int>("clctNplanesHitPattern");
 }
 
 // Check if the ALCT is valid


### PR DESCRIPTION
#### PR description:

- reduced per event memory usage to ~40MB by avoiding holding copies of ParameterSets.
- converted to stream module to allow better concurrency. [Running tests at >64 threads showed this module was the predominant cause of threading inefficiency.]

#### PR validation:

Ran a modified version of the DIGI+HLT step of 11834.99 and job ran fine.