### PR TITLE
Apply clang-tidy and clang-format changes [LLVM 14]

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
@@ -49,7 +49,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
 
     // To be able to interact with non-Alpaka helper code that needs
     // to access edm::Event
-    operator edm::Event const &() const { return constEvent_; }
+    operator edm::Event const&() const { return constEvent_; }
 
     Device device() const { return metadata_->device(); }
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h
@@ -24,7 +24,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
 
     // To be able to interact with non-Alpaka helper code that needs
     // to access edm::EventSetup
-    operator edm::EventSetup const &() const { return setup_; }
+    operator edm::EventSetup const&() const { return setup_; }
 
     // getData()
 


### PR DESCRIPTION
#### PR description:

Code-checks/format changes needed due to llvm 14.0.6 integration.

Equivalent to #41414.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 13.0.x for data taking.