### PR TITLE
Adding filter flag to SiStripApproximateClusters

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -72,7 +72,7 @@ siStripClustersHLT = cms.EDProducer("SiStripClusterizer",
                                         cms.InputTag('siStripZeroSuppressionHLT','ScopeMode')),
                                 )
 
-from RecoLocalTracker.SiStripClusterizer.SiStripClusters2ApproxClusters_cff import hltSiStripClusters2ApproxClusters
+from RecoLocalTracker.SiStripClusterizer.SiStripClusters2ApproxClusters_cff import * 
 
 from EventFilter.Utilities.EvFFEDExcluder_cfi import EvFFEDExcluder as _EvFFEDExcluder
 rawPrimeDataRepacker = _EvFFEDExcluder.clone(

--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -80,5 +80,9 @@ rawPrimeDataRepacker = _EvFFEDExcluder.clone(
     fedsToExclude = [foo for foo in range(50, 490)]
 )
 
-DigiToApproxClusterRawTask = cms.Task(siStripDigisHLT,siStripZeroSuppressionHLT,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
+hltScalersRawToDigi =  cms.EDProducer( "ScalersRawToDigi",
+   scalersInputTag = cms.InputTag( "rawDataRepacker" )
+)
+
+DigiToApproxClusterRawTask = cms.Task(siStripDigisHLT,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
 DigiToApproxClusterRaw = cms.Sequence(DigiToApproxClusterRawTask)

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -8,27 +8,38 @@ class SiStripApproximateCluster {
 public:
   SiStripApproximateCluster() {}
 
-  explicit SiStripApproximateCluster(cms_uint16_t barycenter,
-                                     cms_uint8_t width,
-                                     cms_uint8_t avgCharge,
-                                     bool isSaturated) {
+  explicit SiStripApproximateCluster(
+      cms_uint16_t barycenter, cms_uint8_t width, cms_uint8_t avgCharge, bool filter, bool isSaturated) {
     barycenter_ = barycenter;
     width_ = width;
     avgCharge_ = avgCharge;
+    filter_ = filter;
     isSaturated_ = isSaturated;
   }
 
-  explicit SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat);
+  explicit SiStripApproximateCluster(const SiStripCluster& cluster,
+                                     unsigned int maxNSat,
+                                     float hitPredPos,
+                                     bool peakFilter);
 
   cms_uint16_t barycenter() const { return barycenter_; }
   cms_uint8_t width() const { return width_; }
   cms_uint8_t avgCharge() const { return avgCharge_; }
+  bool filter() const { return filter_; }
   bool isSaturated() const { return isSaturated_; }
+  bool peakFilter() const { return peakFilter_; }
 
 private:
   cms_uint16_t barycenter_ = 0;
   cms_uint8_t width_ = 0;
   cms_uint8_t avgCharge_ = 0;
+  bool filter_ = false;
   bool isSaturated_ = false;
+  bool peakFilter_ = false;
+  static constexpr double trimMaxADC_ = 30.;
+  static constexpr double trimMaxFracTotal_ = .15;
+  static constexpr double trimMaxFracNeigh_ = .25;
+  static constexpr double maxTrimmedSizeDiffNeg_ = .7;
+  static constexpr double maxTrimmedSizeDiffPos_ = 1.;
 };
 #endif  // DataFormats_SiStripCluster_SiStripApproximateCluster_h

--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -82,6 +82,10 @@ public:
    */
   int charge() const;
 
+  bool filter() const;
+
+  bool isFromApprox() const;
+
   /** Test (set) the merged status of the cluster
    *
    */
@@ -99,6 +103,7 @@ private:
   //these are used if amplitude information is not available (using approximate cluster constructor)
   float barycenter_ = 0;
   int charge_ = 0;
+  bool filter_ = false;
 
   // ggiurgiu@fnal.gov, 01/05/12
   // Add cluster errors to be used by rechits from split clusters.

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -3,11 +3,16 @@
 #include <algorithm>
 #include <cmath>
 
-SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat) {
+SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster,
+                                                     unsigned int maxNSat,
+                                                     float hitPredPos,
+                                                     bool peakFilter) {
   barycenter_ = std::round(cluster.barycenter() * 10);
   width_ = cluster.size();
   avgCharge_ = cluster.charge() / cluster.size();
+  filter_ = false;
   isSaturated_ = false;
+  peakFilter_ = peakFilter;
 
   //mimicing the algorithm used in StripSubClusterShapeTrajectoryFilter...
   //Looks for 3 adjacent saturated strips (ADC>=254)
@@ -25,6 +30,32 @@ SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& clust
     maxSat = std::max<int>(maxSat, thisSat);
   }
   if (maxSat >= maxNSat) {
+    filter_ = true;
     isSaturated_ = true;
+  }
+
+  unsigned int hitStripsTrim = ampls.size();
+  int sum = std::accumulate(ampls.begin(), ampls.end(), 0);
+  uint8_t trimCut = std::min<uint8_t>(trimMaxADC_, std::floor(trimMaxFracTotal_ * sum));
+  auto begin = ampls.begin();
+  auto last = ampls.end() - 1;
+  while (hitStripsTrim > 1 && (*begin < std::max<uint8_t>(trimCut, trimMaxFracNeigh_ * (*(begin + 1))))) {
+    hitStripsTrim--;
+    ++begin;
+  }
+  while (hitStripsTrim > 1 && (*last < std::max<uint8_t>(trimCut, trimMaxFracNeigh_ * (*(last - 1))))) {
+    hitStripsTrim--;
+    --last;
+  }
+  if (hitStripsTrim < std::floor(std::abs(hitPredPos) - maxTrimmedSizeDiffNeg_)) {
+    filter_ = false;
+  } else if (hitStripsTrim <= std::ceil(std::abs(hitPredPos) + maxTrimmedSizeDiffPos_)) {
+    filter_ = true;
+  } else {
+    if (peakFilter_) {
+      filter_ = true;
+    } else {
+      filter_ = false;
+    }
   }
 }

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -52,10 +52,6 @@ SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& clust
   } else if (hitStripsTrim <= std::ceil(std::abs(hitPredPos) + maxTrimmedSizeDiffPos_)) {
     filter_ = true;
   } else {
-    if (peakFilter_) {
-      filter_ = true;
-    } else {
-      filter_ = false;
-    }
+    filter_ = peakFilter_;
   }
 }

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -26,6 +26,7 @@ SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const ui
   barycenter_ = cluster.barycenter() / 10.0;
   charge_ = cluster.width() * cluster.avgCharge();
   amplitudes_.resize(cluster.width(), cluster.avgCharge());
