### PR TITLE
[ALCA-DB] [LLVM16]Fix set but unused variables warnings

### DIFF
--- a/CondFormats/DTObjects/src/DTReadOutMapping.cc
+++ b/CondFormats/DTObjects/src/DTReadOutMapping.cc
@@ -202,11 +202,6 @@ int DTReadOutMapping::geometryToReadOut(int wheelId,
   int defaultValue;
   atomicCache()->mType.find(0, defaultValue);
   if (defaultValue) {
-    int loop1 = 0;
-    int loop2 = 0;
-    int loop3 = 0;
-    int loop0 = 0;
-
     int searchStatus;
     int mapId = 0;
     std::vector<int> const* robMLgr;
@@ -227,7 +222,6 @@ int DTReadOutMapping::geometryToReadOut(int wheelId,
     std::vector<int>::const_iterator tdc_iter = robMLgr->begin();
     std::vector<int>::const_iterator tdc_iend = robMLgr->end();
     while (tdc_iter != tdc_iend) {
-      loop1++;
       const DTReadOutGeometryLink& ltdc(readOutChannelDriftTubeMap[*tdc_iter++]);
       channelId = ltdc.channelId;
       tdcId = ltdc.tdcId;
@@ -244,7 +238,6 @@ int DTReadOutMapping::geometryToReadOut(int wheelId,
       std::vector<int>::const_iterator ros_iter = rosMLgr->begin();
       std::vector<int>::const_iterator ros_iend = rosMLgr->end();
       while (ros_iter != ros_iend) {
-        loop2++;
         const DTReadOutGeometryLink& lros(readOutChannelDriftTubeMap[*ros_iter++]);
         int secCk = lros.sectorId;
         int wheCk = lros.wheelId;
@@ -268,11 +261,9 @@ int DTReadOutMapping::geometryToReadOut(int wheelId,
           return searchStatus;
         if (dduMLgr->empty())
           return 1;
-        loop0++;
         std::vector<int>::const_iterator ddu_iter = dduMLgr->begin();
         std::vector<int>::const_iterator ddu_iend = dduMLgr->end();
         while (ddu_iter != ddu_iend) {
-          loop3++;
           const DTReadOutGeometryLink& lddu(readOutChannelDriftTubeMap[*ddu_iter++]);
           if (((sectorId == secCk) || (sectorId == lddu.sectorId)) &&
               ((wheelId == wheCk) || (wheelId == lddu.wheelId))) {

--- a/CondFormats/RPCObjects/src/RPCReadOutMapping.cc
+++ b/CondFormats/RPCObjects/src/RPCReadOutMapping.cc
@@ -70,16 +70,11 @@ std::vector<std::pair<LinkBoardElectronicIndex, LinkBoardPackedStrip> > RPCReadO
           eleIndex.lbNumInLink = board.linkBoardNumInLink();
 
           const std::vector<FebConnectorSpec> &febs = board.febs();
-          int febCheck = 0;
           for (std::vector<FebConnectorSpec>::const_iterator ifc = febs.begin(); ifc != febs.end(); ifc++) {
             const FebConnectorSpec &febConnector = (*ifc);
-            febCheck++;
             if (febConnector.rawId() != rawDetId)
               continue;
             int febInLB = febConnector.linkBoardInputNum();
-            /* if (febInLB != febCheck) {
-              edm::LogError("rawDataFrame") << " problem with febInLB: " <<febInLB<<" "<<febCheck;
-	      } */
             for (int istrip = 0; istrip < febConnector.nstrips(); istrip++) {
               int stripPinInFeb = febConnector.cablePinNum(istrip);
               if (febConnector.chamberStripNum(istrip) == stripInDU) {

--- a/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
+++ b/CondFormats/SiStripObjects/src/SiStripBackPlaneCorrection.cc
@@ -26,13 +26,11 @@ float SiStripBackPlaneCorrection::getBackPlaneCorrection(const uint32_t& detid) 
 void SiStripBackPlaneCorrection::printDebug(std::stringstream& ss, const TrackerTopology* trackerTopo) const {
   std::map<unsigned int, float> detid_la = getBackPlaneCorrections();
   std::map<unsigned int, float>::const_iterator it;
-  size_t count = 0;
   ss << "SiStripBackPlaneCorrectionReader:" << std::endl;
   ss << "detid \t Geometry \t Back Plane Corrections" << std::endl;
   for (it = detid_la.begin(); it != detid_la.end(); ++it) {
     ss << it->first << "\t" << static_cast<int>(trackerTopo->moduleGeometry(it->first)) << "\t" << it->second
        << std::endl;
-    ++count;
   }
 }
 

--- a/CondFormats/SiStripObjects/src/SiStripLorentzAngle.cc
+++ b/CondFormats/SiStripObjects/src/SiStripLorentzAngle.cc
@@ -25,12 +25,10 @@ float SiStripLorentzAngle::getLorentzAngle(const uint32_t& detid) const {
 void SiStripLorentzAngle::printDebug(std::stringstream& ss, const TrackerTopology* /*trackerTopo*/) const {
   std::map<unsigned int, float> detid_la = getLorentzAngles();
   std::map<unsigned int, float>::const_iterator it;
-  size_t count = 0;
   ss << "SiStripLorentzAngleReader:" << std::endl;
   ss << "detid \t Lorentz angle" << std::endl;
   for (it = detid_la.begin(); it != detid_la.end(); ++it) {
     ss << it->first << "\t" << it->second << std::endl;
-    ++count;
   }
 }
 


### PR DESCRIPTION
CLANG IBs (which now use clang16) has a lot of warnings like [a]. This PR fixes few of these

[a]
```
warning: variable 'XXX' set but not used [-Wunused-but-set-variable]
```