### PR TITLE
[DBG_X] Fix error in HGCalTestGuardRing.cc

### DIFF
--- a/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc
+++ b/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc
@@ -105,8 +105,8 @@ HGCalTestGuardRing::HGCalTestGuardRing(const edm::ParameterSet& ps)
           }
           waferID_[id] = orient * 100 + part;
 #ifdef EDM_ML_DEBUG
-          edm::LogVerbatim("HGCalSim") << "HGCalTestGuardRing::Reads " << id << " Orientatoin:Partial " >> orient >>
-              ":" >> part;
+          edm::LogVerbatim("HGCalSim") << "HGCalTestGuardRing::Reads " << id << " Orientation:Partial " << orient << ":"
+                                       << part;
 #endif
         }
       }


### PR DESCRIPTION
#### PR description:

This PR fixes build errors introduced by #41756:
```
>> Compiling bigobj edm plugin /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/02a7881e88394d2e0343aaa70ceddda0/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_DBG_X_2023-05-25-2300/src/SimG4CMS/Calo/plugins/CaloSteppingAction.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=110201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DGNU_GCC -DG4V9 -DGNU_GCC -DG4V9 -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_13_2_DBG_X_2023-05-25-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_2_DBG_X_2023-05-25-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/02a7881e88394d2e0343aaa70ceddda0/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_DBG_X_2023-05-25-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/dd4hep/v01-23x-d97a6baacee20309566b7aaf755762c5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/geant4/11.1.1-ac161db70c0e3e3108ae225f93d223a6/include/Geant4 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/geant4/11.1.1-ac161db70c0e3e3108ae225f93d223a6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/pcre/8.43-5dcc901acc02f624b22dd9840b2357e8/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/boost/1.80.0-7f4aeae1bffcf24aa4723f09435633c2/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/bz2lib/1.0.6-2c1f18484cb66c30aba7929f2be5e7d4/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/clhep/2.4.6.0-a4e46555f840df7cd8747ba64c6e914f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/cuda/11.5.2-66a9473808e7d5863d5bbec0824e2c4a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/expat/2.1.0-5f6457b4c04e97afec6079bd7d2db998/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gsl/2.6-fcf47bcbedd800ca8386c7e2920fa474/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/hepmc/2.06.10-8d052e96205063f65fddfc4cbf40f506/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/hls/2019.08-fd724004387c2a6770dc3517446d30d9/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/libuuid/2.34-0451b31e1b9a58c6aeefab41c18eea34/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/lcg/root/6.26.11-9720c7273eac1c892ddadde973cf1965/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/tbb/v2021.8.0-4e779f195a25a0aba119b27519937ba0/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/cms/vdt/0.4.3-b2ab7c000c16e419f85e9fb6284d3681/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/vecgeom/v1.2.1-d92ce96afe8fcfdf821b0e3277815aae/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/vecgeom/v1.2.1-d92ce96afe8fcfdf821b0e3277815aae/include/VecGeom -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/xerces-c/3.1.3-96261f23c7d6fbfb7d59be544bd882f3/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/xz/5.2.5-83d0a00b575efd1701e07bedf7977343/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/zlib/1.2.11-3dfb2715f3608466b74431b80eb9d788/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/eigen/82dd3710dac619448f50331c1d6a35da673f764a-9ac4aed18ac60d0189693c592862694d/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/fmt/8.0.1-43b841663c2a0d6622910a1ad66d228d/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/hepmc3/3.2.5-a8c3d3d81a1b670617f2caa48c1801ef/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/md5/1.0.0-e68283f2de2e2e709a0db99db3b53205/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/OpenBLAS/0.3.15-26c67b8b638762cfd2e2bcfc936e3ec7/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/tinyxml2/6.2.0-c2bad61e58f94d6db8f640afbd739be2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -ftls-model=global-dynamic -pthread -DBOOST_DISABLE_ASSERTS -g -O3 -DEDM_ML_DEBUG -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -Wl,--exclude-libs,ALL  -fPIC   /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/02a7881e88394d2e0343aaa70ceddda0/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_DBG_X_2023-05-25-2300/src/SimG4CMS/Calo/plugins/CaloSteppingAction.cc -o tmp/el8_amd64_gcc11/src/SimG4CMS/Calo/plugins/SimG4CMSCaloPlugins/bigobj/CaloSteppingAction.cc.o
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/02a7881e88394d2e0343aaa70ceddda0/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_DBG_X_2023-05-25-2300/src/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc: In constructor 'HGCalTestGuardRing::HGCalTestGuardRing(const edm::ParameterSet&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/02a7881e88394d2e0343aaa70ceddda0/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_DBG_X_2023-05-25-2300/src/SimG4CMS/Calo/plugins/HGCalTestGuardRing.cc:108:105: error: no match for 'operator>>' (operand types are 'edm::Log<edm::level::Info, true>::ThisLog' {aka 'edm::Log<edm::level::Info, true>'} and 'int')
   108 |           edm::LogVerbatim("HGCalSim") << "HGCalTestGuardRing::Reads " << id << " Orientatoin:Partial " >> orient >>
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~ ~~~~~~
      |                                                                              |                             |
      |                                                                              |                             int
      |                                                                              edm::Log<edm::level::Info, true>::ThisLog {aka edm::Log<edm::level::Info, true>}
```

#### PR validation:

Bot tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport