### PR TITLE
Make every Alpaka EDProducer to store an unsigned short int for the backend

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -11,6 +11,7 @@
 #include "HeterogeneousCore/AlpakaCore/interface/EventCache.h"
 #include "HeterogeneousCore/AlpakaCore/interface/QueueCache.h"
 #include "HeterogeneousCore/AlpakaCore/interface/module_backend_config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
 #include <memory>
@@ -44,6 +45,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using Base = BaseT<Args..., edm::Transformer>;
 
   public:
+    ProducerBase() : backendToken_(Base::produces("backend")) {}
+
     template <edm::Transition Tr = edm::Transition::Event>
     [[nodiscard]] auto produces() noexcept {
       return ProducerBaseAdaptor<ProducerBase, Tr>(*this);
@@ -59,7 +62,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       cms::alpakatools::module_backend_config(descriptions);
     }
 
+  protected:
+    void putBackend(edm::Event& iEvent) const {
+      iEvent.emplace(this->backendToken_, static_cast<unsigned short>(kBackend));
+    }
+
   private:
+    edm::EDPutTokenT<unsigned short> const backendToken_;
+
     template <typename TProducer, edm::Transition Tr>
     friend class ProducerBaseAdaptor;
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
@@ -22,6 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::Event ev(iEvent, sentry.metadata());
         device::EventSetup const es(iSetup, ev.device());
         produce(sid, ev, es);
+        this->putBackend(iEvent);
         sentry.finish();
       }
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
@@ -22,6 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::Event ev(iEvent, sentry.metadata());
         device::EventSetup const es(iSetup, ev.device());
         produce(ev, es);
+        this->putBackend(iEvent);
         sentry.finish();
       }
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
@@ -35,6 +35,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::Event ev(iEvent, sentry.metadata());
         device::EventSetup const es(iSetup, ev.device());
         produce(ev, es);
+        this->putBackend(iEvent);
         sentry.finish();
       }
 

--- a/HeterogeneousCore/AlpakaInterface/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaInterface/BuildFile.xml
@@ -1,3 +1,6 @@
 <use name="alpaka"/>
 <use name="boost_header"/>
-<use name="FWCore/Utilities" source_only="1"/>
+<use name="FWCore/Utilities"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h
 #define HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h
 