+  filter_ = cluster.filter();
 
   float halfwidth_ = 0.5f * float(cluster.width());
 
@@ -59,4 +60,15 @@ float SiStripCluster::barycenter() const {
   // so one has to add 0.5 to get the correct barycenter position.
   // Need to mask off the high bit of firstStrip_, which contains the merged status.
   return float((firstStrip_ & stripIndexMask)) + float(sumx) / float(suma) + 0.5f;
+}
+bool SiStripCluster::filter() const {
+  if (barycenter_ > 0)
+    return filter_;
+  return false;
+}
+
+bool SiStripCluster::isFromApprox() const {
+  if (barycenter_ > 0)
+    return true;
+  return false;
 }

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -67,6 +67,4 @@ bool SiStripCluster::filter() const {
   return false;
 }
 
-bool SiStripCluster::isFromApprox() const {
-  return (barycenter_ > 0);
-}
+bool SiStripCluster::isFromApprox() const { return (barycenter_ > 0); }

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -68,7 +68,5 @@ bool SiStripCluster::filter() const {
 }
 
 bool SiStripCluster::isFromApprox() const {
-  if (barycenter_ > 0)
-    return true;
-  return false;
+  return (barycenter_ > 0);
 }

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
- <class name="SiStripCluster" ClassVersion="12">
+ <class name="SiStripCluster" ClassVersion="13">
+  <version ClassVersion="13" checksum="1374720584"/>
   <version ClassVersion="12" checksum="2984011925"/>
   <version ClassVersion="11" checksum="3702468681"/>
   <version ClassVersion="10" checksum="3791198690"/>
