### PR TITLE
backporting default decayer behavior from HEAD

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -51,7 +51,8 @@ namespace fastsim {
                     double deltaRchargedMother,
                     const ParticleFilter& particleFilter,
                     std::vector<SimTrack>& simTracks,
-                    std::vector<SimVertex>& simVertices);
+                    std::vector<SimVertex>& simVertices,
+                    bool useFastSimsDecayer);
 
     //! Default destructor.
     ~ParticleManager();
@@ -132,6 +133,7 @@ namespace fastsim {
     const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
     std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
     std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
+    bool useFastSimsDecayer_;
     double momentumUnitConversionFactor_;         //!< Convert pythia units to GeV (FastSim standard)
     double lengthUnitConversionFactor_;           //!< Convert pythia unis to cm (FastSim standard)
     double lengthUnitConversionFactor2_;          //!< Convert pythia unis to cm^2 (FastSim standard)

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -87,7 +87,8 @@ private:
   edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;
   std::unique_ptr<CalorimetryManager> myCalorimetry;  // unfortunately, default constructor cannot be called
   bool simulateMuons;
-
+  bool useFastSimsDecayer;
+  
   fastsim::Decayer decayer_;  //!< Handles decays of non-stable particles using pythia
   std::vector<std::unique_ptr<fastsim::InteractionModel> > interactionModels_;  //!< All defined interaction models
   std::map<std::string, fastsim::InteractionModel*> interactionModelMap_;  //!< Each interaction model has a unique name
@@ -109,6 +110,7 @@ FastSimProducer::FastSimProducer(const edm::ParameterSet& iConfig)
       _randomEngine(nullptr),
       simulateCalorimetry(iConfig.getParameter<bool>("simulateCalorimetry")),
       simulateMuons(iConfig.getParameter<bool>("simulateMuons")),
+      useFastSimsDecayer(iConfig.getParameter<bool>("useFastSimsDecayer")),
       particleDataTableESToken_(esConsumes()) {
   if (simulateCalorimetry) {
     caloGeometryESToken_ = esConsumes();
@@ -196,7 +198,8 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                                            deltaRchargedMother_,
                                            particleFilter_,
                                            *simTracks_,
-                                           *simVertices_);
+                                           *simVertices_,
+                                           useFastSimsDecayer);
 
   //  Initialize the calorimeter geometry
   if (simulateCalorimetry) {
@@ -292,7 +295,8 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
         LogDebug(MESSAGECATEGORY) << "Decaying particle...";
         std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-        decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+        if (useFastSimsDecayer)
+          decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
         LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
         particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
         continue;
@@ -504,7 +508,8 @@ FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
   if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
     LogDebug(MESSAGECATEGORY) << "Decaying particle...";
     std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-    decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+    if (useFastSimsDecayer)
+      decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
     LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
     particleManager->addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
   }

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -13,6 +13,7 @@ fastSimProducer = cms.EDProducer(
     trackerDefinition = TrackerMaterialBlock.TrackerMaterial,
     simulateCalorimetry = cms.bool(True),
     simulateMuons = cms.bool(True),
+    useFastSimsDecayer = cms.bool(False),
     caloDefinition = CaloMaterialBlock.CaloMaterial, #  Hack to interface "old" calorimetry with "new" propagation in tracker
     beamPipeRadius = cms.double(3.),
     deltaRchargedMother = cms.double(0.02), # Maximum angle to associate a charged daughter to a charged mother (mostly done to associate muons to decaying pions)

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -20,7 +20,8 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
                                           double deltaRchargedMother,
                                           const fastsim::ParticleFilter& particleFilter,
                                           std::vector<SimTrack>& simTracks,
-                                          std::vector<SimVertex>& simVertices)
+                                          std::vector<SimVertex>& simVertices,
+                                          bool useFastSimsDecayer)
     : genEvent_(&genEvent),
       genParticleIterator_(genEvent_->particles_begin()),
       genParticleEnd_(genEvent_->particles_end()),
@@ -30,7 +31,8 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
       deltaRchargedMother_(deltaRchargedMother),
       particleFilter_(&particleFilter),
       simTracks_(&simTracks),
-      simVertices_(&simVertices)
+      simVertices_(&simVertices),
+      useFastSimsDecayer_(useFastSimsDecayer)
       // prepare unit convsersions
       //  --------------------------------------------
       // |          |      hepmc               |  cms |
@@ -228,12 +230,12 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     // FastSim will not make hits out of particles that decay before reaching the beam pipe
     const bool decayedWithinBeamPipe =
         endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-    if (decayedWithinBeamPipe) {
+    if (!producedWithinBeamPipe && useFastSimsDecayer_) {
       continue;
     }
 
     // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
-    if (producedWithinBeamPipe && !decayedWithinBeamPipe) {
+    if (producedWithinBeamPipe && !decayedWithinBeamPipe && useFastSimsDecayer_) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
     }
 


### PR DESCRIPTION
#### PR description:
This is to backport the default setting that GEN decays be taken in place of FastSim decayer decays (https://github.com/cms-sw/cmssw/pull/38813). This should be standard for Run 3 MC. 