### PR TITLE
[UBSAN] fix zero size array runtime error

### DIFF
--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
@@ -108,7 +108,7 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
             SL3metaPrimitives.push_back(metaprimitiveIt);
         }
 
-        if (SL1metaPrimitives.empty() and SL3metaPrimitives.empty())
+        if (SL1metaPrimitives.empty() or SL3metaPrimitives.empty())
           continue;
 
         if (debug_)

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
@@ -108,7 +108,7 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
             SL3metaPrimitives.push_back(metaprimitiveIt);
         }
 
-        if (SL1metaPrimitives.empty() and SL3metaPrimitives.empty())
+        if (SL1metaPrimitives.empty() or SL3metaPrimitives.empty())
           continue;
 
         if (debug_)
@@ -119,12 +119,12 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
         bool at_least_one_SL1_confirmation = false;
         bool at_least_one_SL3_confirmation = false;
 
-        bool useFitSL1[SL1metaPrimitives.size()];
+        vector<bool> useFitSL1;
         for (unsigned int i = 0; i < SL1metaPrimitives.size(); i++)
-          useFitSL1[i] = false;
-        bool useFitSL3[SL3metaPrimitives.size()];
+          useFitSL1.push_back(false);
+        vector<bool> useFitSL3;
         for (unsigned int i = 0; i < SL3metaPrimitives.size(); i++)
-          useFitSL3[i] = false;
+          useFitSL3.push_back(false);
 
         //SL1-SL3
         vector<metaPrimitive> chamberMetaPrimitives;
@@ -986,9 +986,9 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 }
 
 void MuonPathAssociator::removeSharingFits(vector<metaPrimitive> &chamberMPaths, vector<metaPrimitive> &allMPaths) {
-  bool useFit[chamberMPaths.size()];
+  vector<bool> useFit;
   for (unsigned int i = 0; i < chamberMPaths.size(); i++) {
-    useFit[i] = true;
+    useFit.push_back(true);
   }
   for (unsigned int i = 0; i < chamberMPaths.size(); i++) {
     if (debug_)


### PR DESCRIPTION
UBSAN IBs generates runtime errors [a]. This change should fix these error. UBSAN complains here https://github.com/cms-sw/cmssw/blob/master/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc#L122-L127 and this can happen when any of `SL1metaPrimitives` or `SL3metaPrimitives` is zero size

[a]
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_13_2_X_2023-05-22-2300/
- 22 L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:122:48: runtime error: variable length array bound evaluates to non-positive value 0
- 20 L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:125:48: runtime error: variable length array bound evaluates to non-positive value 0
