### PR TITLE
Change from numberOfMatches() to segment number in DisplacedMuonFilterProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/DisplacedMuonFilterProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/DisplacedMuonFilterProducer.cc
@@ -170,8 +170,13 @@ void pat::DisplacedMuonFilterProducer::produce(edm::Event& iEvent, const edm::Ev
           oMuons = oMuons - 1;
           continue;
         }
+        // Discard STA-only muons below pt threshold
+      } else if (muon.standAloneMuon()->pt() < minPtSTA_) {
+        filteredmuons[i] = false;
+        oMuons = oMuons - 1;
+        continue;
       } else {
-        // Compute number of DT+CSC segments
+        // Compute number of DT+CSC segments and discard those that have less than the minimum required
         nsegments = 0;
         for (trackingRecHit_iterator hit = muon.standAloneMuon()->recHitsBegin();
              hit != muon.standAloneMuon()->recHitsEnd();
@@ -185,8 +190,8 @@ void pat::DisplacedMuonFilterProducer::produce(edm::Event& iEvent, const edm::Ev
             nsegments++;
           }
         }
-        // Discard STA-only muons with less than minMatches_ segments and below pt threshold
-        if (nsegments < minMatches_ || muon.standAloneMuon()->pt() < minPtSTA_) {
+        // Discard STA-only muons with less than minMatches_ segments
+        if (nsegments < minMatches_) {
           filteredmuons[i] = false;
           oMuons = oMuons - 1;
           continue;


### PR DESCRIPTION
#### PR description:

This PR intends to fix an unexpected behavior observed when validating the performance of the slimmedDisplacedMuons collection in MiniAOD samples. 
The issue consists in a bad filtering of highly displaced muons caused by the definition of muon.numberOfMatches(), which was proved to not be appropriate to effectively select displaced muons when no tracker track is reconstructed.
The fix in this PR proposes to change this variable for another one. Now, the segments of the track are counted through the reco::Track object itself, which yields a more accurate description of the standalone muon track properties. 
This issue was reported to and discussed with the MUO POG, a detailed description can be found at:
https://indico.cern.ch/event/1263952/ ("Update on displaced muon collection performance studies").

Muon number expected to increase in muons from the slimmedDisplacedMuons collection which are not .isGlobal() nor .isTracker() in high displaced signals e.g DisplacedSUSY and Cosmics. These muons are not expected to change in prompt signals except for some small fluctuations. Standard muons should not be affected in any way.

The fix has been checked to work properly in cosmics data and H->SS MC signal (higher and lower displacement). 

See attached plot for a comparison of muon $d_{xy}$ distribution for a highly displaced H->SS signal (ctau=4000mm) between the old filter (red) and the fix in this PR (blue).
![HTo2LongLived_400_150_4000_h_dxy](https://user-images.githubusercontent.com/68101581/235872960-d5666d03-63d1-49bd-80fb-f9309f479912.png)

Other authors: @CeliaFernandez  

#### PR validation:

The code changes have passed all standard runTheMatrix test workflows.
No significant increase in size of MiniAOD is expected (tested on ttbar workflow 11834.21)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We would like to have this also backported to 13_0_0.
