### PR TITLE
[CORE] [CLANG] Fix warnings reported by llvm16 in CLANG IBs

### DIFF
--- a/DataFormats/Common/test/testValueMap.cc
+++ b/DataFormats/Common/test/testValueMap.cc
@@ -43,6 +43,7 @@ void testValueMap::dummy() {
   const double& x = v[edm::Ref<CKey>()];
   double y = x;
   ++y;
+  std::cout << "numberOfAssociations:" << y << std::endl;
   ++f;
   edm::Ref<Assoc> r;
   v.erase(edm::Ref<CKey>());


### PR DESCRIPTION
Fixing set but unused variable by adding a printout. In theory this piece of code is just testing that things compile (https://github.com/cms-sw/cmssw/blob/master/DataFormats/Common/test/testValueMap.cc#L30).

Following the same approach as on https://github.com/cms-sw/cmssw/pull/41522.