### PR TITLE
Remove gen refitted SA muons

### DIFF
--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -247,7 +247,15 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker &iBooker,
   }
 
   h->Sumw2();
-  _elements[name] = iBooker.book1D(name, h);
+
+  if (source == "gen") {
+    if (objType != "refittedStandAloneMuons") {
+      _elements[name] = iBooker.book1D(name, h);
+    }
+  } else {
+    _elements[name] = iBooker.book1D(name, h);
+  }
+
   //    LogDebug("ExoticaValidation") << "                        booked histo
   //    with name " << name << "\n"
   //				  << "                        at location " <<
@@ -265,6 +273,14 @@ void HLTExoticaPlotter::fillHist(const bool &passTrigger,
   std::string name = source + objType + variable + "_" + _hltPath;
 
   LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::fillHist()" << name << " " << value;
-  _elements[name]->Fill(value);
+
+  if (source == "gen") {
+    if (objType != "refittedStandAloneMuons") {
+      _elements[name]->Fill(value);
+    }
+  } else {
+    _elements[name]->Fill(value);
+  }
+
   LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::fillHist()" << name << " worked";
 }

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -1104,7 +1104,15 @@ void HLTExoticaSubAnalysis::bookHist(DQMStore::IBooker &iBooker,
   // This is the trick, that takes a normal TH1F and puts it in in the DQM
   // machinery. Seems to be easy!
   // Updated to use the new iBooker machinery.
-  _elements[name] = iBooker.book1D(name, h);
+
+  if (source == "gen") {
+    if (objType != "refittedStandAloneMuons") {
+      _elements[name] = iBooker.book1D(name, h);
+    }
+  } else {
+    _elements[name] = iBooker.book1D(name, h);
+  }
+
   delete h;
 }
 
@@ -1118,7 +1126,15 @@ void HLTExoticaSubAnalysis::fillHist(const std::string &source,
   std::string name = source + objType + variable;
 
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::fillHist() " << name << " " << value;
-  _elements[name]->Fill(value);
+
+  if (source == "gen") {
+    if (objType != "refittedStandAloneMuons") {
+      _elements[name]->Fill(value);
+    }
+  } else {
+    _elements[name]->Fill(value);
+  }
+
   LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::fillHist() " << name << " worked";
 }
 

--- a/HLTriggerOffline/Exotica/test/run_all.py
+++ b/HLTriggerOffline/Exotica/test/run_all.py
@@ -1,0 +1,8 @@
+import os
+#Create a list of samples to run, e.g.:
+#samples = ["DisplacedSUSY","EtaBToJpsiJpsi","H125GGgluonfusion","MinBias","QCD_FlatPt_15_3000HS","QCD_Pt_1800_2400","SingleMuPt1000","SingleMuPt100","SingleMuPt10","TTbarToDilepton","TTbar","Upsilon1SToMuMu","WToLNu","WprimeToLNu","ZEE","ZMM","ZTT","ZpTT","ZpToEE"]
+
+samples = []
+
+for sample in samples:
+  os.system("cmsRun hltExoticaValidator_cfg.py _input "+sample+"; cmsRun hltExoticaPostProcessor_cfg.py _input "+sample+"; cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root correctVal_DQM_"+sample+".root; root -l -b -q \"saveDQMHistograms.C(\\\"correctVal_DQM_"+sample+".root\\\",\\\"correct"+sample+"\\\")\";")


### PR DESCRIPTION
PR description:

Remove the spurious "generated refitted stand-alone muons" plots from the HLT exotica validation code, and add a "run_all" script to make it easier to run the code.

PR validation:

Passed all the standard tests, and prevented the referred plots to be made after running the code on RelVal samples. This time, also run "scram build code-format" as the previous PR failed because of code style and quality.
