### PR TITLE
[RECONSTRUCTION] [CLANG] Fix warnings reported by clang-16

### DIFF
--- a/MagneticField/Interpolation/src/gridTesters.cc
+++ b/MagneticField/Interpolation/src/gridTesters.cc
@@ -11,7 +11,7 @@ namespace {
     ok &= grid.inRange(i);
 
     ok &= (8 == i);
-    ok &= (0.6 == f);
+    ok &= (0.6f == f);
 
     return ok;
   }

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.cc
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.cc
@@ -960,11 +960,6 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string &name) {
         }
       }
     }
-    int nGoodInd = 0;
-    for (int i = 0; i < 3; ++i) {
-      if (goodIndex[i])
-        ++nGoodInd;
-    }
     // common part of missing coordiate(s) recovery (1 or 2 missing)
     if (nEasy > 0) {
       // sort without resetting of indices

--- a/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
@@ -201,11 +201,8 @@ void EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es
 
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;
-  int i = 0;
   for (aClus = rawClusters->begin(); aClus != rawClusters->end(); aClus++) {
     reco::SuperCluster enecorrClus, crackcorrClus, localContCorrClus;
-
-    i++;
 
     if (applyEnergyCorrection_)
       enecorrClus = energyCorrector_->applyCorrection(*aClus,

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -323,18 +323,14 @@ int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const Traject
   const auto outLayers = navSchool_.compatibleLayers(*detLayer, hitFreeState, alongMomentum);
 
   int nrValidLayers = 1;  //because our current hit is also valid and wont be included in the count otherwise
-  int nrPixInLayers = 0;
-  int nrPixOutLayers = 0;
   for (auto layer : inLayers) {
     if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
-      nrPixInLayers++;
       if (layerHasValidHits(*layer, hitTrajState, backwardPropagator_))
         nrValidLayers++;
     }
   }
   for (auto layer : outLayers) {
     if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
-      nrPixOutLayers++;
       if (layerHasValidHits(*layer, hitTrajState, forwardPropagator_))
         nrValidLayers++;
     }

--- a/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonMIPHaloTagger.cc
@@ -305,8 +305,6 @@ void PhotonMIPHaloTagger::GetSeedHighestE(const reco::Photon* photon,
   seedEnergy = -999.;
 
   std::vector<std::pair<DetId, float> > PhotonHit_DetIds = photon->superCluster()->hitsAndFractions();
-  int ncrys = 0;
-
   std::vector<std::pair<DetId, float> >::const_iterator detitr;
   for (detitr = PhotonHit_DetIds.begin(); detitr != PhotonHit_DetIds.end(); ++detitr) {
     if (((*detitr).first).det() == DetId::Ecal && ((*detitr).first).subdetId() == EcalBarrel) {
@@ -333,8 +331,6 @@ void PhotonMIPHaloTagger::GetSeedHighestE(const reco::Photon* photon,
           std::cout << "Current max Seed = " << SeedE << "   seedIphi = " << seedIphi << "  ieta= " << seedIeta
                     << std::endl;
       }
-
-      ncrys++;
 
     }  //check if in Barrel
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -2263,7 +2263,6 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   //---------------------------------------
 
   countEvents++;
-  int numberOfDetUnits = 0;
   int numberOfClusters = 0;
   int numberOfPixels = 0;
   int numberOfNoneEdgePixels = 0;
@@ -2333,7 +2332,6 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
     if (detType != 1)
       continue;  // look only at pixels
-    ++numberOfDetUnits;
 
     //const GeomDetUnit * genericDet = geom->idToDet(detId);
     //const PixelGeomDetUnit * pixDet =

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -304,14 +304,6 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
         //	bool isCloseIP = false;
         //	bool isCloseRef = false;
 
-        for (trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd(); coshit++) {
-          if ((*coshit)->isValid()) {
-            DetId id((*coshit)->geographicalId());
-          }
-        }
-        // step1
-        //if( !isCosmic1Leg ) continue;
-
         if (outertrack.isNonnull()) {
           // step2
           //UNUSED:          const double ipErr = (double)outertrack->d0Error();

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -294,18 +294,11 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
       reco::TrackRef outertrack = muon.outerTrack();
       reco::TrackRef costrack = cosmicMuon->outerTrack();
 
-      bool isUp = false;
-      if (outertrack->phi() > 0)
-        isUp = true;
-
       // shared hits
       int RecHitsMuon = outertrack->numberOfValidHits();
-      int RecHitsCosmicMuon = 0;
       int shared = 0;
       // count hits for same hemisphere
       if (costrack.isNonnull()) {
-        int nhitsUp = 0;
-        int nhitsDown = 0;
         // unused
         //	bool isCosmic1Leg = false;
         //	bool isCloseIP = false;
@@ -314,20 +307,9 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
         for (trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd(); coshit++) {
           if ((*coshit)->isValid()) {
             DetId id((*coshit)->geographicalId());
-            double hity = trackingGeometry->idToDet(id)->position().y();
-            if (hity > 0)
-              nhitsUp++;
-            if (hity < 0)
-              nhitsDown++;
-
-            if (isUp && hity > 0)
-              RecHitsCosmicMuon++;
-            if (!isUp && hity < 0)
-              RecHitsCosmicMuon++;
           }
         }
         // step1
-        //UNUSED:	if( nhitsUp > 0 && nhitsDown > 0 ) isCosmic1Leg = true;
         //if( !isCosmic1Leg ) continue;
 
         if (outertrack.isNonnull()) {
@@ -364,7 +346,6 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
       double fraction = -1;
       if (RecHitsMuon != 0)
         fraction = shared / (double)RecHitsMuon;
-      // 	     std::cout << "shared = " << shared << " " << fraction << " " << RecHitsMuon << " " << RecHitsCosmicMuon << std::endl;
       if (shared > sharedHits_ && fraction > sharedFrac_) {
         overlappingMuon = true;
         break;

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -297,7 +297,6 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
       // shared hits
       int RecHitsMuon = outertrack->numberOfValidHits();
       int shared = 0;
-      // count hits for same hemisphere
       if (costrack.isNonnull()) {
         // unused
         //	bool isCosmic1Leg = false;
@@ -312,8 +311,8 @@ bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
           //if( !isCloseIP ) continue;
 
           // step3
-          GlobalPoint muonRefVtx(outertrack->vx(), outertrack->vy(), outertrack->vz());
-          GlobalPoint cosmicRefVtx(costrack->vx(), costrack->vy(), costrack->vz());
+          //GlobalPoint muonRefVtx(outertrack->vx(), outertrack->vy(), outertrack->vz());
+          //GlobalPoint cosmicRefVtx(costrack->vx(), costrack->vy(), costrack->vz());
           //UNUSED:	  float dist = (muonRefVtx - cosmicRefVtx).mag();
           //UNUSED:	  if( dist < 0.1 ) isCloseRef = true;
           //if( !isCloseRef ) continue;

--- a/RecoTracker/DisplacedRegionalTracking/plugins/DisplacedRegionSeedingVertexProducer.cc
+++ b/RecoTracker/DisplacedRegionalTracking/plugins/DisplacedRegionSeedingVertexProducer.cc
@@ -166,8 +166,8 @@ void DisplacedRegionSeedingVertexProducer::produce(edm::StreamID streamID,
       farRegionsOfInterest->emplace_back(reco::Vertex::Point(roi.centerOfMass()), errorRegion);
   }
 
-  event.put(move(nearRegionsOfInterest), "nearRegionsOfInterest");
-  event.put(move(farRegionsOfInterest), "farRegionsOfInterest");
+  event.put(std::move(nearRegionsOfInterest), "nearRegionsOfInterest");
+  event.put(std::move(farRegionsOfInterest), "farRegionsOfInterest");
 }
 
 void DisplacedRegionSeedingVertexProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {


### PR DESCRIPTION
Hello,

This PR fixes set but unused warnings, unqualified calls and floating point comparisons from clang-16 in CLANG IBs.

Some reconstruction modules are also reporting warnings on `loop not vectorized`. For example, for `RecoTracker/MkFitCore`:
```
>> Compiling  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/radix_sort.cc
/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/llvm/16.0.3-5d1904f3c7b5c53b7522ba0858baec44/bin/clang++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=110201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DCMSSW_GIT_HASH='CMSSW_13_2_CLANG_X_2023-05-09-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_2_CLANG_X_2023-05-09-2300' -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/pcre/8.43-5dcc901acc02f624b22dd9840b2357e8/include -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/bz2lib/1.0.6-2c1f18484cb66c30aba7929f2be5e7d4/include -isystem/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/lcg/root/6.26.11-9720c7273eac1c892ddadde973cf1965/include -isystem/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/tbb/v2021.8.0-4e779f195a25a0aba119b27519937ba0/include -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/xz/5.2.5-83d0a00b575efd1701e07bedf7977343/include -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/zlib/1.2.11-3dfb2715f3608466b74431b80eb9d788/include -I/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/json/3.10.2-a6d86565b09ec3d0e02bf7b52c31bbfc/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-c99-extensions -Wno-c++11-narrowing -D__STRICT_ANSI__ -Wno-unused-private-field -Wno-unknown-pragmas -Wno-unused-command-line-argument -Wno-unknown-warning-option -ftemplate-depth=512 -Wno-error=potentially-evaluated-expression -Wno-tautological-type-limit-compare -fsized-deallocation --gcc-toolchain=/pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161 -Ofast -fno-reciprocal-math -mrecip=none -DBOOST_DISABLE_ASSERTS -fopenmp-simd  -fPIC    -MMD -MF tmp/el8_amd64_gcc11/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/radix_sort.cc.d /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/radix_sort.cc -o tmp/el8_amd64_gcc11/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/radix_sort.cc.o
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/PropagationMPlex.cc:290:8: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   void helixAtRFromIterativeCCSFullJac(const MPlexLV& inPar,
       ^
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:248:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   void MkFinder::selectHitIndices(const LayerOfHits &layer_of_hits, const int N_proc) {
                 ^
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:248:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:693:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   void MkFinder::addBestHit(const LayerOfHits &layer_of_hits, const int N_proc, const FindingFoos &fnd_foos) {
                 ^
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:905:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   void MkFinder::findCandidates(const LayerOfHits &layer_of_hits,
                 ^
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:1151:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
   void MkFinder::findCandidatesCloneEngine(const LayerOfHits &layer_of_hits,
                 ^
  /pool/condor/dir_43945/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/189e8911dd83c5e66aafe1fe240371ea/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_CLANG_X_2023-05-09-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:1151:18: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]
 1 warning generated.
6 warnings generated.
```

I have seen in older PRs that sometimes this has been fixed by using a pragma statement, others inlining the function (which I believe it won't work here, but correct me if I am wrong) and in other cases the original authors took care of rearranging the code. Any hints on what can we do in those cases?

Many thanks! :)
Andrea.