### PR TITLE
L1T Phase 2: correlator-to-GT interface for jets and MHT

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/sums.h
+++ b/DataFormats/L1TParticleFlow/interface/sums.h
@@ -52,7 +52,7 @@ namespace l1ct {
       sum.valid = (hwPt != 0) || (hwSumPt != 0);
       sum.vector_pt = CTtoGT_pt(hwPt);
       sum.vector_phi = CTtoGT_phi(hwPhi);
-      sum.scalar_pt = CTtoGT_phi(hwSumPt);
+      sum.scalar_pt = CTtoGT_pt(hwSumPt);
       return sum;
     }
   };

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -33,7 +33,8 @@
   <class name="l1t::RegionalOutput<l1t::PFCandidateCollection>" />
   <class name="edm::Wrapper<l1t::RegionalOutput<l1t::PFCandidateCollection>>" />
 
-  <class name="l1t::PFJet"  ClassVersion="5">
+  <class name="l1t::PFJet"  ClassVersion="6">
+        <version ClassVersion="6" checksum="2599349078"/>
         <version ClassVersion="5" checksum="2270932343"/>
         <version ClassVersion="4" checksum="1424452548"/>
         <version ClassVersion="3" checksum="133342988"/>

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc
@@ -204,7 +204,8 @@ std::vector<l1t::PFJet> L1SeedConePFJetProducer::convertHWToEDM(
                       gtJet.v3.pt.V,
                       gtJet.v3.eta.V,
                       gtJet.v3.phi.V);
-    edmJet.setEncodedJet(jet.toGT().pack());
+    edmJet.setEncodedJet(l1t::PFJet::HWEncoding::CT, jet.pack());
+    edmJet.setEncodedJet(l1t::PFJet::HWEncoding::GT, jet.toGT().pack());
     // get back the references to the constituents
     std::vector<edm::Ptr<l1t::PFCandidate>> constituents;
     std::for_each(jet.constituents.begin(), jet.constituents.end(), [&](auto constituent) {

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1pfJetMet_cff.py
@@ -26,7 +26,7 @@ from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
 phase2_hgcalV11.toModify(_correctedJets, correctorFile = "L1Trigger/Phase2L1ParticleFlow/data/jecs/jecs_20220308.root")
 
 from L1Trigger.Phase2L1ParticleFlow.l1tMHTPFProducer_cfi import l1tMHTPFProducer
-l1tSCPFL1PuppiCorrectedEmulatorMHT = l1tMHTPFProducer.clone() 
+l1tSCPFL1PuppiCorrectedEmulatorMHT = l1tMHTPFProducer.clone(jets = 'l1tSCPFL1PuppiCorrectedEmulator')
 
 L1TPFJetsTask = cms.Task(
     l1tLayer2Deregionizer, l1tSCPFL1PF, l1tSCPFL1Puppi, l1tSCPFL1PuppiEmulator, l1tSCPFL1PuppiCorrectedEmulator, l1tSCPFL1PuppiCorrectedEmulatorMHT


### PR DESCRIPTION
#### PR description:

This PR improves and fixes the handoff of emulated jets and MHT collections from phase 2 L1T correlator to global trigger for their emulation.
-  hardware correlator produces jets in an internal format and send them in a different agreed format. Now both are made accessible and more explicitly named
- the MHT emulator was doing some incorrect decoding of the correlator jets, then incorrect encoding of the MHT for GT, that are both now fixed
- MHT in the `L1TPFJetsTask ` was not consuming the correct collection for proper emulation of the L1T hardware, now fixed

#### PR validation:

These changes have been developed and studied in the context of the Phase 2 Global Trigger emulation and validation against the previously not-emulated Menu workflow by the L1T software team.

@aloeliger 