### PR TITLE
[ROOT6] Add legacy header for RooCatType for root update

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -18,6 +18,7 @@
 #include "RooCategory.h"
 #include "RooDataHist.h"
 #include "RooDataSet.h"
+#include "RooFitLegacy/RooCatTypeLegacy.h"
 #include "RooFitResult.h"
 #include "RooFormulaVar.h"
 #include "RooGlobalFunc.h"


### PR DESCRIPTION
This PR adds the legacy header for RooCatType class deprecated as for ROOT 6.22 (See https://root.cern/doc/master/classRooAbsCategory.html).
Fixes compilation error on https://github.com/cms-sw/cmsdist/pull/8505 while looking for a replacement for `RooCatType`.