### PR TITLE
Phase-2 L1T: updated correlator layer 1 e/gamma sorter [master]

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_barrel_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_barrel_ref.h
@@ -1,0 +1,202 @@
+#ifndef REF_PFTKEGSORTER_BARREL_REF_H
+#define REF_PFTKEGSORTER_BARREL_REF_H
+
+#include <cstdio>
+#include <vector>
+
+#include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/common/bitonic_hybrid_sort_ref.h"
+
+#ifdef CMSSW_GIT_HASH
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#endif
+
+namespace edm {
+  class ParameterSet;
+}
+
+namespace l1ct {
+  class PFTkEGSorterBarrelEmulator {
+  public:
+    PFTkEGSorterBarrelEmulator(const unsigned int nObjToSort = 10, const unsigned int nObjSorted = 16)
+        : nObjToSort_(nObjToSort), nObjSorted_(nObjSorted), debug_(false) {}
+
+    PFTkEGSorterBarrelEmulator(const edm::ParameterSet& iConfig);
+
+    virtual ~PFTkEGSorterBarrelEmulator() {}
+
+    void setDebug(bool debug = true) { debug_ = debug; };
+
+    void toFirmware_pho(const OutputRegion& outregions, EGIsoObj (&photons_in)[nObjSorted_]) const {
+      for (unsigned int i = 0; i < nObjToSort_; i++) {
+        EGIsoObj pho;
+        if (i < outregions.egphoton.size()) {
+          pho = outregions.egphoton[i];
+        } else
+          pho.clear();
+
+        photons_in[i] = pho;
+      }
+    }
+
+    void toFirmware_ele(const OutputRegion& outregions, EGIsoEleObj (&eles_in)[nObjSorted_]) const {
+      for (unsigned int i = 0; i < nObjToSort_; i++) {
+        EGIsoEleObj ele;
+        if (i < outregions.egelectron.size()) {
+          ele = outregions.egelectron[i];
+        } else
+          ele.clear();
+
+        eles_in[i] = ele;
+      }
+    }
+
+    template <typename T>
+    void run(const std::vector<PFInputRegion>& pfregions,
+             const std::vector<OutputRegion>& outregions,
+             const std::vector<unsigned int>& region_index,
+             std::vector<T>& eg_sorted_inBoard) {
+      // we copy to be able to resize them
+      std::vector<std::vector<T>> objs_in;
+      objs_in.reserve(nObjToSort_);
+      for (unsigned int i : region_index) {
+        std::vector<T> objs;
+        extractEGObjEmu(pfregions[i].region, outregions[i], objs);
+        if (debug_)
+          dbgCout() << "objs size " << objs.size() << "\n";
+        resize_input(objs);
+        objs_in.push_back(objs);
+        if (debug_)
+          dbgCout() << "objs (re)size and total objs size " << objs.size() << " " << objs_in.size() << "\n";
+      }
+
+      merge(objs_in, eg_sorted_inBoard);
+
+      if (debug_) {
+        dbgCout() << "objs.size() size " << eg_sorted_inBoard.size() << "\n";
+        for (const auto& out : eg_sorted_inBoard)
+          dbgCout() << "kinematics of sorted objects " << out.hwPt << " " << out.hwEta << " " << out.hwPhi << "\n";
+      }
+    }
+
+  private:
+    void extractEGObjEmu(const PFRegionEmu& region,
+                         const l1ct::OutputRegion& outregion,
+                         std::vector<l1ct::EGIsoObjEmu>& eg) {
+      extractEGObjEmu(region, outregion.egphoton, eg);
+    }
+    void extractEGObjEmu(const PFRegionEmu& region,
+                         const l1ct::OutputRegion& outregion,
+                         std::vector<l1ct::EGIsoEleObjEmu>& eg) {
+      extractEGObjEmu(region, outregion.egelectron, eg);
+    }
+    template <typename T>
+    void extractEGObjEmu(const PFRegionEmu& region,
+                         const std::vector<T>& regional_objects,
+                         std::vector<T>& global_objects) {
+      for (const auto& reg_obj : regional_objects) {
+        global_objects.emplace_back(reg_obj);
+        global_objects.back().hwEta = region.hwGlbEta(reg_obj.hwEta);  //<=========== uncomment this
+        global_objects.back().hwPhi = region.hwGlbPhi(reg_obj.hwPhi);  //<=========== uncomment this
+      }
+    }
+
+    template <typename T>
+    void resize_input(std::vector<T>& in) const {
+      if (in.size() > nObjToSort_) {
+        in.resize(nObjToSort_);
+      } else if (in.size() < nObjToSort_) {
+        for (unsigned int i = 0, diff = (nObjToSort_ - in.size()); i < diff; ++i) {
+          in.push_back(T());
+          in.back().clear();
+        }
+      }
+    }
+
+    template <typename T>
+    void merge_regions(const std::vector<T>& in_region1,
+                       const std::vector<T>& in_region2,
+                       std::vector<T>& out,
+                       unsigned int nOut) const {
+      // we crate a bitonic list
+      out = in_region1;
+      if (debug_)
+        for (const auto& tmp : out)
+          dbgCout() << "out " << tmp.hwPt << " " << tmp.hwEta << " " << tmp.hwPhi << "\n";
+      std::reverse(out.begin(), out.end());
+      if (debug_)
+        for (const auto& tmp : out)
+          dbgCout() << "out reverse " << tmp.hwPt << " " << tmp.hwEta << " " << tmp.hwPhi << "\n";
+      std::copy(in_region2.begin(), in_region2.end(), std::back_inserter(out));
+      if (debug_)
+        for (const auto& tmp : out)
+          dbgCout() << "out inserted " << tmp.hwPt << " " << tmp.hwEta << " " << tmp.hwPhi << "\n";
+
+      hybridBitonicMergeRef(&out[0], out.size(), 0, false);
+
+      if (out.size() > nOut) {
+        out.resize(nOut);
+        if (debug_)
+          for (const auto& tmp : out)
+            dbgCout() << "final " << tmp.hwPt << " " << tmp.hwEta << " " << tmp.hwPhi << "\n";
+      }
+    }
+
+    template <typename T>
+    void merge(const std::vector<std::vector<T>>& in_objs, std::vector<T>& out) const {
+      if (in_objs.size() == 1) {  //size is 1, fine!
+        std::copy(in_objs[0].begin(), in_objs[0].end(), std::back_inserter(out));
+        if (out.size() > nObjSorted_)
+          out.resize(nObjSorted_);                                //size 16
+      } else if (in_objs.size() == 2) {                           //size is 2, fine!
+        merge_regions(in_objs[0], in_objs[1], out, nObjSorted_);  //10, 10, 16
+      } else {
+        std::vector<T> pair_merge_01;                                       //size is >2, merge 0 and 1 regions always
+        merge_regions(in_objs[0], in_objs[1], pair_merge_01, nObjSorted_);  //10, 10, 16
+
+        std::vector<std::vector<T>> to_merge;
+        if (in_objs.size() == 3)
+          to_merge.push_back(pair_merge_01);  //push 01 only if size is 3 //and then in_objs[id] will be pushed into it
+
+        std::vector<T> pair_merge_tmp = pair_merge_01;  //
+        for (unsigned int id = 2, idn = 3; id < in_objs.size(); id += 2, idn = id + 1) {
+          if (idn >= in_objs.size()) {        //if size is odd number starting from 3
+            to_merge.push_back(in_objs[id]);  //size 10
+          } else {
+            std::vector<T> pair_merge;
+            merge_regions(in_objs[id],
+                          in_objs[idn],
+                          pair_merge,
+                          nObjSorted_);  //10, 10, 16 // merge two regions: 23, 45, 67, and so on
+
+            //pair_merge_tmp.resize(nObjToSort_);
+            //pair_merge.resize(nObjToSort_);
+            merge_regions(
+                pair_merge_tmp,
+                pair_merge,
+                pair_merge_tmp,
+                nObjSorted_);  //16, 16, 16 //merge 23 with 01 for first time // then merge 45, and then 67, and then 89, and so on
+            to_merge.push_back(
+                pair_merge_tmp);  //push back 0123, 012345, 01234567, and so on (remember 01 is the 0th element)
+          }
+        }
+        if (in_objs.size() % 2 == 1) {
+          //to_merge[to_merge.size()-2].resize(nObjToSort_);
+          merge_regions(
+              to_merge[to_merge.size() - 2],
+              to_merge[to_merge.size() - 1],
+              out,
+              nObjSorted_);  //16, 16, 16 //e.g. is size is 3, we merge 01 and 2, if size is 7, we merge 012345 and 6
+        } else
+          out =
+              pair_merge_tmp;  //if size is even number, e.g. 6, out is 012345 (or we can say to_merge[to_merge.size()-1])
+      }
+    }
+
+    unsigned int nObjToSort_;
+    unsigned int nObjSorted_;
+    bool debug_;
+  };
+}  // namespace l1ct
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_ref.h
@@ -1,5 +1,5 @@
-#ifndef FIRMWARE_PFTKEGSORTER_REF_H
-#define FIRMWARE_PFTKEGSORTER_REF_H
+#ifndef L1Trigger_Phase2L1ParticleFlow_egamma_pftkegsorter_ref_h
+#define L1Trigger_Phase2L1ParticleFlow_egamma_pftkegsorter_ref_h
 
 #include <cstdio>
 #include <vector>
