### PR TITLE
[CORE] [CLANG] Fix warnings reported by llvm16 in CLANG IBs

### DIFF
--- a/DataFormats/Common/test/DetSetNewTS_t.cpp
+++ b/DataFormats/Common/test/DetSetNewTS_t.cpp
@@ -123,17 +123,14 @@ TestDetSet::TestDetSet() : sv(10) {
 }
 
 void read(DSTV const& detsets, bool all = false) {
-  int i = 0;
   for (auto di = detsets.begin(false); di != detsets.end(false); ++di) {
     auto ds = *di;
     auto id = ds.id();
     std::cout << id << ' ';
-    // if (all) CPPUNIT_ASSERT(int(id)==20+i);
     if (ds.isValid()) {
       CPPUNIT_ASSERT(ds[0] == 100 * (id - 20) + 3);
       CPPUNIT_ASSERT(ds[1] == -(100 * (id - 20) + 3));
     }
-    ++i;
   }
   std::cout << std::endl;
 }

--- a/DataFormats/Common/test/testOneToManyAssociation.cc
+++ b/DataFormats/Common/test/testOneToManyAssociation.cc
@@ -46,6 +46,7 @@ void testOneToManyAssociation::dummy() {
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
+    std::cout <<"numberOfAssociations:"<<n<<std::endl;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];
     v.erase(edm::Ref<CKey>());
@@ -67,6 +68,7 @@ void testOneToManyAssociation::dummy() {
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
+    std::cout <<"numberOfAssociations:"<<n<<std::endl;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];
     v.erase(edm::Ref<CKey>());

--- a/DataFormats/Common/test/testOneToManyAssociation.cc
+++ b/DataFormats/Common/test/testOneToManyAssociation.cc
@@ -46,7 +46,7 @@ void testOneToManyAssociation::dummy() {
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
-    std::cout <<"numberOfAssociations:"<<n<<std::endl;
+    std::cout << "numberOfAssociations:" << n << std::endl;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];
     v.erase(edm::Ref<CKey>());
@@ -68,7 +68,7 @@ void testOneToManyAssociation::dummy() {
     ++f;
     n = v.numberOfAssociations(edm::Ref<CKey>());
     ++n;
-    std::cout <<"numberOfAssociations:"<<n<<std::endl;
+    std::cout << "numberOfAssociations:" << n << std::endl;
     edm::Ref<Assoc> r;
     v[edm::Ref<CKey>()];
     v.erase(edm::Ref<CKey>());

--- a/DataFormats/Common/test/testOneToOneAssociation.cc
+++ b/DataFormats/Common/test/testOneToOneAssociation.cc
@@ -45,6 +45,7 @@ void testOneToOneAssociation::dummy() {
   ++f;
   int n = v.numberOfAssociations(edm::Ref<CKey>());
   ++n;
+  std::cout <<"numberOfAssociations:"<<n<<std::endl;
   edm::Ref<Assoc> r;
   v[edm::Ref<CKey>()];
   v.erase(edm::Ref<CKey>());

--- a/DataFormats/Common/test/testOneToOneAssociation.cc
+++ b/DataFormats/Common/test/testOneToOneAssociation.cc
@@ -45,7 +45,7 @@ void testOneToOneAssociation::dummy() {
   ++f;
   int n = v.numberOfAssociations(edm::Ref<CKey>());
   ++n;
-  std::cout <<"numberOfAssociations:"<<n<<std::endl;
+  std::cout << "numberOfAssociations:" << n << std::endl;
   edm::Ref<Assoc> r;
   v[edm::Ref<CKey>()];
   v.erase(edm::Ref<CKey>());

--- a/DataFormats/Provenance/test/productResolverIndexHelperTest.cc
+++ b/DataFormats/Provenance/test/productResolverIndexHelperTest.cc
@@ -161,14 +161,12 @@ int main() {
   unsigned sum = 0;
 
   for (unsigned j = 0; j < 100; ++j) {
-    unsigned int iCount = 0;
     for (auto& n : vNames) {
       unsigned temp = 1;
       // if (n.className == "trigger::TriggerFilterObjectWithRefs") continue;
       temp = phih.index(PRODUCT_TYPE, n.typeID, n.label.c_str(), n.instance.c_str(), n.process.c_str());
 
       sum += temp;
-      ++iCount;
     }
   }
   timer.stop();


### PR DESCRIPTION
- Fixed set but unused warnings from clang-16 in CLANG IBs.
- Added couple of cout sothat compiler do not complain about set but unused variables.