### PR TITLE
 improved file size/buffer size checks in DAQ input source (13_1_X)

### DIFF
--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -192,6 +192,10 @@ public:
       : InputFile(status, lumi, name, deleteFile, rawFd, fileSize, rawHeaderSize, nChunks, nEvents, nullptr),
         sourceParent_(parent) {}
   bool advance(unsigned char*& dataPosition, const size_t size);
+  void advance(const size_t size) {
+    chunkPosition_ += size;
+    bufferPosition_ += size;
+  }
 
 private:
   DAQSource* sourceParent_;

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -312,6 +312,7 @@ public:
     std::shuffle(std::begin(fileOrder_), std::end(fileOrder_), rng);
   }
   uint64_t currentChunkSize() const { return chunks_[currentChunk_]->size_; }
+  int64_t fileSizeLeft() const { return (int64_t)fileSize_ - (int64_t)bufferPosition_; }
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -540,6 +540,11 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
     unsigned char* dataPosition;
 
     //read header, copy it to a single chunk if necessary
+    if (currentFile_->fileSizeLeft() < FRDHeaderVersionSize[detectedFRDversion_])
+      throw cms::Exception("FedRawDataInputSource::getNextEvent")
+          << "Premature end of input file (missing:"
+          << (FRDHeaderVersionSize[detectedFRDversion_] - currentFile_->fileSizeLeft())
+          << ") while reading event data for next event header";
     bool chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_]);
 
     event_ = std::make_unique<FRDEventMsgView>(dataPosition);
@@ -552,9 +557,10 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
 
     const uint32_t msgSize = event_->size() - FRDHeaderVersionSize[detectedFRDversion_];
 
-    if (currentFile_->fileSize_ - currentFile_->bufferPosition_ < msgSize) {
+    if (currentFile_->fileSizeLeft() < msgSize) {
       throw cms::Exception("FedRawDataInputSource::getNextEvent")
-          << "Premature end of input file while reading event data";
+          << "Premature end of input file (missing:" << (msgSize - currentFile_->fileSizeLeft())
+          << ") while reading event data for event " << event_->event() << " lumi:" << event_->lumi();
     }
 
     if (chunkEnd) {
@@ -584,6 +590,12 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
         assert(!chunkEnd);
         chunkIsFree_ = false;
       }
+    }
+    //sanity-check check that the buffer position has not exceeded file size after preparing event
+    if (currentFile_->fileSize_ < currentFile_->bufferPosition_) {
+      throw cms::Exception("FedRawDataInputSource::getNextEvent")
+          << "Exceeded file size by " << currentFile_->bufferPosition_ - currentFile_->fileSize_
+          << " after reading last event declared size of " << event_->size() << " bytes";
     }
   }  //end multibuffer mode
   setMonState(inChecksumEvent);
@@ -800,7 +812,12 @@ void FedRawDataInputSource::readSupervisor() {
       //sleep until woken up by condition or a timeout
       if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout) {
         counter++;
-        //if (!(counter%50)) edm::LogInfo("FedRawDataInputSource") << "No free chunks or threads...";
+        if (!(counter % 6000)) {
+          edm::LogWarning("FedRawDataInputSource")
+              << "No free chunks or threads. Worker pool empty:" << workerPool_.empty()
+              << ", free chunks empty:" << freeChunks_.empty() << ", number of files buffered:" << readingFilesCount_
+              << " / " << maxBufferedFiles_;
+        }
         LogDebug("FedRawDataInputSource") << "No free chunks or threads...";
       } else {
         assert(!(workerPool_.empty() && !singleBufferMode_) || freeChunks_.empty());
@@ -1432,6 +1449,7 @@ inline bool InputFile::advance(unsigned char*& dataPosition, const size_t size) 
 
   if (currentLeft < size) {
     //we need next chunk
+    assert(chunks_.size() > currentChunk_ + 1);
     while (!waitForChunk(currentChunk_ + 1)) {
       parent_->setMonState(inWaitChunk);
       usleep(100000);


### PR DESCRIPTION
#### PR description:

Improved file size limit checks in input sources. Print more debug info when waiting for a buffer.

#### PR validation:

Retested in DAQ test cluster and covered also by unit tests.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #41814
