### PR TITLE
Fix LumiCache in AlcaBeamMonitor and OnlineBeamMonitor

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -60,20 +60,20 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
     histoByCategoryNames_.insert(pair<string, string>("run", "Coordinate"));
     histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-DataBase"));
     histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-BeamFit"));
-    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Online"));
     histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-DataBase"));
     histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-BeamFit"));
-    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Online"));
 
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotFit"));
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex"));
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased DataBase"));
-    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased Online"));
     histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-DataBase fit"));
-    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-Scalers fit"));
-    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
+    histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased PrimaryVertex-Online fit"));
+    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Online-DataBase fit"));
     histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
-    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
+    histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Online"));
   }
 
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
@@ -115,8 +115,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         if (itMM->first == "Coordinate") {
           itMM->second = ibooker.book1D(name, title, 1001, -0.2525, 0.2525);
         } else if (itMM->first == "PrimaryVertex fit-DataBase" || itMM->first == "PrimaryVertex fit-BeamFit" ||
-                   itMM->first == "PrimaryVertex fit-Scalers" || itMM->first == "PrimaryVertex-DataBase" ||
-                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Scalers") {
+                   itMM->first == "PrimaryVertex fit-Online" || itMM->first == "PrimaryVertex-DataBase" ||
+                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Online") {
           itMM->second = ibooker.book1D(name, title, 1001, -0.02525, 0.02525);
         } else {
           //assert(0);
@@ -125,10 +125,10 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         if (itMM->first == "Coordinate") {
           itMM->second = ibooker.book1D(name, title, 101, -5.05, 5.05);
         } else if (itMM->first == "PrimaryVertex fit-DataBase" || itMM->first == "PrimaryVertex fit-BeamFit" ||
-                   itMM->first == "PrimaryVertex fit-Scalers") {
+                   itMM->first == "PrimaryVertex fit-Online") {
           itMM->second = ibooker.book1D(name, title, 101, -0.505, 0.505);
         } else if (itMM->first == "PrimaryVertex-DataBase" || itMM->first == "PrimaryVertex-BeamFit" ||
-                   itMM->first == "PrimaryVertex-Scalers") {
+                   itMM->first == "PrimaryVertex-Online") {
           itMM->second = ibooker.book1D(name, title, 1001, -5.005, 5.005);
         } else {
           //assert(0);
@@ -137,8 +137,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         if (itMM->first == "Coordinate") {
           itMM->second = ibooker.book1D(name, title, 100, 0, 0.015);
         } else if (itMM->first == "PrimaryVertex fit-DataBase" || itMM->first == "PrimaryVertex fit-BeamFit" ||
-                   itMM->first == "PrimaryVertex fit-Scalers" || itMM->first == "PrimaryVertex-DataBase" ||
-                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Scalers") {
+                   itMM->first == "PrimaryVertex fit-Online" || itMM->first == "PrimaryVertex-DataBase" ||
+                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Online") {
           itMM->second = nullptr;
         } else {
           //assert(0);
@@ -147,8 +147,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         if (itMM->first == "Coordinate") {
           itMM->second = ibooker.book1D(name, title, 110, 0, 11);
         } else if (itMM->first == "PrimaryVertex fit-DataBase" || itMM->first == "PrimaryVertex fit-BeamFit" ||
-                   itMM->first == "PrimaryVertex fit-Scalers" || itMM->first == "PrimaryVertex-DataBase" ||
-                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Scalers") {
+                   itMM->first == "PrimaryVertex fit-Online" || itMM->first == "PrimaryVertex-DataBase" ||
+                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Online") {
           itMM->second = ibooker.book1D(name, title, 101, -5.05, 5.05);
         } else {
           //assert(0);
@@ -160,8 +160,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         if (itMM->first == "Coordinate") {
           itMM->second->setAxisTitle(itM->first + "_{0} (cm)", 1);
         } else if (itMM->first == "PrimaryVertex fit-DataBase" || itMM->first == "PrimaryVertex fit-BeamFit" ||
-                   itMM->first == "PrimaryVertex fit-Scalers" || itMM->first == "PrimaryVertex-DataBase" ||
-                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Scalers") {
+                   itMM->first == "PrimaryVertex fit-Online" || itMM->first == "PrimaryVertex-DataBase" ||
+                   itMM->first == "PrimaryVertex-BeamFit" || itMM->first == "PrimaryVertex-Online") {
           itMM->second->setAxisTitle(itMM->first + " " + itM->first + "_{0} (cm)", 1);
         }
         itMM->second->setAxisTitle("Entries", 2);
@@ -181,11 +181,11 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
             ibooker.setCurrentFolder(monitorName_ + "Debug");
             itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
             itMMM->second->setEfficiencyFlag();
-          } else if (itMM->first == "validation" && itMMM->first == "Lumibased Scalers-DataBase fit") {
+          } else if (itMM->first == "validation" && itMMM->first == "Lumibased Online-DataBase fit") {
             ibooker.setCurrentFolder(monitorName_ + "Validation");
             itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
             itMMM->second->setEfficiencyFlag();
-          } else if (itMM->first == "validation" && itMMM->first != "Lumibased Scalers-DataBase fit" &&
+          } else if (itMM->first == "validation" && itMMM->first != "Lumibased Online-DataBase fit" &&
                      (itM->first == "x" || itM->first == "y" || itM->first == "z")) {
             ibooker.setCurrentFolder(monitorName_ + "Validation");
             itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
@@ -224,13 +224,12 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<alcabeammonitor::NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi,
-                                                                                      const EventSetup& iSetup) const {
+std::shared_ptr<alcabeammonitor::BeamSpotInfo> AlcaBeamMonitor::globalBeginLuminosityBlock(
+    const LuminosityBlock& iLumi, const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
-  vertices_.clear();
-  beamSpotsMap_.clear();
-  processedLumis_.push_back(iLumi.id().luminosityBlock());
+  auto beamSpotInfo = std::make_shared<alcabeammonitor::BeamSpotInfo>();
+
   //Read BeamSpot from DB
   ESHandle<BeamSpotObjects> bsDBHandle;
   try {
@@ -252,10 +251,10 @@ std::shared_ptr<alcabeammonitor::NoCache> AlcaBeamMonitor::globalBeginLuminosity
       }
     }
 
-    beamSpotsMap_["DB"] =
+    beamSpotInfo->beamSpotMap_["DB"] =
         BeamSpot(apoint, spotDB->sigmaZ(), spotDB->dxdz(), spotDB->dydz(), spotDB->beamWidthX(), matrix);
 
-    BeamSpot* aSpot = &(beamSpotsMap_["DB"]);
+    BeamSpot* aSpot = &(beamSpotInfo->beamSpotMap_["DB"]);
 
     aSpot->setBeamWidthY(spotDB->beamWidthY());
     aSpot->setEmittanceX(spotDB->emittanceX());
@@ -272,7 +271,7 @@ std::shared_ptr<alcabeammonitor::NoCache> AlcaBeamMonitor::globalBeginLuminosity
   } else {
     LogInfo("AlcaBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
   }
-  return nullptr;
+  return beamSpotInfo;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -282,45 +281,47 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
   //------ PVFitter
   thePVFitter_->readEvent(iEvent);
 
-  if (beamSpotsMap_.find("DB") != beamSpotsMap_.end()) {
+  auto beamSpotInfo = luminosityBlockCache(iEvent.getLuminosityBlock().index());
+  if (beamSpotInfo->beamSpotMap_.find("DB") != beamSpotInfo->beamSpotMap_.end()) {
     //------ Tracks
     Handle<reco::TrackCollection> TrackCollection;
     iEvent.getByToken(trackLabel_, TrackCollection);
     const reco::TrackCollection* tracks = TrackCollection.product();
     for (reco::TrackCollection::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
       hD0Phi0_->Fill(track->phi(), -1 * track->dxy());
-      hDxyBS_->Fill(-1 * track->dxy(beamSpotsMap_["DB"].position()));
+      hDxyBS_->Fill(-1 * track->dxy(beamSpotInfo->beamSpotMap_["DB"].position()));
     }
   }
 
   //------ Primary Vertices
   Handle<VertexCollection> PVCollection;
   if (iEvent.getByToken(primaryVertexLabel_, PVCollection)) {
-    vertices_.push_back(*PVCollection.product());
+    beamSpotInfo->vertices_.push_back(*PVCollection.product());
   }
 
-  if (beamSpotsMap_.find("SC") == beamSpotsMap_.end()) {
+  if (beamSpotInfo->beamSpotMap_.find("SC") == beamSpotInfo->beamSpotMap_.end()) {
     //BeamSpot from file for this stream is = to the scalar BeamSpot
-    Handle<BeamSpot> recoBeamSpotHandle;
-    try {
-      iEvent.getByToken(scalerLabel_, recoBeamSpotHandle);
-    } catch (cms::Exception& exception) {
-      LogInfo("AlcaBeamMonitor") << exception.what();
-      return;
-    }
-    beamSpotsMap_["SC"] = *recoBeamSpotHandle;
-    if (beamSpotsMap_["SC"].BeamWidthX() != 0) {
-      beamSpotsMap_["SC"].setType(reco::BeamSpot::Tracker);
+    if (Handle<BeamSpot> recoBeamSpotHandle = iEvent.getHandle(scalerLabel_)) {
+      beamSpotInfo->beamSpotMap_["SC"] = *recoBeamSpotHandle;
+      if (beamSpotInfo->beamSpotMap_["SC"].BeamWidthX() != 0) {
+        beamSpotInfo->beamSpotMap_["SC"].setType(reco::BeamSpot::Tracker);
+      } else {
+        beamSpotInfo->beamSpotMap_["SC"].setType(reco::BeamSpot::Fake);
+      }
     } else {
-      beamSpotsMap_["SC"].setType(reco::BeamSpot::Fake);
+      LogWarning("AlcaBeamMonitor") << "No BeamSpot from scalers is available";
+      return;
     }
   }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+  processedLumis_.push_back(iLumi.id().luminosityBlock());
+
+  auto beamSpotInfo = luminosityBlockCache(iLumi.index());
   if (theBeamFitter_->runPVandTrkFitter()) {
-    beamSpotsMap_["BF"] = theBeamFitter_->getBeamSpot();
+    beamSpotInfo->beamSpotMap_["BF"] = theBeamFitter_->getBeamSpot();
   }
   theBeamFitter_->resetTrkVector();
   theBeamFitter_->resetLSRange();
@@ -328,7 +329,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
   theBeamFitter_->resetPVFitter();
 
   if (thePVFitter_->runFitter()) {
-    beamSpotsMap_["PV"] = thePVFitter_->getBeamSpot();
+    beamSpotInfo->beamSpotMap_["PV"] = thePVFitter_->getBeamSpot();
   }
   thePVFitter_->resetAll();
 
@@ -338,7 +339,9 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
   MonitorElement* histo = nullptr;
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     resultsMap.clear();
-    for (BeamSpotContainer::iterator itBS = beamSpotsMap_.begin(); itBS != beamSpotsMap_.end(); itBS++) {
+    for (BeamSpotContainer::iterator itBS = beamSpotInfo->beamSpotMap_.begin();
+         itBS != beamSpotInfo->beamSpotMap_.end();
+         itBS++) {
       if (itBS->second.type() == BeamSpot::Tracker) {
         if (*itV == "x") {
           resultsMap[itBS->first] = pair<double, double>(itBS->second.x0(), itBS->second.x0Error());
@@ -360,7 +363,9 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
       }
     }
     vertexResults.clear();
-    for (vector<VertexCollection>::iterator itPV = vertices_.begin(); itPV != vertices_.end(); itPV++) {
+    for (vector<VertexCollection>::iterator itPV = beamSpotInfo->vertices_.begin();
+         itPV != beamSpotInfo->vertices_.end();
+         itPV++) {
       if (!itPV->empty()) {
         for (VertexCollection::const_iterator pv = itPV->begin(); pv != itPV->end(); pv++) {
           if (pv->isFake() || pv->tracksSize() < 10)
@@ -385,7 +390,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
       if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr)
         continue;
       if (itM->second == "Coordinate") {
-        if (beamSpotsMap_.find("DB") != beamSpotsMap_.end()) {
+        if (beamSpotInfo->beamSpotMap_.find("DB") != beamSpotInfo->beamSpotMap_.end()) {
           histo->Fill(resultsMap["DB"].first);
         }
       } else if (itM->second == "PrimaryVertex fit-DataBase") {
@@ -396,7 +401,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("BF") != resultsMap.end()) {
           histo->Fill(resultsMap["PV"].first - resultsMap["BF"].first);
         }
-      } else if (itM->second == "PrimaryVertex fit-Scalers") {
+      } else if (itM->second == "PrimaryVertex fit-Online") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           histo->Fill(resultsMap["PV"].first - resultsMap["SC"].first);
         }
@@ -414,7 +419,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
             histo->Fill(itPV->first - resultsMap["BF"].first);
           }
         }
-      } else if (itM->second == "PrimaryVertex-Scalers") {
+      } else if (itM->second == "PrimaryVertex-Online") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
@@ -436,7 +441,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["DB"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["DB"].second);
         }
-      } else if (itM->second == "Lumibased Scalers") {
+      } else if (itM->second == "Lumibased Online") {
         if (resultsMap.find("SC") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);
@@ -447,13 +452,13 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
           histo->setBinError(iLumi.id().luminosityBlock(),
                              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
         }
-      } else if (itM->second == "Lumibased PrimaryVertex-Scalers fit") {
+      } else if (itM->second == "Lumibased PrimaryVertex-Online fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["SC"].first);
           histo->setBinError(iLumi.id().luminosityBlock(),
                              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));
         }
-      } else if (itM->second == "Lumibased Scalers-DataBase fit") {
+      } else if (itM->second == "Lumibased Online-DataBase fit") {
         if (resultsMap.find("SC") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first - resultsMap["DB"].first);
           histo->setBinError(iLumi.id().luminosityBlock(),
@@ -468,7 +473,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
                                std::sqrt(std::pow((*itPV).second, 2) + std::pow(resultsMap["DB"].second, 2)));
           }
         }
-      } else if (itM->second == "Lumibased PrimaryVertex-Scalers") {
+      } else if (itM->second == "Lumibased PrimaryVertex-Online") {
         if (resultsMap.find("SC") != resultsMap.end() && !vertexResults.empty()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
@@ -478,7 +483,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
           }
         }
       }
-      //      else if(itM->second == "Lumibased Scalers-DataBase"){
+      //      else if(itM->second == "Lumibased Online-DataBase"){
       //      if(resultsMap.find("SC") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()){
       //        itHHH->second->Fill(bin,resultsMap["SC"].first-resultsMap["DB"].first);
       //      }
@@ -518,7 +523,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
             for (int bin = 1; bin <= itHHH->second->getTH1()->GetNbinsX(); bin++) {
               if (itHHH->second->getTH1()->GetBinError(bin) != 0 || itHHH->second->getTH1()->GetBinContent(bin) != 0) {
                 if (itHHH->first == "Lumibased BeamSpotFit" || itHHH->first == "Lumibased PrimaryVertex" ||
-                    itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Scalers") {
+                    itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Online") {
                   if (min > itHHH->second->getTH1()->GetBinContent(bin)) {
                     min = itHHH->second->getTH1()->GetBinContent(bin);
                   }
@@ -526,10 +531,10 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
                     max = itHHH->second->getTH1()->GetBinContent(bin);
                   }
                 } else if (itHHH->first == "Lumibased PrimaryVertex-DataBase fit" ||
-                           itHHH->first == "Lumibased PrimaryVertex-Scalers fit" ||
-                           itHHH->first == "Lumibased Scalers-DataBase fit" ||
+                           itHHH->first == "Lumibased PrimaryVertex-Online fit" ||
+                           itHHH->first == "Lumibased Online-DataBase fit" ||
                            itHHH->first == "Lumibased PrimaryVertex-DataBase" ||
-                           itHHH->first == "Lumibased PrimaryVertex-Scalers") {
+                           itHHH->first == "Lumibased PrimaryVertex-Online") {
                   if (minDelta > itHHH->second->getTH1()->GetBinContent(bin)) {
                     minDelta = itHHH->second->getTH1()->GetBinContent(bin);
                   }
@@ -549,7 +554,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
              itHHH++) {
           if (itHHH->second != nullptr) {
             if (itHHH->first == "Lumibased BeamSpotFit" || itHHH->first == "Lumibased PrimaryVertex" ||
-                itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Scalers") {
+                itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Online") {
               if ((max == -bigNumber && min == bigNumber) || max - min == 0) {
                 itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
                 itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);
@@ -558,10 +563,10 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
                 itHHH->second->getTH1()->SetMaximum(max + 0.1 * (max - min));
               }
             } else if (itHHH->first == "Lumibased PrimaryVertex-DataBase fit" ||
-                       itHHH->first == "Lumibased PrimaryVertex-Scalers fit" ||
-                       itHHH->first == "Lumibased Scalers-DataBase fit" ||
+                       itHHH->first == "Lumibased PrimaryVertex-Online fit" ||
+                       itHHH->first == "Lumibased Online-DataBase fit" ||
                        itHHH->first == "Lumibased PrimaryVertex-DataBase" ||
-                       itHHH->first == "Lumibased PrimaryVertex-Scalers") {
+                       itHHH->first == "Lumibased PrimaryVertex-Online") {
               if ((maxDelta == -bigNumber && minDelta == bigNumber) || maxDelta - minDelta == 0) {
                 itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
                 itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -28,10 +28,14 @@ class BeamFitter;
 class PVFitter;
 
 namespace alcabeammonitor {
-  struct NoCache {};
+  struct BeamSpotInfo {
+    std::vector<reco::VertexCollection> vertices_;
+    typedef std::map<std::string, reco::BeamSpot> BeamSpotContainer;
+    BeamSpotContainer beamSpotMap_;
+  };
 }  // namespace alcabeammonitor
 
-class AlcaBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<alcabeammonitor::NoCache>> {
+class AlcaBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<alcabeammonitor::BeamSpotInfo>> {
 public:
   AlcaBeamMonitor(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions&);
@@ -39,8 +43,8 @@ public:
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  std::shared_ptr<alcabeammonitor::NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
-                                                                       const edm::EventSetup& iSetup) const override;
+  std::shared_ptr<alcabeammonitor::BeamSpotInfo> globalBeginLuminosityBlock(
+      const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
 
@@ -65,8 +69,7 @@ private:
   int numberOfValuesToSave_;
   std::unique_ptr<BeamFitter> theBeamFitter_;
   std::unique_ptr<PVFitter> thePVFitter_;
-  mutable int numberOfProcessedLumis_;
-  mutable std::vector<int> processedLumis_;
+  std::vector<int> processedLumis_;
 
   // MonitorElements:
   MonitorElement* hD0Phi0_;
@@ -74,12 +77,10 @@ private:
   //mutable MonitorElement* theValuesContainer_;
 
   //Containers
-  mutable BeamSpotContainer beamSpotsMap_;
   HistosContainer histosMap_;
   PositionContainer positionsMap_;
   std::vector<std::string> varNamesV_;                            //x,y,z,sigmax(y,z)
   std::multimap<std::string, std::string> histoByCategoryNames_;  //run, lumi
-  mutable std::vector<reco::VertexCollection> vertices_;
 };
 
 #endif

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -172,11 +172,12 @@ std::function<std::string(BSparameters, BeamSpotOnlineObjects)> myStringFunctor 
 };
 
 //----------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLuminosityBlock(
+std::shared_ptr<onlinebeammonitor::BeamSpotInfo> OnlineBeamMonitor::globalBeginLuminosityBlock(
     const LuminosityBlock& iLumi, const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
-  processedLumis_.push_back(iLumi.id().luminosityBlock());
+  auto beamSpotInfo = std::make_shared<onlinebeammonitor::BeamSpotInfo>();
+
   //Read BeamSpot from DB
   ESHandle<BeamSpotOnlineObjects> bsHLTHandle;
   ESHandle<BeamSpotOnlineObjects> bsLegacyHandle;
@@ -214,9 +215,10 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
       }
     }
 
-    beamSpotsMap_["HLT"] = BeamSpot(apoint, spotDB.sigmaZ(), spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
+    beamSpotInfo->beamSpotsMap_["HLT"] =
+        BeamSpot(apoint, spotDB.sigmaZ(), spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
 
-    BeamSpot* aSpot = &(beamSpotsMap_["HLT"]);
+    BeamSpot* aSpot = &(beamSpotInfo->beamSpotsMap_["HLT"]);
 
     aSpot->setBeamWidthY(spotDB.beamWidthY());
     aSpot->setEmittanceX(spotDB.emittanceX());
@@ -254,10 +256,10 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
       }
     }
 
-    beamSpotsMap_["Legacy"] =
+    beamSpotInfo->beamSpotsMap_["Legacy"] =
         BeamSpot(apoint, spotDB.sigmaZ(), spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
 
-    BeamSpot* aSpot = &(beamSpotsMap_["Legacy"]);
+    BeamSpot* aSpot = &(beamSpotInfo->beamSpotsMap_["Legacy"]);
 
     aSpot->setBeamWidthY(spotDB.beamWidthY());
     aSpot->setEmittanceX(spotDB.emittanceX());
@@ -288,10 +290,10 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
       }
     }
 
-    beamSpotsMap_["Transient"] =
+    beamSpotInfo->beamSpotsMap_["Transient"] =
         BeamSpot(apoint, spotDB.sigmaZ(), spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
 
-    BeamSpot* aSpot = &(beamSpotsMap_["Transient"]);
+    BeamSpot* aSpot = &(beamSpotInfo->beamSpotsMap_["Transient"]);
 
     aSpot->setBeamWidthY(spotDB.beamWidthY());
     aSpot->setEmittanceX(spotDB.emittanceX());
@@ -316,16 +318,16 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
       }
       //int lastLumiAnalyzed_ = iLumi.id().luminosityBlock();
 
-      if (beamSpotsMap_.find("Transient") != beamSpotsMap_.end()) {
-        if (beamSpotsMap_.find("HLT") != beamSpotsMap_.end() &&
-            beamSpotsMap_["Transient"].x0() == beamSpotsMap_["HLT"].x0()) {
+      if (beamSpotInfo->beamSpotsMap_.find("Transient") != beamSpotInfo->beamSpotsMap_.end()) {
+        if (beamSpotInfo->beamSpotsMap_.find("HLT") != beamSpotInfo->beamSpotsMap_.end() &&
+            beamSpotInfo->beamSpotsMap_["Transient"].x0() == beamSpotInfo->beamSpotsMap_["HLT"].x0()) {
           // lastLumiAnalyzed_ = lastLumiHLT_;
           startTimeStamp_ = startTimeStampHLT_;
           stopTimeStamp_ = stopTimeStampHLT_;
           lumiRange_ = lumiRangeHLT_;
 
-        } else if (beamSpotsMap_.find("Legacy") != beamSpotsMap_.end() &&
-                   beamSpotsMap_["Transient"].x0() == beamSpotsMap_["Legacy"].x0()) {
+        } else if (beamSpotInfo->beamSpotsMap_.find("Legacy") != beamSpotInfo->beamSpotsMap_.end() &&
+                   beamSpotInfo->beamSpotsMap_["Transient"].x0() == beamSpotInfo->beamSpotsMap_["Legacy"].x0()) {
           //lastLumiAnalyzed_ = lastLumiLegacy_;
           startTimeStamp_ = startTimeStampLegacy_;
           stopTimeStamp_ = stopTimeStampLegacy_;
@@ -368,19 +370,22 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
   } else {
     LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
   }
-  return nullptr;
+  return beamSpotInfo;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 void OnlineBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+  processedLumis_.push_back(iLumi.id().luminosityBlock());
+  auto beamSpotInfo = luminosityBlockCache(iLumi.index());
+
   //Setting up the choice
-  if (beamSpotsMap_.find("Transient") != beamSpotsMap_.end()) {
-    if (beamSpotsMap_.find("HLT") != beamSpotsMap_.end() &&
-        beamSpotsMap_["Transient"].x0() == beamSpotsMap_["HLT"].x0()) {
+  if (beamSpotInfo->beamSpotsMap_.find("Transient") != beamSpotInfo->beamSpotsMap_.end()) {
+    if (beamSpotInfo->beamSpotsMap_.find("HLT") != beamSpotInfo->beamSpotsMap_.end() &&
+        beamSpotInfo->beamSpotsMap_["Transient"].x0() == beamSpotInfo->beamSpotsMap_["HLT"].x0()) {
       bsChoice_->Fill(iLumi.id().luminosityBlock(), 1);
       bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
-    } else if (beamSpotsMap_.find("Legacy") != beamSpotsMap_.end() &&
-               beamSpotsMap_["Transient"].x0() == beamSpotsMap_["Legacy"].x0()) {
+    } else if (beamSpotInfo->beamSpotsMap_.find("Legacy") != beamSpotInfo->beamSpotsMap_.end() &&
+               beamSpotInfo->beamSpotsMap_["Transient"].x0() == beamSpotInfo->beamSpotsMap_["Legacy"].x0()) {
       bsChoice_->Fill(iLumi.id().luminosityBlock(), -1);
       bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
     } else {
@@ -398,7 +403,7 @@ void OnlineBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, c
   MonitorElement* histo = nullptr;
   for (const auto& itV : varNamesV_) {
     resultsMap.clear();
-    for (const auto& itBS : beamSpotsMap_) {
+    for (const auto& itBS : beamSpotInfo->beamSpotsMap_) {
       if (itBS.second.type() == BeamSpot::Tracker) {
         if (itV == "x") {
           resultsMap[itBS.first] = pair<double, double>(itBS.second.x0(), itBS.second.x0Error());

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
@@ -26,18 +26,21 @@
 #include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
 
 namespace onlinebeammonitor {
-  struct NoCache {};
+  struct BeamSpotInfo {
+    typedef std::map<std::string, reco::BeamSpot> BeamSpotContainer;
+    BeamSpotContainer beamSpotsMap_;
+  };
 }  // namespace onlinebeammonitor
 
-class OnlineBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<onlinebeammonitor::NoCache>> {
+class OnlineBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<onlinebeammonitor::BeamSpotInfo>> {
 public:
   OnlineBeamMonitor(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-  std::shared_ptr<onlinebeammonitor::NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
-                                                                         const edm::EventSetup& iSetup) const override;
+  std::shared_ptr<onlinebeammonitor::BeamSpotInfo> globalBeginLuminosityBlock(
+      const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
 
@@ -59,13 +62,11 @@ private:
 
   //Service variables
   int numberOfValuesToSave_;
-  mutable int numberOfProcessedLumis_;
-  mutable std::vector<int> processedLumis_;
+  std::vector<int> processedLumis_;
   // MonitorElements:
   MonitorElement* bsChoice_;
 
   //Containers
-  mutable BeamSpotContainer beamSpotsMap_;
   HistosContainer histosMap_;
   PositionContainer positionsMap_;
   std::vector<std::string> varNamesV_;                            //x,y,z,sigmax(y,z)


### PR DESCRIPTION
#### PR description:
Triggered by [this CMSTalk post](https://cms-talk.web.cern.ch/t/issues-with-alcabeammonitor-in-offline-dqm/23945) and as a follow-up of https://github.com/cms-sw/cmssw/issues/37163 and https://github.com/cms-sw/cmssw/issues/39973, @gennai and I implemented the changes suggested by @makortel in https://github.com/cms-sw/cmssw/issues/37163#issuecomment-1061301312.
The changes include:
 - In AlcaBeamMonitor:
    - redefine (and use) the `LuminosityBlockCache`
    - rename the histogram titles from "Scalers" to "Online"
    - Fixed the `Event::getByToken()` try/catch block as suggested by Matti
    - remove the unused `numberOfProcessedLumis_` variable
    - moved the filling of `processedLumis_` to `globalEndLuminosityBlock()` and removed the obsolete `mutable` declaration
- In OnlineBeamMonitor:
   - redefine (and use) the `LuminosityBlockCache`
    - remove the unused `numberOfProcessedLumis_` variable
    - moved the filling of `processedLumis_` to `globalEndLuminosityBlock()` and removed the obsolete `mutable` declaration

@makortel @mmusich please let us know what you think of these changes.

#### PR validation:
~We tested this with wf `138.5` which runs the full `ALCA` reco sequence in step3, using events from multiple lumisections.
I'm not sure if this is the correct way to do it or if some other trick is needed to properly test this, suggestions are welcome.~
See below the discussion about testing this PR properly

#### Backport:
Not a backport. Backports available at:
 - 13_1_X: #41722
 - 13_0_X: #41723