### PR TITLE
Fix ak8PFJetsPuppiConstituents module configuration at PAT-level

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -15,7 +15,7 @@ def applySubstructure( process, postfix="" ) :
     # Configure the RECO jets
     from RecoJets.JetProducers.ak8PFJets_cfi import ak8PFJetsPuppi, ak8PFJetsPuppiSoftDrop, ak8PFJetsPuppiConstituents
     setattr(process,'ak8PFJetsPuppi'+postfix,ak8PFJetsPuppi.clone())
-    setattr(process,'ak8PFJetsPuppiConstituents'+postfix, ak8PFJetsPuppiConstituents.clone(cut = cms.string('pt > 170.0 && abs(rapidity()) < 2.4') ))
+    setattr(process,'ak8PFJetsPuppiConstituents'+postfix, ak8PFJetsPuppiConstituents.clone())
     setattr(process,'ak8PFJetsPuppiSoftDrop'+postfix, ak8PFJetsPuppiSoftDrop.clone( src = 'ak8PFJetsPuppiConstituents'+postfix+':constituents' ))
     from RecoJets.JetProducers.ak8PFJetsPuppi_groomingValueMaps_cfi import ak8PFJetsPuppiSoftDropMass
     setattr(process,'ak8PFJetsPuppiSoftDropMass'+postfix, ak8PFJetsPuppiSoftDropMass.clone())
@@ -32,6 +32,8 @@ def applySubstructure( process, postfix="" ) :
                                 getattr(process,'ak8PFJetsPuppiSoftDrop'),
                                 getattr(process,'ak8PFJetsPuppiSoftDropMass'))
       (_run2_miniAOD_ANY | pA_2016 ).toReplaceWith(task, _rerun_puppijets_task)
+      (_run2_miniAOD_ANY | pA_2016 ).toModify(getattr(process,'ak8PFJetsPuppiConstituents'+postfix),
+        cut = cms.string('pt > 170.0 && abs(rapidity()) < 2.4'))
     else:
       task.add(getattr(process,'ak8PFJetsPuppi'+postfix),
                getattr(process,'ak8PFJetsPuppiConstituents'+postfix),


### PR DESCRIPTION
####  PR description:

This PR aims to properly configure `ak8PFJetsPuppiConstituents` module at the PAT-level step such that it does not overwrite the RECO-level instance and also preserve the cut value of `pt > 170 GeV` for Run-2 MiniAOD production. The current setup overwrites the cut value of `ak8PFJetsPuppiConstituents` when a production workflow involves RECO step and PAT step in a single production job, like the ongoing Run-3 Data production workflow (RAW->RECO->PAT). This issue was reported in a XPOG meeting earlier today ([17th May 2023](https://indico.cern.ch/event/1282867/#10-mini-from-mini-workflow-upd)).

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`