### PR TITLE
Fix for PPC relvals

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFJet.h
+++ b/DataFormats/L1TParticleFlow/interface/PFJet.h
@@ -5,8 +5,6 @@
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
 #include "DataFormats/Common/interface/Ptr.h"
-#include "DataFormats/L1TParticleFlow/interface/jets.h"
-#include "DataFormats/L1TParticleFlow/interface/gt_datatypes.h"
 
 namespace l1t {
 
@@ -51,8 +49,8 @@ namespace l1t {
     }
 
     // Accessors to HW objects with ap_* types from encoded words
-    l1gt::Jet getHWJetGT() const { return l1gt::Jet::unpack(encodedJet(HWEncoding::GT)); }
-    l1ct::Jet getHWJetCT() const { return l1ct::Jet::unpack(encodedJet(HWEncoding::CT)); }
+    const PackedJet& getHWJetGT() const { return encodedJet(HWEncoding::GT); }
+    const PackedJet& getHWJetCT() const { return encodedJet(HWEncoding::CT); }
 
   private:
     float rawPt_;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MHtPFProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MHtPFProducer.cc
@@ -65,7 +65,7 @@ void L1MhtPfProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
 std::vector<l1ct::Jet> L1MhtPfProducer::convertEDMToHW(std::vector<l1t::PFJet> edmJets) const {
   std::vector<l1ct::Jet> hwJets;
   std::for_each(edmJets.begin(), edmJets.end(), [&](l1t::PFJet jet) {
-    l1ct::Jet hwJet = jet.getHWJetCT();
+    l1ct::Jet hwJet = l1ct::Jet::unpack(jet.getHWJetCT());
     hwJets.push_back(hwJet);
   });
   return hwJets;


### PR DESCRIPTION
No idea but somehow removing the following headers fix the failing relvals for ppc64le IBs [b]. May be inclusion of `ap_int.h` via https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1TParticleFlow/interface/gt_datatypes.h#LL8C11-L8C19 is breaking llvm JIT for ppc64le?

[a]
- [DataFormats/L1TParticleFlow/interface/jets.h](https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1TParticleFlow/interface/jets.h)
- [DataFormats/L1TParticleFlow/interface/gt_datatypes.h](https://github.com/cms-sw/cmssw/blob/master/DataFormats/L1TParticleFlow/interface/gt_datatypes.h)

[b]
```
Singularity> runTheMatrix.py -i all -l 4.22,140.01 --ibeos -t 4 -j 2
4.22_RunCosmics2011A Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Wed May 17 15:33:45 2023-date Wed May 17 15:30:51 2023; exit: 0 0 0 0 0
140.01_RunDoubleMuon2022A Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed May 17 15:42:50 2023-date Wed May 17 15:30:51 2023; exit: 0 0 0 0
2 2 2 2 1 tests passed, 0 0 0 0 0 failed
```