### PR TITLE
Additional memory decrease in CSCTriggerPrimitivesProducer

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCAnodeLCTProcessor.h
@@ -66,7 +66,7 @@ public:
 
   // This is the main routine for normal running.  It gets wire times
   // from the wire digis and then passes them on to another run() function.
-  std::vector<CSCALCTDigi> run(const CSCWireDigiCollection* wiredc);
+  std::vector<CSCALCTDigi> run(const CSCWireDigiCollection* wiredc, CSCChamber const* chamber);
 
   // This version of the run() function can either be called in a standalone
   // test, being passed the time array, or called by the run() function above.

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -58,13 +58,13 @@ public:
   /** Default destructor. */
   virtual ~CSCBaseboard() = default;
 
-  void setCSCGeometry(const CSCGeometry* g);
-
   std::string getCSCName() const { return theCSCName_; }
 
   CSCDetId id() const { return cscId_; }
 
 protected:
+  const CSCChamber* cscChamber(CSCGeometry const&) const;
+
   void checkConfigParameters(unsigned int& var,
                              const unsigned int var_max,
                              const unsigned int var_def,
@@ -99,9 +99,6 @@ protected:
    *                   2: info at every step of the algorithm.
    *                   3: add special-purpose prints. */
   int infoV;
-
-  const CSCGeometry* cscGeometry_;
-  const CSCChamber* cscChamber_;
 
   // chamber name, e.g. ME+1/1/9
   std::string theCSCName_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -57,18 +57,19 @@ public:
   /** Sets configuration parameters obtained via EventSetup mechanism. */
   void setConfigParameters(const CSCDBL1TPParameters* conf);
 
-  void setESLookupTables(const CSCL1TPLookupTableCCLUT* conf);
-
   /** Clears the LCT containers. */
   void clear();
 
   /** Runs the LCT processor code. Called in normal running -- gets info from
       a collection of comparator digis. */
-  std::vector<CSCCLCTDigi> run(const CSCComparatorDigiCollection* compdc);
+  std::vector<CSCCLCTDigi> run(const CSCComparatorDigiCollection* compdc,
+                               const CSCChamber* chamber,
+                               const CSCL1TPLookupTableCCLUT* lookupTable);
 
   /** Called in test mode and by the run(compdc) function; does the actual LCT
       finding. */
-  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
+  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+           const CSCL1TPLookupTableCCLUT* lookupTable);
 
   /** Returns vector of CLCTs in the read-out time window, if any. */
   std::vector<CSCCLCTDigi> readoutCLCTs() const;
@@ -132,7 +133,8 @@ protected:
 
   //--------------- Functions for post-2007 version of the firmware -----------
   virtual std::vector<CSCCLCTDigi> findLCTs(
-      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]);
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+      const CSCL1TPLookupTableCCLUT* lookupTable);
 
   /* Check all half-strip pattern envelopes simultaneously, on every clock cycle, for a matching pattern
      Returns true if a pretrigger was found, and the first BX of the pretrigger */
@@ -153,7 +155,8 @@ protected:
   // build a new CLCT trigger
   CSCCLCTDigi constructCLCT(const int bx,
                             const unsigned halfstrip_withstagger,
-                            const CSCCLCTDigi::ComparatorContainer& hits);
+                            const CSCCLCTDigi::ComparatorContainer& hits,
+                            const CSCL1TPLookupTableCCLUT* lookupTable);
 
   // build a new CLCT pretrigger
   CSCCLCTPreTriggerDigi constructPreCLCT(const int bx, const unsigned halfstrip, const unsigned index) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
@@ -32,11 +32,11 @@ public:
                 const edm::ParameterSet& tmbParams,
                 const edm::ParameterSet& luts);
 
-  void setESLookupTables(const CSCL1TPLookupTableME11ILT* conf);
-  void setESLookupTables(const CSCL1TPLookupTableME21ILT* conf);
-
   // calculate the bending angle
