### PR TITLE
Fix parameters in PPS RawToDigiConverter, and clean up a few related configs

### DIFF
--- a/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_cfg.py
@@ -50,9 +50,9 @@ process.load('DQM.CTPPS.totemT2DQMSource_cfi')
 process.totemDAQMappingESSourceXML_TotemT2.verbosity = 0
 process.totemT2Digis.RawUnpacking.verbosity = 0
 process.totemT2Digis.RawToDigi.verbosity = 0
-process.totemT2Digis.RawToDigi.useOlderT2TestFile = cms.untracked.uint32(1)
-process.totemT2Digis.RawToDigi.printUnknownFrameSummary = 0
-process.totemT2Digis.RawToDigi.printErrorSummary = 0
+process.totemT2Digis.RawToDigi.useOlderT2TestFile = True
+process.totemT2Digis.RawToDigi.printUnknownFrameSummary = False
+process.totemT2Digis.RawToDigi.printErrorSummary = False
 process.totemDAQMappingESSourceXML_TotemT2.multipleChannelsPerPayload = True
 
 process.path = cms.Path(

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -69,29 +69,27 @@ private:
     TotemVFATStatus status;
   };
 
-  unsigned char verbosity;
+  const unsigned char verbosity;
 
-  unsigned int olderTotemT2FileTest;  //Test file with T2 frame ver 2.1
-
-  unsigned int printErrorSummary;
-  unsigned int printUnknownFrameSummary;
+  const bool printErrorSummary;
+  const bool printUnknownFrameSummary;
 
   enum TestFlag { tfNoTest, tfWarn, tfErr };
 
+  const bool olderTotemT2FileTest;  //Test file with T2 frame ver 2.1
+
   /// flags for which tests to run
-  unsigned int testFootprint;
-  unsigned int testCRC;
-  unsigned int testID;
-  unsigned int testECRaw;
-  unsigned int testECDAQ;
-  unsigned int testECMostFrequent;
-  unsigned int testBCMostFrequent;
+  const unsigned int testFootprint;
+  const unsigned int testCRC;
+  const unsigned int testID;
+  const unsigned int testECMostFrequent;
+  const unsigned int testBCMostFrequent;
 
   /// the minimal required number of frames to determine the most frequent counter value
-  unsigned int EC_min, BC_min;
+  const unsigned int EC_min, BC_min;
 
   /// the minimal required (relative) occupancy of the most frequent counter value to be accepted
-  double EC_fraction, BC_fraction;
+  const double EC_fraction, BC_fraction;
 
   /// error summaries
   std::map<TotemFramePosition, std::map<TotemVFATStatus, unsigned int> > errorSummary;

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -52,8 +52,8 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 # various error/warning/info output may be enabled with these flags
 #  totemRPRawToDigi.RawUnpacking.verbosity = 1
 #  totemRPRawToDigi.RawToDigi.verbosity = 1 # or higher number for more output
-#  totemRPRawToDigi.RawToDigi.printErrorSummary = 1
-#  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = 1
+#  totemRPRawToDigi.RawToDigi.printErrorSummary = True
+#  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = True
 
 # ---------- diamonds ----------
 totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
@@ -102,7 +102,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
 )
 
 from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
-ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
+ctppsDiamondRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem Timing ----------
 totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
@@ -132,16 +132,16 @@ totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXM
 )
 
 from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
-totemTimingRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
+totemTimingRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem nT2 ----------
 from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
 from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
-totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
+totemT2Digis.rawDataTag = "rawDataCollector"
 
 # ---------- pixels ----------
 from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
-ctppsPixelDigis.inputLabel = cms.InputTag("rawDataCollector")
+ctppsPixelDigis.inputLabel = "rawDataCollector"
 
 from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017

--- a/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemT2Digis = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TotemT2'),
+    subSystem = 'TotemT2',
     RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
-        testID = cms.uint32(0), #Some ID mismatch in test sample
-        testCRC = cms.uint32(0), # no need to test CRC for diamond frames
-        testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
+        testID = 0, #Some ID mismatch in test sample
+        testCRC = 0, # no need to test CRC for diamond frames
+        testECMostFrequent = 0 # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
     )
 )

