### PR TITLE
do not throw exception in `Trigger{Bx,Rates}Monitor` if L1-uGT results are unavailable [`13_1_X`]

### DIFF
--- a/DQM/HLTEvF/test/testTriggerMonitors.sh
+++ b/DQM/HLTEvF/test/testTriggerMonitors.sh
@@ -7,10 +7,8 @@ function die {
 }
 
 # run test job
-TESTDIR="${LOCALTOP}"/src/DQM/HLTEvF/test
-
-cmsRun "${TESTDIR}"/testTriggerMonitors_dqm_cfg.py \
+cmsRun "${SCRAM_TEST_PATH}"/testTriggerMonitors_dqm_cfg.py \
   || die "Failure running testTriggerMonitors_dqm_cfg.py" $?
 
-cmsRun "${TESTDIR}"/testTriggerMonitors_harvesting_cfg.py \
+cmsRun "${SCRAM_TEST_PATH}"/testTriggerMonitors_harvesting_cfg.py \
   || die "Failure running testTriggerMonitors_harvesting_cfg.py" $?


### PR DESCRIPTION
backport of #41568

#### PR description:

From the description of #41568:

>This PR updates the plugins `Trigger{Bx,Rates}Monitor` in order to avoid that a `ProductNotFound` exception is thrown if the product containing the L1-uGT results is not available.
>
>The exception is replaced with a `LogError` message (this follows what is already done in another somewhat-similar HLT plugin, namely `L1TriggerJSONMonitoring`).
>
>These two plugins are used online in the HLT menu to produce outputs for the online DQM.
>
>This PR relates to https://github.com/cms-sw/cmssw/issues/41512#issuecomment-1533787403, and it might be relevant to current online operations. For this reason, it will be backported down to the `13_0_X` release cycle.

#### PR validation:

None beyond the checks done for #41568.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41568

Improvement to 2 plugins used online in the HLT menu.