### PR TITLE
restrict E-gun energy to be at least the mass value

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8EGun.cc
@@ -63,6 +63,7 @@ namespace gen {
       double the = 2. * atan(exp(-eta));
 
       double mass = (fMasterGen->particleData).m0(particleID);
+      ee = std::max(ee, mass);
 
       double pp = sqrt(ee * ee - mass * mass);
       double px = pp * sin(the) * cos(phi);


### PR DESCRIPTION
while trying to generate some lower E range massive particles (Kshort) I noticed a large failure rate due to `pp = sqrt(ee * ee - mass * mass)` turning to nan.
I'm proposing to trim `ee` at `mass` from below. 

The resulting spectrum will not be flat and will have a non-zero fraction with particles at rest. So, the solution is not ideal.

@cms-sw/generators-l2 
If this simple solution is not acceptable, please treat this PR as an issue and perhaps follow up with a better solution.