### PR TITLE
Phase2 L1T - Ensure cluster ecal_eta/phi are set when not running CombinedCaloLinker.

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/CaloClusterer.cc
@@ -589,6 +589,8 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           float wecal = cluster.ecal_et / cluster.et, whcal = 1.0 - wecal;
           cluster.eta = ecal.eta * wecal + hcal.eta * whcal;
           cluster.phi = ecal.phi * wecal + hcal.phi * whcal;
+          cluster.ecal_eta = cluster.eta;
+          cluster.ecal_phi = cluster.phi;
           // wrap around phi
           cluster.phi = reco::reduceRange(cluster.phi);
           cluster.constituents.emplace_back(-i - 1, 1);
@@ -617,6 +619,8 @@ void l1tpf_calo::SimpleCaloLinker::run() {
           cluster.et = myet + etot;
           cluster.eta = hcal.eta + avg_eta / cluster.et;
           cluster.phi = hcal.phi + avg_phi / cluster.et;
+          cluster.ecal_eta = cluster.eta;
+          cluster.ecal_phi = cluster.phi;
           // wrap around phi
           cluster.phi = reco::reduceRange(cluster.phi);
         }
@@ -676,6 +680,8 @@ void l1tpf_calo::FlatCaloLinker::run() {
     dst.et = src.et;
     dst.eta = src.eta;
     dst.phi = src.phi;
+    dst.ecal_eta = src.eta;
+    dst.ecal_phi = src.phi;
     dst.ecal_et = 0;
     dst.hcal_et = 0;
     for (const auto &pair : src.constituents) {


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced in #41279, where there is now an excess of Puppi candidates (and jets produced from these) at eta/phi=0.  The solution is to ensure variables introduced by the previous PR are always set to something sensible.

The PR to `cms-l1t-offline` is [#1124](https://github.com/cms-l1t-offline/cmssw/pull/1124).

#### PR validation:

See the local PR for before/after validation.