+#include <cstddef>
 #include <limits>
 
 namespace cms::alpakatools {

--- a/HeterogeneousCore/AlpakaInterface/interface/Backend.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/Backend.h
@@ -1,0 +1,14 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_Backend_h
+#define HeterogeneousCore_AlpakaInterface_interface_Backend_h
+
+#include <string_view>
+
+namespace cms::alpakatools {
+  // Enumeration whose value EDModules can put in the event
+  enum class Backend : unsigned short { SerialSync = 0, CudaAsync = 1, ROCmAsync = 2, TbbAsync = 3, size };
+
+  Backend toBackend(std::string_view name);
+  std::string_view toString(Backend backend);
+}  // namespace cms::alpakatools
+
+#endif

--- a/HeterogeneousCore/AlpakaInterface/interface/config.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/config.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
 #include "FWCore/Utilities/interface/stringize.h"
 
 namespace alpaka_common {
@@ -158,6 +159,11 @@ namespace alpaka_tbb_async {
 
 // define a null-terminated string containing the backend-specific identifier
 #define ALPAKA_TYPE_ALIAS_NAME(TYPE) EDM_STRINGIZE(ALPAKA_TYPE_ALIAS(TYPE))
+
+// Ensure the enumeration names are consistent with type suffix
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  inline constexpr const cms::alpakatools::Backend kBackend = cms::alpakatools::Backend::ALPAKA_TYPE_SUFFIX;
+}
 
 #endif  // ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/HeterogeneousCore/AlpakaInterface/interface/host.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/host.h
@@ -3,6 +3,8 @@
 
 #include <cassert>
 
+#include <alpaka/alpaka.hpp>
+
 namespace cms::alpakatools {
 
   namespace detail {

--- a/HeterogeneousCore/AlpakaInterface/src/Backend.cc
+++ b/HeterogeneousCore/AlpakaInterface/src/Backend.cc
@@ -1,0 +1,34 @@
+#include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
+
+#include <algorithm>
+#include <array>
+
+namespace {
+  constexpr const std::array<std::string_view, static_cast<short>(cms::alpakatools::Backend::size)> backendNames = {
+      {"SerialSync", "CudaAsync", "ROCmAsync", "TbbAsync"}};
+}
+
+namespace cms::alpakatools {
+  Backend toBackend(std::string_view name) {
+    auto found = std::find(backendNames.begin(), backendNames.end(), name);
+    if (found == backendNames.end()) {
+      cms::Exception ex("EnumNotFound");
+      ex << "Invalid backend name '" << name << "'";
+      ex.addContext("Calling cms::alpakatools::toBackend()");
+      throw ex;
+    }
+    return static_cast<Backend>(std::distance(backendNames.begin(), found));
+  }
+
+  std::string_view toString(Backend backend) {
+    auto val = static_cast<unsigned short>(backend);
+    if (val >= static_cast<unsigned short>(Backend::size)) {
+      cms::Exception ex("InvalidEnumValue");
+      ex << "Invalid backend enum value " << val;
+      ex.addContext("Calling cms::alpakatools::toString()");
+      throw ex;
+    }
+    return backendNames[val];
+  }
+}  // namespace cms::alpakatools

--- a/HeterogeneousCore/AlpakaInterface/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaInterface/test/BuildFile.xml
@@ -11,3 +11,8 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags ALPAKA_BACKENDS="1"/>
 </bin>
+
+<bin name="alpakaTestBackend" file="testBackend.cc">
+  <use name="catch2"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+</bin>

--- a/HeterogeneousCore/AlpakaInterface/test/testBackend.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/testBackend.cc
@@ -1,0 +1,30 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
+
+TEST_CASE("Test cms::alpakatools::toBackend", "cms::alpakatools::Backend") {
+  SECTION("Valid string") {
+    REQUIRE(cms::alpakatools::toBackend("SerialSync") == cms::alpakatools::Backend::SerialSync);
+    REQUIRE(cms::alpakatools::toBackend("CudaAsync") == cms::alpakatools::Backend::CudaAsync);
+    REQUIRE(cms::alpakatools::toBackend("ROCmAsync") == cms::alpakatools::Backend::ROCmAsync);
+    REQUIRE(cms::alpakatools::toBackend("TbbAsync") == cms::alpakatools::Backend::TbbAsync);
+  }
+  SECTION("Invalid string") {
+    REQUIRE_THROWS_WITH(cms::alpakatools::toBackend("Nonexistent"),
+                        Catch::Contains("EnumNotFound") and Catch::Contains("Invalid backend name"));
+  }
+}
+
+TEST_CASE("Test cms::alpakatools::toString", "cms::alpakatools::Backend") {
+  SECTION("Valid enum") {
+    REQUIRE(cms::alpakatools::toString(cms::alpakatools::Backend::SerialSync) == "SerialSync");
+    REQUIRE(cms::alpakatools::toString(cms::alpakatools::Backend::CudaAsync) == "CudaAsync");
+    REQUIRE(cms::alpakatools::toString(cms::alpakatools::Backend::ROCmAsync) == "ROCmAsync");
+    REQUIRE(cms::alpakatools::toString(cms::alpakatools::Backend::TbbAsync) == "TbbAsync");
+  }
+  SECTION("Invalid enum") {
+    REQUIRE_THROWS_WITH(cms::alpakatools::toString(cms::alpakatools::Backend::size),
+                        Catch::Contains("InvalidEnumValue") and Catch::Contains("Invalid backend enum value"));
+  }
+}

--- a/HeterogeneousCore/AlpakaTest/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/plugins/BuildFile.xml
@@ -8,6 +8,7 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/AlpakaTest"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/HeterogeneousCore/AlpakaTest/test/reader.py
+++ b/HeterogeneousCore/AlpakaTest/test/reader.py
@@ -17,7 +17,8 @@ process.testAnalyzer = cms.EDAnalyzer('TestAlpakaAnalyzer',
 
 # analyse the second product
 process.testAnalyzerSerial = cms.EDAnalyzer('TestAlpakaAnalyzer',
-    source = cms.InputTag('testProducerSerial')
+    source = cms.InputTag('testProducerSerial'),
+    expectBackend = cms.string('SerialSync')
 )
 
 process.cuda_path = cms.Path(process.testAnalyzer)

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -90,19 +90,23 @@ process.alpakaStreamSynchronizingProducer = cms.EDProducer("TestAlpakaStreamSync
 
 process.alpakaGlobalConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaGlobalProducer"),
-    expectSize = cms.int32(10)
+    expectSize = cms.int32(10),
+    expectBackend = cms.string("SerialSync")
 )
 process.alpakaStreamConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaStreamProducer"),
-    expectSize = cms.int32(5)
+    expectSize = cms.int32(5),
+    expectBackend = cms.string("SerialSync")
 )
 process.alpakaStreamInstanceConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaStreamInstanceProducer", "testInstance"),
-    expectSize = cms.int32(6)
+    expectSize = cms.int32(6),
+    expectBackend = cms.string("SerialSync")
 )
 process.alpakaStreamSynchronizingConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     source = cms.InputTag("alpakaStreamSynchronizingProducer"),
-    expectSize = cms.int32(10)
+    expectSize = cms.int32(10),
+    expectBackend = cms.string("SerialSync")
 )
 
 if args.moduleBackend != "":
@@ -111,10 +115,13 @@ if args.moduleBackend != "":
         mod = getattr(process, "alpaka"+name)
         mod.alpaka = cms.untracked.PSet(backend = cms.untracked.string(args.moduleBackend))
 if args.expectBackend == "cuda_async":
-    process.alpakaGlobalConsumer.expectSize = 20
-    process.alpakaStreamConsumer.expectSize = 25
-    process.alpakaStreamInstanceConsumer.expectSize = 36
-    process.alpakaStreamSynchronizingConsumer.expectSize = 20
+    def setExpect(m, size):
+        m.expectSize = size
+        m.expectBackend = "CudaAsync"
+    setExpect(process.alpakaGlobalConsumer, size=20)
+    setExpect(process.alpakaStreamConsumer, size=25)
+    setExpect(process.alpakaStreamInstanceConsumer, size=36)
+    setExpect(process.alpakaStreamSynchronizingConsumer, size=20)
 
 process.output = cms.OutputModule('PoolOutputModule',
     fileName = cms.untracked.string('testAlpaka.root'),


### PR DESCRIPTION
#### PR description:

This PR makes every Alpaka EDProducer to store an `unsigned short` event product to denote the backend of the producer.  This is intended as a temporary measure until we get a more general machinery (#30044).

Resolves https://github.com/makortel/framework/issues/512

#### PR validation:

Touched unit tests succeed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 13_0_X and 13_1_X.