@@ -24,7 +25,8 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripCluster>,SiStripCluster,edmNew::DetSetVector<SiStripCluster>::FindForDetSetVector> > >" />
 
 
- <class name="SiStripApproximateCluster" ClassVersion="5">
+ <class name="SiStripApproximateCluster" ClassVersion="6">
+  <version ClassVersion="6" checksum="132211472"/>
   <version ClassVersion="5" checksum="3495825183"/>
   <version ClassVersion="4" checksum="2854791577"/>
   <version ClassVersion="3" checksum="2041370183"/>

--- a/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h
@@ -44,6 +44,7 @@ namespace sistrip {
   static const uint16_t STRIPS_PER_FEDCH = STRIPS_PER_APV * APVS_PER_FEDCH;
   static const uint16_t STRIPS_PER_FEUNIT = STRIPS_PER_FEDCH * FEDCH_PER_FEUNIT;  // 3072
   static const uint16_t STRIPS_PER_FED = STRIPS_PER_FEUNIT * FEUNITS_PER_FED;     // 24576
+  static constexpr float MeVperADCStrip = 9.5665E-4;
 
   // -------------------- FED buffers --------------------
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -226,6 +226,16 @@ def customizeHLTfor41495(process):
 
     return process
 
+def customizeHLTfor41815(process):
+    # use hlt online BeamSpot for SiStripClusters2ApproxClusters
+    for producer in producers_by_type(process, 'SiStripClusters2ApproxClusters'):
+        producer.beamSpot = cms.InputTag('hltOnlineBeamSpot')
+
+    if hasattr(process, 'HLT_HIRandom_v4'):
+        getattr(process,'HLT_HIRandom_v4').insert(2,process.HLTBeamSpot)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -236,5 +246,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customizeHLTfor41058(process)
     process = customizeHLTfor41495(process)
+    process = customizeHLTfor41815(process)
 
     return process

--- a/RecoLocalTracker/SiStripClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/BuildFile.xml
@@ -6,5 +6,8 @@
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="CUDADataFormats/SiStripCluster"/>
   <use name="cuda"/>
+  <use name="RecoTracker/PixelLowPtUtilities"/>
+  <use name="CalibFormats/SiStripObjects"/>
+  <use name="CalibTracker/SiStripCommon"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
@@ -59,6 +59,7 @@ void SiStripApprox2ApproxClusters::produce(edm::Event& event, edm::EventSetup co
       float barycenter = cluster.barycenter();
       uint8_t width = cluster.width();
       float avgCharge = cluster.avgCharge();
+      bool filter = cluster.filter();
       bool isSaturated = cluster.isSaturated();
 
       switch (approxVersion) {
@@ -86,7 +87,7 @@ void SiStripApprox2ApproxClusters::produce(edm::Event& event, edm::EventSetup co
           break;
       }
 
-      ff.push_back(SiStripApproximateCluster(barycenter, width, avgCharge, isSaturated));
+      ff.push_back(SiStripApproximateCluster(barycenter, width, avgCharge, filter, isSaturated));
     }
   }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
@@ -1,16 +1,33 @@
-
-
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "RecoTracker/PixelLowPtUtilities/interface/ClusterShapeHitFilter.h"
+#include "RecoTracker/PixelLowPtUtilities/interface/SlidingPeakFinder.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 
 #include <vector>
 #include <memory>
@@ -27,6 +44,26 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterToken;
 
   unsigned int maxNSat;
+  static constexpr float MeVperADCStrip = 9.5665E-4;
+  static constexpr double subclusterWindow_ = .7;
+  static constexpr double seedCutMIPs_ = .35;
+  static constexpr double seedCutSN_ = 7.;
+  static constexpr double subclusterCutMIPs_ = .45;
+  static constexpr double subclusterCutSN_ = 12.;
+
+  edm::InputTag beamSpot;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+
+  edm::FileInPath fileInPath;
+  SiStripDetInfo detInfo;
+
+  std::string csfLabel_;
+  edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> csfToken_;
+
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> stripNoiseToken_;
+  edm::ESHandle<SiStripNoises> theNoise;
 };
 
 SiStripClusters2ApproxClusters::SiStripClusters2ApproxClusters(const edm::ParameterSet& conf) {
@@ -34,18 +71,87 @@ SiStripClusters2ApproxClusters::SiStripClusters2ApproxClusters(const edm::Parame
   maxNSat = conf.getParameter<unsigned int>("maxSaturatedStrips");
 
   clusterToken = consumes<edmNew::DetSetVector<SiStripCluster> >(inputClusters);
+
+  beamSpot = conf.getParameter<edm::InputTag>("beamSpot");
+  beamSpotToken = consumes<reco::BeamSpot>(beamSpot);
+
+  tkGeomToken_ = esConsumes();
+
+  fileInPath = edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile);
+  detInfo = SiStripDetInfoFileReader::read(fileInPath.fullPath());
+
+  csfLabel_ = conf.getParameter<std::string>("clusterShapeHitFilterLabel");
+  csfToken_ = esConsumes(edm::ESInputTag("", csfLabel_));
+
+  stripNoiseToken_ = esConsumes();
+
   produces<edmNew::DetSetVector<SiStripApproximateCluster> >();
 }
 
