### PR TITLE
Run3-gex161X Try to avoid compilation warnings in SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc

### DIFF
--- a/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
+++ b/SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc
@@ -389,7 +389,7 @@ void fillABTTFFiles(const char ttFlags[nTTInEta][nTTInPhi], ofstream files[]) {
 
 void fillABSRPFiles(const char barrelSrFlags[nBarrelTTInEta][nTTInPhi],
                     const char endcapSrFlags[nEndcaps][nSupercrystalXBins][nSupercrystalYBins],
-                    ofstream files[nAB]) {
+                    ofstream files[]) {
   // event headers:
   for (int iAB = 0; iAB < nAB; ++iAB) {
     files[iAB] << "# Event " << iEvent << "\n";


### PR DESCRIPTION
#### PR description:

Try to avoid compilation warnings in SimCalorimetry/EcalElectronicsEmulation/bin/GenABIO.cc

#### PR validation:

Only tested by building the libraries

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special