### PR TITLE
[13_0_x] PPS Pixel DQM: assign errors to right plots

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -28,6 +28,9 @@
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelLocalTrack.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 
+#include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
+#include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
+
 #include <string>
 
 //-----------------------------------------------------------------------------
@@ -50,7 +53,9 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelCluster>> tokenCluster;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> tokenTrack;
   edm::EDGetTokenT<edm::TriggerResults> tokenTrigResults;
+  edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tokenPixelDAQMapping;
   std::string randomHLTPath;
+  std::string mappingLabel;
 
   static constexpr int NArms = 2;
   static constexpr int NStationMAX = 3;  // in an arm
@@ -219,6 +224,8 @@ CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
   tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixCluster"));
   tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixLTrack"));
   tokenTrigResults = consumes<edm::TriggerResults>(ps.getUntrackedParameter<edm::InputTag>("tagTrigResults"));
+  tokenPixelDAQMapping = esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>();
+  mappingLabel = ps.getUntrackedParameter<std::string>("mappingLabel");
   offlinePlots = ps.getUntrackedParameter<bool>("offlinePlots", true);
   onlinePlots = ps.getUntrackedParameter<bool>("onlinePlots", true);
 
@@ -690,6 +697,9 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
   Handle<edm::TriggerResults> hltResults;
   event.getByToken(tokenTrigResults, hltResults);
 