-void SiStripClusters2ApproxClusters::produce(edm::Event& event, edm::EventSetup const&) {
+void SiStripClusters2ApproxClusters::produce(edm::Event& event, edm::EventSetup const& iSetup) {
   auto result = std::make_unique<edmNew::DetSetVector<SiStripApproximateCluster> >();
   const auto& clusterCollection = event.get(clusterToken);
+
+  edm::Handle<reco::BeamSpot> beamSpotHandle;
+  event.getByToken(beamSpotToken, beamSpotHandle);  // retrive BeamSpot data
+  reco::BeamSpot const* bs = nullptr;
+  if (beamSpotHandle.isValid()) {
+    bs = &(*beamSpotHandle);
+  } else {
+    edm::LogError("SiStripClusters2ApproxClusters")
+        << "didn't find a valid beamspot with label " << beamSpot.label() << " using 0,0,0";
+    bs = new reco::BeamSpot();
+  }
+
+  const auto& tkGeom = &iSetup.getData(tkGeomToken_);
+  const auto& theFilter = &iSetup.getData(csfToken_);
+  const auto& theNoise = &iSetup.getData(stripNoiseToken_);
 
   for (const auto& detClusters : clusterCollection) {
     edmNew::DetSetVector<SiStripApproximateCluster>::FastFiller ff{*result, detClusters.id()};
 
-    for (const auto& cluster : detClusters)
-      ff.push_back(SiStripApproximateCluster(cluster, maxNSat));
+    unsigned int detId = detClusters.id();
+    const GeomDet* det = tkGeom->idToDet(detId);
+    double nApvs = detInfo.getNumberOfApvsAndStripLength(detId).first;
+    double stripLength = detInfo.getNumberOfApvsAndStripLength(detId).second;
+    double barycenter_ypos = 0.5 * stripLength;
+
+    const StripGeomDetUnit* stripDet = dynamic_cast<const StripGeomDetUnit*>(det);
+    float mip = 3.9 / (MeVperADCStrip / stripDet->surface().bounds().thickness());
+
+    for (const auto& cluster : detClusters) {
+      const LocalPoint& lp = LocalPoint(((cluster.barycenter() * 10 / (sistrip::STRIPS_PER_APV * nApvs)) -
+                                         ((stripDet->surface().bounds().width()) * 0.5f)),
+                                        barycenter_ypos - (0.5f * stripLength),
+                                        0.);
+      const GlobalPoint& gpos = det->surface().toGlobal(lp);
+      GlobalPoint beamspot(bs->position().x(), bs->position().y(), bs->position().z());
+      const GlobalVector& gdir = gpos - beamspot;
+      const LocalVector& ldir = det->toLocal(gdir);
+
+      int hitStrips;
+      float hitPredPos;
+      theFilter->getSizes(detId, cluster, lp, ldir, hitStrips, hitPredPos);
+
+      bool peakFilter = false;
+      SlidingPeakFinder pf(std::max<int>(2, std::ceil(std::abs(hitPredPos) + subclusterWindow_)));
+      float mipnorm = mip / std::abs(ldir.z());
+      PeakFinderTest test(mipnorm,
+                          detId,
+                          cluster.firstStrip(),
+                          theNoise,
+                          seedCutMIPs_,
+                          seedCutSN_,
+                          subclusterCutMIPs_,
+                          subclusterCutSN_);
+      if (pf.apply(cluster.amplitudes(), test)) {
+        peakFilter = true;
+      } else {
+        peakFilter = false;
+      }
+
+      ff.push_back(SiStripApproximateCluster(cluster, maxNSat, hitPredPos, peakFilter));
+    }
   }
 
   event.put(std::move(result));
@@ -55,6 +161,8 @@ void SiStripClusters2ApproxClusters::fillDescriptions(edm::ConfigurationDescript
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("inputClusters", edm::InputTag("siStripClusters"));
   desc.add<unsigned int>("maxSaturatedStrips", 3);
+  desc.add<std::string>("clusterShapeHitFilterLabel", "ClusterShapeHitFilter");  // add CSF label
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));         // add BeamSpot tag
   descriptions.add("SiStripClusters2ApproxClusters", desc);
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
@@ -91,17 +91,6 @@ void SiStripClusters2ApproxClusters::produce(edm::Event& event, edm::EventSetup 
   auto result = std::make_unique<edmNew::DetSetVector<SiStripApproximateCluster> >();
   const auto& clusterCollection = event.get(clusterToken);
 
-  //  edm::Handle<reco::BeamSpot> beamSpotHandle;
-  //  event.getByToken(beamSpotToken, beamSpotHandle);  // retrive BeamSpot data
-  //  reco::BeamSpot const* bs = nullptr;
-  //  if (beamSpotHandle.isValid()) {
-  //    bs = &(*beamSpotHandle);
-  //  } else {
-  //    edm::LogError("SiStripClusters2ApproxClusters")
-  //        << "didn't find a valid beamspot with label " << beamSpot.label() << " using 0,0,0";
-  //    bs = new reco::BeamSpot();
-  //  }
-
   auto const beamSpotHandle = event.getHandle(beamSpotToken_);
   auto const& bs = beamSpotHandle.isValid() ? *beamSpotHandle : reco::BeamSpot();
   if (not beamSpotHandle.isValid()) {

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusters2ApproxClusters_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusters2ApproxClusters_cff.py
@@ -1,5 +1,13 @@
 from RecoLocalTracker.SiStripClusterizer.SiStripClusters2ApproxClusters_cfi import *
 
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+
+from RecoTracker.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
+hltClusterShapeHitFilterESProducer = _ClusterShapeHitFilterESProducer.clone(ComponentName = 'hltClusterShapeHitFilterESProducer')
+
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
 hltSiStripClusters2ApproxClusters = SiStripClusters2ApproxClusters.clone()
-approxSiStripClusters.toModify(hltSiStripClusters2ApproxClusters, inputClusters = "siStripClustersHLT")
+approxSiStripClusters.toModify(hltSiStripClusters2ApproxClusters,
+                               beamSpot = "onlineBeamSpotProducer",
+                               inputClusters = "siStripClustersHLT",
+                               clusterShapeHitFilterLabel = "hltClusterShapeHitFilterESProducer")

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusters2ApproxClusters_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusters2ApproxClusters_cff.py
@@ -5,9 +5,10 @@ from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStr
 from RecoTracker.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import ClusterShapeHitFilterESProducer as _ClusterShapeHitFilterESProducer
 hltClusterShapeHitFilterESProducer = _ClusterShapeHitFilterESProducer.clone(ComponentName = 'hltClusterShapeHitFilterESProducer')
 
-from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import *
+from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+hltBeamSpotProducer = onlineBeamSpotProducer.clone(src = 'hltScalersRawToDigi')
 hltSiStripClusters2ApproxClusters = SiStripClusters2ApproxClusters.clone()
 approxSiStripClusters.toModify(hltSiStripClusters2ApproxClusters,
-                               beamSpot = "onlineBeamSpotProducer",
+                               beamSpot = "hltBeamSpotProducer",
                                inputClusters = "siStripClustersHLT",
                                clusterShapeHitFilterLabel = "hltClusterShapeHitFilterESProducer")

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -201,14 +201,11 @@ pixelLessStepSeeds = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer.
                 FilterStripHits    = cms.bool(True),
                 ClusterShapeHitFilterName = cms.string('pixelLessStepClusterShapeHitFilter'),
                 ClusterShapeCacheSrc      = cms.InputTag('siPixelClusterShapeCache') # not really needed here since FilterPixelHits=False
-            )
+            ),
+            _StripSubClusterShapeSeedFilter.clone()
         )
     )
 )