--- a/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
@@ -9,24 +9,24 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 totemTimingRawToDigi = totemVFATRawToDigi.clone(
     subSystem = 'TotemTiming',
     
-    fedIds = cms.vuint32(586, 587), #as declared in DataFormats/FEDRawData/interface/FEDNumbering.h
+    fedIds = [586, 587],  #as declared in DataFormats/FEDRawData/interface/FEDNumbering.h
     
-    RawToDigi = cms.PSet(
-    verbosity = cms.untracked.uint32(0),
+    RawToDigi = dict(
+        verbosity = 0,
 
-    # disable all the checks
-    testFootprint = cms.uint32(0),
-    testCRC = cms.uint32(0),
-    testID = cms.uint32(0),               # compare the ID from data and mapping
-    testECMostFrequent = cms.uint32(0),   # compare frame's EC with the most frequent value in the event
-    testBCMostFrequent = cms.uint32(0),   # compare frame's BC with the most frequent value in the event
+        # disable all the checks
+        testFootprint = 0,
+        testCRC = 0,
+        testID = 0,               # compare the ID from data and mapping
+        testECMostFrequent = 0,   # compare frame's EC with the most frequent value in the event
+        testBCMostFrequent = 0,   # compare frame's BC with the most frequent value in the event
     
-    # if non-zero, prints a per-VFAT error summary at the end of the job
-    printErrorSummary = cms.untracked.uint32(0),
+        # if non-zero, prints a per-VFAT error summary at the end of the job
+        printErrorSummary = False,
     
-    # if non-zero, prints a summary of frames found in data, but not in the mapping
-    printUnknownFrameSummary = cms.untracked.uint32(0)
-  )
+        # if non-zero, prints a summary of frames found in data, but not in the mapping
+        printUnknownFrameSummary = False
+    )
 )
 
 # for Run 2 backward compatibility

