### PR TITLE
remove MkFit clang16 vectorization warnings 

### DIFF
--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -299,7 +299,11 @@ namespace mkfit {
     };
 
     if (L.is_barrel()) {
-      // Pull out the part of the loop that vectorizes
+      // Pull out the part of the loop that vectorizes with icc and gcc
+      // In llvm16 clang issues a warning that it can't vectorize
+      // the loop.  Unfortunately, there doesn't seem to be a
+      // pragma to suppress the warning, so we ifdef it out.  This
+      // should be rechecked if llvm vectorization improves.
 #if !defined(__clang__)
 #pragma omp simd
 #endif
@@ -341,7 +345,7 @@ namespace mkfit {
       //layer half-thikness for dphi spread calculation; only for very restrictive iters
       const float layerD = std::abs(L.layer_info()->zmax() - L.layer_info()->zmin()) * 0.5f *
                            (m_iteration_params->maxConsecHoles == 0 || m_iteration_params->maxHolesPerCand == 0);
-      // Pull out the part of the loop that vectorizes
+      // Pull out the part of the loop that vectorizes with icc and gcc
 #if !defined(__clang__)
 #pragma omp simd
 #endif
@@ -1210,7 +1214,7 @@ namespace mkfit {
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
-       //#pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
+      //#pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
       for (int itrack = 0; itrack < N_proc; ++itrack) {
         // We can be in failed state from the initial propagation before selectHitIndices
         // and there hit_count for track is set to -1 and WSR state to Failed, handled below.

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -300,7 +300,9 @@ namespace mkfit {
 
     if (L.is_barrel()) {
       // Pull out the part of the loop that vectorizes
+#if !defined(__clang__)
 #pragma omp simd
+#endif
       for (int itrack = 0; itrack < NN; ++itrack) {
         m_XHitSize[itrack] = 0;
 
@@ -340,7 +342,9 @@ namespace mkfit {
       const float layerD = std::abs(L.layer_info()->zmax() - L.layer_info()->zmin()) * 0.5f *
                            (m_iteration_params->maxConsecHoles == 0 || m_iteration_params->maxHolesPerCand == 0);
       // Pull out the part of the loop that vectorizes
+#if !defined(__clang__)
 #pragma omp simd
+#endif
       for (int itrack = 0; itrack < NN; ++itrack) {
         m_XHitSize[itrack] = 0;
 
@@ -716,7 +720,7 @@ namespace mkfit {
 
       mhp.reset();
 
-#pragma omp simd
+      //#pragma omp simd doesn't vectorize with current compilers
       for (int itrack = 0; itrack < N_proc; ++itrack) {
         if (hit_cnt < m_XHitSize[itrack]) {
           mhp.addInputAt(itrack, layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)));
@@ -932,7 +936,7 @@ namespace mkfit {
 
       int charge_pcm[NN];
 
-#pragma omp simd
+      //#pragma omp simd doesn't vectorize with current compilers
       for (int itrack = 0; itrack < N_proc; ++itrack) {
         if (hit_cnt < m_XHitSize[itrack]) {
           const auto &hit = layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0));
@@ -1179,7 +1183,7 @@ namespace mkfit {
 
       int charge_pcm[NN];
 
-#pragma omp simd
+      //#pragma omp simd doesn't vectorize with current compilers
       for (int itrack = 0; itrack < N_proc; ++itrack) {
         if (hit_cnt < m_XHitSize[itrack]) {
           const auto &hit = layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0));
@@ -1206,7 +1210,7 @@ namespace mkfit {
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
-#pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
+       //#pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
       for (int itrack = 0; itrack < N_proc; ++itrack) {
         // We can be in failed state from the initial propagation before selectHitIndices
         // and there hit_count for track is set to -1 and WSR state to Failed, handled below.

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -297,6 +297,9 @@ namespace mkfit {
     MPlexLL errorPropTmp(0.f);   //initialize to zero
     MPlexLL errorPropSwap(0.f);  //initialize to zero
 
+    // loop does not vectorize with llvm16, and it issues a warning
+    // that apparently can't be suppressed with a pragma.  Needs to
+    // be rechecked if future llvm versions improve vectorization.
 #if !defined(__clang__)
 #pragma omp simd
 #endif

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -297,7 +297,9 @@ namespace mkfit {
     MPlexLL errorPropTmp(0.f);   //initialize to zero
     MPlexLL errorPropSwap(0.f);  //initialize to zero
 
+#if !defined(__clang__)
 #pragma omp simd
+#endif
     for (int n = 0; n < NN; ++n) {
       //initialize erroProp to identity matrix
       errorProp(n, 0, 0) = 1.f;


### PR DESCRIPTION
#### PR description:

Removes the "loop not vectorized" warnings in https://github.com/cms-sw/cmssw/issues/41624. Four of the loops are not vectorized by any of our compilers, so I commented out the simd pragma for those. For the others that are vectorized by icc and gcc, I added an ifdef to disable the simd pragma for clang. I would have preferred to suppress the warning messages with a compiler pragma, but that doesn't seem to be possible for the case where vectorization is supposed to be forced.  Resolves #41624.

#### PR validation:

Compiles without warnings with clang16 and gcc.
