### PR TITLE
`TrackSplittingMonitor`: fix bug in the BPix hits counting

### DIFF
--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -205,9 +205,14 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
     }
     // looping through the hits for track 2
     double nRechits2 = 0;
+    double nRechitinBPIX2 = 0;
     for (auto const& iHit : track2.recHits()) {
       if (iHit->isValid()) {
         nRechits2++;
+        int type = iHit->geographicalId().subdetId();
+        if (type == int(PixelSubdetector::PixelBarrel)) {
+          ++nRechitinBPIX2;
+        }
       }
     }
 
@@ -227,7 +232,7 @@ void TrackSplittingMonitor::analyze(const edm::Event& iEvent, const edm::EventSe
 
     // basic selection
     // pixel hits and total hits
-    if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX1 >= pixelHitsPerLeg_) &&
+    if ((nRechitinBPIX1 >= pixelHitsPerLeg_) && (nRechitinBPIX2 >= pixelHitsPerLeg_) &&
         (nRechits1 >= totalHitsPerLeg_) && (nRechits2 >= totalHitsPerLeg_)) {
       // dca cut
       if (((std::abs(d01) < d0Cut_)) && (std::abs(d02) < d0Cut_) && (std::abs(dz1) < dzCut_) &&


### PR DESCRIPTION
#### PR description:

Title says it all, put back lines removed in https://github.com/cms-sw/cmssw/pull/41528 that were hiding a bug in the track selection. Prompted by comment https://github.com/cms-sw/cmssw/pull/41740#issuecomment-1560928678

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be (partially) backported in https://github.com/cms-sw/cmssw/pull/41739 and https://github.com/cms-sw/cmssw/pull/41740 