### PR TITLE
[13.0.X] Produce a fake `BeamSpot` object in `BeamSpotOnlineProducer` when using transient record logic and `OnlineBeamSpotESProducer` returned a fake

### DIFF
--- a/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h
@@ -44,6 +44,9 @@ public:
   enum TimeParamIndex { CREATE_TIME = 0, START_TIMESTAMP = 1, END_TIMESTAMP = 2, TSIZE = 3 };
 
   /// Setters Methods
+  // copy all copiable members from BeamSpotObjects
+  void copyFromBeamSpotObject(const BeamSpotObjects& bs);
+
   // set lastAnalyzedLumi_, last analyzed lumisection
   void setLastAnalyzedLumi(int val) { lastAnalyzedLumi_ = val; }
 

--- a/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/BeamSpotOnlineObjects.cc
@@ -92,6 +92,27 @@ cond::Time_t BeamSpotOnlineObjects::endTimeStamp() const {
 }
 
 // setters
+void BeamSpotOnlineObjects::copyFromBeamSpotObject(const BeamSpotObjects& bs) {
+  setType(bs.beamType());
+  setPosition(bs.x(), bs.y(), bs.z());
+  setSigmaZ(bs.sigmaZ());
+  setdxdz(bs.dxdz());
+  setdydz(bs.dydz());
+  setBeamWidthX(bs.beamWidthX());
+  setBeamWidthY(bs.beamWidthY());
+  setBeamWidthXError(bs.beamWidthXError());
+  setBeamWidthYError(bs.beamWidthYError());
+  setEmittanceX(bs.emittanceX());
+  setEmittanceY(bs.emittanceY());
+  setBetaStar(bs.betaStar());
+
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      setCovariance(i, j, bs.covariance(i, j));
+    }
+  }
+}
+
 void BeamSpotOnlineObjects::setNumTracks(int nTracks) {
   BeamSpotOnlineObjectsImpl::setOneParam(intParams_, NUM_TRACKS, nTracks);
 }

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineFromOfflineConverter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineFromOfflineConverter.cc
@@ -1,0 +1,174 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineFromOfflineConverter
+//
+/**\class BeamSpotOnlineFromOfflineConverter BeamSpotOnlineFromOfflineConverter.cc CondTools/BeamSpot/plugins/BeamSpotOnlineFromOfflineConverter.cc
+
+ Description: EDAnalyzer to create a BeamSpotOnlineHLTObjectsRcd from a BeamSpotObjectsRcd (inserting some parameters manually)
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Sat, 06 May 2023 21:10:00 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <ctime>
+
+// user include files
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineFromOfflineConverter : public edm::one::EDAnalyzer<> {
+public:
+  explicit BeamSpotOnlineFromOfflineConverter(const edm::ParameterSet&);
+  ~BeamSpotOnlineFromOfflineConverter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  cond::Time_t pack(uint32_t, uint32_t);
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  const edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> bsToken_;
+
+  // IoV-structure
+  bool fIsHLT_;
+  uint32_t fIOVStartRun_;
+  uint32_t fIOVStartLumi_;
+  cond::Time_t fnewSince_;
+  bool fuseNewSince_;
+
+  // parameters that can't be copied from the BeamSpotObject
+  int lastAnalyzedLumi_, lastAnalyzedRun_, lastAnalyzedFill_;
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineFromOfflineConverter::BeamSpotOnlineFromOfflineConverter(const edm::ParameterSet& iConfig)
+    : bsToken_(esConsumes()) {
+  lastAnalyzedLumi_ = iConfig.getParameter<double>("lastAnalyzedLumi");
+  lastAnalyzedRun_ = iConfig.getParameter<double>("lastAnalyzedRun");
+  lastAnalyzedFill_ = iConfig.getParameter<double>("lastAnalyzedFill");
+
+  fIsHLT_ = iConfig.getParameter<bool>("isHLT");
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi")) {
+    fIOVStartRun_ = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+    fIOVStartLumi_ = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
+    fnewSince_ = BeamSpotOnlineFromOfflineConverter::pack(fIOVStartRun_, fIOVStartLumi_);
+    fuseNewSince_ = true;
+    edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "useNewSince = True";
+  } else {
+    fuseNewSince_ = false;
+    edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "useNewSince = False";
+  }
+}
+
+//
+// member functions
+//
+
+// ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
+cond::Time_t BeamSpotOnlineFromOfflineConverter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi) {
+  return ((uint64_t)fIOVStartRun << 32 | fIOVStartLumi);
+}
+
+// ------------ method called for each event  ------------
+void BeamSpotOnlineFromOfflineConverter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const std::string fLabel = (fIsHLT_) ? "BeamSpotOnlineHLTObjectsRcd" : "BeamSpotOnlineLegacyObjectsRcd";
+  const BeamSpotObjects* inputSpot = &iSetup.getData(bsToken_);
+
+  BeamSpotOnlineObjects abeam;
+
+  abeam.setLastAnalyzedLumi(lastAnalyzedLumi_);
+  abeam.setLastAnalyzedRun(lastAnalyzedRun_);
+  abeam.setLastAnalyzedFill(lastAnalyzedFill_);
+  abeam.setStartTimeStamp(std::time(nullptr));
+  abeam.setEndTimeStamp(std::time(nullptr));
+  abeam.setType(inputSpot->beamType());
+  abeam.setPosition(inputSpot->x(), inputSpot->y(), inputSpot->z());
+  abeam.setSigmaZ(inputSpot->sigmaZ());
+  abeam.setdxdz(inputSpot->dxdz());
+  abeam.setdydz(inputSpot->dydz());
+  abeam.setBeamWidthX(inputSpot->beamWidthX());
+  abeam.setBeamWidthY(inputSpot->beamWidthY());
+  abeam.setEmittanceX(inputSpot->emittanceX());
+  abeam.setEmittanceY(inputSpot->emittanceY());
+  abeam.setBetaStar(inputSpot->betaStar());
+
+  for (int i = 0; i < 7; ++i) {
+    for (int j = 0; j < 7; ++j) {
+      abeam.setCovariance(i, j, inputSpot->covariance(i, j));
+    }
+  }
+
+  // Set the creation time of the payload to the current time
+  auto creationTime =
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  abeam.setCreationTime(creationTime);
+
+  edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << " Writing results to DB...";
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "poolDBService available";
+    if (poolDbService->isNewTagRequest(fLabel)) {
+      edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "new tag requested";
+      if (fuseNewSince_) {
+        edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "Using a new Since: " << fnewSince_;
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, fnewSince_, fLabel);
+      } else
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), fLabel);
+    } else {
+      edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "no new tag requested";
+      if (fuseNewSince_) {
+        edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "Using a new Since: " << fnewSince_;
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, fnewSince_, fLabel);
+      } else
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), fLabel);
+    }
+  }
+  edm::LogPrint("BeamSpotOnlineFromOfflineConverter") << "[BeamSpotOnlineFromOfflineConverter] endJob done \n";
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BeamSpotOnlineFromOfflineConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("isHLT", true);
+  desc.addOptionalUntracked<uint32_t>("IOVStartRun", 1);
+  desc.addOptionalUntracked<uint32_t>("IOVStartLumi", 1);
+  desc.add<double>("lastAnalyzedLumi", 1000);
+  desc.add<double>("lastAnalyzedRun", 1);
+  desc.add<double>("lastAnalyzedFill", -999);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineFromOfflineConverter);

--- a/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
@@ -1,0 +1,101 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("READ")
+
+options = VarParsing.VarParsing()
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "are we running the unit test?")
+options.register('inputTag',
+                 "myTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "output tag name")
+options.register('inputRecord',
+                 "BeamSpotOnlineLegacyObjectsRcd", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "type of record")
+options.register('startRun',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "location of the input data")
+options.register('startLumi',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "IOV Start Lumi")
+options.parseArguments()
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100000 # do not clog output with IO
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+####################################################################
+# Empty source 
+####################################################################
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.startRun),                  
+                            firstLuminosityBlock = cms.untracked.uint32(options.startLumi),     
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),            
+                            numberEventsInRun = cms.untracked.uint32(1))
+
+####################################################################
+# Connect to conditions DB
+####################################################################
+
+# either from Global Tag
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,"auto:phase2_realistic")
+
+# ...or specify database connection and tag:  
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+#process.dbInput = cms.ESSource("PoolDBESSource",
+#                               CondDBBeamSpotObjects,
+#                               toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotOnlineLegacyObjectsRcd'), # BeamSpotOnlineLegacy record
+#                                                          tag = cms.string('BSLegacy_tag')                       # choose your favourite tag
+#                                                          )
+#                                                 )
+#                               )
+# ...or from a local db file
+# input database (in this case the local sqlite file)
+
+####################################################################
+# Load and configure outputservice
+####################################################################
+if options.unitTest :
+    if options.inputRecord ==  "BeamSpotOnlineLegacyObjectsRcd" : 
+        tag_name = 'BSLegacy_tag'
+    else:
+        tag_name = 'BSHLT_tag'
+else:
+    tag_name = options.inputTag
+
+from CondCore.CondDB.CondDB_cfi import *
+CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % tag_name)) # choose an output name
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBBeamSpotObjects,
+                                          timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string(options.inputRecord), # BeamSpotOnline record
+                                                                     tag = cms.string(tag_name))),             # choose your favourite tag
+                                          loadBlobStreamer = cms.untracked.bool(False)
+                                          )
+
+isForHLT = (options.inputRecord == "BeamSpotOnlineHLTObjectsRcd")
+print("isForHLT: ",isForHLT)
+
+####################################################################
+# Load and configure analyzer
+####################################################################
+from CondTools.BeamSpot.beamSpotOnlineFromOfflineConverter_cfi import beamSpotOnlineFromOfflineConverter
+process.BeamSpotOnlineFromOfflineConverter = beamSpotOnlineFromOfflineConverter.clone(isHLT = isForHLT)
+
+# Put module in path:
+process.p = cms.Path(process.BeamSpotOnlineFromOfflineConverter)

--- a/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteOnlineBSFromDB.sh
@@ -30,5 +30,9 @@ cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputR
 printf "TESTING Reading BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure reading payload for BeamSpotOnlineHLTObjectsRcd" $? 
 
-echo "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
+printf "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
 cmsRun ${LOCAL_TEST_DIR}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?
+
+printf "TESTING converting BeamSpotOnlineObjects from BeamSpotObjects ...\n\n"
+cmsRun ${LOCAL_TEST_DIR}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True || die "Failure running BeamSpotRcdPrinter" $?
+

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -102,39 +102,39 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   bool fallBackToDB = false;
   if (useTransientRecord_) {
     auto const& spotDB = iSetup.getData(beamTransientToken_);
+
     if (spotDB.beamType() != 2) {
       if (shoutMODE && beamTransientRcdESWatcher_.check(iSetup)) {
-        edm::LogWarning("BeamSpotFromDB")
-            << "Online Beam Spot producer falls back to DB value because the ESProducer returned a fake beamspot ";
+        edm::LogWarning("BeamSpotFromDB") << "Online Beam Spot producer writes a fake beamspot value because the "
+                                             "ESProducer returned a fake beamspot!";
       }
-      fallBackToDB = true;
-    } else {
-      // translate from BeamSpotObjects to reco::BeamSpot
-      // in case we need to switch to LHC reference frame
-      // ignore for the moment rotations, and translations
-      double f = 1.;
-      if (changeFrame_)
-        f = -1.;
-      reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
-
-      reco::BeamSpot::CovarianceMatrix matrix;
-      for (int i = 0; i < 7; ++i) {
-        for (int j = 0; j < 7; ++j) {
-          matrix(i, j) = spotDB.covariance(i, j);
-        }
-      }
-      double sigmaZ = spotDB.sigmaZ();
-      if (theSetSigmaZ > 0)
-        sigmaZ = theSetSigmaZ;
-
-      // this assume beam width same in x and y
-      aSpot = reco::BeamSpot(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
-      aSpot.setBeamWidthY(spotDB.beamWidthY());
-      aSpot.setEmittanceX(spotDB.emittanceX());
-      aSpot.setEmittanceY(spotDB.emittanceY());
-      aSpot.setbetaStar(spotDB.betaStar());
-      aSpot.setType(reco::BeamSpot::Tracker);
     }
+
+    // translate from BeamSpotObjects to reco::BeamSpot
+    // in case we need to switch to LHC reference frame
+    // ignore for the moment rotations, and translations
+    double f = 1.;
+    if (changeFrame_)
+      f = -1.;
+    reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
+
+    reco::BeamSpot::CovarianceMatrix matrix;
+    for (int i = 0; i < 7; ++i) {
+      for (int j = 0; j < 7; ++j) {
+        matrix(i, j) = spotDB.covariance(i, j);
+      }
+    }
+    double sigmaZ = spotDB.sigmaZ();
+    if (theSetSigmaZ > 0)
+      sigmaZ = theSetSigmaZ;
+
+    // this assume beam width same in x and y
+    aSpot = reco::BeamSpot(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
+    aSpot.setBeamWidthY(spotDB.beamWidthY());
+    aSpot.setEmittanceX(spotDB.emittanceX());
+    aSpot.setEmittanceY(spotDB.emittanceY());
+    aSpot.setbetaStar(spotDB.betaStar());
+    aSpot.setType(static_cast<reco::BeamSpot::BeamType>(spotDB.beamType()));
   } else {
     // get scalar collection
     Handle<BeamSpotOnlineCollection> handleScaler;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41597 (partial)

#### PR description:

While working on https://github.com/cms-sw/cmssw/pull/41193/, I have noticed that despite `OnlineBeamSpotESProducer`  has a refined logic in order to put into the event setup a fake BeamSpot when certain conditions are not met:

https://github.com/cms-sw/cmssw/blob/a52f2d1ecf97bde0e9f10d45959c88337c481687/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc#L168-L174

the current `BeamSpotOnlineProducer` logic, if `useTransientRecord_` is true and the  `OnlineBeamSpotESProducer` returned a fake beamspot, just falls back to DB (reading the content of `BeamSpotObjectsRcd`, populated by the PCL in realtime workflows)  - which I have understood from the Beam Spot experts is not the right / expected behaviour.

https://github.com/cms-sw/cmssw/blob/a52f2d1ecf97bde0e9f10d45959c88337c481687/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc#L104-L111

In this PR (in commit 5a3afffd4a64b32c6049cee8d8afd4beef9090cf) I change the current behaviour, such that instead now it will indeed produce a fake BS for consumption online (as it was originally devised).

In the master branch, I have found convenient to create a new plugin `BeamSpotOnlineFromOfflineConverter` that taking a `BeamSpotObject` in input creates an sqlite file in output containing a payload of the type `BeamSpotOnlineObjects`. This has been added in commit  0b2e1056426f5188428ea8b0708806e234d00fe1, while commits 6f1912eae5366630cd0543e704bf3c236fa16b47 and  5c011c8a90fbbebd3ac9f7a471538cd6b56123e0 add a utility accessor to the `BeamSpotOnlineObjects` condtion format to be able to readily copy from a `BeamSpotObjects` payload (friend class) all the common parameters. Finally commit 991186be170060dbee10ee3b6912b247fce9fba4 adds this converter to the battery of unit tests of the `CondTools/BeamSpot` package. 

**N.B.**
I have NOT backported commits d5eedb8d39434b42da0a387b7478656d40a27ab0 and 63e821e6fe98cfc774029b4f7798053f21fd2153 in this PR as they are not needed. Indeed in 13.0.X the phase-2 HLT menu uses the offline BeamSpot directly, without using the fallback mechanism, see:

https://github.com/cms-sw/cmssw/blob/3dc3c13aa2c349c35c405a0fb3ba66b4abdb8e6f/HLTrigger/Configuration/python/HLT_75e33/modules/offlineBeamSpot_cfi.py#L1-L3

(the move was done in https://github.com/cms-sw/cmssw/pull/41047 which was not backported)



#### PR validation:

`cmssw` complies. Passes back unit tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport of https://github.com/cms-sw/cmssw/pull/41597, to be backported down to 13.0.X for 2023 data-taking purposes.