### PR TITLE
[PDMV] [LLVM16]Fix set but unused variables warnings

### DIFF
--- a/Configuration/Skimming/src/LeptonSkimming.cc
+++ b/Configuration/Skimming/src/LeptonSkimming.cc
@@ -302,9 +302,7 @@ bool LeptonSkimming::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Save electrons we want to skim
   ElTracks.clear();
   if (!SkimOnlyMuons) {
-    unsigned int count_el = -1;
     for (const reco::GsfElectron& el : *electrons) {
-      count_el++;
       bool passConvVeto = !ConversionTools::hasMatchedConversion(*(&el), *conversions, theBeamSpot->position());
       if (!passConvVeto)
         continue;


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these

[a]
```
warning: variable 'XXX' set but not used [-Wunused-but-set-variable]
```