### PR TITLE
[13.0.X] Modernize `TrackSplittingMonitor` and fix bug with filling ME-s

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -44,6 +44,7 @@ public:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void doProfileX(TH2* th2, MonitorElement* me);

--- a/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackSplittingMonitor.h
@@ -40,7 +40,7 @@ class TProfile;
 class TrackSplittingMonitor : public DQMEDAnalyzer {
 public:
   explicit TrackSplittingMonitor(const edm::ParameterSet&);
-  ~TrackSplittingMonitor() override;
+  ~TrackSplittingMonitor() override = default;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
@@ -50,12 +50,11 @@ private:
   void doProfileX(MonitorElement* th2m, MonitorElement* me);
 
   // ----------member data ---------------------------
-
-  //  unsigned int minTracks_;
+  static constexpr double cmToUm = 10.e4;
+  static constexpr double radToUrad = 10.e3;
+  static constexpr double sqrt2 = 1.41421356237;
 
   std::string histname;  //for naming the histograms according to algorithm used
-
-  DQMStore* dqmStore_;
   edm::ParameterSet conf_;
 
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
@@ -70,18 +69,16 @@ private:
   const CSCGeometry* cscGeometry;
   const RPCGeometry* rpcGeometry;
 
-  edm::InputTag splitTracks_;
-  edm::InputTag splitMuons_;
-  edm::EDGetTokenT<std::vector<reco::Track> > splitTracksToken_;
-  edm::EDGetTokenT<std::vector<reco::Muon> > splitMuonsToken_;
+  const edm::EDGetTokenT<std::vector<reco::Track> > splitTracksToken_;
+  const edm::EDGetTokenT<std::vector<reco::Muon> > splitMuonsToken_;
 
-  bool plotMuons_;
-  int pixelHitsPerLeg_;
-  int totalHitsPerLeg_;
-  double d0Cut_;
-  double dzCut_;
-  double ptCut_;
-  double norchiCut_;
+  const bool plotMuons_;
+  const int pixelHitsPerLeg_;
+  const int totalHitsPerLeg_;
+  const double d0Cut_;
+  const double dzCut_;
+  const double ptCut_;
+  const double norchiCut_;
 
   // histograms
   MonitorElement* ddxyAbsoluteResiduals_tracker_;

--- a/DQM/TrackingMonitor/python/TrackSplittingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackSplittingMonitor_cfi.py
@@ -5,47 +5,35 @@
 
 import FWCore.ParameterSet.Config as cms
 
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-TrackSplitMonitor = DQMEDAnalyzer('TrackSplittingMonitor',
-                 
-    FolderName = cms.string('TrackSplitMonitoring'),
-	
-	splitTrackCollection = cms.InputTag("splittedTracksP5"),
-	splitMuonCollection = cms.InputTag("splitMuons"),
-	ifPlotMuons = cms.bool(True),
-	
-	pixelHitsPerLeg = cms.int32( 1 ),
-	totalHitsPerLeg = cms.int32( 6 ),	
-	d0Cut = cms.double( 12.0 ),
-	dzCut = cms.double( 25.0 ),	
-	ptCut = cms.double( 4.0 ),
-	norchiCut = cms.double( 100.0 ),
-	
-    ddxyBin = cms.int32(100),
-    ddxyMin = cms.double(-200.0),
-    ddxyMax = cms.double(200.0),
-
-    ddzBin = cms.int32(100),
-    ddzMin = cms.double(-400.0),
-    ddzMax = cms.double(400.0),
-
-    dphiBin = cms.int32(100),
-    dphiMin = cms.double(-0.01),
-    dphiMax = cms.double(0.01),
-
-    dthetaBin = cms.int32(100),
-    dthetaMin = cms.double(-0.01),
-    dthetaMax = cms.double(0.01),
-
-    dptBin = cms.int32(100),
-    dptMin = cms.double(-5.0),
-    dptMax = cms.double(5.0),
-
-    dcurvBin = cms.int32(100),
-    dcurvMin = cms.double(-0.005),
-    dcurvMax = cms.double(0.005),
-
-    normBin = cms.int32(100),
-    normMin = cms.double(-5.0),
-    normMax = cms.double(5.0)
-)
+from DQM.TrackingMonitor.trackSplittingMonitor_cfi import trackSplittingMonitor
+TrackSplitMonitor = trackSplittingMonitor.clone(FolderName = cms.string('TrackSplitMonitoring'),
+                                                splitTrackCollection = "splittedTracksP5",
+                                                splitMuonCollection = "splitMuons",
+                                                ifPlotMuons = True,
+                                                pixelHitsPerLeg = 1,
+                                                totalHitsPerLeg = 6 ,
+                                                d0Cut = 12.0 ,
+                                                dzCut = 25.0 ,
+                                                ptCut = 4.0 ,
+                                                norchiCut = 100.0 ,
+                                                ddxyBin = 100 ,
+                                                ddxyMin = -200.0 ,
+                                                ddxyMax = 200.0 ,
+                                                ddzBin = 100,
+                                                ddzMin = -400.0,
+                                                ddzMax = 400.0,
+                                                dphiBin = 100,
+                                                dphiMin = -0.01,
+                                                dphiMax = 0.01,
+                                                dthetaBin = 100,
+                                                dthetaMin = -0.01,
+                                                dthetaMax = 0.01,
+                                                dptBin = 100,
+                                                dptMin = -5.0,
+                                                dptMax = 5.0,
+                                                dcurvBin = 100,
+                                                dcurvMin = -0.005,
+                                                dcurvMax = 0.005,
+                                                normBin = 100,
+                                                normMin = -5.0,
+                                                normMax = 5.0)

--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -20,34 +20,25 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-//#include "DQM/TrackingMonitor/interface/TrackAnalyzer.h"
+
 #include <string>
 
 TrackSplittingMonitor::TrackSplittingMonitor(const edm::ParameterSet& iConfig)
-    : dqmStore_(edm::Service<DQMStore>().operator->()),
-      conf_(iConfig),
+    : conf_(iConfig),
       mfToken_(esConsumes()),
       tkGeomToken_(esConsumes()),
       dtGeomToken_(esConsumes()),
       cscGeomToken_(esConsumes()),
-      rpcGeomToken_(esConsumes()) {
-  splitTracks_ = conf_.getParameter<edm::InputTag>("splitTrackCollection");
-  splitMuons_ = conf_.getParameter<edm::InputTag>("splitMuonCollection");
-  splitTracksToken_ = consumes<std::vector<reco::Track> >(splitTracks_);
-  splitMuonsToken_ = mayConsume<std::vector<reco::Muon> >(splitMuons_);
-
-  plotMuons_ = conf_.getParameter<bool>("ifPlotMuons");
-
-  // cuts
-  pixelHitsPerLeg_ = conf_.getParameter<int>("pixelHitsPerLeg");
-  totalHitsPerLeg_ = conf_.getParameter<int>("totalHitsPerLeg");
-  d0Cut_ = conf_.getParameter<double>("d0Cut");
-  dzCut_ = conf_.getParameter<double>("dzCut");
-  ptCut_ = conf_.getParameter<double>("ptCut");
-  norchiCut_ = conf_.getParameter<double>("norchiCut");
-}
-
-TrackSplittingMonitor::~TrackSplittingMonitor() = default;
+      rpcGeomToken_(esConsumes()),
+      splitTracksToken_(consumes<std::vector<reco::Track> >(conf_.getParameter<edm::InputTag>("splitTrackCollection"))),
+      splitMuonsToken_(mayConsume<std::vector<reco::Muon> >(conf_.getParameter<edm::InputTag>("splitMuonCollection"))),
+      plotMuons_(conf_.getParameter<bool>("ifPlotMuons")),
+      pixelHitsPerLeg_(conf_.getParameter<int>("pixelHitsPerLeg")),
+      totalHitsPerLeg_(conf_.getParameter<int>("totalHitsPerLeg")),
+      d0Cut_(conf_.getParameter<double>("d0Cut")),
+      dzCut_(conf_.getParameter<double>("dzCut")),
+      ptCut_(conf_.getParameter<double>("ptCut")),
+      norchiCut_(conf_.getParameter<double>("norchiCut")) {}
 
 void TrackSplittingMonitor::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& /* iRun */,
@@ -142,33 +133,33 @@ void TrackSplittingMonitor::bookHistograms(DQMStore::IBooker& ibooker,
   }
 
   ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta d_{xy})/#sqrt{2} [#mum]");
