### PR TITLE
[13.1.X] Migrate `DiMuonMassBiasClient` mass bias histograms to profiles

### DIFF
--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -81,10 +81,12 @@ private:
   void bookMEs(DQMStore::IBooker& ibooker);
   void getMEsToHarvest(DQMStore::IGetter& igetter);
   diMuonMassBias::fitOutputs fitLineShape(TH1* hist, const bool& fitBackground = false) const;
-  void fitAndFill(std::pair<std::string, MonitorElement*> toHarvest, DQMStore::IBooker& iBooker);
+  void fitAndFillProfile(std::pair<std::string, MonitorElement*> toHarvest, DQMStore::IBooker& iBooker);
+  void fitAndFillHisto(std::pair<std::string, MonitorElement*> toHarvest, DQMStore::IBooker& iBooker);
 
   // data members
   const std::string TopFolder_;
+  const bool useTH1s_;
   const bool fitBackground_;
   const bool useRooCBShape_;
   const bool useRooCMSShape_;
@@ -98,6 +100,10 @@ private:
   std::vector<std::string> MEtoHarvest_;
 
   // the histograms to be filled
+  std::map<std::string, MonitorElement*> meanHistos_;
+  std::map<std::string, MonitorElement*> widthHistos_;
+
+  // the profiles to be filled
   std::map<std::string, MonitorElement*> meanProfiles_;
   std::map<std::string, MonitorElement*> widthProfiles_;
 

--- a/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
+++ b/DQMOffline/Alignment/interface/DiMuonMassBiasClient.h
@@ -81,6 +81,7 @@ private:
   void bookMEs(DQMStore::IBooker& ibooker);
   void getMEsToHarvest(DQMStore::IGetter& igetter);
   diMuonMassBias::fitOutputs fitLineShape(TH1* hist, const bool& fitBackground = false) const;
+  void fitAndFill(std::pair<std::string, MonitorElement*> toHarvest, DQMStore::IBooker& iBooker);
 
   // data members
   const std::string TopFolder_;

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -83,7 +83,8 @@ ALCARECOTkAlDiMuonAndVertexVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi
 
 ALCARECOTkAlDiMuonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
     muonTracks = 'ALCARECO'+__trackCollName,
-    FolderName = "AlCaReco/"+__selectionName
+    FolderName = "AlCaReco/"+__selectionName,
+    DiMuMassConfig = dict(maxDeltaEta = 3.5)
 )
 
 ALCARECOTkAlDiMuonAndVertexDQM = cms.Sequence(ALCARECOTkAlDiMuonAndVertexTkAlDQM + ALCARECOTkAlDiMuonAndVertexVtxDQM + ALCARECOTkAlDiMuonMassBiasDQM)

--- a/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
@@ -86,7 +86,7 @@ void DiMuonMassBiasClient::bookMEs(DQMStore::IBooker& iBooker)
     const auto& xmax = ME->getAxisMax(1);
 
     MonitorElement* meanToBook =
-        iBooker.book1D(("Mean" + key), (title + ";" + xtitle + ";" + ytitle), nxbins, xmin, xmax);
+        iBooker.book1D(("Mean" + key), (title + ";#LT M_{#mu^{-}#mu^{+}} #GT [GeV];" + ytitle), nxbins, xmin, xmax);
     meanHistos_.insert({key, meanToBook});
 
     MonitorElement* sigmaToBook =
@@ -138,8 +138,12 @@ void DiMuonMassBiasClient::fitAndFillProfile(std::pair<std::string, MonitorEleme
   const auto& xmin = ME->getAxisMin(1);
   const auto& xmax = ME->getAxisMax(1);
 
-  TProfile* p_mean = new TProfile(
-      ("Mean" + key).c_str(), (title + ";" + xtitle + ";#LT" + ytitle + "#GT").c_str(), nxbins, xmin, xmax, "g");
+  TProfile* p_mean = new TProfile(("Mean" + key).c_str(),
+                                  (title + ";" + xtitle + ";#LT M_{#mu^{-}#mu^{+}} #GT [GeV]").c_str(),
+                                  nxbins,
+                                  xmin,
+                                  xmax,
+                                  "g");
 
   TProfile* p_width = new TProfile(
       ("Sigma" + key).c_str(), (title + ";" + xtitle + ";#sigma of " + ytitle).c_str(), nxbins, xmin, xmax, "g");


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41779

#### PR description:

The main goal of this PR is to migrate the underlying ROOT type of the di-muon mass bias ME produced by `DiMuonMassBiasClient` from being `TH1`-s to `TProfile`-s. This would solve the visualization issues when displaying these in the GUI overlaid with a previous run. 
I leave the possibility to produce histograms instead via a dedicated configuration flag, since that might be useful when run in standalone mode. Additionally I restrict the range of the &mu;&mu; pair  &Delta;&eta; for the Z→&mu;&mu; case.

#### PR validation:

I've run successfully the unit tests  of this packages via `scram b runtests_testDiMuonVertexMonitor use-ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/41779 as intermediate step toward 13.0.X (needed for 2023 data-taking)