### PR TITLE
Add an option to HitPairEDProducer to put empty data products if number of hit pairs for any layer pair go over the limit 

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/PixelTripletHLTGenerator.cc
@@ -72,11 +72,11 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
                                            const SeedingLayerSetsHits::SeedingLayerSet& pairLayers,
                                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) {
   auto const& doublets = thePairGenerator->doublets(region, ev, es, pairLayers);
-  if (doublets.empty())
+  if (not doublets or doublets->empty())
     return;
 
   assert(theLayerCache);
-  hitTriplets(region, result, ev, es, doublets, thirdLayers, nullptr, *theLayerCache);
+  hitTriplets(region, result, ev, es, *doublets, thirdLayers, nullptr, *theLayerCache);
 }
 
 void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,

--- a/RecoTracker/PixelSeeding/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/PixelTripletLargeTipGenerator.cc
@@ -109,11 +109,11 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
                                                 const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) {
   auto const& doublets = thePairGenerator->doublets(region, ev, es, pairLayers);
 
-  if (doublets.empty())
+  if (not doublets or doublets->empty())
     return;
 
   assert(theLayerCache);
-  hitTriplets(region, result, ev, es, doublets, thirdLayers, nullptr, *theLayerCache);
+  hitTriplets(region, result, ev, es, *doublets, thirdLayers, nullptr, *theLayerCache);
 }
 
 void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -6,6 +6,8 @@
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
+#include <optional>
+
 class DetLayer;
 class IdealMagneticFieldRecord;
 class MagneticField;
@@ -27,37 +29,40 @@ public:
 
   ~HitPairGeneratorFromLayerPair();
 