+  ESHandle<CTPPSPixelDAQMapping> mapping;
+  mapping = eventSetup.getHandle(tokenPixelDAQMapping);
+
   if (onlinePlots) {
     hBX->Fill(event.bunchCrossing());
     hBXshort->Fill(event.bunchCrossing());
@@ -850,13 +860,13 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
   }      // if(pixDigi.isValid()) {
 
   if (pixError.isValid()) {
+    std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> rocMapping = mapping->ROCMapping;
     for (const auto &ds_error : *pixError) {
       int idet = getDet(ds_error.id);
       if (idet != DetId::VeryForward) {
         if (idet == 15) {  //dummy det id: store in a plot with fed info
 
           for (DetSet<CTPPSPixelDataError>::const_iterator dit = ds_error.begin(); dit != ds_error.end(); ++dit) {
-            h2ErrorCodeUnidDet->Fill(dit->errorType(), dit->fedId());
             // recover fed channel number
             int chanNmbr = -1;
             if (dit->errorType() == 32 || dit->errorType() == 33 || dit->errorType() == 34) {
@@ -866,6 +876,30 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
               uint32_t errorWord = dit->errorWord32();
               chanNmbr = (errorWord >> LINK_shift) & LINK_mask;
             }
+
+            // recover detector Id from chanNmbr and fedId
+            CTPPSPixelFramePosition fPos(dit->fedId(), 0, chanNmbr, 0);  // frame position for ROC 0
+            std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo>::const_iterator mit;
+            int index = -1;
+            int plane = -1;
+            bool goodRecovery = false;
+            mit = rocMapping.find(fPos);
+            if (mit != rocMapping.end()) {
+              CTPPSPixelROCInfo rocInfo = (*mit).second;
+              CTPPSPixelDetId recoveredDetId(rocInfo.iD);
+              plane = recoveredDetId.plane();
+              index = getRPindex(recoveredDetId.arm(), recoveredDetId.station(), recoveredDetId.rp());
+              if (RPindexValid[index] && !isPlanePlotsTurnedOff[recoveredDetId.arm()][recoveredDetId.station()]
+                                                               [recoveredDetId.rp()][recoveredDetId.plane()])
+                goodRecovery = true;
+            }  // if (mit != rocMapping.end())
+
+            if (goodRecovery) {
+              h2ErrorCodeRP[index]->Fill(dit->errorType(), plane);
+            } else {
+              h2ErrorCodeUnidDet->Fill(dit->errorType(), dit->fedId());
+            }
+
             bool fillFED = false;
             int iFed = dit->fedId() - minFedNumber;
             if (iFed >= 0 && iFed < numberOfFeds)
@@ -921,42 +955,74 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
               int t6 = (errorWord >> DB6_shift) & DataBit_mask;
               int t7 = (errorWord >> DB7_shift) & DataBit_mask;
               if (t0 == 1) {
-                h2TBMMessageUnidDet->Fill(0, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(0, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(0, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(0, chanNmbr);
               }
               if (t1 == 1) {
-                h2TBMMessageUnidDet->Fill(1, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(1, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(1, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(1, chanNmbr);
               }
               if (t2 == 1) {
-                h2TBMMessageUnidDet->Fill(2, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(2, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(2, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(2, chanNmbr);
               }
               if (t3 == 1) {
-                h2TBMMessageUnidDet->Fill(3, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(3, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(3, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(3, chanNmbr);
               }
               if (t4 == 1) {
-                h2TBMMessageUnidDet->Fill(4, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(4, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(4, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(4, chanNmbr);
               }
               if (t5 == 1) {
-                h2TBMMessageUnidDet->Fill(5, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(5, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(5, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(5, chanNmbr);
               }
               if (t6 == 1) {
-                h2TBMMessageUnidDet->Fill(6, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(6, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(6, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(6, chanNmbr);
               }
               if (t7 == 1) {
-                h2TBMMessageUnidDet->Fill(7, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMMessageRP[index]->Fill(7, plane);
+                } else {
+                  h2TBMMessageUnidDet->Fill(7, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMMessageFED[iFed]->Fill(7, chanNmbr);
               }
@@ -965,27 +1031,47 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
               uint32_t stateMach_mask = ~(~uint32_t(0) << stateMach_bits);
               uint32_t stateMach = (errorWord >> stateMach_shift) & stateMach_mask;
               if (stateMach == 0) {
-                h2TBMTypeUnidDet->Fill(0, dit->fedId());
+                if (goodRecovery) {
+                  h2TBMTypeRP[index]->Fill(0, plane);
+                } else {
+                  h2TBMTypeUnidDet->Fill(0, dit->fedId());
+                }
                 if (fillFED)
                   h2TBMTypeFED[iFed]->Fill(0, chanNmbr);
               } else {
                 if (((stateMach >> DB0_shift) & DataBit_mask) == 1) {
-                  h2TBMTypeUnidDet->Fill(1, dit->fedId());
+                  if (goodRecovery) {
+                    h2TBMTypeRP[index]->Fill(1, plane);
+                  } else {
+                    h2TBMTypeUnidDet->Fill(1, dit->fedId());
+                  }
                   if (fillFED)
                     h2TBMTypeFED[iFed]->Fill(1, chanNmbr);
                 }
                 if (((stateMach >> DB1_shift) & DataBit_mask) == 1) {
-                  h2TBMTypeUnidDet->Fill(2, dit->fedId());
+                  if (goodRecovery) {
+                    h2TBMTypeRP[index]->Fill(2, plane);
+                  } else {
+                    h2TBMTypeUnidDet->Fill(2, dit->fedId());
+                  }
                   if (fillFED)
                     h2TBMTypeFED[iFed]->Fill(2, chanNmbr);
                 }
                 if (((stateMach >> DB2_shift) & DataBit_mask) == 1) {
-                  h2TBMTypeUnidDet->Fill(3, dit->fedId());
+                  if (goodRecovery) {
+                    h2TBMTypeRP[index]->Fill(3, plane);
+                  } else {
+                    h2TBMTypeUnidDet->Fill(3, dit->fedId());
+                  }
                   if (fillFED)
                     h2TBMTypeFED[iFed]->Fill(3, chanNmbr);
                 }
                 if (((stateMach >> DB3_shift) & DataBit_mask) == 1) {
-                  h2TBMTypeUnidDet->Fill(4, dit->fedId());
+                  if (goodRecovery) {
+                    h2TBMTypeRP[index]->Fill(4, plane);
+                  } else {
+                    h2TBMTypeUnidDet->Fill(4, dit->fedId());
+                  }
                   if (fillFED)
                     h2TBMTypeFED[iFed]->Fill(4, chanNmbr);
                 }
@@ -995,7 +1081,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
               h2ErrorCodeFED[iFed]->Fill(dit->errorType(), chanNmbr);
           }
           continue;
-        }
+        }  // if idet == 15
         if (verbosity > 1)
           LogPrint("CTPPSPixelDQMSource") << "not CTPPS: ds_error.id" << ds_error.id;
         continue;

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -7,7 +7,6 @@
  *
  *******************************************/
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -532,7 +531,7 @@ void CTPPSPixelDQMSource::bookHistograms(DQMStore::IBooker &ibooker, edm::Run co
                                                           0.,
                                                           double(NplaneMAX * NROCsMAX),
                                                           0.,
-                                                          rpixValues::ROCSizeInX *rpixValues::ROCSizeInY,
+                                                          rpixValues::ROCSizeInX * rpixValues::ROCSizeInY,
                                                           "");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetOption("colz");
         hp2HitsMultROC_LS[indexP]->getTProfile2D()->SetMinimum(1.0e-10);
@@ -697,8 +696,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
   Handle<edm::TriggerResults> hltResults;
   event.getByToken(tokenTrigResults, hltResults);
 
-  ESHandle<CTPPSPixelDAQMapping> mapping;
-  mapping = eventSetup.getHandle(tokenPixelDAQMapping);
+  const CTPPSPixelDAQMapping *mapping = &eventSetup.getData(tokenPixelDAQMapping);
 
   if (onlinePlots) {
     hBX->Fill(event.bunchCrossing());

--- a/DQM/CTPPS/python/ctppsDQM_cff.py
+++ b/DQM/CTPPS/python/ctppsDQM_cff.py
@@ -91,6 +91,12 @@ ctpps_2018.toReplaceWith(
     
 )
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+ctpps_2016.toReplaceWith(
+    _ctppsDQMOfflineSource,
+    cms.Sequence(
+    )
+)
 
 # the actually used sequences must be empty for pre-PPS data
 from Configuration.Eras.Modifier_ctpps_cff import ctpps

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -8,13 +8,14 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     tagTrigResults = cms.untracked.InputTag("TriggerResults","","HLT"),
+    mappingLabel = cms.untracked.string("RPix"),
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
     verbosity = cms.untracked.uint32(0),
     randomHLTPath = cms.untracked.string("HLT_Random_v3"),
     offlinePlots = cms.untracked.bool(False),
     onlinePlots = cms.untracked.bool(True),
     turnOffPlanePlots = cms.untracked.vstring(), 	# add tags for planes to be shut off, 
-    												# e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
+    							# e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
 )
 
 ctppsPixelDQMOfflineSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
@@ -23,11 +24,12 @@ ctppsPixelDQMOfflineSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
     tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
     tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     tagTrigResults = cms.untracked.InputTag("TriggerResults","","HLT"),
+    mappingLabel = cms.untracked.string("RPix"),
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout: 220_fr_hr; 210_fr_hr
     verbosity = cms.untracked.uint32(0),
     randomHLTPath = cms.untracked.string("HLT_Random_v3"),
     offlinePlots = cms.untracked.bool(True),
     onlinePlots = cms.untracked.bool(False),
     turnOffPlanePlots = cms.untracked.vstring(), 	# add tags for planes to be shut off, 
-    												# e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
+                                                        # e.g. "0_2_3_4" for arm 0 station 2 rp 3 plane 4
 )


### PR DESCRIPTION
**PR description:**

This PR is a bug fix in filling the plots in PPS Pixel DQM. Using the DAQ map, errors coming from pixels are assigned to the right detector plane instead of being put in a unidentified-detector plot, unless strictly necessary.

**PR validation:**

With matrix wfs 138.4 (run3) and 136.874 (run2) and with brand new 2023 data. Errors are now put inside the right plots.

This fix is needed for the data taking asap.

This is a backport of PR https://github.com/cms-sw/cmssw/pull/41649