### PR TITLE
Run3-alca243 Provide a more meaningful name to a variable in HOCalibAlgo where a variable for pileup was named instlumi

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHOCalibProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHOCalibProducer.cc
@@ -6,14 +6,14 @@
 //runTheMatrix.py -l 4.22
 
 // 7th Nov 2015 :  tmpHOCalib.ecal03 = iso05.sumPt; // iso03.emEt+muonenr.em;
-//                   tmpHOCalib.inslumi=lumiScale->begin()->pileup();
+//                   tmpHOCalib.pileup=lumiScale->begin()->pileup();
 //
 // April 2015 : Remove all digi part
 //  Also look for HO geometry in CMSSW in parallel with stanalone one.
 // Official one has problem in reco geometry, particularly tiles at the edge of wheel
 // Remove all histogrammes except occupancy one
 // Remove Trigger bits
-// But addition of these variables, ilumi (analyser), inslumi (analyser), nprim
+// But addition of these variables, ilumi (analyser), pileup (analyser), nprim
 
 // Feb09 2009
 // Move the initialisation of SteppingHelixPropagator from ::beginJob() to ::produce()
@@ -329,7 +329,7 @@ void AlCaHOCalibProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   bool muonOK(true);
   HOCalibVariables tmpHOCalib;
   tmpHOCalib.nprim = -1;
-  tmpHOCalib.inslumi = -1.;
+  tmpHOCalib.pileup = -1.;
 
   if (m_cosmic) {
     cosmicmuon = iEvent.getHandle(tok_muonsCosmic_);
@@ -344,17 +344,17 @@ void AlCaHOCalibProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         tmpHOCalib.nprim = primaryVertices->size();
       }
 
-      tmpHOCalib.inslumi = 0.;
+      tmpHOCalib.pileup = 0.;
 
       auto const& lumiScale = iEvent.getHandle(tok_lumi_);
       auto const& metaData = iEvent.getHandle(tok_metaData_);
 
       // by default use Run-3 access (onlineMetaDataDigis)
       if (metaData.isValid()) {
-        tmpHOCalib.inslumi = metaData->avgPileUp();
+        tmpHOCalib.pileup = metaData->avgPileUp();
       } else if (lumiScale.isValid() && !lumiScale->empty()) {
         if (lumiScale->begin() != lumiScale->end()) {
-          tmpHOCalib.inslumi = lumiScale->begin()->pileup();
+          tmpHOCalib.pileup = lumiScale->begin()->pileup();
         }
       } else {
         edm::LogWarning("HOCalib") << "Neither LumiScalers nor OnlineMetadata collections found in the event";

--- a/Calibration/HcalCalibAlgos/macros/hocalib_tmpfit.C
+++ b/Calibration/HcalCalibAlgos/macros/hocalib_tmpfit.C
@@ -198,7 +198,7 @@ int main() {
   unsigned ievt, hoflag;
   int irun, ilumi, nprim, isect, isect2, ndof, nmuon;
 
-  float inslumi, trkdr, trkdz, trkvx, trkvy, trkvz, trkmm, trkth, trkph, chisq, therr, pherr, hodx, hody, hoang, htime,
+  float pileup, trkdr, trkdz, trkvx, trkvy, trkvz, trkmm, trkth, trkph, chisq, therr, pherr, hodx, hody, hoang, htime,
       hosig[9], hocorsig[18], hocro, hbhesig[9], caloen[3];
   float momatho, tkpt03, ecal03, hcal03;
   float tmphoang;
@@ -217,7 +217,7 @@ int main() {
 
     Tin->SetBranchAddress("ilumi", &ilumi);
     if (!m_cosmic) {
-      Tin->SetBranchAddress("inslumi", &inslumi);
+      Tin->SetBranchAddress("pileup", &pileup);
       Tin->SetBranchAddress("nprim", &nprim);
       Tin->SetBranchAddress("tkpt03", &tkpt03);
       Tin->SetBranchAddress("ecal03", &ecal03);

--- a/Calibration/HcalCalibAlgos/plugins/HOCalibAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HOCalibAnalyzer.cc
@@ -12,7 +12,7 @@
      <Notes on implementation>
 
 April 2015
-// Addition of these variables, ilumi (analyser), inslumi (analyser), nprim
+// Addition of these variables, ilumi (analyser), pileup (analyser), nprim
 
 
 */
@@ -120,7 +120,7 @@ private:
   unsigned ievt, hoflag;
   int irun, ilumi, nprim, isect, isect2, ndof, nmuon;
 
-  float inslumi, trkdr, trkdz, trkvx, trkvy, trkvz, trkmm, trkth, trkph, chisq, therr, pherr, hodx, hody, hoang, htime,
+  float pileup, trkdr, trkdz, trkvx, trkvy, trkvz, trkmm, trkth, trkph, chisq, therr, pherr, hodx, hody, hoang, htime,
       hosig[9], hocorsig[18], hocro, hbhesig[9], caloen[3];
   float momatho, tkpt03, ecal03, hcal03;
   float tmphoang;
@@ -183,7 +183,7 @@ HOCalibAnalyzer::HOCalibAnalyzer(const edm::ParameterSet& iConfig)
 
   T1->Branch("ilumi", &ilumi, "ilumi/I");
   if (!m_cosmic) {
-    T1->Branch("inslumi", &inslumi, "inslumi/F");
+    T1->Branch("pileup", &pileup, "pileup/F");
     T1->Branch("nprim", &nprim, "nprim/I");
     T1->Branch("tkpt03", &tkpt03, " tkpt03/F");
     T1->Branch("ecal03", &ecal03, " ecal03/F");
@@ -384,7 +384,7 @@ void HOCalibAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
       if (!m_cosmic) {
         nprim = (*hoC).nprim;
-        inslumi = (*hoC).inslumi;
+        pileup = (*hoC).pileup;
         tkpt03 = (*hoC).tkpt03;
         ecal03 = (*hoC).ecal03;
         hcal03 = (*hoC).hcal03;

--- a/DataFormats/HcalCalibObjects/interface/HOCalibVariables.h
+++ b/DataFormats/HcalCalibObjects/interface/HOCalibVariables.h
@@ -1,13 +1,13 @@
 #ifndef AlCaHOCalibProducer_HOCalibVariables_h
 #define AlCaHOCalibProducer_HOCalibVariables_h
 #include <vector>
-//April 2015 : Added more variables, e.g., momatho, tkpt03, ecal03, hcal03, inslumi, nprim
+//April 2015 : Added more variables, e.g., momatho, tkpt03, ecal03, hcal03, pileup, nprim
 class HOCalibVariables {
 public:
   int nmuon;  //number of muons in the event
   int nprim;  // number of primary vertices
 
-  float inslumi;  //instantaneous luminosity
+  float pileup;  //Number of pileup events in the bunch crossing
 
   float trkdr;  //r-phi coordinate of track wrt vertex
   float trkdz;  //Z coordinate of track wrt vertex

--- a/DataFormats/HcalCalibObjects/src/classes_def.xml
+++ b/DataFormats/HcalCalibObjects/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
-  <class name="HOCalibVariables" ClassVersion="16">
+  <class name="HOCalibVariables" ClassVersion="17">
    <version ClassVersion="16" checksum="2161587371"/>
+   <version ClassVersion="17" checksum="1351689277"/>
   </class>
   <class name="std::vector<HOCalibVariables>"/>
   <class name="edm::Wrapper<std::vector<HOCalibVariables> >"/>


### PR DESCRIPTION
#### PR description:

Provide a more meaningful name to a variable in HOCalibAlgo where a variable for pileup was named instlumi

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special