### PR TITLE
do not allow crashes in `isEmpty(int bx)` method of `BXVector` [`13_0_X`]

### DIFF
--- a/DataFormats/L1Trigger/interface/BXVector.h
+++ b/DataFormats/L1Trigger/interface/BXVector.h
@@ -1,5 +1,5 @@
-#ifndef BXVector_h
-#define BXVector_h
+#ifndef DataFormats_L1Trigger_BXVector_h
+#define DataFormats_L1Trigger_BXVector_h
 
 // this class is an extension of std::vector
 // designed to store objects corresponding to several time-samples (BX)
@@ -134,4 +134,4 @@ private:
 
 #include "BXVector.icc"
 
-#endif
+#endif  // DataFormats_L1Trigger_BXVector_h

--- a/DataFormats/L1Trigger/interface/BXVector.icc
+++ b/DataFormats/L1Trigger/interface/BXVector.icc
@@ -1,6 +1,8 @@
+#include <cassert>
+
+// FIXME: these 3 lines are required by other packages
 #include <vector>
 #include <iostream>
-#include <cassert>
 using namespace std;
 
 template <class T>
@@ -211,15 +213,27 @@ unsigned BXVector<T>::indexFromBX(int bx) const {
 // check to see if bx is empty
 template <class T>
 bool BXVector<T>::isEmpty(int bx) const {
-  if (itrs_[indexFromBX(bx)] == data_.size()) {
+  if (bx < bxFirst_) {
     return true;
   }
 
-  if (indexFromBX(bx + 1) >= itrs_.size()) {
+  auto const index_bx = indexFromBX(bx);
+
+  if (index_bx >= itrs_.size()) {
+    return true;
+  }
+
+  if (itrs_[index_bx] == data_.size()) {
+    return true;
+  }
+
+  auto const index_bxPlus1 = indexFromBX(bx + 1);
+
+  if (index_bxPlus1 >= itrs_.size()) {
     return false;
   }
 
-  if (itrs_[indexFromBX(bx)] == itrs_[indexFromBX(bx + 1)]) {
+  if (itrs_[index_bx] == itrs_[index_bxPlus1]) {
     return true;
   }
 


### PR DESCRIPTION
backport of #41572

#### PR description:

From the description of #41572:

>This PR aims to make the method `BXVector::isEmpty(int bx)` more robust, removing the possibility of runtime crashes when this method is called.
>
>This public method can currently crash if the value of its `bx` argument is outside the range of valid BXs, or if the `itrs_` class member is empty (as seen in the problematic events that led to the crashes fixed by #41466).

#### PR validation:

None beyond the checks done for #41572.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41572

Fix to public method used by several plugins in CMSSW.