-  ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
-  ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
-  ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
-  ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
-  ddxyAbsoluteResiduals_tracker_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
+  ddzAbsoluteResiduals_tracker_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
+  dphiAbsoluteResiduals_tracker_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
+  dthetaAbsoluteResiduals_tracker_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
+  dptAbsoluteResiduals_tracker_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
+  dcurvAbsoluteResiduals_tracker_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
 
   ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy}");
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta p_{T}/#sigma(p_{T})");
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta 1/p_{T}/#sigma(1/p_{T})");
+  ddzNormalizedResiduals_tracker_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
+  dphiNormalizedResiduals_tracker_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
+  dthetaNormalizedResiduals_tracker_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");
+  dptNormalizedResiduals_tracker_->setAxisTitle("#delta p_{T}/#sigma(p_{T})");
+  dcurvNormalizedResiduals_tracker_->setAxisTitle("#delta 1/p_{T}/#sigma(1/p_{T})");
 
   if (plotMuons_) {
     ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta d_{xy})/#sqrt{2} [#mum]");
-    ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
-    ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
-    ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
-    ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
-    ddxyAbsoluteResiduals_global_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
+    ddzAbsoluteResiduals_global_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
+    dphiAbsoluteResiduals_global_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
+    dthetaAbsoluteResiduals_global_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
+    dptAbsoluteResiduals_global_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
+    dcurvAbsoluteResiduals_global_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
 
     ddxyNormalizedResiduals_global_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy}");
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta p_{T}/#sigma(p_{T})");
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta 1/p_{T}/#sigma(1/p_{T})");
+    ddzNormalizedResiduals_global_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
+    dphiNormalizedResiduals_global_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
+    dthetaNormalizedResiduals_global_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");
+    dptNormalizedResiduals_global_->setAxisTitle("#delta p_{T}/#sigma(p_{T})");
+    dcurvNormalizedResiduals_global_->setAxisTitle("#delta 1/p_{T}/#sigma(1/p_{T})");
   }
 }
 
