### PR TITLE
Fixed problem 40764: heap-buffer-overflow in EcalDetailedTimeRecHitProducer

### DIFF
--- a/DataFormats/EcalDigi/src/EcalTimeDigi.cc
+++ b/DataFormats/EcalDigi/src/EcalTimeDigi.cc
@@ -10,11 +10,9 @@ EcalTimeDigi::EcalTimeDigi(const DetId& id)
     : id_(id), size_(0), sampleOfInterest_(-1), waveform_(WAVEFORMSAMPLES), data_(MAXSAMPLES) {}
 
 void EcalTimeDigi::setSize(unsigned int size) {
+  size_ = size;
   if (size > MAXSAMPLES)
-    size_ = MAXSAMPLES;
-  else
-    size_ = size;
-  data_.resize(size_);
+    data_.resize(size_);
 }
 
 void EcalTimeDigi::setWaveform(float* waveform) {

--- a/SimCalorimetry/EcalSimAlgos/src/EcalTimeMapDigitizer.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalTimeMapDigitizer.cc
@@ -221,14 +221,16 @@ void EcalTimeMapDigitizer::run(EcalTimeDigiCollection& output) {
       output.back().setWaveform(vSamAll(m_index[i])->waveform);
 
     unsigned int nTimeHits = 0;
-    float timeHits[vSamAll(m_index[i])->time_average_capacity];
-    unsigned int timeBX[vSamAll(m_index[i])->time_average_capacity];
+    unsigned int nTimeHitsMax = vSamAll(m_index[i])->time_average_capacity;
+    float timeHits[nTimeHitsMax];
+    unsigned int timeBX[nTimeHitsMax];
 
-    for (unsigned int j(0); j != vSamAll(m_index[i])->time_average_capacity; ++j)  //here sampling on the OOTPU
+    for (unsigned int j(0); j != nTimeHitsMax; ++j)  //here sampling on the OOTPU
     {
       if (vSamAll(m_index[i])->nhits[j] > 0) {
         timeHits[nTimeHits] = vSamAll(m_index[i])->average_time[j];
-        timeBX[nTimeHits++] = m_minBunch + j;
+        timeBX[nTimeHits] = m_minBunch + j;
+        nTimeHits++;
       }
     }
 


### PR DESCRIPTION
#### PR description:
Attempt to fix the issue https://github.com/cms-sw/cmssw/issues/40764 : heap-buffer-overflow in EcalDetailedTimeRecHitProducer.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: 

