### PR TITLE
[13.0.X] use `onlineMetaDataDigis` when available for retrieval of average PU in `AlCaHOCalibProducer`

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/HcalAlCaRecoProducers/plugins/BuildFile.xml
@@ -13,6 +13,7 @@
 <use name="DataFormats/HcalRecHit"/>
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/Luminosity"/>
+<use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/Scalers"/>


### PR DESCRIPTION
backport of #41486

#### PR description:

This PR addresses one of the worst offenders in terms of `LogError` emissions recently collected at https://github.com/cms-sw/cmssw/issues/41456. 
As the title says, use `onlineMetaDataDigis` when available for retrieval of average online PU in `AlCaHOCalibProducer` (lumiscalers were decommisioned at the beginning of Run-3).
See https://github.com/cms-sw/cmssw/issues/41456#issuecomment-1530967785 and following for more details.
 
#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #41486, needed for data-taking (reduce amount of `LogError`-s in Prompt Reco)
