### PR TITLE
guard `HLTRecHitInAllL1RegionsProducer<T>` against empty collection of L1T candidates [`13_0_X`]

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
 <use name="DataFormats/EgammaCandidates"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="RecoEcal/EgammaCoreTools"/>


### PR DESCRIPTION
backport of #41466

#### PR description:

This PR adds a check to `HLTRecHitInAllL1RegionsProducer<T>` to handle gracefully events where the input collection of L1T candidates is empty (either completely empty, or even empty just for BX=0).

For such events, pre-PR the plugin can crash [here](https://github.com/cms-sw/cmssw/blob/0d6218db24f97d34933bda623816949d340262ba/RecoEgamma/EgammaHLTProducers/plugins/HLTRecHitInAllL1RegionsProducer.cc#L92). This type of crash was observed multiple times online in the last days. The root cause of the problem (i.e. missing L1T candidates) is likely related to issues with the L1T menu deployed a couple of weeks ago ([CMSLITOPS-411](https://its.cern.ch/jira/browse/CMSLITOPS-411)).

A reproducer is in [1], and it produces the [stack trace attached here](https://github.com/cms-sw/cmssw/files/11360931/run366727.log) (which matches the error log seen online).

FYI: @Sam-Harper @swagata87 (as this module is used by E/gamma triggers)

[1]
```bash
#!/bin/bash

# cmsrel CMSSW_13_0_3
# cd CMSSW_13_0_3/src
# cmsenv

hltGetConfiguration run:366727 \
  --globaltag 130X_dataRun3_HLT_v2 --data \
  --no-prescale --no-output \
  --max-events -1 \
  --input dummy.root \
  > hlt.py

cat <<@EOF >> hlt.py
del process.DQMOutput

process.options.numberOfThreads = 1
process.options.numberOfStreams = 0

process.hltOnlineBeamSpotESProducer.timeThreshold = int(1e6)

del process.MessageLogger
process.load('FWCore.MessageService.MessageLogger_cfi')
process.MessageLogger.cerr.FwkReport.reportEvery = 1
process.MessageLogger.cerr.enableStatistics = False
process.MessageLogger.cerr.threshold = 'INFO'

from EventFilter.Utilities.FedRawDataInputSource_cfi import source as _source
process.source = _source.clone(
    eventChunkSize = 200,
    eventChunkBlock = 200,
    numBuffers = 4,
    maxBufferedFiles = 4,
    fileListMode = True,
    fileNames = [
      "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/FOG/error_stream/run366727/run366727_ls0136_index000137_fu-c2b04-34-01_pid3305175.raw",
    ]
)

from EventFilter.Utilities.EvFDaqDirector_cfi import EvFDaqDirector as _EvFDaqDirector
process.EvFDaqDirector = _EvFDaqDirector.clone(buBaseDir = '.', runNumber = 0)
@EOF

cmsRun hlt.py &> hlt.log
```

#### PR validation:

With the changes in this PR, the reproducer does not crash.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41466

Bugfix to plugin used at HLT in release cycle used for data-taking in 2023.