@@ -205,10 +196,10 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
     // looping through the hits for track 1
     double nRechits1 = 0;
     double nRechitinBPIX1 = 0;
-    for (trackingRecHit_iterator iHit = track1.recHitsBegin(); iHit != track1.recHitsEnd(); ++iHit) {
-      if ((*iHit)->isValid()) {
+    for (auto const& iHit : track1.recHits()) {
+      if (iHit->isValid()) {
         nRechits1++;
-        int type = (*iHit)->geographicalId().subdetId();
+        int type = iHit->geographicalId().subdetId();
         if (type == int(PixelSubdetector::PixelBarrel)) {
           ++nRechitinBPIX1;
         }
@@ -217,10 +208,10 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
     // looping through the hits for track 2
     double nRechits2 = 0;
     double nRechitinBPIX2 = 0;
-    for (trackingRecHit_iterator iHit = track2.recHitsBegin(); iHit != track2.recHitsEnd(); ++iHit) {
-      if ((*iHit)->isValid()) {
+    for (auto const& iHit : track2.recHits()) {
+      if (iHit->isValid()) {
         nRechits2++;
-        int type = (*iHit)->geographicalId().subdetId();
+        int type = iHit->geographicalId().subdetId();
         if (type == int(PixelSubdetector::PixelBarrel)) {
           ++nRechitinBPIX2;
         }
@@ -246,7 +237,8 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
     if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX1 >= pixelHitsPerLeg_) &&
         (nRechits1 >= totalHitsPerLeg_) && (nRechits2 >= totalHitsPerLeg_)) {
       // dca cut
-      if (((fabs(d01) < d0Cut_)) && (fabs(d02) < d0Cut_) && (fabs(dz2) < dzCut_) && (fabs(dz2) < dzCut_)) {
+      if (((std::abs(d01) < d0Cut_)) && (std::abs(d02) < d0Cut_) && (std::abs(dz2) < dzCut_) &&
+          (std::abs(dz2) < dzCut_)) {
         // pt cut
         if ((pt1 + pt2) / 2 < ptCut_) {
           // chi2 cut
@@ -272,20 +264,20 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
             double pt1ErrVal = track1.ptError();
             double pt2ErrVal = track2.ptError();
 
-            ddxyAbsoluteResiduals_tracker_->Fill(10000.0 * ddxyVal / sqrt(2.0));
-            ddxyAbsoluteResiduals_tracker_->Fill(10000.0 * ddzVal / sqrt(2.0));
-            ddxyAbsoluteResiduals_tracker_->Fill(1000.0 * dphiVal / sqrt(2.0));
-            ddxyAbsoluteResiduals_tracker_->Fill(1000.0 * dthetaVal / sqrt(2.0));
-            ddxyAbsoluteResiduals_tracker_->Fill(dptVal / sqrt(2.0));
-            ddxyAbsoluteResiduals_tracker_->Fill(dcurvVal / sqrt(2.0));
+            ddxyAbsoluteResiduals_tracker_->Fill(cmToUm * ddxyVal / sqrt2);
+            ddzAbsoluteResiduals_tracker_->Fill(cmToUm * ddzVal / sqrt2);
+            dphiAbsoluteResiduals_tracker_->Fill(radToUrad * dphiVal / sqrt2);
+            dthetaAbsoluteResiduals_tracker_->Fill(radToUrad * dthetaVal / sqrt2);
+            dptAbsoluteResiduals_tracker_->Fill(dptVal / sqrt2);
+            dcurvAbsoluteResiduals_tracker_->Fill(dcurvVal / sqrt2);
 
             ddxyNormalizedResiduals_tracker_->Fill(ddxyVal / sqrt(d01ErrVal * d01ErrVal + d02ErrVal * d02ErrVal));
-            ddxyNormalizedResiduals_tracker_->Fill(ddzVal / sqrt(dz1ErrVal * dz1ErrVal + dz2ErrVal * dz2ErrVal));
-            ddxyNormalizedResiduals_tracker_->Fill(dphiVal / sqrt(phi1ErrVal * phi1ErrVal + phi2ErrVal * phi2ErrVal));
-            ddxyNormalizedResiduals_tracker_->Fill(dthetaVal /
-                                                   sqrt(theta1ErrVal * theta1ErrVal + theta2ErrVal * theta2ErrVal));
-            ddxyNormalizedResiduals_tracker_->Fill(dptVal / sqrt(pt1ErrVal * pt1ErrVal + pt2ErrVal * pt2ErrVal));
-            ddxyNormalizedResiduals_tracker_->Fill(
+            ddzNormalizedResiduals_tracker_->Fill(ddzVal / sqrt(dz1ErrVal * dz1ErrVal + dz2ErrVal * dz2ErrVal));
+            dphiNormalizedResiduals_tracker_->Fill(dphiVal / sqrt(phi1ErrVal * phi1ErrVal + phi2ErrVal * phi2ErrVal));
+            dthetaNormalizedResiduals_tracker_->Fill(dthetaVal /
+                                                     sqrt(theta1ErrVal * theta1ErrVal + theta2ErrVal * theta2ErrVal));
+            dptNormalizedResiduals_tracker_->Fill(dptVal / sqrt(pt1ErrVal * pt1ErrVal + pt2ErrVal * pt2ErrVal));
+            dcurvNormalizedResiduals_tracker_->Fill(
                 dcurvVal / sqrt(pow(pt1ErrVal, 2) / pow(pt1, 4) + pow(pt2ErrVal, 2) / pow(pt2, 4)));
 
             // if do the same for split muons
@@ -347,12 +339,12 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
                 double pt1ErrValGlb = glb1->ptError();
                 double pt2ErrValGlb = glb2->ptError();
 
-                ddxyAbsoluteResiduals_global_->Fill(10000.0 * ddxyValGlb / sqrt(2.0));
-                ddxyAbsoluteResiduals_global_->Fill(10000.0 * ddzValGlb / sqrt(2.0));
-                ddxyAbsoluteResiduals_global_->Fill(1000.0 * dphiValGlb / sqrt(2.0));
-                ddxyAbsoluteResiduals_global_->Fill(1000.0 * dthetaValGlb / sqrt(2.0));
-                ddxyAbsoluteResiduals_global_->Fill(dptValGlb / sqrt(2.0));
-                ddxyAbsoluteResiduals_global_->Fill(dcurvValGlb / sqrt(2.0));
+                ddxyAbsoluteResiduals_global_->Fill(cmToUm * ddxyValGlb / sqrt2);
+                ddzAbsoluteResiduals_global_->Fill(cmToUm * ddzValGlb / sqrt2);
+                dphiAbsoluteResiduals_global_->Fill(radToUrad * dphiValGlb / sqrt2);
+                dthetaAbsoluteResiduals_global_->Fill(radToUrad * dthetaValGlb / sqrt2);
+                dptAbsoluteResiduals_global_->Fill(dptValGlb / sqrt2);
+                dcurvAbsoluteResiduals_global_->Fill(dcurvValGlb / sqrt2);
 
                 ddxyNormalizedResiduals_global_->Fill(ddxyValGlb /
                                                       sqrt(d01ErrValGlb * d01ErrValGlb + d02ErrValGlb * d02ErrValGlb));

--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -134,10 +134,10 @@ void TrackSplittingMonitor::bookHistograms(DQMStore::IBooker& ibooker,
   ddzAbsoluteResiduals_tracker_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
   dphiAbsoluteResiduals_tracker_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
   dthetaAbsoluteResiduals_tracker_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
-  dptAbsoluteResiduals_tracker_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
-  dcurvAbsoluteResiduals_tracker_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
+  dptAbsoluteResiduals_tracker_->setAxisTitle("(#delta p_{T})/#sqrt{2} [GeV]");
+  dcurvAbsoluteResiduals_tracker_->setAxisTitle("(#delta (1/p_{T}))/#sqrt{2} [GeV^{-1}]");
 
-  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy}");
+  ddxyNormalizedResiduals_tracker_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy})");
   ddzNormalizedResiduals_tracker_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
   dphiNormalizedResiduals_tracker_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
   dthetaNormalizedResiduals_tracker_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");
@@ -149,10 +149,10 @@ void TrackSplittingMonitor::bookHistograms(DQMStore::IBooker& ibooker,
     ddzAbsoluteResiduals_global_->setAxisTitle("(#delta d_{z})/#sqrt{2} [#mum]");
     dphiAbsoluteResiduals_global_->setAxisTitle("(#delta #phi)/#sqrt{2} [mrad]");
     dthetaAbsoluteResiduals_global_->setAxisTitle("(#delta #theta)/#sqrt{2} [mrad]");
-    dptAbsoluteResiduals_global_->setAxisTitle("(#delta pT)/#sqrt{2} [GeV]");
-    dcurvAbsoluteResiduals_global_->setAxisTitle("(#delta (1/pT))/#sqrt{2} [GeV^{-1}]");
+    dptAbsoluteResiduals_global_->setAxisTitle("(#delta p_{T})/#sqrt{2} [GeV]");
+    dcurvAbsoluteResiduals_global_->setAxisTitle("(#delta (1/p_{T}))/#sqrt{2} [GeV^{-1}]");
 
-    ddxyNormalizedResiduals_global_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy}");
+    ddxyNormalizedResiduals_global_->setAxisTitle("#delta d_{xy}/#sigma(d_{xy})");
     ddzNormalizedResiduals_global_->setAxisTitle("#delta d_{z}/#sigma(d_{z})");
     dphiNormalizedResiduals_global_->setAxisTitle("#delta #phi/#sigma(d_{#phi})");
     dthetaNormalizedResiduals_global_->setAxisTitle("#delta #theta/#sigma(d_{#theta})");

--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -232,7 +232,7 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
 
     // basic selection
     // pixel hits and total hits
-    if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX1 >= pixelHitsPerLeg_) &&
+    if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX2 >= pixelHitsPerLeg_) &&
         (nRechits1 >= totalHitsPerLeg_) && (nRechits2 >= totalHitsPerLeg_)) {
       // dca cut
       if (((std::abs(d01) < d0Cut_)) && (std::abs(d02) < d0Cut_) && (std::abs(dz1) < dzCut_) &&

--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -42,9 +42,7 @@ TrackSplittingMonitor::TrackSplittingMonitor(const edm::ParameterSet& iConfig)
 
 void TrackSplittingMonitor::bookHistograms(DQMStore::IBooker& ibooker,
                                            edm::Run const& /* iRun */,
-                                           edm::EventSetup const& /* iSetup */)
-
-{
+                                           edm::EventSetup const& /* iSetup */) {
   std::string MEFolderName = conf_.getParameter<std::string>("FolderName");
   ibooker.setCurrentFolder(MEFolderName);
 
@@ -366,6 +364,45 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
       }
     }
   }
+}
+
+void TrackSplittingMonitor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment(
+      "Validates track parameters resolution by splitting cosmics tracks at the PCA and comparing the parameters of "
+      "the two halves");
+  desc.add<std::string>("FolderName", "TrackSplitMonitoring");
+  desc.add<edm::InputTag>("splitTrackCollection", edm::InputTag("splittedTracksP5"));
+  desc.add<edm::InputTag>("splitMuonCollection", edm::InputTag("splitMuons"));
+  desc.add<bool>("ifPlotMuons", true);
+  desc.add<int>("pixelHitsPerLeg", 1);
+  desc.add<int>("totalHitsPerLeg", 6);
+  desc.add<double>("d0Cut", 12.0);
+  desc.add<double>("dzCut", 25.0);
+  desc.add<double>("ptCut", 4.0);
+  desc.add<double>("norchiCut", 100.0);
+  desc.add<int>("ddxyBin", 100);
+  desc.add<double>("ddxyMin", -200.0);
+  desc.add<double>("ddxyMax", 200.0);
+  desc.add<int>("ddzBin", 100);
+  desc.add<double>("ddzMin", -400.0);
+  desc.add<double>("ddzMax", 400.0);
+  desc.add<int>("dphiBin", 100);
+  desc.add<double>("dphiMin", -0.01);
+  desc.add<double>("dphiMax", 0.01);
+  desc.add<int>("dthetaBin", 100);
+  desc.add<double>("dthetaMin", -0.01);
+  desc.add<double>("dthetaMax", 0.01);
+  desc.add<int>("dptBin", 100);
+  desc.add<double>("dptMin", -5.0);
+  desc.add<double>("dptMax", 5.0);
+  desc.add<int>("dcurvBin", 100);
+  desc.add<double>("dcurvMin", -0.005);
+  desc.add<double>("dcurvMax", 0.005);
+  desc.add<int>("normBin", 100);
+  desc.add<double>("normMin", -5.);
+  desc.add<double>("normMax", 5.);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_MODULE(TrackSplittingMonitor);

--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -235,7 +235,7 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
     if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX1 >= pixelHitsPerLeg_) &&
         (nRechits1 >= totalHitsPerLeg_) && (nRechits2 >= totalHitsPerLeg_)) {
       // dca cut
-      if (((std::abs(d01) < d0Cut_)) && (std::abs(d02) < d0Cut_) && (std::abs(dz2) < dzCut_) &&
+      if (((std::abs(d01) < d0Cut_)) && (std::abs(d02) < d0Cut_) && (std::abs(dz1) < dzCut_) &&
           (std::abs(dz2) < dzCut_)) {
         // pt cut
         if ((pt1 + pt2) / 2 < ptCut_) {

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -29,7 +29,7 @@ TrackMon_ckf.FolderName                            = 'Tracking/TrackParameters/T
 #TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'
 #TrackEffMon_bhmuon.FolderName                      = 'Tracking/TrackParameters/TrackEfficiency'
 
-# # Split Tracking
+# Split Tracking
 # from  DQM.TrackingMonitor.TrackSplittingMonitor_cfi import *
 # TrackSplitMonitor.FolderName = 'Tracking/TrackParameters/SplitTracks'
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -29,9 +29,9 @@ TrackMon_ckf.FolderName                            = 'Tracking/TrackParameters/T
 #TrackEffMon_bhmuon.AlgoName                        = 'BHMuonTk'
 #TrackEffMon_bhmuon.FolderName                      = 'Tracking/TrackParameters/TrackEfficiency'
 
-# Split Tracking
-from  DQM.TrackingMonitor.TrackSplittingMonitor_cfi import *
-TrackSplitMonitor.FolderName = 'Tracking/TrackParameters/SplitTracks'
+# # Split Tracking
+# from  DQM.TrackingMonitor.TrackSplittingMonitor_cfi import *
+# TrackSplitMonitor.FolderName = 'Tracking/TrackParameters/SplitTracks'
 
 
 # DQM Services
@@ -352,7 +352,7 @@ run3_common.toModify(primaryVertexResolution, forceSCAL = False)
 # Sequence
 TrackingDQMSourceTier0 = cms.Sequence(cms.ignore(trackingDQMgoodOfflinePrimaryVertices))
 # dEdx monitoring
-TrackingDQMSourceTier0 += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon   * TrackMon_ckf * TrackSplitMonitor * dqmInfoTracking
+TrackingDQMSourceTier0 += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon * TrackMon_ckf * dqmInfoTracking
 #TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoTracking
 #    # temporary patch in order to have BXlumi
 #    * lumiProducer
@@ -399,7 +399,7 @@ TrackingDQMSourceTier0 += dqmInfoTracking
 
 TrackingDQMSourceTier0Common = cms.Sequence(cms.ignore(trackingDQMgoodOfflinePrimaryVertices))
 # dEdx monitoring
-TrackingDQMSourceTier0Common += (dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon * TrackMon_ckf * TrackSplitMonitor * dqmInfoTracking)
+TrackingDQMSourceTier0Common += (dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon * TrackMon_ckf * dqmInfoTracking)
 #TrackEffMon_ckf*TrackSplitMonitor*dqmInfoTracking)    
 ## monitor track collections
 for tracks in selectedTracks :
@@ -420,7 +420,7 @@ TrackingDQMSourceTier0Common += dqmInfoTracking
 
 TrackingDQMSourceTier0MinBias = cms.Sequence(cms.ignore(trackingDQMgoodOfflinePrimaryVertices))
 # dEdx monitoring
-TrackingDQMSourceTier0MinBias += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon * TrackMon_ckf * TrackSplitMonitor * dqmInfoTracking
+TrackingDQMSourceTier0MinBias += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon * TrackMon_ckf * dqmInfoTracking
 #TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoTracking#TrackMon_ckf*TrackEffMon_ckf 
 #    * lumiProducer
 # monitor track collections


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41690

#### PR description:

The main goal of this PR is to fix the filling of the residuals in the `TrackSplittingMonitor` DQM code. I noticed that in recent cosmic data these plots are almost all empty (see e.g.https://tinyurl.com/2q9tgomk). This was caused by a bug in the filling of the `MonitorElements` which is fixed in this PR.
I profit of it to:
   * modernize the code of the module
   * introduce a `fillDescriptions` method and use it in the related configurations
   * remove the `TrackSplitMonitor` from the Tracking DQM collisions setup as anyway there are no right input tracks to be fed to the module.

#### PR validation:

Run successfully `runTheMatrix.py -l 138.1 -t 4 -j 8 --custom_command='-n 5000' --ibeos` and checked that the cosmic plots are all filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/41690 needed for 2023 data-taking.