### PR TITLE
Update 13000 to 13600 in ReweightUserHooks.h for Run3

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -27,7 +27,7 @@ private:
 class PtHatEmpReweightUserHook : public Pythia8::UserHooks {
 public:
   PtHatEmpReweightUserHook(const std::string& tuneName = "") {
-    if (tuneName == "CP5")
+    if (tuneName == "CP5" || tuneName == "CP5Run3")
       p = {7377.94700788, 8.38168461349, -4.70983112392, -0.0310148108446, -0.028798537937, 925.335472326};
     //Default reweighting - works good for tune CUEPT8M1
     else
@@ -37,10 +37,15 @@ public:
            -5.1575514014931e-01,
            5.5951279807561e-02,
            3.5e+02};
-    sigma = [this](double x) -> double {
-      return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-              pow(1 - 2 * x / (13600. + p[5]), p[1])) *
-             x;
+    if (tuneName == "CP5Run3")
+      sigma = [this](double x) -> double {
+        return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
+              pow(1 - 2 * x / (13600. + p[5]), p[1])) * x;
+    else
+      sigma = [this](double x) -> double {
+        return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
+              pow(1 - 2 * x / (13000. + p[5]), p[1])) * x;
+      
     };
   }
   ~PtHatEmpReweightUserHook() override {}

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -37,16 +37,11 @@ public:
            -5.1575514014931e-01,
            5.5951279807561e-02,
            3.5e+02};
-    if (tuneName == "CP5Run3")
-      sigma = [this](double x) -> double {
-        return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-              pow(1 - 2 * x / (13600. + p[5]), p[1])) * x;
-      }
-    else
-      sigma = [this](double x) -> double {
-        return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-              pow(1 - 2 * x / (13000. + p[5]), p[1])) * x;
-      };
+    const double ecms = ( tuneName == "CP5Run3" ? 13600. : 13000.);
+    sigma = [this](double x) -> double {
+      return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
+                  pow(1 - 2 * x / (ecms + p[5]), p[1])) * x;
+    };
   }
   ~PtHatEmpReweightUserHook() override {}
 

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -41,12 +41,12 @@ public:
       sigma = [this](double x) -> double {
         return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
               pow(1 - 2 * x / (13600. + p[5]), p[1])) * x;
+      }
     else
       sigma = [this](double x) -> double {
         return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
               pow(1 - 2 * x / (13000. + p[5]), p[1])) * x;
-      
-    };
+      };
   }
   ~PtHatEmpReweightUserHook() override {}
 

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -37,10 +37,11 @@ public:
            -5.1575514014931e-01,
            5.5951279807561e-02,
            3.5e+02};
-    const double ecms = ( tuneName == "CP5Run3" ? 13600. : 13000.);
+    const double ecms = (tuneName == "CP5Run3" ? 13600. : 13000.);
     sigma = [this](double x) -> double {
       return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-                  pow(1 - 2 * x / (ecms + p[5]), p[1])) * x;
+              pow(1 - 2 * x / (ecms + p[5]), p[1])) *
+             x;
     };
   }
   ~PtHatEmpReweightUserHook() override {}

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -39,7 +39,7 @@ public:
            3.5e+02};
     sigma = [this](double x) -> double {
       return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-              pow(1 - 2 * x / (13000. + p[5]), p[1])) *
+              pow(1 - 2 * x / (13600. + p[5]), p[1])) *
              x;
     };
   }

--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -38,7 +38,7 @@ public:
            5.5951279807561e-02,
            3.5e+02};
     const double ecms = (tuneName == "CP5Run3" ? 13600. : 13000.);
-    sigma = [this](double x) -> double {
+    sigma = [this, ecms](double x) -> double {
       return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
               pow(1 - 2 * x / (ecms + p[5]), p[1])) *
              x;


### PR DESCRIPTION
#### PR description:

Update 13000 to 13600 in ReweightUserHooks.h for Run3

#### PR validation:
the plot below shows the difference between QCD samples using 13000 and 13600, the red histogram is the distribution we want.
![image](https://github.com/cms-sw/cmssw/assets/19426117/2353ff80-2553-4d21-9a44-3b60d3a1f576)

