### PR TITLE
Add prototype HcalNanoAOD

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_production.py
+++ b/Configuration/PyReleaseValidation/python/relval_production.py
@@ -38,6 +38,9 @@ workflows[1045] = ['',['RunRawPPS2022B','TIER0EXPPPSCALRUN3','ALCASPLITPPSALIGRU
 workflows[1052] = ['',['RunCosmics2022F','TIER0EXPCOSMICSRUN3','ALCAEXPCOSMICSRUN3','ALCAHARVDSIPIXELLAMCS']]
 workflows[1052.1] = ['',['RunSiPixelCalCosmics2022F','ALCASPLITSIPIXELLAMCS','ALCAHARVDSIPIXELLAMCS']]
 
+workflows[1060.1] = ['',['RunZeroBias2022D', 'HcalNano']]
+workflows[1060.2] = ['',['TestEnablesEcalHcal2023C', 'HcalNanoCalibGap']]
+
 ## MC production test
 #workflows[1100] = [ '',[]]
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -584,6 +584,9 @@ steps['RunEGamma2023B']={'INPUT':InputInfo(dataSet='/EGamma1/Run2023B-v1/RAW',la
 steps['RunTau2023B']={'INPUT':InputInfo(dataSet='/Tau/Run2023B-v1/RAW',label='2023B',events=100000,location='STD', ls=Run2023B)}
 steps['RunMuonEG2023B']={'INPUT':InputInfo(dataSet='/MuonEG/Run2023B-v1/RAW',label='2023B',events=100000,location='STD', ls=Run2023B)}
 
+Run2023C_LS500={368489: [[46,546]]}
+steps['TestEnablesEcalHcal2023C']={'INPUT':InputInfo(dataSet='/TestEnablesEcalHcal/Run2023C-Express-v4/RAW',label='2023C',events=100000,location='STD', ls=Run2023C_LS500)}
+
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
 steps['RunHLTPhy2015DHS']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2015D-v1/RAW',label='2015DHS',events=100000,location='STD', ls=Run2015DHS)}
@@ -3926,6 +3929,24 @@ steps['NanoFullHEfail']={'-s':'NANO',
                          '--datatier':'NANOAODSIM',
                          '--eventcontent':'NANOEDMAODSIM',
                          '--filein':'file:step3_inMINIAODSIM.root'}
+
+steps['HcalNano']={'-s':'RAW2DIGI,RECO,USER:DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
+                         '--conditions':'auto:run3_data_prompt',
+                         '-n':'10',
+                         '--era' : 'Run3',
+                         '--geometry' : 'DB:Extended',
+                         '--datatier':'NANOAOD',
+                         '--eventcontent':'NANOAOD'}
+
+steps['HcalNanoCalibGap']={'-s':'RAW2DIGI,RECO,USER:DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
+                         '--conditions':'auto:run3_data_prompt',
+                         '-n':'10',
+                         '--era' : 'Run3',
+                         '--geometry' : 'DB:Extended',
+                         '--datatier':'NANOAOD',
+                         '--eventcontent':'NANOAOD', 
+                         '--customise':'DPGAnalysis/HcalNanoAOD/hcalNano_cff.customiseHcalCalib', 
+                         '--processName': 'USER'}
                          
 #################################################################################
 ####From this line till the end of the file :

--- a/DPGAnalysis/HcalNanoAOD/BuildFile.xml
+++ b/DPGAnalysis/HcalNanoAOD/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="DataFormats/Common"/>
+<use name="DataFormats/NanoAOD"/>
+<use name="DataFormats/HcalDetId"/>
+<use name="DQM/HcalCommon"/>
+<use name="boost"/>
+<export>
+  <lib name="1"/>
+</export>
+

--- a/DPGAnalysis/HcalNanoAOD/README.md
+++ b/DPGAnalysis/HcalNanoAOD/README.md
@@ -1,0 +1,5 @@
+### HcalNanoAOD
+
+This package provides modules for saving HCAL raw data to NanoAOD. Specifically, modules are provided for HB/HE/HF/HO digis, RecHits, trigger primitives (TPs), HF pre-RecHits, and calibration metadata. Also see DPGAnalysis/CaloNanoAOD for modules related to HCAL+particle flow. 
+
+The digis are saved as a dense array (counting on compression to minimize the space consumed by 0s). The outputs are also sorted by DetId; the sorting is performed by the classes named *SortedTable.

--- a/DPGAnalysis/HcalNanoAOD/interface/HFPreRecHitSortedTable.h
+++ b/DPGAnalysis/HcalNanoAOD/interface/HFPreRecHitSortedTable.h
@@ -1,0 +1,31 @@
+#ifndef HFPreRecHitSortedTable_h
+#define HFPreRecHitSortedTable_h
+
+#include <vector>
+#include <map>
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+
+class HFPreRecHitSortedTable {
+public:
+  std::vector<HcalDetId> dids_;
+  std::map<HcalDetId, unsigned int> did_indexmap_;  // Use std::map for efficient lookup, rather than std::find
+
+  std::vector<int> charges_;
+  std::vector<int> chargeAsymmetries_;
+  std::vector<bool> valids_;
+
+  HFPreRecHitSortedTable(const std::vector<HcalDetId>& dids);
+  void add(const HFPreRecHitCollection::const_iterator itPreRecHit);
+  void reset();
+};
+#endif

--- a/DPGAnalysis/HcalNanoAOD/interface/HODigiSortedTable.h
+++ b/DPGAnalysis/HcalNanoAOD/interface/HODigiSortedTable.h
@@ -1,0 +1,47 @@
+#ifndef HODigiSortedTable_h
+#define HODigiSortedTable_h
+
+#include <vector>
+#include <map>
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "DQM/HcalCommon/interface/Utilities.h"
+
+class HODigiSortedTable {
+public:
+  std::vector<HcalDetId> dids_;
+  std::map<HcalDetId, unsigned int> did_indexmap_;  // Use std::map for efficient lookup, rather than std::find
+
+  std::vector<int> ietas_;
+  std::vector<int> iphis_;
+  std::vector<int> subdets_;
+  std::vector<int> depths_;
+  std::vector<int> rawIds_;
+  std::vector<int> fiberIdleOffsets_;
+  std::vector<int> sois_;
+  std::vector<bool> valids_;
+
+  unsigned int nTS_;
+  std::vector<std::vector<int>> adcs_;
+  std::vector<std::vector<float>> fcs_;
+  std::vector<std::vector<float>> pedestalfcs_;
+  std::vector<std::vector<int>> capids_;
+  std::vector<std::vector<int>> fibers_;
+  std::vector<std::vector<int>> fiberChans_;
+  std::vector<std::vector<int>> dvs_;
+  std::vector<std::vector<int>> ers_;
+
+  HODigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS);
+  void add(const HODataFrame* digi, const edm::ESHandle<HcalDbService>& dbService);
+  void reset();
+};
+
+#endif

--- a/DPGAnalysis/HcalNanoAOD/interface/QIE10DigiSortedTable.h
+++ b/DPGAnalysis/HcalNanoAOD/interface/QIE10DigiSortedTable.h
@@ -1,0 +1,49 @@
+#ifndef QIE10DigiSortedTable_h
+#define QIE10DigiSortedTable_h
+
+#include <vector>
+#include <map>
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "DQM/HcalCommon/interface/Utilities.h"
+
+class QIE10DigiSortedTable {
+public:
+  std::vector<HcalDetId> dids_;
+  std::map<HcalDetId, unsigned int> did_indexmap_;  // Use std::map for efficient lookup, rather than std::find
+
+  std::vector<int> ietas_;
+  std::vector<int> iphis_;
+  std::vector<int> subdets_;
+  std::vector<int> depths_;
+  std::vector<int> rawIds_;
+  std::vector<bool> linkErrors_;
+  std::vector<int> flags_;
+  std::vector<int> sois_;
+  std::vector<bool> valids_;
+  //std::vector<uint8_t> sipmTypes_;
+
+  unsigned int nTS_;
+  std::vector<std::vector<int>> adcs_;
+  std::vector<std::vector<float>> fcs_;
+  std::vector<std::vector<float>> pedestalfcs_;
+  std::vector<std::vector<int>> tdcs_;
+  std::vector<std::vector<int>> capids_;
+  std::vector<std::vector<bool>> oks_;
+
+  QIE10DigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS);
+  void add(const QIE10DataFrame* digi, const edm::ESHandle<HcalDbService>& dbService);
+  void reset();
+};
+
+typedef QIE10DigiSortedTable HFDigiSortedTable;
+
+#endif

--- a/DPGAnalysis/HcalNanoAOD/interface/QIE11DigiSortedTable.h
+++ b/DPGAnalysis/HcalNanoAOD/interface/QIE11DigiSortedTable.h
@@ -1,0 +1,49 @@
+#ifndef QIE11DigiSortedTable_h
+#define QIE11DigiSortedTable_h
+
+#include <vector>
+#include <map>
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "DQM/HcalCommon/interface/Utilities.h"
+
+class QIE11DigiSortedTable {
+public:
+  std::vector<HcalDetId> dids_;
+  std::map<HcalDetId, unsigned int> did_indexmap_;  // Use std::map for efficient lookup, rather than std::find
+
+  std::vector<int> ietas_;
+  std::vector<int> iphis_;
+  std::vector<int> subdets_;
+  std::vector<int> depths_;
+  std::vector<int> rawIds_;
+  std::vector<bool> linkErrors_;
+  std::vector<bool> capidErrors_;
+  std::vector<int> flags_;
+  std::vector<int> sois_;
+  std::vector<bool> valids_;
+  std::vector<uint8_t> sipmTypes_;
+
+  unsigned int nTS_;
+  std::vector<std::vector<int>> adcs_;
+  std::vector<std::vector<float>> fcs_;
+  std::vector<std::vector<float>> pedestalfcs_;
+  std::vector<std::vector<int>> tdcs_;
+  std::vector<std::vector<int>> capids_;
+
+  QIE11DigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS);
+  void add(const QIE11DataFrame* digi, const edm::ESHandle<HcalDbService>& dbService);
+  void reset();
+};
+
+typedef QIE11DigiSortedTable HBDigiSortedTable;
+typedef QIE11DigiSortedTable HEDigiSortedTable;
+#endif

--- a/DPGAnalysis/HcalNanoAOD/plugins/BuildFile.xml
+++ b/DPGAnalysis/HcalNanoAOD/plugins/BuildFile.xml
@@ -1,0 +1,27 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
+<use name="DataFormats/Candidate"/>
+<use name="DataFormats/PatCandidates"/>
+<use name="DataFormats/NanoAOD"/>
+<use name="DataFormats/L1TGlobal"/>
+<use name="DataFormats/CTPPSDetId"/>
+<use name="DataFormats/CTPPSReco"/>
+<use name="DataFormats/ProtonReco"/>
+<use name="DataFormats/HcalDetId"/>
+<use name="DataFormats/FEDRawData"/>
+<use name="EventFilter/HcalRawToDigi"/>
+<use name="PhysicsTools/PatAlgos"/>
+<use name="roothistmatrix"/>
+<use name="IOPool/Provenance"/>
+<use name="CondFormats/L1TObjects"/>
+<use name="CondFormats/HcalObjects"/>
+<use name="CondFormats/RunInfo"/>
+<use name="CondFormats/DataRecord"/>
+<use name="DQM/HcalCommon"/>
+<use name="CalibFormats/CaloObjects"/>
+<use name="DPGAnalysis/HcalNanoAOD"/>
+<library file="*.cc" name="DPGAnalysisHcalNanoAOD_plugins">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalDetIdTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalDetIdTableProducer.cc
@@ -1,0 +1,108 @@
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+class HcalDetIdTableProducer : public edm::global::EDProducer<edm::BeginRunProducer> {
+private:
+  edm::ESGetToken<HcalDbService, HcalDbRecord> tokenHcalDbService_;
+  edm::EDPutTokenT<std::vector<HcalDetId>> hbDetIdListToken_;
+  edm::EDPutTokenT<std::vector<HcalDetId>> heDetIdListToken_;
+  edm::EDPutTokenT<std::vector<HcalDetId>> hfDetIdListToken_;
+  edm::EDPutTokenT<std::vector<HcalDetId>> hoDetIdListToken_;
+
+public:
+  explicit HcalDetIdTableProducer(const edm::ParameterSet& iConfig)
+      : tokenHcalDbService_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()) {
+    hbDetIdListToken_ = produces<std::vector<HcalDetId>, edm::Transition::BeginRun>("HBDetIdList");
+    heDetIdListToken_ = produces<std::vector<HcalDetId>, edm::Transition::BeginRun>("HEDetIdList");
+    hfDetIdListToken_ = produces<std::vector<HcalDetId>, edm::Transition::BeginRun>("HFDetIdList");
+    hoDetIdListToken_ = produces<std::vector<HcalDetId>, edm::Transition::BeginRun>("HODetIdList");
+
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>("HBDetIdList");
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>("HEDetIdList");
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>("HFDetIdList");
+    produces<nanoaod::FlatTable, edm::Transition::BeginRun>("HODetIdList");
+  };
+
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+  void globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const& iSetup) const override;
+};
+
+void HcalDetIdTableProducer::produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const {}
+
+void HcalDetIdTableProducer::globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const& iSetup) const {
+  // Setup products
+  const std::vector<HcalSubdetector> subdets = {HcalBarrel, HcalEndcap, HcalForward, HcalOuter};
+  std::map<HcalSubdetector, std::unique_ptr<std::vector<HcalDetId>>> didLists;
+  didLists[HcalBarrel] = std::make_unique<std::vector<HcalDetId>>();
+  didLists[HcalEndcap] = std::make_unique<std::vector<HcalDetId>>();
+  didLists[HcalForward] = std::make_unique<std::vector<HcalDetId>>();
+  didLists[HcalOuter] = std::make_unique<std::vector<HcalDetId>>();
+
+  // Load channels from emap
+  edm::ESHandle<HcalDbService> dbService = iSetup.getHandle(tokenHcalDbService_);
+  HcalElectronicsMap const* emap = dbService->getHcalMapping();
+
+  std::vector<HcalGenericDetId> alldids = emap->allPrecisionId();
+  for (auto it_did = alldids.begin(); it_did != alldids.end(); ++it_did) {
+    if (!it_did->isHcalDetId()) {
+      continue;
+    }
+    HcalDetId did = HcalDetId(it_did->rawId());
+    if (!(did.subdet() == HcalBarrel || did.subdet() == HcalEndcap || did.subdet() == HcalForward ||
+          did.subdet() == HcalOuter)) {
+      continue;
+    }
+
+    // TODO: Add filtering, for example on FED whitelist
+
+    didLists[did.subdet()]->push_back(did);
+  }
+
+  // Sort HcalDetIds
+  for (auto& it_subdet : subdets) {
+    std::sort(didLists[it_subdet]->begin(), didLists[it_subdet]->end());
+  }
+
+  // Make NanoAOD tables
+  std::map<HcalSubdetector, std::string> subdetNames = {
+      {HcalBarrel, "HB"}, {HcalEndcap, "HE"}, {HcalForward, "HF"}, {HcalOuter, "HO"}};
+
+  for (auto& it_subdet : subdets) {
+    auto didTable =
+        std::make_unique<nanoaod::FlatTable>(didLists[it_subdet]->size(), subdetNames[it_subdet], false, false);
+
+    std::vector<int> vdids;
+    for (auto& it_did : *(didLists[it_subdet])) {
+      vdids.push_back(it_did.rawId());
+    }
+    didTable->addColumn<int>("did", vdids, "HcalDetId");
+
+    iRun.put(std::move(didTable), subdetNames[it_subdet] + "DetIdList");
+    iRun.put(std::move(didLists[it_subdet]), subdetNames[it_subdet] + "DetIdList");
+  }
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalDetIdTableProducer);

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalDigiSortedTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalDigiSortedTableProducer.cc
@@ -1,0 +1,337 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
+#include "CondFormats/HcalObjects/interface/HcalChannelQuality.h"
+
+#include "DPGAnalysis/HcalNanoAOD/interface/QIE11DigiSortedTable.h"
+#include "DPGAnalysis/HcalNanoAOD/interface/QIE10DigiSortedTable.h"
+#include "DPGAnalysis/HcalNanoAOD/interface/HODigiSortedTable.h"
+
+class HcalDigiSortedTableProducer : public edm::stream::EDProducer<> {
+private:
+  std::map<HcalSubdetector, edm::Handle<std::vector<HcalDetId>>> dids_;
+
+  //std::map<HcalSubdetector, std::vector<HcalElectronicsId> > eids_;
+  static const std::vector<HcalSubdetector> subdets_;
+  HcalElectronicsMap const* emap_;
+
+  edm::InputTag tagHBDetIdList_;
+  edm::InputTag tagHEDetIdList_;
+  edm::InputTag tagHFDetIdList_;
+  edm::InputTag tagHODetIdList_;
+
+  edm::EDGetTokenT<std::vector<HcalDetId>> tokenHBDetIdList_;
+  edm::EDGetTokenT<std::vector<HcalDetId>> tokenHEDetIdList_;
+  edm::EDGetTokenT<std::vector<HcalDetId>> tokenHFDetIdList_;
+  edm::EDGetTokenT<std::vector<HcalDetId>> tokenHODetIdList_;
+
+  edm::InputTag tagQIE11_;
+  edm::InputTag tagQIE10_;
+  edm::InputTag tagHO_;
+
+  edm::EDGetTokenT<QIE11DigiCollection> tokenQIE11_;
+  edm::EDGetTokenT<QIE10DigiCollection> tokenQIE10_;
+  edm::EDGetTokenT<HODigiCollection> tokenHO_;
+
+  edm::ESGetToken<HcalDbService, HcalDbRecord> tokenHcalDbService_;
+  edm::ESHandle<HcalDbService> dbService_;
+
+  HBDigiSortedTable* hbDigiTable_;
+  HEDigiSortedTable* heDigiTable_;
+  HFDigiSortedTable* hfDigiTable_;
+  HODigiSortedTable* hoDigiTable_;
+
+  const unsigned int nTS_HB_;
+  const unsigned int nTS_HE_;
+  const unsigned int nTS_HF_;
+  const unsigned int nTS_HO_;
+
+public:
+  explicit HcalDigiSortedTableProducer(const edm::ParameterSet& iConfig)
+      : tokenHBDetIdList_(consumes<edm::InRun>(iConfig.getUntrackedParameter<edm::InputTag>(
+            "HBDetIdList", edm::InputTag("hcalDetIdTable", "HBDetIdList")))),
+        tokenHEDetIdList_(consumes<edm::InRun>(iConfig.getUntrackedParameter<edm::InputTag>(
+            "HEDetIdList", edm::InputTag("hcalDetIdTable", "HEDetIdList")))),
+        tokenHFDetIdList_(consumes<edm::InRun>(iConfig.getUntrackedParameter<edm::InputTag>(
+            "HFDetIdList", edm::InputTag("hcalDetIdTable", "HFDetIdList")))),
+        tokenHODetIdList_(consumes<edm::InRun>(iConfig.getUntrackedParameter<edm::InputTag>(
+            "HODetIdList", edm::InputTag("hcalDetIdTable", "HODetIdList")))),
+        tagQIE11_(iConfig.getUntrackedParameter<edm::InputTag>("tagQIE11", edm::InputTag("hcalDigis"))),
+        tagQIE10_(iConfig.getUntrackedParameter<edm::InputTag>("tagQIE10", edm::InputTag("hcalDigis"))),
+        tagHO_(iConfig.getUntrackedParameter<edm::InputTag>("tagHO", edm::InputTag("hcalDigis"))),
+        tokenHcalDbService_(esConsumes<HcalDbService, HcalDbRecord, edm::Transition::BeginRun>()),
+        nTS_HB_(iConfig.getUntrackedParameter<unsigned int>("nTS_HB", 8)),
+        nTS_HE_(iConfig.getUntrackedParameter<unsigned int>("nTS_HE", 8)),
+        nTS_HF_(iConfig.getUntrackedParameter<unsigned int>("nTS_HF", 3)),
+        nTS_HO_(iConfig.getUntrackedParameter<unsigned int>("nTS_HO", 10)) {
+    tokenQIE11_ = consumes<QIE11DigiCollection>(tagQIE11_);
+    tokenHO_ = consumes<HODigiCollection>(tagHO_);
+    tokenQIE10_ = consumes<QIE10DigiCollection>(tagQIE10_);
+
+    produces<nanoaod::FlatTable>("HBDigiSortedTable");
+    produces<nanoaod::FlatTable>("HEDigiSortedTable");
+    produces<nanoaod::FlatTable>("HFDigiSortedTable");
+    produces<nanoaod::FlatTable>("HODigiSortedTable");
+
+    hbDigiTable_ = nullptr;
+    heDigiTable_ = nullptr;
+    hfDigiTable_ = nullptr;
+    hoDigiTable_ = nullptr;
+  }
+
+  ~HcalDigiSortedTableProducer() override {
+    delete hbDigiTable_;
+    delete heDigiTable_;
+    delete hfDigiTable_;
+    delete hoDigiTable_;
+  };
+
+  /*
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<edm::InputTag>("tagQIE11")->setComment("Input QIE 11 digi collection");
+        // desc.add<std::string>("name")->setComment("");
+        descriptions.add("HcalDigiTable", desc);
+    }
+    */
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
+};
+
+const std::vector<HcalSubdetector> HcalDigiSortedTableProducer::subdets_ = {
+    HcalBarrel, HcalEndcap, HcalForward, HcalOuter};
+
+void HcalDigiSortedTableProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  // List DetIds of interest from emap
+  dbService_ = iSetup.getHandle(tokenHcalDbService_);
+  emap_ = dbService_->getHcalMapping();
+
+  iRun.getByToken(tokenHBDetIdList_, dids_[HcalBarrel]);
+  iRun.getByToken(tokenHEDetIdList_, dids_[HcalEndcap]);
+  iRun.getByToken(tokenHFDetIdList_, dids_[HcalForward]);
+  iRun.getByToken(tokenHODetIdList_, dids_[HcalOuter]);
+
+  // Create persistent, sorted digi storage
+  hbDigiTable_ = new HBDigiSortedTable(*(dids_[HcalBarrel]), nTS_HB_);
+  heDigiTable_ = new HEDigiSortedTable(*(dids_[HcalEndcap]), nTS_HE_);
+  hfDigiTable_ = new HFDigiSortedTable(*(dids_[HcalForward]), nTS_HF_);
+  hoDigiTable_ = new HODigiSortedTable(*(dids_[HcalOuter]), nTS_HO_);
+}
+
+void HcalDigiSortedTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // * Load digis */
+  edm::Handle<QIE11DigiCollection> qie11Digis;
+  iEvent.getByToken(tokenQIE11_, qie11Digis);
+
+  edm::Handle<QIE10DigiCollection> qie10Digis;
+  iEvent.getByToken(tokenQIE10_, qie10Digis);
+
+  edm::Handle<HODigiCollection> hoDigis;
+  iEvent.getByToken(tokenHO_, hoDigis);
+
+  // * Process digis */
+  // HB
+  hbDigiTable_->reset();
+  for (QIE11DigiCollection::const_iterator itDigi = qie11Digis->begin(); itDigi != qie11Digis->end(); ++itDigi) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*itDigi);
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalBarrel)
+      continue;
+
+    hbDigiTable_->add(&digi, dbService_);
+  }  // End loop over qie11 HB digis
+
+  // HE
+  heDigiTable_->reset();
+  for (QIE11DigiCollection::const_iterator itDigi = qie11Digis->begin(); itDigi != qie11Digis->end(); ++itDigi) {
+    const QIE11DataFrame digi = static_cast<const QIE11DataFrame>(*itDigi);
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalEndcap)
+      continue;
+
+    heDigiTable_->add(&digi, dbService_);
+  }  // End loop over qie11 HE digis
+
+  // HF
+  hfDigiTable_->reset();
+  for (QIE10DigiCollection::const_iterator itDigi = qie10Digis->begin(); itDigi != qie10Digis->end(); ++itDigi) {
+    const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*itDigi);
+    HcalDetId const& did = digi.detid();
+    if (did.subdet() != HcalForward)
+      continue;
+
+    hfDigiTable_->add(&digi, dbService_);
+  }  // End loop over qie10 HF digis
+
+  // HO
+  hoDigiTable_->reset();
+  for (HODigiCollection::const_iterator itDigi = hoDigis->begin(); itDigi != hoDigis->end(); ++itDigi) {
+    const HODataFrame digi = static_cast<const HODataFrame>(*itDigi);
+    HcalDetId const& did = digi.id();
+    if (did.subdet() != HcalOuter)
+      continue;
+
+    hoDigiTable_->add(&digi, dbService_);
+  }  // End loop over HO digis
+
+  // * Save to NanoAOD tables */
+
+  // HB
+  auto hbNanoTable = std::make_unique<nanoaod::FlatTable>(dids_[HcalBarrel]->size(), "DigiHB", false, false);
+  hbNanoTable->addColumn<int>("rawId", hbDigiTable_->rawIds_, "rawId");
+  hbNanoTable->addColumn<int>("ieta", hbDigiTable_->ietas_, "ieta");
+  hbNanoTable->addColumn<int>("iphi", hbDigiTable_->iphis_, "iphi");
+  hbNanoTable->addColumn<int>("depth", hbDigiTable_->depths_, "depth");
+  hbNanoTable->addColumn<int>("subdet", hbDigiTable_->subdets_, "subdet");
+  hbNanoTable->addColumn<bool>("linkError", hbDigiTable_->linkErrors_, "linkError");
+  hbNanoTable->addColumn<bool>("capidError", hbDigiTable_->capidErrors_, "capidError");
+  hbNanoTable->addColumn<int>("flags", hbDigiTable_->flags_, "flags");
+  hbNanoTable->addColumn<int>("soi", hbDigiTable_->sois_, "soi");
+  hbNanoTable->addColumn<bool>("valid", hbDigiTable_->valids_, "valid");
+  hbNanoTable->addColumn<uint8_t>("sipmTypes", hbDigiTable_->sipmTypes_, "sipmTypes");
+
+  for (unsigned int iTS = 0; iTS < 8; ++iTS) {
+    hbNanoTable->addColumn<int>(
+        std::string("adc") + std::to_string(iTS), hbDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
+    hbNanoTable->addColumn<int>(
+        std::string("tdc") + std::to_string(iTS), hbDigiTable_->tdcs_[iTS], std::string("tdc") + std::to_string(iTS));
+    hbNanoTable->addColumn<int>(std::string("capid") + std::to_string(iTS),
+                                hbDigiTable_->capids_[iTS],
+                                std::string("capid") + std::to_string(iTS));
+    hbNanoTable->addColumn<float>(
+        std::string("fc") + std::to_string(iTS), hbDigiTable_->fcs_[iTS], std::string("fc") + std::to_string(iTS));
+    hbNanoTable->addColumn<float>(std::string("pedestalfc") + std::to_string(iTS),
+                                  hbDigiTable_->pedestalfcs_[iTS],
+                                  std::string("pedestalfc") + std::to_string(iTS));
+  }
+  iEvent.put(std::move(hbNanoTable), "HBDigiSortedTable");
+
+  // HE
+  auto heNanoTable = std::make_unique<nanoaod::FlatTable>(dids_[HcalEndcap]->size(), "DigiHE", false, false);
+  heNanoTable->addColumn<int>("rawId", heDigiTable_->rawIds_, "rawId");
+  heNanoTable->addColumn<int>("ieta", heDigiTable_->ietas_, "ieta");
+  heNanoTable->addColumn<int>("iphi", heDigiTable_->iphis_, "iphi");
+  heNanoTable->addColumn<int>("depth", heDigiTable_->depths_, "depth");
+  heNanoTable->addColumn<int>("subdet", heDigiTable_->subdets_, "subdet");
+  heNanoTable->addColumn<bool>("linkError", heDigiTable_->linkErrors_, "linkError");
+  heNanoTable->addColumn<bool>("capidError", heDigiTable_->capidErrors_, "capidError");
+  heNanoTable->addColumn<int>("flags", heDigiTable_->flags_, "flags");
+  heNanoTable->addColumn<int>("soi", heDigiTable_->sois_, "soi");
+  heNanoTable->addColumn<bool>("valid", heDigiTable_->valids_, "valid");
+  heNanoTable->addColumn<uint8_t>("sipmTypes", heDigiTable_->sipmTypes_, "sipmTypes");
+
+  for (unsigned int iTS = 0; iTS < 8; ++iTS) {
+    heNanoTable->addColumn<int>(
+        std::string("adc") + std::to_string(iTS), heDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
+    heNanoTable->addColumn<int>(
+        std::string("tdc") + std::to_string(iTS), heDigiTable_->tdcs_[iTS], std::string("tdc") + std::to_string(iTS));
+    heNanoTable->addColumn<int>(std::string("capid") + std::to_string(iTS),
+                                heDigiTable_->capids_[iTS],
+                                std::string("capid") + std::to_string(iTS));
+    heNanoTable->addColumn<float>(
+        std::string("fc") + std::to_string(iTS), heDigiTable_->fcs_[iTS], std::string("fc") + std::to_string(iTS));
+    heNanoTable->addColumn<float>(std::string("pedestalfc") + std::to_string(iTS),
+                                  heDigiTable_->pedestalfcs_[iTS],
+                                  std::string("pedestalfc") + std::to_string(iTS));
+  }
+  iEvent.put(std::move(heNanoTable), "HEDigiSortedTable");
+
+  // HF
+  auto hfNanoTable = std::make_unique<nanoaod::FlatTable>(dids_[HcalForward]->size(), "DigiHF", false, false);
+  hfNanoTable->addColumn<int>("rawId", hfDigiTable_->rawIds_, "rawId");
+  hfNanoTable->addColumn<int>("ieta", hfDigiTable_->ietas_, "ieta");
+  hfNanoTable->addColumn<int>("iphi", hfDigiTable_->iphis_, "iphi");
+  hfNanoTable->addColumn<int>("depth", hfDigiTable_->depths_, "depth");
+  hfNanoTable->addColumn<int>("subdet", hfDigiTable_->subdets_, "subdet");
+  hfNanoTable->addColumn<bool>("linkError", hfDigiTable_->linkErrors_, "linkError");
+  hfNanoTable->addColumn<int>("flags", hfDigiTable_->flags_, "flags");
+  hfNanoTable->addColumn<int>("soi", hfDigiTable_->sois_, "soi");
+  hfNanoTable->addColumn<bool>("valid", hfDigiTable_->valids_, "valid");
+  //hfNanoTable->addColumn<uint8_t>("sipmTypes", hfDigiTable_->sipmTypes_, "sipmTypes");
+
+  for (unsigned int iTS = 0; iTS < 3; ++iTS) {
+    hfNanoTable->addColumn<int>(
+        std::string("adc") + std::to_string(iTS), hfDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
+    hfNanoTable->addColumn<int>(
+        std::string("tdc") + std::to_string(iTS), hfDigiTable_->tdcs_[iTS], std::string("tdc") + std::to_string(iTS));
+    //hfNanoTable->addColumn<int>(std::string("tetdc") + std::to_string(iTS),
+    //                                hfDigiTable_->tetdcs_[iTS],
+    //                                std::string("tetdc") + std::to_string(iTS));
+    hfNanoTable->addColumn<int>(std::string("capid") + std::to_string(iTS),
+                                hfDigiTable_->capids_[iTS],
+                                std::string("capid") + std::to_string(iTS));
+    hfNanoTable->addColumn<float>(
+        std::string("fc") + std::to_string(iTS), hfDigiTable_->fcs_[iTS], std::string("fc") + std::to_string(iTS));
+    hfNanoTable->addColumn<float>(std::string("pedestalfc") + std::to_string(iTS),
+                                  hfDigiTable_->pedestalfcs_[iTS],
+                                  std::string("pedestalfc") + std::to_string(iTS));
+    hfNanoTable->addColumn<float>(
+        std::string("ok") + std::to_string(iTS), hfDigiTable_->oks_[iTS], std::string("ok") + std::to_string(iTS));
+  }
+  iEvent.put(std::move(hfNanoTable), "HFDigiSortedTable");
+
+  // HO
+  auto hoNanoTable = std::make_unique<nanoaod::FlatTable>(dids_[HcalOuter]->size(), "DigiHO", false, false);
+  hoNanoTable->addColumn<int>("rawId", hoDigiTable_->rawIds_, "rawId");
+  hoNanoTable->addColumn<int>("ieta", hoDigiTable_->ietas_, "ieta");
+  hoNanoTable->addColumn<int>("iphi", hoDigiTable_->iphis_, "iphi");
+  hoNanoTable->addColumn<int>("depth", hoDigiTable_->depths_, "depth");
+  hoNanoTable->addColumn<int>("subdet", hoDigiTable_->subdets_, "subdet");
+  hoNanoTable->addColumn<int>("fiberIdleOffset", hoDigiTable_->fiberIdleOffsets_, "fiberIdleOffset");
+  hoNanoTable->addColumn<int>("soi", hoDigiTable_->sois_, "soi");
+  hoNanoTable->addColumn<bool>("valid", hoDigiTable_->valids_, "valid");
+
+  for (unsigned int iTS = 0; iTS < 10; ++iTS) {
+    hoNanoTable->addColumn<int>(
+        std::string("adc") + std::to_string(iTS), hoDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
+    hoNanoTable->addColumn<int>(std::string("capid") + std::to_string(iTS),
+                                hoDigiTable_->capids_[iTS],
+                                std::string("capid") + std::to_string(iTS));
+    hoNanoTable->addColumn<float>(
+        std::string("fc") + std::to_string(iTS), hoDigiTable_->fcs_[iTS], std::string("fc") + std::to_string(iTS));
+    hoNanoTable->addColumn<float>(std::string("pedestalfc") + std::to_string(iTS),
+                                  hoDigiTable_->pedestalfcs_[iTS],
+                                  std::string("pedestalfc") + std::to_string(iTS));
+    hoNanoTable->addColumn<int>(std::string("fiber") + std::to_string(iTS),
+                                hoDigiTable_->fibers_[iTS],
+                                std::string("fiber") + std::to_string(iTS));
+    hoNanoTable->addColumn<int>(std::string("fiberChan") + std::to_string(iTS),
+                                hoDigiTable_->fiberChans_[iTS],
+                                std::string("fiberChan") + std::to_string(iTS));
+    hoNanoTable->addColumn<int>(
+        std::string("dv") + std::to_string(iTS), hoDigiTable_->dvs_[iTS], std::string("dv") + std::to_string(iTS));
+    hoNanoTable->addColumn<int>(
+        std::string("er") + std::to_string(iTS), hoDigiTable_->ers_[iTS], std::string("er") + std::to_string(iTS));
+  }
+  iEvent.put(std::move(hoNanoTable), "HODigiSortedTable");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalDigiSortedTableProducer);

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalRecHitTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalRecHitTableProducer.cc
@@ -1,0 +1,15 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+typedef SimpleFlatTableProducer<HBHERecHit> HBHERecHitFlatTableProducer;
+
+#include "DataFormats/HcalRecHit/interface/HFRecHit.h"
+typedef SimpleFlatTableProducer<HFRecHit> HFRecHitFlatTableProducer;
+
+#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+typedef SimpleFlatTableProducer<HORecHit> HORecHitFlatTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HBHERecHitFlatTableProducer);
+DEFINE_FWK_MODULE(HFRecHitFlatTableProducer);
+DEFINE_FWK_MODULE(HORecHitFlatTableProducer);

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalUHTRTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalUHTRTableProducer.cc
@@ -1,0 +1,106 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "EventFilter/HcalRawToDigi/interface/HcalUHTRData.h"
+#include "EventFilter/HcalRawToDigi/interface/AMC13Header.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include <iostream>
+
+class HcalUHTRTableProducer : public edm::stream::EDProducer<> {
+private:
+  edm::EDGetTokenT<FEDRawDataCollection> tokenRaw_;
+  edm::InputTag tagRaw_;
+  std::vector<int> fedUnpackList_;
+
+public:
+  explicit HcalUHTRTableProducer(const edm::ParameterSet& iConfig)
+      : tagRaw_(iConfig.getParameter<edm::InputTag>("InputLabel")),
+        fedUnpackList_(iConfig.getUntrackedParameter<std::vector<int>>("FEDs", std::vector<int>())) {
+    tokenRaw_ = consumes<FEDRawDataCollection>(tagRaw_);
+    produces<nanoaod::FlatTable>("uHTRTable");
+
+    if (fedUnpackList_.empty()) {
+      // VME range for back-compatibility
+      for (int i = FEDNumbering::MINHCALFEDID; i <= FEDNumbering::MAXHCALFEDID; i++)
+        fedUnpackList_.push_back(i);
+
+      // uTCA range
+      for (int i = FEDNumbering::MINHCALuTCAFEDID; i <= FEDNumbering::MAXHCALuTCAFEDID; i++)
+        fedUnpackList_.push_back(i);
+    }
+  }
+
+  ~HcalUHTRTableProducer() override{};
+
+  /*
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<edm::InputTag>("tagUHTR")->setComment("Input uMNio digi collection");
+        descriptions.add("HcalUHTRTable", desc);
+    }
+    */
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
+};
+
+void HcalUHTRTableProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
+
+void HcalUHTRTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::vector<int> crate;
+  std::vector<int> slot;
+  std::vector<uint32_t> evn;
+  std::vector<uint32_t> bcn;
+  std::vector<uint32_t> orn;
+  std::vector<int> eventType;
+
+  edm::Handle<FEDRawDataCollection> raw;
+  iEvent.getByToken(tokenRaw_, raw);
+  for (std::vector<int>::const_iterator i = fedUnpackList_.begin(); i != fedUnpackList_.end(); i++) {
+    const FEDRawData& fed = raw->FEDData(*i);
+    hcal::AMC13Header const* hamc13 = (hcal::AMC13Header const*)fed.data();
+    if (!hamc13) {
+      continue;
+    }
+    int namc = hamc13->NAMC();
+    for (int iamc = 0; iamc < namc; iamc++) {
+      HcalUHTRData uhtr(hamc13->AMCPayload(iamc), hamc13->AMCSize(iamc));
+      crate.push_back(uhtr.crateId());
+      slot.push_back(uhtr.slot());
+      evn.push_back(uhtr.l1ANumber());
+      bcn.push_back(uhtr.bunchNumber());
+      orn.push_back(uhtr.orbitNumber());
+      eventType.push_back(uhtr.getEventType());
+    }
+  }
+
+  auto uHTRNanoTable = std::make_unique<nanoaod::FlatTable>(crate.size(), "uHTR", false, false);
+  uHTRNanoTable->addColumn<int>("crate", crate, "crate");
+  uHTRNanoTable->addColumn<int>("slot", slot, "slot");
+  uHTRNanoTable->addColumn<uint32_t>("evn", evn, "evn");
+  uHTRNanoTable->addColumn<uint32_t>("bcn", bcn, "bcn");
+  uHTRNanoTable->addColumn<uint32_t>("orn", orn, "orn");
+  uHTRNanoTable->addColumn<int>("eventType", eventType, "eventType");
+
+  iEvent.put(std::move(uHTRNanoTable), "uHTRTable");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalUHTRTableProducer);

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalUMNioTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalUMNioTableProducer.cc
@@ -1,0 +1,66 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/Transition.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/HcalDigi/interface/HcalUMNioDigi.h"
+
+class HcalUMNioTableProducer : public edm::stream::EDProducer<> {
+private:
+  edm::EDGetTokenT<HcalUMNioDigi> tokenUMNio_;
+  edm::InputTag tagUMNio_;
+
+public:
+  explicit HcalUMNioTableProducer(const edm::ParameterSet& iConfig)
+      : tagUMNio_(iConfig.getUntrackedParameter<edm::InputTag>("tagUMNio", edm::InputTag("hcalDigis"))) {
+    tokenUMNio_ = consumes<HcalUMNioDigi>(tagUMNio_);
+
+    produces<nanoaod::FlatTable>("uMNioTable");
+  }
+
+  ~HcalUMNioTableProducer() override{};
+
+  /*
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<edm::InputTag>("tagUMNio")->setComment("Input uMNio digi collection");
+        descriptions.add("HcalUMNioTable", desc);
+    }
+    */
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
+};
+
+void HcalUMNioTableProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
+
+void HcalUMNioTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<HcalUMNioDigi> uMNioDigi;
+  iEvent.getByToken(tokenUMNio_, uMNioDigi);
+  uint8_t eventType = uMNioDigi->eventType();
+
+  auto uMNioNanoTable = std::make_unique<nanoaod::FlatTable>(1, "uMNio", true);
+  uMNioNanoTable->addColumnValue<uint8_t>("EventType", eventType, "EventType");
+  for (int iWord = 0; iWord < uMNioDigi->numberUserWords(); ++iWord) {
+    uint32_t thisWord = uMNioDigi->valueUserWord(iWord);
+    uMNioNanoTable->addColumnValue<uint32_t>(
+        "UserWord" + std::to_string(iWord), thisWord, "UserWord" + std::to_string(iWord));
+  }
+  iEvent.put(std::move(uMNioNanoTable), "uMNioTable");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalUMNioTableProducer);

--- a/DPGAnalysis/HcalNanoAOD/python/customiseHcalCalib_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/customiseHcalCalib_cff.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+# Customization for running on testEnablesEcalHcal
+#   - Call from cmsDriver.py with: `--customise DPGAnalysis/HcalNanoAOD/customiseHcalCalib_cff.customiseHcalCalib`
+def customiseHcalCalib(process):
+    # Add uMNio digi (special digi identifies calib event type)
+    process.load("DPGAnalysis.HcalNanoAOD.hcalUMNioTable_cff")
+    process.hcalNanoTask.add(process.uMNioTable)
+    process.hcalNanoDigiTask.add(process.uMNioTable)
+
+    process.load("DPGAnalysis.HcalNanoAOD.hcalUHTRTable_cff")
+    process.hcalNanoTask.add(process.uHTRTable)
+    process.hcalNanoDigiTask.add(process.uHTRTable)
+
+    # Raw data has a different name, hltHcalCalibrationRaw instead of rawDataCollector
+    process.hcalDigis.InputLabel = cms.InputTag('hltHcalCalibrationRaw')
+    process.uHTRTable.InputLabel = process.hcalDigis.InputLabel
+    
+    # Create EDFilter for HLT_HcalCalibration
+    # (HCAL raw data is not present in ECAL-triggered events, annoyingly. The filter stops downstream modules from throwing ProductNotFound.)
+    process.hcalCalibHLTFilter = cms.EDFilter("TriggerResultsFilter",
+        triggerConditions = cms.vstring(
+          'HLT_HcalCalibration_v* / 1'),
+        hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+        l1tResults = cms.InputTag( "" ),
+        l1tIgnoreMask = cms.bool( False ),
+        l1techIgnorePrescales = cms.bool( False ),
+        daqPartitions = cms.uint32( 1 ),
+        throw = cms.bool( True )
+    )
+
+    # Remove hcalDigis from normal raw2digi task, and put on a sequence after the HLT filter
+    process.RawToDigiTask.remove(process.hcalDigis)
+    process.hcalCalibDigiSequence = cms.Sequence(process.hcalCalibHLTFilter + process.hcalDigis)
+    process.raw2digi_step = cms.Path(process.hcalCalibDigiSequence, process.RawToDigiTask)
+
+    # Insert the HLT filter at start of user path and nanoaod endpath
+    process.user_step.insert(0, process.hcalCalibHLTFilter)
+    process.NANOAODoutput_step.insert(0, process.hcalCalibHLTFilter)
+
+
+    #process.raw2digi_step = cms.Path(process.hcalCalibHLTFilter + process.RawToDigi)
+    #process.raw2digi_step.replace(process.hcalDigis, process.hcalCalibDigis)
+    #process.hcalDigiSortedTableTask.add(process.hcalCalibDigis)
+    #process.hcalDigiSortedTableSeq.add(process.hcalCalibDigis)
+
+    #process.options.SkipEvent.append('ProductNotFound')
+
+    #process.hcalDigiSortedTable.tagQIE11 = cms.untracked.InputTag("hcalCalibDigis")
+    #process.hcalDigiSortedTable.tagQIE10 = cms.untracked.InputTag("hcalCalibDigis")
+    #process.hcalDigiSortedTable.tagHO    = cms.untracked.InputTag("hcalCalibDigis")
+
+    process.load("FWCore.MessageService.MessageLogger_cfi")
+    process.MessageLogger.cout.threshold = "DEBUG"
+    process.MessageLogger.cerr.threshold = "DEBUG"
+    # enable LogDebug messages only for specific modules
+    process.MessageLogger.debugModules = ["*"]
+
+    return process

--- a/DPGAnalysis/HcalNanoAOD/python/customiseHcalLocal_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/customiseHcalLocal_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+# Customization for running on HCAL local run data
+#   - Call from cmsDriver.py with: `--customise DPGAnalysis/HcalNanoAOD/customise_hcalLocal_cff.customiseHcalLocal`
+def customiseHcalLocal(process):
+    input_files = process.source.fileNames
+    max_events = process.maxEvents.input
+    process.source = cms.Source("HcalTBSource",
+        fileNames = input_files,
+        maxEvents = max_events,
+        firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID([]),
+    )
+    process.hcalDigis.InputLabel = cms.InputTag('source')
+    #process.hcalDigis.saveQIE10DataNSamples = cms.untracked.vint32(10) 
+    #process.hcalDigis.saveQIE10DataTags = cms.untracked.vstring("ZDC")
+
+    if hasattr(process, "hcalDigiSortedTableTask"):
+        process.hcalDigiSortedTable.nTS_HB = cms.untracked.uint32(8)
+        process.hcalDigiSortedTable.nTS_HE = cms.untracked.uint32(8)
+        process.hcalDigiSortedTable.nTS_HF = cms.untracked.uint32(6)
+        process.hcalDigiSortedTable.nTS_HO = cms.untracked.uint32(10)
+
+    process.load("DPGAnalysis.HcalNanoAOD.hcalUMNioTable_cff")
+    if hasattr(process, "hcalNanoTask"):
+        process.hcalNanoTask.add(process.uMNioTable)
+    if hasattr(process, "hcalNanoDigiTask"):
+        process.hcalNanoDigiTask.add(process.uMNioTable)
+
+    return process

--- a/DPGAnalysis/HcalNanoAOD/python/hcalDetIdTable_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalDetIdTable_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from  PhysicsTools.NanoAOD.common_cff import *
+
+hcalDetIdTable = cms.EDProducer("HcalDetIdTableProducer")
+hcalDetIdTableTask = cms.Task(hcalDetIdTable)
+hcalDetIdTableSeq = cms.Sequence(hcalDetIdTable)

--- a/DPGAnalysis/HcalNanoAOD/python/hcalDigiSortedTable_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalDigiSortedTable_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+from  PhysicsTools.NanoAOD.common_cff import *
+
+# IMPORTANT: This variable has to end in "Table"! 
+#     Otherwise, the NanoAODOutputModule will ignore it by default 
+#     (e.g., the `keep nanoaodFlatTable_*Table_*_*"` bit in 
+#     process.NanoAODEDMEventContent.outputCommands, 
+#     see cmssw source code for details on this arcane syntax)
+hcalDigiSortedTable= cms.EDProducer("HcalDigiSortedTableProducer",
+  tagQIE11    = cms.untracked.InputTag("hcalDigis"),
+  tagQIE10    = cms.untracked.InputTag("hcalDigis"),
+  tagHO       = cms.untracked.InputTag("hcalDigis"),
+  #taguMNio   = cms.untracked.InputTag("hcalDigis"),
+  #StoreLaser = cms.untracked.bool(False),
+  #chargeSkim = cms.untracked.double(0)
+)
+
+hcalDigiSortedTableTask = cms.Task(hcalDigiSortedTable)
+hcalDigiSortedTableSeq = cms.Sequence(hcalDigiSortedTable)

--- a/DPGAnalysis/HcalNanoAOD/python/hcalNano_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalNano_cff.py
@@ -1,0 +1,108 @@
+from PhysicsTools.NanoAOD.common_cff import Var,CandVars
+from DPGAnalysis.HcalNanoAOD.hcalRecHitTable_cff import *
+from DPGAnalysis.HcalNanoAOD.hcalDigiSortedTable_cff import *
+from DPGAnalysis.HcalNanoAOD.hcalDetIdTable_cff import *
+
+nanoMetadata = cms.EDProducer("UniqueStringProducer",
+    strings = cms.PSet(
+        tag = cms.string("untagged"),
+    )
+)
+
+hcalNanoTask = cms.Task(
+    nanoMetadata, 
+    hcalDetIdTableTask, 
+    hcalDigiSortedTableTask, 
+    hcalRecHitTableTask, 
+)
+
+hcalNanoDigiTask = cms.Task(
+    nanoMetadata, 
+    hcalDetIdTableTask, 
+    hcalDigiSortedTableTask, 
+)
+
+hcalNanoRecHitTask = cms.Task(
+    nanoMetadata, 
+    hcalDetIdTableTask, 
+    hcalRecHitTableTask, 
+)
+
+# Tasks for HCAL AlCa workflows
+hcalNanoPhiSymTask = cms.Task(
+    nanoMetadata, 
+    hcalDetIdTableTask, 
+    hbheRecHitTable,
+    hfRecHitTable,
+)
+
+hcalNanoIsoTrkTask = cms.Task(
+    nanoMetadata, 
+    hcalDetIdTableTask, 
+    hbheRecHitTable,
+)
+
+# Customization for running on testEnablesEcalHcal
+#   - Call from cmsDriver.py with: `--customise DPGAnalysis/HcalNanoAOD/hcalNano_cff.customiseHcalCalib`
+def customiseHcalCalib(process):
+    # Add uMNio digi (special digi identifies calib event type)
+    process.load("DPGAnalysis.HcalNanoAOD.hcalUMNioTable_cff")
+    process.hcalNanoTask.add(process.uMNioTable)
+    process.hcalNanoDigiTask.add(process.uMNioTable)
+
+    # Raw data has a different name, hltHcalCalibrationRaw instead of rawDataCollector
+    process.hcalDigis.InputLabel = cms.InputTag('hltHcalCalibrationRaw')
+
+    # Create EDFilter for HLT_HcalCalibration
+    # (HCAL raw data is not present in ECAL-triggered events, annoyingly. The filter stops downstream modules from throwing ProductNotFound.)
+    process.hcalCalibHLTFilter = cms.EDFilter("TriggerResultsFilter",
+        triggerConditions = cms.vstring(
+          'HLT_HcalCalibration_v* / 1'),
+        hltResults = cms.InputTag( "TriggerResults", "", "HLT" ),
+        l1tResults = cms.InputTag( "" ),
+        l1tIgnoreMask = cms.bool( False ),
+        l1techIgnorePrescales = cms.bool( False ),
+        daqPartitions = cms.uint32( 1 ),
+        throw = cms.bool( True )
+    )
+
+    # Remove hcalDigis from normal raw2digi task, and put on a sequence after the HLT filter
+    process.RawToDigiTask.remove(process.hcalDigis)
+    process.hcalCalibDigiSequence = cms.Sequence(process.hcalCalibHLTFilter + process.hcalDigis)
+    process.raw2digi_step = cms.Path(process.hcalCalibDigiSequence, process.RawToDigiTask)
+
+    # Insert the HLT filter at start of user path and nanoaod endpath
+    process.user_step.insert(0, process.hcalCalibHLTFilter)
+    process.NANOAODoutput_step.insert(0, process.hcalCalibHLTFilter)
+
+    return process
+
+# Customization for running on HCAL local run data
+#   - Call from cmsDriver.py with: `--customise DPGAnalysis/HcalNanoAOD/customise_hcalLocal_cff.customiseHcalLocal`
+def customiseHcalLocal(process):
+    input_files = process.source.fileNames
+    max_events = process.maxEvents.input
+    process.source = cms.Source("HcalTBSource",
+        fileNames = input_files,
+        maxEvents = max_events,
+        firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID([]),
+    )
+    process.hcalDigis.InputLabel = cms.InputTag('source')
+
+    # Uncomment if ZDC digis (QIE10, nTS=10) are causing problems
+    #process.hcalDigis.saveQIE10DataNSamples = cms.untracked.vint32(10) 
+    #process.hcalDigis.saveQIE10DataTags = cms.untracked.vstring("ZDC")
+
+    if hasattr(process, "hcalDigiSortedTableTask"):
+        process.hcalDigiSortedTable.nTS_HB = cms.untracked.uint32(8)
+        process.hcalDigiSortedTable.nTS_HE = cms.untracked.uint32(8)
+        process.hcalDigiSortedTable.nTS_HF = cms.untracked.uint32(6)
+        process.hcalDigiSortedTable.nTS_HO = cms.untracked.uint32(10)
+
+    process.load("DPGAnalysis.HcalNanoAOD.hcalUMNioTable_cff")
+    if hasattr(process, "hcalNanoTask"):
+        process.hcalNanoTask.add(process.uMNioTable)
+    if hasattr(process, "hcalNanoDigiTask"):
+        process.hcalNanoDigiTask.add(process.uMNioTable)
+
+    return process

--- a/DPGAnalysis/HcalNanoAOD/python/hcalRecHitTable_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalRecHitTable_cff.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import Var,P3Vars
+
+hbheRecHitTable = cms.EDProducer("HBHERecHitFlatTableProducer",
+    src       = cms.InputTag("hbhereco"),
+    cut       = cms.string(""), 
+    name      = cms.string("RecHitHBHE"),
+    doc       = cms.string("HCAL barrel and endcap rec hits"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the object
+    variables = cms.PSet(
+                    detId  = Var('detid().rawId()', 'int', precision=-1, doc='detId'),
+                    energy = Var('energy', 'float', precision=14, doc='energy'),
+                    time   = Var('time', 'float', precision=14, doc='hit time'),
+                    ieta   = Var('id().ieta()', 'int', precision=-1, doc='ieta'),
+                    iphi   = Var('id().iphi()', 'int', precision=-1, doc='iphi'),
+                    depth  = Var('id().depth()', 'int', precision=-1, doc='depth')
+                )
+)
+
+hfRecHitTable = cms.EDProducer("HFRecHitFlatTableProducer",
+    src       = cms.InputTag("hfreco"),
+    cut       = cms.string(""), 
+    name      = cms.string("RecHitHF"),
+    doc       = cms.string("HCAL forward (HF) rec hits"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the object
+    variables = cms.PSet(
+                    detId  = Var('detid().rawId()', 'int', precision=-1, doc='detId'),
+                    energy = Var('energy', 'float', precision=14, doc='energy'),
+                    time   = Var('time', 'float', precision=14, doc='hit time'),
+                    ieta   = Var('id().ieta()', 'int', precision=-1, doc='ieta'),
+                    iphi   = Var('id().iphi()', 'int', precision=-1, doc='iphi'),
+                    depth  = Var('id().depth()', 'int', precision=-1, doc='depth')
+                )
+)
+
+hoRecHitTable = cms.EDProducer("HORecHitFlatTableProducer",
+    src       = cms.InputTag("horeco"),
+    cut       = cms.string(""), 
+    name      = cms.string("RecHitHO"),
+    doc       = cms.string("HCAL outer (HO) rec hits"),
+    singleton = cms.bool(False), # the number of entries is variable
+    extension = cms.bool(False), # this is the main table for the object
+    variables = cms.PSet(
+                    detId  = Var('detid().rawId()', 'int', precision=-1, doc='detId'),
+                    energy = Var('energy', 'float', precision=14, doc='energy'),
+                    time   = Var('time', 'float', precision=14, doc='hit time'),
+                    ieta   = Var('id().ieta()', 'int', precision=-1, doc='ieta'),
+                    iphi   = Var('id().iphi()', 'int', precision=-1, doc='iphi'),
+                    depth  = Var('id().depth()', 'int', precision=-1, doc='depth')
+                )
+)
+
+hcalRecHitTableSeq = cms.Sequence(
+    hbheRecHitTable
+    + hfRecHitTable
+    + hoRecHitTable
+)
+
+hcalRecHitTableTask = cms.Task(
+    hbheRecHitTable,
+    hfRecHitTable,
+    hoRecHitTable,
+)

--- a/DPGAnalysis/HcalNanoAOD/python/hcalUHTRTable_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalUHTRTable_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+from  PhysicsTools.NanoAOD.common_cff import *
+
+# IMPORTANT: This variable has to end in "Table"! 
+uHTRTable= cms.EDProducer("HcalUHTRTableProducer",
+  InputLabel = cms.untracked.InputTag("rawDataCollector"),
+  FEDs = cms.untracked.vint32(),
+)
+
+uHTRTableTask = cms.Task(uHTRTable)
+uHTRTableSeq = cms.Sequence(uHTRTable)

--- a/DPGAnalysis/HcalNanoAOD/python/hcalUMNioTable_cff.py
+++ b/DPGAnalysis/HcalNanoAOD/python/hcalUMNioTable_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+from  PhysicsTools.NanoAOD.common_cff import *
+
+# IMPORTANT: This variable has to end in "Table"! 
+uMNioTable= cms.EDProducer("HcalUMNioTableProducer",
+  tagUMNio = cms.untracked.InputTag("hcalDigis"),
+)
+
+uMNioTableTask = cms.Task(uMNioTable)
+uMNioTableSeq = cms.Sequence(uMNioTable)

--- a/DPGAnalysis/HcalNanoAOD/src/HFPreRecHitSortedTable.cc
+++ b/DPGAnalysis/HcalNanoAOD/src/HFPreRecHitSortedTable.cc
@@ -1,0 +1,28 @@
+#include "DPGAnalysis/HcalNanoAOD/interface/HFPreRecHitSortedTable.h"
+
+HFPreRecHitSortedTable::HFPreRecHitSortedTable(const std::vector<HcalDetId>& dids) {
+  dids_ = dids;
+  for (std::vector<HcalDetId>::const_iterator it_did = dids_.begin(); it_did != dids_.end(); ++it_did) {
+    did_indexmap_[*it_did] = (unsigned int)(it_did - dids_.begin());
+  }
+
+  charges_.resize(dids_.size());
+  chargeAsymmetries_.resize(dids_.size());
+  valids_.resize(dids_.size());
+}
+
+void HFPreRecHitSortedTable::add(const HFPreRecHitCollection::const_iterator itPreRecHit) {
+  HcalDetId did = itPreRecHit->id();
+  unsigned int index = did_indexmap_.at(did);
+
+  charges_[index] = itPreRecHit->charge();
+  chargeAsymmetries_[index] =
+      itPreRecHit->chargeAsymmetry(0.).first;  // chargeAsymmetry() returns std::pair<float qAsym, bool passCut>
+  valids_[index] = true;
+}
+
+void HFPreRecHitSortedTable::reset() {
+  std::fill(charges_.begin(), charges_.end(), 0);
+  std::fill(chargeAsymmetries_.begin(), chargeAsymmetries_.end(), 0);
+  std::fill(valids_.begin(), valids_.end(), false);
+}

--- a/DPGAnalysis/HcalNanoAOD/src/HODigiSortedTable.cc
+++ b/DPGAnalysis/HcalNanoAOD/src/HODigiSortedTable.cc
@@ -1,0 +1,78 @@
+#include "DPGAnalysis/HcalNanoAOD/interface/HODigiSortedTable.h"
+
+HODigiSortedTable::HODigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS) {
+  dids_ = dids;
+  for (std::vector<HcalDetId>::const_iterator it_did = dids_.begin(); it_did != dids_.end(); ++it_did) {
+    did_indexmap_[*it_did] = (unsigned int)(it_did - dids_.begin());
+  }
+
+  nTS_ = nTS;
+
+  ietas_.resize(dids_.size());
+  iphis_.resize(dids_.size());
+  subdets_.resize(dids_.size());
+  depths_.resize(dids_.size());
+  rawIds_.resize(dids_.size());
+  fiberIdleOffsets_.resize(dids_.size());
+  sois_.resize(dids_.size());
+  valids_.resize(dids_.size());
+
+  adcs_.resize(nTS_, std::vector<int>(dids_.size()));
+  fcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  pedestalfcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  capids_.resize(nTS_, std::vector<int>(dids_.size()));
+  fibers_.resize(nTS_, std::vector<int>(dids_.size()));
+  fiberChans_.resize(nTS_, std::vector<int>(dids_.size()));
+  dvs_.resize(nTS_, std::vector<int>(dids_.size()));
+  ers_.resize(nTS_, std::vector<int>(dids_.size()));
+}
+
+void HODigiSortedTable::add(const HODataFrame* digi, const edm::ESHandle<HcalDbService>& dbService) {
+  HcalDetId did = digi->id();
+  unsigned int index = did_indexmap_.at(did);
+
+  CaloSamples digiCaloSamples = hcaldqm::utilities::loadADC2fCDB<HODataFrame>(dbService, did, *digi);
+  HcalCalibrations calibrations = dbService->getHcalCalibrations(did);
+
+  ietas_[index] = did.ieta();
+  iphis_[index] = did.iphi();
+  subdets_[index] = did.subdet();
+  depths_[index] = did.depth();
+  rawIds_[index] = did.rawId();
+  fiberIdleOffsets_[index] = digi->fiberIdleOffset();
+  sois_[index] = digi->presamples();
+
+  for (unsigned int iTS = 0; iTS < (unsigned int)digi->size(); ++iTS) {
+    adcs_[iTS][index] = digi->sample(iTS).adc();
+    capids_[iTS][index] = digi->sample(iTS).capid();
+    fcs_[iTS][index] = digiCaloSamples[iTS];
+    pedestalfcs_[iTS][index] = calibrations.pedestal(digi->sample(iTS).capid());
+    dvs_[iTS][index] = digi->sample(iTS).dv();
+    ers_[iTS][index] = digi->sample(iTS).er();
+  }
+  valids_[index] = true;
+}
+
+void HODigiSortedTable::reset() {
+  std::fill(ietas_.begin(), ietas_.end(), 0);
+  std::fill(iphis_.begin(), iphis_.end(), -100);
+  std::fill(subdets_.begin(), subdets_.end(), -1);
+  std::fill(depths_.begin(), depths_.end(), 0);
+  std::fill(rawIds_.begin(), rawIds_.end(), 0);
+  std::fill(fiberIdleOffsets_.begin(), fiberIdleOffsets_.end(), 0);
+  std::fill(sois_.begin(), sois_.end(), -1);
+  std::fill(valids_.begin(), valids_.end(), false);
+
+  for (unsigned int i = 0; i < nTS_; ++i) {
+    for (unsigned int j = 0; j < dids_.size(); ++j) {
+      adcs_[i][j] = 0;
+      fcs_[i][j] = 0;
+      pedestalfcs_[i][j] = 0;
+      capids_[i][j] = 0;
+      fibers_[i][j] = 0;
+      fiberChans_[i][j] = 0;
+      dvs_[i][j] = 0;
+      ers_[i][j] = 0;
+    }
+  }
+}

--- a/DPGAnalysis/HcalNanoAOD/src/QIE10DigiSortedTable.cc
+++ b/DPGAnalysis/HcalNanoAOD/src/QIE10DigiSortedTable.cc
@@ -1,0 +1,82 @@
+#include "DPGAnalysis/HcalNanoAOD/interface/QIE10DigiSortedTable.h"
+
+QIE10DigiSortedTable::QIE10DigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS) {
+  dids_ = dids;
+  for (std::vector<HcalDetId>::const_iterator it_did = dids_.begin(); it_did != dids_.end(); ++it_did) {
+    did_indexmap_[*it_did] = (unsigned int)(it_did - dids_.begin());
+  }
+
+  nTS_ = nTS;
+  ietas_.resize(dids_.size());
+  iphis_.resize(dids_.size());
+  subdets_.resize(dids_.size());
+  depths_.resize(dids_.size());
+  rawIds_.resize(dids_.size());
+  linkErrors_.resize(dids_.size());
+  flags_.resize(dids_.size());
+  sois_.resize(dids_.size());
+  valids_.resize(dids_.size());
+  //sipmTypes_.resize(dids_.size());
+
+  adcs_.resize(nTS_, std::vector<int>(dids_.size()));
+  fcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  pedestalfcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  tdcs_.resize(nTS_, std::vector<int>(dids_.size()));
+  capids_.resize(nTS_, std::vector<int>(dids_.size()));
+  oks_.resize(nTS_, std::vector<bool>(dids_.size()));
+}
+
+void QIE10DigiSortedTable::add(const QIE10DataFrame* digi, const edm::ESHandle<HcalDbService>& dbService) {
+  HcalDetId did = digi->detid();
+  unsigned int index = did_indexmap_.at(did);
+
+  CaloSamples digiCaloSamples = hcaldqm::utilities::loadADC2fCDB<QIE10DataFrame>(dbService, did, *digi);
+  HcalCalibrations calibrations = dbService->getHcalCalibrations(did);
+
+  ietas_[index] = did.ieta();
+  iphis_[index] = did.iphi();
+  subdets_[index] = did.subdet();
+  depths_[index] = did.depth();
+  rawIds_[index] = did.rawId();
+  linkErrors_[index] = digi->linkError();
+  flags_[index] = digi->flags();
+  //sipmTypes_[index] = (uint8_t)dbService->getHcalSiPMParameter(did)->getType();
+
+  for (unsigned int iTS = 0; iTS < (unsigned int)digi->samples(); ++iTS) {
+    if ((*digi)[iTS].soi()) {
+      sois_[index] = iTS;
+    }
+    oks_[iTS][index] = (*digi)[iTS].ok();
+    adcs_[iTS][index] = (*digi)[iTS].adc();
+    tdcs_[iTS][index] = (*digi)[iTS].le_tdc();
+    //tetdcs_[iTS][index]    = (*digi)[iTS].te_tdc();
+    capids_[iTS][index] = (*digi)[iTS].capid();
+    fcs_[iTS][index] = digiCaloSamples[iTS];
+    pedestalfcs_[iTS][index] = calibrations.pedestal((*digi)[iTS].capid());
+  }
+  valids_[index] = true;
+}
+
+void QIE10DigiSortedTable::reset() {
+  std::fill(ietas_.begin(), ietas_.end(), 0);
+  std::fill(iphis_.begin(), iphis_.end(), 0);
+  std::fill(subdets_.begin(), subdets_.end(), 0);
+  std::fill(depths_.begin(), depths_.end(), 0);
+  std::fill(rawIds_.begin(), rawIds_.end(), 0);
+  std::fill(linkErrors_.begin(), linkErrors_.end(), 0);
+  std::fill(flags_.begin(), flags_.end(), 0);
+  std::fill(sois_.begin(), sois_.end(), -1);
+  std::fill(valids_.begin(), valids_.end(), false);
+  //std::fill(sipmTypes_.begin(), sipmTypes_.end(), 0);
+
+  for (unsigned int i = 0; i < nTS_; ++i) {
+    for (unsigned int j = 0; j < dids_.size(); ++j) {
+      adcs_[i][j] = 0;
+      fcs_[i][j] = 0.;
+      pedestalfcs_[i][j] = 0.;
+      tdcs_[i][j] = 0;
+      capids_[i][j] = 0;
+      oks_[i][j] = false;
+    }
+  }
+}

--- a/DPGAnalysis/HcalNanoAOD/src/QIE11DigiSortedTable.cc
+++ b/DPGAnalysis/HcalNanoAOD/src/QIE11DigiSortedTable.cc
@@ -1,0 +1,87 @@
+#include "DPGAnalysis/HcalNanoAOD/interface/QIE11DigiSortedTable.h"
+
+QIE11DigiSortedTable::QIE11DigiSortedTable(const std::vector<HcalDetId>& dids, const unsigned int nTS) {
+  dids_ = dids;
+  for (std::vector<HcalDetId>::const_iterator it_did = dids_.begin(); it_did != dids_.end(); ++it_did) {
+    did_indexmap_[*it_did] = (unsigned int)(it_did - dids_.begin());
+  }
+
+  nTS_ = nTS;
+  ietas_.resize(dids_.size());
+  iphis_.resize(dids_.size());
+  subdets_.resize(dids_.size());
+  depths_.resize(dids_.size());
+  rawIds_.resize(dids_.size());
+  linkErrors_.resize(dids_.size());
+  capidErrors_.resize(dids_.size());
+  flags_.resize(dids_.size());
+  sois_.resize(dids_.size());
+  valids_.resize(dids_.size());
+  sipmTypes_.resize(dids_.size());
+
+  adcs_.resize(nTS_, std::vector<int>(dids_.size()));
+  fcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  pedestalfcs_.resize(nTS_, std::vector<float>(dids_.size()));
+  tdcs_.resize(nTS_, std::vector<int>(dids_.size()));
+  capids_.resize(nTS_, std::vector<int>(dids_.size()));
+}
+
+void QIE11DigiSortedTable::add(const QIE11DataFrame* digi, const edm::ESHandle<HcalDbService>& dbService) {
+  HcalDetId did = digi->detid();
+  unsigned int index = did_indexmap_.at(did);
+
+  CaloSamples digiCaloSamples = hcaldqm::utilities::loadADC2fCDB<QIE11DataFrame>(dbService, did, *digi);
+  HcalCalibrations calibrations = dbService->getHcalCalibrations(did);
+
+  ietas_[index] = did.ieta();
+  iphis_[index] = did.iphi();
+  subdets_[index] = did.subdet();
+  depths_[index] = did.depth();
+  rawIds_[index] = did.rawId();
+  linkErrors_[index] = digi->linkError();
+  capidErrors_[index] = digi->capidError();
+  flags_[index] = digi->flags();
+  sipmTypes_[index] = (uint8_t)dbService->getHcalSiPMParameter(did)->getType();
+
+  for (unsigned int iTS = 0; iTS < (unsigned int)digi->samples(); ++iTS) {
+    if ((*digi)[iTS].soi()) {
+      sois_[index] = iTS;
+    }
+    adcs_[iTS][index] = (*digi)[iTS].adc();
+    tdcs_[iTS][index] = (*digi)[iTS].tdc();
+    capids_[iTS][index] = (*digi)[iTS].capid();
+    fcs_[iTS][index] = digiCaloSamples[iTS];
+    pedestalfcs_[iTS][index] = calibrations.pedestal((*digi)[iTS].capid());
+  }
+  valids_[index] = true;
+}
+
+void QIE11DigiSortedTable::reset() {
+  std::fill(ietas_.begin(), ietas_.end(), 0);
+  std::fill(iphis_.begin(), iphis_.end(), 0);
+  std::fill(subdets_.begin(), subdets_.end(), 0);
+  std::fill(depths_.begin(), depths_.end(), 0);
+  std::fill(rawIds_.begin(), rawIds_.end(), 0);
+  std::fill(linkErrors_.begin(), linkErrors_.end(), false);
+  std::fill(capidErrors_.begin(), capidErrors_.end(), false);
+  std::fill(flags_.begin(), flags_.end(), 0);
+  std::fill(sois_.begin(), sois_.end(), 0);
+  std::fill(valids_.begin(), valids_.end(), false);
+  std::fill(sipmTypes_.begin(), sipmTypes_.end(), 0);
+
+  for (auto& it : adcs_) {
+    std::fill(it.begin(), it.end(), 0);
+  }
+  for (auto& it : fcs_) {
+    std::fill(it.begin(), it.end(), 0);
+  }
+  for (auto& it : pedestalfcs_) {
+    std::fill(it.begin(), it.end(), 0);
+  }
+  for (auto& it : tdcs_) {
+    std::fill(it.begin(), it.end(), 0);
+  }
+  for (auto& it : capids_) {
+    std::fill(it.begin(), it.end(), 0);
+  }
+}

--- a/DPGAnalysis/HcalNanoAOD/src/classes_def.xml
+++ b/DPGAnalysis/HcalNanoAOD/src/classes_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+    <!--<class name="hcalnano::HcalChannelInfo" persistent="false"/>-->
+</lcgdict>

--- a/DPGAnalysis/HcalNanoAOD/test/testhcalnano_cfg.py
+++ b/DPGAnalysis/HcalNanoAOD/test/testhcalnano_cfg.py
@@ -1,0 +1,159 @@
+#------------------------------------------------------------------------------------
+# Imports
+#------------------------------------------------------------------------------------
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from Configuration.StandardSequences.Eras import eras
+
+#------------------------------------------------------------------------------------
+# Options
+#------------------------------------------------------------------------------------
+options = VarParsing.VarParsing()
+
+options.register('skipEvents',
+                 0, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Number of events to skip")
+
+options.register('processEvents',
+                 -1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Number of events to process")
+
+options.register('inputFiles',
+                 "file:inputFile.root",
+                 VarParsing.VarParsing.multiplicity.list,
+                 VarParsing.VarParsing.varType.string,
+                 "Input files")
+
+options.register('outputFile',
+                 "file:hcalnano.root", # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Output file")
+
+options.register('nThreads', 
+                4, 
+                VarParsing.VarParsing.multiplicity.singleton, 
+                VarParsing.VarParsing.varType.int)
+
+options.register('compressionAlgorithm', 
+                "ZLIB", 
+                VarParsing.VarParsing.multiplicity.singleton, 
+                VarParsing.VarParsing.varType.string)
+
+options.register('compressionLevel', 
+                5, 
+                VarParsing.VarParsing.multiplicity.singleton, 
+                VarParsing.VarParsing.varType.int)
+
+options.register('reportEvery', 
+                100, 
+                VarParsing.VarParsing.multiplicity.singleton, 
+                VarParsing.VarParsing.varType.int)
+
+options.parseArguments()
+
+print(" ")
+print("Using options:")
+print(" skipEvents    =", options.skipEvents)
+print(" processEvents =", options.processEvents)
+print(" inputFiles    =", options.inputFiles)
+print(" outputFile    =", options.outputFile)
+print(" nThreads.     =", options.nThreads)
+print(" ")
+
+#------------------------------------------------------------------------------------
+# Declare the process and input variables
+#------------------------------------------------------------------------------------
+process = cms.Process('HCALNANO', eras.Run3)
+
+#------------------------------------------------------------------------------------
+# Get and parse the command line arguments
+#------------------------------------------------------------------------------------
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.processEvents) )
+
+process.source = cms.Source(
+    "PoolSource",
+    fileNames  = cms.untracked.vstring(options.inputFiles),
+    skipEvents = cms.untracked.uint32(options.skipEvents)
+    )
+
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string(options.outputFile)
+    )
+process.options.numberOfThreads=cms.untracked.uint32(options.nThreads)
+process.options.numberOfStreams=cms.untracked.uint32(0)
+#------------------------------------------------------------------------------------
+# import of standard configurations
+#------------------------------------------------------------------------------------
+
+# Reduce message log output
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(options.reportEvery)
+
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+
+#------------------------------------------------------------------------------------
+# Specify Global Tag
+#------------------------------------------------------------------------------------
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.GlobalTag.globaltag = '122X_dataRun3_HLT_v3'
+print("GlobalTag = ", str(process.GlobalTag.globaltag).split("'")[1])
+print(" ")
+
+#------------------------------------------------------------------------------------
+# HcalNano sequence definition
+#------------------------------------------------------------------------------------
+#from PhysicsTools.NanoAOD.common_cff import *
+process.load("PhysicsTools.NanoAOD.nano_cff")
+process.load("RecoLocalCalo/Configuration/hcalLocalReco_cff")
+process.load("RecoLocalCalo/Configuration/hcalGlobalReco_cff")
+process.load("DPGAnalysis.HcalNanoAOD.hcalRecHitTable_cff")
+process.load("DPGAnalysis.HcalNanoAOD.hcalDetIdTable_cff")
+process.load("DPGAnalysis.HcalNanoAOD.hcalDigiSortedTable_cff")
+
+# This creates a sorted list of HcalDetIds for use by downstream HcalNano table producers
+process.hcalNanoPrep = cms.Sequence(process.hcalDetIdTable)
+
+process.hcalNanoTask = cms.Task(
+    process.hcalDigis, 
+
+    ## Do energy reconstruction
+    process.hcalLocalRecoTask,
+    process.hcalGlobalRecoTask,
+
+    # Make digi tables
+    process.hcalDigiSortedTable,
+
+    # Make RecHit tables
+    process.hbheRecHitTable,
+    process.hfRecHitTable,
+    process.hoRecHitTable,
+)
+
+process.preparation = cms.Path(process.hcalNanoPrep, process.hcalNanoTask)
+
+process.NanoAODEDMEventContent.outputCommands = cms.untracked.vstring(
+        'drop *',
+        "keep nanoaodFlatTable_*Table_*_*",     # event data
+        "keep edmTriggerResults_*_*_*",  # event data
+        "keep String_*_genModel_*",  # generator model data
+        "keep nanoaodMergeableCounterTable_*Table_*_*", # accumulated per/run or per/lumi data
+        "keep nanoaodUniqueString_nanoMetadata_*_*",   # basic metadata
+    )
+
+process.out = cms.OutputModule("NanoAODOutputModule",
+    fileName = cms.untracked.string(options.outputFile),
+    outputCommands = process.NanoAODEDMEventContent.outputCommands,
+    compressionLevel = cms.untracked.int32(options.compressionLevel),
+    compressionAlgorithm = cms.untracked.string(options.compressionAlgorithm),
+
+)
+process.end = cms.EndPath(process.out)  

--- a/DataFormats/HcalDetId/src/classes.h
+++ b/DataFormats/HcalDetId/src/classes.h
@@ -9,4 +9,5 @@
 #include "DataFormats/HcalDetId/interface/HcalDcsDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDetId/interface/CastorElectronicsId.h"
+#include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>

--- a/DataFormats/HcalDetId/src/classes_def.xml
+++ b/DataFormats/HcalDetId/src/classes_def.xml
@@ -45,6 +45,8 @@
   <class name="CastorElectronicsId" ClassVersion="10">
    <version ClassVersion="10" checksum="849697027"/>
   </class>
+  <class name="std::vector<HcalDetId>"/>
+  <class name="edm::Wrapper<std::vector<HcalDetId>>"/>
   <class name="std::vector<HcalElectronicsId>"/>
   <class name="std::vector<HcalFrontEndId>"/>
   <class name="std::vector<CastorElectronicsId>"/>


### PR DESCRIPTION
#### PR description:

This PR is a continuation of https://github.com/cms-sw/cmssw/pull/40489, which was mistakenly closed after a rebase. 

This PR implements a NanoAOD format for HCAL digis and RecHits. This data format is intended to replace the old [HcalTupleMaker](https://gitlab.cern.ch/cmshcal/hcalpfg/HcalTupleMaker) used by most HCAL workflows. 

Example:
```
cmsDriver.py NANO \
    -s RAW2DIGI,RECO,USER:DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask \
    --datatier NANOAOD \
    --eventcontent NANOAOD \
    --filein root://eoscms.cern.ch//store/group/dpg_hcal/comm_hcal/RAW/ZeroBias/361579/be9a0a12-548c-4aa0-837a-2d5654f8e63b.root \
    --fileout hcalnano_testcmsdriver.root \
    -n 100 \
    --nThreads 4 \
    --conditions auto:run3_data_prompt \
    --era Run3 \
    --python_filename testcmsdriver_cfg.py \
    --no_exec
cmsRun testcmsdriver_cfg.py
```

RecHits are implemented following @kdlong's PFNano branch, https://github.com/kdlong/cmssw/tree/pfNano_HCALOnly_12_6_0_pre4. The specific modules, however, are defined in `DPGAnalysis/HcalNanoAOD` (e.g. `HBHERecHitFlatTableProducer`), rather than `DPGAnalysis/CaloNanoAOD` (e.g. `SimpleCaloRecHitFlatTableProducer`). Hence, this package is independent of `DPGAnalysis/CaloNanoAOD`. 

Digis are handled by dedicated modules in `DPGAnalysis/HcalNanoAOD` that output dense arrays, sorted by DetId. A list of the DetIds (i.e. the column labels) is placed in `Run`. For the moment, DetIds are also saved in `Event`, for development purposes although we might decide to keep them for ease of analysis. 

Metadata from the uHTRs (calib event type) and the uMNio (the labeling of calibration events (pedestal/LED/laser) and which type of laser event), are also handled by dedicated modules. 

Two customization functions are provided for special datasets:
1.  `hcalNano_cff.customiseHcalCalib`: for calibration sequence events in the TestEnablesEcalHcal dataset (i.e. events in the abort gap of type pedestal, LED, or laser). Specifies the correct label for the raw data; adds uMNio metadata; adds an important HLT filter to all Paths and Endpaths, which selects events triggered by HLT_HcalCalibration. This filter essential to avoid a crash, because ECAL-triggered events are missing the HCAL raw data collection (aside: HCAL needs to revisit the definition of this dataset; the trigger is based on a majority-wins vote of calibration flags from the HCAL uHTRs. A single uHTR flagging the event as calibration should be enough to consider the event calibration and not real physics!). 
2. `hcalNano_cff.customiseHcalLocal`: for HCAL local runs. Loads the raw data using `HcalTBSource`; adjusts the number of time slices per digi; adds uMNio metadata.

TBD: trigger primitives. 

#### PR validation:

Produces useful HCAL NanoAOD ntuples. Data validated event-by-event against HcalTupleMaker. Calibration and local run customization functions work on recent MWGR 2023 data. 

#### Other
The contents of this PR are ready for use by HCAL DPG right away. An eventual merge should take into account @kdlong's PFNanoAOD branch, but this package is independent of `DPGAnalysis/CaloNanoAOD`. 

@vlimant @swertz this should be assigned to XPOG again.

@mariadalfonso @wang-hui @jhakala 
