### PR TITLE
[12.6.X] Oracle test: Use fake/random DB name

### DIFF
--- a/OnlineDB/Oracle/test/test.cpp
+++ b/OnlineDB/Oracle/test/test.cpp
@@ -7,32 +7,33 @@
 using namespace oracle::occi;
 using namespace std;
 
-int main(int argc, char *argv[]){
+int main(int argc, char* argv[]) {
+  const char* fake_db = "cms-fake-unknown-db-server-1234567890";
+  char* p = std::getenv("CMSTEST_FAKE_ORACLE_DBNAME");
+  fake_db = p ? p : fake_db;
   int errCode = 0;
-  if (argc==2){errCode = stoi(argv[1]);}
-  if (errCode==24960){
-    cout <<"Tesing: 'ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255'"<<endl;    
+  if (argc == 2) {
+    errCode = stoi(argv[1]);
   }
-  else if (errCode==12154){
-    cout <<"Tesing: 'ORA-12154: TNS:could not resolve the connect identifier specified'"<<endl;    
+  if (errCode == 24960) {
+    cout << "Tesing: 'ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255'"
+         << endl;
+  } else if (errCode == 12154) {
+    cout << "Tesing: 'ORA-12154: TNS:could not resolve the connect identifier specified'" << endl;
+  } else {
+    cout << "Testing exception error code:" << errCode << endl;
   }
-  else{
-    cout<<"Testing exception error code:"<<errCode<<endl;
-  }
-  try
-  {
+  try {
     auto env = Environment::createEnvironment(Environment::OBJECT);
-    auto conn = env->createConnection("a", "b", "c");
+    auto conn = env->createConnection("a", "b", fake_db);
     env->terminateConnection(conn);
     Environment::terminateEnvironment(env);
-  }catch(oracle::occi::SQLException &e)
-  {
-    cout <<"Caught oracle::occi::SQLException exception with error code: "<<e.getErrorCode()<<endl;
-    cout <<"Exception Message:"<< e.getMessage()<<endl;
-    if (e.getErrorCode()==errCode){
+  } catch (oracle::occi::SQLException& e) {
+    cout << "Caught oracle::occi::SQLException exception with error code: " << e.getErrorCode() << endl;
+    cout << "Exception Message:" << e.getMessage() << endl;
+    if (e.getErrorCode() == errCode) {
       cout << "OK: Expected exception found:" << errCode << endl;
-    }
-    else{
+    } else {
       throw;
     }
   }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41630

Fix oracle unit test. We know why test is failing, so it is really not required to get this change in this release cycle. Feel free to reject/close it.
