### PR TITLE
[DAQ] silence ExceptionGenerator gcc12 warning

### DIFF
--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -216,7 +216,7 @@ namespace evf {
           void *vp = malloc(1024);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
-          memset((char *)vp - 32, 0, 1024);
+          memset((char *)vp - 32 + intqualifier_, 0, 1024);
 #pragma GCC diagnostic pop
           free(vp);
         } break;


### PR DESCRIPTION
#### PR description:

Adds runtime variable to a pointer, which silences gcc warning reported in issue #41809

#### PR validation:

None.
Involves only a test module used to intentionally generate crashes.
