### PR TITLE
Fix gcc 12 error: result of pointer addition is never NULL

### DIFF
--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -66,8 +66,7 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
     auto* ptr = fed_data.data();
     size_t fed_size = fed_data.size();
     for (size_t i = 0; i < fed_size; i += 4)
-      data_32bit.emplace_back(((*(ptr + i) & 0xff) << 0) +
-                              (((i + 1) < fed_size) ? ((*(ptr + i + 1) & 0xff) << 8)  : 0) +
+      data_32bit.emplace_back(((*(ptr + i) & 0xff) << 0) + (((i + 1) < fed_size) ? ((*(ptr + i + 1) & 0xff) << 8) : 0) +
                               (((i + 2) < fed_size) ? ((*(ptr + i + 2) & 0xff) << 16) : 0) +
                               (((i + 3) < fed_size) ? ((*(ptr + i + 3) & 0xff) << 24) : 0));
 

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -64,11 +64,12 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
     std::vector<uint32_t> data_32bit;
     auto* ptr = fed_data.data();
-    for (size_t i = 0; i < fed_data.size(); i += 4)
-      data_32bit.emplace_back(((ptr + i) ? ((*(ptr + i) & 0xff) << 0) : 0) +
-                              ((ptr + i + 1) ? ((*(ptr + i + 1) & 0xff) << 8) : 0) +
-                              ((ptr + i + 2) ? ((*(ptr + i + 2) & 0xff) << 16) : 0) +
-                              ((ptr + i + 3) ? ((*(ptr + i + 3) & 0xff) << 24) : 0));
+    size_t fed_size = fed_data.size();
+    for (size_t i = 0; i < fed_size; i += 4)
+      data_32bit.emplace_back(((*(ptr + i) & 0xff) << 0) +
+                              (((i + 1) < fed_size) ? ((*(ptr + i + 1) & 0xff) << 8)  : 0) +
+                              (((i + 2) < fed_size) ? ((*(ptr + i + 2) & 0xff) << 16) : 0) +
+                              (((i + 3) < fed_size) ? ((*(ptr + i + 3) & 0xff) << 24) : 0));
 
     unpacker_->parseSLink(
         data_32bit,


### PR DESCRIPTION
GCC 12 IBs have [build errors](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_2_X_2023-05-27-1100/EventFilter/HGCalRawToDigi) like [a]. GCC 12 suggest to avoid the comparison of pointer addition with NULL as the result will never be null. This PR avoids the comparison of ptr with NULL and adds the check that code does not access out of bound memory e.g. when `fed_data` is not modulo of 4

[a]
```
  EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc:68:37: error: comparing the result of pointer addition '(ptr + ((sizetype)i))' and NULL [-Werror=address]
    68 |       data_32bit.emplace_back(((ptr + i) ? ((*(ptr + i) & 0xff) << 0) : 0) +
      |                                ~~~~~^~~~
  EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc:69:41: error: comparing the result of pointer addition '(ptr + (((sizetype)i) + 1))' and NULL [-Werror=address]
    69 |                               ((ptr + i + 1) ? ((*(ptr + i + 1) & 0xff) << 8) : 0) +
      |                                ~~~~~~~~~^~~~
  EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc:70:41: error: comparing the result of pointer addition '(ptr + (((sizetype)i) + 2))' and NULL [-Werror=address]
    70 |                               ((ptr + i + 2) ? ((*(ptr + i + 2) & 0xff) << 16) : 0) +
      |                                ~~~~~~~~~^~~~
  EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc:71:41: error: comparing the result of pointer addition '(ptr + (((sizetype)i) + 3))' and NULL [-Werror=address]
    71 |                               ((ptr + i + 3) ? ((*(ptr + i + 3) & 0xff) << 24) : 0));

```