### PR TITLE
Payload inspector for PF Calibration object

### DIFF
--- a/CondCore/PhysicsToolsPlugins/plugins/BuildFile.xml
+++ b/CondCore/PhysicsToolsPlugins/plugins/BuildFile.xml
@@ -2,3 +2,9 @@
   <use name="CondCore/Utilities"/>
   <use name="CondCore/CondDB"/>
 </library>
+
+<library file="PfCalibration_PayloadInspector.cc" name="PerformancePayloadFromTFormula_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/PhysicsToolsObjects"/>
+</library>

--- a/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
@@ -1,0 +1,132 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
+#include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
+
+#include <memory>
+#include <sstream>
+#include <fstream>
+#include <iostream>
+#include <array>
+#include <map>
+
+// include ROOT
+#include "TH2F.h"
+#include "TF1.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+using namespace cond::payloadInspector;
+
+class PerformancePayloadFromTFormulaExposed : public PerformancePayloadFromTFormula {
+public:
+  int resultPos(PerformanceResult::ResultType rt) const override {
+    return PerformancePayloadFromTFormula::resultPos(rt);
+  }
+};
+
+static std::map<PerformanceResult::ResultType, std::string> functType = {
+    {PerformanceResult::PFfa_BARREL, "PFfa_BARREL"},
+    {PerformanceResult::PFfa_ENDCAP, "PFfa_ENDCAP"},
+    {PerformanceResult::PFfb_BARREL, "PFfb_BARREL"},
+    {PerformanceResult::PFfb_ENDCAP, "PFfb_ENDCAP"},
+    {PerformanceResult::PFfc_BARREL, "PFfc_BARREL"},
+    {PerformanceResult::PFfc_ENDCAP, "PFfc_ENDCAP"},
+
+    {PerformanceResult::PFfaEta_BARRELH, "PFfaEta_BARRELH"},
+    {PerformanceResult::PFfaEta_ENDCAPH, "PFfaEta_ENDCAPH"},
+    {PerformanceResult::PFfbEta_BARRELH, "PFfbEta_BARRELH"},
+    {PerformanceResult::PFfbEta_ENDCAPH, "PFfbEta_ENDCAPH"},
+    {PerformanceResult::PFfaEta_BARRELEH, "PFfaEta_BARRELEH"},
+    {PerformanceResult::PFfaEta_ENDCAPEH, "PFfaEta_ENDCAPEH"},
+    {PerformanceResult::PFfbEta_BARRELEH, "PFfbEta_BARRELEH"},
+    {PerformanceResult::PFfbEta_ENDCAPEH, "PFfbEta_ENDCAPEH"},
+
+    {PerformanceResult::PFfaEta_BARREL, "PFfaEta_BARREL"},
+    {PerformanceResult::PFfaEta_ENDCAP, "PFfaEta_ENDCAP"},
+    {PerformanceResult::PFfbEta_BARREL, "PFfbEta_BARREL"},
+    {PerformanceResult::PFfbEta_ENDCAP, "PFfbEta_ENDCAP"},
+
+    {PerformanceResult::PFfcEta_BARRELH, "PFfcEta_BARRELH"},
+    {PerformanceResult::PFfcEta_ENDCAPH, "PFfcEta_ENDCAPH"},
+    {PerformanceResult::PFfdEta_ENDCAPH, "PFfdEta_ENDCAPH"},
+    {PerformanceResult::PFfcEta_BARRELEH, "PFfcEta_BARRELEH"},
+    {PerformanceResult::PFfcEta_ENDCAPEH, "PFfcEta_ENDCAPEH"},
+    {PerformanceResult::PFfdEta_ENDCAPEH, "PFfdEta_ENDCAPEH"}};
+
+template <PerformanceResult::ResultType T>
+class PfCalibration : public cond::payloadInspector::PlotImage<PerformancePayloadFromTFormula, SINGLE_IOV> {
+public:
+  PfCalibration()
+      : cond::payloadInspector::PlotImage<PerformancePayloadFromTFormula, SINGLE_IOV>("Performance Payload formula") {}
+  bool fill() override {
+    auto tag = PlotBase::getTag<0>();
+    auto iov = tag.iovs.front();
+    std::string tagname = tag.name;
+    auto payload = fetchPayload(std::get<1>(iov));
+
+    if (!payload.get())
+      return false;
+
+    int pos = ((PerformancePayloadFromTFormulaExposed*)payload.get())->resultPos(T);
+    auto formula = payload->formulaPayload();
+    auto formula_vec = formula.formulas();
+    auto limits_vec = formula.limits();
+
+    TCanvas canvas("PfCalibration", "PfCalibration", 1500, 800);
+    canvas.cd();
+    auto formula_string = formula_vec[pos];
+    auto limits = limits_vec[pos];
+
+    auto function_plot = new TF1("f1", formula_string.c_str(), limits.first, limits.second);
+    function_plot->SetTitle((functType[T] + " " + formula_string).c_str());
+    function_plot->GetXaxis()->SetTitle("GeV");
+    function_plot->Draw("");
+
+    std::string fileName(m_imageFileName);
+    canvas.SaveAs(fileName.c_str());
+
+    return true;
+  }
+};
+
+// Register the classes as boost python plugin
+PAYLOAD_INSPECTOR_MODULE(PerformancePayloadFromTFormula) {
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfa_BARREL>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfa_ENDCAP>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfb_BARREL>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfb_ENDCAP>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfc_BARREL>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfc_ENDCAP>);
+
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_BARRELH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_ENDCAPH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_BARRELH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_ENDCAPH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_BARRELEH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_ENDCAPEH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_BARRELEH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_ENDCAPEH>);
+
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_BARREL>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfaEta_ENDCAP>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_BARREL>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfbEta_ENDCAP>);
+
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfcEta_BARRELH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfcEta_ENDCAPH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfdEta_ENDCAPH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfcEta_BARRELEH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfcEta_ENDCAPEH>);
+  PAYLOAD_INSPECTOR_CLASS(PfCalibration<PerformanceResult::PFfdEta_ENDCAPEH>);
+}

