### PR TITLE
[12_4_X] Update run3 offline data GT for 2022ABCDE partial rereco

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -41,10 +41,10 @@ autoCond = {
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v9',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v10 but with snapshot at 2022-12-19 18:00:00 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v8',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-12-15 07:25:06 (UTC)
-    'run3_data'                    : '124X_dataRun3_v14',
-    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2022-12-19 18:12:44 (UTC)
-    'run3_data_relval'             : '124X_dataRun3_relval_v12',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:28:13 (UTC)
+    'run3_data'                    : '124X_dataRun3_v15',
+    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu - snapshot at 2023-05-09 15:28:13 (UTC)
+    'run3_data_relval'             : '124X_dataRun3_relval_v13',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
(partial) Backport of #41609

This PR updates the run3 offline data GT:
- Update the run3 offline data GT to include two fixes:
    - EcalLaserAPDPNRatios tag from prompt (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/use-prompt-ecallaserapdpnratios-in-the-2022-rereco/22934))
    - High granularity Hcal Pedestals (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/gt-offline-update-of-hcal-offline-pedestal-conditions-for-the-2022abcde-partial-re-reco/23066))

GT differences:
- **Run3 offline GT**:
   - https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v14/124X_dataRun3_v15

- **Run3 offline relval GT**:
   - https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_relval_v12/124X_dataRun3_relval_v13

- **Diff offline vs offline relval**:
   - https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v15/124X_dataRun3_relval_v13

As described in [this CMSTalk post](https://cms-talk.web.cern.ch/t/offline-gts-for-2022-abcde-partial-re-reco/23864) this GT will be used in the partial 2022ABCDE rereco and, given that we might need another 12_4_X release for that (to include the HcalPFcuts threshold update), we can direcatly include the new GT in the new release.
FYI @jordan-martins @maeshima @malbouis 

#### PR validation:
Code compiles - will use the bot to run the matrix tests

#### Backport:
(partial) Backport of #41609