### PR TITLE
extend x-axis range of "vs-lumi" harvesting outputs in HLT online-DQM

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -47,9 +47,9 @@ process.fastTimerServiceClient.doPlotsVsPixelLumi = False
 process.fastTimerServiceClient.onlineLumiME = dict(
     folder = 'HLT/LumiMonitoring',
     name   = 'lumiVsLS',
-    nbins  = 5000,
+    nbins  = 6000,
     xmin   = 0,
-    xmax   = 20000
+    xmax   = 30000,
 )
 
 # ThroughputService client
@@ -63,13 +63,10 @@ process.psColumnVsLumi = process.dqmCorrelationClient.clone(
       folder = cms.string("HLT/PSMonitoring"),
       name   = cms.string("psColumnVSlumi"),
       doXaxis = cms.bool( True ),
-      nbinsX = cms.int32( 5000),
-      xminX  = cms.double(    0.),
-      xmaxX  = cms.double(20000.),
+      nbinsX = cms.int32( 6000 ),
+      xminX  = cms.double( 0. ),
+      xmaxX  = cms.double( 30000. ),
       doYaxis = cms.bool( False ),
-      nbinsY = cms.int32 (   8),
-      xminY  = cms.double(   0.),
-      xmaxY  = cms.double(   8.),
    ),
    me1 = cms.PSet(
       folder   = cms.string("HLT/LumiMonitoring"),


### PR DESCRIPTION
#### PR description:

This PR adjusts the x-axis upper limit of the "vs-lumi" harvesting outputs produced by one HLT client of the online DQM (i.e. `hlt_dqm_clientPB-live`). The relevant quantity is the instantaneous luminosity, and the upper limit is changed from 2e34 Hz/cm^2 to 3e34 Hz/cm^2. More details can be found in [CMSHLT-2803](https://its.cern.ch/jira/browse/CMSHLT-2803).

#### PR validation:

Manual checks, e.g.
```bash
#!/bin/bash -ex

INPUTFILE=file:/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/RAW/Run2022G_EphemeralHLTPhysics0_run362616/82ed6819-9c96-49e1-a5ed-b5edc1a90108.root

RUNNUM=362616

rm -rf run"${RUNNUM}"* upload
convertToRaw -f 500 -l 500 -r "${RUNNUM}":209 -o . -- "${INPUTFILE}"

tmpfile=$(mktemp)
hltConfigFromDB --runNumber 367406 > "${tmpfile}"
cat <<@EOF >> "${tmpfile}"
process.load("run${RUNNUM}_cff")
process.hltLumiMonitor.histoPSet.lumiPSet.xmax = 30000
process.hltLumiMonitor.histoPSet.lumiPSet.nbins = 6000
process.hltOnlineBeamSpotESProducer.timeThreshold = int(1e6)
del process.PrescaleService
removeObjs = [pathName for pathName in process.paths_() if not pathName.endswith('Path')] + [pathName for pathName in process.finalpaths_()]
for foo in removeObjs:
    process.__delattr__(foo)
@EOF
edmConfigDump "${tmpfile}" > hlt.py

cmsRun hlt.py &> hlt.log

cmsRun "${CMSSW_BASE}"/src/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py \
  runInputDir=. runNumber="${RUNNUM}" runkey=pp_run scanOnce=True \
  datafnPosition=4
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_0_X`
`CMSSW_13_1_X`