-
-from RecoTracker.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi import StripSubClusterShapeSeedFilter as _StripSubClusterShapeSeedFilter
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-(~approxSiStripClusters).toModify(pixelLessStepSeeds.SeedComparitorPSet.comparitors, func = lambda list: list.append(_StripSubClusterShapeSeedFilter.clone()) )
 
 trackingLowPU.toModify(pixelLessStepHitDoublets, produceSeedingHitSets=True, produceIntermediateHitDoublets=False)
 trackingLowPU.toModify(pixelLessStepSeeds,

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -93,6 +93,7 @@ tobTecStepHitTripletsTripl = _multiHitFromChi2EDProducer.clone(
     extraPhiKDBox = 0.01,
 )
 from RecoTracker.TkSeedGenerator.seedCreatorFromRegionConsecutiveHitsEDProducer_cff import seedCreatorFromRegionConsecutiveHitsEDProducer as _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProducer
+from RecoTracker.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi import StripSubClusterShapeSeedFilter as _StripSubClusterShapeSeedFilter
 _tobTecStepSeedComparitorPSet = dict(
     ComponentName = 'CombinedSeedComparitor',
     mode          = cms.string('and'),
@@ -104,7 +105,8 @@ _tobTecStepSeedComparitorPSet = dict(
             FilterStripHits    = cms.bool(True),
             ClusterShapeHitFilterName = cms.string('tobTecStepClusterShapeHitFilter'),
             ClusterShapeCacheSrc = cms.InputTag('siPixelClusterShapeCache') # not really needed here since FilterPixelHits=False
-        )
+        ),
+        _StripSubClusterShapeSeedFilter.clone()
     )
 )
 