--- a/EventFilter/CTPPSRawToDigi/python/totemVFATRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemVFATRawToDigi_cfi.py
@@ -38,11 +38,14 @@ totemVFATRawToDigi = cms.EDProducer("TotemVFATRawToDigi",
     # the most frequent counter value is accepted provided its relative occupancy is higher than this fraction
     EC_fraction = cms.untracked.double(0.6),
     BC_fraction = cms.untracked.double(0.6),
+
+    # True is only used for special test runs
+    useOlderT2TestFile = cms.bool(False),
     
-    # if non-zero, prints a per-VFAT error summary at the end of the job
-    printErrorSummary = cms.untracked.uint32(0),
+    # prints a per-VFAT error summary at the end of the job
+    printErrorSummary = cms.untracked.bool(False),
     
-    # if non-zero, prints a summary of frames found in data, but not in the mapping
-    printUnknownFrameSummary = cms.untracked.uint32(0),
+    # prints a summary of frames found in data, but not in the mapping
+    printUnknownFrameSummary = cms.untracked.bool(False),
   )
 )

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -25,14 +25,15 @@ using namespace edm;
 
 RawToDigiConverter::RawToDigiConverter(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
-      printErrorSummary(conf.existsAs<bool>("printErrorSummary") ? conf.getUntrackedParameter<bool>("printErrorSummary")
-                                                                 : true),
-      printUnknownFrameSummary(conf.existsAs<bool>("printUnknownFrameSummary")
+      printErrorSummary(conf.existsAs<bool>("printErrorSummary", false)
+                            ? conf.getUntrackedParameter<bool>("printErrorSummary")
+                            : true),
+      printUnknownFrameSummary(conf.existsAs<bool>("printUnknownFrameSummary", false)
                                    ? conf.getUntrackedParameter<bool>("printUnknownFrameSummary")
                                    : true),
 
-      olderTotemT2FileTest(conf.existsAs<bool>("useOlderT2TestFile") ? conf.getParameter<bool>("useOlderT2TestFile")
-                                                                     : false),
+      olderTotemT2FileTest(
+          conf.existsAs<bool>("useOlderT2TestFile", true) ? conf.getParameter<bool>("useOlderT2TestFile") : false),
       testFootprint(conf.getParameter<unsigned int>("testFootprint")),
       testCRC(conf.getParameter<unsigned int>("testCRC")),
       testID(conf.getParameter<unsigned int>("testID")),

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -25,10 +25,14 @@ using namespace edm;
 
 RawToDigiConverter::RawToDigiConverter(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
-      olderTotemT2FileTest(conf.getUntrackedParameter<unsigned int>("useOlderT2TestFile", 0)),
-      printErrorSummary(conf.getUntrackedParameter<unsigned int>("printErrorSummary", 1)),
-      printUnknownFrameSummary(conf.getUntrackedParameter<unsigned int>("printUnknownFrameSummary", 1)),
+      printErrorSummary(conf.existsAs<bool>("printErrorSummary") ? conf.getUntrackedParameter<bool>("printErrorSummary")
+                                                                 : true),
+      printUnknownFrameSummary(conf.existsAs<bool>("printUnknownFrameSummary")
+                                   ? conf.getUntrackedParameter<bool>("printUnknownFrameSummary")
+                                   : true),
 
+      olderTotemT2FileTest(conf.existsAs<bool>("useOlderT2TestFile") ? conf.getParameter<bool>("useOlderT2TestFile")
+                                                                     : false),
       testFootprint(conf.getParameter<unsigned int>("testFootprint")),
       testCRC(conf.getParameter<unsigned int>("testCRC")),
       testID(conf.getParameter<unsigned int>("testID")),
@@ -395,8 +399,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
   int allT2 = 0;
   int goodT2 = 0;
   int foundT2 = 0;
-  const int T2shiftOld =
-      (olderTotemT2FileTest > 0 ? 8 : 0);  //Run on TOTEM T2 test file (ver 2.1) or final T2 data ver 2.2
+  const int T2shiftOld = (olderTotemT2FileTest ? 8 : 0);  //Run on TOTEM T2 test file (ver 2.1) or final T2 data ver 2.2
 
   // second loop over data
   for (auto &p : records) {

--- a/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
@@ -31,14 +31,14 @@ process.maxEvents = cms.untracked.PSet(
 # raw-to-digi conversion
 process.load('CalibPPS.ESProducers.totemT2DAQMapping_cff')
 process.load('EventFilter.CTPPSRawToDigi.totemT2Digis_cfi')
-process.totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
-process.totemDAQMappingESSourceXML.verbosity = cms.untracked.uint32(1)
-process.totemT2Digis.RawUnpacking.verbosity = cms.untracked.uint32(1)
-process.totemT2Digis.RawToDigi.verbosity = cms.untracked.uint32(3)
-process.totemT2Digis.RawToDigi.useOlderT2TestFile = cms.untracked.uint32(1)
-process.totemT2Digis.RawToDigi.printUnknownFrameSummary = cms.untracked.uint32(3)
-process.totemT2Digis.RawToDigi.printErrorSummary = cms.untracked.uint32(3)
-process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = cms.untracked.bool(True)
+process.totemT2Digis.rawDataTag = "rawDataCollector"
+process.totemDAQMappingESSourceXML.verbosity = 1
+process.totemT2Digis.RawUnpacking.verbosity = 1
+process.totemT2Digis.RawToDigi.verbosity = 3
+process.totemT2Digis.RawToDigi.useOlderT2TestFile = True
+process.totemT2Digis.RawToDigi.printUnknownFrameSummary = True
+process.totemT2Digis.RawToDigi.printErrorSummary = True
+process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = True
 
 # rechits production
 process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')


### PR DESCRIPTION
#### PR description:

(This replaces #41784 that I somehow messed up)

Fix a few parameters in PPS RawToDigiConverter:

- Make "useOlderT2TestFile" tracked
- Make "useOlderT2TestFile", "printErrorSummary", "printUnknownFrameSummary" bool parameters, instead of unsigned int
- Propagate those modified parameters in the corresponding python configs

While doing so I also:

- Made constant a few class members of RawToDigiConverter that should have been so
- Moved to a safer syntax, with no explicit type declaration, in the touched configs when possible

This is a follow up of the https://github.com/cms-sw/cmssw/pull/41777#issuecomment-1564189810 posted when merging PR https://github.com/cms-sw/cmssw/pull/41777

#### PR validation:

It builds and a few matrix workflows run

@oljemark @forthommel and https://github.com/orgs/cms-sw/teams/ctpps-dpg-l2 please check that this actually corresponds to what you need (nothing should change in the final results with respect to the code currently merged in the master release). I did not try the totemt2_dqm_test because I miss some input: could you please give it a try and report if you get any error from it?