### PR TITLE
bug fix for DBG IB: use correct variable name

### DIFF
--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc
@@ -403,7 +403,7 @@ struct HGCalMixRotatedLayer {
                                       << cms::convert2mm(r1) << ":" << cms::convert2mm(r2) << " Thick "
                                       << cms::convert2mm((2.0 * hthickl)) << " phi " << fimin << ":" << fimax << ":"
                                       << convertRadToDeg(phi1) << ":" << convertRadToDeg(phi2) << " cassette "
-                                      << cassette << ":" << cassett0 << " Shift " << cshift.first << ":"
+                                      << cassette << ":" << cassette0 << " Shift " << cshift.first << ":"
                                       << cshift.second;
 #endif
         std::string name = namesTop_[ii] + "L" + std::to_string(copy) + "F" + std::to_string(k);


### PR DESCRIPTION
This fixes the DBG build error
```
  CMSSW_13_2_DBG_X_2023-05-04-2300/src/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc:406:61: error: 'cassett0' was not declared in this scope; did you mean 'cassette0'?
   406 |                                       << cassette << ":" << cassett0 << " Shift " << cshift.first << ":"
      |                                                             ^~~~~~~~
      |                                                             cassette0
  CMSSW_13_2_DBG_X_2023-05-04-2300/src/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedLayer.cc:399:13: warning: unused variable 'cassette0' [-Wunused-variable]
   399 |         int cassette0 = HGCalCassette::cassetteType(2, 1, cassette);  //
```