### PR TITLE
Oracle test: Use fake/random DB name

### DIFF
--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -7,35 +7,33 @@
 using namespace oracle::occi;
 using namespace std;
 
-int main(int argc, char *argv[]){
+int main(int argc, char* argv[]) {
   const char* fake_db = "cms-fake-unknown-db-server-1234567890";
   char* p = std::getenv("CMSTEST_FAKE_ORACLE_DBNAME");
   fake_db = p ? p : fake_db;
   int errCode = 0;
-  if (argc==2){errCode = stoi(argv[1]);}
-  if (errCode==24960){
-    cout <<"Tesing: 'ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255'"<<endl;    
+  if (argc == 2) {
+    errCode = stoi(argv[1]);
   }
-  else if (errCode==12154){
-    cout <<"Tesing: 'ORA-12154: TNS:could not resolve the connect identifier specified'"<<endl;    
+  if (errCode == 24960) {
+    cout << "Tesing: 'ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255'"
+         << endl;
+  } else if (errCode == 12154) {
+    cout << "Tesing: 'ORA-12154: TNS:could not resolve the connect identifier specified'" << endl;
+  } else {
+    cout << "Testing exception error code:" << errCode << endl;
   }
-  else{
-    cout<<"Testing exception error code:"<<errCode<<endl;
-  }
-  try
-  {
+  try {
     auto env = Environment::createEnvironment(Environment::OBJECT);
     auto conn = env->createConnection("a", "b", fake_db);
     env->terminateConnection(conn);
     Environment::terminateEnvironment(env);
-  }catch(oracle::occi::SQLException &e)
-  {
-    cout <<"Caught oracle::occi::SQLException exception with error code: "<<e.getErrorCode()<<endl;
-    cout <<"Exception Message:"<< e.getMessage()<<endl;
-    if (e.getErrorCode()==errCode){
+  } catch (oracle::occi::SQLException& e) {
+    cout << "Caught oracle::occi::SQLException exception with error code: " << e.getErrorCode() << endl;
+    cout << "Exception Message:" << e.getMessage() << endl;
+    if (e.getErrorCode() == errCode) {
       cout << "OK: Expected exception found:" << errCode << endl;
-    }
-    else{
+    } else {
       throw;
     }
   }

--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -8,6 +8,9 @@ using namespace oracle::occi;
 using namespace std;
 
 int main(int argc, char *argv[]){
+  const char* fake_db = "cms-fake-unknown-db-server-1234567890";
+  char* p = std::getenv("CMSTEST_FAKE_ORACLE_DBNAME");
+  fake_db = p ? p : fake_db;
   int errCode = 0;
   if (argc==2){errCode = stoi(argv[1]);}
   if (errCode==24960){
@@ -22,7 +25,7 @@ int main(int argc, char *argv[]){
   try
   {
     auto env = Environment::createEnvironment(Environment::OBJECT);
-    auto conn = env->createConnection("a", "b", "c");
+    auto conn = env->createConnection("a", "b", fake_db);
     env->terminateConnection(conn);
     Environment::terminateEnvironment(env);
   }catch(oracle::occi::SQLException &e)


### PR DESCRIPTION
Oracle test for checking the Oracle OCCI build with new GCC ABI is failing in nearly all release cycles. This test was try to connect to oracle DB at non-existing server `c`. But since 8th of May, now there is a real server `c` which is causing this test to fail. The change makes sure that we use a more random DB name with possibility to change it via `CMSTEST_FAKE_ORACLE_DBNAME` env (if needed in future).

Once this is merged in master IBs then I will open backport PRs for old release cycles too.
