### PR TITLE
Fixing a typo in nano documentation in `TrigObj_filterBits`

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -88,7 +88,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEG90HEFilter')","hltEG90HEFilter"),
                 mksel("filter('hltEG120HEFilter')","hltEG120HEFilter"),
                 mksel("filter('hltEG150HEFilter')","hltEG150HEFilter"),
-                mksel("filter('hltEG175HEFilter')","hltEG150HEFilter"),
+                mksel("filter('hltEG175HEFilter')","hltEG175HEFilter"),
                 mksel("filter('hltEG200HEFilter')","hltEG200HEFilter"),
                 mksel("filter('hltHtEcal800')","hltHtEcal800"),
                 mksel("filter('hltEG110EBTightIDTightIsoTrackIsoFilter')","hltEG110EBTightIDTightIsoTrackIsoFilter"),


### PR DESCRIPTION
#### PR description:
Fixing a typo in nano documentation in `TrigObj_filterBits` regarding a photon HLT path. 
We can see from [here](https://cms-nanoaod-integration.web.cern.ch/autoDoc/NanoAODv11/2022preEE/doc_ZZ_TuneCP5_13p6TeV_pythia8_Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1.html#TrigObj) that the documentation says:
```
5 => hltEG150HEFilter, 6 => hltEG150HEFilter
```
while actually, it should be:
```
5 => hltEG150HEFilter, 6 => hltEG175HEFilter
```
The typo is here:
https://github.com/cms-sw/cmssw/blob/180ab5d41d7de98702efd7d8122cfa9b899e8a5a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py#L90-L91
This is fixed in this PR. No change in physics is expected, just a change in documentation.