### PR TITLE
[13_0_X] Add VertexSmearing scenario for 2023 MC

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -68,6 +68,7 @@ VtxSmeared = {
     'Realistic25ns900GeV2021Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns900GeV2021Collision_cfi',
     'Realistic25ns13p6TeVEarly2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi',
     'Realistic25ns13p6TeVEOY2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEOY2022Collision_cfi',
+    'Realistic25ns13p6TeVEarly2023Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2023Collision_cfi',
     'Nominal2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedNominal2022PbPbCollision_cfi',
     'Realistic2022PbPbCollision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic2022PbPbCollision_cfi',
 }

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -843,6 +843,37 @@ Realistic25ns13p6TeVEOY2022CollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.101756)
 )
 
+# BS parameters extracted averaging Fills 8728-8750 (2023C):
+# X0         =  0.117154 [cm]
+# Y0         = -0.186556 [cm]
+# Z0         = -0.431777 [cm]
+# sigmaZ0    =  3.599 cm [cm]
+# BeamWidthX = 0.0007333 [cm]
+# BeamWidthY = 0.0008046 [cm]
+#
+# set SigmaZ0 = 3.6 [cm]
+# set BeamWidthX = BeamWidthY = 7.7 [um]
+# set beta* = 30 cm
+# energy = 13.6 TeV
+# From LHC calculator, emittance is 3.931e-8 cm
+# https://lpc.web.cern.ch/lumiCalc.html
+#
+# BPIX absolute position (from Runs 367094-367589):
+# X =  0.0713008 cm
+# Y = -0.169590  cm
+# Z = -0.356785  cm
+Realistic25ns13p6TeVEarly2023CollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(30.0),
+    Emittance = cms.double(3.931e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(3.6),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0458532),
+    Y0 = cms.double(-0.016966),
+    Z0 = cms.double(-0.074992)
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEarly2023Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEarly2023Collision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13p6TeVEarly2023CollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic25ns13p6TeVEarly2023CollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:
Backport of #41719 

This PR adds the realistic VertexSmearing scenario to be used for the 2023 MC production:  
- `Realistic25ns13p6TeVEarly2023Collision`

Input parameters:
 - The BeamSpot is extracted from Run2023C averaging Fills 8728-8750 (thanks @dzuolo!)
 - The BPIX barycenter is taken from [this twiki](https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition?rev=53#Run2023C)

*IMPORTANT NOTE:*
Even though at the moment this scenario is not used anywhere in the release, we need this merged asap in order to produce relvals with this smearing and fit the BeamSpot to be added to the GTs for 2023 MC.

#### PR validation:
Code compiles (at the moment this scenario is not used anywhere in the release)

#### Backport:
Backport of #41719 


FYI @mmusich @cms-sw/alca-l2 