### PR TITLE
Oracle test: Use fake/random DB name

### DIFF
--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -8,6 +8,9 @@ using namespace oracle::occi;
 using namespace std;
 
 int main(int argc, char *argv[]){
+  const char* fake_db = "cms-fake-unknown-db-server-1234567890";
+  char* p = std::getenv("CMSTEST_FAKE_ORACLE_DBNAME");
+  fake_db = p ? p : fake_db;
   int errCode = 0;
   if (argc==2){errCode = stoi(argv[1]);}
   if (errCode==24960){
@@ -22,7 +25,7 @@ int main(int argc, char *argv[]){
   try
   {
     auto env = Environment::createEnvironment(Environment::OBJECT);
-    auto conn = env->createConnection("a", "b", "c");
+    auto conn = env->createConnection("a", "b", fake_db);
     env->terminateConnection(conn);
     Environment::terminateEnvironment(env);
   }catch(oracle::occi::SQLException &e)


### PR DESCRIPTION
Oracle test for checking the Oracle OCCI build with new GCC ABI is failing in nearly all release cycles. This test was try to connect to oracle DB at non-existing server `c`. But since 8th of May, now there is a real server `c` which is causing this test to fail. The change makes sure that we use a more random DB name with possibility to change it via `CMSTEST_FAKE_ORACLE_DBNAME` env (if needed in future).

Once this is merged in master IBs then I will open backport PRs for old release cycles too.