-  HitDoublets doublets(const TrackingRegion& reg, const edm::Event& ev, const edm::EventSetup& es, Layers layers) {
+  std::optional<HitDoublets> doublets(const TrackingRegion& reg,
+                                      const edm::Event& ev,
+                                      const edm::EventSetup& es,
+                                      Layers layers) {
     assert(theLayerCache);
     return doublets(reg, ev, es, layers, *theLayerCache);
   }
-  HitDoublets doublets(const TrackingRegion& reg,
-                       const edm::Event& ev,
-                       const edm::EventSetup& es,
-                       const Layer& innerLayer,
-                       const Layer& outerLayer) {
+  std::optional<HitDoublets> doublets(const TrackingRegion& reg,
+                                      const edm::Event& ev,
+                                      const edm::EventSetup& es,
+                                      const Layer& innerLayer,
+                                      const Layer& outerLayer) {
     assert(theLayerCache);
     return doublets(reg, ev, es, innerLayer, outerLayer, *theLayerCache);
   }
-  HitDoublets doublets(const TrackingRegion& reg,
-                       const edm::Event& ev,
-                       const edm::EventSetup& es,
-                       Layers layers,
-                       LayerCacheType& layerCache) {
+  std::optional<HitDoublets> doublets(const TrackingRegion& reg,
+                                      const edm::Event& ev,
+                                      const edm::EventSetup& es,
+                                      Layers layers,
+                                      LayerCacheType& layerCache) {
     Layer innerLayerObj = innerLayer(layers);
     Layer outerLayerObj = outerLayer(layers);
     return doublets(reg, ev, es, innerLayerObj, outerLayerObj, layerCache);
   }
-  HitDoublets doublets(const TrackingRegion& reg,
-                       const edm::Event& ev,
-                       const edm::EventSetup& es,
-                       const Layer& innerLayer,
-                       const Layer& outerLayer,
-                       LayerCacheType& layerCache);
+  std::optional<HitDoublets> doublets(const TrackingRegion& reg,
+                                      const edm::Event& ev,
+                                      const edm::EventSetup& es,
+                                      const Layer& innerLayer,
+                                      const Layer& outerLayer,
+                                      LayerCacheType& layerCache);
 
-  void hitPairs(
+  bool hitPairs(
       const TrackingRegion& reg, OrderedHitPairs& prs, const edm::Event& ev, const edm::EventSetup& es, Layers layers);
-  static void doublets(const TrackingRegion& region,
+  static bool doublets(const TrackingRegion& region,
                        const DetLayer& innerHitDetLayer,
                        const DetLayer& outerHitDetLayer,
                        const RecHitsSortedInPhi& innerHitsMap,

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -51,6 +51,7 @@ namespace {
     edm::RunningAverage localRA_;
     const unsigned int maxElement_;
     const unsigned int maxElementTotal_;
+    const bool putEmptyIfMaxElementReached_;
 
     HitPairGeneratorFromLayerPair generator_;
     std::vector<unsigned> layerPairBegins_;
@@ -58,6 +59,7 @@ namespace {
   ImplBase::ImplBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector iC)
       : maxElement_(iConfig.getParameter<unsigned int>("maxElement")),
         maxElementTotal_(iConfig.getParameter<unsigned int>("maxElementTotal")),
+        putEmptyIfMaxElementReached_(iConfig.getParameter<bool>("putEmptyIfMaxElementReached")),
         generator_(
             iC, 0, 1, nullptr, maxElement_),  // these indices are dummy, TODO: cleanup HitPairGeneratorFromLayerPair
         layerPairBegins_(iConfig.getParameter<std::vector<unsigned>>("layerPairs")) {
@@ -105,7 +107,16 @@ namespace {
         auto hitCachePtr = std::get<0>(hitCachePtr_filler_ihd);
 
         for (SeedingLayerSetsHits::SeedingLayerSet layerSet : regionLayers.layerPairs()) {
-          auto doublets = generator_.doublets(region, iEvent, iSetup, layerSet, *hitCachePtr);
+          auto doubletsOpt = generator_.doublets(region, iEvent, iSetup, layerSet, *hitCachePtr);
+          if (not doubletsOpt) {
+            if (putEmptyIfMaxElementReached_) {
+              putEmpty(iEvent, regionsLayers);
+              return;
+            } else {
+              continue;
+            }
+          }
+          auto& doublets = *doubletsOpt;
           LogTrace("HitPairEDProducer") << " created " << doublets.size() << " doublets for layers "
                                         << layerSet[0].index() << "," << layerSet[1].index();
           if (doublets.empty())
@@ -113,11 +124,7 @@ namespace {
           nDoublets += doublets.size();
           if (nDoublets >= maxElementTotal_) {
             edm::LogError("TooManyPairs") << "number of total pairs exceed maximum, no pairs produced";
-            auto seedingHitSetsProducerDummy = T_SeedingHitSets(&localRA_);
-            auto intermediateHitDoubletsProducerDummy =
-                T_IntermediateHitDoublets(regionsLayers.seedingLayerSetsHitsPtr());
-            seedingHitSetsProducerDummy.putEmpty(iEvent);
-            intermediateHitDoubletsProducerDummy.putEmpty(iEvent);
+            putEmpty(iEvent, regionsLayers);
             return;
           }
           seedingHitSetsProducer.fill(std::get<1>(hitCachePtr_filler_shs), doublets);
@@ -130,6 +137,14 @@ namespace {
     }
 
   private:
+    template <typename T>
+    void putEmpty(edm::Event& iEvent, T& regionsLayers) {
+      auto seedingHitSetsProducerDummy = T_SeedingHitSets(&localRA_);
+      auto intermediateHitDoubletsProducerDummy = T_IntermediateHitDoublets(regionsLayers.seedingLayerSetsHitsPtr());
+      seedingHitSetsProducerDummy.putEmpty(iEvent);
+      intermediateHitDoubletsProducerDummy.putEmpty(iEvent);
+    }
+
     T_RegionLayers regionsLayers_;
   };
 
@@ -504,6 +519,11 @@ void HitPairEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<bool>("produceIntermediateHitDoublets", false);
   desc.add<unsigned int>("maxElement", 1000000);
   desc.add<unsigned int>("maxElementTotal", 50000000);
+  desc.add<bool>("putEmptyIfMaxElementReached", false)
+      ->setComment(
+          "If set to true (default is 'false'), abort processing and put empty data products also if any layer pair "
+          "yields at least maxElement doublets, in addition to aborting processing if the sum of doublets from all "
+          "layer pairs reaches maxElementTotal.");
   desc.add<std::vector<unsigned>>("layerPairs", std::vector<unsigned>{0})
       ->setComment("Indices to the pairs of consecutive layers, i.e. 0 means (0,1), 1 (1,2) etc.");
 

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -173,13 +173,13 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 
   auto const& doublets = thePairGenerator->doublets(region, ev, es, pairLayers);
   LogTrace("MultiHitGeneratorFromChi2") << "";
-  if (doublets.empty()) {
+  if (not doublets or doublets->empty()) {
     //  LogDebug("MultiHitGeneratorFromChi2") << "empy pairs";
     return;
   }
 
   assert(theLayerCache);
-  hitSets(region, result, doublets, thirdLayers, *theLayerCache, cache);
+  hitSets(region, result, *doublets, thirdLayers, *theLayerCache, cache);
 }
 
 void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,


### PR DESCRIPTION
#### PR description:


This PR is an attempt to reduce memory usage in the case reported in https://github.com/cms-sw/cmssw/issues/41457 following my question in https://github.com/cms-sw/cmssw/issues/41457#issuecomment-1532312159. It adds a configuration option `putEmptyIfMaxElementReached` (better name welcome)  to `HitPairEDProducer` (defaults to `false`), that will make the `HitPairEDProducer` to "abort" the processing and put empty data products into the Event also in the case where any layer pair yields more doublets than the `maxElement` threshold, in addition of the condition of the total number of doublets from all layer pairs reaching `maxElementTotal`.

#### PR validation:

In addition to https://github.com/cms-sw/cmssw/pull/41514, code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 13_0_X (well, already done in https://github.com/cms-sw/cmssw/pull/41514) and 13_1_X.