### PR TITLE
Backport/restore FastSim options with proc mods to override decays with GEN for 10_6 UL

### DIFF
--- a/Configuration/ProcessModifiers/python/useFastSimsDecayer_cff.py
+++ b/Configuration/ProcessModifiers/python/useFastSimsDecayer_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# Desiged to disable the bug in Run II samples that duplicates hits for long lived particles
+useFastSimsDecayer =  cms.Modifier()

--- a/Configuration/ProcessModifiers/python/useGenNotFastSimDecays_cff.py
+++ b/Configuration/ProcessModifiers/python/useGenNotFastSimDecays_cff.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 # Desiged to disable the bug in Run II samples that duplicates hits for long lived particles
-useFastSimsDecayer =  cms.Modifier()
+useGenNotFastSimDecays =  cms.Modifier()

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -132,16 +132,17 @@ namespace fastsim {
     const double
         deltaRchargedMother_;  //!< For FastSim (cheat) tracking: cut on the angle between a charged mother and charged daughter.
     const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
-    std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
-    std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
-    double momentumUnitConversionFactor_;  //!< Convert pythia units to GeV (FastSim standard)
-    double lengthUnitConversionFactor_;    //!< Convert pythia unis to cm (FastSim standard)
-    double lengthUnitConversionFactor2_;   //!< Convert pythia unis to cm^2 (FastSim standard)
-    double timeUnitConversionFactor_;      //!< Convert pythia unis to ns (FastSim standard)
-    std::vector<std::unique_ptr<Particle> >
+    std::vector<SimTrack>* simTracks_;  //!< The generated SimTrack of this event.
+    std::vector<SimVertex>* simVertices_;  //!< The generated SimVertices of this event.
+    bool fixLongLivedBug_;        
+    bool useFastSimsDecayer_;    
+    double momentumUnitConversionFactor_;  //!< Convert Pythia units to GeV (FastSim standard).
+    double lengthUnitConversionFactor_;  //!< Convert Pythia units to cm (FastSim standard).
+    double lengthUnitConversionFactor2_;  //!< Convert Pythia units to cm^2 (FastSim standard).
+    double timeUnitConversionFactor_;  //!< Convert Pythia units to ns (FastSim standard).
+    std::vector<std::unique_ptr<Particle>> 
         particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
-    bool useFastSimsDecayer_;        
-    bool fixLongLivedBug_;
+        
   };
 }  // namespace fastsim
 

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -52,6 +52,7 @@ namespace fastsim {
                     const ParticleFilter& particleFilter,
                     std::vector<SimTrack>& simTracks,
                     std::vector<SimVertex>& simVertices,
+                    bool fixLongLivedBug,
                     bool useFastSimsDecayer);
 
     //! Default destructor.
@@ -133,13 +134,14 @@ namespace fastsim {
     const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
     std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
     std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
-    bool useFastSimsDecayer_;
     double momentumUnitConversionFactor_;  //!< Convert pythia units to GeV (FastSim standard)
     double lengthUnitConversionFactor_;    //!< Convert pythia unis to cm (FastSim standard)
     double lengthUnitConversionFactor2_;   //!< Convert pythia unis to cm^2 (FastSim standard)
     double timeUnitConversionFactor_;      //!< Convert pythia unis to ns (FastSim standard)
     std::vector<std::unique_ptr<Particle> >
         particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
+    bool useFastSimsDecayer_;        
+    bool fixLongLivedBug_;
   };
 }  // namespace fastsim
 

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -84,3 +84,8 @@ fastSimProducer = cms.EDProducer(
 from Configuration.ProcessModifiers.fastSimFixLongLivedBug_cff import fastSimFixLongLivedBug
 
 fastSimFixLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))
