### PR TITLE
DQM: Online mode for DQMStore

### DIFF
--- a/DQM/Integration/python/config/environment_cfi.py
+++ b/DQM/Integration/python/config/environment_cfi.py
@@ -58,7 +58,7 @@ if dqmFileConfig.has_option("host", "collectorHost"):
 # now start the actual configuration
 print("dqmRunConfig:", dqmRunConfig)
 
-from DQMServices.Core.DQMStore_cfi import *
+from DQMServices.Core.DQMStore_Online_cfi import *
 
 DQM = cms.Service("DQM",
                   debug = cms.untracked.bool(False),

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -753,7 +753,8 @@ namespace dqm {
       void debugTrackME(const char* message, MonitorElement* me_local, MonitorElement* me_global) const;
       // accesor to keep MEsToSave_ private
       const auto& getMEsToSave() const { return MEsToSave_; }
-
+      // accesor to keep onlineMode_ private
+      const bool& getMode() const { return onlineMode_;}
     private:
       // MEComparison is a name-only comparison on MEs and Paths, allowing
       // heterogeneous lookup.
@@ -800,6 +801,9 @@ namespace dqm {
       // if non-empty, debugTrackME calls will log some information whenever a
       // ME path contains this string.
       std::string trackME_;
+
+      // Online mode
+      bool onlineMode_;
     };
   }  // namespace implementation
 

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -754,7 +754,8 @@ namespace dqm {
       // accesor to keep MEsToSave_ private
       const auto& getMEsToSave() const { return MEsToSave_; }
       // accesor to keep onlineMode_ private
-      const bool& getMode() const { return onlineMode_;}
+      const bool& getMode() const { return onlineMode_; }
+
     private:
       // MEComparison is a name-only comparison on MEs and Paths, allowing
       // heterogeneous lookup.

--- a/DQMServices/Core/python/DQMStore_Online_cfi.py
+++ b/DQMServices/Core/python/DQMStore_Online_cfi.py
@@ -16,5 +16,5 @@ DQMStore = cms.Service("DQMStore",
     # remains here, even though the DQMStore does not use it any more.
     enableMultiThread = cms.untracked.bool(True),
     # Online mode
-    onlineMode = cms.untracked.bool(False)
+    onlineMode = cms.untracked.bool(True)
 )

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -781,7 +781,7 @@ namespace dqm::implementation {
     doSaveByLumi_ = pset.getUntrackedParameter<bool>("saveByLumi", false);
     MEsToSave_ = pset.getUntrackedParameter<std::vector<std::string>>("MEsToSave", std::vector<std::string>());
     trackME_ = pset.getUntrackedParameter<std::string>("trackME", "");
-    onlineMode_ =  pset.getUntrackedParameter<bool>("onlineMode", false);
+    onlineMode_ = pset.getUntrackedParameter<bool>("onlineMode", false);
 
     // Set lumi and run for legacy booking.
     // This is no more than a guess with concurrent runs/lumis, but should be

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -684,7 +684,7 @@ namespace dqm::implementation {
         for (std::vector<std::string>::const_iterator ipath = store_->MEsToSave_.begin();
              ipath != store_->MEsToSave_.end();
              ++ipath) {
-          std::string nameToSave = *ipath;
+          const std::string& nameToSave = *ipath;
           // option 1 (used in the past): inclusive selection
           // (store all MEs that contain any of the requested patterns)
           // if (name.find(nameToSave) != std::string::npos) {

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -102,7 +102,7 @@ namespace dqm::implementation {
 
       const auto& MEs = store_->getMEsToSave();
 
-      if (not MEs.empty()) {
+      if (not MEs.empty() && not store_->getMode()) {
         bool pathInList = false;
         for (const auto& thepath : MEs) {
           if (fullpath == thepath) {
@@ -781,6 +781,7 @@ namespace dqm::implementation {
     doSaveByLumi_ = pset.getUntrackedParameter<bool>("saveByLumi", false);
     MEsToSave_ = pset.getUntrackedParameter<std::vector<std::string>>("MEsToSave", std::vector<std::string>());
     trackME_ = pset.getUntrackedParameter<std::string>("trackME", "");
+    onlineMode_ =  pset.getUntrackedParameter<bool>("onlineMode", false);
 
     // Set lumi and run for legacy booking.
     // This is no more than a guess with concurrent runs/lumis, but should be


### PR DESCRIPTION
#### PR description:
 After the merging of https://github.com/cms-sw/cmssw/pull/41400 and its master PR version, some plots[0-3] in Online DQM started misbehaving due to the change of scope introduced by perLS.

This PR tries to distangle Online and Offline modes for DQMStore to avoid such problem

[0] https://github.com/cms-sw/cmssw/blob/master/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py#L29-L31
[1] https://github.com/cms-sw/cmssw/blob/master/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py#L89-L106
[2] https://github.com/jfernan2/cmssw/blob/5053a4c9343a94ed630a8f824a76f01c3618708f/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py#L35-L56
[3] https://github.com/jfernan2/cmssw/blob/5053a4c9343a94ed630a8f824a76f01c3618708f/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py#L58-L70

#### PR validation:

Successfully tested in DQM Online playback, not affecting Offline