### PR TITLE
[12_4_X] WFs to test era Run3_2022_rereco

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2005,7 +2005,7 @@ upgradeProperties[2017] = {
     },
    '2022ReReco' : {
         'Geom' : 'DB:Extended',
-        'GT' : 'auto:phase1_2022_realistic',
+        'GT' : 'auto:phase1_2022_realistic_postEE',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3_2022_rereco',
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -28,6 +28,8 @@ upgradeKeys[2017] = [
     '2021FSPU',
     '2021postEE',
     '2021postEEPU',
+    '2022ReReco',
+    '2022ReRecoPU'
 ]
 
 upgradeKeys[2026] = [
@@ -1844,7 +1846,7 @@ upgradeWFs['DD4hepDB'].allowReuse = False
 
 class UpgradeWorkflow_DDDDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Run3' in stepDict[step][k]['--era'] and 'Fast' not in stepDict[step][k]['--era']:
+        if 'Run3' in stepDict[step][k]['--era'] and 'rereco' not in stepDict[step][k]['--era'] and 'Fast' not in stepDict[step][k]['--era']: 
             # retain any other eras
             tmp_eras = stepDict[step][k]['--era'].split(',')
             tmp_eras[tmp_eras.index("Run3")] = 'Run3_DDD'
@@ -2001,6 +2003,15 @@ upgradeProperties[2017] = {
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
+   '2022ReReco' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2022_realistic',
+        'HLTmenu': '@relval2022',
+        'Era' : 'Run3_2022_rereco',
+        'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
+        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
+    },
+
 }
 
 # standard PU sequences

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2005,7 +2005,7 @@ upgradeProperties[2017] = {
     },
    '2022ReReco' : {
         'Geom' : 'DB:Extended',
-        'GT' : 'auto:phase1_2022_realistic_postEE',
+        'GT' : 'auto:phase1_2022_realistic',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3_2022_rereco',
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',


### PR DESCRIPTION
This PR is to add WFs to run with era Run3_2022_rereco introduced by #41581 which is an urgent PR to validate the new HB thresholds. 
This PR has to be validated with #41581. 