@@ -10,10 +10,6 @@
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #endif
-
-namespace edm {
-  class ParameterSet;
-}
 
 namespace l1ct {
   class PFTkEGSorterEmulator {
@@ -28,9 +24,22 @@ namespace l1ct {
 
 #endif
 
-    ~PFTkEGSorterEmulator(){};
+    virtual ~PFTkEGSorterEmulator() {}
 
     void setDebug(bool debug = true) { debug_ = debug; };
+
+    virtual void runPho(const std::vector<l1ct::PFInputRegion>& pfregions,
+                        const std::vector<l1ct::OutputRegion>& outregions,
+                        const std::vector<unsigned int>& region_index,
+                        std::vector<l1ct::EGIsoObjEmu>& eg_sorted_inBoard) {
+      run<l1ct::EGIsoObjEmu>(pfregions, outregions, region_index, eg_sorted_inBoard);
+    }
+    virtual void runEle(const std::vector<l1ct::PFInputRegion>& pfregions,
+                        const std::vector<l1ct::OutputRegion>& outregions,
+                        const std::vector<unsigned int>& region_index,
+                        std::vector<l1ct::EGIsoEleObjEmu>& eg_sorted_inBoard) {
+      run<l1ct::EGIsoEleObjEmu>(pfregions, outregions, region_index, eg_sorted_inBoard);
+    }
 
     template <typename T>
     void run(const std::vector<l1ct::PFInputRegion>& pfregions,
@@ -64,7 +73,7 @@ namespace l1ct {
       }
     }
 
-  private:
+  protected:
     unsigned int nObjToSort_, nObjSorted_;
     bool debug_;
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
@@ -8,11 +8,7 @@
 #include <cassert>
 #include <algorithm>
 
-#ifdef CMSSW_GIT_HASH
 #include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"
-#else
-#include "../../utils/dbgPrintf.h"
-#endif
 
 namespace l1ct {
   namespace tdr_regionizer {

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -107,6 +107,7 @@ l1tLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEMCALO_EGIN = 10,
         nEM_EGOUT = 10,
     ),
+    tkEgSorterAlgo = cms.string("Barrel"),
     tkEgSorterParameters=tkEgSorterParameters.clone(
         nObjToSort = 10
     ),
@@ -266,6 +267,7 @@ l1tLayer1HGCal = cms.EDProducer("L1TCorrelatorLayer1Producer",
         writeEGSta=True,
         doCompositeTkEle=True,
         trkQualityPtMin=0.), # This should be 10 GeV when doCompositeTkEle=False
+    tkEgSorterAlgo = cms.string("Endcap"),
     tkEgSorterParameters=tkEgSorterParameters.clone(
         nObjToSort = 5
     ),
@@ -360,6 +362,7 @@ l1tLayer1HGCalNoTK = cms.EDProducer("L1TCorrelatorLayer1Producer",
         doEndcapHwQual=True,
         writeBeforeBremRecovery=False,
         writeEGSta=True),
+    tkEgSorterAlgo = cms.string("Endcap"),
     tkEgSorterParameters=tkEgSorterParameters.clone(
         nObjToSort=5
     ),
@@ -443,6 +446,7 @@ l1tLayer1HF = cms.EDProducer("L1TCorrelatorLayer1Producer",
         nEM_EGOUT = 5,        # to be defined
         doBremRecovery=True,
         writeEGSta=True),
+    tkEgSorterAlgo = cms.string("Endcap"),
     tkEgSorterParameters=tkEgSorterParameters.clone(),
     caloSectors = cms.VPSet(
         cms.PSet( 

--- a/L1Trigger/Phase2L1ParticleFlow/src/egamma/pftkegalgo_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/egamma/pftkegalgo_ref.cpp
@@ -156,6 +156,16 @@ void PFTkEGAlgoEmulator::link_emCalo2tk_elliptic(const PFRegionEmu &r,
       float dEtaMax = cfg.dEtaValues[eta_index];
       float dPhiMax = cfg.dPhiValues[eta_index];
 
+      if (debug_ > 2 && calo.hwPt > 0) {
+        dbgCout() << "[REF] tried to link calo " << ic << " (pt " << calo.intPt() << ", eta " << calo.intEta()
+                  << ", phi " << calo.intPhi() << ") "
+                  << " to tk " << itk << " (pt " << tk.intPt() << ", eta " << tk.intEta() << ", phi " << tk.intPhi()
+                  << "): "
+                  << " eta_index " << eta_index << ", "
+                  << " dEta " << d_eta << " (max " << dEtaMax << "), dPhi " << d_phi << " (max " << dPhiMax << ") "
+                  << " ellipse = "
+                  << (((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))) << "\n";
+      }
       if ((((d_phi / dPhiMax) * (d_phi / dPhiMax)) + ((d_eta / dEtaMax) * (d_eta / dEtaMax))) < 1.) {
         // NOTE: for now we implement only best pt match. This is NOT what is done in the L1TkElectronTrackProducer
         if (fabs(tk.floatPt() - calo.floatPt()) < dPtMin) {

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -82,11 +82,33 @@ process.l1tLayer1Barrel9.boards=cms.VPSet(
             regions=cms.vuint32(*[6+9*ie+i for ie in range(3) for i in range(3)])),
     )
 
+process.l1tLayer1BarrelSerenity = process.l1tLayer1Barrel.clone()
+process.l1tLayer1BarrelSerenity.regionizerAlgo = "MultififoBarrel"
+process.l1tLayer1BarrelSerenity.regionizerAlgoParameters = cms.PSet(
+        barrelSetup = cms.string("Full54"),
+        useAlsoVtxCoords = cms.bool(True),
+        nClocks = cms.uint32(54),
+        nHCalLinks = cms.uint32(2),
+        nECalLinks = cms.uint32(1),
+        nTrack = cms.uint32(22),
+        nCalo = cms.uint32(15),
+        nEmCalo = cms.uint32(12),
+        nMu = cms.uint32(2))
+process.l1tLayer1BarrelSerenity.pfAlgoParameters.nTrack = 22
+process.l1tLayer1BarrelSerenity.pfAlgoParameters.nSelCalo = 15
+process.l1tLayer1BarrelSerenity.pfAlgoParameters.nCalo = 15
+process.l1tLayer1BarrelSerenity.pfAlgoParameters.nAllNeutral = 27
+process.l1tLayer1BarrelSerenity.puAlgoParameters.nTrack = 22
+process.l1tLayer1BarrelSerenity.puAlgoParameters.nIn = 27
+process.l1tLayer1BarrelSerenity.puAlgoParameters.nOut = 27
+process.l1tLayer1BarrelSerenity.puAlgoParameters.finalSortAlgo = "FoldedHybrid"
+
 from L1Trigger.Phase2L1ParticleFlow.l1ctLayer1_patternWriters_cff import *
 if not args.patternFilesOFF:
     process.l1tLayer1Barrel.patternWriters = cms.untracked.VPSet(*barrelWriterConfigs)
     # process.l1tLayer1Barrel9.patternWriters = cms.untracked.VPSet(*barrel9WriterConfigs) # not enabled for now
     process.l1tLayer1HGCal.patternWriters = cms.untracked.VPSet(*hgcalWriterConfigs)
+    process.l1tLayer1HGCalElliptic.patternWriters = cms.untracked.VPSet(*hgcalWriterConfigs)
     process.l1tLayer1HGCalNoTK.patternWriters = cms.untracked.VPSet(*hgcalNoTKWriterConfigs)
     process.l1tLayer1HF.patternWriters = cms.untracked.VPSet(*hfWriterConfigs)
 
@@ -95,8 +117,10 @@ process.runPF = cms.Path(
         process.l1tGTTInputProducer +
         process.l1tVertexFinderEmulator +
         process.l1tLayer1Barrel +
+        process.l1tLayer1BarrelSerenity +
         process.l1tLayer1Barrel9 +
         process.l1tLayer1HGCal +
+        process.l1tLayer1HGCalElliptic +
         process.l1tLayer1HGCalNoTK +
         process.l1tLayer1HF +
         process.l1tLayer1 +
@@ -124,7 +148,7 @@ if not args.patternFilesOFF:
     process.l1tLayer2SeedConeJetWriter.maxLinesPerFile = eventsPerFile_*54
 
 if not args.dumpFilesOFF:
-  for det in "Barrel", "Barrel9", "HGCal", "HGCalNoTK", "HF":
+  for det in "Barrel", "BarrelSerenity", "Barrel9", "HGCal", "HGCalElliptic", "HGCalNoTK", "HF":
         l1pf = getattr(process, 'l1tLayer1'+det)
         l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
 


### PR DESCRIPTION
#### PR description:

This PR implements a new sorter of e/gamma objects based on iterative merge-sort, to be used in the barrel part of the correlator layer 1. 
Currently in CMSSW both the barrel and the endcaps were configured to use the sorter based on iterative insertion sort, but in the barrel that sorter can't be implemented in firmware as there aren't enough clock cycles to sort all objects.

From a CMSSW point of view the only change this PR may make in the output is that objects with the same p<sub>T</sub> may end up in different order in the output collection.

The corresponding PR to cms-l1t-offline is https://github.com/cms-l1t-offline/cmssw/pull/1129 for @aloeliger and @epalencia 

#### PR validation:

In this branch, beyond the obvious `scram b code-format && scram b code-checks && scram b runtests` it was tested with matrix workflow 23234.0

In CMSSW_12_5_X, this was validated comparing against the previous sorter and against firmware implementation of this sorting.