### PR TITLE
re-improve check on size of L1-uGT digis in `HLTL1TSeed` plugin

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -475,7 +475,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
     return false;
   }
 
-  // check size
+  // check size (all BXs)
+  if (uGtAlgoBlocks->size() == 0) {
+    edm::LogWarning("HLTL1TSeed") << " Warning: GlobalAlgBlkBxCollection with input tag " << m_l1GlobalTag
+                                  << " is empty for all BXs.";
+    return false;
+  }
+
+  // check size (BX 0)
   if (uGtAlgoBlocks->isEmpty(0)) {
     edm::LogWarning("HLTL1TSeed") << " Warning: GlobalAlgBlkBxCollection with input tag " << m_l1GlobalTag
                                   << " is empty for BX=0.";


### PR DESCRIPTION
#### PR description:

This PR amends a mistake introduced in #40655. The check on `size == 0` should not have been removed in #40655, mainly because, if `BXVector::size() == 0`, the call to `BXVector::isEmpty(0)` might lead to a crash (which is arguably a limit of the implementation of [`BXVector::isEmpty(int bx)`](https://github.com/cms-sw/cmssw/blob/0d6218db24f97d34933bda623816949d340262ba/DataFormats/L1Trigger/interface/BXVector.icc#L213)).

Thanks to @swagata87 for indirectly reminding me of this.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_0_X`