### PR TITLE
remove unused parameters from `HLTPixelIsolTrackL1TFilter` plugin

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -217,6 +217,15 @@ def customizeHLTfor41058(process):
 
     return process
 
+def customizeHLTfor41495(process):
+    for producer in filters_by_type(process, 'HLTPixelIsolTrackL1TFilter'):
+        if hasattr(producer, 'L1GTSeedLabel'):
+            del producer.L1GTSeedLabel
+        if hasattr(producer, 'MinDeltaPtL1Jet'):
+            del producer.MinDeltaPtL1Jet
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -226,5 +235,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customizeHLTfor41058(process)
+    process = customizeHLTfor41495(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -210,7 +210,7 @@ def customiseForOffline(process):
 
     return process
 
-def customizeForRecoPixelVertexing(process):
+def customizeHLTfor41058(process):
     for prod in esproducers_by_type(process, 'ClusterShapeHitFilterESProducer'):
         prod.PixelShapeFile = "RecoTracker/PixelLowPtUtilities/data/pixelShapePhase1_noL1.par"
         prod.PixelShapeFileL1 = "RecoTracker/PixelLowPtUtilities/data/pixelShapePhase1_loose.par"
@@ -225,6 +225,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 
-    process = customizeForRecoPixelVertexing(process)
+    process = customizeHLTfor41058(process)
 
     return process

--- a/HLTrigger/special/plugins/HLTPixelIsolTrackL1TFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelIsolTrackL1TFilter.cc
@@ -1,49 +1,39 @@
 #include "HLTPixelIsolTrackL1TFilter.h"
 
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/RefToBase.h"
-
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-//#define DebugLog
-
-HLTPixelIsolTrackL1TFilter::HLTPixelIsolTrackL1TFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
-  candTag_ = iConfig.getParameter<edm::InputTag>("candTag");
-  hltGTseedlabel_ = iConfig.getParameter<edm::InputTag>("L1GTSeedLabel");
-  minDeltaPtL1Jet_ = iConfig.getParameter<double>("MinDeltaPtL1Jet");
-  minpttrack_ = iConfig.getParameter<double>("MinPtTrack");
-  maxptnearby_ = iConfig.getParameter<double>("MaxPtNearby");
-  maxetatrack_ = iConfig.getParameter<double>("MaxEtaTrack");
-  minetatrack_ = iConfig.getParameter<double>("MinEtaTrack");
-  filterE_ = iConfig.getParameter<bool>("filterTrackEnergy");
-  minEnergy_ = iConfig.getParameter<double>("MinEnergyTrack");
-  nMaxTrackCandidates_ = iConfig.getParameter<int>("NMaxTrackCandidates");
-  dropMultiL2Event_ = iConfig.getParameter<bool>("DropMultiL2Event");
-  candToken_ = consumes<reco::IsolatedPixelTrackCandidateCollection>(candTag_);
-  hltGTseedToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(hltGTseedlabel_);
-}
-
-HLTPixelIsolTrackL1TFilter::~HLTPixelIsolTrackL1TFilter() = default;
+HLTPixelIsolTrackL1TFilter::HLTPixelIsolTrackL1TFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      candTag_{iConfig.getParameter<edm::InputTag>("candTag")},
+      candToken_{consumes(candTag_)},
+      maxptnearby_{iConfig.getParameter<double>("MaxPtNearby")},
+      minEnergy_{iConfig.getParameter<double>("MinEnergyTrack")},
+      minpttrack_{iConfig.getParameter<double>("MinPtTrack")},
+      maxetatrack_{iConfig.getParameter<double>("MaxEtaTrack")},
+      minetatrack_{iConfig.getParameter<double>("MinEtaTrack")},
+      filterE_{iConfig.getParameter<bool>("filterTrackEnergy")},
+      nMaxTrackCandidates_{iConfig.getParameter<int>("NMaxTrackCandidates")},
+      dropMultiL2Event_{iConfig.getParameter<bool>("DropMultiL2Event")} {}
 
 void HLTPixelIsolTrackL1TFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("candTag", edm::InputTag("hltIsolPixelTrackProd"));
-  desc.add<edm::InputTag>("L1GTSeedLabel", edm::InputTag("hltL1sV0SingleJet60"));
   desc.add<double>("MaxPtNearby", 2.0);
   desc.add<double>("MinEnergyTrack", 12.0);
   desc.add<double>("MinPtTrack", 3.5);
   desc.add<double>("MaxEtaTrack", 1.15);
   desc.add<double>("MinEtaTrack", 0.0);
-  desc.add<double>("MinDeltaPtL1Jet", -40000.0);
   desc.add<bool>("filterTrackEnergy", true);
   desc.add<int>("NMaxTrackCandidates", 10);
   desc.add<bool>("DropMultiL2Event", false);
