### PR TITLE
Run3-alca243 Add the ioread statement to read back old HOCalibVariables in the new cases

### DIFF
--- a/DataFormats/HcalCalibObjects/src/classes_def.xml
+++ b/DataFormats/HcalCalibObjects/src/classes_def.xml
@@ -3,6 +3,9 @@
    <version ClassVersion="16" checksum="2161587371"/>
    <version ClassVersion="17" checksum="1351689277"/>
   </class>
+   <ioread sourceClass="HOCalibVariables" targetClass="HOCalibVariables" version="[-16]" target="pileup" source="float inslumi" embed="false">
+    <![CDATA[ pileup = onfile.inslumi; ]]>
+  </ioread>
   <class name="std::vector<HOCalibVariables>"/>
   <class name="edm::Wrapper<std::vector<HOCalibVariables> >"/>
   <class name="HcalHBHEMuonVariables" ClassVersion="20">


### PR DESCRIPTION
#### PR description:

Add the ioread statement to read back old HOCalibVariables in the new cases

#### PR validation:

No specific test is done

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special