### PR TITLE
[SIMULATION] [CLANG] Check Comparison results in Simulation modules when fixing unused variable warnings

### DIFF
--- a/SimG4CMS/Calo/plugins/CaloSimHitAnalysis.cc
+++ b/SimG4CMS/Calo/plugins/CaloSimHitAnalysis.cc
@@ -317,7 +317,11 @@ void CaloSimHitAnalysis::analyze(edm::Event const& e, edm::EventSetup const& set
 
 void CaloSimHitAnalysis::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
   int nHit = hits.size();
-  int nHB = 0, nHE = 0, nHO = 0, nHF = 0, nEB = 0, nEE = 0, nBad = 0, iHit = 0;
+  int nHB = 0, nHE = 0, nHO = 0, nHF = 0, nEB = 0, nEE = 0, nBad = 0;
+#ifdef EDM_ML_DEBUG
+  int iHit = 0;
+#endif
+
   std::map<CaloHitID, std::pair<double, double> > hitMap;
   double etot[nCalo_], etotG[nCalo_];
   for (unsigned int k = 0; k < nCalo_; ++k) {
@@ -364,8 +368,8 @@ void CaloSimHitAnalysis::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
     edm::LogVerbatim("HitStudy") << "Hit[" << iHit << ":" << nHit << ":" << idx << "] E " << edep << ":" << edepEM
                                  << ":" << edepHad << " T " << time << " itra " << itra << " ID " << std::hex << id
                                  << std::dec;
-#endif
     ++iHit;
+#endif
     if (idx >= 0) {
       CaloHitID hid(id, time, itra, 0, timeSliceUnit_[indx]);
       auto itr = hitMap.find(hid);

--- a/SimG4CMS/Calo/plugins/CaloSimHitStudy.cc
+++ b/SimG4CMS/Calo/plugins/CaloSimHitStudy.cc
@@ -389,9 +389,9 @@ void CaloSimHitStudy::analyze(edm::Event const& e, edm::EventSetup const& set) {
 
 void CaloSimHitStudy::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
   int nHit = hits.size();
-  int nHB(0), nHE(0), nHO(0), nHF(0), nEB(0), nEBAPD(0), nEBATJ(0), nEE(0), nES(0);
+  int nHB(0), nHE(0), nHO(0), nHF(0), nEB(0), nEBAPD(0), nEBATJ(0);
 #ifdef EDM_ML_DEBUG
-  int nBad(0);
+  int nBad(0), nEE(0), nES(0);
 #endif
   std::map<unsigned int, double> hitMap;
   std::vector<double> etot(nCalo_, 0), etotG(nCalo_, 0);
@@ -447,11 +447,11 @@ void CaloSimHitStudy::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
         nEBAPD++;
       else if (idx == 2)
         nEBATJ++;
+#ifdef EDM_ML_DEBUG
       else if (idx == 3)
         nEE++;
       else if (idx == 4)
         nES++;
-#ifdef EDM_ML_DEBUG
       else
         nBad++;
 #endif

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -738,7 +738,7 @@ void CaloSD::update(const ::EndOfEvent*) {
       ++wrong;
     }
 #else
-  saveHit((*theHC)[i]);
+    saveHit((*theHC)[i]);
 #endif
 
     ++count;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -737,7 +737,10 @@ void CaloSD::update(const ::EndOfEvent*) {
     if (!saveHit((*theHC)[i])) {
       ++wrong;
     }
+#else
+  saveHit((*theHC)[i]);
 #endif
+
     ++count;
     double x = (*theHC)[i]->getEM();
     eEM += x;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -720,12 +720,12 @@ void CaloSD::update(const ::EndOfEvent*) {
   slave.get()->ReserveMemory(theHC->entries());
 
   int count(0);
-  int wrong(0);
   double eEM(0.0);
   double eHAD(0.0);
   double eEM2(0.0);
   double eHAD2(0.0);
 #ifdef EDM_ML_DEBUG
+  int wrong(0);
   double tt(0.0);
   double zloc(0.0);
   double zglob(0.0);
@@ -733,9 +733,11 @@ void CaloSD::update(const ::EndOfEvent*) {
 #endif
   int hc_entries = theHC->entries();
   for (int i = 0; i < hc_entries; ++i) {
+#ifdef EDM_ML_DEBUG
     if (!saveHit((*theHC)[i])) {
       ++wrong;
     }
+#endif
     ++count;
     double x = (*theHC)[i]->getEM();
     eEM += x;

--- a/SimG4CMS/Calo/src/HFGflash.cc
+++ b/SimG4CMS/Calo/src/HFGflash.cc
@@ -233,8 +233,11 @@ std::vector<HFGflash::Hit> HFGflash::gfParameterization(const G4Step* aStep, boo
   z1 *= 9.76972e-01 - 3.85026e-01 * std::tanh(1.82790e+00 * std::log(energy) - 3.66237e+00);
   p1 *= 0.96;
 
+#ifdef EDM_ML_DEBUG
+  G4int nSpots_sd = 0;  // count total number of spots in SD
+#endif
+
   G4double stepLengthLeft = 10000;
-  G4int nSpots_sd = 0;                // count total number of spots in SD
   G4double zInX0 = 0.0;               // shower depth in X0 unit
   G4double deltaZInX0 = 0.0;          // segment of depth in X0 unit
   G4double deltaZ = 0.0;              // segment of depth in cm
@@ -440,7 +443,9 @@ std::vector<HFGflash::Hit> HFGflash::gfParameterization(const G4Step* aStep, boo
       oneHit.time = timeGlobal;
       oneHit.edep = emSpotEnergy * invgev;
       hit.push_back(oneHit);
+#ifdef EDM_ML_DEBUG
       nSpots_sd++;
+#endif
 
     }  // end of for spot iteration
 

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -39,10 +39,10 @@ HFShower::HFShower(const std::string &name,
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight) {
   std::vector<HFShower::Hit> hits;
-  int nHit = 0;
 
   double edep = weight * (aStep->GetTotalEnergyDeposit());
 #ifdef EDM_ML_DEBUG
+  int nHit = 0;
   edm::LogVerbatim("HFShower") << "HFShower::getHits: energy " << aStep->GetTotalEnergyDeposit() << " weight " << weight
                                << " edep " << edep;
 #endif
@@ -152,7 +152,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
         }
         hit.position = globalPos;
         hits.push_back(hit);
+#ifdef EDM_ML_DEBUG
         nHit++;
+#endif
       }
     }
   }
@@ -169,8 +171,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, double weight)
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibraryProducer, double zoffset) {
   std::vector<HFShower::Hit> hits;
+#ifdef EDM_ML_DEBUG
   int nHit = 0;
-
+#endif
   double edep = aStep->GetTotalEnergyDeposit();
   double stepl = 0.;
 
@@ -239,7 +242,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
       hit.momentum = momz[i];
       hit.position = globalPos;
       hits.push_back(hit);
+#ifdef EDM_ML_DEBUG
       nHit++;
+#endif
     }
   }
 
@@ -255,8 +260,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
 
 std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrary) {
   std::vector<HFShower::Hit> hits;
+#ifdef EDM_ML_DEBUG
   int nHit = 0;
-
+#endif
   double edep = aStep->GetTotalEnergyDeposit();
   double stepl = 0.;
 
@@ -342,7 +348,9 @@ std::vector<HFShower::Hit> HFShower::getHits(const G4Step *aStep, bool forLibrar
     hit.momentum = momz[i];
     hit.position = globalPos;
     hits.push_back(hit);
+#ifdef EDM_ML_DEBUG
     nHit++;
+#endif
   }
 
   return hits;


### PR DESCRIPTION
As discussed with @smuzaffar, we would like to understand from where the comparison differences of https://github.com/cms-sw/cmssw/pull/41584 are coming. So this PR is for testing the same modifications for `SimG4CMS/Calo` only.

Thanks,
Andrea.