### PR TITLE
extend x-axis range of "vs-lumi" harvesting outputs in HLT online-DQM [`13_0_X`]

### DIFF
--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -47,9 +47,9 @@ process.fastTimerServiceClient.doPlotsVsPixelLumi = False
 process.fastTimerServiceClient.onlineLumiME = dict(
     folder = 'HLT/LumiMonitoring',
     name   = 'lumiVsLS',
-    nbins  = 5000,
+    nbins  = 6000,
     xmin   = 0,
-    xmax   = 20000
+    xmax   = 30000,
 )
 
 # ThroughputService client
@@ -63,13 +63,10 @@ process.psColumnVsLumi = process.dqmCorrelationClient.clone(
       folder = cms.string("HLT/PSMonitoring"),
       name   = cms.string("psColumnVSlumi"),
       doXaxis = cms.bool( True ),
-      nbinsX = cms.int32( 5000),
-      xminX  = cms.double(    0.),
-      xmaxX  = cms.double(20000.),
+      nbinsX = cms.int32( 6000 ),
+      xminX  = cms.double( 0. ),
+      xmaxX  = cms.double( 30000. ),
       doYaxis = cms.bool( False ),
-      nbinsY = cms.int32 (   8),
-      xminY  = cms.double(   0.),
-      xmaxY  = cms.double(   8.),
    ),
    me1 = cms.PSet(
       folder   = cms.string("HLT/LumiMonitoring"),


### PR DESCRIPTION
backport of #41665

#### PR description:

From the description of #41665:

>This PR adjusts the x-axis upper limit of the "vs-lumi" harvesting outputs produced by one HLT client of the online DQM (i.e. `hlt_dqm_clientPB-live`). The relevant quantity is the instantaneous luminosity, and the upper limit is changed from 2e34 Hz/cm^2 to 3e34 Hz/cm^2. More details can be found in [CMSHLT-2803](https://its.cern.ch/jira/browse/CMSHLT-2803).

#### PR validation:

None beyond the checks done for #41665.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#41665

Fix to online-DQM HLT client for 2023 data-taking.
