### PR TITLE
Adding track isolation of mustache superclusters in dataformats

### DIFF
--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -29,7 +29,8 @@ namespace reco {
           phiWidth_(0),
           etaWidth_(0),
           preshowerEnergy1_(0),
-          preshowerEnergy2_(0) {}
+          preshowerEnergy2_(0),
+          trkiso_(0) {}
 
     /// constructor defined by CaloCluster - will have to use setSeed and add() separately
     SuperCluster(double energy, const Point& position);
@@ -42,7 +43,8 @@ namespace reco {
                  double phiWidth = 0.,
                  double etaWidth = 0.,
                  double Epreshower1 = 0.,
-                 double Epreshower2 = 0.);
+                 double Epreshower2 = 0.,
+		 double trkiso =0.);
 
     // to be merged in the previous one? -- FIXME
     SuperCluster(double energy,
@@ -54,7 +56,8 @@ namespace reco {
                  double phiWidth = 0.,
                  double etaWidth = 0.,
                  double Epreshower1 = 0.,
-                 double Epreshower2 = 0.);
+                 double Epreshower2 = 0.,
+		 double trkiso =0.);
 
     /// raw uncorrected energy (sum of energies of component BasicClusters)
     double rawEnergy() const { return rawEnergy_; }
@@ -67,6 +70,7 @@ namespace reco {
     /// obtain phi and eta width of the Super Cluster
     double phiWidth() const { return phiWidth_; }
     double etaWidth() const { return etaWidth_; }
+    double trkiso() const { return trkiso_; }
 
     //Assign new variables to supercluster
     void setPreshowerEnergy(double preshowerEnergy) { preshowerEnergy_ = preshowerEnergy; };
@@ -74,6 +78,7 @@ namespace reco {
     void setPreshowerEnergyPlane2(double preshowerEnergy2) { preshowerEnergy2_ = preshowerEnergy2; };
     void setPhiWidth(double pw) { phiWidth_ = pw; }
     void setEtaWidth(double ew) { etaWidth_ = ew; }
+    void setTrackIsolation(double trkiso) {trkiso_ = trkiso;}
 
     /// seed BasicCluster
     const CaloClusterPtr& seed() const { return seed_; }
@@ -194,9 +199,10 @@ namespace reco {
 
     double phiWidth_;
     double etaWidth_;
-
     double preshowerEnergy1_;
     double preshowerEnergy2_;
+    double trkiso_;
+
   };
 
 }  // namespace reco

--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -44,7 +44,7 @@ namespace reco {
                  double etaWidth = 0.,
                  double Epreshower1 = 0.,
                  double Epreshower2 = 0.,
-		 double trkiso =0.);
+                 double trkiso = 0.);
 
     // to be merged in the previous one? -- FIXME
     SuperCluster(double energy,
@@ -57,7 +57,7 @@ namespace reco {
                  double etaWidth = 0.,
                  double Epreshower1 = 0.,
                  double Epreshower2 = 0.,
-		 double trkiso =0.);
+                 double trkiso = 0.);
 
     /// raw uncorrected energy (sum of energies of component BasicClusters)
     double rawEnergy() const { return rawEnergy_; }
@@ -78,7 +78,7 @@ namespace reco {
     void setPreshowerEnergyPlane2(double preshowerEnergy2) { preshowerEnergy2_ = preshowerEnergy2; };
     void setPhiWidth(double pw) { phiWidth_ = pw; }
     void setEtaWidth(double ew) { etaWidth_ = ew; }
-    void setTrackIsolation(double trkiso) {trkiso_ = trkiso;}
+    void setTrackIsolation(double trkiso) { trkiso_ = trkiso; }
 
     /// seed BasicCluster
     const CaloClusterPtr& seed() const { return seed_; }
@@ -202,7 +202,6 @@ namespace reco {
     double preshowerEnergy1_;
     double preshowerEnergy2_;
     double trkiso_;
-
   };
 
 }  // namespace reco

--- a/DataFormats/EgammaReco/src/SuperCluster.cc
+++ b/DataFormats/EgammaReco/src/SuperCluster.cc
@@ -10,7 +10,8 @@ SuperCluster::SuperCluster(double energy, const math::XYZPoint& position)
       phiWidth_(0),
       etaWidth_(0),
       preshowerEnergy1_(0),