@@ -112,10 +114,6 @@ tobTecStepSeedsTripl = _seedCreatorFromRegionConsecutiveHitsTripletOnlyEDProduce
     seedingHitSets     = 'tobTecStepHitTripletsTripl',
     SeedComparitorPSet = _tobTecStepSeedComparitorPSet,
 )
-
-from RecoTracker.PixelLowPtUtilities.StripSubClusterShapeSeedFilter_cfi import StripSubClusterShapeSeedFilter as _StripSubClusterShapeSeedFilter
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-(~approxSiStripClusters).toModify(tobTecStepSeedsTripl.SeedComparitorPSet.comparitors, func = lambda list: list.append(_StripSubClusterShapeSeedFilter.clone()) )
 
 #fastsim
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi

--- a/RecoTracker/PixelLowPtUtilities/interface/SlidingPeakFinder.h
+++ b/RecoTracker/PixelLowPtUtilities/interface/SlidingPeakFinder.h
@@ -1,0 +1,102 @@
+#ifndef RecoTracker_PixelLowPtUtilities_SlidingPeakFinder_h
+#define RecoTracker_PixelLowPtUtilities_SlidingPeakFinder_h
+
+#include <algorithm>
+#include <vector>
+#include <cmath>
+#include <cstdint>
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+
+class SlidingPeakFinder {
+public:
+  SlidingPeakFinder(unsigned int size) : size_(size), half_((size + 1) / 2) {}
+
+  template <typename Test>
+  bool apply(const uint8_t *x,
+             const uint8_t *begin,
+             const uint8_t *end,
+             const Test &test,
+             bool verbose = false,
+             int firststrip = 0) {
+    const uint8_t *ileft = (x != begin) ? std::min_element(x - 1, x + half_) : begin - 1;
+    const uint8_t *iright = ((x + size_) < end) ? std::min_element(x + half_, std::min(x + size_ + 1, end)) : end;
+    uint8_t left = (ileft < begin ? 0 : *ileft);
+    uint8_t right = (iright >= end ? 0 : *iright);
+    uint8_t center = *std::max_element(x, std::min(x + size_, end));
+    uint8_t maxmin = std::max(left, right);
+    if (maxmin < center) {
+      bool ret = test(center, maxmin);
+      if (ret) {
+        ret = test(ileft, iright, begin, end);
+      }
+      return ret;
+    } else {
+      return false;
+    }
+  }
+
+  template <typename V, typename Test>
+  bool apply(const V &ampls, const Test &test, bool verbose = false, int firststrip = 0) {
+    const uint8_t *begin = &*ampls.begin();
+    const uint8_t *end = &*ampls.end();
+    for (const uint8_t *x = begin; x < end - (half_ - 1); ++x) {
+      if (apply(x, begin, end, test, verbose, firststrip)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+private:
+  unsigned int size_, half_;
+};
+
+struct PeakFinderTest {
+  PeakFinderTest(float mip,
+                 uint32_t detid,
+                 uint32_t firstStrip,
+                 const SiStripNoises *theNoise,
+                 float seedCutMIPs,
+                 float seedCutSN,
+                 float subclusterCutMIPs,
+                 float subclusterCutSN)
+      : mip_(mip),
+        detid_(detid),
+        firstStrip_(firstStrip),
+        noiseObj_(theNoise),
+        noises_(theNoise->getRange(detid)),
+        subclusterCutMIPs_(subclusterCutMIPs),
+        sumCut_(subclusterCutMIPs_ * mip_),
+        subclusterCutSN2_(subclusterCutSN * subclusterCutSN) {
+    cut_ = std::min<float>(seedCutMIPs * mip, seedCutSN * noiseObj_->getNoise(firstStrip + 1, noises_));
+  }
+
+  bool operator()(uint8_t max, uint8_t min) const { return max - min > cut_; }
+  bool operator()(const uint8_t *left, const uint8_t *right, const uint8_t *begin, const uint8_t *end) const {
+    int yleft = (left < begin ? 0 : *left);
+    int yright = (right >= end ? 0 : *right);
+    float sum = 0.0;
+    int maxval = 0;
+    float noise = 0;
+    for (const uint8_t *x = left + 1; x < right; ++x) {
+      int baseline = (yleft * int(right - x) + yright * int(x - left)) / int(right - left);
+      sum += int(*x) - baseline;
+      noise += std::pow(noiseObj_->getNoise(firstStrip_ + int(x - begin), noises_), 2);
+      maxval = std::max(maxval, int(*x) - baseline);
+    }
+    if (sum > sumCut_ && sum * sum > noise * subclusterCutSN2_)
+      return true;
+    return false;
+  }
+
+private:
+  float mip_;
+  unsigned int detid_;
+  int firstStrip_;
+  const SiStripNoises *noiseObj_;
+  SiStripNoises::Range noises_;
+  uint8_t cut_;
+  float subclusterCutMIPs_, sumCut_, subclusterCutSN2_;
+};
+#endif

--- a/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -10,6 +10,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -152,7 +153,6 @@ StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase(const edm::Parame
 #ifdef StripSubClusterShapeFilterBase_COUNTERS
       ,
       called_(0),
-      saturated_(0),
       test_(0),
       passTrim_(0),
       failTooLarge_(0),
@@ -315,9 +315,8 @@ bool StripSubClusterShapeFilterBase::testLastHit(const TrackingRecHit *hit,
         return true;
       }
 
-      float MeVperADCStrip = 9.5665E-4;  // conversion constant from ADC counts to MeV for the SiStrip detector
       float mip =
-          3.9 / (MeVperADCStrip / stripDetUnit->surface().bounds().thickness());  // 3.9 MeV/cm = ionization in silicon
+          3.9 / (sistrip::MeVperADCStrip / stripDetUnit->surface().bounds().thickness());  // 3.9 MeV/cm = ionization in silicon
       float mipnorm = mip / std::abs(ldir.z());
       ::SlidingPeakFinder pf(std::max<int>(2, std::ceil(std::abs(hitPredPos) + subclusterWindow_)));
       ::PeakFinderTest test(mipnorm,

--- a/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -316,8 +316,8 @@ bool StripSubClusterShapeFilterBase::testLastHit(const TrackingRecHit *hit,
         return true;
       }
 
-      float mip =
-          3.9 / (sistrip::MeVperADCStrip / stripDetUnit->surface().bounds().thickness());  // 3.9 MeV/cm = ionization in silicon
+      float mip = 3.9 / (sistrip::MeVperADCStrip /
+                         stripDetUnit->surface().bounds().thickness());  // 3.9 MeV/cm = ionization in silicon
       float mipnorm = mip / std::abs(ldir.z());
       ::SlidingPeakFinder pf(std::max<int>(2, std::ceil(std::abs(hitPredPos) + subclusterWindow_)));
       ::PeakFinderTest test(mipnorm,

--- a/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
+++ b/RecoTracker/PixelLowPtUtilities/src/StripSubClusterShapeTrajectoryFilter.cc
@@ -153,6 +153,7 @@ StripSubClusterShapeFilterBase::StripSubClusterShapeFilterBase(const edm::Parame
 #ifdef StripSubClusterShapeFilterBase_COUNTERS
       ,
       called_(0),
+      saturated_(0),
       test_(0),
       passTrim_(0),
       failTooLarge_(0),


### PR DESCRIPTION
#### PR description:

This PR extends the SiStripApproximateCluster data format to include a boolean flag of the outcome of the StripSubClusterShapeTrajectoryFilter sequence. This boolean flag serves the purpose of overriding the three checks in StripSubClusterShapeTrajectoryFilter module which introduced inefficiencies in tracking performance. These inefficiencies arise due to the uniform shape of the approximated clusters.  The problem-causing filters were the "saturated", "trimming" and "peak finder" filters with the latter two requiring information on the trajectory state on the surface at the measurement layer which is not available during clustering.

This PR utilises information on the beamspot, tracker geometry, and strip module to approximate the global position of the cluster and the track direction. The latter is done by drawing a vector from the beamspot to the cluster barycenter.  A boolean for the 3 filters is then set up using this information following the logic in the StripSubClusterShapeTrajectoryFilter module. 

#### PR validation:

This PR was tested by running workflows 11884.0 and 11941.0 (step3). The DQM outputs have been checked and compared to the original clusters to compare any performance gains from this new implementation.

@mmusich @mtosi 
