### PR TITLE
Add missing L1T phase 2 customizations

### DIFF
--- a/L1Trigger/Configuration/python/customisePhase2.py
+++ b/L1Trigger/Configuration/python/customisePhase2.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def customisePhase2TTNoMC(process):
+    process.L1TrackTrigger.replace(process.L1PromptExtendedHybridTracksWithAssociators, process.L1PromptExtendedHybridTracks)
+    process.L1TrackTrigger.remove(process.TrackTriggerAssociatorClustersStubs)
+    process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+
+    return process
+
+def addHcalTriggerPrimitives(process):
+    process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
+
+    return process
+
+def addMenuNtuples(process):
+    process.load("L1Trigger.L1TNtuples.l1PhaseIITreeStep1Producer_cfi")
+    process.TFileService = cms.Service("TFileService",
+        fileName = cms.string('L1NtuplePhaseII_Step1.root')
+    )
+
+    return process


### PR DESCRIPTION
### PR description:

This PR adds some python configuration customizations [that are a current default recommendation for Phase 2 L1T developers](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#CMSSW_12_5_2_patch1), and may be needed outside for these recipes when the full prototype is available.

Thanks to @qvzy for pointing out these were missing and showed up in a diff for the intergration branch and current state of the main branch.

#### PR validation:

This has been used in multiple Phase2 recipe workflows.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and is not intended to be backported.
