### PR TITLE
improve how `HLTPrescaler` checks presence of (Stage-2) L1-uGT results [`13_1_X`]

### DIFF
--- a/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
@@ -81,7 +81,7 @@ bool HLTPrescaler::filter(edm::Event& iEvent, const edm::EventSetup&) {
       edm::Handle<GlobalAlgBlkBxCollection> handle2;
       iEvent.getByToken(gtDigi2Token_, handle2);
       if (handle2.isValid()) {
-        if (handle2->begin(0) != handle2->end(0)) {
+        if (not handle2->isEmpty(0)) {
           prescaleSet_ = static_cast<unsigned int>(handle2->begin(0)->getPreScColumn());
           prescaleFactor_ = prescaleService_->getPrescale(prescaleSet_, pathName);
         } else {


### PR DESCRIPTION
backport of #41575

#### PR description:

From the description of #41575:
>This PR improves how the `HLTPrescaler` checks for the availability of the Stage-2 L1-uGT results of BX=0 before accessing them to find the index of the prescale column.
>
>This check is currently done by first calling `BXVector::begin(0)`, but the latter call can in principle result in a runtime error if the content of the `BXVector` is empty, see [here](https://github.com/cms-sw/cmssw/blob/6c4577670a3b8f8b317dff3e713eb5ff97d81392/DataFormats/L1Trigger/interface/BXVector.icc#L92).
>
>The check is updated using `BXVector::isEmpty(0)`, which shouldn't lead to runtime crashes under any circumstances provided #41572 and its backports are integrated.
>
>Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41575

Preemptive fix to a plugin used online in the HLT menu.