-  descriptions.add("hltPixelIsolTrackL1TFilter", desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 bool HLTPixelIsolTrackL1TFilter::hltFilter(edm::Event& iEvent,
@@ -56,8 +46,7 @@ bool HLTPixelIsolTrackL1TFilter::hltFilter(edm::Event& iEvent,
   edm::Ref<reco::IsolatedPixelTrackCandidateCollection> candref;
 
   // get hold of filtered candidates
-  edm::Handle<reco::IsolatedPixelTrackCandidateCollection> recotrackcands;
-  iEvent.getByToken(candToken_, recotrackcands);
+  auto const recotrackcands = iEvent.getHandle(candToken_);
 
   //Filtering
   int n = 0;
@@ -69,11 +58,10 @@ bool HLTPixelIsolTrackL1TFilter::hltFilter(edm::Event& iEvent,
         fabs(candref->track()->eta()) < maxetatrack_ && fabs(candref->track()->eta()) > minetatrack_) {
       filterproduct.addObject(trigger::TriggerTrack, candref);
       n++;
-#ifdef DebugLog
-      edm::LogInfo("HcalIsoTrack") << "PixelIsolP:Candidate[" << n << "] pt|eta|phi " << candref->pt() << "|"
-                                   << candref->track()->pt() << "|" << candref->track()->eta() << "|"
-                                   << candref->track()->phi() << "\n";
-#endif
+
+      LogDebug("HcalIsoTrack") << "PixelIsolP:Candidate[" << n << "] pt|eta|phi " << candref->pt() << "|"
+                               << candref->track()->pt() << "|" << candref->track()->eta() << "|"
+                               << candref->track()->phi() << "\n";
     }
 
     // select on momentum
@@ -82,11 +70,10 @@ bool HLTPixelIsolTrackL1TFilter::hltFilter(edm::Event& iEvent,
           fabs(candref->track()->eta()) < maxetatrack_ && fabs(candref->track()->eta()) > minetatrack_) {
         filterproduct.addObject(trigger::TriggerTrack, candref);
         n++;
-#ifdef DebugLog
-        edm::LogInfo("HcalIsoTrack") << "PixelIsolE:Candidate[" << n << "] pt|eta|phi " << candref->pt() << "|"
-                                     << candref->track()->pt() << "|" << candref->track()->eta() << "|"
-                                     << candref->track()->phi() << "\n";
-#endif
+
+        LogDebug("HcalIsoTrack") << "PixelIsolE:Candidate[" << n << "] pt|eta|phi " << candref->pt() << "|"
+                                 << candref->track()->pt() << "|" << candref->track()->eta() << "|"
+                                 << candref->track()->phi() << "\n";
       }
     }
 
@@ -100,9 +87,9 @@ bool HLTPixelIsolTrackL1TFilter::hltFilter(edm::Event& iEvent,
 
   if (dropMultiL2Event_ && n > nMaxTrackCandidates_)
     accept = false;
-#ifdef DebugLog
-  edm::LogInfo("HcalIsoTrack") << "PixelIsolL1Filter: Tracks " << n << " accept " << accept << "\n";
-#endif
+
+  LogDebug("HcalIsoTrack") << "PixelIsolL1Filter: Tracks " << n << " accept " << accept << "\n";
+
   return accept;
 }
 

--- a/HLTrigger/special/plugins/HLTPixelIsolTrackL1TFilter.h
+++ b/HLTrigger/special/plugins/HLTPixelIsolTrackL1TFilter.h
@@ -1,39 +1,36 @@
-#ifndef HLTPixelIsolTrackL1TFilter_h
-#define HLTPixelIsolTrackL1TFilter_h
-
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#ifndef HLTrigger_special_HLTPixelIsolTrackL1TFilter_h
+#define HLTrigger_special_HLTPixelIsolTrackL1TFilter_h
 
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 
 namespace edm {
   class ConfigurationDescriptions;
-}
+  class ParameterSet;
+}  // namespace edm
 
 class HLTPixelIsolTrackL1TFilter : public HLTFilter {
 public:
   explicit HLTPixelIsolTrackL1TFilter(const edm::ParameterSet&);
-  ~HLTPixelIsolTrackL1TFilter() override;
+  ~HLTPixelIsolTrackL1TFilter() override = default;
+
   bool hltFilter(edm::Event&,
                  const edm::EventSetup&,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  edm::EDGetTokenT<reco::IsolatedPixelTrackCandidateCollection> candToken_;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> hltGTseedToken_;
-  edm::InputTag candTag_;
-  edm::InputTag hltGTseedlabel_;
-  double maxptnearby_;
-  double minpttrack_;
-  double minetatrack_;
-  double maxetatrack_;
-  bool filterE_;
-  double minEnergy_;
-  int nMaxTrackCandidates_;
-  bool dropMultiL2Event_;
-  double minDeltaPtL1Jet_;
+  edm::InputTag const candTag_;
+  edm::EDGetTokenT<reco::IsolatedPixelTrackCandidateCollection> const candToken_;
+  double const maxptnearby_;
+  double const minEnergy_;
+  double const minpttrack_;
+  double const maxetatrack_;
+  double const minetatrack_;
+  bool const filterE_;
+  int const nMaxTrackCandidates_;
+  bool const dropMultiL2Event_;
 };
 
-#endif
+#endif  // HLTrigger_special_HLTPixelIsolTrackL1TFilter_h


### PR DESCRIPTION
#### PR description:

This PR removes the unused parameters `L1GTSeedLabel` and `MinDeltaPtL1Jet` from the plugin `HLTPixelIsolTrackL1TFilter`.

Minor technical improvements are also applied to the latter plugin.

a49ed25c86ac20c19f72032343e59c7b8a90e6f9 is an unrelated minor change to address https://github.com/cms-sw/cmssw/pull/41058#discussion_r1139306442.

Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A