-  int calculateGEMCSCBending(const CSCCLCTDigi& clct, const GEMInternalCluster& cluster) const;
+  int calculateGEMCSCBending(const CSCCLCTDigi& clct,
+                             const GEMInternalCluster& cluster,
+                             const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                             const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   // match by location
 
@@ -49,18 +49,24 @@ public:
   void matchingClustersLoc(const CSCCLCTDigi& clct,
                            const GEMInternalClusters& clusters,
                            GEMInternalClusters& output,
-                           bool ignoreALCTGEMmatch) const;
+                           bool ignoreALCTGEMmatch,
+                           const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                           const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   // matching candidate distance in 1/8 strip, always the total without extrapolation correction, if ForceTotal is true
   int matchedClusterDistES(const CSCCLCTDigi& clct,
                            const GEMInternalCluster& cluster,
                            const bool isLayer2,
-                           const bool ForceTotal) const;
+                           const bool ForceTotal,
+                           const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                           const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   // ALCT-CLCT-GEM
   void matchingClustersLoc(const CSCALCTDigi& alct,
                            const CSCCLCTDigi& clct,
                            const GEMInternalClusters& clusters,
+                           const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                           const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                            GEMInternalClusters& output) const;
 
   // best matching clusters by location
@@ -69,24 +75,32 @@ public:
   void bestClusterLoc(const CSCALCTDigi& alct, const GEMInternalClusters& clusters, GEMInternalCluster& best) const;
 
   // CLCT-GEM
-  void bestClusterLoc(const CSCCLCTDigi& clct, const GEMInternalClusters& clusters, GEMInternalCluster& best) const;
+  void bestClusterLoc(const CSCCLCTDigi& clct,
+                      const GEMInternalClusters& clusters,
+                      const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                      const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
+                      GEMInternalCluster& best) const;
 
   // ALCT-CLCT-GEM
   void bestClusterLoc(const CSCALCTDigi& alct,
                       const CSCCLCTDigi& clct,
                       const GEMInternalClusters& clusters,
+                      const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                      const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                       GEMInternalCluster& best) const;
 
 private:
-  // access to lookup tables via eventsetup
-  const CSCL1TPLookupTableME11ILT* lookupTableME11ILT_;
-  const CSCL1TPLookupTableME21ILT* lookupTableME21ILT_;
-
   //mitigate slope by consistency of slope indicator, if necessary
-  uint16_t mitigatedSlopeByConsistency(const CSCCLCTDigi& clct) const;
+  uint16_t mitigatedSlopeByConsistency(const CSCCLCTDigi& clct,
+                                       const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                       const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   // calculate slope correction
-  int CSCGEMSlopeCorrector(const bool isME1a, const int cscSlope, bool isLayer2) const;
+  int CSCGEMSlopeCorrector(const bool isME1a,
+                           const int cscSlope,
+                           bool isLayer2,
+                           const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                           const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) const;
 
   unsigned endcap_;
   unsigned station_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMotherboard.h
@@ -38,15 +38,24 @@ public:
   //helper function to convert GEM-CSC amended slopes into Run2 patterns
   uint16_t Run2PatternConverter(const int slope) const;
 
+  struct RunContext {
+    // set CSC and GEM geometries for the matching needs
+    const GEMGeometry* gemGeometry_;
+    const CSCGeometry* cscGeometry_;
+    // access to lookup tables via eventsetup
+    const CSCL1TPLookupTableCCLUT* lookupTableCCLUT_;
+    const CSCL1TPLookupTableME11ILT* lookupTableME11ILT_;
+    const CSCL1TPLookupTableME21ILT* lookupTableME21ILT_;
+    const CSCDBL1TPParameters* parameters_;
+  };
+
   void run(const CSCWireDigiCollection* wiredc,
            const CSCComparatorDigiCollection* compdc,
-           const GEMPadDigiClusterCollection* gemPads);
+           const GEMPadDigiClusterCollection* gemPads,
+           RunContext const&);
 
   /* GEM cluster processor */
   std::shared_ptr<GEMClusterProcessor> clusterProc() const { return clusterProc_; }
-
-  // set CSC and GEM geometries for the matching needs
-  void setGEMGeometry(const GEMGeometry* g) { gem_g = g; }
 
 private:
   /*
@@ -60,19 +69,26 @@ private:
     6) Copy over valid to invalid
     7) ALCT-CLCT with unused combination
   */
-  void matchALCTCLCTGEM();
+  void matchALCTCLCTGEM(const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                        const CSCL1TPLookupTableME21ILT* lookupTableME21ILT);
 
   // correlate ALCT, CLCT with matched pads or copads
   void correlateLCTsGEM(const CSCALCTDigi& ALCT,
                         const CSCCLCTDigi& CLCT,
                         const GEMInternalClusters& clusters,
+                        const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                        const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                         CSCCorrelatedLCTDigi& lct) const;
 
   // correlate ALCT and CLCT, no GEM
   void correlateLCTsGEM(const CSCALCTDigi& ALCT, const CSCCLCTDigi& CLCT, CSCCorrelatedLCTDigi& lct) const;
 
   // correlate CLCT with matched pads or copads
-  void correlateLCTsGEM(const CSCCLCTDigi& CLCT, const GEMInternalClusters& clusters, CSCCorrelatedLCTDigi& lct) const;
+  void correlateLCTsGEM(const CSCCLCTDigi& CLCT,
+                        const GEMInternalClusters& clusters,
+                        const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                        const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
+                        CSCCorrelatedLCTDigi& lct) const;
 
   // correlate ALCT with matched pads or copads
   void correlateLCTsGEM(const CSCALCTDigi& ALCT, const GEMInternalClusters& clusters, CSCCorrelatedLCTDigi& lct) const;
@@ -81,13 +97,19 @@ private:
   void constructLCTsGEM(const CSCALCTDigi& alct,
                         const CSCCLCTDigi& clct,
                         const GEMInternalCluster& gem,
+                        const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                        const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                         CSCCorrelatedLCTDigi& lct) const;
 
   // Construct LCT from CSC and no GEM information. ALCT+CLCT
   void constructLCTsGEM(const CSCALCTDigi& alct, const CSCCLCTDigi& clct, CSCCorrelatedLCTDigi& lct) const;
 
   // Construct LCT from CSC and GEM information. CLCT+2GEM
-  void constructLCTsGEM(const CSCCLCTDigi& clct, const GEMInternalCluster& gem, CSCCorrelatedLCTDigi& lct) const;
+  void constructLCTsGEM(const CSCCLCTDigi& clct,
+                        const GEMInternalCluster& gem,
+                        const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                        const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
+                        CSCCorrelatedLCTDigi& lct) const;
 
   // Construct LCT from CSC and GEM information. ALCT+2GEM
   void constructLCTsGEM(const CSCALCTDigi& alct, const GEMInternalCluster& gem, CSCCorrelatedLCTDigi& lct) const;
@@ -98,7 +120,6 @@ private:
 
   /** Chamber id (trigger-type labels). */
   unsigned gemId;
-  const GEMGeometry* gem_g;
 
   // map of BX to vectors of GEM clusters. Makes it easier to match objects
   std::map<int, GEMInternalClusters> clusters_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -204,48 +204,14 @@ private:
   /* Container with sorted and selected LCTs */
   std::vector<CSCCorrelatedLCTDigi> lctV;
 
-  CSCShowerDigi showers_[CSCConstants::MAX_LCT_TBINS];
-
-  unsigned int mpc_block_me1a_;
-  unsigned int alct_trig_enable_, clct_trig_enable_, match_trig_enable_;
-  unsigned int match_trig_window_size_, tmb_l1a_window_size_;
-  //protected:
-  /** Phase2: whether to not reuse CLCTs that were used by previous matching ALCTs */
-  bool drop_used_clcts;
-
-  /** Phase2: separate handle for early time bins */
-  int early_tbins;
-
-  /** Phase2: whether to readout only the earliest two LCTs in readout window */
-  bool readout_earliest_2;
-
-  // when set to true, ignore CLCTs found in later BX's
-  bool match_earliest_clct_only_;
-
-  // encode special bits for high-multiplicity triggers
-  std::vector<unsigned> showerSource_;
-  unsigned thisShowerSource_;
-
-  unsigned minbx_readout_;
-  unsigned maxbx_readout_;
-  //protected:
-  bool ignoreAlctCrossClct_;
-
   /*
      Preferential index array in matching window, relative to the ALCT BX.
      Where the central match BX goes first,
      then the closest early, the closest late, etc.
   */
   std::vector<int> preferred_bx_match_;
-
-  /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
-  bool sort_clct_bx_;
-
-  /** Default values of configuration parameters. */
-  static const unsigned int def_mpc_block_me1a;
-  static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
-  static const unsigned int def_match_trig_enable, def_match_trig_window_size;
-  static const unsigned int def_tmb_l1a_window_size;
+  // encode special bits for high-multiplicity triggers
+  std::vector<unsigned> showerSource_;
 
   /* quality control */
   std::unique_ptr<LCTQualityControl> qualityControl_;
@@ -257,5 +223,40 @@ private:
     function is not implemented in the firmware.
   */
   std::unique_ptr<CSCALCTCrossCLCT> cscOverlap_;
+
+  CSCShowerDigi showers_[CSCConstants::MAX_LCT_TBINS];
+
+  unsigned int mpc_block_me1a_;
+  unsigned int alct_trig_enable_, clct_trig_enable_, match_trig_enable_;
+  unsigned int match_trig_window_size_, tmb_l1a_window_size_;
+
+  /** Phase2: separate handle for early time bins */
+  int early_tbins;
+
+  // encode special bits for high-multiplicity triggers
+  unsigned thisShowerSource_;
+
+  unsigned minbx_readout_;
+  unsigned maxbx_readout_;
+
+  /** Phase2: whether to not reuse CLCTs that were used by previous matching ALCTs */
+  bool drop_used_clcts;
+
+  /** Phase2: whether to readout only the earliest two LCTs in readout window */
+  bool readout_earliest_2;
+
+  // when set to true, ignore CLCTs found in later BX's
+  bool match_earliest_clct_only_;
+
+  bool ignoreAlctCrossClct_;
+
+  /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
+  bool sort_clct_bx_;
+
+  /** Default values of configuration parameters. */
+  static const unsigned int def_mpc_block_me1a;
+  static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
+  static const unsigned int def_match_trig_enable, def_match_trig_window_size;
+  static const unsigned int def_tmb_l1a_window_size;
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCMotherboard.h
@@ -60,9 +60,19 @@ public:
   /** Default destructor. */
   ~CSCMotherboard() override = default;
 
+  struct RunContext {
+    const CSCGeometry* cscGeometry_;
+    // access to lookup tables via eventsetup
+    const CSCL1TPLookupTableCCLUT* lookupTableCCLUT_;
+    const CSCL1TPLookupTableME11ILT* lookupTableME11ILT_;
+    const CSCL1TPLookupTableME21ILT* lookupTableME21ILT_;
+    /** Set configuration parameters obtained via EventSetup mechanism. */
+    const CSCDBL1TPParameters* parameters_;
+  };
+
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */
-  void run(const CSCWireDigiCollection* wiredc, const CSCComparatorDigiCollection* compdc);
+  void run(const CSCWireDigiCollection* wiredc, const CSCComparatorDigiCollection* compdc, const RunContext&);
 
   /*
     Returns vector of good correlated LCTs in the read-out time window.
@@ -90,16 +100,6 @@ public:
   /** Returns shower bits */
   std::vector<CSCShowerDigi> readoutShower() const;
 
-  /** Clears correlated LCT and passes clear signal on to cathode and anode
-      LCT processors. */
-  void clear();
-
-  /** Set configuration parameters obtained via EventSetup mechanism. */
-  void setConfigParameters(const CSCDBL1TPParameters* conf);
-  void setESLookupTables(const CSCL1TPLookupTableCCLUT* conf);
-  void setESLookupTables(const CSCL1TPLookupTableME11ILT* conf);
-  void setESLookupTables(const CSCL1TPLookupTableME21ILT* conf);
-
   /** Anode LCT processor. */
   std::unique_ptr<CSCAnodeLCTProcessor> alctProc;
 
@@ -108,89 +108,45 @@ public:
 
   // VK: change to protected, to allow inheritance
 protected:
-  // access to lookup tables via eventsetup
-  const CSCL1TPLookupTableCCLUT* lookupTableCCLUT_;
-  const CSCL1TPLookupTableME11ILT* lookupTableME11ILT_;
-  const CSCL1TPLookupTableME21ILT* lookupTableME21ILT_;
-
-  /* Containers for reconstructed ALCTs and CLCTs */
-  std::vector<CSCALCTDigi> alctV;
-  std::vector<CSCCLCTDigi> clctV;
-
-  /** Container with all LCTs prior to sorting and selecting. */
-  LCTContainer allLCTs_;
-
-  /* Container with sorted and selected LCTs */
-  std::vector<CSCCorrelatedLCTDigi> lctV;
-
-  CSCShowerDigi showers_[CSCConstants::MAX_LCT_TBINS];
+  std::tuple<std::vector<CSCALCTDigi>, std::vector<CSCCLCTDigi>> runCommon(const CSCWireDigiCollection* wiredc,
+                                                                           const CSCComparatorDigiCollection* compdc,
+                                                                           const RunContext& context);
 
   // helper function to return ALCT/CLCT with correct central BX
   CSCALCTDigi getBXShiftedALCT(const CSCALCTDigi&) const;
   CSCCLCTDigi getBXShiftedCLCT(const CSCCLCTDigi&) const;
 
   /** Configuration parameters. */
-  unsigned int mpc_block_me1a;
-  unsigned int alct_trig_enable, clct_trig_enable, match_trig_enable;
-  unsigned int match_trig_window_size, tmb_l1a_window_size;
+  unsigned int match_trig_window_size() const { return match_trig_window_size_; }
+  unsigned int match_trig_enable() const { return match_trig_enable_; }
 
-  /** Phase2: whether to not reuse CLCTs that were used by previous matching ALCTs */
-  bool drop_used_clcts;
-
-  /** Phase2: separate handle for early time bins */
-  int early_tbins;
-
-  /** Phase2: whether to readout only the earliest two LCTs in readout window */
-  bool readout_earliest_2;
-
-  // when set to true, ignore CLCTs found in later BX's
-  bool match_earliest_clct_only_;
-
-  // encode special bits for high-multiplicity triggers
-  std::vector<unsigned> showerSource_;
-  unsigned thisShowerSource_;
-  unsigned minbx_readout_;
-  unsigned maxbx_readout_;
-
-  bool ignoreAlctCrossClct_;
-
-  /*
-     Preferential index array in matching window, relative to the ALCT BX.
-     Where the central match BX goes first,
-     then the closest early, the closest late, etc.
-  */
-  std::vector<int> preferred_bx_match_;
-
-  /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
-  bool sort_clct_bx_;
-
-  /** Default values of configuration parameters. */
-  static const unsigned int def_mpc_block_me1a;
-  static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
-  static const unsigned int def_match_trig_enable, def_match_trig_window_size;
-  static const unsigned int def_tmb_l1a_window_size;
-
-  /* quality assignment */
-  std::unique_ptr<LCTQualityAssignment> qualityAssignment_;
-
-  /* quality control */
-  std::unique_ptr<LCTQualityControl> qualityControl_;
-
-  /*
-    Helper class to check if an ALCT intersects with a CLCT. Normally
-    this class should not be used. It is left in the code as a potential
-    improvement for ME1/1 when unphysical LCTs are not desired. This
-    function is not implemented in the firmware.
-  */
-  std::unique_ptr<CSCALCTCrossCLCT> cscOverlap_;
-
-  /** Make sure that the parameter values are within the allowed range. */
-  void checkConfigParameters();
+  int preferred_bx_match(unsigned int index) const { return preferred_bx_match_[index]; }
+  bool sort_clct_bx() const { return sort_clct_bx_; }
 
   /*sort CLCT by quality+bending and if CLCTs from different BX have
     same quality+bending, then rank CLCT by timing
    */
   void sortCLCTByQualBend(int alct_bx, std::vector<unsigned>& clctBxVector);
+
+  bool doesALCTCrossCLCT(const CSCALCTDigi&, const CSCCLCTDigi&) const;
+
+  // CLCT pattern number: encodes the pattern number itself
+  unsigned int encodePattern(const int clctPattern) const;
+
+  /** Container with all LCTs prior to sorting and selecting. */
+  LCTContainer allLCTs_;
+
+  /* quality assignment */
+  std::unique_ptr<LCTQualityAssignment> qualityAssignment_;
+
+private:
+  /** Clears correlated LCT and passes clear signal on to cathode and anode
+      LCT processors. */
+  void clear();
+
+  /** Make sure that the parameter values are within the allowed range. */
+  void checkConfigParameters();
+
   /*
      For valid ALCTs in the trigger time window, look for CLCTs within the
      match-time window. Valid CLCTs are matched in-time. If a match was found
@@ -234,11 +190,6 @@ protected:
   void copyValidToInValidALCT(CSCALCTDigi&, CSCALCTDigi&) const;
   void copyValidToInValidCLCT(CSCCLCTDigi&, CSCCLCTDigi&) const;
 
-  bool doesALCTCrossCLCT(const CSCALCTDigi&, const CSCCLCTDigi&) const;
-
-  // CLCT pattern number: encodes the pattern number itself
-  unsigned int encodePattern(const int clctPattern) const;
-
   /** Dump TMB/MPC configuration parameters. */
   void dumpConfigParams() const;
 
@@ -247,5 +198,64 @@ protected:
 
   /* encode high multiplicity bits for Run-3 exotic triggers */
   void encodeHighMultiplicityBits();
+
+  void setConfigParameters(const CSCDBL1TPParameters* conf);
+
+  /* Container with sorted and selected LCTs */
+  std::vector<CSCCorrelatedLCTDigi> lctV;
+
+  CSCShowerDigi showers_[CSCConstants::MAX_LCT_TBINS];
+
+  unsigned int mpc_block_me1a_;
+  unsigned int alct_trig_enable_, clct_trig_enable_, match_trig_enable_;
+  unsigned int match_trig_window_size_, tmb_l1a_window_size_;
+  //protected:
+  /** Phase2: whether to not reuse CLCTs that were used by previous matching ALCTs */
+  bool drop_used_clcts;
+
+  /** Phase2: separate handle for early time bins */
+  int early_tbins;
+
+  /** Phase2: whether to readout only the earliest two LCTs in readout window */
+  bool readout_earliest_2;
+
+  // when set to true, ignore CLCTs found in later BX's
+  bool match_earliest_clct_only_;
+
+  // encode special bits for high-multiplicity triggers
+  std::vector<unsigned> showerSource_;
+  unsigned thisShowerSource_;
+
+  unsigned minbx_readout_;
+  unsigned maxbx_readout_;
+  //protected:
+  bool ignoreAlctCrossClct_;
+
+  /*
+     Preferential index array in matching window, relative to the ALCT BX.
+     Where the central match BX goes first,
+     then the closest early, the closest late, etc.
+  */
+  std::vector<int> preferred_bx_match_;
+
+  /* sort CLCT by bx if true, otherwise sort CLCT by quality+bending */
+  bool sort_clct_bx_;
+
+  /** Default values of configuration parameters. */
+  static const unsigned int def_mpc_block_me1a;
+  static const unsigned int def_alct_trig_enable, def_clct_trig_enable;
+  static const unsigned int def_match_trig_enable, def_match_trig_window_size;
+  static const unsigned int def_tmb_l1a_window_size;
+
+  /* quality control */
+  std::unique_ptr<LCTQualityControl> qualityControl_;
+
+  /*
+    Helper class to check if an ALCT intersects with a CLCT. Normally
+    this class should not be used. It is left in the code as a potential
+    improvement for ME1/1 when unphysical LCTs are not desired. This
+    function is not implemented in the firmware.
+  */
+  std::unique_ptr<CSCALCTCrossCLCT> cscOverlap_;
 };
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCTriggerPrimitivesBuilder.h
@@ -51,15 +51,14 @@ public:
 
   ~CSCTriggerPrimitivesBuilder();
 
