### PR TITLE
Update run3 data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,14 +31,14 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-03-16 19:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v1',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v2 but with snapshot at 2023-03-16 19:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v1',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v2 but with snapshot at 2023-03-16 19:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-03-16 19:00:00 (UTC)
-    'run3_data'                    : '130X_dataRun3_v1',
+    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-05-10 09:00:00 (UTC)
+    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v2',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v2 but with snapshot at 2023-05-10 09:00:00 (UTC)
+    'run3_data_express'            : '130X_dataRun3_Express_frozen_v2',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v3 but with snapshot at 2023-05-10 09:00:00 (UTC)
+    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v2',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20  (UTC)
+    'run3_data'                    : '130X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
This PR updates the run3 data GTs:
 - Update snapshot of the frozen HLT/Express/Prompt GTs
 - The frozen Prompt GT is now based on v3 which includes the BeamSpotOnline tags
    - See issue https://github.com/cms-sw/cmssw/issues/41459
    - Successfully tested in Tier0 replay in https://github.com/dmwm/T0/pull/4817 
 - Update the run3 offline data GT to include two fixes:
    - EcalLaserAPDPNRatios tag from prompt (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/use-prompt-ecallaserapdpnratios-in-the-2022-rereco/22934))
    - High granularity Hcal Pedestals (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/gt-offline-update-of-hcal-offline-pedestal-conditions-for-the-2022abcde-partial-re-reco/23066))

GT differences:
- **2023 HLT data**:
   - Diff from previous frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_frozen_v1/130X_dataRun3_HLT_frozen_v2
   - Diff from online GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_v2/130X_dataRun3_HLT_frozen_v2

- **2023 Express data**:
   - Diff from previous frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_frozen_v1/130X_dataRun3_Express_frozen_v2
   - Diff from online GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_v2/130X_dataRun3_Express_frozen_v2

- **2023 Prompt data**:
   - Diff from previous frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_frozen_v1/130X_dataRun3_Prompt_frozen_v2
   - Diff from online GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_v3/130X_dataRun3_Prompt_frozen_v2

- **Run3 offline GT**:
   - https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_v1/130X_dataRun3_v2


#### PR validation:
Code compiles - will use the bot to run the matrix tests

#### Backport:
Not a backport, but backports to 13_1_X, 13_0_X and 12_4_X (for the offline GT only) will be provided soon