### PR TITLE
[RECONSTRUCTION] [LLVM16]Fix set but unused variables warnings

### DIFF
--- a/CommonTools/Clustering1D/interface/DivisiveClusterizer1D.h
+++ b/CommonTools/Clustering1D/interface/DivisiveClusterizer1D.h
@@ -102,11 +102,9 @@ void DivisiveClusterizer1D<T>::findCandidates(const std::vector<Cluster1D<T> >& 
     return;
   }
   sort(input.begin(), input.end(), ComparePairs<T>());
-  int ncount = 0;
   std::vector<Cluster1D<T> > partOfPTracks;
   partOfPTracks.push_back(input.front());
   for (typename std::vector<Cluster1D<T> >::const_iterator ic = (input.begin()) + 1; ic != input.end(); ic++) {
-    ncount++;
     if (fabs((*ic).position().value() - (*(ic - 1)).position().value()) < (double)theZSeparation) {
       partOfPTracks.push_back((*ic));
     } else {

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -349,7 +349,6 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     lWeights = fPuppiContainer->puppiWeights();
   } else {
     //Use the existing weights
-    int lPackCtr = 0;
     lWeights.reserve(pfCol->size());
     for (auto const& aPF : *pfCol) {
       const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
@@ -370,7 +369,6 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons))
         curpupweight = 1;
       lWeights.push_back(curpupweight);
-      lPackCtr++;
     }
   }
 


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these

[a]
```
warning: variable 'XXX' set but not used [-Wunused-but-set-variable]
```