### PR TITLE
[UBSAN] Fix for FWCore unit tests

### DIFF
--- a/FWCore/Integration/test/run_SubProcess.sh
+++ b/FWCore/Integration/test/run_SubProcess.sh
@@ -13,7 +13,7 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
   cmsRun -p ${LOCAL_TEST_DIR}/${test}_cfg.py >& ${test}.log 2>&1 || die "cmsRun ${test}_cfg.py" $?
   grep Doodad ${test}.log > testSubProcess.grep.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep.txt testSubProcess.grep.txt || die "comparing testSubProcess.grep.txt" $?
-  grep "++" ${test}.log | grep -v "Disabling gnu" > testSubProcess.grep2.txt
+  grep "^++" ${test}.log | grep -v "Disabling gnu" > testSubProcess.grep2.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep2.txt testSubProcess.grep2.txt || die "comparing testSubProcess.grep2.txt" $?
 
   echo cmsRun readSubProcessOutput_cfg.py

--- a/FWCore/MessageService/test/u2.sh
+++ b/FWCore/MessageService/test/u2.sh
@@ -4,7 +4,7 @@
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
 status=0
-  
+if [ "$UBSAN_OPTIONS" != "" ] ; then export UBSAN_OPTIONS="log_path=ubsan.log:${UBSAN_OPTIONS}"; fi
 rm -f  u2_warnings.log u2_cerr.mout 
 
 cmsRun -p ${SCRAM_TEST_PATH}/u2_cfg.py 2> ./u2_cerr.mout || exit $?

--- a/FWCore/MessageService/test/u20.sh
+++ b/FWCore/MessageService/test/u20.sh
@@ -4,7 +4,7 @@
 case `uname` in Darwin) SED_OPT="-i '' -E";;*) SED_OPT="-i -r";; esac ;
 
 status=0
-  
+if [ "$UBSAN_OPTIONS" != "" ] ; then export UBSAN_OPTIONS="log_path=ubsan.log:${UBSAN_OPTIONS}"; fi
 rm -f u20_cerr.log FrameworkJobReport.xml
 
 cmsRun -e -p ${SCRAM_TEST_PATH}/u20_cfg.py 2> u20_cerr.log || exit $?

--- a/FWCore/Services/test/test_resource_succeed_cfg.py
+++ b/FWCore/Services/test/test_resource_succeed_cfg.py
@@ -1,11 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+import os
+
+mem_limit = 1.0 if not '_UBSAN_X' in os.getenv('CMSSW_VERSION', '') else 1.5
+
 process = cms.Process("TEST")
 
 process.source = cms.Source("EmptySource")
 
 process.add_(cms.Service("ResourceEnforcer",
-                         maxVSize = cms.untracked.double(1.0),
-                         maxRSS = cms.untracked.double(1.0),
+                         maxVSize = cms.untracked.double(mem_limit),
+                         maxRSS = cms.untracked.double(mem_limit),
                          maxTime = cms.untracked.double(1.0)))
 
 process.thing = cms.EDProducer("ThingProducer")


### PR DESCRIPTION
This should fix the FW unit tests failure for UBSAN.
- For UBSAN IBs , there was some output like [a] and `grep '++'` was matching some of these extra line which contained  `/c++/`  string. This change makes sure that we only match lines which starts with '++'.

- For MessageService tests, add `log_path` in `UBSAN_OPTIONS` env so that ubsan dumps its output in separate file.

- For FWCore/Services: Increase the RSS/VSize limits to 1.5 ( ubsan consumes a bit more memory)

Local tests for UBSAN shows that test runs after this change

[a]
```
 /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/future:212:62: runtime error: member call on address 0x2acb0679b880 which does not point to an object of type '_Result_base'
     #0 0x2acafdf8368a in std::__future_base::_Result_base::_Deleter::operator()(std::__future_base::_Result_base*) const /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/future:212
     #1 0x2acafdf8368a in std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>::~unique_ptr() /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/bits/unique_ptr.h:361
     #2 0x2acafdf8368a in std::__future_base::_State_baseV2::~_State_baseV2() /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/future:327
     #18 0x2acb021cd618 in std::_MakeUniq<TFileAdaptor>::__single_object std::make_unique<TFileAdaptor, edm::ParameterSet const&, edm::ActivityRegistry&>(edm::ParameterSet const&, edm::ActivityRegistry&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/bits/unique_ptr.h:962
     #27 0x2acaf451a388 in void __gnu_cxx::new_allocator<edm::serviceregistry::ServicesManager>::construct<edm::serviceregistry::ServicesManager, edm::ServiceToken&, edm::serviceregistry::ServiceLegacy&, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&, bool&>(edm::serviceregistry::ServicesManager*, edm::ServiceToken&, 
```