### PR TITLE
[DB-RECONSTRUCTION] [LLVM16]Fix mismatched bound warnings

### DIFF
--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -2271,7 +2271,7 @@ void SiPixelTemplate::ysigma2(float qpixel, int index, float& ysig2)
 //! \param xsum - (input) 11-element vector of pixel signals
 //! \param xsig2 - (output) 11-element vector of x errors (squared)
 // ************************************************************************************************************
-void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11], float xsig2[11])
+void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[BXSIZE], float xsig2[BXSIZE])
 
 {
   // Interpolate using quantities already stored in the private variables


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these

[a]
```
warning: argument 'xsum' of type 'float[11]' with mismatched bound [-Warray-parameter]
 void SiPixelTemplate::xsigma2(int fxpix, int lxpix, float sxthr, float xsum[11], float xsig2[11])
```