### PR TITLE
New T2 multi-channel payload unpacker for special TOTEM run in June

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -96,6 +96,9 @@ private:
   //subdetector id for sampic
   unsigned int sampicSubDetId;
 
+  //Unpack multiple channels per payload for T2
+  bool packedPayload;
+
   /// the mapping files
   std::vector<std::string> mappingFileNames;
 
@@ -201,6 +204,9 @@ private:
   /// extracts VFAT's DAQ channel from XML attributes
   TotemFramePosition ChipFramePosition(xercesc::DOMNode *chipnode);
 
+  /// extracts VFAT's DAQ channel from XML attributes for packed T2 payload
+  TotemT2FramePosition ChipT2FramePosition(xercesc::DOMNode *chipnode);
+
   void GetChannels(xercesc::DOMNode *n, std::set<unsigned char> &channels);
 
   bool RPNode(NodeType type) {
@@ -270,6 +276,7 @@ TotemDAQMappingESSourceXML::TotemDAQMappingESSourceXML(const edm::ParameterSet &
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
       subSystemName(conf.getUntrackedParameter<string>("subSystem")),
       sampicSubDetId(conf.getParameter<unsigned int>("sampicSubDetId")),
+      packedPayload(conf.getUntrackedParameter<bool>("multipleChannelsPerPayload", false)),
       currentBlock(0),
       currentBlockValid(false) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {
@@ -869,13 +876,19 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemT2(ParseType pType,
       // parse tag attributes
       unsigned int hw_id = 0;
       bool hw_id_set = false;
+      unsigned int channel_in_payload = 0;
+      bool payload_set = false;
       DOMNamedNodeMap *attr = child->getAttributes();
 
       for (unsigned int j = 0; j < attr->getLength(); j++) {
         DOMNode *a = attr->item(j);
         if (!strcmp(cms::xerces::toString(a->getNodeName()).c_str(), "hwId")) {
-          sscanf(cms::xerces::toString(a->getNodeValue()).c_str(), "%u", &hw_id);
+          sscanf(cms::xerces::toString(a->getNodeValue()).c_str(), "%x", &hw_id);
           hw_id_set = true;
+        }
+        if (packedPayload && (!strcmp(cms::xerces::toString(a->getNodeName()).c_str(), "pay"))) {
+          sscanf(cms::xerces::toString(a->getNodeValue()).c_str(), "%u", &channel_in_payload);
+          payload_set = true;
         }
       }
 
@@ -886,15 +899,28 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemT2(ParseType pType,
       if (!hw_id_set)
         throw cms::Exception("TotemDAQMappingESSourceXML::ParseTreeTotemT2")
             << "hwId not given for element `" << cms::xerces::toString(child->getNodeName()) << "'";
+      if (packedPayload && (!payload_set))
+        throw cms::Exception("TotemDAQMappingESSourceXML::ParseTreeTotemT2")
+            << "Payload position in fibre not given for element `" << cms::xerces::toString(child->getNodeName())
+            << "'";
 
       // store mapping data
-      const TotemFramePosition &framepos = ChipFramePosition(child);
+      const TotemT2FramePosition &framepos = (packedPayload ? ChipT2FramePosition(child) : TotemT2FramePosition());
+      const TotemFramePosition &frameposSingle = (packedPayload ? TotemFramePosition() : ChipFramePosition(child));
       TotemVFATInfo vfatInfo;
       vfatInfo.hwID = hw_id;
       unsigned int arm = parentID / 10, plane = parentID % 10;
       vfatInfo.symbolicID.symbolicID = TotemT2DetId(arm, plane, id);
+      if (verbosity > 2) {
+        edm::LogWarning("Totem") << "Print T2 frame pos (payload):" << framepos << " ("
+                                 << (packedPayload ? "true" : "false") << ") hw_id / T2 DetID" << hw_id << "/"
+                                 << TotemT2DetId(arm, plane, id) << endl;
+      }
 
-      mapping->insert(framepos, vfatInfo);
+      if (packedPayload)
+        mapping->insert(framepos, vfatInfo);
+      else
+        mapping->insert(frameposSingle, vfatInfo);
 
       continue;
     }
@@ -928,6 +954,30 @@ TotemFramePosition TotemDAQMappingESSourceXML::ChipFramePosition(xercesc::DOMNod
   return fp;
 }
 
+//----------------------------------------------------------------------------------------------------
+
+TotemT2FramePosition TotemDAQMappingESSourceXML::ChipT2FramePosition(xercesc::DOMNode *chipnode) {
+  TotemT2FramePosition fp;
+  unsigned char attributeFlag = 0;
+
+  DOMNamedNodeMap *attr = chipnode->getAttributes();
+  for (unsigned int j = 0; j < attr->getLength(); j++) {
+    DOMNode *a = attr->item(j);
+    if (fp.setXMLAttribute(
+            cms::xerces::toString(a->getNodeName()), cms::xerces::toString(a->getNodeValue()), attributeFlag) > 1) {
+      throw cms::Exception("TotemDAQMappingESSourceXML")
+          << "Unrecognized T2 tag `" << cms::xerces::toString(a->getNodeName()) << "' or incompatible value `"
+          << cms::xerces::toString(a->getNodeValue()) << "'.";
+    }
+  }
+
+  if (!fp.checkXMLAttributeFlag(attributeFlag)) {
+    throw cms::Exception("TotemDAQMappingESSourceXML")
+        << "Wrong/incomplete T2 DAQ channel specification (attributeFlag = " << attributeFlag << ").";
+  }
+
+  return fp;
+}
 //----------------------------------------------------------------------------------------------------
 
 TotemDAQMappingESSourceXML::NodeType TotemDAQMappingESSourceXML::GetNodeType(xercesc::DOMNode *n) {

--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -890,6 +890,7 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemT2(ParseType pType,
       // store mapping data
       const TotemFramePosition &framepos = ChipFramePosition(child);
       TotemVFATInfo vfatInfo;
+      vfatInfo.hwID = hw_id;
       unsigned int arm = parentID / 10, plane = parentID % 10;
       vfatInfo.symbolicID.symbolicID = TotemT2DetId(arm, plane, id);
 

--- a/CalibPPS/ESProducers/python/totemT2DAQMapping_cff.py
+++ b/CalibPPS/ESProducers/python/totemT2DAQMapping_cff.py
@@ -4,10 +4,18 @@ from CalibPPS.ESProducers.totemDAQMappingESSourceXML_cfi import totemDAQMappingE
 
 totemDAQMappingESSourceXML = _xml.clone(
     subSystem = "TotemT2",
+    multipleChannelsPerPayload = cms.untracked.bool(False),
     configuration = cms.VPSet(
+        #initial dummy diamond map copy
         cms.PSet(
-            validityRange = cms.EventRange("1:min - 999999999:max"),
+            validityRange = cms.EventRange("1:min - 364982:max"),
             mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_nt2_2021.xml"),
+            maskFileNames = cms.vstring()
+        ),
+        #T2 firmware test files
+        cms.PSet(
+            validityRange = cms.EventRange("364983:min - 999999999:max"),
+            mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_nt2_2023.xml"),
             maskFileNames = cms.vstring()
         )
     ),

--- a/CondFormats/PPSObjects/interface/TotemDAQMapping.h
+++ b/CondFormats/PPSObjects/interface/TotemDAQMapping.h
@@ -11,6 +11,7 @@
 #define CondFormats_PPSObjects_TotemDAQMapping
 
 #include "CondFormats/PPSObjects/interface/TotemFramePosition.h"
+#include "CondFormats/PPSObjects/interface/TotemT2FramePosition.h"
 
 #include "CondFormats/PPSObjects/interface/TotemSymbId.h"
 
@@ -51,6 +52,7 @@ public:
   std::map<uint8_t, TotemTimingPlaneChannelPair> totemTimingChannelMap;
 
   void insert(const TotemFramePosition& fp, const TotemVFATInfo& vi);
+  void insert(const TotemT2FramePosition& fp2, const TotemVFATInfo& vi);
 
   /// Given the hardware ID, returns the corresponding Plane, Channel pair (TotemTimingPlaneChannelPair)
   const TotemTimingPlaneChannelPair getTimingChannel(const uint8_t hwId) const;

--- a/CondFormats/PPSObjects/interface/TotemT2FramePosition.h
+++ b/CondFormats/PPSObjects/interface/TotemT2FramePosition.h
@@ -1,0 +1,109 @@
+/****************************************************************************
+*
+* This is a part of the TOTEM offline software.
+* Authors: 
+*   Jan Kašpar (jan.kaspar@gmail.com) 
+*
+****************************************************************************/
+
+#ifndef CondFormats_PPSObjects_TotemT2FramePosition
+#define CondFormats_PPSObjects_TotemT2FramePosition
+#include "CondFormats/PPSObjects/interface/TotemFramePosition.h"
+
+#include <iostream>
+#include <string>
+
+/**
+ * Uniquely identifies the DAQ channel through which a VFAT frame has been received.
+ * 
+ * The internal representation has the following structure:
+ * \verbatim
+ * |                   32 bits raw position                    |
+ * | 12 bits | 2 bits     |  10 bits | 4 bits |       4 bits       |
+ * |  empty  | T2 payload |  FED ID  | GOH ID | index within fiber |
+ * \endverbatim
+ *
+ **/
+class TotemT2FramePosition : public TotemFramePosition {
+public:
+  static const unsigned int offsetPayload = 18, maskPayload = 0x3;
+
+  /// the preferred constructor
+  TotemT2FramePosition(unsigned short SubSystemId,
+                       unsigned short TOTFEDId,
+                       unsigned short OptoRxId,
+                       unsigned short GOHId,
+                       unsigned short IdxInFiber,
+                       unsigned short payload)
+      : rawPosition(IdxInFiber << offsetIdxInFiber | GOHId << offsetGOHId | OptoRxId << offsetOptoRxId |
+                    TOTFEDId << offsetTOTFEDId | SubSystemId << offsetSubSystemId | (payload + 1) << offsetPayload) {}
+
+  /// don't use this constructor unless you have a good reason
+  TotemT2FramePosition(unsigned int pos = 0) : rawPosition(pos) {}
+
+  ~TotemT2FramePosition() {}
+
+  /// recomended getters and setters
+
+  unsigned short getFEDId() const { return (rawPosition >> offsetFEDId) & maskFEDId; }
+  unsigned short getPayload() const { return (((rawPosition >> offsetPayload) & maskPayload) - 1); }
+
+  void setFEDId(unsigned short v) {
+    v &= maskFEDId;
+    rawPosition &= 0xFFFFFFFF - (maskFEDId << offsetFEDId);
+    rawPosition |= (v << offsetFEDId);
+  }
+  void setPayload(unsigned short v) {
+    unsigned short av = (v + 1) & maskPayload;
+    rawPosition &= 0xFFFFFFFF - (maskPayload << offsetPayload);
+    rawPosition |= (av << offsetPayload);
+  }
+
+  unsigned short getGOHId() const { return (rawPosition >> offsetGOHId) & maskGOHId; }
+
+  void setGOHId(unsigned short v) {
+    v &= maskGOHId;
+    rawPosition &= 0xFFFFFFFF - (maskGOHId << offsetGOHId);
+    rawPosition |= (v << offsetGOHId);
+  }
+
+  unsigned short getIdxInFiber() const { return (rawPosition >> offsetIdxInFiber) & maskIdxInFiber; }
+
+  void setIdxInFiber(unsigned short v) {
+    v &= maskIdxInFiber;
+    rawPosition &= 0xFFFFFFFF - (maskIdxInFiber << offsetIdxInFiber);
+    rawPosition |= (v << offsetIdxInFiber);
+  }
+
+  /// the getters and setters below are deprecated
+
+  /// don't use this method unless you have a good reason
+  unsigned int getRawPosition() const { return rawPosition; }
+
+  bool operator<(const TotemT2FramePosition &pos) const { return (rawPosition < pos.rawPosition); }
+  bool operator<(const TotemFramePosition &pos) const { return (rawPosition < pos.getRawPosition()); }
+
+  bool operator==(const TotemT2FramePosition &pos) const { return (rawPosition == pos.rawPosition); }
+  bool operator==(const TotemFramePosition &pos) const { return (rawPosition == pos.getRawPosition()); }
+
+  /// Condensed representation of the DAQ channel.
+  /// prints 5-digit hex number, the digits correspond to SubSystem, TOTFED ID, OptoRx ID,
+  /// GOH ID, index within fiber in this order
+  friend std::ostream &operator<<(std::ostream &s, const TotemT2FramePosition &fp);
+
+  /// prints XML formatted DAQ channel to stdout
+  void printXML();
+
+  /// Sets attribute with XML name 'attribute' and value 'value'.
+  /// Also turns on attribute presents bit in the flag parameter
+  /// returns 0 if the attribute is known, non-zero value else
+  unsigned char setXMLAttribute(const std::string &attribute, const std::string &value, unsigned char &flag);
+
+  /// returns true if all attributes have been set
+  static bool checkXMLAttributeFlag(unsigned char flag) { return (flag == 0x3f); }
+
+protected:
+  unsigned int rawPosition;
+};
+
+#endif

--- a/CondFormats/PPSObjects/src/TotemDAQMapping.cc
+++ b/CondFormats/PPSObjects/src/TotemDAQMapping.cc
@@ -7,6 +7,7 @@
 ****************************************************************************/
 
 #include "FWCore/Utilities/interface/typelookup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
 
@@ -25,13 +26,27 @@ std::ostream &operator<<(std::ostream &s, const TotemVFATInfo &vi) {
 void TotemDAQMapping::insert(const TotemFramePosition &fp, const TotemVFATInfo &vi) {
   auto it = VFATMapping.find(fp);
   if (it != VFATMapping.end()) {
-    cerr << "WARNING in DAQMapping::insert > Overwriting entry at " << fp << ". Previous: " << endl
-         << "    " << VFATMapping[fp] << "," << endl
-         << "  new: " << endl
-         << "    " << vi << ". " << endl;
+    edm::LogWarning("Totem") << "WARNING in DAQMapping::insert > Overwriting entry at " << fp << ". Previous: "
+                             << "    " << VFATMapping[fp] << ","
+                             << "  new: "
+                             << "    " << vi << ". " << endl;
   }
 
   VFATMapping[fp] = vi;
+}
+
+//----------------------------------------------------------------------------------------------------
+void TotemDAQMapping::insert(const TotemT2FramePosition &fp2, const TotemVFATInfo &vi) {
+  const TotemFramePosition fp1(fp2.getRawPosition());
+  auto it = VFATMapping.find(fp1);
+  if (it != VFATMapping.end()) {
+    edm::LogWarning("Totem") << "WARNING in DAQMapping::insert > Overwriting T2 entry at " << fp2 << ". Previous: "
+                             << "    " << VFATMapping[fp1] << ","
+                             << "  new: "
+                             << "    " << vi << ". " << endl;
+  }
+
+  VFATMapping[fp1] = vi;
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CondFormats/PPSObjects/src/TotemT2FramePosition.cc
+++ b/CondFormats/PPSObjects/src/TotemT2FramePosition.cc
@@ -1,0 +1,61 @@
+/****************************************************************************
+*
+* This is a part of the TOTEM offline software.
+* Authors: 
+*   Jan Kašpar (jan.kaspar@gmail.com) 
+*
+****************************************************************************/
+
+#include "CondFormats/PPSObjects/interface/TotemT2FramePosition.h"
+
+#include <iomanip>
+#include <cstdlib>
+
+using namespace std;
+
+//----------------------------------------------------------------------------------------------------
+
+std::ostream &operator<<(std::ostream &s, const TotemT2FramePosition &fp) {
+  return s << fp.getFEDId() << ":" << fp.getGOHId() << ":" << fp.getIdxInFiber() << ":" << fp.getPayload();
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void TotemT2FramePosition::printXML() {
+  cout << "\" FEDId=\"" << getFEDId() << "\" GOHId=\"" << getGOHId() << "\" IdxInFiber=\"" << getIdxInFiber()
+       << "\" pay=\"" << getPayload() << "\"";
+}
+
+//----------------------------------------------------------------------------------------------------
+
+unsigned char TotemT2FramePosition::setXMLAttribute(const std::string &attribute,
+                                                    const std::string &value,
+                                                    unsigned char &flag) {
+  unsigned int v = atoi(value.c_str());
+
+  if (attribute == "FEDId") {
+    setFEDId(v);
+    flag |= 0x1C;  // SubSystem + TOTFED + OptoRx
+    return 0;
+  }
+
+  if (attribute == "pay") {
+    setPayload(v);
+    flag |= 0x20;  //T2 payload
+    return 0;
+  }
+
+  if (attribute == "GOHId") {
+    setGOHId(v);
+    flag |= 0x2;
+    return 0;
+  }
+
+  if (attribute == "IdxInFiber") {
+    setIdxInFiber(v);
+    flag |= 0x1;
+    return 0;
+  }
+
+  return 1;
+}

--- a/CondFormats/PPSObjects/xml/mapping_totem_nt2_2023.xml
+++ b/CondFormats/PPSObjects/xml/mapping_totem_nt2_2023.xml
@@ -1,0 +1,103 @@
+<!-- This mapping is a preliminary real T2 mapping, still to be updated and validated
+     and made unique in each arm. -->
+<top>
+  <arm id="0">  <!-- sector 45, CMS negative z -->
+    <nt2_plane id="0">
+      <nt2_tile id="0" hwId="0x20" FEDId="577" GOHId="1" IdxInFiber="0" pay="0"/>
+      <nt2_tile id="1" hwId="0x21" FEDId="577" GOHId="1" IdxInFiber="0" pay="1"/>
+      <nt2_tile id="2" hwId="0x22" FEDId="577" GOHId="1" IdxInFiber="1" pay="0"/>
+      <nt2_tile id="3" hwId="0x23" FEDId="577" GOHId="1" IdxInFiber="1" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="1">
+      <nt2_tile id="0" hwId="0x24" FEDId="577" GOHId="1" IdxInFiber="2" pay="0"/>
+      <nt2_tile id="1" hwId="0x25" FEDId="577" GOHId="1" IdxInFiber="2" pay="1"/>
+      <nt2_tile id="2" hwId="0x26" FEDId="577" GOHId="1" IdxInFiber="3" pay="0"/>
+      <nt2_tile id="3" hwId="0x27" FEDId="577" GOHId="1" IdxInFiber="3" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="2">
+      <nt2_tile id="0" hwId="0x28" FEDId="577" GOHId="1" IdxInFiber="4" pay="0"/>
+      <nt2_tile id="1" hwId="0x29" FEDId="577" GOHId="1" IdxInFiber="4" pay="1"/>
+      <nt2_tile id="2" hwId="0x2A" FEDId="577" GOHId="1" IdxInFiber="5" pay="0"/>
+      <nt2_tile id="3" hwId="0x2B" FEDId="577" GOHId="1" IdxInFiber="5" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="3">
+      <nt2_tile id="0" hwId="0x2C" FEDId="577" GOHId="1" IdxInFiber="6" pay="0"/>
+      <nt2_tile id="1" hwId="0x2D" FEDId="577" GOHId="1" IdxInFiber="6" pay="1"/>
+      <nt2_tile id="2" hwId="0x2E" FEDId="577" GOHId="1" IdxInFiber="7" pay="0"/>
+      <nt2_tile id="3" hwId="0x2F" FEDId="577" GOHId="1" IdxInFiber="7" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="4">
+      <nt2_tile id="0" hwId="0x30" FEDId="577" GOHId="1" IdxInFiber="8" pay="0"/>
+      <nt2_tile id="1" hwId="0x31" FEDId="577" GOHId="1" IdxInFiber="8" pay="1"/>
+      <nt2_tile id="2" hwId="0x32" FEDId="577" GOHId="1" IdxInFiber="9" pay="0"/>
+      <nt2_tile id="3" hwId="0x33" FEDId="577" GOHId="1" IdxInFiber="9" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="5">
+      <nt2_tile id="0" hwId="0x34" FEDId="577" GOHId="1" IdxInFiber="10" pay="0"/>
+      <nt2_tile id="1" hwId="0x35" FEDId="577" GOHId="1" IdxInFiber="10" pay="1"/>
+      <nt2_tile id="2" hwId="0x36" FEDId="577" GOHId="1" IdxInFiber="11" pay="0"/>
+      <nt2_tile id="3" hwId="0x37" FEDId="577" GOHId="1" IdxInFiber="11" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="6">
+      <nt2_tile id="0" hwId="0x38" FEDId="577" GOHId="1" IdxInFiber="12" pay="0"/>
+      <nt2_tile id="1" hwId="0x39" FEDId="577" GOHId="1" IdxInFiber="12" pay="1"/>
+      <nt2_tile id="2" hwId="0x3A" FEDId="577" GOHId="1" IdxInFiber="13" pay="0"/>
+      <nt2_tile id="3" hwId="0x3B" FEDId="577" GOHId="1" IdxInFiber="13" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="7">
+      <nt2_tile id="0" hwId="0x3C" FEDId="577" GOHId="1" IdxInFiber="14" pay="0"/>
+      <nt2_tile id="1" hwId="0x3D" FEDId="577" GOHId="1" IdxInFiber="14" pay="1"/>
+      <nt2_tile id="2" hwId="0x3E" FEDId="577" GOHId="1" IdxInFiber="15" pay="0"/>
+      <nt2_tile id="3" hwId="0x3F" FEDId="577" GOHId="1" IdxInFiber="15" pay="1"/>
+    </nt2_plane>
+  </arm>
+  <arm id="1">  <!-- sector 56, CMS positive z -->
+    <nt2_plane id="0">
+      <nt2_tile id="0" hwId="0x20" FEDId="577" GOHId="0" IdxInFiber="0" pay="0"/>
+      <nt2_tile id="1" hwId="0x21" FEDId="577" GOHId="0" IdxInFiber="0" pay="1"/>
+      <nt2_tile id="2" hwId="0x22" FEDId="577" GOHId="0" IdxInFiber="1" pay="0"/>
+      <nt2_tile id="3" hwId="0x23" FEDId="577" GOHId="0" IdxInFiber="1" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="1">
+      <nt2_tile id="0" hwId="0x24" FEDId="577" GOHId="0" IdxInFiber="2" pay="0"/>
+      <nt2_tile id="1" hwId="0x25" FEDId="577" GOHId="0" IdxInFiber="2" pay="1"/>
+      <nt2_tile id="2" hwId="0x26" FEDId="577" GOHId="0" IdxInFiber="3" pay="0"/>
+      <nt2_tile id="3" hwId="0x27" FEDId="577" GOHId="0" IdxInFiber="3" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="2">
+      <nt2_tile id="0" hwId="0x28" FEDId="577" GOHId="0" IdxInFiber="4" pay="0"/>
+      <nt2_tile id="1" hwId="0x29" FEDId="577" GOHId="0" IdxInFiber="4" pay="1"/>
+      <nt2_tile id="2" hwId="0x2A" FEDId="577" GOHId="0" IdxInFiber="5" pay="0"/>
+      <nt2_tile id="3" hwId="0x2B" FEDId="577" GOHId="0" IdxInFiber="5" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="3">
+      <nt2_tile id="0" hwId="0x2C" FEDId="577" GOHId="0" IdxInFiber="6" pay="0"/>
+      <nt2_tile id="1" hwId="0x2D" FEDId="577" GOHId="0" IdxInFiber="6" pay="1"/>
+      <nt2_tile id="2" hwId="0x2E" FEDId="577" GOHId="0" IdxInFiber="7" pay="0"/>
+      <nt2_tile id="3" hwId="0x2F" FEDId="577" GOHId="0" IdxInFiber="7" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="4">
+      <nt2_tile id="0" hwId="0x30" FEDId="577" GOHId="0" IdxInFiber="8" pay="0"/>
+      <nt2_tile id="1" hwId="0x31" FEDId="577" GOHId="0" IdxInFiber="8" pay="1"/>
+      <nt2_tile id="2" hwId="0x32" FEDId="577" GOHId="0" IdxInFiber="9" pay="0"/>
+      <nt2_tile id="3" hwId="0x33" FEDId="577" GOHId="0" IdxInFiber="9" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="5">
+      <nt2_tile id="0" hwId="0x34" FEDId="577" GOHId="0" IdxInFiber="10" pay="0"/>
+      <nt2_tile id="1" hwId="0x35" FEDId="577" GOHId="0" IdxInFiber="10" pay="1"/>
+      <nt2_tile id="2" hwId="0x36" FEDId="577" GOHId="0" IdxInFiber="11" pay="0"/>
+      <nt2_tile id="3" hwId="0x37" FEDId="577" GOHId="0" IdxInFiber="11" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="6">
+      <nt2_tile id="0" hwId="0x38" FEDId="577" GOHId="0" IdxInFiber="12" pay="0"/>
+      <nt2_tile id="1" hwId="0x39" FEDId="577" GOHId="0" IdxInFiber="12" pay="1"/>
+      <nt2_tile id="2" hwId="0x3A" FEDId="577" GOHId="0" IdxInFiber="13" pay="0"/>
+      <nt2_tile id="3" hwId="0x3B" FEDId="577" GOHId="0" IdxInFiber="13" pay="1"/>
+    </nt2_plane>
+    <nt2_plane id="7">
+      <nt2_tile id="0" hwId="0x3C" FEDId="577" GOHId="0" IdxInFiber="14" pay="0"/>
+      <nt2_tile id="1" hwId="0x3D" FEDId="577" GOHId="0" IdxInFiber="14" pay="1"/>
+      <nt2_tile id="2" hwId="0x3E" FEDId="577" GOHId="0" IdxInFiber="15" pay="0"/>
+      <nt2_tile id="3" hwId="0x3F" FEDId="577" GOHId="0" IdxInFiber="15" pay="1"/>
+    </nt2_plane>
+  </arm>

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -12,18 +12,20 @@
 class TotemT2Digi {
 public:
   TotemT2Digi() = default;
-  TotemT2Digi(unsigned char geo, unsigned char id, unsigned char marker, unsigned short le, unsigned short te);
+  TotemT2Digi(unsigned short id, unsigned char marker, unsigned short le, unsigned short te);
 
   void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
   unsigned short leadingEdge() const { return lead_edge_; }
   void setTrailingEdge(unsigned short te) { trail_edge_ = te; }
   unsigned short trailingEdge() const { return trail_edge_; }
+  bool hasLE() const { return marker_ & 0x1; }
+  bool hasTE() const { return marker_ & 0x2; }
+  bool hasManyLE() const { return marker_ & 0x4; }
+  bool hasManyTE() const { return marker_ & 0x8; }
 
 private:
-  /// Geo ID
-  unsigned char geo_id_{0};
-  /// Channel ID
-  unsigned char channel_id_{0};
+  /// New HW ID in ver 2.2
+  unsigned short id_{0};
   /// Channel marker
   unsigned char marker_{0};
   /// Leading edge time

--- a/DataFormats/TotemReco/src/TotemT2Digi.cc
+++ b/DataFormats/TotemReco/src/TotemT2Digi.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 
-TotemT2Digi::TotemT2Digi(unsigned char geo, unsigned char id, unsigned char marker, unsigned short le, unsigned short te)
-    : geo_id_(geo), channel_id_(id), marker_(marker), lead_edge_(le), trail_edge_(te) {}
+TotemT2Digi::TotemT2Digi(unsigned short id, unsigned char marker, unsigned short le, unsigned short te)
+    : id_(id), marker_(marker), lead_edge_(le), trail_edge_(te) {}
 
 bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs) {
   if (lhs.leadingEdge() < rhs.leadingEdge())

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="TotemT2Digi" ClassVersion="3">
+  <class name="TotemT2Digi" ClassVersion="4">
+    <version ClassVersion="4" checksum="708922079"/>
     <version ClassVersion="3" checksum="4024006040"/>
   </class>
   <class name="edmNew::DetSet<TotemT2Digi>"/>

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -17,6 +17,7 @@
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h"
 #include "EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h"
+#include "CondFormats/PPSObjects/interface/TotemT2FramePosition.h"
 
 namespace pps {
   /// \brief Collection of code for unpacking of TOTEM raw-data.

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -71,6 +71,8 @@ private:
 
   unsigned char verbosity;
 
+  unsigned int olderTotemT2FileTest;  //Test file with T2 frame ver 2.1
+
   unsigned int printErrorSummary;
   unsigned int printUnknownFrameSummary;
 

--- a/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
+++ b/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
@@ -11,6 +11,7 @@
 #define EventFilter_CTPPSRawToDigi_SimpleVFATFrameCollection
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h"
+#include "CondFormats/PPSObjects/interface/TotemT2FramePosition.h"
 
 #include <map>
 
@@ -39,7 +40,9 @@ public:
   bool Empty() const override { return (data.empty()); }
 
   void Insert(const TotemFramePosition& index, const VFATFrame& frame) { data.insert({index, frame}); }
-
+  void Insert(const TotemT2FramePosition& index, const VFATFrame& frame) {
+    data.insert({TotemFramePosition(index.getRawPosition()), frame});
+  }
   /// inserts an empty (default) frame to the given position and returns pointer to the frame
   VFATFrame* InsertEmptyFrame(TotemFramePosition index) { return &data.insert({index, VFATFrame()}).first->second; }
 

--- a/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
@@ -22,25 +22,23 @@ namespace totem::nt2::vfat {
   static constexpr size_t num_words_per_channel = 4;
   /// multiplicity of channels combined into a single payload
   static constexpr size_t num_channels_per_payload = 2;
+  static constexpr size_t header_offset = 3;
   /// get timing information for single leading edge
   inline uint16_t leadingEdgeTime(const VFATFrame& frame, size_t ch_id) {
-    return frame.getData()[2 + num_words_per_channel * ch_id] & 0xffff;
+    return frame.getData()[header_offset + 2 + num_words_per_channel * ch_id] & 0xffff;
   }
   /// get timing information for single trailing edge
   inline uint16_t trailingEdgeTime(const VFATFrame& frame, size_t ch_id) {
-    return frame.getData()[3 + num_words_per_channel * ch_id] & 0xffff;
+    return frame.getData()[header_offset + 3 + num_words_per_channel * ch_id] & 0xffff;
   }
   /// retrieve this channel marker
   inline uint8_t channelMarker(const VFATFrame& frame, size_t ch_id) {
-    return frame.getData()[1 + num_words_per_channel * ch_id] & 0x1f;
+    return frame.getData()[header_offset + 1 + num_words_per_channel * ch_id] & 0x1f;
   }
-  /// retrieve the GEO information for this channel
-  inline uint8_t geoId(const VFATFrame& frame, size_t ch_id) {
-    return frame.getData()[0 + num_words_per_channel * ch_id] & 0xff;
-  }
-  /// retrieve this channel identifier
-  inline uint8_t channelId(const VFATFrame& frame, size_t ch_id) {
-    return (frame.getData()[0 + num_words_per_channel * ch_id] >> 8) & 0xff;
+
+  /// retrieve the HW identifier for this channel, in firmware >2.1
+  inline uint16_t newChannelId(const VFATFrame& frame, size_t ch_id) {
+    return frame.getData()[header_offset + 0 + num_words_per_channel * ch_id] & 0xffff;
   }
 }  // namespace totem::nt2::vfat
 

--- a/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
@@ -18,16 +18,30 @@
  * Utilitary namespace to retrieve timing/status information from nT2 VFAT frame
 **/
 namespace totem::nt2::vfat {
+  /// multiplicity of 32-bit words combined into a single channel payload
+  static constexpr size_t num_words_per_channel = 4;
+  /// multiplicity of channels combined into a single payload
+  static constexpr size_t num_channels_per_payload = 2;
   /// get timing information for single leading edge
-  inline uint16_t leadingEdgeTime(const VFATFrame& frame) { return frame.getData()[2] & 0xffff; }
+  inline uint16_t leadingEdgeTime(const VFATFrame& frame, size_t ch_id) {
+    return frame.getData()[2 + num_words_per_channel * ch_id] & 0xffff;
+  }
   /// get timing information for single trailing edge
-  inline uint16_t trailingEdgeTime(const VFATFrame& frame) { return frame.getData()[3] & 0xffff; }
+  inline uint16_t trailingEdgeTime(const VFATFrame& frame, size_t ch_id) {
+    return frame.getData()[3 + num_words_per_channel * ch_id] & 0xffff;
+  }
   /// retrieve this channel marker
-  inline uint8_t channelMarker(const VFATFrame& frame) { return frame.getData()[1] & 0x1f; }
+  inline uint8_t channelMarker(const VFATFrame& frame, size_t ch_id) {
+    return frame.getData()[1 + num_words_per_channel * ch_id] & 0x1f;
+  }
   /// retrieve the GEO information for this channel
-  inline uint8_t geoId(const VFATFrame& frame) { return frame.getData()[0] & 0x3f; }
+  inline uint8_t geoId(const VFATFrame& frame, size_t ch_id) {
+    return frame.getData()[0 + num_words_per_channel * ch_id] & 0xff;
+  }
   /// retrieve this channel identifier
-  inline uint8_t channelId(const VFATFrame& frame) { return (frame.getData()[0] >> 8) & 0x3f; }
+  inline uint8_t channelId(const VFATFrame& frame, size_t ch_id) {
+    return (frame.getData()[0 + num_words_per_channel * ch_id] >> 8) & 0xff;
+  }
 }  // namespace totem::nt2::vfat
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
@@ -104,6 +104,9 @@ public:
   /// If binary is true, binary format is used.
   void Print(bool binary = false) const;
 
+  //Follow the VFAT2 manual format, not reversed
+  void PrintT2(bool binary = false) const;
+
   /// internaly used to check CRC
   static word calculateCRC(word crc_in, word dato);
 

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -126,10 +126,16 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
     }
 
     else if (subSystem == ssTotemT2) {
-      for (int id = FEDNumbering::MINTotemT2FEDID; id < FEDNumbering::MAXTotemT2FEDID; ++id)
+      for (int id = FEDNumbering::MINTotemT2FEDID; id <= FEDNumbering::MAXTotemT2FEDID; ++id)
         fedIds.push_back(id);
     }
   }
+  LogDebug("TotemVFATRawToDigi").log([this](auto &log) {
+    log << "List of FEDs handled by this instance: ";
+    string sep;
+    for (const auto &fedId : fedIds)
+      log << sep << fedId, sep = ", ";
+  });
 
   // conversion status
   produces<DetSetVector<TotemVFATStatus>>(subSystemName);

--- a/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
@@ -5,6 +5,7 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 totemT2Digis = totemVFATRawToDigi.clone(
     subSystem = cms.string('TotemT2'),
     RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
+        testID = cms.uint32(0), #Some ID mismatch in test sample
         testCRC = cms.uint32(0), # no need to test CRC for diamond frames
         testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
     )

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -71,10 +71,11 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf,
 
   LogDebug("Totem") << "RawDataUnpacker::processOptoRxFrame: "
                     << "OptoRxId = " << optoRxId << ", BX = " << bx << ", LV1 = " << lv1
-                    << ", frameSize = " << frameSize;
+                    << ", frameSize = " << frameSize << ", fov = " << fov;
 
-  if (optoRxId >= FEDNumbering::MINTotemRPTimingVerticalFEDID &&
-      optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) {
+  if ((optoRxId >= FEDNumbering::MINTotemRPTimingVerticalFEDID &&
+       optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) |
+      (optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID)) {
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
   }

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -74,8 +74,11 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf,
                     << ", frameSize = " << frameSize << ", fov = " << fov;
 
   if ((optoRxId >= FEDNumbering::MINTotemRPTimingVerticalFEDID &&
-       optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) |
-      (optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID)) {
+       optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID)) {
+    processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
+    return 0;
+  }
+  if ((optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID)) {
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
   }
@@ -439,6 +442,8 @@ int RawDataUnpacker::processOptoRxFrameSampic(const word *buf,
     unsigned int fiberIdx = (*(++VFATFrameWordPtr)) & 0xF;
     unsigned int gohIdx = (*VFATFrameWordPtr >> 4) & 0xF;
     TotemFramePosition fp(0, 0, optoRxId, gohIdx, fiberIdx);
+    TotemT2FramePosition fp2a(0, 0, optoRxId, gohIdx, fiberIdx, 0);
+    TotemT2FramePosition fp2b(0, 0, optoRxId, gohIdx, fiberIdx, 1);
 
     LogDebug("RawDataUnpacker::processOptoRxFrameSampic")
         << "OptoRx: " << optoRxId << " Goh: " << gohIdx << " Idx: " << fiberIdx;
@@ -453,7 +458,16 @@ int RawDataUnpacker::processOptoRxFrameSampic(const word *buf,
     }
     // save frame to output
     frame.setPresenceFlags(1);
-    fc->Insert(fp, frame);
+    if ((optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID)) {
+      if (verbosity > 0)
+        edm::LogWarning("Totem") << "T2 Frame Positions created: " << fp2a << "/" << fp2b << std::endl;
+
+      fc->Insert(
+          fp2a,
+          frame);  //Fill twice with the mapping for both payloads packed into the same frame, will match only once for each
+      fc->Insert(fp2b, frame);
+    } else
+      fc->Insert(fp, frame);
 
     LogDebug("RawDataUnpacker::processOptoRxFrameSampic") << "Trailer: " << std::hex << *VFATFrameWordPtr;
   }

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -25,6 +25,7 @@ using namespace edm;
 
 RawToDigiConverter::RawToDigiConverter(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      olderTotemT2FileTest(conf.getUntrackedParameter<unsigned int>("useOlderT2TestFile", 0)),
       printErrorSummary(conf.getUntrackedParameter<unsigned int>("printErrorSummary", 1)),
       printUnknownFrameSummary(conf.getUntrackedParameter<unsigned int>("printUnknownFrameSummary", 1)),
 
@@ -391,33 +392,69 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
   // common processing - frame validation
   runCommon(coll, mapping, records);
 
+  int allT2 = 0;
+  int goodT2 = 0;
+  int foundT2 = 0;
+  const int T2shiftOld =
+      (olderTotemT2FileTest > 0 ? 8 : 0);  //Run on TOTEM T2 test file (ver 2.1) or final T2 data ver 2.2
+
   // second loop over data
   for (auto &p : records) {
     Record &record = p.second;
 
+    allT2++;
     // calculate ids
     TotemT2DetId detId(record.info->symbolicID.symbolicID);
 
     if (record.status.isOK()) {
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);
-
-      for (size_t frame_id = 0; frame_id < totem::nt2::vfat::num_channels_per_payload; ++frame_id)
-        if (const auto hw_id = totem::nt2::vfat::channelId(*record.frame, frame_id);
-            hw_id == record.info->hwID)  // only unpack the payload associated to this hardware ID
+      goodT2++;
+      if (verbosity > 2) {
+        LogWarning("Totem") << "RawToDigiConverter: VFAT frame number " << allT2
+                            << " is OK , mapping HW_ID (decimal) is: " << (record.info->hwID)
+                            << ", T2DetId arm/plane/channel = " << (detId) << endl;
+        LogWarning("Totem") << "HW_id_16b CH0 (dec), LE CH0, TE CH0, marker CH0, HW_id_16b CH1 (dec), LE CH1,"
+                            << " TE CH1, marker CH1 = ";
+        for (size_t y = 0; y < 2; y++) {
+          LogWarning("Totem") << ((unsigned int)totem::nt2::vfat::newChannelId(*record.frame, y)) << "/"
+                              << ((unsigned int)totem::nt2::vfat::leadingEdgeTime(*record.frame, y)) << "/"
+                              << ((unsigned int)totem::nt2::vfat::trailingEdgeTime(*record.frame, y)) << "/"
+                              << ((unsigned int)totem::nt2::vfat::channelMarker(*record.frame, y)) << "/";
+        }
+      }
+      for (size_t frame_id = 0; frame_id < totem::nt2::vfat::num_channels_per_payload; ++frame_id) {
+        if (const uint16_t hw_id = totem::nt2::vfat::newChannelId(*record.frame, frame_id) >> T2shiftOld;
+            hw_id == record.info->hwID) {  // only unpack the payload associated to this hardware ID
           // create the digi
           edmNew::DetSetVector<TotemT2Digi>::FastFiller(digi, detId)
-              .emplace_back(totem::nt2::vfat::geoId(*record.frame, frame_id),
-                            hw_id,
+              .emplace_back(hw_id,
                             totem::nt2::vfat::channelMarker(*record.frame, frame_id),
                             totem::nt2::vfat::leadingEdgeTime(*record.frame, frame_id),
                             totem::nt2::vfat::trailingEdgeTime(*record.frame, frame_id));
+          foundT2++;
+        } else {
+          if (verbosity > 2)
+            LogWarning("Totem") << "HW_ID comparison fail (CH#/Channel HwID/Mapping HwID): " << ((int)frame_id) << "/"
+                                << ((unsigned int)hw_id) << "/" << (record.info->hwID) << endl;
+        }
+      }
+    } else {
+      if (verbosity > 1)
+        LogWarning("Totem") << "Bad T2 record, is missing/IDmismatch/footprintError"
+                            << "/CRCerror/ECprogressBad/BCprogressBad: " << record.status.isMissing() << "/"
+                            << record.status.isIDMismatch() << "/" << record.status.isFootprintError() << "/"
+                            << record.status.isCRCError() << "/" << record.status.isECProgressError() << "/"
+                            << record.status.isBCProgressError() << "/" << endl;
     }
 
     // save status
     DetSet<TotemVFATStatus> &statusDetSet = status.find_or_insert(detId);
     statusDetSet.push_back(record.status);
   }
+  if (verbosity > 1)
+    LogWarning("Totem") << "RawToDigiConverter:: VFAT frames per event, total/good/matched the xml mapping"
+                        << " (T2Digi created): " << allT2 << "/" << goodT2 << "/" << foundT2 << endl;
 }
 
 void RawToDigiConverter::printSummaries() const {

--- a/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
+++ b/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
@@ -146,3 +146,29 @@ void VFATFrame::Print(bool binary) const {
     printf("\n");
   }
 }
+
+void VFATFrame::PrintT2(bool binary) const {
+  if (binary) {
+    for (int i = 0; i < 12; i++) {
+      const word &w = data[i];
+      word mask = (1 << 15);
+      for (int j = 0; j < 16; j++) {
+        if (w & mask)
+          printf("1");
+        else
+          printf("0");
+        mask = (mask >> 1);
+        if ((j + 1) % 4 == 0)
+          printf("|");
+      }
+      printf("\n");
+    }
+  } else {
+    printf("Frame = %04x|%04x|%04x|", data[0], data[1], data[2]);
+    for (int i = 3; i < 11; i++)
+      printf("%04x", data[i]);
+    printf("|%04x", data[11]);
+
+    printf("\n");
+  }
+}

--- a/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
+++ b/RecoPPS/Local/plugins/TotemT2RecHitProducer.cc
@@ -12,7 +12,6 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -28,8 +27,6 @@
 
 #include "Geometry/Records/interface/TotemGeometryRcd.h"
 #include "Geometry/CommonTopologies/interface/TrapezoidalStripTopology.h"
-#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
-#include "CondFormats/DataRecord/interface/PPSTimingCalibrationLUTRcd.h"
 
 class TotemT2RecHitProducer : public edm::stream::EDProducer<> {
 public:
@@ -41,13 +38,10 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::EDGetTokenT<edmNew::DetSetVector<TotemT2Digi> > digiToken_;
-  edm::ESGetToken<PPSTimingCalibration, PPSTimingCalibrationRcd> timingCalibrationToken_;
-  edm::ESGetToken<PPSTimingCalibrationLUT, PPSTimingCalibrationLUTRcd> timingCalibrationLUTToken_;
   edm::ESGetToken<TotemGeometry, TotemGeometryRcd> geometryToken_;
   /// A watcher to detect timing calibration changes.
-  edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
-  const bool applyCalib_;
+  const bool applyCalib_;  //Diamond calibration not used
   TotemT2RecHitProducerAlgorithm algo_;
 };
 
@@ -56,9 +50,6 @@ TotemT2RecHitProducer::TotemT2RecHitProducer(const edm::ParameterSet& iConfig)
       geometryToken_(esConsumes<TotemGeometry, TotemGeometryRcd>()),
       applyCalib_(iConfig.getParameter<bool>("applyCalibration")),
       algo_(iConfig) {
-  if (applyCalib_)
-    timingCalibrationToken_ = esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>(
-        edm::ESInputTag(iConfig.getParameter<std::string>("timingCalibrationTag")));
   produces<edmNew::DetSetVector<TotemT2RecHit> >();
 }
 
@@ -69,9 +60,6 @@ void TotemT2RecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   const auto& digis = iEvent.get(digiToken_);
 
   if (!digis.empty()) {
-    if (applyCalib_ && calibWatcher_.check(iSetup))
-      algo_.setCalibration(iSetup.getData(timingCalibrationToken_), iSetup.getData(timingCalibrationLUTToken_));
-
     // produce the rechits collection
     algo_.build(iSetup.getData(geometryToken_), digis, *pOut);
   }
@@ -84,11 +72,9 @@ void TotemT2RecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 
   desc.add<edm::InputTag>("digiTag", edm::InputTag("totemT2Digis", "TotemT2"))
       ->setComment("input digis collection to retrieve");
-  desc.add<std::string>("timingCalibrationTag", "GlobalTag:TotemT2TimingCalibration")
-      ->setComment("input tag for timing calibrations retrieval");
-  desc.add<double>("timeSliceNs", 25.0 / 1024.0)
+  desc.add<double>("timeSliceNs", 25.0 / 4.0)
       ->setComment("conversion constant between timing bin size and nanoseconds");
-  desc.add<bool>("applyCalibration", false)->setComment("switch on/off the timing calibration");
+  desc.add<bool>("applyCalibration", false)->setComment("switch on/off the timing calibration (not in use)");
 
   descr.add("totemT2RecHits", desc);
 }

--- a/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemT2RecHitProducerAlgorithm.cc
@@ -6,7 +6,6 @@
 *
 ****************************************************************************/
 
-#include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoPPS/Local/interface/TotemT2RecHitProducerAlgorithm.h"
 
 #include "DataFormats/Common/interface/DetSetNew.h"
@@ -17,36 +16,24 @@ void TotemT2RecHitProducerAlgorithm::build(const TotemGeometry& geom,
                                            edmNew::DetSetVector<TotemT2RecHit>& output) {
   for (const auto& vec : input) {
     const TotemT2DetId detid(vec.detId());
-    const int sector = detid.arm(), plane = detid.plane(), channel = detid.channel();
-
-    // retrieve the timing calibration part for this channel
-    const auto& ch_params = (apply_calib_) ? calib_->parameters(sector, 0, plane, channel) : std::vector<double>{};
-    // default values for offset + time precision if calibration object not found
-    const double ch_t_offset = (apply_calib_) ? calib_->timeOffset(sector, 0, plane, channel) : 0.;
-    const double ch_t_precis = (apply_calib_) ? calib_->timePrecision(sector, 0, plane, channel) : 0.;
 
     // prepare the output collection filler
     edmNew::DetSetVector<TotemT2RecHit>::FastFiller filler(output, detid);
 
     for (const auto& digi : vec) {
       const int t_lead = digi.leadingEdge(), t_trail = digi.trailingEdge();
-      if (t_lead == 0 && t_trail == 0)  // skip invalid digis
-        continue;
-      double tot = -1., ch_t_twc = 0.;
-      if (t_lead != 0 && t_trail != 0) {
+      // don't skip no-edge digis
+      double tot = 0.;
+      if (digi.hasLE() && digi.hasTE()) {
         tot = (t_trail - t_lead) * ts_to_ns_;  // in ns
-        if (calib_fct_ && apply_calib_) {      // compute the time-walk correction
-          ch_t_twc = calib_fct_->evaluate(std::vector<double>{tot}, ch_params);
-          if (edm::isNotFinite(ch_t_twc))
-            ch_t_twc = 0.;
-        }
       }
+      double ch_t_precis = ts_to_ns_ / 2.0;  //without a calibration, assume LE/TE precision is +-0.5
 
       // retrieve the geometry element associated to this DetID
       const auto& tile = geom.tile(detid);
 
       // store to the output collection
-      filler.emplace_back(tile.centre(), t_lead * ts_to_ns_ - ch_t_offset - ch_t_twc, ch_t_precis, tot);
+      filler.emplace_back(tile.centre(), t_lead * ts_to_ns_, ch_t_precis, tot);
     }
   }
 }

--- a/RecoPPS/Local/test/BuildFile.xml
+++ b/RecoPPS/Local/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="RecoPPSLocalNewT2" command="testNT2.sh"/>

--- a/RecoPPS/Local/test/testNT2.sh
+++ b/RecoPPS/Local/test/testNT2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ; exit $2; }
+
+F1=${CMSSW_BASE}/src/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+(cmsRun $F1) || die "Failure using $F1" $?

--- a/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
@@ -15,11 +15,12 @@ process.load('Configuration.EventContent.EventContent_cff')
 #from Configuration.AlCa.GlobalTag import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
 
+#dummy = cms.untracked.FileInPath('RecoPPS/Local/data/run364983_ls0001_streamA_StorageManager.dat'),
+
 # raw data source
 process.source = cms.Source("NewEventStreamFileReader",
-    fileNames = cms.untracked.vstring(
-        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/run364983_ls0001_streamA_StorageManager.dat',
-#        '/store/t0streamer/Minidaq/A/000/364/983/run364983_ls0001_streamA_StorageManager.dat',
+fileNames = cms.untracked.vstring('http://cmsrep.cern.ch/cmssw/download/data/RecoPPS/Local/V1/run364983_ls0001_streamA_StorageManager.dat'
+#        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/run364983_ls0001_streamA_StorageManager.dat',
     )
 )
 

--- a/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.threshold = "DEBUG"
+# enable LogDebug messages only for specific modules
+process.MessageLogger.debugModules = ["Totem"]
+
+process.load('Configuration.EventContent.EventContent_cff')
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+
+# raw data source
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring(
+        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/run364983_ls0001_streamA_StorageManager.dat',
+#        '/store/t0streamer/Minidaq/A/000/364/983/run364983_ls0001_streamA_StorageManager.dat',
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# raw-to-digi conversion
+process.load('CalibPPS.ESProducers.totemT2DAQMapping_cff')
+process.load('EventFilter.CTPPSRawToDigi.totemT2Digis_cfi')
+process.totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
+process.totemDAQMappingESSourceXML.verbosity = cms.untracked.uint32(1)
+process.totemT2Digis.RawUnpacking.verbosity = cms.untracked.uint32(1)
+process.totemT2Digis.RawToDigi.verbosity = cms.untracked.uint32(3)
+process.totemT2Digis.RawToDigi.useOlderT2TestFile = cms.untracked.uint32(1)
+process.totemT2Digis.RawToDigi.printUnknownFrameSummary = cms.untracked.uint32(3)
+process.totemT2Digis.RawToDigi.printErrorSummary = cms.untracked.uint32(3)
+process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = cms.untracked.bool(True)
+
+# rechits production
+process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')
+process.load('Geometry.ForwardGeometry.totemGeometryESModule_cfi')
+process.load('RecoPPS.Local.totemT2RecHits_cfi')
+
+process.output = cms.OutputModule("PoolOutputModule",
+        fileName = cms.untracked.string("file:output-miniDaq2303-T2testFile-ver2.1--1ev.root"),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_totemT2*_*_*',
+    ),
+)
+
+# execution configuration
+process.p = cms.Path(
+    process.totemT2Digis
+    * process.totemT2RecHits
+)
+
+process.outpath = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

For the TOTEM special run around 25.6.2023, the new T2 telescope will be used to veto diffractive p+p collisions, when measuring the elastic and total p+p cross section.
The T2 offline code needed to be updated since the common TOTEM/PPS raw data unpacking was previously mapping each payload to a unique (FED ID, GOH ID, fibre)-triplet, but now 2 T2 channels are connected to each fibre, so a single T2 VFAT frame has two payloads. Therefore the xml mapping for T2 in 2023 was updated with a fourth keyword. The xml mapping is preliminary and will still be updated at least for arm 4-5, and pending final validation of physical connectivity.

The T2 firmware data format read in by the unpacker was changed from version 2.0 to final version 2.2, so the T2Digi DataFormat class was also changed.
TOTEM/PPS diamond-specific timing calibration was also removed from the T2 RecHit chain.

#### PR validation:

The PR was tested with a streamer file ( run 364983, available in my lxplus directory: ~foljemar/public/) produced by emulated T2 firmware v2.1 (T2 Frame format: https://github.com/CTPPS/cmssw/files/11351944/FrameFormat_V1.xlsx ).

The input mapping was successfully used to create T2Digis with the correct input values for leading and trailing edges, ID's and other bits, and the correct number of T2Digis (twice the number of T2 frames). If you run the new T2 test file in RecoPPS/Local/test on the streamer file above, you will get a hwID mismatch since only the upper 8 bits were non-0 in version 2.1.

I also tested that turning off the new T2 multipayload mapping parser didn't crash on test data, and that the shared TOTEM mapping code changes did not affect DQM plots for TOTEM Timing diamond & Tracking strip detectors, for streamer files from the recent run 366192. 
@fabferro likewise checked that no changes in other PPS detectors were observed, see https://github.com/CTPPS/cmssw/pull/73#issuecomment-1527230561
The runTheMatrix tests all passed just now. 
Here I squashed the commits together, the same commits without squashing can be found in CTPPS/cmssw:fo_nt2_unpacker branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Since the 13_1_X cycle will not be used for p+p data taking, we may need to backport to a special TOTEM-only point release of 13_0_X, so the T2 data can be checked at the DQM level during data taking in the special run.

