### PR TITLE
[12_4] Unique upgrade workflow ID

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -82,7 +82,13 @@ numWFStart={
 }
 numWFSkip=200
 # temporary measure to keep other WF numbers the same
-numWFConflict = [[20000,23200],[23600,28200],[28600,31400],[31800,32200],[32600,34600],[50000,51000]]
+numWFConflict = [[14000,14400], #2023FS,2023FSPU in 13_0 or beyond
+                 [20000,23200],
+                 [23600,28200],
+                 [28600,31400],
+                 [31800,32200],
+                 [32600,34600],
+                 [50000,51000]]
 numWFAll={
     2017: [],
     2026: []


### PR DESCRIPTION
#### PR description:
This to make a unique upgrade workflow ID between CMSSW_12_4 and beyond after https://github.com/cms-sw/cmssw/pull/41591

#### PR validation:
Using `runTheMatrix.py --what upgrade -n | grep 2022ReReco` to check the workflow ID

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This PR is for 12_4 only. Master (and maybe 13_1) will have the same kind of PR but with different `numWFConflict`. Here is the master PR, https://github.com/cms-sw/cmssw/pull/41689