-      preshowerEnergy2_(0) {}
+      preshowerEnergy2_(0),
+      trkiso_(0) {}
 
 SuperCluster::SuperCluster(double energy,
                            const math::XYZPoint& position,
@@ -20,7 +21,8 @@ SuperCluster::SuperCluster(double energy,
                            double phiWidth,
                            double etaWidth,
                            double Epreshower1,
-                           double Epreshower2)
+                           double Epreshower2,
+			   double trkiso)
     : CaloCluster(energy, position), rawEnergy_(0) {
   phiWidth_ = phiWidth;
   etaWidth_ = etaWidth;
@@ -28,6 +30,7 @@ SuperCluster::SuperCluster(double energy,
   preshowerEnergy_ = Epreshower;
   preshowerEnergy1_ = Epreshower1;
   preshowerEnergy2_ = Epreshower2;
+  trkiso_ = trkiso;
 
   // set references to constituent basic clusters and update list of rechits
   for (CaloClusterPtrVector::const_iterator bcit = clusters.begin(); bcit != clusters.end(); ++bcit) {
@@ -52,7 +55,8 @@ SuperCluster::SuperCluster(double energy,
                            double phiWidth,
                            double etaWidth,
                            double Epreshower1,
-                           double Epreshower2)
+                           double Epreshower2,
+			   double trkiso)
     : CaloCluster(energy, position), rawEnergy_(-1.) {
   phiWidth_ = phiWidth;
   etaWidth_ = etaWidth;
@@ -60,6 +64,7 @@ SuperCluster::SuperCluster(double energy,
   preshowerEnergy_ = Epreshower;
   preshowerEnergy1_ = Epreshower1;
   preshowerEnergy2_ = Epreshower2;
+  trkiso_ = trkiso;
 
   // set references to constituent basic clusters and update list of rechits
   for (CaloClusterPtrVector::const_iterator bcit = clusters.begin(); bcit != clusters.end(); ++bcit) {

--- a/DataFormats/EgammaReco/src/SuperCluster.cc
+++ b/DataFormats/EgammaReco/src/SuperCluster.cc
@@ -22,7 +22,7 @@ SuperCluster::SuperCluster(double energy,
                            double etaWidth,
                            double Epreshower1,
                            double Epreshower2,
-			   double trkiso)
+                           double trkiso)
     : CaloCluster(energy, position), rawEnergy_(0) {
   phiWidth_ = phiWidth;
   etaWidth_ = etaWidth;
@@ -56,7 +56,7 @@ SuperCluster::SuperCluster(double energy,
                            double etaWidth,
                            double Epreshower1,
                            double Epreshower2,
-			   double trkiso)
+                           double trkiso)
     : CaloCluster(energy, position), rawEnergy_(-1.) {
   phiWidth_ = phiWidth;
   etaWidth_ = etaWidth;

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -17,7 +17,8 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
-  <class name="reco::SuperCluster" ClassVersion="15">
+  <class name="reco::SuperCluster" ClassVersion="16">
+   <version ClassVersion="16" checksum="1334973347"/>
    <version ClassVersion="15" checksum="705520405"/>
    <version ClassVersion="14" checksum="3716250139"/>
    <version ClassVersion="13" checksum="1878352437"/>

--- a/RecoEcal/EgammaClusterAlgos/BuildFile.xml
+++ b/RecoEcal/EgammaClusterAlgos/BuildFile.xml
@@ -18,6 +18,7 @@
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
 <use name="RecoEgamma/EgammaTools"/>
+<use name="RecoEgamma/EgammaIsolationAlgos"/>
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="RecoParticleFlow/PFClusterTools"/>
 <use name="HeterogeneousCore/SonicTriton"/>

--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -29,6 +29,7 @@
 #include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h"
 #include "RecoEcal/EgammaCoreTools/interface/CalibratedPFCluster.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h" 
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -116,12 +117,23 @@ public:
 
   void loadAndSortPFClusters(const edm::Event& evt);
 
-  void run();
+  void run(const edm::Event& iEvent);
 
 private:
   edm::EDGetTokenT<edm::View<reco::PFCluster> > inputTagPFClusters_;
   edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> inputTagPFClustersES_;
   edm::EDGetTokenT<reco::BeamSpot> inputTagBeamSpot_;
+
+  // track isolation parameters: begin
+  edm::EDGetTokenT<reco::TrackCollection> trackProducer_;
+  double trkIsoPtMin_;
+  double trkIsoConeSize_;
+  double trkIsoZSpan_;
+  double trkIsoRSpan_;
+  double trkIsoVetoConeSize_;
+  double trkIsoStripBarrel_;
+  double trkIsoStripEndcap_;
+  // track isolation parameters: end
 
   edm::ESGetToken<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd> esEEInterCalibToken_;
   edm::ESGetToken<ESChannelStatus, ESChannelStatusRcd> esChannelStatusToken_;
@@ -130,6 +142,7 @@ private:
   edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
 
+  EgammaHLTTrackIsolation* isoCalculator_;
   const reco::BeamSpot* beamSpot_;
   const ESChannelStatus* channelStatus_;
   const CaloGeometry* geometry_;
@@ -149,11 +162,11 @@ private:
   std::shared_ptr<PFEnergyCalibration> _pfEnergyCalibration;
   clustering_type _clustype;
   energy_weight _eweight;
-  void buildAllSuperClusters(CalibratedPFClusterVector&, double seedthresh);
-  void buildAllSuperClustersMustacheOrBox(CalibratedPFClusterVector&, double seedthresh);
-  void buildAllSuperClustersDeepSC(CalibratedPFClusterVector&, double seedthresh);
-  void buildSuperClusterMustacheOrBox(CalibratedPFCluster&, CalibratedPFClusterVector&);
-  void finalizeSuperCluster(CalibratedPFCluster& seed, CalibratedPFClusterVector& clustered, bool isEE);
+  void buildAllSuperClusters(CalibratedPFClusterVector&, double seedthresh, const edm::Event&);
+  void buildAllSuperClustersMustacheOrBox(CalibratedPFClusterVector&, double seedthresh, const edm::Event&);
+  void buildAllSuperClustersDeepSC(CalibratedPFClusterVector&, double seedthresh,  const edm::Event&);
+  void buildSuperClusterMustacheOrBox(CalibratedPFCluster&, CalibratedPFClusterVector&,  const edm::Event&);
+  void finalizeSuperCluster(CalibratedPFCluster& seed, CalibratedPFClusterVector& clustered, bool isEE, const edm::Event&);
 
   bool verbose_;
 

--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -29,7 +29,7 @@
 #include "RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClustersGraph.h"
 #include "RecoEcal/EgammaCoreTools/interface/CalibratedPFCluster.h"
-#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h" 
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -164,9 +164,12 @@ private:
   energy_weight _eweight;
   void buildAllSuperClusters(CalibratedPFClusterVector&, double seedthresh, const edm::Event&);
   void buildAllSuperClustersMustacheOrBox(CalibratedPFClusterVector&, double seedthresh, const edm::Event&);
-  void buildAllSuperClustersDeepSC(CalibratedPFClusterVector&, double seedthresh,  const edm::Event&);
-  void buildSuperClusterMustacheOrBox(CalibratedPFCluster&, CalibratedPFClusterVector&,  const edm::Event&);
-  void finalizeSuperCluster(CalibratedPFCluster& seed, CalibratedPFClusterVector& clustered, bool isEE, const edm::Event&);
+  void buildAllSuperClustersDeepSC(CalibratedPFClusterVector&, double seedthresh, const edm::Event&);
+  void buildSuperClusterMustacheOrBox(CalibratedPFCluster&, CalibratedPFClusterVector&, const edm::Event&);
+  void finalizeSuperCluster(CalibratedPFCluster& seed,
+                            CalibratedPFClusterVector& clustered,
+                            bool isEE,
+                            const edm::Event&);
 
   bool verbose_;
 

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -130,7 +130,13 @@ void PFECALSuperClusterAlgo::setTokens(const edm::ParameterSet& iConfig, edm::Co
   trkIsoVetoConeSize_ = iConfig.getParameter<double>("trkIsoVetoConeSize");
   trkIsoStripBarrel_ = iConfig.getParameter<double>("trkIsoStripBarrel");
   trkIsoStripEndcap_ = iConfig.getParameter<double>("trkIsoStripEndcap");
-  isoCalculator_ = new EgammaHLTTrackIsolation(trkIsoPtMin_, trkIsoConeSize_, trkIsoZSpan_, trkIsoRSpan_, trkIsoVetoConeSize_,  trkIsoStripBarrel_, trkIsoStripEndcap_);
+  isoCalculator_ = new EgammaHLTTrackIsolation(trkIsoPtMin_,
+                                               trkIsoConeSize_,
+                                               trkIsoZSpan_,
+                                               trkIsoRSpan_,
+                                               trkIsoVetoConeSize_,
+                                               trkIsoStripBarrel_,
+                                               trkIsoStripEndcap_);
 
   esEEInterCalibToken_ =
       cc.esConsumes<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd, edm::Transition::BeginLuminosityBlock>();
@@ -274,12 +280,14 @@ void PFECALSuperClusterAlgo::loadAndSortPFClusters(const edm::Event& iEvent) {
 
 void PFECALSuperClusterAlgo::run(const edm::Event& iEvent) {
   // clusterize the EB
-  buildAllSuperClusters(_clustersEB, threshPFClusterSeedBarrel_,iEvent);
+  buildAllSuperClusters(_clustersEB, threshPFClusterSeedBarrel_, iEvent);
   // clusterize the EE
-  buildAllSuperClusters(_clustersEE, threshPFClusterSeedEndcap_,iEvent);
+  buildAllSuperClusters(_clustersEE, threshPFClusterSeedEndcap_, iEvent);
 }
 
-void PFECALSuperClusterAlgo::buildAllSuperClusters(CalibratedPFClusterVector& clusters, double seedthresh, const edm::Event& iEvent) {
+void PFECALSuperClusterAlgo::buildAllSuperClusters(CalibratedPFClusterVector& clusters,
+                                                   double seedthresh,
+                                                   const edm::Event& iEvent) {
   if (_clustype == PFECALSuperClusterAlgo::kMustache || _clustype == PFECALSuperClusterAlgo::kBOX)
     buildAllSuperClustersMustacheOrBox(clusters, seedthresh, iEvent);
   else if (_clustype == PFECALSuperClusterAlgo::kDeepSC)
@@ -287,7 +295,8 @@ void PFECALSuperClusterAlgo::buildAllSuperClusters(CalibratedPFClusterVector& cl
 }
 
 void PFECALSuperClusterAlgo::buildAllSuperClustersMustacheOrBox(CalibratedPFClusterVector& clusters,
-                                                                double seedthresh, const edm::Event& iEvent) {
+                                                                double seedthresh,
+                                                                const edm::Event& iEvent) {
   auto seedable = std::bind(isSeed, _1, seedthresh, threshIsET_);
 
   // make sure only seeds appear at the front of the list of clusters
@@ -302,7 +311,9 @@ void PFECALSuperClusterAlgo::buildAllSuperClustersMustacheOrBox(CalibratedPFClus
   }
 }
 
-void PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC(CalibratedPFClusterVector& clusters, double seedthresh,  const edm::Event& iEvent) {
+void PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC(CalibratedPFClusterVector& clusters,
+                                                         double seedthresh,
+                                                         const edm::Event& iEvent) {
   auto seedable = std::bind(isSeed, _1, seedthresh, threshIsET_);
   // EcalClustersGraph utility class for DeepSC algorithm application
   // make sure only seeds appear at the front of the list of clusters
@@ -336,7 +347,8 @@ void PFECALSuperClusterAlgo::buildAllSuperClustersDeepSC(CalibratedPFClusterVect
 }
 
 void PFECALSuperClusterAlgo::buildSuperClusterMustacheOrBox(CalibratedPFCluster& seed,
-                                                            CalibratedPFClusterVector& clusters,  const edm::Event& iEvent) {
+                                                            CalibratedPFClusterVector& clusters,
+                                                            const edm::Event& iEvent) {
   CalibratedPFClusterVector clustered;
 
   double etawidthSuperCluster = 0.0;
@@ -423,7 +435,8 @@ void PFECALSuperClusterAlgo::buildSuperClusterMustacheOrBox(CalibratedPFCluster&
 
 void PFECALSuperClusterAlgo::finalizeSuperCluster(CalibratedPFCluster& seed,
                                                   CalibratedPFClusterVector& clustered,
-                                                  bool isEE, const edm::Event& iEvent) {
+                                                  bool isEE,
+                                                  const edm::Event& iEvent) {
   // need the vector of raw pointers for a PF width class
   std::vector<const reco::PFCluster*> bare_ptrs;
   // calculate necessary parameters and build the SC

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -131,7 +131,6 @@ void PFECALSuperClusterAlgo::setTokens(const edm::ParameterSet& iConfig, edm::Co
   trkIsoStripBarrel_ = iConfig.getParameter<double>("trkIsoStripBarrel");
   trkIsoStripEndcap_ = iConfig.getParameter<double>("trkIsoStripEndcap");
   isoCalculator_ = new EgammaHLTTrackIsolation(trkIsoPtMin_, trkIsoConeSize_, trkIsoZSpan_, trkIsoRSpan_, trkIsoVetoConeSize_,  trkIsoStripBarrel_, trkIsoStripEndcap_);
-  //isoCalculator_ = new EgammaHLTTrackIsolation(0.5,      0.4,             999999,       999999,       0.06,                 0.03,               0.03);   
 
   esEEInterCalibToken_ =
       cc.esConsumes<ESEEIntercalibConstants, ESEEIntercalibConstantsRcd, edm::Transition::BeginLuminosityBlock>();

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -2,7 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECALMustache_cfi import particleFlowSuperClusterECALMustache as _particleFlowSuperClusterECALMustache
 # define the default ECAL clustering (Mustache or Box or DeepSC)
-particleFlowSuperClusterECAL = _particleFlowSuperClusterECALMustache.clone()
+particleFlowSuperClusterECAL = _particleFlowSuperClusterECALMustache.clone(
+    trackProducer = cms.InputTag("generalTracks")
+)
 
 from Configuration.ProcessModifiers.ecal_deepsc_cff import ecal_deepsc
 _particleFlowSuperClusterECALDeepSC = _particleFlowSuperClusterECALMustache.clone(

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -355,8 +355,8 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("thresh_PFClusterBarrel", 0.0);
   desc.add<std::string>("PFBasicClusterCollectionBarrel", "particleFlowBasicClusterECALBarrel");
   desc.add<bool>("useRegression", true);
+
   // Track isolation parameters: begin
-  //  desc.add<edm::InputTag>("trackProducer", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("trackProducer", edm::InputTag(""));
   desc.add<double>("trkIsoPtMin", 0.5);
   desc.add<double>("trkIsoConeSize", 0.4);
@@ -365,8 +365,8 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("trkIsoVetoConeSize", 0.06);
   desc.add<double>("trkIsoStripBarrel", 0.03);
   desc.add<double>("trkIsoStripEndcap", 0.03);
-
   // Track isolation parameters: end
+
   desc.add<double>("satelliteMajorityFraction", 0.5);
   desc.add<double>("thresh_PFClusterEndcap", 0.0);
   desc.add<edm::InputTag>("ESAssociation", edm::InputTag("particleFlowClusterECAL"));

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -1,4 +1,3 @@
-
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
 #include "CondFormats/GBRForest/interface/GBRForest.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
@@ -229,7 +228,7 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent, const edm::EventSet
   superClusterAlgo_.updateSCParams(iSetup);
   // do clustering
   superClusterAlgo_.loadAndSortPFClusters(iEvent);
-  superClusterAlgo_.run();
+  superClusterAlgo_.run(iEvent);
 
   //build collections of output CaloClusters from the used PFClusters
   auto caloClustersEB = std::make_unique<reco::CaloClusterCollection>();
@@ -356,6 +355,18 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("thresh_PFClusterBarrel", 0.0);
   desc.add<std::string>("PFBasicClusterCollectionBarrel", "particleFlowBasicClusterECALBarrel");
   desc.add<bool>("useRegression", true);
+  // Track isolation parameters: begin
+  //  desc.add<edm::InputTag>("trackProducer", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("trackProducer", edm::InputTag(""));
+  desc.add<double>("trkIsoPtMin", 0.5);
+  desc.add<double>("trkIsoConeSize", 0.4);
+  desc.add<double>("trkIsoZSpan", 999999.9);
+  desc.add<double>("trkIsoRSpan", 999999.9);
+  desc.add<double>("trkIsoVetoConeSize", 0.06);
+  desc.add<double>("trkIsoStripBarrel", 0.03);
+  desc.add<double>("trkIsoStripEndcap", 0.03);
+
+  // Track isolation parameters: end
   desc.add<double>("satelliteMajorityFraction", 0.5);
   desc.add<double>("thresh_PFClusterEndcap", 0.0);
   desc.add<edm::InputTag>("ESAssociation", edm::InputTag("particleFlowClusterECAL"));

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
@@ -58,7 +58,7 @@ public:
     /*
 	std::cout << "EgammaHLTTrackIsolation instance:"
 	<< " ptMin=" << ptMin << " "
-	<< " conesiz="<< conesize << " "
+	<< " conesize="<< conesize << " "
 	<< " zspan=" << zspan << " "
 	<< " rspan=" << rspan << " "
 	<< " vetoConesize="<< vetoConesize

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
@@ -58,7 +58,7 @@ public:
     /*
 	std::cout << "EgammaHLTTrackIsolation instance:"
 	<< " ptMin=" << ptMin << " "
-	<< " conesize="<< conesize << " "
+	<< " conesiz="<< conesize << " "
 	<< " zspan=" << zspan << " "
 	<< " rspan=" << rspan << " "
 	<< " vetoConesize="<< vetoConesize
@@ -88,6 +88,9 @@ public:
                                         const reco::ElectronCollection* allEle,
                                         const reco::TrackCollection* isoTracks);
 
+  std::pair<int, float> scIsolation(const reco::SuperCluster& recocandidate,
+				    const reco::TrackCollection* isoTracks);
+
   /// Get number of tracks inside an isolation cone for electrons
   int electronTrackCount(const reco::Track* const tr, const reco::TrackCollection* isoTracks) {
     return electronIsolation(tr, isoTracks).first;
@@ -104,6 +107,11 @@ public:
                        bool useVertex) {
     return photonIsolation(recocand, isoTracks, useVertex).first;
   }
+
+  float scTrackCount(const reco::SuperCluster& recocand, const reco::TrackCollection* isoTracks) {
+    return scIsolation(recocand, isoTracks).first;
+  }
+
   int photonTrackCount(const reco::RecoCandidate* const recocand,
                        const reco::TrackCollection* isoTracks,
                        GlobalPoint vertex) {
@@ -134,6 +142,11 @@ public:
   float photonPtSum(const reco::RecoCandidate* const recocand, const reco::TrackCollection* isoTracks, bool useVertex) {
     return photonIsolation(recocand, isoTracks, useVertex).second;
   }
+
+  float scPtSum(const reco::SuperCluster& recocand, const reco::TrackCollection* isoTracks) {
+    return scIsolation(recocand, isoTracks).second;
+  }
+
   float photonPtSum(const reco::RecoCandidate* const recocand,
                     const reco::TrackCollection* isoTracks,
                     GlobalPoint vertex) {

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHLTTrackIsolation.h
@@ -88,8 +88,7 @@ public:
                                         const reco::ElectronCollection* allEle,
                                         const reco::TrackCollection* isoTracks);
 
-  std::pair<int, float> scIsolation(const reco::SuperCluster& recocandidate,
-				    const reco::TrackCollection* isoTracks);
+  std::pair<int, float> scIsolation(const reco::SuperCluster& recocandidate, const reco::TrackCollection* isoTracks);
 
   /// Get number of tracks inside an isolation cone for electrons
   int electronTrackCount(const reco::Track* const tr, const reco::TrackCollection* isoTracks) {

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaHLTTrackIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaHLTTrackIsolation.cc
@@ -56,10 +56,10 @@ std::pair<int, float> EgammaHLTTrackIsolation::photonIsolation(const reco::RecoC
 }
 
 std::pair<int, float> EgammaHLTTrackIsolation::scIsolation(const reco::SuperCluster& recocandidate,
-                                                               const reco::TrackCollection* isoTracks) {
-    reco::RecoCandidate::Point pos = recocandidate.position();
-    GlobalVector mom(pos.x(), pos.y(), pos.z());
-    return findIsoTracks(mom, GlobalPoint(), isoTracks, false, false);  
+                                                           const reco::TrackCollection* isoTracks) {
+  const reco::RecoCandidate::Point& pos = recocandidate.position();
+  GlobalVector mom(pos.x(), pos.y(), pos.z());
+  return findIsoTracks(mom, GlobalPoint(), isoTracks, false, false);
 }
 
 std::pair<int, float> EgammaHLTTrackIsolation::photonIsolation(const reco::RecoCandidate* const recocandidate,
@@ -86,7 +86,6 @@ std::pair<int, float> EgammaHLTTrackIsolation::findIsoTracks(
     GlobalVector mom, GlobalPoint vtx, const reco::TrackCollection* isoTracks, bool isElectron, bool useVertex) {
   // Check that reconstructed tracks fit within cone boundaries,
   // (Note: tracks will not always stay within boundaries)
-
 
   int ntrack = 0;
   float ptSum = 0.;

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaHLTTrackIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaHLTTrackIsolation.cc
@@ -55,6 +55,13 @@ std::pair<int, float> EgammaHLTTrackIsolation::photonIsolation(const reco::RecoC
   }
 }
 
+std::pair<int, float> EgammaHLTTrackIsolation::scIsolation(const reco::SuperCluster& recocandidate,
+                                                               const reco::TrackCollection* isoTracks) {
+    reco::RecoCandidate::Point pos = recocandidate.position();
+    GlobalVector mom(pos.x(), pos.y(), pos.z());
+    return findIsoTracks(mom, GlobalPoint(), isoTracks, false, false);  
+}
+
 std::pair<int, float> EgammaHLTTrackIsolation::photonIsolation(const reco::RecoCandidate* const recocandidate,
                                                                const reco::TrackCollection* isoTracks,
                                                                GlobalPoint zvtx) {
@@ -79,6 +86,8 @@ std::pair<int, float> EgammaHLTTrackIsolation::findIsoTracks(
     GlobalVector mom, GlobalPoint vtx, const reco::TrackCollection* isoTracks, bool isElectron, bool useVertex) {
   // Check that reconstructed tracks fit within cone boundaries,
   // (Note: tracks will not always stay within boundaries)
+
+
   int ntrack = 0;
   float ptSum = 0.;
 
@@ -139,7 +148,6 @@ std::pair<int, float> EgammaHLTTrackIsolation::findIsoTracks(
   }
 
   // if (isElectron) ntrack-=1; //to exclude electron track
-
   return (std::pair<int, float>(ntrack, ptSum));
 }
 


### PR DESCRIPTION
#### PR description:
This PR adds track isolation of mustache superclusters in dataformats. 
EGamma POG use this variable in Tag-and-Probe framework for measuring reconstruction efficiency and scale-factor. And every time we calculate it on the fly in the ntuplization step using the generalTrack collection, which also means that we have to use a data-tier that has generalTrack collection saved in it. Adding this variable directly to dataformat will make things easier. 

The exact definition of track isolation closely follows the definition currently used in EGamma tag-and-probe setup (see [here](https://github.com/swagata87/EgammaAnalysis-TnPTreeProducer/blob/Run3_13XY/plugins/SCVariableHelper.h) and [here](https://github.com/swagata87/EgammaAnalysis-TnPTreeProducer/blob/Run3_13XY/python/egmGoodParticlesDef_cff.py#L185-L196) ). Parameters like cone-size etc are not hard-coded and can be changed from config file if needed.  

Running on a few DY MC events, I checked that both approaches produce similar results. 
```
From EGM T&P tool  | From CMSSW after this PR
SC trk Iso 1.9281  | 1.9280990362167358
SC trk Iso 10.9376 | 10.937553405761719
SC trk Iso 3.22729 | 3.227292060852051

SC trk Iso 1.1073   | 1.107303261756897
SC trk Iso 0.545862 | 0.5458621978759766 
SC trk Iso 2.90094  | 2.9009439945220947
```
#### PR validation:
Checked with workflows `23634.0` and `12434.0` that they ran fine.