--- a/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc
@@ -82,7 +82,11 @@ public:
     auto formula = payload->formulaPayload();
     auto formula_vec = formula.formulas();
     auto limits_vec = formula.limits();
-
+    if (pos < 0 || pos > (int)formula_vec.size()) {
+      edm::LogError("PfCalibration") << "Will not display image for " << functType[T]
+                                     << " as it's not contained in the payload!";
+      return false;
+    }
     TCanvas canvas("PfCalibration", "PfCalibration", 1500, 800);
     canvas.cd();
     auto formula_string = formula_vec[pos];

--- a/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
+++ b/CondCore/PhysicsToolsPlugins/test/BuildFile.xml
@@ -2,3 +2,5 @@
 <use name="FWCore/PluginManager"/>
 <bin file="test_DropBoxMetadata_PayloadInspector.cpp" name="test_DropBoxMetadata_PayloadInspector">
 </bin>
+<bin file="test_PfCalibration_PayloadInspector.cpp" name="test_PfCalibration_PayloadInspector">
+</bin>

--- a/CondCore/PhysicsToolsPlugins/test/test_PfCalibration_PayloadInspector.cpp
+++ b/CondCore/PhysicsToolsPlugins/test/test_PfCalibration_PayloadInspector.cpp
@@ -1,0 +1,68 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/PhysicsToolsPlugins/plugins/PfCalibration_PayloadInspector.cc"
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  std::string tag = "PFCalibration_v10_mc";
+
+  cond::Time_t start = static_cast<unsigned long long>(1);
+  cond::Time_t end = static_cast<unsigned long long>(1);
+
+  edm::LogWarning("test_PfCalibration") << "test running";
+
+  cond::payloadInspector::PlotImage<PerformancePayloadFromTFormula, SINGLE_IOV>* histograms[] = {
+      new PfCalibration<PerformanceResult::PFfa_BARREL>(),
+      new PfCalibration<PerformanceResult::PFfa_ENDCAP>(),
+      new PfCalibration<PerformanceResult::PFfb_BARREL>(),
+      new PfCalibration<PerformanceResult::PFfb_ENDCAP>(),
+      new PfCalibration<PerformanceResult::PFfc_BARREL>(),
+      new PfCalibration<PerformanceResult::PFfc_ENDCAP>(),
+      new PfCalibration<PerformanceResult::PFfaEta_BARRELH>(),
+      new PfCalibration<PerformanceResult::PFfaEta_ENDCAPH>(),
+      new PfCalibration<PerformanceResult::PFfbEta_BARRELH>(),
+      new PfCalibration<PerformanceResult::PFfbEta_ENDCAPH>(),
+      new PfCalibration<PerformanceResult::PFfaEta_BARRELEH>(),
+      new PfCalibration<PerformanceResult::PFfaEta_ENDCAPEH>(),
+      new PfCalibration<PerformanceResult::PFfbEta_BARRELEH>(),
+      new PfCalibration<PerformanceResult::PFfbEta_ENDCAPEH>(),
+      new PfCalibration<PerformanceResult::PFfaEta_BARREL>(),
+      new PfCalibration<PerformanceResult::PFfaEta_ENDCAP>(),
+      new PfCalibration<PerformanceResult::PFfbEta_BARREL>(),
+      new PfCalibration<PerformanceResult::PFfbEta_ENDCAP>(),
+      new PfCalibration<PerformanceResult::PFfcEta_BARRELH>(),
+      new PfCalibration<PerformanceResult::PFfcEta_ENDCAPH>(),
+      new PfCalibration<PerformanceResult::PFfdEta_ENDCAPH>(),
+      new PfCalibration<PerformanceResult::PFfcEta_BARRELEH>(),
+      new PfCalibration<PerformanceResult::PFfcEta_ENDCAPEH>(),
+      new PfCalibration<PerformanceResult::PFfdEta_ENDCAPEH>()};
+
+  for (auto hist : histograms) {
+    hist->process(connectionString, PI::mk_input(tag, start, end));
+    std::cout << hist->data() << std::endl;
+  }
+
+  Py_Finalize();
+}


### PR DESCRIPTION
#### PR description:
This PR implements PI plots for PF Calibration object.

#### PR validation:

Validated with getPayloadData.py 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

not a backport