### PR TITLE
Introduce generic class to display  `TH2Poly`-based tracker maps of values of selected template header parameters 

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelTemplateHelper.h
@@ -595,6 +595,7 @@ namespace templateHelper {
 
       auto tag = cond::payloadInspector::PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
+      const auto& tagname = tag.name;
       std::vector<StoreType> thePixelTemp_;
       std::shared_ptr<PayloadType> payload = this->fetchPayload(std::get<1>(iov));
 
@@ -749,6 +750,17 @@ namespace templateHelper {
         }
 
         canvas.cd();
+        TPaveText ksPt(0, 0, 0.88, 0.04, "NDC");
+        ksPt.SetBorderSize(0);
+        ksPt.SetFillColor(0);
+        const char* textToAdd = Form("%s Tag: #color[2]{%s}, IOV: #color[2]{%s}. Payload hash: #color[2]{%s}",
+                                     (isTemplate_ ? "Template" : "GenError"),
+                                     tagname.c_str(),
+                                     std::to_string(std::get<0>(iov)).c_str(),
+                                     (std::get<1>(iov)).c_str());
+        ksPt.AddText(textToAdd);
+        ksPt.Draw();
+
         std::string fileName(this->m_imageFileName);
         canvas.SaveAs(fileName.c_str());
       }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -137,6 +137,7 @@ namespace {
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
+      const auto& tagname = tag.name;
       std::vector<SiPixelTemplateStore> thePixelTemp_;
       std::shared_ptr<SiPixelTemplateDBObject> payload = fetchPayload(std::get<1>(iov));
 
@@ -242,6 +243,17 @@ namespace {
         } else if (myType == SiPixelPI::t_all) {
           theMaps.drawSummaryMaps("templateLA", canvas);
         }
+
+        canvas.cd();
+        TPaveText ksPt(0, 0, 0.88, 0.04, "NDC");
+        ksPt.SetBorderSize(0);
+        ksPt.SetFillColor(0);
+        const char* textToAdd = Form("Template Tag: #color[2]{%s}, IOV: #color[2]{%s}. Payload hash: #color[2]{%s}",
+                                     tagname.c_str(),
+                                     std::to_string(std::get<0>(iov)).c_str(),
+                                     (std::get<1>(iov)).c_str());
+        ksPt.AddText(textToAdd);
+        ksPt.Draw();
 
         canvas.cd();
         std::string fileName(m_imageFileName);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelTemplateDBObject_PayloadInspector.cc
@@ -281,6 +281,43 @@ namespace {
   using SiPixelTemplateIDsFPixMap = SiPixelIDs<SiPixelTemplateDBObject, SiPixelPI::t_forward>;
   using SiPixelTemplateIDsMap = SiPixelIDs<SiPixelTemplateDBObject, SiPixelPI::t_all>;
 
+  //************************************************
+  // TH2Poly Map of qScale
+  //***********************************************/
+  using SiPixelTemplateQScaleBPixMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                                 SiPixelTemplateStore,
+                                                                 SiPixelTemplate,
+                                                                 SiPixelPI::t_barrel,
+                                                                 headerParam::k_qscale>;
+  using SiPixelTemplateQScaleFPixMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                                 SiPixelTemplateStore,
+                                                                 SiPixelTemplate,
+                                                                 SiPixelPI::t_forward,
+                                                                 headerParam::k_qscale>;
+  using SiPixelTemplateQScaleMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                             SiPixelTemplateStore,
+                                                             SiPixelTemplate,
+                                                             SiPixelPI::t_all,
+                                                             headerParam::k_qscale>;
+
+  //************************************************
+  // TH2Poly Map of Vbias
+  //***********************************************/
+  using SiPixelTemplateVbiasBPixMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                                SiPixelTemplateStore,
+                                                                SiPixelTemplate,
+                                                                SiPixelPI::t_barrel,
+                                                                headerParam::k_Vbias>;
+  using SiPixelTemplateVbiasFPixMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                                SiPixelTemplateStore,
+                                                                SiPixelTemplate,
+                                                                SiPixelPI::t_forward,
+                                                                headerParam::k_Vbias>;
+  using SiPixelTemplateVbiasMap = SiPixelTemplateHeaderInfo<SiPixelTemplateDBObject,
+                                                            SiPixelTemplateStore,
+                                                            SiPixelTemplate,
+                                                            SiPixelPI::t_all,
+                                                            headerParam::k_Vbias>;
 }  // namespace
 
 // Register the classes as boost python plugin
@@ -295,4 +332,10 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelTemplateDBObject) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateLAMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateLABPixMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateLAFPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateQScaleBPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateQScaleFPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateQScaleMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateVbiasBPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateVbiasFPixMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelTemplateVbiasMap);
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -156,6 +156,10 @@ int main(int argc, char** argv) {
   histo19.process(connectionString, PI::mk_input(tag, start, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo19.data() << std::endl;
 
+  SiPixelTemplateQScaleMap histoQscale;
+  histoQscale.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histoQscale.data() << std::endl;
+
   // SiPixelVCal
 
   tag = "SiPixelVCal_v1";

--- a/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelTemplateDBObject.sh
@@ -91,6 +91,17 @@ getPayloadData.py \
 mv *.png $W_DIR/plots_Template/HeaderTitles.png
 
 getPayloadData.py \
+    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
+    --plot plot_SiPixelTemplateQScaleMap \
+    --tag SiPixelTemplateDBObject38Tv3_express \
+    --time_type Run \
+    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/plots_Template/QScaleMap.png
+
+getPayloadData.py \
     --plugin pluginSiPixel2DTemplateDBObject_PayloadInspector \
     --plot plot_SiPixel2DTemplateHeaderTable \
     --tag SiPixel2DTemplateDBObject_38T_v1_express \

--- a/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelMaps.cc
@@ -7,6 +7,7 @@
 
 #include <fmt/printf.h>
 #include <fstream>
+#include <iostream>
 #include <boost/tokenizer.hpp>
 #include <boost/range/adaptor/indexed.hpp>
 
@@ -334,7 +335,6 @@ void Phase1PixelMaps::setForwardScale(const std::string& currentHistoName, std::
 
 //============================================================================
 void Phase1PixelMaps::drawBarrelMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption) {
-  canvas.Divide(2, 2);
   auto found = (std::find(m_knownNames.begin(), m_knownNames.end(), currentHistoName) != m_knownNames.end());
 
   if (!m_isBooked.first || !found) {
@@ -342,15 +342,20 @@ void Phase1PixelMaps::drawBarrelMaps(const std::string& currentHistoName, TCanva
     return;
   }
 
+  TPad* pad1 = new TPad("pad1", "pad1", 0.0, 0.025, 1.0, 1.0);
+  TPad* pad2 = new TPad("pad2", "pad2", 0.0, 0.00, 1.0, 0.025);
+  pad1->Divide(2, 2);
+  pad1->Draw();
+  pad2->Draw();
   for (int i = 1; i <= 4; i++) {
-    canvas.cd(i);
+    pad1->cd(i);
     if (strcmp(m_option, "text") == 0) {
-      canvas.cd(i)->SetRightMargin(0.02);
+      pad1->cd(i)->SetRightMargin(0.02);
       pxbTh2PolyBarrel[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
     } else {
       if (m_autorescale)
         rescaleAllBarrel(currentHistoName);
-      adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
+      adjustCanvasMargins(pad1->cd(i), 0.07, 0.12, 0.10, 0.18);
     }
     if (drawOption) {
       pxbTh2PolyBarrel[currentHistoName].at(i - 1)->Draw("L");
@@ -364,7 +369,6 @@ void Phase1PixelMaps::drawBarrelMaps(const std::string& currentHistoName, TCanva
 
 //============================================================================
 void Phase1PixelMaps::drawForwardMaps(const std::string& currentHistoName, TCanvas& canvas, const char* drawOption) {
-  canvas.Divide(3, 2);
   auto found = (std::find(m_knownNames.begin(), m_knownNames.end(), currentHistoName) != m_knownNames.end());
 
   if (!m_isBooked.second || !found) {
@@ -372,15 +376,21 @@ void Phase1PixelMaps::drawForwardMaps(const std::string& currentHistoName, TCanv
     return;
   }
 
+  TPad* pad1 = new TPad("pad1", "pad1", 0.0, 0.025, 1.0, 1.0);
+  TPad* pad2 = new TPad("pad2", "pad2", 0.0, 0.00, 1.0, 0.025);
+  pad1->Divide(3, 2);
+  pad1->Draw();
+  pad2->Draw();
+
   for (int i = 1; i <= 6; i++) {
-    canvas.cd(i);
+    pad1->cd(i);
     if (strcmp(m_option, "text") == 0) {
-      canvas.cd(i)->SetRightMargin(0.02);
+      pad1->cd(i)->SetRightMargin(0.02);
       pxfTh2PolyForward[currentHistoName].at(i - 1)->SetMarkerColor(kRed);
     } else {
       if (m_autorescale)
         rescaleAllForward(currentHistoName);
-      adjustCanvasMargins(canvas.cd(i), 0.07, 0.12, 0.10, 0.18);
+      adjustCanvasMargins(pad1->cd(i), 0.07, 0.12, 0.10, 0.18);
     }
     if (drawOption) {
       pxfTh2PolyForward[currentHistoName].at(i - 1)->Draw("L");
@@ -401,11 +411,16 @@ void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanv
     return;
   }
 
-  canvas.Divide(2, 1);
-  canvas.cd(1);
+  TPad* pad1 = new TPad("pad1", "pad1", 0.0, 0.025, 1.0, 1.0);
+  TPad* pad2 = new TPad("pad2", "pad2", 0.0, 0.00, 1.0, 0.025);
+  pad1->Divide(2, 1);
+  pad1->Draw();
+  pad2->Draw();
+
+  pad1->cd(1);
   std::string temp(m_option);  // create a std string
   auto isText = (temp.find("text") != std::string::npos);
-  adjustCanvasMargins(canvas.cd(1), 0.07, 0.02, 0.01, isText ? 0.05 : 0.15);
+  adjustCanvasMargins(pad1->cd(1), 0.07, 0.02, 0.01, isText ? 0.05 : 0.15);
   if (isText) {
     pxbTh2PolyBarrelSummary[currentHistoName]->SetMarkerColor(kRed);
     pxbTh2PolyBarrelSummary[currentHistoName]->SetMarkerSize(0.5);
@@ -414,8 +429,8 @@ void Phase1PixelMaps::drawSummaryMaps(const std::string& currentHistoName, TCanv
   pxbTh2PolyBarrelSummary[currentHistoName]->Draw("AL");
   pxbTh2PolyBarrelSummary[currentHistoName]->Draw(fmt::sprintf("%s%ssame", m_option, drawOption).c_str());
 
-  canvas.cd(2);
-  adjustCanvasMargins(canvas.cd(2), 0.07, 0.02, 0.01, isText ? 0.05 : 0.15);
+  pad1->cd(2);
+  adjustCanvasMargins(pad1->cd(2), 0.07, 0.02, 0.01, isText ? 0.05 : 0.15);
   if (isText) {
     pxfTh2PolyForwardSummary[currentHistoName]->SetMarkerColor(kRed);
     pxfTh2PolyForwardSummary[currentHistoName]->SetMarkerSize(0.5);


### PR DESCRIPTION
#### PR description:

With the revamping of the `qScale` parameter for pixel charge re-weighting (see https://github.com/cms-sw/cmssw/pull/41623) it becomes important to be able to monitor the content of the `SiPixelTemplate`s in terms of this parameter. I provide here a generic heavily-templated class `SiPixelTemplateHeaderInfo` that can print into a `TH2Poly`-based tracker map the values of selected template header parameters, and a concrete implementation for the `qScale` and `Vbias` as these seem the most interesting for the time being. More plots can be added as deemed needed.

#### PR validation:

Relies on the augmented unit tests. Also run privately:
```bash
getPayloadData.py \
    --plugin pluginSiPixelTemplateDBObject_PayloadInspector \
    --plot plot_SiPixelTemplateQScaleBPixMap \
    --tag SiPixelTemplateDBObject38Tv3_express \
    --time_type Run \
    --iovs '{"start_iov": "326083", "end_iov": "326083"}' \
    --db Prod \
    --test ;
```

and obtained the following plot:

![image](https://github.com/cms-sw/cmssw/assets/5082376/fef0d7a7-f755-42d3-9e43-9775a78c429e)



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A