### PR TITLE
use qScale in pixel cluster charge reweighting

### DIFF
--- a/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/Common/interface/SiPixelChargeReweightingAlgorithm.h
@@ -501,7 +501,7 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
   q10r = 0.2f * q50r;
 
   // calculate ratio of charge scaling factors (14/4/2023)
-  rqscale = qscalei/templ2D.qscale();
+  rqscale = qscalei / templ2D.qscale();
 
   // Find all non-zero denominator pixels in the input template and generate "inside" weights
 
@@ -597,15 +597,15 @@ inline int SiPixelChargeReweightingAlgorithm::PixelTempRewgt2D(int id_in, int id
       }
     }
   }
-  
-  // final rescaling by the ratio of charge scaling factors (14/4/2023)  
-  // put this here to avoid changing the threshold tests above and to be vectorizable 
+
+  // final rescaling by the ratio of charge scaling factors (14/4/2023)
+  // put this here to avoid changing the threshold tests above and to be vectorizable
   for (i = 0; i < TYSIZE; ++i) {
     for (j = 0; j < TXSIZE; ++j) {
-       cluster[j][i] *= rqscale;
+      cluster[j][i] *= rqscale;
     }
   }
-  
+
   return success;
 }  // PixelTempRewgt2D
 


### PR DESCRIPTION
#### PR description:
Introducing qScale in the cluster charge reweighting as it is now different from 1 in Run 3. This change is supposed to alleviate the data/mc discrepancy in cluster charge, for example, slide 4 in backup of the following contribution https://indico.cern.ch/event/1271486/contributions/5397175/attachments/2644044/4576218/Pixel_Dynamic_Inefficiency_simulation_Validation___update2.pdf

#### PR validation:
Run the matrix tests (`runTheMatrix.py -l limited -i all --ibeos`) all passed:
 "47 46 45 35 22 4 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed"

Privately ran over ZMM GEN-SIM sample (file `/store/relval/CMSSW_12_4_12/RelValZMM_PU_13p6/GEN-SIM/PU_124X_mcRun3_2022_realistic_postEE_v1_PDMVRELVALS188_HS_2023PU-v1/00000/8501a177-d79f-4e60-9ceb-40eac7ec3371.root`) and the changes in cluster charge are as expected (red is without change, blue is with the change)
![image](https://github.com/cms-sw/cmssw/assets/23121063/52c67b9c-0512-4fcb-a431-fefd333326e0)


