### PR TITLE
Add input parameters on fixed bins for JetMET JER/JEC PI test codes.

### DIFF
--- a/CondCore/JetMETPlugins/plugins/JetCorrector_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetCorrector_PayloadInspector.cc
@@ -111,12 +111,12 @@ namespace {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_JetPt = std::stod(ip->second);
-        edm::LogWarning("JEC_PI") << "Jet Pt: " << par_JetPt;
+        edm::LogPrint("JEC_PI") << "Jet Pt: " << par_JetPt;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
-        edm::LogWarning("JEC_PI") << "Rho: " << par_Rho;
+        edm::LogPrint("JEC_PI") << "Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/JetMETPlugins/plugins/JetCorrector_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetCorrector_PayloadInspector.cc
@@ -111,10 +111,12 @@ namespace {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_JetPt = std::stod(ip->second);
+        edm::LogWarning("JEC_PI") << "Jet Pt: " << par_JetPt;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
+        edm::LogWarning("JEC_PI") << "Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -64,10 +64,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -129,10 +131,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -358,10 +362,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -420,10 +426,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
+        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
       }
 
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
+++ b/CondCore/JetMETPlugins/plugins/JetResolution_PayloadInspector.cc
@@ -64,12 +64,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
+        edm::LogPrint("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Rho: " << par_Rho;
+        edm::LogPrint("JER_PI") << "Jet Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -131,12 +131,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
+        edm::LogPrint("JER_PI") << "Jet Eta: " << par_Eta;
       }
       ip = paramValues.find("Jet_Rho");
       if (ip != paramValues.end()) {
         par_Rho = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Rho: " << par_Rho;
+        edm::LogPrint("JER_PI") << "Jet Rho: " << par_Rho;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -362,12 +362,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
+        edm::LogPrint("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
+        edm::LogPrint("JER_PI") << "Jet Eta: " << par_Eta;
       }
 
       auto tag = PlotBase::getTag<0>();
@@ -426,12 +426,12 @@ namespace JME {
       auto ip = paramValues.find("Jet_Pt");
       if (ip != paramValues.end()) {
         par_Pt = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Pt: " << par_Pt;
+        edm::LogPrint("JER_PI") << "Jet Pt: " << par_Pt;
       }
       ip = paramValues.find("Jet_Eta");
       if (ip != paramValues.end()) {
         par_Eta = std::stod(ip->second);
-        edm::LogWarning("JER_PI") << "Jet Eta: " << par_Eta;
+        edm::LogPrint("JER_PI") << "Jet Eta: " << par_Eta;
       }
 
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/JetMETPlugins/test/testJetCorrectorPayloadInspector.cpp
+++ b/CondCore/JetMETPlugins/test/testJetCorrectorPayloadInspector.cpp
@@ -30,36 +30,54 @@ int main(int argc, char** argv) {
   std::string tag_data = "JetCorrectorParametersCollection_Autumn18_RunABCD_V19_DATA_AK4PF";
   cond::Time_t start = static_cast<unsigned long long>(1);
   cond::Time_t end = static_cast<unsigned long long>(1);
+  py::dict inputs;
 
-  edm::LogWarning("JEC_PI") << "## Jet Energy Corrector Vs. Eta Histograms MC" << std::endl;
+  inputs["Jet_Pt"] = "120.";
+  inputs["Jet_Eta"] = "0.";
+  inputs["Jet_Rho"] = "30.";
+
+  edm::LogPrint("JEC_PI") << "## Jet Energy Corrector Vs. Eta Histograms MC" << std::endl;
 
   JetCorrectorVsEtaL1Offset histo1;
+  histo1.setInputParamValues(inputs);
   histo1.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo1.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo1.data() << std::endl;
 
   JetCorrectorVsEtaL1FastJet histo2;
+  histo2.setInputParamValues(inputs);
   histo2.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo2.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo2.data() << std::endl;
 
   JetCorrectorVsEtaL2Relative histo3;
+  histo3.setInputParamValues(inputs);
   histo3.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo3.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo3.data() << std::endl;
 
   JetCorrectorVsEtaL3Absolute histo4;
+  histo4.setInputParamValues(inputs);
   histo4.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo4.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo4.data() << std::endl;
 
   JetCorrectorVsEtaL2L3Residual histo5;
+  histo5.setInputParamValues(inputs);
   histo5.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo5.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo5.data() << std::endl;
 
   JetCorrectorVsEtaUncertainty histo6;
+  histo6.setInputParamValues(inputs);
   histo6.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo6.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo6.data() << std::endl;
 
   JetCorrectorVsEtaL1RC histo7;
+  histo7.setInputParamValues(inputs);
   histo7.process(connectionString, PI::mk_input(tag_mc, start, end));
-  edm::LogWarning("JEC_PI") << histo7.data() << std::endl;
+  edm::LogPrint("JEC_PI") << histo7.data() << std::endl;
+
+  inputs.clear();
+#if PY_MAJOR_VERSION >= 3
+  // TODO check why this Py_INCREF is necessary...
+  Py_INCREF(inputs.ptr());
+#endif
 
   Py_Finalize();
 }

--- a/CondCore/JetMETPlugins/test/testJetResolutionPayloadInspector.cpp
+++ b/CondCore/JetMETPlugins/test/testJetResolutionPayloadInspector.cpp
@@ -31,56 +31,77 @@ int main(int argc, char** argv) {
   std::string tag_sf = "JR_Fall17_V3_106X_MC_SF_AK4PF";
   cond::Time_t start = static_cast<unsigned long long>(1);
   cond::Time_t end = static_cast<unsigned long long>(1);
+  py::dict inputs;
 
-  edm::LogWarning("JER_PI") << "## Jet Pt Resolution Histograms" << std::endl;
+  inputs["Jet_Pt"] = "120.";
+  inputs["Jet_Eta"] = "0.";
+  inputs["Jet_Rho"] = "30.";
+
+  edm::LogPrint("JER_PI") << "## Jet Pt Resolution Histograms" << std::endl;
 
   JME::JetResolutionVsEta histo1;
+  histo1.setInputParamValues(inputs);
   histo1.process(connectionString, PI::mk_input(tag_pt, start, end));
-  edm::LogWarning("JER_PI") << histo1.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo1.data() << std::endl;
 
   JME::JetResolutionVsPt histo2;
+  histo2.setInputParamValues(inputs);
   histo2.process(connectionString, PI::mk_input(tag_pt, start, end));
-  edm::LogWarning("JER_PI") << histo2.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo2.data() << std::endl;
 
-  edm::LogWarning("JER_PI") << "## Jet Eta Resolution Histograms" << std::endl;
+  edm::LogPrint("JER_PI") << "## Jet Eta Resolution Histograms" << std::endl;
 
   JME::JetResolutionVsEta histo3;
+  histo3.setInputParamValues(inputs);
   histo3.process(connectionString, PI::mk_input(tag_eta, start, end));
-  edm::LogWarning("JER_PI") << histo3.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo3.data() << std::endl;
 
   JME::JetResolutionVsPt histo4;
+  histo4.setInputParamValues(inputs);
   histo4.process(connectionString, PI::mk_input(tag_eta, start, end));
-  edm::LogWarning("JER_PI") << histo4.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo4.data() << std::endl;
 
-  edm::LogWarning("JER_PI") << "## Jet SF vs. Eta Histograms" << std::endl;
+  edm::LogPrint("JER_PI") << "## Jet SF vs. Eta Histograms" << std::endl;
 
   JME::JetScaleFactorVsEtaNORM histo5;
+  histo5.setInputParamValues(inputs);
   histo5.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo5.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo5.data() << std::endl;
 
   JME::JetScaleFactorVsEtaDOWN histo6;
+  histo6.setInputParamValues(inputs);
   histo6.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo6.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo6.data() << std::endl;
 
   JME::JetScaleFactorVsEtaUP histo7;
+  histo7.setInputParamValues(inputs);
   histo7.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo7.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo7.data() << std::endl;
 
   tag_sf = "JR_Autumn18_V7_MC_SF_AK4PF";
 
-  edm::LogWarning("JER_PI") << "## Jet SF vs. Pt Histograms" << std::endl;
+  edm::LogPrint("JER_PI") << "## Jet SF vs. Pt Histograms" << std::endl;
 
   JME::JetScaleFactorVsPtNORM histo8;
+  histo8.setInputParamValues(inputs);
   histo8.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo8.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo8.data() << std::endl;
 
   JME::JetScaleFactorVsPtDOWN histo9;
+  histo9.setInputParamValues(inputs);
   histo9.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo9.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo9.data() << std::endl;
 
   JME::JetScaleFactorVsPtUP histo10;
+  histo10.setInputParamValues(inputs);
   histo10.process(connectionString, PI::mk_input(tag_sf, start, end));
-  edm::LogWarning("JER_PI") << histo10.data() << std::endl;
+  edm::LogPrint("JER_PI") << histo10.data() << std::endl;
+
+  inputs.clear();
+#if PY_MAJOR_VERSION >= 3
+  // TODO check why this Py_INCREF is necessary...
+  Py_INCREF(inputs.ptr());
+#endif
 
   Py_Finalize();
 }


### PR DESCRIPTION
As requested during the AlCa meeting, input parameters for fixed bin values are added for the test codes of JetResolution and JetCorrector payload inspector. Log messages on the input parameters are added such that the input values can be seen.

#### PR validation:

Local tests with test code and getPayloadData.py script.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.