-  /** Sets configuration parameters obtained via EventSetup mechanism. */
-  void setConfigParameters(const CSCDBL1TPParameters* conf);
-  void setESLookupTables(const CSCL1TPLookupTableCCLUT* conf);
-  void setESLookupTables(const CSCL1TPLookupTableME11ILT* conf);
-  void setESLookupTables(const CSCL1TPLookupTableME21ILT* conf);
-
-  /// set CSC and GEM geometries for the matching needs
-  void setCSCGeometry(const CSCGeometry* g) { csc_g = g; }
-  void setGEMGeometry(const GEMGeometry* g) { gem_g = g; }
+  struct BuildContext {
+    const CSCL1TPLookupTableCCLUT* cclut_;
+    const CSCL1TPLookupTableME11ILT* me11ilt_;
+    const CSCL1TPLookupTableME21ILT* me21ilt_;
+    const CSCGeometry* cscgeom_;
+    const GEMGeometry* gemgeom_;
+    const CSCDBL1TPParameters* parameters_;
+  };
 
   // Build anode, cathode, and correlated LCTs in each chamber and fill them
   // into output collections.  Pass collections of wire and comparator digis
@@ -74,6 +73,7 @@ public:
              const CSCWireDigiCollection* wiredc,
              const CSCComparatorDigiCollection* compdc,
              const GEMPadDigiClusterCollection* gemPadClusters,
+             const BuildContext& context,
              CSCALCTDigiCollection& oc_alct,
              CSCCLCTDigiCollection& oc_clct,
              CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,
@@ -140,10 +140,6 @@ private:
 
   /** Pointer to MPC processors. */
   std::unique_ptr<CSCMuonPortCard> mpc_[MAX_ENDCAPS][MAX_STATIONS][MAX_SECTORS];
