### PR TITLE
Add unit test for GlobalObjectMapRecord format

### DIFF
--- a/DataFormats/L1TGlobal/README.md
+++ b/DataFormats/L1TGlobal/README.md
@@ -1,0 +1,10 @@
+#  DataFormats/L1TGlobal
+
+## `GlobalObjectMapRecord`
+
+The class `GlobalObjectMapRecord` is part of the RAW data, and any changes must be backwards compatible. In order to ensure it can be read by all future CMSSW releases, there is a `TestGlobalObjectMapRecordFormat` unit test, which makes use of the `TestReadGlobalObjectMapRecord` analyzer and the `TestWriteGlobalObjectMapRecord` producer. The unit test checks that the object can be read properly from
+
+* a file written by the same release
+* files written by (some) earlier releases
+
+If the persistent format of class `GlobalObjectMapRecord` gets changed in the future, please adjust the `TestReadGlobalObjectMapRecord` and `TestWriteGlobalObjectMapRecord` modules accordingly. It is important that every member container has some content in this test. Please also add a new file to the [https://github.com/cms-data/DataFormats-L1TGlobal/](https://github.com/cms-data/DataFormats-L1TGlobal/) repository, and update the `TestGlobalObjectMapRecord` unit test to read the newly created file. The file name should contain the release or pre-release with which it was written.

--- a/DataFormats/L1TGlobal/test/BuildFile.xml
+++ b/DataFormats/L1TGlobal/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="DataFormats/L1TGlobal"/>
+
+<library name="testGlobalObjectMapRecord" file="TestReadGlobalObjectMapRecord.cc,TestWriteGlobalObjectMapRecord.cc">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+</library>
+
+<test name="TestGlobalObjectMapRecordFormat" command="TestGlobalObjectMapRecordFormat.sh"/>

--- a/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
+++ b/DataFormats/L1TGlobal/test/TestGlobalObjectMapRecordFormat.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -ex
+
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+cmsRun ${LOCAL_TEST_DIR}/create_GlobalObjectMapRecord_test_file_cfg.py || die 'Failure using create_GlobalObjectMapRecord_test_file_cfg.py' $?
+
+file=testGlobalObjectMapRecord.root
+
+cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py "$file" || die "Failure using test_readGlobalObjectMapRecord_cfg.py $file" $?
+
+oldFiles="testGlobalObjectMapRecord_CMSSW_13_0_0.root testGlobalObjectMapRecord_CMSSW_13_1_0_pre3.root"
+for file in $oldFiles; do
+  inputfile=$(edmFileInPath DataFormats/L1TGlobal/data/$file) || die "Failure edmFileInPath DataFormats/L1TGlobal/data/$file" $?
+  cmsRun ${LOCAL_TEST_DIR}/test_readGlobalObjectMapRecord_cfg.py "$inputfile" || die "Failed to read old file $file" $?
+done
+
+exit 0

--- a/DataFormats/L1TGlobal/test/TestReadGlobalObjectMapRecord.cc
+++ b/DataFormats/L1TGlobal/test/TestReadGlobalObjectMapRecord.cc
@@ -1,0 +1,190 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/L1TGlobal
+// Class:      TestReadGlobalObjectMapRecord
+//
+/**\class edmtest::TestReadGlobalObjectMapRecord
+  Description: Used as part of tests that ensure the GlobalObjectMapRecord
+  data format can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the GlobalObjectMapRecord persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  3 May 2023
+
+#include "DataFormats/L1TGlobal/interface/GlobalObject.h"
+#include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
+#include "DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <string>
+#include <vector>
+
+namespace edmtest {
+
+  class TestReadGlobalObjectMapRecord : public edm::global::EDAnalyzer<> {
+  public:
+    TestReadGlobalObjectMapRecord(edm::ParameterSet const&);
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+    void throwWithMessage(const char*) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    // These expected values are meaningless other than we use them
+    // to check that values read from persistent storage match the values
+    // we know were written.
+    std::vector<std::string> expectedAlgoNames_;
+    std::vector<int> expectedAlgoBitNumbers_;
+    std::vector<int> expectedAlgoGtlResults_;
+    std::vector<std::string> expectedTokenNames0_;
+    std::vector<int> expectedTokenNumbers0_;
+    std::vector<int> expectedTokenResults0_;
+    std::vector<std::string> expectedTokenNames3_;
+    std::vector<int> expectedTokenNumbers3_;
+    std::vector<int> expectedTokenResults3_;
+    int expectedFirstElement_;
+    int expectedElementDelta_;
+    int expectedFinalValue_;
+
+    edm::EDGetTokenT<GlobalObjectMapRecord> globalObjectMapRecordToken_;
+  };
+
+  TestReadGlobalObjectMapRecord::TestReadGlobalObjectMapRecord(edm::ParameterSet const& iPSet)
+      : expectedAlgoNames_(iPSet.getParameter<std::vector<std::string>>("expectedAlgoNames")),
+        expectedAlgoBitNumbers_(iPSet.getParameter<std::vector<int>>("expectedAlgoBitNumbers")),
+        expectedAlgoGtlResults_(iPSet.getParameter<std::vector<int>>("expectedAlgoGtlResults")),
+        expectedTokenNames0_(iPSet.getParameter<std::vector<std::string>>("expectedTokenNames0")),
+        expectedTokenNumbers0_(iPSet.getParameter<std::vector<int>>("expectedTokenNumbers0")),
+        expectedTokenResults0_(iPSet.getParameter<std::vector<int>>("expectedTokenResults0")),
+        expectedTokenNames3_(iPSet.getParameter<std::vector<std::string>>("expectedTokenNames3")),
+        expectedTokenNumbers3_(iPSet.getParameter<std::vector<int>>("expectedTokenNumbers3")),
+        expectedTokenResults3_(iPSet.getParameter<std::vector<int>>("expectedTokenResults3")),
+        expectedFirstElement_(iPSet.getParameter<int>("expectedFirstElement")),
+        expectedElementDelta_(iPSet.getParameter<int>("expectedElementDelta")),
+        expectedFinalValue_(iPSet.getParameter<int>("expectedFinalValue")),
+
+        globalObjectMapRecordToken_(consumes(iPSet.getParameter<edm::InputTag>("globalObjectMapRecordTag"))) {
+    if (expectedAlgoNames_.size() != expectedAlgoBitNumbers_.size() ||
+        expectedAlgoNames_.size() != expectedAlgoGtlResults_.size() ||
+        expectedAlgoNames_.size() != expectedTokenNames0_.size() ||
+        expectedAlgoNames_.size() != expectedTokenNumbers0_.size() ||
+        expectedAlgoNames_.size() != expectedTokenResults0_.size() ||
+        expectedAlgoNames_.size() != expectedTokenNames3_.size() ||
+        expectedAlgoNames_.size() != expectedTokenNumbers3_.size() ||
+        expectedAlgoNames_.size() != expectedTokenResults3_.size()) {
+      throw cms::Exception("TestFailure") << "TestWriteGlobalObjectMapRecord, test configuration error: "
+                                             "expectedAlgoNames, expectedAlgoBitNumbers, expectedAlgoGtlResults, "
+                                             "expectedTokenNames0_, expectedTokenNumbers0_, expectedTokenResults0_, "
+                                             "expectedTokenNames3_, expectedTokenNumbers3_, and expectedTokenResults3_ "
+                                             "should have the same size.";
+    }
+  }
+
+  void TestReadGlobalObjectMapRecord::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+    auto const& globalObjectMapRecord = iEvent.get(globalObjectMapRecordToken_);
+
+    std::vector<GlobalObjectMap> const& globalObjectMaps = globalObjectMapRecord.gtObjectMap();
+
+    if (expectedAlgoNames_.size() != globalObjectMaps.size()) {
+      throwWithMessage("globalObjectMaps does not have expected size");
+    }
+
+    unsigned int index = 0;
+    for (auto const& globalObjectMap : globalObjectMaps) {
+      if (globalObjectMap.algoName() != expectedAlgoNames_[index]) {
+        throwWithMessage("algoName does not have expected value");
+      }
+      if (globalObjectMap.algoBitNumber() != expectedAlgoBitNumbers_[index]) {
+        throwWithMessage("algoBitNumber does not have expected value");
+      }
+      if (globalObjectMap.algoGtlResult() != static_cast<bool>(expectedAlgoGtlResults_[index])) {
+        throwWithMessage("algoGtlResult does not have expected value");
+      }
+
+      std::vector<GlobalLogicParser::OperandToken> const& operandTokens = globalObjectMap.operandTokenVector();
+      if (operandTokens[0].tokenName != expectedTokenNames0_[index]) {
+        throwWithMessage("tokenName0 does not have expected value");
+      }
+      if (operandTokens[0].tokenNumber != expectedTokenNumbers0_[index]) {
+        throwWithMessage("tokenNumber0 does not have expected value");
+      }
+      if (operandTokens[0].tokenResult != static_cast<bool>(expectedTokenResults0_[index])) {
+        throwWithMessage("tokenResult0 does not have expected value");
+      }
+      if (operandTokens[3].tokenName != expectedTokenNames3_[index]) {
+        throwWithMessage("tokenName3 does not have expected value");
+      }
+      if (operandTokens[3].tokenNumber != expectedTokenNumbers3_[index]) {
+        throwWithMessage("tokenNumber3 does not have expected value");
+      }
+      if (operandTokens[3].tokenResult != static_cast<bool>(expectedTokenResults3_[index])) {
+        throwWithMessage("tokenResult3 does not have expected value");
+      }
+
+      int expectedValue = expectedFirstElement_;
+      for (auto const& combinationsInCond : globalObjectMap.combinationVector()) {
+        for (auto const& singleCombInCond : combinationsInCond) {
+          for (auto const& value : singleCombInCond) {
+            if (value != expectedValue) {
+              throwWithMessage("element in inner combination vector does have expected value");
+            }
+            expectedValue += expectedElementDelta_;
+          }
+        }
+      }
+
+      for (auto const& l1tObjectTypeInCond : globalObjectMap.objectTypeVector()) {
+        for (auto const& globalObject : l1tObjectTypeInCond) {
+          if (static_cast<int>(globalObject) != (expectedValue % 28)) {
+            throwWithMessage("globalObject does have expected value");
+          }
+          expectedValue += expectedElementDelta_;
+        }
+      }
+      if (expectedValue != expectedFinalValue_) {
+        throw cms::Exception("TestFailure")
+            << "final value = " << expectedValue << " which does not match the expected value of "
+            << expectedFinalValue_ << " this might mean the vectors did not contain the expected number of elements";
+      }
+      ++index;
+    }
+  }
+
+  void TestReadGlobalObjectMapRecord::throwWithMessage(const char* msg) const {
+    throw cms::Exception("TestFailure") << "TestReadGlobalObjectMapRecord::analyze, " << msg;
+  }
+
+  void TestReadGlobalObjectMapRecord::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<std::string>>("expectedAlgoNames");
+    desc.add<std::vector<int>>("expectedAlgoBitNumbers");
+    desc.add<std::vector<int>>("expectedAlgoGtlResults");
+    desc.add<std::vector<std::string>>("expectedTokenNames0");
+    desc.add<std::vector<int>>("expectedTokenNumbers0");
+    desc.add<std::vector<int>>("expectedTokenResults0");
+    desc.add<std::vector<std::string>>("expectedTokenNames3");
+    desc.add<std::vector<int>>("expectedTokenNumbers3");
+    desc.add<std::vector<int>>("expectedTokenResults3");
+    desc.add<int>("expectedFirstElement");
+    desc.add<int>("expectedElementDelta");
+    desc.add<int>("expectedFinalValue");
+    desc.add<edm::InputTag>("globalObjectMapRecordTag");
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestReadGlobalObjectMapRecord;
+DEFINE_FWK_MODULE(TestReadGlobalObjectMapRecord);

--- a/DataFormats/L1TGlobal/test/TestWriteGlobalObjectMapRecord.cc
+++ b/DataFormats/L1TGlobal/test/TestWriteGlobalObjectMapRecord.cc
@@ -1,0 +1,181 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/L1TGlobal
+// Class:      TestWriteGlobalObjectMapRecord
+//
+/**\class edmtest::TestWriteGlobalObjectMapRecord
+  Description: Used as part of tests that ensure the GlobalObjectMapRecord
+  data format can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the GlobalObjectMapRecord persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  3 May 2023
+
+#include "DataFormats/L1TGlobal/interface/GlobalObjectMap.h"
+#include "DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace edmtest {
+
+  class TestWriteGlobalObjectMapRecord : public edm::global::EDProducer<> {
+  public:
+    TestWriteGlobalObjectMapRecord(edm::ParameterSet const&);
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    unsigned int nGlobalObjectMaps_;
+    std::vector<std::string> algoNames_;
+    std::vector<int> algoBitNumbers_;
+    std::vector<int> algoResults_;
+    std::vector<std::string> tokenNames0_;
+    std::vector<int> tokenNumbers0_;
+    std::vector<int> tokenResults0_;
+    std::vector<std::string> tokenNames3_;
+    std::vector<int> tokenNumbers3_;
+    std::vector<int> tokenResults3_;
+    unsigned int nElements1_;
+    unsigned int nElements2_;
+    unsigned int nElements3_;
+    int firstElement_;
+    int elementDelta_;
+
+    edm::EDPutTokenT<GlobalObjectMapRecord> globalObjectMapRecordPutToken_;
+  };
+
+  TestWriteGlobalObjectMapRecord::TestWriteGlobalObjectMapRecord(edm::ParameterSet const& iPSet)
+      : nGlobalObjectMaps_(iPSet.getParameter<unsigned int>("nGlobalObjectMaps")),
+        algoNames_(iPSet.getParameter<std::vector<std::string>>("algoNames")),
+        algoBitNumbers_(iPSet.getParameter<std::vector<int>>("algoBitNumbers")),
+        algoResults_(iPSet.getParameter<std::vector<int>>("algoResults")),
+        tokenNames0_(iPSet.getParameter<std::vector<std::string>>("tokenNames0")),
+        tokenNumbers0_(iPSet.getParameter<std::vector<int>>("tokenNumbers0")),
+        tokenResults0_(iPSet.getParameter<std::vector<int>>("tokenResults0")),
+        tokenNames3_(iPSet.getParameter<std::vector<std::string>>("tokenNames3")),
+        tokenNumbers3_(iPSet.getParameter<std::vector<int>>("tokenNumbers3")),
+        tokenResults3_(iPSet.getParameter<std::vector<int>>("tokenResults3")),
+        nElements1_(iPSet.getParameter<unsigned int>("nElements1")),
+        nElements2_(iPSet.getParameter<unsigned int>("nElements2")),
+        nElements3_(iPSet.getParameter<unsigned int>("nElements3")),
+        firstElement_(iPSet.getParameter<int>("firstElement")),
+        elementDelta_(iPSet.getParameter<int>("elementDelta")),
+        globalObjectMapRecordPutToken_(produces()) {
+    if (algoNames_.size() != nGlobalObjectMaps_ || algoBitNumbers_.size() != nGlobalObjectMaps_ ||
+        algoResults_.size() != nGlobalObjectMaps_ || tokenNames0_.size() != nGlobalObjectMaps_ ||
+        tokenNumbers0_.size() != nGlobalObjectMaps_ || tokenResults0_.size() != nGlobalObjectMaps_ ||
+        tokenNames3_.size() != nGlobalObjectMaps_ || tokenNumbers3_.size() != nGlobalObjectMaps_ ||
+        tokenResults3_.size() != nGlobalObjectMaps_) {
+      throw cms::Exception("TestFailure")
+          << "TestWriteGlobalObjectMapRecord, test configuration error: "
+             "algoNames, algoBitNumbers, algoResults, tokenNames0, tokenNumbers0, tokenResults0, "
+             "tokenNames3, tokenNumbers3, and tokenResults3 should have size equal to nGlobalObjectMaps";
+    }
+  }
+
+  void TestWriteGlobalObjectMapRecord::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+    // Fill a GlobalObjectMapRecord. Make sure all the containers inside
+    // of it have something in them (not empty). The values are meaningless.
+    // We will later check that after writing this object to persistent storage
+    // and then reading it in a later process we obtain matching values for
+    // all this content.
+
+    std::vector<GlobalObjectMap> globalObjectMapVector(nGlobalObjectMaps_);
+    for (unsigned int i = 0; i < nGlobalObjectMaps_; ++i) {
+      GlobalObjectMap& globalObjectMap = globalObjectMapVector[i];
+      globalObjectMap.setAlgoName(algoNames_[i]);
+      globalObjectMap.setAlgoBitNumber(algoBitNumbers_[i]);
+      globalObjectMap.setAlgoGtlResult(static_cast<bool>(algoResults_[i]));
+
+      std::vector<GlobalLogicParser::OperandToken> tokenVector;
+      // We will later check elements 0 and 3 after writing to persistent
+      // storage and then reading (seemed like checking two elements
+      // would be enough to verify the reading and writing was working properly,
+      // the selection of 0 and 3 was meaningless and rather arbitrary)
+      GlobalLogicParser::OperandToken token0{tokenNames0_[i], tokenNumbers0_[i], static_cast<bool>(tokenResults0_[i])};
+      GlobalLogicParser::OperandToken token3{tokenNames3_[i], tokenNumbers3_[i], static_cast<bool>(tokenResults3_[i])};
+      tokenVector.push_back(token0);  // We check this element
+      tokenVector.push_back(token0);
+      tokenVector.push_back(token0);
+      tokenVector.push_back(token3);  // we also check this element
+      globalObjectMap.swapOperandTokenVector(tokenVector);
+
+      // We fill these with an arithmetic sequence of values.
+      // Again, this is just an arbitrary meaningless test pattern.
+      // The only purpose is to later check that when
+      // we read we get values that match what we wrote.
+      int value = firstElement_;
+      std::vector<CombinationsInCond> combinationsInCondVector;
+      for (unsigned int i = 0; i < nElements1_; ++i) {
+        CombinationsInCond combinationsInCond;
+        for (unsigned int j = 0; j < nElements2_; ++j) {
+          SingleCombInCond singleCombInCond;
+          for (unsigned int k = 0; k < nElements3_; ++k) {
+            singleCombInCond.push_back(value);
+            value += elementDelta_;
+          }
+          combinationsInCond.push_back(std::move(singleCombInCond));
+        }
+        combinationsInCondVector.push_back(combinationsInCond);
+      }
+      globalObjectMap.swapCombinationVector(combinationsInCondVector);
+
+      std::vector<L1TObjectTypeInCond> objectTypeVector;
+      for (unsigned int i = 0; i < nElements1_; ++i) {
+        L1TObjectTypeInCond globalObjects;
+        for (unsigned int j = 0; j < nElements2_; ++j) {
+          globalObjects.push_back(static_cast<l1t::GlobalObject>(value % 28));
+          value += elementDelta_;
+        }
+        objectTypeVector.push_back(std::move(globalObjects));
+      }
+      globalObjectMap.swapObjectTypeVector(objectTypeVector);
+    }
+
+    auto globalObjectMapRecord = std::make_unique<GlobalObjectMapRecord>();
+    globalObjectMapRecord->swapGtObjectMap(globalObjectMapVector);
+    iEvent.put(globalObjectMapRecordPutToken_, std::move(globalObjectMapRecord));
+  }
+
+  void TestWriteGlobalObjectMapRecord::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<unsigned int>("nGlobalObjectMaps");
+    desc.add<std::vector<std::string>>("algoNames");
+    desc.add<std::vector<int>>("algoBitNumbers");
+    desc.add<std::vector<int>>("algoResults");
+
+    desc.add<std::vector<std::string>>("tokenNames0");
+    desc.add<std::vector<int>>("tokenNumbers0");
+    desc.add<std::vector<int>>("tokenResults0");
+    desc.add<std::vector<std::string>>("tokenNames3");
+    desc.add<std::vector<int>>("tokenNumbers3");
+    desc.add<std::vector<int>>("tokenResults3");
+
+    desc.add<unsigned int>("nElements1");
+    desc.add<unsigned int>("nElements2");
+    desc.add<unsigned int>("nElements3");
+    desc.add<int>("firstElement");
+    desc.add<int>("elementDelta");
+
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestWriteGlobalObjectMapRecord;
+DEFINE_FWK_MODULE(TestWriteGlobalObjectMapRecord);

--- a/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
+++ b/DataFormats/L1TGlobal/test/create_GlobalObjectMapRecord_test_file_cfg.py
@@ -1,0 +1,35 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 1
+
+process.globalObjectMapRecordProducer = cms.EDProducer("TestWriteGlobalObjectMapRecord",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    nGlobalObjectMaps = cms.uint32(2),
+    algoNames = cms.vstring('muonAlgo', 'electronAlgo'),
+    algoBitNumbers = cms.vint32(11, 21),
+    algoResults = cms.vint32(1, 0),
+    tokenNames0     = cms.vstring('testnameA', 'testNameB'),
+    tokenNumbers0 = cms.vint32(101, 102),
+    tokenResults0 = cms.vint32(1, 0),
+    tokenNames3 = cms.vstring('testNameC', 'testNameD'),
+    tokenNumbers3 = cms.vint32(1001, 1002),
+    tokenResults3 = cms.vint32(0, 1),
+    nElements1 = cms.uint32(3),
+    nElements2 = cms.uint32(4),
+    nElements3 = cms.uint32(5),
+    firstElement = cms.int32(11),
+    elementDelta = cms.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testGlobalObjectMapRecord.root')
+)
+
+process.path = cms.Path(process.globalObjectMapRecordProducer)
+process.endPath = cms.EndPath(process.out)

--- a/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
+++ b/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.maxEvents.input = 1
+
+process.testReadGlobalObjectMapRecord = cms.EDAnalyzer("TestReadGlobalObjectMapRecord",
+    expectedAlgoNames = cms.vstring('muonAlgo', 'electronAlgo'),
+    expectedAlgoBitNumbers = cms.vint32(11, 21),
+    expectedAlgoGtlResults = cms.vint32(1, 0),
+    expectedTokenNames0 = cms.vstring('testnameA', 'testNameB'),
+    expectedTokenNumbers0 = cms.vint32(101, 102),
+    expectedTokenResults0 = cms.vint32(1, 0),
+    expectedTokenNames3 = cms.vstring('testNameC', 'testNameD'),
+    expectedTokenNumbers3 = cms.vint32(1001, 1002),
+    expectedTokenResults3 = cms.vint32(0, 1),
+    expectedFirstElement = cms.int32(11),
+    expectedElementDelta = cms.int32(3),
+    # 3 (delta) * (3*4*5 + 3*4) + 11 = 227
+    expectedFinalValue = cms.int32(227),
+    globalObjectMapRecordTag = cms.InputTag("globalObjectMapRecordProducer", "", "PROD"),
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testGlobalObjectMapRecord2.root')
+)
+
+process.path = cms.Path(process.testReadGlobalObjectMapRecord)
+
+process.endPath = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

Add a new unit test for the GlobalObjectMapRecord data format. This generates a data file containing a GlobalObjectMapRecord object with known content. Then it reads it. It verifies that when we read it we obtain values that match the known written values for all the data fields in the object. In particular all containers have content so all contained types are also read.

It also reads the old files in the DataFormats/L1TGlobal data repository which are listed in the shell script. The plan is that each time the data format of GlobalObjectMapRecord is modified a file will added.

#### PR validation:

This only adds a unit test in DataFormats/L1TGlobal which passes. It shouldn't affect anything else.
