### PR TITLE
[13.0.X] add `PileupSummaryInfos_addPileupInfo` to `SiPixelCalSingleMuonTight` output data-tier

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_Output_cff.py
@@ -11,6 +11,7 @@ OutALCARECOSiPixelCalSingleMuonTight_noDrop = cms.PSet(
         'keep *_*riggerResults_*_HLT',
         'keep *_*closebyPixelClusters*_*_*',
         'keep *_*trackDistances*_*_*',
+        'keep PileupSummaryInfos_addPileupInfo_*_*'
      )
 )
 OutALCARECOSiPixelCalSingleMuonTight=OutALCARECOSiPixelCalSingleMuonTight_noDrop.clone()


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41411

#### PR description:

Title says it all. Needed for pixel dynamic inefficiency studies, as reported [here](https://indico.cern.ch/event/1271485/contributions/5377156/attachments/2635145/4558662/Pixel_Dynamic_Inefficiency_simulation_Validation___update.pdf#page=2), see for long version also [here](https://github.com/CMSTrackerDPG/Tasks/issues/1).

#### PR validation:

Run the command:
```
cmsDriver.py -s ALCA:SiPixelCalSingleMuonTight --conditions 124X_mcRun3_2022_realistic_postEE_forPixelIneff_v5 --eventcontent=ALCARECO --datatier ALCARECO -n 10000 --no_exec --era Run3 --python_filename=SingleMuonTightCombinedMC.py --nThreads=8 --filein=/store/relval/CMSSW_12_4_12/RelValZMM_PU_13p6/GEN-SIM-RECO/PU_124X_mcRun3_2022_realistic_postEE_forPixelIneff_v5_PDMVRELVALS188_HS_2023PU-v1/00000/05930f72-62dc-45fd-814b-2652a4ddd08d.root
```
with this branch and without and found the following changes:

```diff
< File SiPixelCalSingleMuonTight_new.root Events 1103
---
> File SiPixelCalSingleMuonTight.root Events 1103
4,22c4,21
< PileupSummaryInfos_addPileupInfo__HLT. 24663 8817.56
< recoMuons_muons__RECO. 18709.7 6319.87
< recoVertexs_offlinePrimaryVertices__RECO. 45693.1 5982.61
< recoVertexsedmAssociation_offlinePrimaryVertices__RECO. 5417.33 1329.82
< EventProductProvenance 4409.7 651.125
< intedmValueMap_offlinePrimaryVertices__RECO. 5398.31 371.293
< recoTrackExtras_ALCARECOSiPixelCalSingleMuonTight__ALCA. 473.744 348.975
< recoTracks_ALCARECOSiPixelCalSingleMuonTight__ALCA. 589.343 261.811
< SiStripClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 682.138 229.76
< floatedmValueMap_offlinePrimaryVertices__RECO. 247.966 190.427
< TrackingRecHitsOwned_ALCARECOSiPixelCalSingleMuonTight__ALCA. 1648.62 183.922
< SiPixelClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 346.11 166.796
< SiPixelClusteredmNewDetSetVector_closebyPixelClusters__ALCA. 344.534 164.618
< edmTriggerResults_TriggerResults__HLT. 1527.38 63.7217
< Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 78.7643 35.2466
< EventAuxiliary 115.829 14.3083
< floatsedmValueMap_trackDistances__ALCA. 65.3626 13.2248
< EventSelections 92.1442 6.30372
< BranchListIndexes 25.1686 3.18223
---
> recoMuons_muons__RECO. 18718 6361.84
> recoVertexs_offlinePrimaryVertices__RECO. 45703.9 6008.53
> recoVertexsedmAssociation_offlinePrimaryVertices__RECO. 5421.87 1336.26
> EventProductProvenance 4410.01 883.01
> intedmValueMap_offlinePrimaryVertices__RECO. 5402.4 377.336
> recoTrackExtras_ALCARECOSiPixelCalSingleMuonTight__ALCA. 465.82 339.411
> recoTracks_ALCARECOSiPixelCalSingleMuonTight__ALCA. 581.367 252.24
> SiStripClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 678.673 223.561
> floatedmValueMap_offlinePrimaryVertices__RECO. 247.745 190.081
> TrackingRecHitsOwned_ALCARECOSiPixelCalSingleMuonTight__ALCA. 1649.56 186.464
> SiPixelClusteredmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 342.141 161.065
> SiPixelClusteredmNewDetSetVector_closebyPixelClusters__ALCA. 340.872 159.252
> edmTriggerResults_TriggerResults__HLT. 1528.05 66.9565
> Phase2TrackerCluster1DedmNewDetSetVector_ALCARECOSiPixelCalSingleMuonTight__ALCA. 75.6074 31.505
> EventAuxiliary 115.728 14.0508
> floatsedmValueMap_trackDistances__ALCA. 65.0462 12.796
> EventSelections 92.4488 6.83862
> BranchListIndexes 25.0834 3.07978
```

**The additional collection (as measured on around 1k events) adds about 8kB/event, so the overall on-file size is increased by 40%**
   * this is undoubtedly sizeable, but as per AlCa conveners advice (@tvami): "this ALCARECO has an order of magnitude less events than other ALCARECOs, so even the 40% increase will make the size reasonable ". 
   * Moreover it should only be there for MC (which I think we unfrequently run, except in relvals)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport to 13.0.X of https://github.com/cms-sw/cmssw/pull/41411

cc:
@ferencek @mroguljic FYI