### PR TITLE
use `HLT:@relval2022_postEE` in re-reco MC RelVal using 'postEE' GT [`12_4_X` only]

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2003,10 +2003,10 @@ upgradeProperties[2017] = {
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
-   '2022ReReco' : {
+    '2022ReReco' : {
         'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2022_realistic_postEE',
-        'HLTmenu': '@relval2022',
+        'HLTmenu': '@relval2022_postEE',
         'Era' : 'Run3_2022_rereco',
         'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],


### PR DESCRIPTION
#### PR description:

The MC wfs added in #41591 use the MC GT `auto:phase1_2022_realistic_postEE`. To be consistent with the HLT conditions in that GT, the HLT menu used in those wfs should be `HLT:@relval2022_postEE`, not `HLT:@relval2022`.

#### PR validation:

`runTheMatrix.py -nel 14034.0 -w upgrade`

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A