### PR TITLE
[12_4_X] New HB thresholds for 2022 data rereco

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2022_rereco_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2022_rereco_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_egamma_2022_rereco_cff import run3_egamma_2022_rereco
+
+Run3_2022_rereco = cms.ModifierChain(Run3, run3_egamma_2022_rereco)

--- a/Configuration/Eras/python/Modifier_run3_egamma_2022_rereco_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_egamma_2022_rereco_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_egamma_2022_rereco = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -34,6 +34,7 @@ class Eras (object):
                  'Run2_2018_highBetaStar',
                  'Run2_2018_noMkFit',
                  'Run3',
+                 'Run3_2022_rereco',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',
                  'Run3_dd4hep',

--- a/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egammaHBHERecHitThreshold_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1
+from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHBHE_cfi import _thresholdsHBphase1, _thresholdsHEphase1, _thresholdsHBphase1_2022_rereco
 
 egammaHBHERecHit = cms.PSet(
     hbheRecHits = cms.InputTag('hbhereco'),
@@ -8,3 +8,10 @@ egammaHBHERecHit = cms.PSet(
     recHitEThresholdHE = _thresholdsHEphase1,
     maxHcalRecHitSeverity = cms.int32(9),
 )
+
+egammaHBHERecHit_2022_rereco = egammaHBHERecHit.clone(
+    recHitEThresholdHB = _thresholdsHBphase1_2022_rereco
+)
+
+from Configuration.Eras.Modifier_run3_egamma_2022_rereco_cff import run3_egamma_2022_rereco
+run3_egamma_2022_rereco.toReplaceWith(egammaHBHERecHit,egammaHBHERecHit_2022_rereco)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -9,7 +9,10 @@ _seedingThresholdsHB = cms.vdouble(1.0, 1.0, 1.0, 1.0)
 _seedingThresholdsHE = cms.vdouble(1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1)
 _seedingThresholdsHBphase1 = cms.vdouble(0.125, 0.25, 0.35, 0.35)
 _seedingThresholdsHEphase1 = cms.vdouble(0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275)
-
+#updated HB RecHit threshold for 2022 rereco
+_thresholdsHBphase1_2022_rereco = cms.vdouble(0.25, 0.25, 0.3, 0.3)
+#updated HB seeding threshold for 2022_rereco
+_seedingThresholdsHBphase1_2022_rereco = cms.vdouble(0.3625, 0.375, 0.425, 0.425)
 
 #### PF CLUSTER HCAL ####
 particleFlowClusterHBHE = cms.EDProducer(
@@ -139,6 +142,18 @@ run3_HB.toModify(particleFlowClusterHBHE,
         recHitEnergyNorms = {0 : dict(recHitEnergyNorm = _thresholdsHBphase1) },
         positionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+    ),
+)
+
+# offline 2022 rereco
+from Configuration.Eras.Modifier_run3_egamma_2022_rereco_cff import run3_egamma_2022_rereco
+run3_egamma_2022_rereco.toModify(particleFlowClusterHBHE,
+    seedFinder = dict(thresholdsByDetector = {0 : dict(seedingThreshold = _seedingThresholdsHBphase1_2022_rereco) } ),
+    initialClusteringStep = dict(thresholdsByDetector = {0 : dict(gatheringThreshold = _thresholdsHBphase1_2022_rereco) } ),
+    pfClusterBuilder = dict(
+        recHitEnergyNorms = {0 : dict(recHitEnergyNorm = _thresholdsHBphase1_2022_rereco) },
+        positionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2022_rereco) } ),
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2022_rereco) } ),
     ),
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -4,6 +4,8 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+#updated HB RecHit threshold for 2022 rereco
+_thresholdsHBphase1_2022_rereco = cms.vdouble(0.25, 0.25, 0.3, 0.3)
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),
@@ -48,6 +50,14 @@ from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(particleFlowClusterHCAL,
     pfClusterBuilder = dict(
         allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1) } ),
+    ),
+)
+
+# offline 2022 rereco
+from Configuration.Eras.Modifier_run3_egamma_2022_rereco_cff import run3_egamma_2022_rereco
+run3_egamma_2022_rereco.toModify(particleFlowClusterHCAL,
+    pfClusterBuilder = dict(
+        allCellsPositionCalc = dict(logWeightDenominatorByDetector = {0 : dict(logWeightDenominator = _thresholdsHBphase1_2022_rereco) } ),
     ),
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -4,6 +4,8 @@ _thresholdsHB = cms.vdouble(0.8, 0.8, 0.8, 0.8)
 _thresholdsHE = cms.vdouble(0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8)
 _thresholdsHBphase1 = cms.vdouble(0.1, 0.2, 0.3, 0.3)
 _thresholdsHEphase1 = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+#updated HB RecHit threshold for 2022 rereco
+_thresholdsHBphase1_2022_rereco = cms.vdouble(0.25, 0.25, 0.3, 0.3)
 
 particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
     navigator = cms.PSet(
@@ -52,6 +54,11 @@ from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HEColla
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1) } ) } ) },
+)
+
+from Configuration.Eras.Modifier_run3_egamma_2022_rereco_cff import run3_egamma_2022_rereco
+run3_egamma_2022_rereco.toModify(particleFlowRecHitHBHE,
+    producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1_2022_rereco) } ) } ) },
 )
 
 # HCALonly WF


### PR DESCRIPTION
#### PR description:
Run3 2022 data has issues with HB noise which affects HCAL related quantities of leptons and photons. 
For example, here are the plots of electron's PF neutral hadron isolation and H/E in 2022 EraE and EraG respectively, in prompt reco, which shows that the noise in data is not modelled in MC.

<img src="https://user-images.githubusercontent.com/5052706/236679903-3274d622-a1fe-4e98-a75f-72de12c38c18.png" width="350"> <img src="https://user-images.githubusercontent.com/5052706/236679918-cb3fa8f4-fd46-42ed-b5b2-6b6ed266d2cb.png" width="350">

In this PR, new HB thresholds are introduced via a new era called `Run3_2022_rereco`.
The thresholds are obtained from HCAL DPG.
The plan is to do a rereco of [some parts of] 2022 data using a new 12_4_X release that includes this PR.
This was discussed in Cross-coordination meeting of 5th May: https://indico.cern.ch/event/1283310/
It was agreed that, these new HB thresholds will be validated using relVals, to check if data/MC agreement improves or not. The validation/sign-off should be concluded by May 18th. If a resolution cannot be achieved by this time, the rereco will proceed w/o addressing the HB issue. So, this PR is urgent.

FYI @cms-sw/hcal-dpg-l2 @cms-sw/pf-l2 @cms-sw/egamma-pog-l2 @cms-sw/jetmet-pog-l2 

#### PR validation:
Checked with `11834.0` and with `--era Run3_2022_rereco`.

This PR is needed only for 12_4_X because 2022 data rereco will be done in 12_4_X only.