### PR TITLE
enable dnn tracking for heavy ions for Run 3 eras

### DIFF
--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -5,6 +5,6 @@ from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 
-Run3_pp_on_PbPb = cms.ModifierChain(Run3.copyAndExclude([trackdnn, trackdnn_CKF]), pp_on_AA, pp_on_PbPb_run3)
+Run3_pp_on_PbPb = cms.ModifierChain(Run3.copyAndExclude([trackdnn_CKF]), pp_on_AA, pp_on_PbPb_run3)
 
 

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -242,6 +242,10 @@ detachedQuadStep = TrackMVAClassifierDetached.clone(
     src         = 'detachedQuadStepTracks',
     qualityCuts = [-0.5,0.0,0.5]
 )
+pp_on_AA.toModify(detachedQuadStep, 
+        mva         = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1'),
+        qualityCuts = [-0.2, 0.2, 0.5],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -253,10 +257,8 @@ trackdnn.toReplaceWith(detachedQuadStep, trackTfClassifier.clone(
 
 
 highBetaStar_2018.toModify(detachedQuadStep,qualityCuts = [-0.7,0.0,0.5])
-pp_on_AA.toModify(detachedQuadStep, 
-        mva         = dict(GBRForestLabel = 'HIMVASelectorDetachedQuadStep_Phase1'),
-        qualityCuts = [-0.2, 0.2, 0.5],
-)
+
+(pp_on_AA & trackdnn).toModify(detachedQuadStep, qualityCuts =  [-0.63, 0.5, 0.94] )
 
 fastSim.toModify(detachedQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -287,6 +287,10 @@ trackingPhase1.toReplaceWith(detachedTripletStep, detachedTripletStepClassifier1
     mva = dict(GBRForestLabel = 'MVASelectorDetachedTripletStep_Phase1'),
     qualityCuts = [-0.2,0.3,0.8]
 ))
+pp_on_AA.toModify(detachedTripletStep, 
+        mva = dict(GBRForestLabel = 'HIMVASelectorDetachedTripletStep_Phase1'),
+        qualityCuts = [-0.2, 0.4, 0.85],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -297,11 +301,9 @@ trackdnn.toReplaceWith(detachedTripletStep, trackTfClassifier.clone(
 ))
 (trackdnn & fastSim).toModify(detachedTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
+(pp_on_AA & trackdnn).toModify(detachedTripletStep, qualityCuts =  [-0.32, 0.5, 0.98] )
+
 highBetaStar_2018.toModify(detachedTripletStep,qualityCuts = [-0.5,0.0,0.5])
-pp_on_AA.toModify(detachedTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorDetachedTripletStep_Phase1'),
-        qualityCuts = [-0.2, 0.4, 0.85],
-)
 
 # For LowPU
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -287,6 +287,10 @@ highPtTripletStep = TrackMVAClassifierPrompt.clone(
      src         = 'highPtTripletStepTracks',
      qualityCuts = [0.2,0.3,0.4]
 )
+pp_on_AA.toModify(highPtTripletStep, 
+        mva = dict(GBRForestLabel = 'HIMVASelectorHighPtTripletStep_Phase1'),
+        qualityCuts = [-0.9, -0.3, 0.85],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -296,12 +300,10 @@ trackdnn.toReplaceWith(highPtTripletStep, trackTfClassifier.clone(
     qualityCuts = qualityCutDictionary.HighPtTripletStep.value()
 ))
 highBetaStar_2018.toModify(highPtTripletStep,qualityCuts = [-0.2,0.3,0.4])
-pp_on_AA.toModify(highPtTripletStep, 
-        mva = dict(GBRForestLabel = 'HIMVASelectorHighPtTripletStep_Phase1'),
-        qualityCuts = [-0.9, -0.3, 0.85],
-)
 
 fastSim.toModify(highPtTripletStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
+
+(pp_on_AA & trackdnn).toModify(highPtTripletStep, qualityCuts =  [-0.5, 0.5, 0.94] )
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -343,6 +343,10 @@ trackingPhase1.toReplaceWith(initialStep, initialStepClassifier1.clone(
      mva         = dict(GBRForestLabel = 'MVASelectorInitialStep_Phase1'),
      qualityCuts = [-0.95,-0.85,-0.75]
 ))
+pp_on_AA.toModify(initialStep, 
+        mva         = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),
+        qualityCuts = [-0.9, -0.5, 0.2],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -354,11 +358,7 @@ trackdnn.toReplaceWith(initialStep, trackTfClassifier.clone(
 
 (trackdnn & fastSim).toModify(initialStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-
-pp_on_AA.toModify(initialStep, 
-        mva         = dict(GBRForestLabel = 'HIMVASelectorInitialStep_Phase1'),
-        qualityCuts = [-0.9, -0.5, 0.2],
-)
+(pp_on_AA & trackdnn).toModify(initialStep, qualityCuts = [0.35, 0.69, 0.88] )
 
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -232,6 +232,10 @@ lowPtQuadStep = TrackMVAClassifierPrompt.clone(
      src         = 'lowPtQuadStepTracks',
      qualityCuts = [-0.7,-0.35,-0.15]
 )
+pp_on_AA.toModify(lowPtQuadStep, 
+        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),
+        qualityCuts = [-0.9, -0.4, 0.3],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -241,14 +245,12 @@ trackdnn.toReplaceWith(lowPtQuadStep, trackTfClassifier.clone(
     qualityCuts = qualityCutDictionary.LowPtQuadStep.value()
 ))
 highBetaStar_2018.toModify(lowPtQuadStep,qualityCuts = [-0.9,-0.35,-0.15])
-pp_on_AA.toModify(lowPtQuadStep, 
-        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtQuadStep_Phase1'),
-        qualityCuts = [-0.9, -0.4, 0.3],
-)
 fastSim.toModify(lowPtQuadStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 ((~trackingMkFitLowPtQuadStep) & trackdnn).toModify(lowPtQuadStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
                                                     qualityCuts = [-0.33,  0.13,  0.35])
+
+(pp_on_AA & trackdnn).toModify(lowPtQuadStep, qualityCuts =  [-0.35, 0.8, 0.98] )
 
 # For Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -311,6 +311,10 @@ trackingPhase1.toReplaceWith(lowPtTripletStep, lowPtTripletStep.clone(
      mva         = dict(GBRForestLabel = 'MVASelectorLowPtTripletStep_Phase1'),
      qualityCuts = [-0.4,0.0,0.3],
 ))
+pp_on_AA.toModify(lowPtTripletStep, 
+        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),
+        qualityCuts = [-0.8, -0.4, 0.5],
+)
 
 from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
@@ -320,14 +324,13 @@ trackdnn.toReplaceWith(lowPtTripletStep, trackTfClassifier.clone(
     qualityCuts = qualityCutDictionary.LowPtTripletStep.value()
 ))
 highBetaStar_2018.toModify(lowPtTripletStep,qualityCuts = [-0.7,-0.3,-0.1])
-pp_on_AA.toModify(lowPtTripletStep, 
-        mva         = dict(GBRForestLabel = 'HIMVASelectorLowPtTripletStep_Phase1'),
-        qualityCuts = [-0.8, -0.4, 0.5],
-)
+
 fastSim.toModify(lowPtTripletStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 ((~trackingMkFitLowPtTripletStep) & trackdnn).toModify(lowPtTripletStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
                                                     qualityCuts = [-0.23,  0.15,  0.41])
+
+(pp_on_AA & trackdnn).toModify(lowPtTripletStep, qualityCuts =  [-0.29, 0.65, 0.98] )
 
 # For LowPU and Phase2PU140
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -116,6 +116,10 @@ _trackClusterRemoverBase = _trackClusterRemover.clone(
     minNumberOfLayersWithMeasBeforeFiltering = 0,
 )
 
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
+(pp_on_AA & (~trackdnn) ).toModify(_trackClusterRemoverBase, TrackQuality = 'tight')
+
 #Phase2 : configuring the phase2 track Cluster Remover
 from RecoLocalTracker.SubCollectionProducers.phase2trackClusterRemover_cfi import phase2trackClusterRemover as _phase2trackClusterRemover
 _trackClusterRemoverBase_trackingPhase2PU140 = _phase2trackClusterRemover.clone(

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -116,9 +116,6 @@ _trackClusterRemoverBase = _trackClusterRemover.clone(
     minNumberOfLayersWithMeasBeforeFiltering = 0,
 )
 
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(_trackClusterRemoverBase, TrackQuality = 'tight')
-
 #Phase2 : configuring the phase2 track Cluster Remover
 from RecoLocalTracker.SubCollectionProducers.phase2trackClusterRemover_cfi import phase2trackClusterRemover as _phase2trackClusterRemover
 _trackClusterRemoverBase_trackingPhase2PU140 = _phase2trackClusterRemover.clone(


### PR DESCRIPTION
#### PR description:

The heavy-ion reconstruction (eras based on `pp_on_AA`) use track selection calibrations based on a BDT that was trained on Run 2 PbPb MC for six of the tracking iterations.
In the meantime, pp has migrated to a DNN-based track selection.  
There is an ongoing effort to perform a DNN training for heavy ions, but this is not 100% sure to converge for 13_2_X, which is the intended release for 2023 PbPb. 
As a back-up solution we have tested the default pp calibrations, but tightening the working points to give a similar efficiency to the old BDT calibrations.   
It was found that the efficiency and fake rate are very similar, except at high pT where the fake rate is dramatically lower with the DNN track selection. 
The performance is shown here:
https://indico.cern.ch/event/1278968/contributions/5372961/attachments/2646731/4581824/Performance_of_DNN_with_pp_training_in_heavy_ions.pdf
This PR switches to the DNN as the default for heavy ions.
We also remove an additional difference between pp and HI tracking, which was the use of the `tight` quality bit in the hit cleaning between steps. 


#### PR validation:

Tested with wf 160

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport will be needed.

@CesarBernardes @abaty @sayanchatterjee38 @icali 
