### PR TITLE
[CLANG] Fix warnings about set but unused variables

### DIFF
--- a/SimDataFormats/CrossingFrame/interface/MixCollection.h
+++ b/SimDataFormats/CrossingFrame/interface/MixCollection.h
@@ -240,10 +240,6 @@ bool MixCollection<T>::MixItr::getNewPileups(typename std::vector<const T *>::co
   // gets the next pileup collection , changing subdet if necessary
   while (iPileup_ < nrDets_) {
     mixCol_->crossingFrames_[iPileup_]->getPileups(first, last);
-    int s = 0;
-    for (typename std::vector<const T *>::const_iterator it = first; it != last; it++) {
-      s++;
-    }
     myCF_ = mixCol_->crossingFrames_[iPileup_];
     iPileup_++;
     if (first != last)

--- a/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
@@ -391,7 +391,6 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   float xsize, ysize, q50i, q100i, q50r, q10r, xhit2D, yhit2D, dist2, dmin2;
   float xy_in[BXM2][BYM2], xy_rewgt[BXM2][BYM2], xy_clust[TXSIZE][TYSIZE];
   int denx_clust[TXSIZE][TYSIZE], deny_clust[TXSIZE][TYSIZE];
-  int goodWeightsUsed, nearbyWeightsUsed, noWeightsUsed;
   float cotalpha, cotbeta;
   // success = 0 is returned if everthing is OK
   success = 0;
@@ -544,18 +543,10 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
     printCluster(xy_clust);
   }
 
-  // Do the reweighting
-  goodWeightsUsed = 0;
-  nearbyWeightsUsed = 0;
-  noWeightsUsed = 0;
-
   for (i = 0; i < TYSIZE; ++i) {
     for (j = 0; j < TXSIZE; ++j) {
       if (xy_clust[j][i] > 0.f) {
         cluster[j][i] = xy_clust[j][i] * clust[denx_clust[j][i]][deny_clust[j][i]];
-        if (cluster[j][i] > 0) {
-          goodWeightsUsed++;
-        }
       } else {
         if (clust[j][i] > 0.f) {
           ++ncpix;
@@ -582,10 +573,8 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
         }
       }
       if (dmin2 < 5.f) {
-        nearbyWeightsUsed++;
         cluster[j][i] *= xy_clust[xtclust[kclose]][ytclust[kclose]];
       } else {
-        noWeightsUsed++;
         cluster[j][i] = 0.f;
       }
     }

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -183,7 +183,6 @@ bool TTClusterAssociationMap<T>::isGenuine(TTClusterRefT<T> aCluster) const {
     return false;
 
   /// If we are here, it means there are some TrackingParticles
-  unsigned int nullTPs = 0;
   unsigned int goodDifferentTPs = 0;
   std::vector<const TrackingParticle*> tpAddressVector;
 
@@ -198,7 +197,6 @@ bool TTClusterAssociationMap<T>::isGenuine(TTClusterRefT<T> aCluster) const {
 
     /// Count the NULL TrackingParticles
     if (curTP.isNull()) {
-      //      nullTPs++;
       tp_mom.push_back(0);
     } else {
       tp_mom.push_back(curTP.get()->p4().pt());
@@ -214,9 +212,7 @@ bool TTClusterAssociationMap<T>::isGenuine(TTClusterRefT<T> aCluster) const {
     TrackingParticlePtr curTP = theseTrackingParticles.at(itp);
 
     /// Count the NULL TrackingParticles
-    if (tp_mom.at(itp) <= 0.01 * tp_tot) {
-      nullTPs++;
-    } else {
+    if (tp_mom.at(itp) > 0.01 * tp_tot) {
       /// Store the pointers (addresses) of the TrackingParticle
       /// to be able to count how many different there are
       tpAddressVector.push_back(curTP.get());
@@ -284,7 +280,6 @@ bool TTClusterAssociationMap<T>::isCombinatoric(TTClusterRefT<T> aCluster) const
   return true;
 
   /// If we are here, it means there are some TrackingParticles
-  unsigned int nullTPs = 0;
   unsigned int goodDifferentTPs = 0;
   std::vector<const TrackingParticle*> tpAddressVector;
 
@@ -294,9 +289,7 @@ bool TTClusterAssociationMap<T>::isCombinatoric(TTClusterRefT<T> aCluster) const
     TrackingParticlePtr curTP = theseTrackingParticles.at(itp);
 
     /// Count the NULL TrackingParticles
-    if (curTP.isNull()) {
-      nullTPs++;
-    } else {
+    if (!curTP.isNull()) {
       /// Store the pointers (addresses) of the TrackingParticle
       /// to be able to count how many different there are
       tpAddressVector.push_back(curTP.get());
@@ -308,9 +301,6 @@ bool TTClusterAssociationMap<T>::isCombinatoric(TTClusterRefT<T> aCluster) const
   tpAddressVector.erase(std::unique(tpAddressVector.begin(), tpAddressVector.end()), tpAddressVector.end());
   goodDifferentTPs = tpAddressVector.size();
 
-  /// COMBINATORIC means no NULLs and more than one good TP
-  /// OR, in alternative, only one good TP but non-zero NULLS
-  //return ( ( nullTPs == 0 && goodDifferentTPs > 1 ) || ( nullTPs > 0 && goodDifferentTPs > 0 ) );
   return (goodDifferentTPs > 1);
 }
 

--- a/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
@@ -106,8 +106,8 @@ namespace tt {
       if (setup_->useForAlgEff(*p.first))
         selection.insert(p.first, p.second);
     }
-    iEvent.emplace(putTokenReconstructable_, move(reconstructable));
-    iEvent.emplace(putTokenSelection_, move(selection));
+    iEvent.emplace(putTokenReconstructable_, std::move(reconstructable));
+    iEvent.emplace(putTokenSelection_, std::move(selection));
   }
 
 }  // namespace tt


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these for sim packages

[a]
```
warning: variable 'XXX' set but not used [-Wunused-but-set-variable]
```