### PR TITLE
add utility returning hashed version of firmware-uuid of a L1T menu

### DIFF
--- a/CondTools/L1Trigger/bin/BuildFile.xml
+++ b/CondTools/L1Trigger/bin/BuildFile.xml
@@ -1,0 +1,3 @@
+<bin name="l1tHashMenuFirmwareUUID" file="l1tHashMenuFirmwareUUID.cpp">
+  <use name="CondFormats/L1TObjects"/>
+</bin>

--- a/CondTools/L1Trigger/bin/l1tHashMenuFirmwareUUID.cpp
+++ b/CondTools/L1Trigger/bin/l1tHashMenuFirmwareUUID.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <string>
+
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+
+void showHelpMessage() {
+  std::cout << "---------------------------------------------------------------\n";
+  std::cout << "===                 l1tHashMenuFirmwareUUID                 ===\n";
+  std::cout << "=== compute 32-bit hashed version of L1T-menu firmware UUID ===\n";
+  std::cout << "---------------------------------------------------------------\n";
+  std::cout << "\n"
+            << "Purpose:\n"
+            << "  return 32-bit hashed version (type: int) of the firmware-UUID of a L1T menu\n\n"
+            << "Input:\n"
+            << "  firmware-UUID of a L1T menu, i.e. value of the field \"uuid-firmware\""
+            << " in the .xml file containing the L1T menu;\n"
+            << "  given a database payload XYZ, the .xml file can be obtained via \"conddb dump XYZ > tmp.xml\"\n"
+            << "  (if \"-h\" or \"--help\" are specified, this help message is shown)\n\n"
+            << "Exit code:\n"
+            << "  1 if no command-line arguments are specified, 0 otherwise\n\n"
+            << "Example:\n"
+            << "  > l1tHashMenuFirmwareUUID 7a1a9c0b-5e34-4c25-804f-2ae8094c4832\n\n";
+}
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "ERROR: no L1T-menu firmware UUID specified (hint: specify --help for more info).\n";
+    return 1;
+  } else {
+    for (int idx = 1; idx < argc; ++idx) {
+      std::string const argv_i = argv[idx];
+      if (argv_i == "-h" or argv_i == "--help") {
+        showHelpMessage();
+        return 0;
+      }
+    }
+
+    if (argc > 2) {
+      std::cerr << "WARNING: specified " << argc - 1 << " command-line arguments,"
+                << " but only the first one will be used (" << argv[1] << ").\n";
+    }
+  }
+
+  L1TUtmTriggerMenu foo;
+  foo.setFirmwareUuid(argv[1]);
+
+  std::cout << int(foo.getFirmwareUuidHashed()) << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
#### PR description:

This PR adds a simple cpp program to get the hashed version of the firmware-uuid of a L1T menu.

This utility can be useful in debugging [exceptions thrown by `L1TGlobalProducer`](https://github.com/cms-sw/cmssw/blob/d636fedd54218a07737bf87fcb0f2c55318d4884/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc#L343) like the one below:
```
An exception of category 'ConditionsError' occurred while
[0] Processing Event run: 367301 lumi: 10 event: 105191 stream: 23
[1] Running path 'HLT_DoubleEle10_eta1p22_mMax6_trkHits10_v2'
[2] Calling method for module L1TGlobalProducer/'hltGtStage2ObjectMap'
Exception Message:
Error L1 menu loaded in via conditions does not match the L1 actually run -931659658 vs 1554451404.
This means that the mapping of the names to the bits may be incorrect.
Please check the L1TUtmTriggerMenuRcd record supplied.
Unless you know what you are doing, do not simply disable this check via the config
as this a major error and the indication of something very wrong
```

#### PR validation:

The corresponding executable works as expected. Example:
```bash
$ l1tHashMenuFirmwareUUID 7a1a9c0b-5e34-4c25-804f-2ae8094c4832
1554451404
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A