### PR TITLE
[DAQ] fix unsafe vector handling in FedRawData input source (13_0_X)

### DIFF
--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -152,7 +152,7 @@ private:
   tbb::concurrent_queue<std::unique_ptr<InputFile>> fileQueue_;
 
   std::mutex mReader_;
-  std::vector<std::condition_variable*> cvReader_;
+  std::vector<std::unique_ptr<std::condition_variable>> cvReader_;
   std::vector<unsigned int> tid_active_;
 
   std::atomic<bool> quit_threads_;


### PR DESCRIPTION
#### PR description:

Rare, spurious crashes have been obsever in input source initialization in HLT. Analysis points to a possibility of a vector being reallocated to a different heap location while threads wait on a condition variable.
(Not an urgent issue, since it causes minimal impact online and no data loss).

Solution is to initialize vectors before spawning threads using them.

Also, an opportunity was taken to wrap CV variables within a unique pointer instead of having to delete them in destructor and to remove a memory synchronization point, since creation of a thread already is one.

#### PR validation:

Tested with 13_0_6 in a DAQ test cluster for production FedRawDataInputSource . Also covered by unit tests for both sources.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #41668
(only applicable code)
Applies to FedRawDataInputSource and the patch is identical to master branch for this class.
Another class, DAQSource, is only found in CMSSW_13_1_X and master and will not be backported to 13_0_X.
