### PR TITLE
[8_0_X] Make sure to report an error if process.options.numberOfThreads has wrong type

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -292,12 +292,15 @@ int main(int argc, char* argv[]) {
       {
         if(not setNThreadsOnCommandLine) {
           std::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
-          if(pset->existsAs<edm::ParameterSet>("options",false)) {
+          // Note: it is important to not check the type or trackedness in
+          // exists() call to ensure that the getUntrackedParameter() calls
+          // will fail if the parameters have an incorrect type
+          if(pset->exists("options")) {
             auto const& ops = pset->getUntrackedParameterSet("options");
-            if(ops.existsAs<unsigned int>("numberOfThreads",false)) {
+            if(ops.exists("numberOfThreads")) {
               unsigned int nThreads = ops.getUntrackedParameter<unsigned int>("numberOfThreads");
               unsigned int stackSize=kDefaultSizeOfStackForThreadsInKB;
-              if(ops.existsAs<unsigned int>("sizeOfStackForThreadsInKB",false)) {
+              if(ops.exists("sizeOfStackForThreadsInKB")) {
                 stackSize = ops.getUntrackedParameter<unsigned int>("sizeOfStackForThreadsInKB");
               }
               const auto nThreadsUsed = setNThreads(nThreads,stackSize,tsiPtr);
@@ -312,7 +315,7 @@ int main(int argc, char* argv[]) {
           //inject it into the top level ParameterSet
           edm::ParameterSet newOp;
           std::shared_ptr<edm::ParameterSet> pset = processDesc->getProcessPSet();
-          if(pset->existsAs<edm::ParameterSet>("options",false)) {
+          if(pset->exists("options")) {
             newOp = pset->getUntrackedParameterSet("options");
           }
           newOp.addUntrackedParameter<unsigned int>("numberOfThreads",nThreadsOnCommandLine);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -417,7 +417,7 @@ namespace edm {
     forceESCacheClearOnNewRun_ = optionsPset.getUntrackedParameter<bool>("forceEventSetupCacheClearOnNewRun", false);
     //threading
     unsigned int nThreads=1;
-    if(optionsPset.existsAs<unsigned int>("numberOfThreads",false)) {
+    if(optionsPset.exists("numberOfThreads")) {
       nThreads = optionsPset.getUntrackedParameter<unsigned int>("numberOfThreads");
       if(nThreads == 0) {
         nThreads = 1;
@@ -427,7 +427,7 @@ namespace edm {
     unsigned int nStreams =nThreads;
      */
     unsigned int nStreams =1;
-    if(optionsPset.existsAs<unsigned int>("numberOfStreams",false)) {
+    if(optionsPset.exists("numberOfStreams")) {
       nStreams = optionsPset.getUntrackedParameter<unsigned int>("numberOfStreams");
       if(nStreams==0) {
         nStreams = nThreads;


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/41349, title says it all. Contrary to the other backports, I did not include the unit tests here, because apparently 8_0_X does not support the `<test ...>` syntax for defining unit tests, and therefore making them functional would have required quite some work (that I would not want to do).

#### PR validation:

Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/41349