### PR TITLE
Changed delayed jet skim to add HT350 and L1Tau paths [13_1_X]

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODelayedJet_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODelayedJet_cff.py
@@ -4,7 +4,7 @@ import HLTrigger.HLTfilters.hltHighLevel_cfi
 DelayedJetHTTrigger = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
 DelayedJetHTTrigger.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
 DelayedJetHTTrigger.HLTPaths = cms.vstring(
-    "HLT_HT430_DelayedJet40*"
+    ["HLT_HT430_DelayedJet40*","HLT_HT350_DelayedJet40*","HLT_L1Tau_DelayedJet40*"]
 )
 DelayedJetHTTrigger.throw = False
 DelayedJetHTTrigger.andOr = True


### PR DESCRIPTION
#### PR description:

Backport of #41592 

> Since the first delayed jet skim (#37509), new delayed jet paths have been added to the HLT which have different selections and a slightly different naming convention. These include the following unprescaled paths:
>
>Prompt:
>HLT_L1Tau_DelayedJet40_DoubleDelay1nsTrackless_v1
>HLT_L1Tau_DelayedJet40_DoubleDelay1p25nsInclusive_v1
>HLT_L1Tau_DelayedJet40_SingleDelay2p5nsTrackless_v1
>HLT_L1Tau_DelayedJet40_SingleDelay3p5nsInclusive_v1
>HLT_HT350_DelayedJet40_SingleDelay3nsInclusive_v1
>
>Parking:
>HLT_HT350_DelayedJet40_SingleDelay1p5To3nsInclusive_v1
>HLT_HT350_DelayedJet40_SingleDelay1p6To3nsInclusive_v1 (backup)
>HLT_HT350_DelayedJet40_SingleDelay1p75To3nsInclusive_v1 (backup)
>HLT_HT430_DelayedJet40_SingleDelay1To1p5nsInclusive_v1
>HLT_HT430_DelayedJet40_SingleDelay1p1To1p6nsInclusive_v1 (backup)
>HLT_HT430_DelayedJet40_SingleDelay1p25To1p75nsInclusive_v1 (backup)
>HLT_L1Tau_DelayedJet40_SingleDelay2p5To3p5nsInclusive_v1
>HLT_L1Tau_DelayedJet40_SingleDelay2p6To3p5nsInclusive_v1 (backup)
>HLT_L1Tau_DelayedJet40_SingleDelay2p75To3p5nsInclusive_v1 (backup)
>
>This simple commit changes the skim from only picking up a fraction of the current delayed jet paths (HT430) to picking up all of them as intended (HT430, HT350, L1Tau).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

#41592 

Fix for delayed jet skim for 2023 data-taking