### PR TITLE
Fix logical error in the check of mask flag bits [13_0_X]

### DIFF
--- a/DQM/EcalMonitorClient/src/MLClient.cc
+++ b/DQM/EcalMonitorClient/src/MLClient.cc
@@ -58,7 +58,7 @@ namespace ecaldqm {
     double pu = sPU.getFloatValue();
 
     //Do not compute ML quality if PU is non existent.
-    if (pu < 0.) {
+    if (pu <= 0.) {
       return;
     }
     uint32_t mask(1 << EcalDQMStatusHelper::PEDESTAL_ONLINE_HIGH_GAIN_RMS_ERROR |

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -39,13 +39,13 @@ namespace ecaldqm {
     MESet& meHit(MEs_.at("Hit"));
     MESet& meHitAll(MEs_.at("HitAll"));
 
-    uint32_t neitherGoodNorPoorCalib(~(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kPoorCalib));
-    uint32_t neitherGoodNorOOT(~(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kOutOfTime));
+    uint32_t goodORPoorCalibBits(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kPoorCalib);
+    uint32_t goodOROOTBits(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kOutOfTime);
 
     for (EcalRecHitCollection::const_iterator hitItr(_hits.begin()); hitItr != _hits.end(); ++hitItr) {
-      if (isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorPoorCalib))
+      if (isPhysicsRun_ && !hitItr->checkFlagMask(goodORPoorCalibBits))
         continue;
-      if (!isPhysicsRun_ && hitItr->checkFlagMask(neitherGoodNorOOT))
+      if (!isPhysicsRun_ && !hitItr->checkFlagMask(goodOROOTBits))
         continue;
 
       float energy(hitItr->energy());

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -198,7 +198,7 @@ namespace ecaldqm {
     MESet& meRecHitThr1D(MEs_.at("RecHitThr1D"));
     MESet& meTrendNRecHitThr(MEs_.at("TrendNRecHitThr"));
 
-    uint32_t mask(~(0x1 << EcalRecHit::kGood));
+    uint32_t goodBits(0x1 << EcalRecHit::kGood);
     double nFiltered(0.);
 
     float nRHThrp(0), nRHThrm(0);
@@ -210,7 +210,7 @@ namespace ecaldqm {
       meRecHitProjEta.fill(getEcalDQMSetupObjects(), id);
       meRecHitProjPhi.fill(getEcalDQMSetupObjects(), id);
 
-      if (!hit.checkFlagMask(mask) && hit.energy() > recHitThreshold_) {
+      if (hit.checkFlagMask(goodBits) && hit.energy() > recHitThreshold_) {
         meRecHitThrProjEta.fill(getEcalDQMSetupObjects(), id);
         meRecHitThrProjPhi.fill(getEcalDQMSetupObjects(), id);
         meRecHitThrAll.fill(getEcalDQMSetupObjects(), id);

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -69,11 +69,11 @@ namespace ecaldqm {
     MESet& meTime1D(MEs_.at("Time1D"));
     MESet& meChi2(MEs_.at("Chi2"));
 
-    uint32_t mask(~((0x1 << EcalRecHit::kGood) | (0x1 << EcalRecHit::kOutOfTime)));
+    uint32_t goodOROOTBits(0x1 << EcalRecHit::kGood | 0x1 << EcalRecHit::kOutOfTime);
     int signedSubdet;
 
     std::for_each(_hits.begin(), _hits.end(), [&](EcalRecHitCollection::value_type const& hit) {
-      if (hit.checkFlagMask(mask))
+      if (!hit.checkFlagMask(goodOROOTBits))
         return;
 
       DetId id(hit.id());


### PR DESCRIPTION
#### PR description:

1) This PR fixes a bug in the ECAL DQM code which affected the check of status flag bits set on each channel.
For eg in EnergyTask.cc [here](https://github.com/cms-sw/cmssw/pull/41830/files#diff-e149a50e5de8ea1748eb4c84b4e56343a2bc188557b1f50268ce94230986d823L42) and [here](https://github.com/cms-sw/cmssw/pull/41830/files#diff-e149a50e5de8ea1748eb4c84b4e56343a2bc188557b1f50268ce94230986d823L46) all other flag bits except kGood and kPoorCalib are being checked when the mask is bitwise inverted, but this is not what was intended. 
The intended behaviour is to check whether kGood or kPoorCalib is set, if not then ignore that channel.
Similar changes are made in other affected files OccupancyTask.cc and TimingTask.cc

2) Another small fix is made to change the PU condition in MLClient.cc to ignore the PU=0 runs for the ML inference.

#### PR validation:

This was validated by running the online DQM workflow and testing the plots on a test DQM GUI.
Also validated by running the runtheMatrix workflow 136.874

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 13_0_X, which is currently used in production.
Master PR is : https://github.com/cms-sw/cmssw/pull/41830
