### PR TITLE
Add CaloIdL_MW unseeded filter to nanoAOD filterBits

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -54,7 +54,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
         Electron = cms.PSet(
             doc = cms.string("PixelMatched e/gamma"), # this may also select photons!
             id = cms.int32(11),
-            sel = cms.string("type(92) && pt > 7 && coll('hltEgammaCandidates') && filter('*PixelMatchFilter')"),
+            sel = cms.string("type(92) && pt > 7 && (coll('hltEgammaCandidates') || coll('hltEgammaCandidatesUnseeded')) && (filter('*PixelMatchFilter') || filter('*PixelMatchUnseededFilter'))"),
             l1seed = cms.string("type(-98)"),  l1deltaR = cms.double(0.3),
             #l2seed = cms.string("type(92) && coll('')"),  l2deltaR = cms.double(0.5),
             skipObjectsNotPassingQualityBits = cms.bool(True),
@@ -73,6 +73,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEle*CaloIdVTGsfTrkIdTGsfDphiFilter')","1e (CaloIdVT_GsfTrkIdT)"),
                 mksel("path('HLT_Ele*PFJet*')","1e (PFJet)"),
                 mksel(["hltEG175HEFilter","hltEG200HEFilter"],"1e (Photon175_OR_Photon200)"),
+                mksel("filter('hltDiEle*CaloIdLMWPMS2UnseededFilter')","2e (CaloIdL_MW unseeded)")
                 )
         ),
         Photon = cms.PSet(


### PR DESCRIPTION
The purpose of this PR is to add another wildcard-type filter to the electron filterBit selection in nanoAOD. The filter is:

`hltDiEle*CaloIdLMWPMS2UnseededFilter`

It is the last filter of the unseeded leg of `HLT_DoubleEle*_CaloIdL_MW`, which are used by several analysis. Such an addition is supposed to make it possible for analyzers to calculate data/MC scale factors for these triggers using nanoAOD.

In order to make this possible, a couple changes had to be made at the level of the trigger object selection:

- added the collection `hltEgammaCandidatesUnseeded`, which are the objects on which the selection of the unseeded trigger leg is made;
- allowed `*PixelMatchUnseededFilter`, in OR with `*PixelMatchFilter`.