-
-  // pointers to the geometry
-  const CSCGeometry* csc_g;
-  const GEMGeometry* gem_g;
 };
 
 template <class T, class S>

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeCathodeLCTProcessor.h
@@ -38,8 +38,8 @@ private:
 
   /* Phase-2 version of the CLCT finder function */
   std::vector<CSCCLCTDigi> findLCTs(
-      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER])
-      override;
+      const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+      const CSCL1TPLookupTableCCLUT* lookupTable) override;
 
   // mark half-strip zones around pretriggers that happened at the current first_bx
   void markPreTriggerZone(bool pretrig_zone[CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) const;

--- a/L1Trigger/CSCTriggerPrimitives/interface/ComparatorCodeLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/ComparatorCodeLUT.h
@@ -29,10 +29,8 @@ public:
   // constructor
   ComparatorCodeLUT(const edm::ParameterSet& conf);
 
-  void setESLookupTables(const CSCL1TPLookupTableCCLUT* conf);
-
   // runs the CCLUT procedure
-  void run(CSCCLCTDigi& digi, unsigned numCFEBs) const;
+  void run(CSCCLCTDigi& digi, unsigned numCFEBs, const CSCL1TPLookupTableCCLUT* lookupTableCCLUT) const;
 
 private:
   //calculates the id based on location of hits
@@ -48,9 +46,6 @@ private:
 
   // verbosity level
   unsigned infoV_;
-
-  // access to lookup tables via eventsetup
-  const CSCL1TPLookupTableCCLUT* lookupTableCCLUT_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/interface/GEMClusterProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/GEMClusterProcessor.h
@@ -25,7 +25,9 @@ public:
   void clear();
 
   /** Runs the CoPad processor code. */
-  void run(const GEMPadDigiClusterCollection*);
+  void run(const GEMPadDigiClusterCollection*,
+           const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+           const CSCL1TPLookupTableME21ILT* lookupTableME21ILT);
 
   /* Returns clusters around deltaBX for a given BX
     The parameter option determines which clusters should be returned
@@ -39,10 +41,6 @@ public:
 
   bool hasGE21Geometry16Partitions() const { return hasGE21Geometry16Partitions_; }
 
-  void setESLookupTables(const CSCL1TPLookupTableME11ILT* conf);
-
-  void setESLookupTables(const CSCL1TPLookupTableME21ILT* conf);
-
 private:
   // put coincidence clusters in GEMInternalCluster vector
   void addCoincidenceClusters(const GEMPadDigiClusterCollection*);
@@ -54,7 +52,8 @@ private:
   // translate the cluster central pad numbers into 1/8-strip number,
   // and roll numbers into min and max wiregroup numbers
   // for matching with CSC trigger primitives
-  void doCoordinateConversion();
+  void doCoordinateConversion(const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                              const CSCL1TPLookupTableME21ILT* lookupTableME21ILT);
 
   // Chamber id (trigger-type labels)
   const int region_;
@@ -72,9 +71,6 @@ private:
 
   // output collection
   std::vector<GEMInternalCluster> clusters_;
-
-  const CSCL1TPLookupTableME11ILT* lookupTableME11ILT_;
-  const CSCL1TPLookupTableME21ILT* lookupTableME21ILT_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCAnodeLCTProcessor.cc
@@ -198,7 +198,7 @@ void CSCAnodeLCTProcessor::clear(const int wire, const int pattern) {
   }
 }
 
-std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc) {
+std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* wiredc, const CSCChamber* cscChamber) {
   static std::atomic<bool> config_dumped{false};
   if ((infoV > 0 || (runPhase2_)) && !config_dumped) {
     dumpConfigParams();
@@ -208,8 +208,8 @@ std::vector<CSCALCTDigi> CSCAnodeLCTProcessor::run(const CSCWireDigiCollection* 
   // Get the number of wire groups for the given chamber.  Do it only once
   // per chamber.
   if (numWireGroups <= 0 or numWireGroups > CSCConstants::MAX_NUM_WIREGROUPS) {
-    if (cscChamber_) {
-      numWireGroups = cscChamber_->layer(1)->geometry()->numberOfWireGroups();
+    if (cscChamber) {
+      numWireGroups = cscChamber->layer(1)->geometry()->numberOfWireGroups();
       if (numWireGroups > CSCConstants::MAX_NUM_WIREGROUPS) {
         edm::LogError("CSCAnodeLCTProcessor|SetupError")
             << "+++ Number of wire groups, " << numWireGroups << " found in " << theCSCName_ << " (sector " << theSector

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -110,10 +110,7 @@ CSCBaseboard::CSCBaseboard() : theEndcap(1), theStation(1), theSector(1), theSub
   gangedME1a_ = false;
 }
 
-void CSCBaseboard::setCSCGeometry(const CSCGeometry* g) {
-  cscGeometry_ = g;
-  cscChamber_ = cscGeometry_->chamber(cscId_);
-}
+CSCChamber const* CSCBaseboard::cscChamber(const CSCGeometry& g) const { return g.chamber(cscId_); }
 
 void CSCBaseboard::checkConfigParameters(unsigned int& var,
                                          const unsigned int var_max,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -154,8 +154,6 @@ void CSCCathodeLCTProcessor::setConfigParameters(const CSCDBL1TPParameters* conf
   maxbx_readout_ = CSCConstants::LCT_CENTRAL_BX + tmb_l1a_window_size / 2;
 }
 
-void CSCCathodeLCTProcessor::setESLookupTables(const CSCL1TPLookupTableCCLUT* conf) { cclut_->setESLookupTables(conf); }
-
 void CSCCathodeLCTProcessor::checkConfigParameters() {
   // Make sure that the parameter values are within the allowed range.
 
@@ -198,7 +196,9 @@ void CSCCathodeLCTProcessor::clear() {
   }
 }
 
-std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
+std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc,
+                                                     const CSCChamber* cscChamber,
+                                                     const CSCL1TPLookupTableCCLUT* lookupTable) {
   // This is the version of the run() function that is called when running
   // over the entire detector.  It gets the comparator & timing info from the
   // comparator digis and then passes them on to another run() function.
@@ -212,8 +212,8 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
   // Get the number of strips and stagger of layers for the given chamber.
   // Do it only once per chamber.
   if (numStrips_ <= 0 or numStrips_ > CSCConstants::MAX_NUM_STRIPS_RUN2) {
-    if (cscChamber_) {
-      numStrips_ = cscChamber_->layer(1)->geometry()->numberOfStrips();
+    if (cscChamber) {
+      numStrips_ = cscChamber->layer(1)->geometry()->numberOfStrips();
 
       // ME1/a is known to the readout hardware as strips 65-80 of ME1/1.
       // Still need to decide whether we do any special adjustments to
@@ -263,7 +263,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
       // negative half-strip numbers.  This will necessitate a
       // subtraction of 1 half-strip for TMB-07 later on. -SV.
       for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
-        stagger[i_layer] = (cscChamber_->layer(i_layer + 1)->geometry()->stagger() + 1) / 2;
+        stagger[i_layer] = (cscChamber->layer(i_layer + 1)->geometry()->stagger() + 1) / 2;
       }
     } else {
       edm::LogError("CSCCathodeLCTProcessor|ConfigError")
@@ -313,7 +313,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
     // to fire is not null.  (Pre-trigger decisions are used for the
     // strip read-out conditions in DigiToRaw.)
     if (layersHit >= nplanes_hit_pretrig)
-      run(halfStripTimes);
+      run(halfStripTimes, lookupTable);
 
     // Get the high multiplicity bits in this chamber
     encodeHighMultiplicityBits();
@@ -337,7 +337,8 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::run(const CSCComparatorDigiColl
 }
 
 void CSCCathodeLCTProcessor::run(
-    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
+    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+    const CSCL1TPLookupTableCCLUT* lookupTable) {
   // This version of the run() function can either be called in a standalone
   // test, being passed the halfstrip times, or called by the
   // run() function above.  It uses the findLCTs() method to find vectors
@@ -348,7 +349,7 @@ void CSCCathodeLCTProcessor::run(
   // add 1 for possible stagger
   pulse_.initialize(numHalfStrips_ + 1);
 
-  std::vector<CSCCLCTDigi> CLCTlist = findLCTs(halfstrip);
+  std::vector<CSCCLCTDigi> CLCTlist = findLCTs(halfstrip, lookupTable);
 
   for (const auto& p : CLCTlist) {
     const int bx = p.getBX();
@@ -572,7 +573,8 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 
 // TMB-07 version.
 std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
-    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
+    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+    const CSCL1TPLookupTableCCLUT* lookupTable) {
   std::vector<CSCCLCTDigi> lctList;
 
   if (infoV > 1)
@@ -663,7 +665,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
           // construct a CLCT if the trigger condition has been met
           if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
             // overwrite the current best CLCT
-            tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pid[best_hs]]);
+            tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pid[best_hs]], lookupTable);
           }
         }
       }
@@ -689,7 +691,8 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
           // construct a CLCT if the trigger condition has been met
           if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
             // overwrite the current second best CLCT
-            tempSecondCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pid[best_hs]]);
+            tempSecondCLCT =
+                constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pid[best_hs]], lookupTable);
           }
         }
 
@@ -1003,7 +1006,8 @@ void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
 
 CSCCLCTDigi CSCCathodeLCTProcessor::constructCLCT(const int bx,
                                                   const unsigned halfstrip_withstagger,
-                                                  const CSCCLCTDigi::ComparatorContainer& hits) {
+                                                  const CSCCLCTDigi::ComparatorContainer& hits,
+                                                  const CSCL1TPLookupTableCCLUT* lookupTable) {
   // Assign the CLCT properties
   const unsigned quality = nhits[halfstrip_withstagger];
   const unsigned pattern = best_pid[halfstrip_withstagger];
@@ -1032,7 +1036,7 @@ CSCCLCTDigi CSCCathodeLCTProcessor::constructCLCT(const int bx,
 
   // do the CCLUT procedures for Run-3
   if (runCCLUT_) {
-    cclut_->run(clct, numCFEBs_);
+    cclut_->run(clct, numCFEBs_, lookupTable);
   }
 
   // purge the comparator digi collection from the obsolete "65535" entries...

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -42,10 +42,7 @@ CSCGEMMotherboard::CSCGEMMotherboard(unsigned endcap,
 
 CSCGEMMotherboard::~CSCGEMMotherboard() {}
 
-void CSCGEMMotherboard::clear() {
-  CSCMotherboard::clear();
-  clusterProc_->clear();
-}
+void CSCGEMMotherboard::clear() { clusterProc_->clear(); }
 
 //function to convert GEM-CSC amended signed slope into Run2 legacy pattern number
 uint16_t CSCGEMMotherboard::Run2PatternConverter(const int slope) const {
@@ -69,63 +66,42 @@ uint16_t CSCGEMMotherboard::Run2PatternConverter(const int slope) const {
 
 void CSCGEMMotherboard::run(const CSCWireDigiCollection* wiredc,
                             const CSCComparatorDigiCollection* compdc,
-                            const GEMPadDigiClusterCollection* gemClusters) {
+                            const GEMPadDigiClusterCollection* gemClusters,
+                            const RunContext& context) {
   // Step 1: Setup
   clear();
 
   // check for GEM geometry
-  if (gem_g == nullptr) {
+  if (context.gemGeometry_ == nullptr) {
     edm::LogError("CSCGEMMotherboard") << "run() called for GEM-CSC integrated trigger without valid GEM geometry! \n";
     return;
   }
 
-  // Check that the processors can deliver data
-  if (!(alctProc and clctProc)) {
-    edm::LogError("CSCGEMMotherboard") << "run() called for non-existing ALCT/CLCT processor! \n";
-    return;
-  }
-
-  alctProc->setCSCGeometry(cscGeometry_);
-  clctProc->setCSCGeometry(cscGeometry_);
-
-  // set CCLUT parameters if necessary
-  if (runCCLUT_) {
-    clctProc->setESLookupTables(lookupTableCCLUT_);
-  }
-
   // Step 2: Run the processors
-  const std::vector<CSCALCTDigi>& alctV = alctProc->run(wiredc);  // run anodeLCT
-  const std::vector<CSCCLCTDigi>& clctV = clctProc->run(compdc);  // run cathodeLCT
-
-  // Step 2b: encode high multiplicity bits (independent of LCT construction)
-  encodeHighMultiplicityBits();
+  CSCMotherboard::RunContext mbc{context.cscGeometry_,
+                                 context.lookupTableCCLUT_,
+                                 context.lookupTableME11ILT_,
+                                 context.lookupTableME21ILT_,
+                                 context.parameters_};
+  auto [alctV, clctV] = runCommon(wiredc, compdc, mbc);
 
   // if there are no ALCTs and no CLCTs, do not run the ALCT-CLCT correlation
   if (alctV.empty() and clctV.empty())
     return;
 
-  // set the lookup tables for coordinate conversion and matching
-  if (isME11_) {
-    clusterProc_->setESLookupTables(lookupTableME11ILT_);
-    cscGEMMatcher_->setESLookupTables(lookupTableME11ILT_);
-  }
-  if (isME21_) {
-    clusterProc_->setESLookupTables(lookupTableME21ILT_);
-    cscGEMMatcher_->setESLookupTables(lookupTableME21ILT_);
-  }
-
   // Step 3: run the GEM cluster processor to get the internal clusters
-  clusterProc_->run(gemClusters);
+  clusterProc_->run(gemClusters, context.lookupTableME11ILT_, context.lookupTableME21ILT_);
   hasGE21Geometry16Partitions_ = clusterProc_->hasGE21Geometry16Partitions();
 
   // Step 4: ALCT-CLCT-GEM matching
-  matchALCTCLCTGEM();
+  matchALCTCLCTGEM(context.lookupTableME11ILT_, context.lookupTableME21ILT_);
 
   // Step 5: Select at most 2 LCTs per BX
   selectLCTs();
 }
 
-void CSCGEMMotherboard::matchALCTCLCTGEM() {
+void CSCGEMMotherboard::matchALCTCLCTGEM(const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                         const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) {
   // no matching is done for GE2/1 geometries with 8 eta partitions
   // this has been superseded by 16-eta partition geometries
   if (isME21_ and !hasGE21Geometry16Partitions_)
@@ -159,14 +135,14 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     sortCLCTByQualBend(bx_alct, clctBx_qualbend_match);
 
     bool hasLocalShower = false;
-    for (unsigned ibx = 1; ibx <= match_trig_window_size / 2; ibx++)
+    for (unsigned ibx = 1; ibx <= match_trig_window_size() / 2; ibx++)
       hasLocalShower = (hasLocalShower or clctProc->getLocalShowerFlag(bx_alct - CSCConstants::ALCT_CLCT_OFFSET - ibx));
     // BestCLCT and secondCLCT
-    for (unsigned mbx = 0; mbx < match_trig_window_size; mbx++) {
+    for (unsigned mbx = 0; mbx < match_trig_window_size(); mbx++) {
       //bx_clct_run2 would be overflow when bx_alct is small but it is okay
-      unsigned bx_clct_run2 = bx_alct + preferred_bx_match_[mbx] - CSCConstants::ALCT_CLCT_OFFSET;
+      unsigned bx_clct_run2 = bx_alct + preferred_bx_match(mbx) - CSCConstants::ALCT_CLCT_OFFSET;
       unsigned bx_clct_qualbend = clctBx_qualbend_match[mbx];
-      bx_clct = (sort_clct_bx_ or not(hasLocalShower)) ? bx_clct_run2 : bx_clct_qualbend;
+      bx_clct = (sort_clct_bx() or not(hasLocalShower)) ? bx_clct_run2 : bx_clct_qualbend;
 
       if (bx_clct >= CSCConstants::MAX_CLCT_TBINS)
         continue;
@@ -195,13 +171,14 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
     // ALCT + CLCT + GEM
 
     for (unsigned gmbx = 0; gmbx < alct_gem_bx_window_size_; gmbx++) {
-      unsigned bx_gem = bx_alct + preferred_bx_match_[gmbx];
+      unsigned bx_gem = bx_alct + preferred_bx_match(gmbx);
       clustersGEM = clusterProc_->getClusters(bx_gem, GEMClusterProcessor::AllClusters);
       if (!clustersGEM.empty()) {
-        correlateLCTsGEM(bestALCT, bestCLCT, clustersGEM, LCTbestAbestCgem);
-        correlateLCTsGEM(bestALCT, secondCLCT, clustersGEM, LCTbestAsecondCgem);
-        correlateLCTsGEM(secondALCT, bestCLCT, clustersGEM, LCTsecondAbestCgem);
-        correlateLCTsGEM(secondALCT, secondCLCT, clustersGEM, LCTsecondAsecondCgem);
+        correlateLCTsGEM(bestALCT, bestCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTbestAbestCgem);
+        correlateLCTsGEM(bestALCT, secondCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTbestAsecondCgem);
+        correlateLCTsGEM(secondALCT, bestCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTsecondAbestCgem);
+        correlateLCTsGEM(
+            secondALCT, secondCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTsecondAsecondCgem);
         break;
       }
     }
@@ -219,16 +196,16 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
       unsigned bx_gem = bx_alct;
 
       clustersGEM = clusterProc_->getClusters(bx_gem, GEMClusterProcessor::CoincidenceClusters);
-      correlateLCTsGEM(bestCLCT, clustersGEM, LCTbestCLCTgem);
+      correlateLCTsGEM(bestCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTbestCLCTgem);
       clustersGEM = clusterProc_->getClusters(bx_gem, GEMClusterProcessor::CoincidenceClusters);
-      correlateLCTsGEM(secondCLCT, clustersGEM, LCTsecondCLCTgem);
+      correlateLCTsGEM(secondCLCT, clustersGEM, lookupTableME11ILT, lookupTableME21ILT, LCTsecondCLCTgem);
     }
 
     // ALCT + 2 GEM
 
     if (build_lct_from_alct_gem_) {
       for (unsigned gmbx = 0; gmbx < alct_gem_bx_window_size_; gmbx++) {
-        unsigned bx_gem = bx_alct + preferred_bx_match_[gmbx];
+        unsigned bx_gem = bx_alct + preferred_bx_match(gmbx);
         clustersGEM = clusterProc_->getClusters(bx_gem, GEMClusterProcessor::CoincidenceClusters);
         if (!clustersGEM.empty()) {
           correlateLCTsGEM(bestALCT, clustersGEM, LCTbestALCTgem);
@@ -402,6 +379,8 @@ void CSCGEMMotherboard::matchALCTCLCTGEM() {
 void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
                                          const CSCCLCTDigi& CLCT,
                                          const GEMInternalClusters& clusters,
+                                         const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                         const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& lct) const {
   // Sanity checks on ALCT, CLCT, GEM clusters
   if (!ALCT.isValid()) {
@@ -424,9 +403,9 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
   // We can now check possible triplets and construct all LCTs with
   // valid ALCT, valid CLCTs and GEM clusters
   GEMInternalCluster bestCluster;
-  cscGEMMatcher_->bestClusterLoc(ALCT, CLCT, ValidClusters, bestCluster);
+  cscGEMMatcher_->bestClusterLoc(ALCT, CLCT, ValidClusters, lookupTableME11ILT, lookupTableME21ILT, bestCluster);
   if (bestCluster.isValid())
-    constructLCTsGEM(ALCT, CLCT, bestCluster, lct);
+    constructLCTsGEM(ALCT, CLCT, bestCluster, lookupTableME11ILT, lookupTableME21ILT, lct);
 }
 
 // Correlate CSC information. Option ALCT-CLCT
@@ -449,7 +428,7 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
   }
 
   // construct LCT
-  if (match_trig_enable and doesALCTCrossCLCT(ALCT, CLCT)) {
+  if (match_trig_enable() and doesALCTCrossCLCT(ALCT, CLCT)) {
     constructLCTsGEM(ALCT, CLCT, lct);
   }
 }
@@ -457,6 +436,8 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
 // Correlate CSC and GEM information. Option CLCT-GEM
 void CSCGEMMotherboard::correlateLCTsGEM(const CSCCLCTDigi& CLCT,
                                          const GEMInternalClusters& clusters,
+                                         const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                         const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& lct) const {
   // Sanity checks on CLCT, GEM clusters
   bool dropLowQualityCLCT = drop_low_quality_clct_;
@@ -477,11 +458,11 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCCLCTDigi& CLCT,
 
   // get the best matching cluster
   GEMInternalCluster bestCluster;
-  cscGEMMatcher_->bestClusterLoc(CLCT, ValidClusters, bestCluster);
+  cscGEMMatcher_->bestClusterLoc(CLCT, ValidClusters, lookupTableME11ILT, lookupTableME21ILT, bestCluster);
 
   // construct all LCTs with valid CLCTs and coincidence clusters
   if (bestCluster.isCoincidence()) {
-    constructLCTsGEM(CLCT, bestCluster, lct);
+    constructLCTsGEM(CLCT, bestCluster, lookupTableME11ILT, lookupTableME21ILT, lct);
   }
 }
 
@@ -516,6 +497,8 @@ void CSCGEMMotherboard::correlateLCTsGEM(const CSCALCTDigi& ALCT,
 void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
                                          const CSCCLCTDigi& clct,
                                          const GEMInternalCluster& gem,
+                                         const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                         const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
   thisLCT.setValid(true);
   if (gem.isCoincidence())
@@ -542,7 +525,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct,
     thisLCT.setRun3(true);
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem);
+      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(std::signbit(slope));
       thisLCT.setPattern(Run2PatternConverter(slope));
@@ -586,6 +569,8 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& aLCT,
 // Construct LCT from CSC and GEM information. Option CLCT-2GEM
 void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
                                          const GEMInternalCluster& gem,
+                                         const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                         const CSCL1TPLookupTableME21ILT* lookupTableME21ILT,
                                          CSCCorrelatedLCTDigi& thisLCT) const {
   thisLCT.setValid(true);
   thisLCT.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
@@ -607,7 +592,7 @@ void CSCGEMMotherboard::constructLCTsGEM(const CSCCLCTDigi& clct,
     thisLCT.setRun3(true);
     if (assign_gem_csc_bending_ &&
         gem.isValid()) {  //calculate new slope from strip difference between CLCT and associated GEM
-      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem);
+      int slope = cscGEMMatcher_->calculateGEMCSCBending(clct, gem, lookupTableME11ILT, lookupTableME21ILT);
       thisLCT.setSlope(abs(slope));
       thisLCT.setBend(pow(-1, std::signbit(slope)));
       thisLCT.setPattern(Run2PatternConverter(slope));

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -80,75 +80,11 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
 //------------
 CSCTriggerPrimitivesBuilder::~CSCTriggerPrimitivesBuilder() {}
 
-void CSCTriggerPrimitivesBuilder::setConfigParameters(const CSCDBL1TPParameters* conf) {
-  // Receives CSCDBL1TPParameters percolated down from ESProducer.
-
-  for (int endc = min_endcap; endc <= max_endcap; endc++) {
-    for (int stat = min_station; stat <= max_station; stat++) {
-      int numsubs = ((stat == 1) ? max_subsector : 1);
-      for (int sect = min_sector; sect <= max_sector; sect++) {
-        for (int subs = min_subsector; subs <= numsubs; subs++) {
-          for (int cham = min_chamber; cham <= max_chamber; cham++) {
-            tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->setConfigParameters(conf);
-          }
-        }
-      }
-    }
-  }
-}
-
-void CSCTriggerPrimitivesBuilder::setESLookupTables(const CSCL1TPLookupTableCCLUT* conf) {
-  // Receives CSCL1TPLookupTableCCLUT percolated down from ESProducer.
-  for (int endc = min_endcap; endc <= max_endcap; endc++) {
-    for (int stat = min_station; stat <= max_station; stat++) {
-      int numsubs = ((stat == 1) ? max_subsector : 1);
-      for (int sect = min_sector; sect <= max_sector; sect++) {
-        for (int subs = min_subsector; subs <= numsubs; subs++) {
-          for (int cham = min_chamber; cham <= max_chamber; cham++) {
-            tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->setESLookupTables(conf);
-          }
-        }
-      }
-    }
-  }
-}
-
-void CSCTriggerPrimitivesBuilder::setESLookupTables(const CSCL1TPLookupTableME11ILT* conf) {
-  for (int endc = min_endcap; endc <= max_endcap; endc++) {
-    for (int stat = min_station; stat <= max_station; stat++) {
-      int numsubs = ((stat == 1) ? max_subsector : 1);
-      for (int sect = min_sector; sect <= max_sector; sect++) {
-        for (int subs = min_subsector; subs <= numsubs; subs++) {
-          for (int cham = min_chamber; cham <= max_chamber; cham++) {
-            if (tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->id().isME11())
-              tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->setESLookupTables(conf);
-          }
-        }
-      }
-    }
-  }
-}
-
-void CSCTriggerPrimitivesBuilder::setESLookupTables(const CSCL1TPLookupTableME21ILT* conf) {
-  for (int endc = min_endcap; endc <= max_endcap; endc++) {
-    for (int stat = min_station; stat <= max_station; stat++) {
-      int numsubs = ((stat == 1) ? max_subsector : 1);
-      for (int sect = min_sector; sect <= max_sector; sect++) {
-        for (int subs = min_subsector; subs <= numsubs; subs++) {
-          for (int cham = min_chamber; cham <= max_chamber; cham++) {
-            if (tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->id().isME21())
-              tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1]->setESLookupTables(conf);
-          }
-        }
-      }
-    }
-  }
-}
-
 void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         const CSCWireDigiCollection* wiredc,
                                         const CSCComparatorDigiCollection* compdc,
                                         const GEMPadDigiClusterCollection* gemClusters,
+                                        const BuildContext& context,
                                         CSCALCTDigiCollection& oc_alct,
                                         CSCCLCTDigiCollection& oc_clct,
                                         CSCALCTPreTriggerDigiCollection& oc_alctpretrigger,
@@ -161,6 +97,9 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
                                         CSCShowerDigiCollection& oc_shower,
                                         GEMCoPadDigiCollection& oc_gemcopad) {
   // CSC geometry.
+  CSCMotherboard::RunContext mbcontext{
+      context.cscgeom_, context.cclut_, context.me11ilt_, context.me21ilt_, context.parameters_};
+
   for (int endc = min_endcap; endc <= max_endcap; endc++) {
     for (int stat = min_station; stat <= max_station; stat++) {
       int numsubs = ((stat == 1) ? max_subsector : 1);
@@ -176,8 +115,6 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
 
             CSCMotherboard* tmb = tmb_[endc - 1][stat - 1][sect - 1][subs - 1][cham - 1].get();
 
-            tmb->setCSCGeometry(csc_g);
-
             // actual chamber number =/= trigger chamber number
             int chid = CSCTriggerNumbering::chamberFromTriggerLabels(sect, subs, stat, cham);
 
@@ -185,7 +122,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             CSCDetId detid(endc, stat, ring, chid, 0);
 
             // Run processors only if chamber exists in geometry.
-            if (tmb == nullptr || csc_g->chamber(detid) == nullptr)
+            if (tmb == nullptr || context.cscgeom_->chamber(detid) == nullptr)
               continue;
 
             // Skip chambers marked as bad (usually includes most of ME4/2 chambers;
@@ -207,10 +144,14 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             // GE1/1-ME1/1 integrated local trigger or GE2/1-ME2/1 integrated local trigger
             if (upgradeGE11 or upgradeGE21) {
               // run the TMB
+              CSCGEMMotherboard::RunContext c{context.gemgeom_,
+                                              context.cscgeom_,
+                                              context.cclut_,
+                                              context.me11ilt_,
+                                              context.me21ilt_,
+                                              context.parameters_};
               CSCGEMMotherboard* tmbGEM = static_cast<CSCGEMMotherboard*>(tmb);
-              tmbGEM->setGEMGeometry(gem_g);
-              tmbGEM->setCSCGeometry(csc_g);
-              tmbGEM->run(wiredc, compdc, gemClusters);
+              tmbGEM->run(wiredc, compdc, gemClusters, c);
 
               // 0th layer means whole chamber.
               GEMDetId gemId(detid.zendcap(), 1, stat, 0, chid, 0);
@@ -220,7 +161,7 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
             // default case: regular TMBs and OTMBs without GEMs
             else {
               // run the TMB
-              tmb->run(wiredc, compdc);
+              tmb->run(wiredc, compdc, mbcontext);
             }
 
             // get the collections

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCUpgradeCathodeLCTProcessor.cc
@@ -104,10 +104,11 @@ bool CSCUpgradeCathodeLCTProcessor::preTrigger(const int start_bx, int& first_bx
 
 // Phase2 version.
 std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
-    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER]) {
+    const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_HALF_STRIPS_RUN2_TRIGGER],
+    const CSCL1TPLookupTableCCLUT* lookupTable) {
   // run the original algorithm in case we do not use dead time zoning
   if (runPhase2_ and !use_dead_time_zoning_) {
-    return CSCCathodeLCTProcessor::findLCTs(halfstrip);
+    return CSCCathodeLCTProcessor::findLCTs(halfstrip, lookupTable);
   }
 
   std::vector<CSCCLCTDigi> lctList;
@@ -219,7 +220,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
             // construct a CLCT if the trigger condition has been met
             if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
               // overwrite the current best CLCT
-              tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+              tempBestCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat], lookupTable);
             }
           }
         }
@@ -248,7 +249,7 @@ std::vector<CSCCLCTDigi> CSCUpgradeCathodeLCTProcessor::findLCTs(
             // construct a CLCT if the trigger condition has been met
             if (best_hs >= 0 && nhits[best_hs] >= nplanes_hit_pattern) {
               // overwrite the current second best CLCT
-              tempSecondCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat]);
+              tempSecondCLCT = constructCLCT(first_bx, best_hs, hits_in_patterns[best_hs][best_pat], lookupTable);
             }
           }
         }

--- a/L1Trigger/CSCTriggerPrimitives/src/ComparatorCodeLUT.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/ComparatorCodeLUT.cc
@@ -5,9 +5,9 @@ ComparatorCodeLUT::ComparatorCodeLUT(const edm::ParameterSet& conf) {
   clct_pattern_ = CSCPatternBank::clct_pattern_run3_;
 }
 
-void ComparatorCodeLUT::setESLookupTables(const CSCL1TPLookupTableCCLUT* conf) { lookupTableCCLUT_ = conf; }
-
-void ComparatorCodeLUT::run(CSCCLCTDigi& digi, unsigned numCFEBs) const {
+void ComparatorCodeLUT::run(CSCCLCTDigi& digi,
+                            unsigned numCFEBs,
+                            const CSCL1TPLookupTableCCLUT* lookupTableCCLUT) const {
   // print out the old CLCT for debugging
   if (infoV_ > 2) {
     std::ostringstream strm;
@@ -59,8 +59,8 @@ void ComparatorCodeLUT::run(CSCCLCTDigi& digi, unsigned numCFEBs) const {
   digi.setRun3Pattern(pattern);
 
   // look-up the unsigned values
-  const unsigned positionCC(lookupTableCCLUT_->cclutPosition(pattern, comparatorCode));
-  const unsigned slopeCC(lookupTableCCLUT_->cclutSlope(pattern, comparatorCode));
+  const unsigned positionCC(lookupTableCCLUT->cclutPosition(pattern, comparatorCode));
+  const unsigned slopeCC(lookupTableCCLUT->cclutSlope(pattern, comparatorCode));
   const unsigned run2PatternCC(convertSlopeToRun2Pattern(slopeCC));
 
   // if the slope is negative, set bending to 0

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -5,12 +5,7 @@
 #include <iostream>
 
 GEMClusterProcessor::GEMClusterProcessor(int region, unsigned station, unsigned chamber, const edm::ParameterSet& conf)
-    : region_(region),
-      station_(station),
-      chamber_(chamber),
-      hasGE21Geometry16Partitions_(false),
-      lookupTableME11ILT_(nullptr),
-      lookupTableME21ILT_(nullptr) {
+    : region_(region), station_(station), chamber_(chamber), hasGE21Geometry16Partitions_(false) {
   isEven_ = chamber_ % 2 == 0;
 
   const edm::ParameterSet aux(conf.getParameter<edm::ParameterSet>("commonParam"));
@@ -43,11 +38,9 @@ GEMClusterProcessor::GEMClusterProcessor(int region, unsigned station, unsigned 
 
 void GEMClusterProcessor::clear() { clusters_.clear(); }
 
-void GEMClusterProcessor::setESLookupTables(const CSCL1TPLookupTableME11ILT* conf) { lookupTableME11ILT_ = conf; }
-
-void GEMClusterProcessor::setESLookupTables(const CSCL1TPLookupTableME21ILT* conf) { lookupTableME21ILT_ = conf; }
-
-void GEMClusterProcessor::run(const GEMPadDigiClusterCollection* in_clusters) {
+void GEMClusterProcessor::run(const GEMPadDigiClusterCollection* in_clusters,
+                              const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                              const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) {
   // Step 1: clear the GEMInternalCluster vector
   clear();
 
@@ -63,7 +56,7 @@ void GEMClusterProcessor::run(const GEMPadDigiClusterCollection* in_clusters) {
   addSingleClusters(in_clusters);
 
   // Step 4: translate the cluster central pad numbers into 1/8-strip number for matching with CSC trigger primitives
-  doCoordinateConversion();
+  doCoordinateConversion(lookupTableME11ILT, lookupTableME21ILT);
 }
 
 std::vector<GEMInternalCluster> GEMClusterProcessor::getClusters(int bx, ClusterTypes option) const {
@@ -204,7 +197,8 @@ void GEMClusterProcessor::addSingleClusters(const GEMPadDigiClusterCollection* i
   }
 }
 
-void GEMClusterProcessor::doCoordinateConversion() {
+void GEMClusterProcessor::doCoordinateConversion(const CSCL1TPLookupTableME11ILT* lookupTableME11ILT,
+                                                 const CSCL1TPLookupTableME21ILT* lookupTableME21ILT) {
   // loop on clusters
   for (auto& cluster : clusters_) {
     if (cluster.cl1().isValid()) {
@@ -223,28 +217,28 @@ void GEMClusterProcessor::doCoordinateConversion() {
       if (station_ == 1) {
         if (isEven_) {
           // ME1/b
-          layer1_pad_to_first_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_even(layer1_first_pad);
-          layer1_pad_to_last_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_even(layer1_last_pad);
+          layer1_pad_to_first_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_even(layer1_first_pad);
+          layer1_pad_to_last_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_even(layer1_last_pad);
           // ME1/a
-          layer1_pad_to_first_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_even(layer1_first_pad);
-          layer1_pad_to_last_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_even(layer1_last_pad);
+          layer1_pad_to_first_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_even(layer1_first_pad);
+          layer1_pad_to_last_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_even(layer1_last_pad);
         } else {
           // ME1/b
-          layer1_pad_to_first_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_odd(layer1_first_pad);
-          layer1_pad_to_last_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_odd(layer1_last_pad);
+          layer1_pad_to_first_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_odd(layer1_first_pad);
+          layer1_pad_to_last_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_odd(layer1_last_pad);
           // ME1/a
-          layer1_pad_to_first_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_odd(layer1_first_pad);
-          layer1_pad_to_last_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_odd(layer1_last_pad);
+          layer1_pad_to_first_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_odd(layer1_first_pad);
+          layer1_pad_to_last_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_odd(layer1_last_pad);
         }
       }
       // ME2/1
       if (station_ == 2) {
         if (isEven_) {
-          layer1_pad_to_first_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_even(layer1_first_pad);
-          layer1_pad_to_last_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_even(layer1_last_pad);
+          layer1_pad_to_first_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_even(layer1_first_pad);
+          layer1_pad_to_last_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_even(layer1_last_pad);
         } else {
-          layer1_pad_to_first_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_odd(layer1_first_pad);
-          layer1_pad_to_last_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_odd(layer1_last_pad);
+          layer1_pad_to_first_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_odd(layer1_first_pad);
+          layer1_pad_to_last_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_odd(layer1_last_pad);
         }
       }
       // middle 1/8-strip
@@ -271,22 +265,22 @@ void GEMClusterProcessor::doCoordinateConversion() {
       // ME1/1
       if (station_ == 1) {
         if (isEven_) {
-          roll_l1_to_min_wg = lookupTableME11ILT_->GEM_roll_CSC_min_wg_ME11_even(roll);
-          roll_l1_to_max_wg = lookupTableME11ILT_->GEM_roll_CSC_max_wg_ME11_even(roll);
+          roll_l1_to_min_wg = lookupTableME11ILT->GEM_roll_CSC_min_wg_ME11_even(roll);
+          roll_l1_to_max_wg = lookupTableME11ILT->GEM_roll_CSC_max_wg_ME11_even(roll);
         } else {
-          roll_l1_to_min_wg = lookupTableME11ILT_->GEM_roll_CSC_min_wg_ME11_odd(roll);
-          roll_l1_to_max_wg = lookupTableME11ILT_->GEM_roll_CSC_max_wg_ME11_odd(roll);
+          roll_l1_to_min_wg = lookupTableME11ILT->GEM_roll_CSC_min_wg_ME11_odd(roll);
+          roll_l1_to_max_wg = lookupTableME11ILT->GEM_roll_CSC_max_wg_ME11_odd(roll);
         }
       }
 
       // ME2/1
       if (station_ == 2) {
         if (isEven_) {
-          roll_l1_to_min_wg = lookupTableME21ILT_->GEM_roll_L1_CSC_min_wg_ME21_even(roll);
-          roll_l1_to_max_wg = lookupTableME21ILT_->GEM_roll_L1_CSC_max_wg_ME21_even(roll);
+          roll_l1_to_min_wg = lookupTableME21ILT->GEM_roll_L1_CSC_min_wg_ME21_even(roll);
+          roll_l1_to_max_wg = lookupTableME21ILT->GEM_roll_L1_CSC_max_wg_ME21_even(roll);
         } else {
-          roll_l1_to_min_wg = lookupTableME21ILT_->GEM_roll_L1_CSC_min_wg_ME21_odd(roll);
-          roll_l1_to_max_wg = lookupTableME21ILT_->GEM_roll_L1_CSC_max_wg_ME21_odd(roll);
+          roll_l1_to_min_wg = lookupTableME21ILT->GEM_roll_L1_CSC_min_wg_ME21_odd(roll);
+          roll_l1_to_max_wg = lookupTableME21ILT->GEM_roll_L1_CSC_max_wg_ME21_odd(roll);
         }
       }
 
@@ -310,29 +304,29 @@ void GEMClusterProcessor::doCoordinateConversion() {
       if (station_ == 1) {
         if (isEven_) {
           // ME1/b
-          layer2_pad_to_first_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_even(layer2_first_pad);
-          layer2_pad_to_last_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_even(layer2_last_pad);
+          layer2_pad_to_first_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_even(layer2_first_pad);
+          layer2_pad_to_last_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_even(layer2_last_pad);
           // ME1/a
-          layer2_pad_to_first_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_even(layer2_first_pad);
-          layer2_pad_to_last_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_even(layer2_last_pad);
+          layer2_pad_to_first_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_even(layer2_first_pad);
+          layer2_pad_to_last_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_even(layer2_last_pad);
         } else {
           // ME1/b
-          layer2_pad_to_first_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_odd(layer2_first_pad);
-          layer2_pad_to_last_es = lookupTableME11ILT_->GEM_pad_CSC_es_ME11b_odd(layer2_last_pad);
+          layer2_pad_to_first_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_odd(layer2_first_pad);
+          layer2_pad_to_last_es = lookupTableME11ILT->GEM_pad_CSC_es_ME11b_odd(layer2_last_pad);
           // ME1/a
-          layer2_pad_to_first_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_odd(layer2_first_pad);
-          layer2_pad_to_last_es_me1a = lookupTableME11ILT_->GEM_pad_CSC_es_ME11a_odd(layer2_last_pad);
+          layer2_pad_to_first_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_odd(layer2_first_pad);
+          layer2_pad_to_last_es_me1a = lookupTableME11ILT->GEM_pad_CSC_es_ME11a_odd(layer2_last_pad);
         }
       }
 
       // ME2/1
       if (station_ == 2) {
         if (isEven_) {
-          layer2_pad_to_first_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_even(layer2_first_pad);
-          layer2_pad_to_last_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_even(layer2_last_pad);
+          layer2_pad_to_first_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_even(layer2_first_pad);
+          layer2_pad_to_last_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_even(layer2_last_pad);
         } else {
-          layer2_pad_to_first_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_odd(layer2_first_pad);
-          layer2_pad_to_last_es = lookupTableME21ILT_->GEM_pad_CSC_es_ME21_odd(layer2_last_pad);
+          layer2_pad_to_first_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_odd(layer2_first_pad);
+          layer2_pad_to_last_es = lookupTableME21ILT->GEM_pad_CSC_es_ME21_odd(layer2_last_pad);
         }
       }
       // middle 1/8-strip
@@ -360,22 +354,22 @@ void GEMClusterProcessor::doCoordinateConversion() {
     // ME1/1
     if (station_ == 1) {
       if (isEven_) {
-        roll_l2_to_min_wg = lookupTableME11ILT_->GEM_roll_CSC_min_wg_ME11_even(roll);
-        roll_l2_to_max_wg = lookupTableME11ILT_->GEM_roll_CSC_max_wg_ME11_even(roll);
+        roll_l2_to_min_wg = lookupTableME11ILT->GEM_roll_CSC_min_wg_ME11_even(roll);
+        roll_l2_to_max_wg = lookupTableME11ILT->GEM_roll_CSC_max_wg_ME11_even(roll);
       } else {
-        roll_l2_to_min_wg = lookupTableME11ILT_->GEM_roll_CSC_min_wg_ME11_odd(roll);
-        roll_l2_to_max_wg = lookupTableME11ILT_->GEM_roll_CSC_max_wg_ME11_odd(roll);
+        roll_l2_to_min_wg = lookupTableME11ILT->GEM_roll_CSC_min_wg_ME11_odd(roll);
+        roll_l2_to_max_wg = lookupTableME11ILT->GEM_roll_CSC_max_wg_ME11_odd(roll);
       }
     }
 
     // ME2/1
     if (station_ == 2) {
       if (isEven_) {
-        roll_l2_to_min_wg = lookupTableME21ILT_->GEM_roll_L2_CSC_min_wg_ME21_even(roll);
-        roll_l2_to_max_wg = lookupTableME21ILT_->GEM_roll_L2_CSC_max_wg_ME21_even(roll);
+        roll_l2_to_min_wg = lookupTableME21ILT->GEM_roll_L2_CSC_min_wg_ME21_even(roll);
+        roll_l2_to_max_wg = lookupTableME21ILT->GEM_roll_L2_CSC_max_wg_ME21_even(roll);
       } else {
-        roll_l2_to_min_wg = lookupTableME21ILT_->GEM_roll_L2_CSC_min_wg_ME21_odd(roll);
-        roll_l2_to_max_wg = lookupTableME21ILT_->GEM_roll_L2_CSC_max_wg_ME21_odd(roll);
+        roll_l2_to_min_wg = lookupTableME21ILT->GEM_roll_L2_CSC_min_wg_ME21_odd(roll);
+        roll_l2_to_max_wg = lookupTableME21ILT->GEM_roll_L2_CSC_max_wg_ME21_odd(roll);
       }
     }
 


### PR DESCRIPTION
#### PR description:

- Removed use of 'temporary' member data (i.e. member data used as temporary state instead of passing data via member function arguments).
- Reordered member data to avoid unnecessary padding. 
- Moved more member data/functions to private in CSCMotherboard.

#### PR validation:

Code compiles. At 32 threads this appears to save an additional 2.4GB of memory.