### PR TITLE
[13_0_X] Add correct L1TCaloParams in 130X 2022 HI MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -72,7 +72,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v5',
+    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '130X_mcRun3_2023_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023


### PR DESCRIPTION
#### PR description:
Prompted by [this comment](https://github.com/cms-sw/cmssw/pull/41490#issuecomment-1536255186) and following the official request in [this CMSTalk post](https://cms-talk.web.cern.ch/t/request-for-new-run3-hi-mc-gt-with-updated-l1-menu-for-130x/23559/8), this PR updates the 2022 130X HI MC GT with the correct L1TCaloParams tag: `L1TCaloParams_static_HI_2022_v0_05_mc_v1`.

This PR is a backport of https://github.com/cms-sw/cmssw/pull/41437 and complements the other 13_0_X backport https://github.com/cms-sw/cmssw/pull/41440.

GT difference:
- **2022 realistic HI**
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_v5/130X_mcRun3_2022_realistic_HI_v6


#### PR validation:
Successfully run: `runTheMatrix.py -l 312.0 -j 8 --ibeos`

#### Backport:
Backport of #41437