### PR TITLE
Record max for VSize and RSS in SimpleMemoryCheck

### DIFF
--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -758,10 +758,14 @@ namespace edm {
     }
 
     void SimpleMemoryCheck::updateMax() {
-      if ((*current_ > max_) || oncePerEventMode_) {
-        if (count_ >= num_to_skip_) {
+      auto v = *current_;
+      if ((v > max_) || oncePerEventMode_) {
+        if (max_.vsize < v.vsize) {
+          max_.vsize = v.vsize;
         }
-        max_ = *current_;
+        if (max_.rss < v.rss) {
+          max_.rss = v.rss;
+        }
       }
     }
 


### PR DESCRIPTION
#### PR description:

Previously a new max for VSize or RSS would overwrite the max for the other measurement as well.

#### PR validation:

Code compiles.