### PR TITLE
[ALCA] [LLVM16]Fix set but unused variables warnings

### DIFF
--- a/Alignment/CocoaFit/src/Fit.cc
+++ b/Alignment/CocoaFit/src/Fit.cc
@@ -887,7 +887,6 @@ void Fit::multiplyMatrices() {
   }
 
   ALIint nEnt = 0;
-  ALIint nEntUnk = 0;
   for (vecite = Model::EntryList().begin(); vecite != Model::EntryList().end(); ++vecite) {
     //------------------ Number of parameters 'cal'
     //                  (= No parameters to be fitted - No parameters 'unk' )
@@ -901,8 +900,6 @@ void Fit::multiplyMatrices() {
       }
       nEnt++;
     }
-    if ((*vecite)->quality() == 2)
-      nEntUnk++;
   }
 
   if (ALIUtils::debug >= 5)

--- a/Alignment/CocoaFit/src/FittedEntriesManager.cc
+++ b/Alignment/CocoaFit/src/FittedEntriesManager.cc
@@ -93,7 +93,7 @@ void FittedEntriesManager::MakeHistos() {
       fout2 << (*vfescite)->getDate() << " " << (*vfescite)->getTime() << " ";
     }
 
-    ALIint ii = 0;
+    //ALIint ii = 0;
     for (vfecite = ((*vfescite)->FittedEntries()).begin(); vfecite != ((*vfescite)->FittedEntries()).end(); ++vfecite) {
       //      std::cout << ii << *vfescite << " FITTEDENTRY: "   << vfecite << " " <<*vfecite << " " << (*vfecite)->Value() << std::endl;
       //      if( ii == 2 || ii == 4 ) {
@@ -107,7 +107,7 @@ void FittedEntriesManager::MakeHistos() {
       ALIstring filename = createFileName((*vfecite)->getOptOName(), (*vfecite)->getEntryName());
       fout2 << std::setprecision(8) << std::setw(10) << filename << " " << (*vfecite)->getValue() << " "
             << (*vfecite)->getSigma() << "  ";
-      ii++;
+      //ii++;
     }
     //    dumpEntriesSubstraction( fout, *(*vfescite), 2, 4);
     fout << std::endl;

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentStats.cc
@@ -143,7 +143,6 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
                                         << "  Phi=" << Phi[trk_cnt] << "  P=" << P[trk_cnt]
                                         << "   Nhits=" << Nhits[trk_cnt][0];
 
-    int nhit = 0;
     //loop on tracking rechits
     //edm::LogVerbatim("AlignmenStats") << "   loop on hits of track #" << (itt - tracks->begin());
     for (auto const &hit : ittrk->recHits()) {
@@ -242,7 +241,6 @@ void AlignmentStats::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
       if (ntracks > 1)
         edm::LogVerbatim("AlignmenStats") << "Hit in SubDet=" << subdethit;
       Nhits[trk_cnt][subdethit] = Nhits[trk_cnt][subdethit] + 1;
-      nhit++;
     }  //end loop on trackingrechits
     trk_cnt++;
 

--- a/Alignment/Geners/src/ClassId.cc
+++ b/Alignment/Geners/src/ClassId.cc
@@ -107,8 +107,7 @@ namespace gs {
           return false;
         char *endptr;
         // Compiler can complain about unused result of "strtoul"
-        unsigned long dummy = strtoul(prefix + vstart, &endptr, 10);
-        ++dummy;
+        strtoul(prefix + vstart, &endptr, 10);
         if (endptr != prefix + i)
           return false;
       }

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -617,10 +617,8 @@ void MillePedeMonitor::fillTrack(const reco::Track *track,
   int nhitinTIDplus = 0, nhitinTIDminus = 0;
   int nhitinFPIXplus = 0, nhitinFPIXminus = 0;
   int nhitinTECplus = 0, nhitinTECminus = 0;
-  unsigned int thishit = 0;
 
   for (auto const &hit : track->recHits()) {
-    thishit++;
     const DetId detId(hit->geographicalId());
     const int subdetId = detId.subdetId();
 

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
@@ -102,9 +102,7 @@ MuonGeometryArrange::MuonGeometryArrange(const edm::ParameterSet& cfg)
   if (_weightById) {
     std::ifstream inFile;
     inFile.open(_weightByIdFile.c_str());
-    int ctr = 0;
     while (!inFile.eof()) {
-      ctr++;
       unsigned int listId;
       inFile >> listId;
       inFile.ignore(256, '\n');

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCPairResidualsConstraint.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCPairResidualsConstraint.cc
@@ -464,7 +464,6 @@ bool CSCPairResidualsConstraint::dphidzFromTrack(const std::vector<TrajectoryMea
                                                  double &dphidz) {
   // make a list of hits on all chambers *other* than the ones associated with this constraint
   std::map<int, int> stations;
-  int total = 0;
   TransientTrackingRecHit::ConstRecHitContainer cscHits;
   for (std::vector<TrajectoryMeasurement>::const_iterator measurement = measurements.begin();
        measurement != measurements.end();
@@ -482,7 +481,6 @@ bool CSCPairResidualsConstraint::dphidzFromTrack(const std::vector<TrajectoryMea
           stations[station] = 0;
         }
         stations[station]++;
-        total++;
 
         cscHits.push_back(measurement->recHit());
       }

--- a/Alignment/MuonAlignmentAlgorithms/src/MuonResiduals1DOFFitter.cc
+++ b/Alignment/MuonAlignmentAlgorithms/src/MuonResiduals1DOFFitter.cc
@@ -68,7 +68,6 @@ bool MuonResiduals1DOFFitter::fit(Alignable *ali) {
   double resid_sum = 0.;
   double resid_sum2 = 0.;
   double resid_N = 0.;
-  int N = 0;
 
   for (std::vector<double *>::const_iterator resiter = residuals_begin(); resiter != residuals_end(); ++resiter) {
     const double residual = (*resiter)[MuonResiduals1DOFFitter::kResid];
@@ -82,7 +81,6 @@ bool MuonResiduals1DOFFitter::fit(Alignable *ali) {
         resid_sum += weight * residual;
         resid_sum2 += weight * residual * residual;
         resid_N += weight;
-        N++;
       }
     }
   }

--- a/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiElectronVertexValidation.cc
@@ -233,9 +233,7 @@ void DiElectronVertexValidation::analyze(const edm::Event& iEvent, const edm::Ev
 
   std::vector<const reco::GsfTrack*> myGoodGsfTracks;
 
-  unsigned int i = 0;
   for (const auto& electron : theZElectronVector) {
-    i++;
     float minD = 1000.;
     const reco::GsfTrack* theMatch = nullptr;
     for (const auto& track : iEvent.get(gsfTracksToken_)) {

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -120,9 +120,7 @@ TrackerGeometryCompare::TrackerGeometryCompare(const edm::ParameterSet& cfg)
   if (weightById_) {
     std::ifstream inFile;
     inFile.open(weightByIdFile_.c_str());
-    int ctr = 0;
     while (!inFile.eof()) {
-      ctr++;
       unsigned int listId;
       inFile >> listId;
       inFile.ignore(256, '\n');

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
@@ -265,14 +265,12 @@ void TrackerGeometryIntoNtuples::analyze(const edm::Event& iEvent, const edm::Ev
 
   // Get GeomDetUnits for the current tracker
   auto const& detUnits = theCurTracker->detUnits();
-  int detUnit(0);
   //\\for (unsigned int iDet = 0; iDet < detUnits.size(); ++iDet) {
   for (auto iunit = detUnits.begin(); iunit != detUnits.end(); ++iunit) {
     DetId detid = (*iunit)->geographicalId();
     m_rawid = detid.rawId();
     m_subdetid = detid.subdetId();
 
-    ++detUnit;
     //\\GeomDetUnit* geomDetUnit = detUnits.at(iDet) ;
     auto geomDetUnit = *iunit;
 

--- a/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.cc
+++ b/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.cc
@@ -343,7 +343,6 @@ void ValidationMisalignedTracker::analyze(const edm::Event& iEvent, const edm::E
   const edm::Handle<TrackingParticleCollection>& TPCollectionHfake = iEvent.getHandle(tpfakeToken_);
   const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
 
-  int w = 0;
   for (unsigned int ww = 0; ww < associators.size(); ww++) {
     //
     //get collections from the event
@@ -367,7 +366,6 @@ void ValidationMisalignedTracker::analyze(const edm::Event& iEvent, const edm::E
       edm::LogVerbatim("ValidationMisalignedTracker") << "Computing Efficiency";
 
       edm::LogVerbatim("TrackValidator") << "\n# of TrackingParticles (before cuts): " << tPCeff.size() << "\n";
-      int ats = 0;
       int st = 0;
       for (TrackingParticleCollection::size_type i = 0; i < tPCeff.size(); i++) {
         // Initialize variables
@@ -457,7 +455,6 @@ void ValidationMisalignedTracker::analyze(const edm::Event& iEvent, const edm::E
             rt = simRecColl[tp];
             if (!rt.empty()) {
               edm::RefToBase<reco::Track> t = rt.begin()->first;
-              ats++;
 
               // bool flagptused=false;
               // for (unsigned int j=0;j<ptused.size();j++){
@@ -767,8 +764,6 @@ void ValidationMisalignedTracker::analyze(const edm::Event& iEvent, const edm::E
       }
 
     }  // End of loop on fakerate
-
-    w++;
 
   }  // End of loop on associators
 }

--- a/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
+++ b/Alignment/TrackerAlignment/plugins/AlignmentPrescaler.cc
@@ -121,20 +121,16 @@ void AlignmentPrescaler::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   //prepare the output of the ValueMap flagging tracks
   std::vector<int> trackflags(Tracks->size(), 0);
 
-  int npxlhits = 0;
-
   //loop on tracks
   for (std::vector<reco::Track>::const_iterator ittrk = Tracks->begin(), edtrk = Tracks->end(); ittrk != edtrk;
        ++ittrk) {
     //loop on tracking rechits
     LogDebug("AlignmentPrescaler") << "Loop on hits of track #" << (ittrk - Tracks->begin()) << std::endl;
-    int nhit = 0;
     int ntakenhits = 0;
     bool firstTakenHit = false;
 
     for (auto const& hit : ittrk->recHits()) {
       if (!hit->isValid()) {
-        nhit++;
         continue;
       }
       uint32_t tmpdetid = hit->geographicalId().rawId();
@@ -198,7 +194,6 @@ void AlignmentPrescaler::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       else {
         //	const SiPixelRecHit*   pixelhit= dynamic_cast<const SiPixelRecHit*>(hit);
         if (pixelhit != nullptr) {
-          npxlhits++;
           SiPixelClusterRefNew pixclust(pixelhit->cluster());
           tmpflag = InValMap[pixclust];
           tmpflag.SetDetId(hit->geographicalId());
@@ -240,8 +235,7 @@ void AlignmentPrescaler::produce(edm::Event& iEvent, const edm::EventSetup& iSet
         }
         ntakenhits++;
       }  //end if take this hit
-      nhit++;
-    }  //end loop on RecHits
+    }    //end loop on RecHits
     trackflags[ittrk - Tracks->begin()] = ntakenhits;
   }  //end loop on tracks
 

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -327,7 +327,6 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     int nhitinTECplus = 0;
     int nhitinTIDminus = 0;
     int nhitinTIDplus = 0;
-    int countHit = 0;
 
     for (auto const& hit1 : itTrack1->recHits()) {
       const DetId detId1(hit1->geographicalId());
@@ -441,7 +440,6 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
         }
       }
 
-      countHit++;
     }  // for Loop over Hits
 
     nh_PIXEL.push_back(nHits_PIXEL);

--- a/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXML.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/src/MiscalibReaderXML.cc
@@ -81,7 +81,6 @@ bool MiscalibReaderFromXML::parseXMLMiscalibFile(std::string configFile) {
   if (linkTagsNum == 0)
     std::cout << "Number of Cells in file is 0 - probably bad file format" << std::endl;
 
-  int count = 0;
   for (unsigned int i = 0; i < linkTagsNum; i++) {
     DOMNode* linkNode = doc->getElementsByTagName(_toDOMS("Cell"))->item(i);
     ///Get ME name
@@ -101,7 +100,6 @@ bool MiscalibReaderFromXML::parseXMLMiscalibFile(std::string configFile) {
     DetId cell = parseCellEntry(attributes);
 
     if (cell != DetId(0)) {
-      count++;
       caloMap_.addCell(cell, scalingfactor);
     } else {
       //		std::cout << "Null received" << std::endl;

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalMatacqAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalMatacqAnalyzer.cc
@@ -232,7 +232,6 @@ void EcalMatacqAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) 
   // Decode Matacq Information
   // ===========================
 
-  int iCh = 0;
   double max = 0;
 
   for (EcalMatacqDigiCollection::const_iterator it = matacqDigi->begin(); it != matacqDigi->end();
@@ -241,7 +240,6 @@ void EcalMatacqAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) 
     //
     const EcalMatacqDigi& digis = *it;
 
-    //if(digis.size()==0 || iCh>=N_channels) continue;
     if (_debug == 1) {
       edm::LogVerbatim("EcalMatacqAnalyzzer") << "-- debug test -- Inside digis -- digi size=" << digis.size();
     }
@@ -267,8 +265,6 @@ void EcalMatacqAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c) 
       edm::LogVerbatim("EcalMatacqAnalyzzer")
           << "-- debug test -- Inside digis -- nsamples=" << nsamples << ", max=" << max;
     }
-
-    iCh++;
   }
 
   if (_debug == 1)

--- a/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCCrosstalkDBConditions.h
@@ -65,8 +65,6 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
   std::vector<float> new_intercept_l;
 
   int counter;
-  int db_nrlines = 0;
-  int new_nrlines = 0;
 
   std::ifstream dbdata;
   dbdata.open("old_dbxtalk.dat", std::ios::in);
@@ -82,7 +80,6 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
     db_slope_l.push_back(db_slope_left);
     db_intercept_r.push_back(db_intercept_right);
     db_intercept_l.push_back(db_intercept_left);
-    db_nrlines++;
   }
   dbdata.close();
 
@@ -100,7 +97,6 @@ inline CSCDBCrosstalk *CSCCrosstalkDBConditions::prefillDBCrosstalk() {
     new_slope_l.push_back(new_slope_left);
     new_intercept_r.push_back(new_intercept_right);
     new_intercept_l.push_back(new_intercept_left);
-    new_nrlines++;
   }
   newdata.close();
 

--- a/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCGainsDBConditions.h
@@ -64,8 +64,6 @@ inline CSCDBGains *CSCGainsDBConditions::prefillDBGains() {
   std::vector<float> new_chi2;
 
   int counter;
-  int db_nrlines = 0;
-  int new_nrlines = 0;
 
   std::ifstream dbdata;
   dbdata.open("old_dbgains.dat", std::ios::in);
@@ -80,7 +78,6 @@ inline CSCDBGains *CSCGainsDBConditions::prefillDBGains() {
     db_slope.push_back(db_gainslope);
     // db_intercept.push_back(db_intercpt);
     // db_chi2.push_back(db_chisq);
-    db_nrlines++;
   }
   dbdata.close();
 
@@ -97,7 +94,6 @@ inline CSCDBGains *CSCGainsDBConditions::prefillDBGains() {
     new_slope.push_back(new_gainslope);
     new_intercept.push_back(new_intercpt);
     new_chi2.push_back(new_chisq);
-    new_nrlines++;
   }
   newdata.close();
 

--- a/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCNoiseMatrixDBConditions.h
@@ -84,8 +84,6 @@ inline CSCDBNoiseMatrix *CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix() {
   CSCDBNoiseMatrix *cndbmatrix = new CSCDBNoiseMatrix();
 
   int counter;
-  int db_nrlines = 0;
-  int new_nrlines = 0;
 
   std::ifstream dbdata;
   dbdata.open("old_dbmatrix.dat", std::ios::in);
@@ -110,7 +108,6 @@ inline CSCDBNoiseMatrix *CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix() {
     db_elem66.push_back(db_elm66);
     db_elem67.push_back(db_elm67);
     db_elem77.push_back(db_elm77);
-    db_nrlines++;
   }
   dbdata.close();
 
@@ -138,7 +135,6 @@ inline CSCDBNoiseMatrix *CSCNoiseMatrixDBConditions::prefillDBNoiseMatrix() {
     new_elem66.push_back(new_elm66);
     new_elem67.push_back(new_elm67);
     new_elem77.push_back(new_elm77);
-    new_nrlines++;
   }
   newdata.close();
 

--- a/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
+++ b/CalibMuon/CSCCalibration/interface/CSCPedestalsDBConditions.h
@@ -65,8 +65,6 @@ inline CSCDBPedestals *CSCPedestalsDBConditions::prefillDBPedestals() {
   std::vector<float> new_pedrms;
 
   int counter;
-  int db_nrlines = 0;
-  int new_nrlines = 0;
 
   std::ifstream dbdata;
   dbdata.open("old_dbpeds.dat", std::ios::in);
@@ -80,7 +78,6 @@ inline CSCDBPedestals *CSCPedestalsDBConditions::prefillDBPedestals() {
     db_index_id.push_back(db_index);
     db_peds.push_back(db_ped);
     db_pedrms.push_back(db_rms);
-    db_nrlines++;
   }
   dbdata.close();
 
@@ -96,7 +93,6 @@ inline CSCDBPedestals *CSCPedestalsDBConditions::prefillDBPedestals() {
     new_index_id.push_back(new_index);
     new_peds.push_back(new_ped);
     new_pedrms.push_back(new_rms);
-    new_nrlines++;
   }
   newdata.close();
 

--- a/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/CSCIndexerAnalyzer2.cc
@@ -119,7 +119,6 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetu
             << std::endl;
 
   int icount = 0;
-  int icountAll = 0;
 
   // Iterate over the DetUnits in the CSCGeometry
   for (const auto &it : pDD->detUnits()) {
@@ -127,8 +126,6 @@ void CSCIndexerAnalyzer2::analyze(const edm::Event &iEvent, const edm::EventSetu
     auto layer = dynamic_cast<const CSCLayer *>(it);
 
     if (layer) {
-      ++icountAll;  // how many layers we see
-
       // Get DetId in various ways
 
       DetId detId = layer->geographicalId();

--- a/CalibMuon/CSCCalibration/test/stubs/Compare.cc
+++ b/CalibMuon/CSCCalibration/test/stubs/Compare.cc
@@ -243,8 +243,6 @@ Compare::Compare(const edm::ParameterSet &iConfig) {
 
   counter = 0;
   counter1 = 0;
-  int old_nrlines = 0;
-  int new_nrlines = 0;
 
   std::ifstream olddata2;
   olddata2.open("old_dbgains.dat", std::ios::in);
@@ -257,7 +255,6 @@ Compare::Compare(const edm::ParameterSet &iConfig) {
     olddata2 >> old_index >> old_slope;
     old_index_id.push_back(old_index);
     old_gains.push_back(old_slope);
-    old_nrlines++;
   }
   olddata2.close();
 
@@ -275,7 +272,6 @@ Compare::Compare(const edm::ParameterSet &iConfig) {
     new_gains.push_back(new_slope);
     new_intercept.push_back(new_int);
     new_chi.push_back(new_chi2);
-    new_nrlines++;
   }
   newdata2.close();
   diffGains.resize(MAX_SIZE);

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -45,21 +45,13 @@ void DTGeometryParserFromDDD::parseGeometry(DDFilteredView& fv,
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
-  int ChamCounter = 0;
   while (doChamber) {
-    ChamCounter++;
-
     // Loop on SLs
     bool doSL = fv.firstChild();
-    int SLCounter = 0;
     while (doSL) {
-      SLCounter++;
-
       bool doL = fv.firstChild();
-      int LCounter = 0;
       // Loop on SLs
       while (doL) {
-        LCounter++;
         //DTLayer* layer =
         buildLayer(fv, muonConstants, theLayerIdWiresMap);
 

--- a/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
+++ b/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
@@ -39,7 +39,6 @@ RPCCalibSetUp::RPCCalibSetUp(const edm::ParameterSet &ps) {
 
   std::vector<std::string> words;
 
-  int count = 0;
   while (getline(_infile1, buff, '\n')) {
     words.clear();
     vnoise.clear();
@@ -63,8 +62,6 @@ RPCCalibSetUp::RPCCalibSetUp(const edm::ParameterSet &ps) {
     }
 
     _mapDetIdNoise.insert(make_pair(static_cast<uint32_t>(rpcdetid), vnoise));
-
-    count++;
   }
   _infile1.close();
 

--- a/CalibPPS/AlignmentRelative/plugins/PPSFastLocalSimulation.cc
+++ b/CalibPPS/AlignmentRelative/plugins/PPSFastLocalSimulation.cc
@@ -424,13 +424,13 @@ void PPSFastLocalSimulation::produce(edm::Event &event, const edm::EventSetup &e
   if (makeHepMC_) {
     unique_ptr<HepMCProduct> hepMCoutput(new HepMCProduct());
     hepMCoutput->addHepMCData(gEv);
-    event.put(move(hepMCoutput));
+    event.put(std::move(hepMCoutput));
   }
 
   if (makeHits_) {
-    event.put(move(stripHitColl));
-    event.put(move(diamondHitColl));
-    event.put(move(pixelHitColl));
+    event.put(std::move(stripHitColl));
+    event.put(std::move(diamondHitColl));
+    event.put(std::move(pixelHitColl));
   }
 }
 

--- a/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
+++ b/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
@@ -90,7 +90,6 @@ SiPixelFedCablingTree* SiPixelFedCablingMapBuilder::produce(const edm::EventSetu
   const TrackerTopology* tt = tTopo.product();
 
   typedef TrackerGeometry::DetContainer::const_iterator ITG;
-  int npxdets = 0;
 
   typedef std::vector<pair<PixelModuleName*, uint32_t> > UNITS;
   UNITS units;
@@ -99,7 +98,6 @@ SiPixelFedCablingTree* SiPixelFedCablingMapBuilder::produce(const edm::EventSetu
     const PixelGeomDetUnit* pxUnit = dynamic_cast<const PixelGeomDetUnit*>(*it);
     if (pxUnit == nullptr)
       continue;
-    npxdets++;
     DetId geomid = pxUnit->geographicalId();
     PixelModuleName* name = nullptr;
     if (1 == geomid.subdetId()) {  // bpix

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainESSource.cc
@@ -42,22 +42,18 @@ SiPixelFakeGainESSource::~SiPixelFakeGainESSource() {
 
 std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const SiPixelGainCalibrationRcd&) {
   using namespace edm::es;
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
   SiPixelGainCalibration* obj = new SiPixelGainCalibration(25., 30., 2., 3.);
   SiPixelDetInfoFileReader reader(fp_.fullPath());
   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
   // Loop over detectors
   for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
-    nmodules++;
     std::vector<char> theSiPixelGainCalibration;
     const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
     // Loop over columns and rows
     for (int i = 0; i < detUnitDimensions.first; i++) {
       for (int j = 0; j < detUnitDimensions.second; j++) {
-        nchannels++;
         float gain = 2.8;
         float ped = 28.2;
         obj->setData(ped, gain, theSiPixelGainCalibration);
@@ -71,8 +67,6 @@ std::unique_ptr<SiPixelGainCalibration> SiPixelFakeGainESSource::produce(const S
       edm::LogError("SiPixelFakeGainESSource")
           << "[SiPixelFakeGainESSource::produce] detid already exists" << std::endl;
   }
-
-  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
   //
   return std::unique_ptr<SiPixelGainCalibration>(obj);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainForHLTESSource.cc
@@ -43,15 +43,12 @@ SiPixelFakeGainForHLTESSource::~SiPixelFakeGainForHLTESSource() {
 std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::produce(
     const SiPixelGainCalibrationForHLTRcd&) {
   using namespace edm::es;
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
   SiPixelGainCalibrationForHLT* obj = new SiPixelGainCalibrationForHLT(25., 30., 2., 3.);
   SiPixelDetInfoFileReader reader(fp_.fullPath());
   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
   // Loop over detectors
   for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
-    nmodules++;
     std::vector<char> theSiPixelGainCalibration;
     const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
@@ -62,7 +59,6 @@ std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::pro
       float totalPed = 0.0;
       float totalEntries = 0.0;
       for (int j = 0; j < detUnitDimensions.second; j++) {
-        nchannels++;
         totalGain += 2.8;
         totalPed += 28.2;
         totalEntries++;
@@ -86,8 +82,6 @@ std::unique_ptr<SiPixelGainCalibrationForHLT> SiPixelFakeGainForHLTESSource::pro
       edm::LogError("SiPixelFakeGainForHLTESSource")
           << "[SiPixelFakeGainForHLTESSource::produce] detid already exists" << std::endl;
   }
-
-  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
   //
   return std::unique_ptr<SiPixelGainCalibrationForHLT>(obj);

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelFakeGainOfflineESSource.cc
@@ -43,15 +43,12 @@ SiPixelFakeGainOfflineESSource::~SiPixelFakeGainOfflineESSource() {
 std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::produce(
     const SiPixelGainCalibrationOfflineRcd&) {
   using namespace edm::es;
-  unsigned int nmodules = 0;
-  uint32_t nchannels = 0;
   SiPixelGainCalibrationOffline* obj = new SiPixelGainCalibrationOffline(25., 30., 2., 3.);
   SiPixelDetInfoFileReader reader(fp_.fullPath());
   const std::vector<uint32_t>& DetIds = reader.getAllDetIds();
 
   // Loop over detectors
   for (std::vector<uint32_t>::const_iterator detit = DetIds.begin(); detit != DetIds.end(); detit++) {
-    nmodules++;
     std::vector<char> theSiPixelGainCalibrationOffline;
     const std::pair<int, int>& detUnitDimensions = reader.getDetUnitDimensions(*detit);
 
@@ -60,7 +57,6 @@ std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::p
       float totalGain = 0.0;
       float totalEntries = 0.0;
       for (int j = 0; j < detUnitDimensions.second; j++) {
-        nchannels++;
         totalGain += 2.8;
         float ped = 28.2;
         totalEntries += 1.0;
@@ -84,8 +80,6 @@ std::unique_ptr<SiPixelGainCalibrationOffline> SiPixelFakeGainOfflineESSource::p
       edm::LogError("SiPixelFakeGainOfflineESSource")
           << "[SiPixelFakeGainOfflineESSource::produce] detid already exists" << std::endl;
   }
-
-  //std::cout << "Modules = " << nmodules << " Channels " << nchannels << std::endl;
 
   //
   return std::unique_ptr<SiPixelGainCalibrationOffline>(obj);

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -1356,8 +1356,6 @@ void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup&
               float distx, disty, dist;
               bool found_hit_from_generated_particle = false;
 
-              int n_assoc_muon = 0;
-
               vector<PSimHit>::const_iterator closestit = matched.begin();
               for (vector<PSimHit>::const_iterator m = matched.begin(); m < matched.end(); ++m) {
                 if (checkType_) {  // only consider associated simhits with the generated pid (muons)
@@ -1374,8 +1372,6 @@ void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup&
                 dist = sqrt(distx * distx + disty * disty);
 
                 if (dist < mindist) {
-                  n_assoc_muon++;
-
                   mindist = dist;
                   closestit = m;
                   found_hit_from_generated_particle = true;
@@ -1386,12 +1382,6 @@ void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup&
               // Ignore it as most probably come from delta rays.
               if (checkType_ && !found_hit_from_generated_particle)
                 continue;
-
-              //if ( n_assoc_muon > 1 )
-              //{
-              //  // cout << " ----- This is not good: n_assoc_muon = " << n_assoc_muon << endl;
-              //  // cout << "evt = " << evt << endl;
-              //}
 
               DetId detId = hit->geographicalId();
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelStatusManager.cc
@@ -153,7 +153,6 @@ void SiPixelStatusManager::createBadComponents() {
     SiPixelDetectorStatus tmpSiPixelStatus;
     bool isNewIOV = true;
 
-    int counter = 0;
     for (siPixelStatusVtr_iterator it = firstStatus; it != lastStatus; it++) {
       if (isNewIOV) {  // if it is new IOV, init with the current data
         tmpLumi = edm::LuminosityBlockNumber_t(it->getLSRange().first);
@@ -173,7 +172,6 @@ void SiPixelStatusManager::createBadComponents() {
         siPixelStatusMap_[tmpLumi] = tmpSiPixelStatus;
         // so next loop is the begining of a new IOV
       }
-      counter++;
 
     }  // end of siPixelStatusMap
 

--- a/Calibration/EcalCalibAlgos/src/ElectronCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/ElectronCalibration.cc
@@ -410,7 +410,6 @@ EBDetId ElectronCalibration::findMaxHit(edm::Handle<EBRecHitCollection>& phits) 
 
   EcalRecHitCollection ecrh = *phits;
   EcalRecHitCollection::iterator it;
-  int count = 0;
   EBDetId save;
   float en_save = 0;
   for (it = ecrh.begin(); it != ecrh.end(); it++) {
@@ -419,7 +418,6 @@ EBDetId ElectronCalibration::findMaxHit(edm::Handle<EBRecHitCollection>& phits) 
       en_save = it->energy();
       save = p;
     }
-    count++;
   }
   return save;
 }

--- a/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/Pi0FixedMassWindowCalibration.cc
@@ -327,7 +327,6 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
 
   EcalRecHitCollection* recalibEcalRecHitCollection(new EcalRecHitCollection);
 
-  int nRecHitsEB = 0;
   Handle<EcalRecHitCollection> pEcalRecHitBarrelCollection;
   event.getByToken(recHitToken_, pEcalRecHitBarrelCollection);
   const EcalRecHitCollection* ecalRecHitBarrelCollection = pEcalRecHitBarrelCollection.product();
@@ -335,8 +334,6 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
   for (EcalRecHitCollection::const_iterator aRecHitEB = ecalRecHitBarrelCollection->begin();
        aRecHitEB != ecalRecHitBarrelCollection->end();
        aRecHitEB++) {
-    //cout << " ECAL Barrel RecHit #,E,time,det,subdetid: "<<nRecHitsEB<<" "<<aRecHitEB->energy()<<" "<<aRecHitEB->time()<<" "<<aRecHitEB->detid().det()<<" "<<aRecHitEB->detid().subdetId()<<endl;
-
     EBDetId ebrhdetid = aRecHitEB->detid();
     //cout << " EBDETID: z,ieta,iphi "<<ebrhdetid.zside()<<" "<<ebrhdetid.ieta()<<" "<<ebrhdetid.iphi()<<endl;
     //cout << " EBDETID: tower_ieta,tower_iphi "<<ebrhdetid.tower_ieta()<<" "<<ebrhdetid.tower_iphi()<<endl;
@@ -347,17 +344,12 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
                     aRecHitEB->energy() * oldCalibs_barl[abs(ebrhdetid.ieta()) - 1][ebrhdetid.iphi() - 1][sign],
                     aRecHitEB->time());
     recalibEcalRecHitCollection->push_back(aHit);
-
-    nRecHitsEB++;
   }
 
   //  cout<<" Recalib size: "<<recalibEcalRecHitCollection->size()<<endl;
-  int irecalib = 0;
   for (EcalRecHitCollection::const_iterator aRecHitEB = recalibEcalRecHitCollection->begin();
        aRecHitEB != recalibEcalRecHitCollection->end();
        aRecHitEB++) {
-    //cout << " [recalibrated] ECAL Barrel RecHit #,E,time,det,subdetid: "<<irecalib<<" "<<aRecHitEB->energy()<<" "<<aRecHitEB->time()<<" "<<aRecHitEB->detid().det()<<" "<<aRecHitEB->detid().subdetId()<<endl;
-
     //    EBDetId ebrhdetid = aRecHitEB->detid();
     //cout << " [recalibrated] EBDETID: z,ieta,iphi "<<ebrhdetid.zside()<<" "<<ebrhdetid.ieta()<<" "<<ebrhdetid.iphi()<<endl;
     //cout << " [recalibrated] EBDETID: tower_ieta,tower_iphi "<<ebrhdetid.tower_ieta()<<" "<<ebrhdetid.tower_iphi()<<endl;
@@ -365,8 +357,6 @@ edm::EDLooper::Status Pi0FixedMassWindowCalibration::duringLoop(const edm::Event
 
     std::pair<DetId, EcalRecHit> map_entry(aRecHitEB->id(), *aRecHitEB);
     recHitsEB_map->insert(map_entry);
-
-    irecalib++;
   }
 
   const CaloSubdetectorGeometry* geometry_p;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
@@ -786,7 +786,7 @@ std::array<int, 3> AlCaHcalIsotrkProducer::getProducts(int goodPV,
                                                        HcalIsoTrkEventVariables& hocalibEvent,
                                                        const edm::EventID& eventId) {
   int nSave(0), nLoose(0), nTight(0);
-  unsigned int nTracks(0), nselTracks(0);
+  unsigned int nTracks(0);
   double rhohEV = (tower.isValid()) ? rhoh(tower) : 0;
 
   //Loop over tracks
@@ -884,7 +884,6 @@ std::array<int, 3> AlCaHcalIsotrkProducer::getProducts(int goodPV,
       flag += 8;
 #endif
     if (isoTk.qltyFlag_ && notMuon) {
-      nselTracks++;
       int nNearTRKs(0);
       ////////////////////////////////-MIP STUFF-//////////////////////////////
       std::vector<DetId> eIds;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -357,7 +357,7 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
         edm::LogVerbatim("HcalIsoTrack") << "AlCaIsoTracksFilter:: Has " << trkCaloDirections.size()
                                          << " propagated tracks from a total of " << trkCollection->size();
 #endif
-      unsigned int nTracks(0), nselTracks(0), ntrin(0), ntrout(0), ntrH(0);
+      unsigned int nTracks(0), ntrin(0), ntrout(0), ntrH(0);
       for (trkDetItr = trkCaloDirections.begin(), nTracks = 0; trkDetItr != trkCaloDirections.end();
            trkDetItr++, nTracks++) {
         const reco::Track* pTrack = &(*(trkDetItr->trkItr));
@@ -382,7 +382,6 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
 #endif
         if (qltyFlag && trkDetItr->okECAL && trkDetItr->okHCAL) {
           double t_p = pTrack->p();
-          nselTracks++;
           int nNearTRKs(0);
           std::vector<DetId> eIds;
           std::vector<double> eHit;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksProducer.cc
@@ -507,7 +507,7 @@ reco::HcalIsolatedTrackCandidateCollection* AlCaIsoTracksProducer::select(
   spr::propagateCALO(trkCollection, geo, bField, theTrackQuality_, trkCaloDirections, false);
 
   std::vector<spr::propagatedTrackDirection>::const_iterator trkDetItr;
-  unsigned int nTracks(0), nselTracks(0);
+  unsigned int nTracks(0);
   for (trkDetItr = trkCaloDirections.begin(), nTracks = 0; trkDetItr != trkCaloDirections.end();
        trkDetItr++, nTracks++) {
     const reco::Track* pTrack = &(*(trkDetItr->trkItr));
@@ -524,7 +524,6 @@ reco::HcalIsolatedTrackCandidateCollection* AlCaIsoTracksProducer::select(
 #endif
     if (qltyFlag && trkDetItr->okECAL && trkDetItr->okHCAL) {
       double t_p = pTrack->p();
-      nselTracks++;
       int nRH_eMipDR(0), nNearTRKs(0);
       double eMipDR = spr::eCone_ecal(geo,
                                       barrelRecHitsHandle,

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -960,7 +960,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
                                                 const edm::Handle<reco::MuonCollection>& muonh) {
   int nSave(0), nLoose(0), nTight(0);
   //Loop over tracks
-  unsigned int nTracks(0), nselTracks(0);
+  unsigned int nTracks(0);
   t_nTrk = trkCaloDirections.size();
   t_rhoh = (tower.isValid()) ? rhoh(tower) : 0;
   for (const auto& trkDetItr : trkCaloDirections) {
@@ -1025,7 +1025,6 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
     t_qltyFlag = (qltyFlag && trkDetItr.okECAL && trkDetItr.okHCAL);
     bool notMuon = (muonh.isValid()) ? notaMuon(pTrack, muonh) : true;
     if (t_qltyFlag && notMuon) {
-      nselTracks++;
       int nNearTRKs(0);
       ////////////////////////////////-MIP STUFF-//////////////////////////////
       std::vector<DetId> eIds;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
@@ -887,7 +887,7 @@ std::array<int, 3> HcalIsoTrkSimAnalyzer::fillTree(std::vector<math::XYZTLorentz
                                                    const HcalRespCorrs* respCorrs) {
   int nSave(0), nLoose(0), nTight(0);
   //Loop over tracks
-  unsigned int nTracks(0), nselTracks(0);
+  unsigned int nTracks(0);
   t_nTrk = trackIDs.size();
   t_rhoh = (tower.isValid()) ? rhoh(tower) : 0;
   for (auto const& trkDetItr : trackIDs) {
@@ -930,7 +930,6 @@ std::array<int, 3> HcalIsoTrkSimAnalyzer::fillTree(std::vector<math::XYZTLorentz
     t_qltyFlag = (t_selectTk && trkDetItr.okECAL && trkDetItr.okHCAL);
     bool notMuon = notaMuon(pTrack);
     if (t_qltyFlag && notMuon) {
-      nselTracks++;
       int nNearTRKs(0);
       ////////////////////////////////-MIP STUFF-//////////////////////////////
       std::vector<DetId> eIds;

--- a/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/test/DiJetAnalyzer.cc
@@ -258,25 +258,6 @@ void DiJetAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& evS
   const CaloSubdetectorGeometry* HOGeom = geo->getSubdetectorGeometry(DetId::Hcal, 3);
   const CaloSubdetectorGeometry* HFGeom = geo->getSubdetectorGeometry(DetId::Hcal, 4);
 
-  int HBHE_n = 0;
-  for (edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>::const_iterator ith = hbhereco->begin();
-       ith != hbhereco->end();
-       ++ith) {
-    HBHE_n++;
-  }
-  int HF_n = 0;
-  for (edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith = hfreco->begin();
-       ith != hfreco->end();
-       ++ith) {
-    HF_n++;
-  }
-  int HO_n = 0;
-  for (edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>::const_iterator ith = horeco->begin();
-       ith != horeco->end();
-       ++ith) {
-    HO_n++;
-  }
-
   // Get primary vertices
   const edm::Handle<std::vector<reco::Vertex>> pv = iEvent.getHandle(tok_Vertex_);
   if (!pv.isValid()) {

--- a/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/GammaJetAnalysis.cc
@@ -1006,36 +1006,14 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
     HERE("work");
 
-    int HBHE_n = 0;
     if (hbhereco.isValid()) {
       for (edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit>>::const_iterator ith =
                hbhereco->begin();
            ith != hbhereco->end();
            ++ith) {
-        HBHE_n++;
         if (iEvent.id().event() == debugEvent) {
           if (debug_ > 1)
             edm::LogVerbatim("GammaJetAnalysis") << (*ith).id().ieta() << " " << (*ith).id().iphi();
-        }
-      }
-    }
-    int HF_n = 0;
-    if (hfreco.isValid()) {
-      for (edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith = hfreco->begin();
-           ith != hfreco->end();
-           ++ith) {
-        HF_n++;
-        if (iEvent.id().event() == debugEvent) {
-        }
-      }
-    }
-    int HO_n = 0;
-    if (horeco.isValid()) {
-      for (edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit>>::const_iterator ith = horeco->begin();
-           ith != horeco->end();
-           ++ith) {
-        HO_n++;
-        if (iEvent.id().event() == debugEvent) {
         }
       }
     }
@@ -1128,8 +1106,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       }
 
       HERE("fill PF jet");
-
-      int ntypes = 0;
 
       /////////////////////////////////////////////
       // Get PF constituents and fill HCAL towers
@@ -1382,8 +1358,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
           float HFHAD_E = 0;
           float HFEM_E = 0;
-          int HFHAD_n_ = 0;
-          int HFEM_n_ = 0;
           int maxElement = (*it)->elementsInBlocks().size();
           if (debug_ > 1)
             edm::LogVerbatim("GammaJetAnalysis") << "maxElement=" << maxElement;
@@ -1490,9 +1464,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                   }                                                               // Loop over hits
                 }                                                                 // Test if element is from HCAL
                 else if (elements[iEle].type() == reco::PFBlockElement::HFHAD) {  // Element is HF
-                  ntypes++;
-                  HFHAD_n_++;
-
                   ////	h_etaHFHAD_->Fill((*it)->eta());
 
                   for (edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith =
@@ -1542,9 +1513,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                     }
                   }
                 } else if (elements[iEle].type() == reco::PFBlockElement::HFEM) {  // Element is HF
-                  ntypes++;
-                  HFEM_n_++;
-
                   for (edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit>>::const_iterator ith =
                            hfreco->begin();
                        ith != hfreco->end();
@@ -1592,7 +1560,6 @@ void GammaJetAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                     }
                   }
                 } else if (elements[iEle].type() == reco::PFBlockElement::HO) {  // Element is HO
-                  ntypes++;
                   reco::PFClusterRef clusterref = elements[iEle].clusterRef();
                   reco::PFCluster cluster = *clusterref;
                   double cluster_dR = deltaR(ppfjet_eta_, ppfjet_phi_, cluster.eta(), cluster.phi());

--- a/Calibration/HcalCalibAlgos/test/HcalCorrPFCalculation.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalCorrPFCalculation.cc
@@ -250,7 +250,6 @@ void HcalCorrPFCalculation::analyze(edm::Event const& ev, edm::EventSetup const&
 
   // MC particle with highest pt is taken as a direction reference
   double maxPt = -99999.;
-  int npart = 0;
 
   GlobalPoint initpos(0, 0, 0);
 
@@ -261,7 +260,6 @@ void HcalCorrPFCalculation::analyze(edm::Event const& ev, edm::EventSetup const&
     double pt = (*p)->momentum().perp();
     mom_MC = (*p)->momentum().rho();
     if (pt > maxPt) {
-      npart++;
       maxPt = pt; /*phi_MC = phiParticle; eta_MC = etaParticle;*/
     }
     GlobalVector mom((*p)->momentum().x(), (*p)->momentum().y(), (*p)->momentum().z());

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -940,7 +940,7 @@ std::array<int, 3> HcalIsoTrackStudy::fillTree(std::vector<math::XYZTLorentzVect
   int nSave(0), nLoose(0), nTight(0);
   //Loop over tracks
   std::vector<spr::propagatedTrackDirection>::const_iterator trkDetItr;
-  unsigned int nTracks(0), nselTracks(0);
+  unsigned int nTracks(0);
   t_nTrk = trkCaloDirections.size();
   t_rhoh = (tower.isValid()) ? rhoh(tower) : 0;
   for (trkDetItr = trkCaloDirections.begin(), nTracks = 0; trkDetItr != trkCaloDirections.end();
@@ -997,7 +997,6 @@ std::array<int, 3> HcalIsoTrackStudy::fillTree(std::vector<math::XYZTLorentzVect
 #endif
     t_qltyFlag = (qltyFlag && trkDetItr->okECAL && trkDetItr->okHCAL);
     if (t_qltyFlag) {
-      nselTracks++;
       int nNearTRKs(0);
       std::vector<DetId> eIds;
       std::vector<double> eHit;

--- a/Calibration/HcalIsolatedTrackReco/plugins/IsolatedEcalPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/IsolatedEcalPixelTrackCandidateProducer.cc
@@ -151,19 +151,16 @@ void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID,
                                      << " coneSize_: " << coneSize_;
 #endif
     if (etaAbs < 1.7) {
-      int nin(0), nout(0);
       for (auto eItr : *(ecalEB.product())) {
         const GlobalPoint& pos = geo->getPosition(eItr.detid());
         double R = reco::deltaR(pos.eta(), pos.phi(), etaPhi.first, etaPhi.second);
         if (R < coneSize_) {
           nhitIn++;
           inEnergy += (eItr.energy());
-          ++nin;
           if (eItr.energy() > hitCountEthrEB_)
             nhitOut++;
           if (eItr.energy() > hitEthrEB_) {
             outEnergy += (eItr.energy());
-            ++nout;
           }
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HcalIsoTrack") << "EBRechit close to the track has E " << eItr.energy()
@@ -173,7 +170,6 @@ void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID,
       }
     }
     if (etaAbs > 1.25) {
-      int nin(0), nout(0);
       for (auto eItr : *(ecalEE.product())) {
         const GlobalPoint& pos = geo->getPosition(eItr.detid());
         double R = reco::deltaR(pos.eta(), pos.phi(), etaPhi.first, etaPhi.second);
@@ -184,12 +180,10 @@ void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID,
             hitEthr = hitEthrEB_;
           nhitIn++;
           inEnergy += (eItr.energy());
-          ++nin;
           if (eItr.energy() > fachitCountEE_ * hitEthr)
             nhitOut++;
           if (eItr.energy() > hitEthr) {
             outEnergy += (eItr.energy());
-            ++nout;
           }
 #ifdef EDM_ML_DEBUG
           edm::LogVerbatim("HcalIsoTrack") << "EERechit close to the track has E " << eItr.energy()

--- a/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateL1TProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateL1TProducer.cc
@@ -224,7 +224,9 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
                                << ":" << etaTriggered << ":" << phiTriggered;
 #endif
   double drMaxL1Track_ = tauAssocCone_;
+#ifdef EDM_ML_DEBUG
   int ntr = 0;
+#endif
   std::vector<seedAtEC> VecSeedsatEC;
   //loop to select isolated tracks
   for (unsigned iS = 0; iS < pixelTrackRefs.size(); iS++) {
@@ -349,7 +351,9 @@ void IsolatedPixelTrackCandidateL1TProducer::produce(edm::Event& theEvent, const
           pixelTrackRefs[iSeed], l1t::TauRef(l1eTauJets, selj - l1eTauJets->begin()), maxP, sumP);
       newCandidate.setEtaPhiEcal(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi);
       trackCollection->push_back(newCandidate);
+#ifdef EDM_ML_DEBUG
       ntr++;
+#endif
     }
   }
 #ifdef EDM_ML_DEBUG

--- a/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/plugins/IsolatedPixelTrackCandidateProducer.cc
@@ -191,8 +191,9 @@ void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const ed
   const edm::Handle<reco::VertexCollection>& pVert = theEvent.getHandle(tok_vert_);
 
   double drMaxL1Track_ = tauAssocCone_;
-
+#ifdef EDM_ML_DEBUG
   int ntr = 0;
+#endif
   std::vector<seedAtEC> VecSeedsatEC;
   //loop to select isolated tracks
   for (unsigned iS = 0; iS < pixelTrackRefs.size(); iS++) {
@@ -306,7 +307,9 @@ void IsolatedPixelTrackCandidateProducer::produce(edm::Event& theEvent, const ed
           pixelTrackRefs[iSeed], l1extra::L1JetParticleRef(l1eTauJets, selj - l1eTauJets->begin()), maxP, sumP);
       newCandidate.setEtaPhiEcal(VecSeedsatEC[i].eta, VecSeedsatEC[i].phi);
       trackCollection->push_back(newCandidate);
+#ifdef EDM_ML_DEBUG
       ntr++;
+#endif
     }
   }
   // put the product in the event

--- a/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
+++ b/Calibration/IsolatedParticles/interface/CaloSimInfo.icc
@@ -602,8 +602,6 @@ namespace spr {
     std::set<int> uniqueIds_rest;
 
     // Counters for SimHits
-    int nMatched = 0, nRest = 0, nGamma = 0, nNeutralHad = 0, nChargedHad = 0;
-
     double energySum = 0.0;
     double energyGamma = 0.0, energyNeutral = 0.0, energyCharged = 0.0, energyRest = 0.0;
 
@@ -629,7 +627,6 @@ namespace spr {
           energySum += spr::getEnergy(hit[ihit]);
           uniqueIds_matched.insert(uniqueId);
           uniqueIds_total.insert(uniqueId);
-          nMatched++;
         } else {
           bool found = false;
           for (auto simTrkItr = SimTk->begin(); simTrkItr != SimTk->end(); simTrkItr++) {
@@ -640,7 +637,6 @@ namespace spr {
                 energySum += spr::getEnergy(hit[ihit]);
                 uniqueIds_matched.insert(uniqueId);
                 uniqueIds_total.insert(uniqueId);
-                nMatched++;
               } else {
                 edm::SimTrackContainer::const_iterator parentItr = spr::parentSimTrack(simTrkItr, SimTk, SimVtx, debug);
                 if (debug) {
@@ -657,22 +653,18 @@ namespace spr {
                   energyRest += spr::getEnergy(hit[ihit]);
                   uniqueIds_rest.insert(uniqueId);
                   uniqueIds_total.insert(uniqueId);
-                  nRest++;
                 } else if (parentItr->type() == 22) {
                   energyGamma += spr::getEnergy(hit[ihit]);
                   uniqueIds_gamma.insert(uniqueId);
                   uniqueIds_total.insert(uniqueId);
-                  nGamma++;
                 } else if ((int)parentItr->charge() == 0) {
                   energyNeutral += spr::getEnergy(hit[ihit]);
                   uniqueIds_neut.insert(uniqueId);
                   uniqueIds_total.insert(uniqueId);
-                  nNeutralHad++;
                 } else {
                   energyCharged += spr::getEnergy(hit[ihit]);
                   uniqueIds_char.insert(uniqueId);
                   uniqueIds_total.insert(uniqueId);
-                  nChargedHad++;
                 }
               }
               break;
@@ -683,7 +675,6 @@ namespace spr {
             energyRest += spr::getEnergy(hit[ihit]);
             uniqueIds_rest.insert(uniqueId);
             uniqueIds_total.insert(uniqueId);
-            nRest++;
           }
 
           if (debug)

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalib.cc
@@ -435,7 +435,7 @@ void IsoTrackCalib::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         edm::LogVerbatim("IsoTrack") << "jets pt/eta/phi = " << ptTriggered << "/" << etaTriggered << "/"
                                      << phiTriggered;
       //////////////////////loop over tracks////////////////////////////////////////
-      unsigned int nTracks(0), nselTracks(0);
+      unsigned int nTracks(0);
       for (trkDetItr = trkCaloDirections.begin(), nTracks = 0; trkDetItr != trkCaloDirections.end();
            trkDetItr++, nTracks++) {
         const reco::Track* pTrack = &(*(trkDetItr->trkItr));
@@ -491,7 +491,6 @@ void IsoTrackCalib::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
           }
         }
         if (t_qltyFlag) {
-          nselTracks++;
           h_tketa2[0]->Fill(t_ieta);
           for (unsigned int k = 1; k < pbin.size(); ++k) {
             if (t_p >= pbin[k - 1] && t_p < pbin[k]) {

--- a/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrackCalibration.cc
@@ -295,7 +295,7 @@ void IsoTrackCalibration::analyze(const edm::Event &iEvent, const edm::EventSetu
     spr::propagateCALO(trkCollection, geo, bField, theTrackQuality_, trkCaloDirections, ((verbosity_ / 100) % 10 > 2));
     //Loop over tracks
     std::vector<spr::propagatedTrackDirection>::const_iterator trkDetItr;
-    unsigned int nTracks(0), nselTracks(0);
+    unsigned int nTracks(0);
     t_nTrk = trkCaloDirections.size();
 
     for (trkDetItr = trkCaloDirections.begin(), nTracks = 0; trkDetItr != trkCaloDirections.end();
@@ -335,7 +335,6 @@ void IsoTrackCalibration::analyze(const edm::Event &iEvent, const edm::EventSetu
         edm::LogVerbatim("IsoTrack") << "qltyFlag|okECAL|okHCAL : " << qltyFlag << "|" << trkDetItr->okECAL << "/"
                                      << trkDetItr->okHCAL;
       if (qltyFlag && trkDetItr->okECAL && trkDetItr->okHCAL) {
-        nselTracks++;
         int nRH_eMipDR(0), nNearTRKs(0);
         //------ ecal energy around track -------------------------------
         t_eMipDR = spr::eCone_ecal(geo,

--- a/Calibration/IsolatedParticles/plugins/IsoTrig.cc
+++ b/Calibration/IsolatedParticles/plugins/IsoTrig.cc
@@ -1712,7 +1712,7 @@ void IsoTrig::studyIsolation(edm::Handle<reco::TrackCollection> &trkCollection,
                                      << hit->energy();
       }
     }
-    unsigned int nTracks = 0, ngoodTk = 0, nselTk = 0;
+    unsigned int nTracks = 0;
     int ieta = 999;
     for (trkDetItr = trkCaloDirections.begin(); trkDetItr != trkCaloDirections.end(); trkDetItr++, nTracks++) {
       bool l3Track = (std::find(goodTks.begin(), goodTks.end(), trkDetItr->trkItr) != goodTks.end());
@@ -1733,7 +1733,6 @@ void IsoTrig::studyIsolation(edm::Handle<reco::TrackCollection> &trkCollection,
         edm::LogVerbatim("IsoTrack") << "Track ECAL " << trkDetItr->okECAL << " HCAL " << trkDetItr->okHCAL << " Flag "
                                      << selectTk;
       if (selectTk && trkDetItr->okECAL && trkDetItr->okHCAL) {
-        ngoodTk++;
         int nRH_eMipDR = 0, nNearTRKs = 0;
         double e1 = spr::eCone_ecal(geo_,
                                     barrelRecHitsHandle_,
@@ -1779,8 +1778,6 @@ void IsoTrig::studyIsolation(edm::Handle<reco::TrackCollection> &trkCollection,
                                 iphiHotCell,
                                 gposHotCell,
                                 -1);
-        if (eMipDR < 1.0)
-          nselTk++;
       }
       if (l3Track) {
         fillHist(10, v4);
@@ -1822,7 +1819,6 @@ void IsoTrig::studyIsolation(edm::Handle<reco::TrackCollection> &trkCollection,
         }
       }
     }
-    //   edm::LogVerbatim("IsoTrack") << "Number of tracks selected offline " << nselTk;
   }
 }
 

--- a/Calibration/Tools/src/DetIdAssociator.cc
+++ b/Calibration/Tools/src/DetIdAssociator.cc
@@ -138,7 +138,6 @@ std::vector<GlobalPoint> HDetIdAssociator::getTrajectory(const FreeTrajectorySta
 std::set<DetId> HDetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& direction, const int idR) {
   std::set<DetId> set;
   check_setup();
-  int nDets = 0;
   if (!theMap_)
     buildMap();
   LogTrace("MatchPoint") << "point (eta,phi): " << direction.eta() << "," << direction.phi() << "\n";
@@ -149,7 +148,6 @@ std::set<DetId> HDetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& dire
 
   if (ieta >= 0 && ieta < nEta_ && iphi >= 0 && iphi < nPhi_) {
     set = (*theMap_)[ieta][iphi];
-    nDets++;
     if (idR > 0) {
       LogTrace("MatchPoint") << "Add neighbors (ieta,iphi): " << ieta << "," << iphi << "\n";
       //add neighbors
@@ -172,7 +170,6 @@ std::set<DetId> HDetIdAssociator::getDetIdsCloseToAPoint(const GlobalPoint& dire
           if (i == ieta && j == iphi)
             continue;  // already in the set
           set.insert((*theMap_)[i][j % nPhi_].begin(), (*theMap_)[i][j % nPhi_].end());
-          nDets++;
         }
     }
   }

--- a/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPulseShapeGrapher.cc
@@ -86,8 +86,6 @@ void EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSe
   using namespace edm;
   using namespace std;
 
-  int numHitsWithActivity = 0;
-
   const Handle<EcalUncalibratedRecHitCollection>& EBHits = iEvent.getHandle(EBUncalibratedRecHitCollection_);
   const Handle<EcalUncalibratedRecHitCollection>& EEHits = iEvent.getHandle(EEUncalibratedRecHitCollection_);
   const Handle<EBDigiCollection>& EBdigis = iEvent.getHandle(EBDigis_);
@@ -118,7 +116,6 @@ void EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSe
       continue;
 
     cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-    numHitsWithActivity++;
     EBDigiCollection::const_iterator digiItr = EBdigis->begin();
     while (digiItr != EBdigis->end() && digiItr->id() != hitItr->id()) {
       digiItr++;
@@ -178,7 +175,6 @@ void EcalPulseShapeGrapher::analyze(const edm::Event& iEvent, const edm::EventSe
       continue;
 
     cutAmpHistMap_[hitDetId.hashedIndex()]->Fill(amplitude);
-    numHitsWithActivity++;
     EEDigiCollection::const_iterator digiItr = EEdigis->begin();
     while (digiItr != EEdigis->end() && digiItr->id() != hitItr->id()) {
       digiItr++;


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these

[a]
```
warning: variable 'XXX' set but not used [-Wunused-but-set-variable]
```