### PR TITLE
Remove PF candidates with nan for energy

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -150,7 +150,8 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       edm::Ptr<reco::PFCandidate> candPtr(pfCandidates, i);
       reco::PFCandidate cand(candPtr);
 
-      if(!(cand.energy()>0) ) continue;
+      if (!(cand.energy() > 0))
+        continue;
 
       bool isphoton = cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma() > 0.;
       bool iselectron = cand.particleId() == reco::PFCandidate::e;

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -150,6 +150,8 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       edm::Ptr<reco::PFCandidate> candPtr(pfCandidates, i);
       reco::PFCandidate cand(candPtr);
 
+      if(!(cand.energy()>0) ) continue;
+
       bool isphoton = cand.particleId() == reco::PFCandidate::gamma && cand.mva_nothing_gamma() > 0.;
       bool iselectron = cand.particleId() == reco::PFCandidate::e;
       // PFCandidates may have a valid MuonRef though they are not muons.


### PR DESCRIPTION
Addresses issue #41397 by simply filtering out PF candidates with nan for energy.
This is a short-term fix to stop the crashes in prompt reco.
Should be replaced by finding the source of these nan's in `PFAlgo.cc`

Verified that this removes the segmentation violation using the recipe provided in  #41397

Will need a backport to 13_0_X