### PR TITLE
[L1] [CLANG] Fix warnings reported by llvm16 in CLANG IBs

### DIFF
--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerRecord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerRecord.cc
@@ -138,7 +138,6 @@ void L1GlobalTriggerRecord::printGtDecision(std::ostream& myCout) const {
   int sizeW64 = 64;  // 64 bits words
 
   int iBit = 0;
-  int jBit = m_gtDecisionWord.size();
   int nrDecWord = m_gtDecisionWord.size() / sizeW64;
 
   std::ostringstream stream64;
@@ -162,7 +161,6 @@ void L1GlobalTriggerRecord::printGtDecision(std::ostream& myCout) const {
     }
 
     iBit++;
-    jBit--;
   }
 
   int iWord = 0;

--- a/DataFormats/L1GlobalTrigger/src/L1GtFdlWord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtFdlWord.cc
@@ -288,7 +288,6 @@ void L1GtFdlWord::printGtDecisionWord(std::ostream& myCout) const {
   int sizeW64 = 64;  // 64 bits words
 
   int iBit = 0;
-  int jBit = m_gtDecisionWord.size();
   int nrDecWord = m_gtDecisionWord.size() / sizeW64;
 
   std::ostringstream stream64;
@@ -312,7 +311,6 @@ void L1GtFdlWord::printGtDecisionWord(std::ostream& myCout) const {
     }
 
     iBit++;
-    jBit--;
   }
 
   int iWord = 0;

--- a/DataFormats/L1Trigger/src/L1DataEmulRecord.cc
+++ b/DataFormats/L1Trigger/src/L1DataEmulRecord.cc
@@ -11,9 +11,9 @@ L1DataEmulRecord::L1DataEmulRecord() : deAgree(false), deGlt() {
 }
 
 L1DataEmulRecord::L1DataEmulRecord(bool evt_match,
-                                   bool sys_comp[],
-                                   bool sys_match[],
-                                   int nCand[][2],
+                                   bool sys_comp[DEnsys],
+                                   bool sys_match[DEnsys],
+                                   int nCand[DEnsys][2],
                                    const L1DEDigiCollection& coll,
                                    const GltDEDigi& glt)
     : deAgree(evt_match), deGlt(glt) {


### PR DESCRIPTION
- Fixed set but unused warnings from clang-16 in CLANG IBs
- Fixed argument `variable' of type 'type[]' with mismatched bound `[-Warray-parameter]` . This is to match the method signature as it is declared in header file.