### PR TITLE
 improved file size/buffer size checks in DAQ input source (13_0_X)

### DIFF
--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -263,6 +263,7 @@ struct InputFile {
   void moveToPreviousChunk(const size_t size, const size_t offset);
   void rewindChunk(const size_t size);
   void unsetDeleteFile() { deleteFile_ = false; }
+  int64_t fileSizeLeft() const { return (int64_t)fileSize_ - (int64_t)bufferPosition_; }
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h


### PR DESCRIPTION
#### PR description:

Improved file size limit checks in input sources. Print more debug info when waiting for a buffer.

#### PR validation:

Retested in DAQ test cluster and covered also by unit tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #41814
Note: only changes to FedRawDataInputSource backported because DAQSource is not present in this branch.