### PR TITLE
L1T: remove ESPrefer in L1Ntuples

### DIFF
--- a/L1Trigger/L1TNtuples/python/customiseL1CustomReco.py
+++ b/L1Trigger/L1TNtuples/python/customiseL1CustomReco.py
@@ -32,7 +32,6 @@ def L1NtupleCustomReco(process):
     delattr(process, 'patJetGenJetMatchCorrectedPuppiJets')
     delattr(process, 'patJetPartonMatchCorrectedPuppiJets')
 
-    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource', 'GlobalTag')
 
 
 ####  Custom Met Filter reco


### PR DESCRIPTION
Removes the ESPrefer for the JEC in the L1Ntuples since this prevents overriding the L1T conditions from the GT using the caloParams