### PR TITLE
Integration of #41467 and #41470 in patch release for HLT on top of `CMSSW_13_0_3`

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -475,7 +475,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
     return false;
   }
 
-  // check size
+  // check size (all BXs)
+  if (uGtAlgoBlocks->size() == 0) {
+    edm::LogWarning("HLTL1TSeed") << " Warning: GlobalAlgBlkBxCollection with input tag " << m_l1GlobalTag
+                                  << " is empty for all BXs.";
+    return false;
+  }
+
+  // check size (BX 0)
   if (uGtAlgoBlocks->isEmpty(0)) {
     edm::LogWarning("HLTL1TSeed") << " Warning: GlobalAlgBlkBxCollection with input tag " << m_l1GlobalTag
                                   << " is empty for BX=0.";

--- a/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="FWCore/Framework"/>
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
 <use name="DataFormats/EgammaCandidates"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="RecoEcal/EgammaCoreTools"/>


### PR DESCRIPTION
#### PR description:

#41467 adds a check to `HLTRecHitInAllL1RegionsProducer<T>` to handle gracefully events where the input collection of L1T candidates is empty (either completely empty, or even empty just for BX=0). This is meant to fix several HLT crashes seen online in April 2023.

#41470 amends a mistake introduced in #40655. The check on `size == 0` should not have been removed in #40655, mainly because, if `BXVector::size() == 0`, the call to `BXVector::isEmpty(0)` might lead to a crash (which is arguably a limit of the implementation of [`BXVector::isEmpty(int bx)`](https://github.com/cms-sw/cmssw/blob/0d6218db24f97d34933bda623816949d340262ba/DataFormats/L1Trigger/interface/BXVector.icc#L213)).

Discussed in #41475.

#### PR validation:

None beyond what was done for the integration of those PRs.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A