+
+from Configuration.ProcessModifiers.useFastSimsDecayer_cff import useFastSimsDecayer
+useFastSimsDecayer.toModify(fastSimProducer, useFastSimsDecayer = cms.bool(True))
+
+

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -13,7 +13,6 @@ fastSimProducer = cms.EDProducer(
     trackerDefinition = TrackerMaterialBlock.TrackerMaterial,
     simulateCalorimetry = cms.bool(True),
     simulateMuons = cms.bool(True),
-    useFastSimsDecayer = cms.bool(False),
     caloDefinition = CaloMaterialBlock.CaloMaterial, #  Hack to interface "old" calorimetry with "new" propagation in tracker
     beamPipeRadius = cms.double(3.),
     deltaRchargedMother = cms.double(0.02), # Maximum angle to associate a charged daughter to a charged mother (mostly done to associate muons to decaying pions)
@@ -78,4 +77,10 @@ fastSimProducer = cms.EDProducer(
     MaterialEffectsForMuonsInECAL = MaterialEffectsForMuonsInECALBlock.MaterialEffectsForMuonsInECAL,
     MaterialEffectsForMuonsInHCAL = MaterialEffectsForMuonsInHCALBlock.MaterialEffectsForMuonsInHCAL,
     GFlash = FamosCalorimetryBlock.GFlash,
+    fixLongLivedBug = cms.bool(False),
+    useFastSimsDecayer = cms.bool(True),
 )
+
+from Configuration.ProcessModifiers.fastSimFixLongLivedBug_cff import fastSimFixLongLivedBug
+
+fastSimFixLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -82,10 +82,9 @@ fastSimProducer = cms.EDProducer(
 )
 
 from Configuration.ProcessModifiers.fastSimFixLongLivedBug_cff import fastSimFixLongLivedBug
-
 fastSimFixLongLivedBug.toModify(fastSimProducer, fixLongLivedBug = cms.bool(True))
 
-from Configuration.ProcessModifiers.useFastSimsDecayer_cff import useFastSimsDecayer
-useFastSimsDecayer.toModify(fastSimProducer, useFastSimsDecayer = cms.bool(True))
+from Configuration.ProcessModifiers.useGenNotFastSimDecays_cff import useGenNotFastSimDecays
+useGenNotFastSimDecays.toModify(fastSimProducer, useFastSimsDecayer = cms.bool(False))
 
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -21,6 +21,7 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
                                           const fastsim::ParticleFilter& particleFilter,
                                           std::vector<SimTrack>& simTracks,
                                           std::vector<SimVertex>& simVertices,
+                                          bool fixLongLivedBug,
                                           bool useFastSimsDecayer)
     : genEvent_(&genEvent),
       genParticleIterator_(genEvent_->particles_begin()),
@@ -45,7 +46,8 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
       momentumUnitConversionFactor_(conversion_factor(genEvent_->momentum_unit(), HepMC::Units::GEV)),
       lengthUnitConversionFactor_(conversion_factor(genEvent_->length_unit(), HepMC::Units::LengthUnit::CM)),
       lengthUnitConversionFactor2_(lengthUnitConversionFactor_ * lengthUnitConversionFactor_),
-      timeUnitConversionFactor_(lengthUnitConversionFactor_ / fastsim::Constants::speedOfLight)
+      timeUnitConversionFactor_(lengthUnitConversionFactor_ / fastsim::Constants::speedOfLight),
+      fixLongLivedBug_(fixLongLivedBug)
 
 {
   // add the main vertex from the signal event to the simvertex collection
@@ -235,7 +237,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
 
     // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
-    if (producedWithinBeamPipe && !decayedWithinBeamPipe && useFastSimsDecayer_) {
+    if (fixLongLivedBug_ && useFastSimsDecayer_ && producedWithinBeamPipe && !decayedWithinBeamPipe){
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
     }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -33,6 +33,7 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
       particleFilter_(&particleFilter),
       simTracks_(&simTracks),
       simVertices_(&simVertices),
+      fixLongLivedBug_(fixLongLivedBug),
       useFastSimsDecayer_(useFastSimsDecayer)
       // prepare unit convsersions
       //  --------------------------------------------
@@ -46,8 +47,7 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
       momentumUnitConversionFactor_(conversion_factor(genEvent_->momentum_unit(), HepMC::Units::GEV)),
       lengthUnitConversionFactor_(conversion_factor(genEvent_->length_unit(), HepMC::Units::LengthUnit::CM)),
       lengthUnitConversionFactor2_(lengthUnitConversionFactor_ * lengthUnitConversionFactor_),
-      timeUnitConversionFactor_(lengthUnitConversionFactor_ / fastsim::Constants::speedOfLight),
-      fixLongLivedBug_(fixLongLivedBug)
+      timeUnitConversionFactor_(lengthUnitConversionFactor_ / fastsim::Constants::speedOfLight)
 
 {
   // add the main vertex from the signal event to the simvertex collection


### PR DESCRIPTION
To preserve physics, the proc modifier for fixing the long-lived bug is restored, and the option to disregard all FastSim decays in place of GEN decays is now activated with a proc modifier. The main issue was that the backport https://github.com/cms-sw/cmssw/pull/39022 was missing two lines in FastSimProducer.cc conditioning the decay action of the FastSim decayer on the relevant option flag. 