### PR TITLE
[13_2] Unique upgrade workflow ID

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -64,7 +64,8 @@ numWFStart={
 }
 numWFSkip=200
 # temporary measure to keep other WF numbers the same
-numWFConflict = [[20400,20800], #D87
+numWFConflict = [[14400,14800], #2022ReReco, 2022ReRecoPU (in 12_4)
+                 [20400,20800], #D87
                  [21200,22000], #D89-D90
                  [50000,51000]]
 numWFAll={


### PR DESCRIPTION
#### PR description:
This to make a unique upgrade workflow ID between CMSSW_12_4 and beyond after https://github.com/cms-sw/cmssw/pull/41591

#### PR validation:
Running `runTheMatrix.py --what upgrade -n | grep 2023FS`, still get expected wf id.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
There is a PR for 12_4, https://github.com/cms-sw/cmssw/pull/41688. It has different defined `numWFConflict` to reflect the workflow in the release.
Backport should be done to 13_1 (the same as this PR)

