### PR TITLE
Phase-2 L1T: update Correlator layer 1 barrel "TDR" regionizer emulator

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
@@ -3,8 +3,8 @@
 
 #include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
 
-#include <list>
 #include <vector>
+#include <map>
 #include <cassert>
 #include <algorithm>
 
@@ -21,58 +21,32 @@ namespace l1ct {
       return local_phi;
     }
 
-    struct RegionInfo {
-      RegionInfo(unsigned int idx, int regphi, int regeta) : index(idx), phi(regphi), eta(regeta) {}
-      unsigned int index;
-      int phi;
-      int eta;
-    };
-
-    inline bool sortRegionInfo(RegionInfo& a, RegionInfo& b) {
-      if (a.phi < b.phi)
-        return true;
-      if (a.phi > b.phi)
-        return false;
-      if (a.eta < b.eta)
-        return true;
-      if (a.eta > b.eta)
-        return false;
-      return false;
-    }
-
+    // These are done per-sector (= per-input link)
     template <typename T>
     class PipeObject {
     public:
       PipeObject() {}
-      PipeObject(const T& obj,
-                 unsigned int phiindex,
-                 unsigned int etaindex,
-                 bool phioverlap,
-                 bool etaoverlap,
-                 int glbphi,
-                 int glbeta,
-                 unsigned int clk);
+      PipeObject(const T& obj, std::vector<size_t> srIndices, int glbphi, int glbeta, unsigned int clk);
 
-      const unsigned int getClock() { return linkobjclk_; }
+      unsigned int getClock() const { return linkobjclk_; }
       void setClock(unsigned int clock) { linkobjclk_ = clock; }
-      const unsigned int getPhi() { return phiindex_; }
-      const unsigned int getEta() { return etaindex_; }
-      const bool getPhiOverlap() { return phioverlap_; }
-      const bool getEtaOverlap() { return etaoverlap_; }
-      const unsigned int getCount() { return objcount_; }
-      unsigned int getCountAndInc() { return objcount_++; }
+      const std::vector<size_t>& getSRIndices() const { return srIndices_; }
+      size_t getNextSRIndex() const { return srIndices_.at(objcount_); }
+      unsigned int getCount() const { return objcount_; }
       void incCount() { objcount_++; }
-      const int getPt() { return obj_.hwPt.to_int(); }
-      const int getGlbPhi() { return glbphi_; }
-      const int getGlbEta() { return glbeta_; }
+      int getPt() const { return obj_.hwPt.to_int(); }
+      int getGlbPhi() const { return glbphi_; }
+      int getGlbEta() const { return glbeta_; }
 
-      T getObj() { return obj_; }
+      T& getRawObj() { return obj_; }
+      const T& getRawObj() const { return obj_; }
 
     private:
       T obj_;
-      unsigned int phiindex_, etaindex_;
-      bool phioverlap_, etaoverlap_;
-      int glbphi_, glbeta_;
+      /// the SR linearized indices (can index regionmap_) where this object needs to go
+      std::vector<size_t> srIndices_;
+      /// The global eta and phi of the object (somewhat redundant with obj_)
+      int glbeta_, glbphi_;
       unsigned int linkobjclk_, objcount_;
     };
 
@@ -81,29 +55,25 @@ namespace l1ct {
     public:
       Pipe(unsigned int nphi = 9) : clkindex_(0), nphi_(nphi) {}
 
-      void addObj(
-          T obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta);
-      PipeObject<T>& getObj(unsigned int index) { return data_[index]; }
-      T getRawObj(unsigned int index) { return data_[index].getObj(); }
+      void addObj(T obj, std::vector<size_t> srs, int glbeta, int glbphi);
 
-      unsigned int getClock(unsigned int index = 0) { return getObj(index).getClock(); }
+      PipeObject<T>& getObj(unsigned int index = 0) { return data_[index]; }
+      const PipeObject<T>& getObj(unsigned int index = 0) const { return data_[index]; }
+
+      unsigned int getClock(unsigned int index = 0) const { return getObj(index).getClock(); }
       void setClock(unsigned int clock, unsigned int index = 0) { return getObj(index).setClock(clock); }
-      unsigned int getPhi(unsigned int index = 0) { return getObj(index).getPhi(); }
-      unsigned int getEta(unsigned int index = 0) { return getObj(index).getEta(); }
-      bool getPhiOverlap(unsigned int index = 0) { return getObj(index).getPhiOverlap(); }
-      bool getEtaOverlap(unsigned int index = 0) { return getObj(index).getEtaOverlap(); }
-      unsigned int getCount(unsigned int index = 0) { return getObj(index).getCount(); }
-      unsigned int getCountAndInc(unsigned int index = 0) { return getObj(index).getCountAndInc(); }
+      unsigned int getCount(unsigned int index = 0) const { return getObj(index).getCount(); }
       void incCount(unsigned int index = 0) { getObj(index).incCount(); }
       void erase(unsigned int index = 0) { data_.erase(data_.begin() + index); }
-      int getPt(unsigned int index = 0) { return getObj(index).getPt(); }
-      int getGlbPhi(unsigned int index = 0) { return getObj(index).getGlbPhi(); }
-      int getGlbEta(unsigned int index = 0) { return getObj(index).getGlbEta(); }
+      int getPt(unsigned int index = 0) const { return getObj(index).getPt(); }
+      int getGlbPhi(unsigned int index = 0) const { return getObj(index).getGlbPhi(); }
+      int getGlbEta(unsigned int index = 0) const { return getObj(index).getGlbEta(); }
 
       int getClosedIndexForObject(unsigned int index = 0);
-      int getPipeIndexForObject(unsigned int index = 0);
+      /// This returns the hardware pipe index (since there are one per SR pair)
+      size_t getPipeIndexForObject(unsigned int index = 0);
 
-      unsigned int getSize() { return data_.size(); }
+      unsigned int getPipeSize() const { return data_.size(); }
 
       void reset() {
         clkindex_ = 0;
@@ -119,85 +89,110 @@ namespace l1ct {
     class Regionizer {
     public:
       Regionizer() {}
-      Regionizer(
-          unsigned int neta, unsigned int nregions, unsigned int maxobjects, int etaoffset, int etawidth, int nclocks);
+      Regionizer(unsigned int neta,
+                 unsigned int nphi,      //the number of eta and phi SRs in a big region (board)
+                 unsigned int nregions,  // The total number of small regions in the full barrel
+                 unsigned int maxobjects,
+                 int bigRegionMin,
+                 int bigRegionMax,  // the phi range covered by this board
+                 int nclocks);
+
       void initSectors(const std::vector<DetectorSector<T>>& sectors);
       void initSectors(const DetectorSector<T>& sector);
       void initRegions(const std::vector<PFInputRegion>& regions);
 
-      unsigned int getSize() { return pipes_.size(); }
-      unsigned int getPipeSize(unsigned int index) { return getPipe(index).getSize(); }
+      // is the given small region in the big region
+      bool isInBigRegion(const PFRegionEmu& reg) const;
 
-      bool setIndicesOverlaps(const T& obj,
-                              unsigned int& phiindex,
-                              unsigned int& etaindex,
-                              bool& phioverlap,
-                              bool& etaoverlap,
-                              int& glbphi,
-                              int& glbeta,
-                              unsigned int index);
+      unsigned int getSize() const { return pipes_.size(); }
+      unsigned int getPipeSize(unsigned int linkIndex) const { return pipes_[linkIndex].getPipeSize(); }
+
+      std::vector<size_t> getSmallRegions(int glbeta, int glbphi) const;
 
       void addToPipe(const T& obj, unsigned int index);
       void setPipe(const std::vector<T>& objvec, unsigned int index);
       void setPipes(const std::vector<std::vector<T>>& objvecvec);
-      Pipe<T>& getPipe(unsigned int index) { return pipes_[index]; }
 
+      // linkIndex == sector
       int getPipeTime(int linkIndex, int linkTimeOfObject, int linkAlgoClockRunningTime);
+
+      /// This either removes the next object on the link or inrements the count; It returns the next time
       int popLinkObject(int linkIndex, int currentTimeOfObject);
-      int timeNextFromIndex(unsigned int index, int time) { return getPipeTime(index, pipes_[index].getClock(), time); }
+      int timeNextFromIndex(unsigned int linkIndex, int time) {
+        return getPipeTime(linkIndex, pipes_[linkIndex].getClock(), time);
+      }
 
       void initTimes();
 
       int getClosedIndexForObject(unsigned int linknum, unsigned int index = 0) {
         return pipes_[linknum].getClosedIndexForObject(index);
       }
-      int getPipeIndexForObject(unsigned int linknum, unsigned int index = 0) {
+
+      /// This retruns the linearized small region associated with the given item
+      size_t getPipeIndexForObject(unsigned int linknum, unsigned int index = 0) {
         return pipes_[linknum].getPipeIndexForObject(index);
       }
+
+      /// This returns the hardware pipe number of the item. Generally two SRs share a pipe
+      size_t getHardwarePipeIndexForObject(unsigned int linknum, unsigned int index = 0) {
+        return getHardwarePipeIndex(getPipeIndexForObject(linknum, index));
+      }
+
+      /// 'put' object in small region
       void addToSmallRegion(unsigned int linkNum, unsigned int index = 0);
 
       void run(bool debug = false);
 
       void reset();
 
-      std::vector<T> getSmallRegion(unsigned int index);
+      /// Return a map of of the SRs indexed by SR index (covering only those from board)
+      std::map<size_t, std::vector<T>> fillRegions(bool doSort);
 
-      void printDebug(int count) {
-        dbgCout() << count << "\tindex\tpt\teta\tphi" << std::endl;
-        dbgCout() << "PIPES" << std::endl;
-        for (unsigned int i = 0; i < getSize(); i++) {
-          for (unsigned int j = 0; j < getPipeSize(i); j++) {
-            dbgCout() << "\t" << i << " " << j << "\t" << getPipe(i).getPt(j) << "\t" << getPipe(i).getGlbEta(j) << "\t"
-                      << getPipe(i).getGlbPhi(j) << std::endl;
-          }
-          dbgCout() << "-------------------------------" << std::endl;
-        }
-        dbgCout() << "SMALL REGIONS" << std::endl;
-        for (unsigned int i = 0; i < nregions_; i++) {
-          for (unsigned int j = 0; j < smallRegionObjects_[i].size(); j++) {
-            dbgCout() << "\t" << i << " " << j << "\t" << smallRegionObjects_[i][j].hwPt.to_int() << "\t"
-                      << smallRegionObjects_[i][j].hwEta.to_int() + regionmap_[i].eta << "\t"
-                      << smallRegionObjects_[i][j].hwPhi.to_int() + regionmap_[i].phi << std::endl;
-          }
-          dbgCout() << "-------------------------------" << std::endl;
-        }
-        dbgCout() << "TIMES" << std::endl;
-        for (unsigned int i = 0; i < timeOfNextObject_.size(); i++) {
-          dbgCout() << "  " << timeOfNextObject_[i];
-        }
-        dbgCout() << "\n-------------------------------" << std::endl;
-      }
+      void printDebug(int count) const;
 
     private:
-      unsigned int neta_, nregions_, maxobjects_, nsectors_;
-      int etaoffset_, etawidth_, nclocks_;
-      std::vector<l1ct::PFRegionEmu> sectors_;
-      std::vector<l1ct::PFRegionEmu> regions_;
-      std::vector<RegionInfo> regionmap_;
+      /// SRs share RAMs (and hardware pipes)
+      static size_t constexpr SRS_PER_RAM = 2;
 
+      /// Because some SRs share pipes, this determines the pipe index for a linearize SR index
+      /// (This is based on the VHDL function, get_target_pipe_index_subindex)
+      size_t getHardwarePipeIndex(size_t srIndex) const { return srIndex / SRS_PER_RAM; }
+
+      // this function is for sorting small regions first in phi and then in eta.
+      // It takes regions_ indices
+      bool sortRegionsRegular(size_t a, size_t b) const;
+
+      /// The numbers of eta and phi in a big region (board)
+      unsigned int neta_, nphi_;
+      /// The total number of small regions in the barrel (not just in the board)
+      unsigned int nregions_;
+      /// The maximum number of objects to output per small region
+      unsigned int maxobjects_;
+      /// The number of input sectors for this type of device
+      unsigned int nsectors_;
+      /// the minimumum phi of this board
+      int bigRegionMin_;
+      /// the maximum phi of this board
+      int bigRegionMax_;
+      /// the number of clocks to receive one event
+      int nclocks_;
+
+      /// the region information assopciated with each input sector
+      std::vector<l1ct::PFRegionEmu> sectors_;
+
+      /// the region information associated with each SR
+      std::vector<l1ct::PFRegionEmu> regions_;
+
+      /// indices of regions that are in the big region (board)
+      std::vector<size_t> regionmap_;
+
+      /// One pipe per each sector (link). These do not correspond to the firmware pipes
       std::vector<Pipe<T>> pipes_;
+      /// One entry per sector (= link = pipe). If the pipe is empty, this is always -1
       std::vector<int> timeOfNextObject_;
-      std::vector<std::vector<T>> smallRegionObjects_;  //keep count to see if small region is full
+
+      /// The objects in each small region handled in board; Indexing corresponds to that in regionmap_
+      std::vector<std::vector<T>> smallRegionObjects_;
     };
 
   }  // namespace  tdr_regionizer

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <map>
+#include <deque>
 #include <cassert>
 #include <algorithm>
 
@@ -13,7 +14,7 @@
 namespace l1ct {
   namespace tdr_regionizer {
 
-    inline int dphi_wrap(int local_phi) {
+    inline int phi_wrap(int local_phi) {
       if (local_phi > l1ct::Scales::INTPHI_PI)
         local_phi -= l1ct::Scales::INTPHI_TWOPI;
       else if (local_phi <= -l1ct::Scales::INTPHI_PI)
@@ -21,127 +22,210 @@ namespace l1ct {
       return local_phi;
     }
 
-    // These are done per-sector (= per-input link)
+    /// corresponds to level1_to_2_pipe_t in firmware
     template <typename T>
-    class PipeObject {
+    class PipeEntry {
     public:
-      PipeObject() {}
-      PipeObject(const T& obj, std::vector<size_t> srIndices, int glbphi, int glbeta, unsigned int clk);
+      PipeEntry() : obj_(), sr_(-1) {}
+      PipeEntry(const T& obj, int sr, int glbeta, int glbphi) : obj_(obj), sr_(sr), glbeta_(glbeta), glbphi_(glbphi) {}
 
-      unsigned int getClock() const { return linkobjclk_; }
-      void setClock(unsigned int clock) { linkobjclk_ = clock; }
-      const std::vector<size_t>& getSRIndices() const { return srIndices_; }
-      size_t getNextSRIndex() const { return srIndices_.at(objcount_); }
-      unsigned int getCount() const { return objcount_; }
-      void incCount() { objcount_++; }
-      int getPt() const { return obj_.hwPt.to_int(); }
-      int getGlbPhi() const { return glbphi_; }
-      int getGlbEta() const { return glbeta_; }
+      int sr() const { return sr_; }
 
-      T& getRawObj() { return obj_; }
-      const T& getRawObj() const { return obj_; }
+      // Note, this returns a copy so you can modify
+      T obj() const { return obj_; }
+
+      bool valid() const { return sr_ >= 0; }
+
+      void setInvalid() { sr_ = -1; }
+
+      int pt() const { return obj_.intPt(); }
+      int glbPhi() const { return glbphi_; }
+      int glbEta() const { return glbeta_; }
+
+    private:
+      T obj_;
+      /// the SR linearized indices (can index regionmap_) where this object needs to go; -1 means invalid
+      int sr_;
+      /// The global eta and phi of the object (hard to get with duplicates)
+      int glbeta_, glbphi_;
+    };
+
+    /// The pipe, with multiple inputs and one output
+    template <typename T>
+    class Pipe {
+    public:
+      /// if using the default constructor, have to call setTaps before use
+      Pipe() : pipe_() {}
+
+      Pipe(size_t ntaps) : pipe_(ntaps) {}
+
+      void setTaps(size_t taps) { pipe_.resize(taps); }
+
+      /// check if the entry is valid (i.e. already has data)
+      bool valid(size_t idx) const { return pipe_.at(idx).valid(); }
+
+      /// should check if valid before adding an entry
+      void addEntry(size_t idx, const PipeEntry<T>& entry) { pipe_[idx] = entry; }
+
+      /// perform one tick, shifting all the entries to higher indices, and returning the last
+      PipeEntry<T> popEntry();
+
+      void reset();
+
+      size_t size() const { return pipe_.size(); }
+
+      /// for debug
+      const PipeEntry<T>& entry(size_t idx) const { return pipe_[idx]; }
+
+    private:
+      std::vector<PipeEntry<T>> pipe_;
+    };
+
+    /// The pipe, with multiple inputs and one output
+    template <typename T>
+    class Pipes {
+    public:
+      /// the number of pipes
+      Pipes(size_t nregions) : pipes_(nregions / SRS_PER_RAM) {}
+
+      /// set the number of taps in each pipe
+      void setTaps(size_t taps);
+
+      /// check if the entry is valid (i.e. already has data)
+      bool valid(int sr, size_t logicBufIdx) const { return pipes_[pipeIndex(sr)].valid(logicBufIdx); }
+
+      /// should check if valid before adding an entry
+      void addEntry(int sr, size_t logicBufIdx, const PipeEntry<T>& entry) {
+        pipes_[pipeIndex(sr)].addEntry(logicBufIdx, entry);
+      }
+
+      /// perform one tick, shifting all the entries to higher indices, and returning the last
+      PipeEntry<T> popEntry(size_t pipe) { return pipes_[pipe].popEntry(); };
+
+      void reset();
+
+      size_t size() const { return pipes_.size(); }
+
+      size_t numTaps() const { return pipes_.at(0).size(); }
+
+      /// for debug
+      const PipeEntry<T>& entry(size_t pipe, size_t tap) const { return pipes_[pipe].entry(tap); }
+
+    private:
+      /// SRs share RAMs (and hardware pipes)
+      static size_t constexpr SRS_PER_RAM = 2;
+
+      /// Because some SRs share pipes, this determines the pipe index for a linearize SR index
+      /// (This is based on the VHDL function, get_target_pipe_index_subindex)
+      size_t pipeIndex(int sr) const { return sr / SRS_PER_RAM; }
+
+      std::vector<Pipe<T>> pipes_;
+    };
+
+    /// the components that make up the L1 regionizer buffer
+    template <typename T>
+    class BufferEntry {
+    public:
+      BufferEntry() {}
+      BufferEntry(const T& obj, std::vector<size_t> srIndices, int glbeta, int glbphi, unsigned int clk);
+
+      unsigned int clock() const { return linkobjclk_; }
+      int nextSR() const { return (objcount_ < srIndices_.size()) ? srIndices_[objcount_] : -1; }
+      void incSR() { objcount_++; }
+      int pt() const { return obj_.intPt(); }
+      int glbPhi() const { return glbphi_; }
+      int glbEta() const { return glbeta_; }
+
+      //T obj() { return obj_; }
+      const T& obj() const { return obj_; }
 
     private:
       T obj_;
       /// the SR linearized indices (can index regionmap_) where this object needs to go
       std::vector<size_t> srIndices_;
-      /// The global eta and phi of the object (somewhat redundant with obj_)
+      /// The global eta and phi of the object (hard to get with duplicates)
       int glbeta_, glbphi_;
       unsigned int linkobjclk_, objcount_;
     };
 
+    /// The L1 regionizer buffer (corresponding to level1_fifo_buffer.vhd)
     template <typename T>
-    class Pipe {
+    class Buffer {
     public:
-      Pipe(unsigned int nphi = 9) : clkindex_(0), nphi_(nphi) {}
+      Buffer() : clkindex360_(INIT360), clkindex240_(INIT240), timeOfNextObject_(-1) {}
 
-      void addObj(T obj, std::vector<size_t> srs, int glbeta, int glbphi);
+      void addEntry(
+          const T& obj, std::vector<size_t> srs, int glbeta, int glbphi, unsigned int dupNum, unsigned int ndup);
 
-      PipeObject<T>& getObj(unsigned int index = 0) { return data_[index]; }
-      const PipeObject<T>& getObj(unsigned int index = 0) const { return data_[index]; }
+      BufferEntry<T>& front() { return data_.front(); }
+      const BufferEntry<T>& front() const { return data_.front(); }
 
-      unsigned int getClock(unsigned int index = 0) const { return getObj(index).getClock(); }
-      void setClock(unsigned int clock, unsigned int index = 0) { return getObj(index).setClock(clock); }
-      unsigned int getCount(unsigned int index = 0) const { return getObj(index).getCount(); }
-      void incCount(unsigned int index = 0) { getObj(index).incCount(); }
-      void erase(unsigned int index = 0) { data_.erase(data_.begin() + index); }
-      int getPt(unsigned int index = 0) const { return getObj(index).getPt(); }
-      int getGlbPhi(unsigned int index = 0) const { return getObj(index).getGlbPhi(); }
-      int getGlbEta(unsigned int index = 0) const { return getObj(index).getGlbEta(); }
+      /// sets the next time something is taken from this buffer
+      void updateNextObjectTime(int currentTime);
 
-      int getClosedIndexForObject(unsigned int index = 0);
-      /// This returns the hardware pipe index (since there are one per SR pair)
-      size_t getPipeIndexForObject(unsigned int index = 0);
+      /// delete the front element
+      void pop() { data_.pop_front(); }
 
-      unsigned int getPipeSize() const { return data_.size(); }
+      // mostly for debug
+      unsigned int clock(unsigned int index = 0) const { return data_[index].clock(); }
+      int pt(unsigned int index = 0) const { return data_[index].pt(); }
+      int glbPhi(unsigned int index = 0) const { return data_[index].glbPhi(); }
+      int glbEta(unsigned int index = 0) const { return data_[index].glbEta(); }
+
+      unsigned int numEntries() const { return data_.size(); }
+
+      /// pop the first entry, formatted for inclusion in pipe
+      PipeEntry<T> popEntry(int currTime, bool debug);
+
+      int timeOfNextObject() const { return timeOfNextObject_; }
 
       void reset() {
-        clkindex_ = 0;
+        clkindex360_ = INIT360;
+        clkindex240_ = INIT240;
         data_.clear();
+        timeOfNextObject_ = -1;
       }
 
     private:
-      unsigned int clkindex_, nphi_;
-      std::vector<PipeObject<T>> data_;
+      // used when building up the linkobjclk_ entries for the BufferEntries
+      unsigned int nextObjClk(unsigned int ndup);
+
+      // transient--used only during event construction, not used after
+      // Counts in 1.39ns increments (i.e. 360 increments by 2, 240 by 3)
+      unsigned int clkindex360_;
+      unsigned int clkindex240_;
+
+      static unsigned int constexpr INIT360 = 1;
+      static unsigned int constexpr INIT240 = 0;
+
+      /// The actual data
+      std::deque<BufferEntry<T>> data_;
+
+      /// the time of the next object in the buffer (-1 if none)
+      int timeOfNextObject_;
     };
 
     template <typename T>
     class Regionizer {
     public:
-      Regionizer() {}
+      Regionizer() = delete;
       Regionizer(unsigned int neta,
-                 unsigned int nphi,      //the number of eta and phi SRs in a big region (board)
-                 unsigned int nregions,  // The total number of small regions in the full barrel
+                 unsigned int nphi,  //the number of eta and phi SRs in a big region (board)
                  unsigned int maxobjects,
                  int bigRegionMin,
                  int bigRegionMax,  // the phi range covered by this board
-                 int nclocks);
+                 unsigned int nclocks,
+                 unsigned int ndup = 1,  // how much one duplicates the inputs (to increase processing bandwidth)
+                 bool debug = false);
 
       void initSectors(const std::vector<DetectorSector<T>>& sectors);
       void initSectors(const DetectorSector<T>& sector);
       void initRegions(const std::vector<PFInputRegion>& regions);
 
-      // is the given small region in the big region
-      bool isInBigRegion(const PFRegionEmu& reg) const;
+      void fillBuffers(const std::vector<DetectorSector<T>>& sectors);
+      void fillBuffers(const DetectorSector<T>& sector);
 
-      unsigned int getSize() const { return pipes_.size(); }
-      unsigned int getPipeSize(unsigned int linkIndex) const { return pipes_[linkIndex].getPipeSize(); }
-
-      std::vector<size_t> getSmallRegions(int glbeta, int glbphi) const;
-
-      void addToPipe(const T& obj, unsigned int index);
-      void setPipe(const std::vector<T>& objvec, unsigned int index);
-      void setPipes(const std::vector<std::vector<T>>& objvecvec);
-
-      // linkIndex == sector
-      int getPipeTime(int linkIndex, int linkTimeOfObject, int linkAlgoClockRunningTime);
-
-      /// This either removes the next object on the link or inrements the count; It returns the next time
-      int popLinkObject(int linkIndex, int currentTimeOfObject);
-      int timeNextFromIndex(unsigned int linkIndex, int time) {
-        return getPipeTime(linkIndex, pipes_[linkIndex].getClock(), time);
-      }
-
-      void initTimes();
-
-      int getClosedIndexForObject(unsigned int linknum, unsigned int index = 0) {
-        return pipes_[linknum].getClosedIndexForObject(index);
-      }
-
-      /// This retruns the linearized small region associated with the given item
-      size_t getPipeIndexForObject(unsigned int linknum, unsigned int index = 0) {
-        return pipes_[linknum].getPipeIndexForObject(index);
-      }
-
-      /// This returns the hardware pipe number of the item. Generally two SRs share a pipe
-      size_t getHardwarePipeIndexForObject(unsigned int linknum, unsigned int index = 0) {
-        return getHardwarePipeIndex(getPipeIndexForObject(linknum, index));
-      }
-
-      /// 'put' object in small region
-      void addToSmallRegion(unsigned int linkNum, unsigned int index = 0);
-
-      void run(bool debug = false);
+      void run();
 
       void reset();
 
@@ -151,21 +235,47 @@ namespace l1ct {
       void printDebug(int count) const;
 
     private:
-      /// SRs share RAMs (and hardware pipes)
-      static size_t constexpr SRS_PER_RAM = 2;
+      /// is the given small region in the big region
+      bool isInBigRegion(const PFRegionEmu& reg) const;
 
-      /// Because some SRs share pipes, this determines the pipe index for a linearize SR index
-      /// (This is based on the VHDL function, get_target_pipe_index_subindex)
-      size_t getHardwarePipeIndex(size_t srIndex) const { return srIndex / SRS_PER_RAM; }
+      /// Does the given region fit in the big region, taking into account overlaps?
+      bool isInBigRegionLoose(const PFRegionEmu& reg) const;
+
+      unsigned int numBuffers() const { return buffers_.size(); }
+      unsigned int numEntries(unsigned int bufferIndex) const { return buffers_[bufferIndex].numEntries(); }
+
+      std::vector<size_t> getSmallRegions(int glbeta, int glbphi) const;
+
+      void addToBuffer(const T& obj, unsigned int index, unsigned int dupNum);
+      void setBuffer(const std::vector<T>& objvec, unsigned int index);
+      void setBuffers(const std::vector<std::vector<T>>&& objvecvec);
+
+      /// This retruns the linearized small region associated with the given item (-1 is throwout)
+      int nextSR(unsigned int linknum, unsigned int index = 0) { return buffers_[linknum].nextSR(index); }
+
+      /// 'put' object in small region
+      void addToSmallRegion(PipeEntry<T>&&);
+
+      /// returns 2D arrays, sectors (links) first dimension, objects second
+      std::vector<std::vector<T>> fillLinks(const std::vector<DetectorSector<T>>& sectors) const;
+      std::vector<std::vector<T>> fillLinks(const DetectorSector<T>& sector) const;
 
       // this function is for sorting small regions first in phi and then in eta.
       // It takes regions_ indices
       bool sortRegionsRegular(size_t a, size_t b) const;
 
+      bool sortSectors(size_t a, size_t b) const;
+
+      bool sortRegionsHelper(int etaa, int etab, int phia, int phib) const;
+
+      /// get the index in regions_ for a particular SR.
+      size_t regionIndex(int sr) const { return regionmap_.at(sr); }
+
+      /// get the logical buffer index (i.e. the index in the order in the firmware)
+      size_t logicBuffIndex(size_t bufIdx) const;
+
       /// The numbers of eta and phi in a big region (board)
       unsigned int neta_, nphi_;
-      /// The total number of small regions in the barrel (not just in the board)
-      unsigned int nregions_;
       /// The maximum number of objects to output per small region
       unsigned int maxobjects_;
       /// The number of input sectors for this type of device
@@ -175,7 +285,9 @@ namespace l1ct {
       /// the maximum phi of this board
       int bigRegionMax_;
       /// the number of clocks to receive one event
-      int nclocks_;
+      unsigned int nclocks_;
+      /// How many buffers per link (default 1)
+      unsigned int ndup_;
 
       /// the region information assopciated with each input sector
       std::vector<l1ct::PFRegionEmu> sectors_;
@@ -186,13 +298,28 @@ namespace l1ct {
       /// indices of regions that are in the big region (board)
       std::vector<size_t> regionmap_;
 
-      /// One pipe per each sector (link). These do not correspond to the firmware pipes
-      std::vector<Pipe<T>> pipes_;
-      /// One entry per sector (= link = pipe). If the pipe is empty, this is always -1
-      std::vector<int> timeOfNextObject_;
+      /// indices maps the sectors from the way they appear in the software to the order they are done in the regionizer
+      std::vector<size_t> sectormap_;
+
+      /// the inverse mapping of sectormap_ (only used for debug printing)
+      std::vector<size_t> invsectormap_;
+
+      /// The buffers. There are ndup_ buffers per link/sector
+      std::vector<Buffer<T>> buffers_;
+
+      /// The pipes, one per ram (see SRS_PER_RAM)
+      Pipes<T> pipes_;
 
       /// The objects in each small region handled in board; Indexing corresponds to that in regionmap_
       std::vector<std::vector<T>> smallRegionObjects_;
+
+      /// Whether this is the first event (since timing is a bit different then)
+      bool firstEvent_;
+
+      /// This is the delay (only applied after first event) before processing starts
+      static unsigned int constexpr DELAY_TO_START = 10;
+
+      bool debug_;
     };
 
   }  // namespace  tdr_regionizer

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
@@ -1,3 +1,6 @@
+#include <stdexcept>
+
+#include "L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.h"
 
 // PIPE ENTRY AND BUFFER
 template <typename T>
@@ -74,7 +77,9 @@ inline unsigned int l1ct::tdr_regionizer::Buffer<T>::nextObjClk(unsigned int ndu
 // explicit for tracks
 template <>
 inline unsigned int l1ct::tdr_regionizer::Buffer<l1ct::TkObjEmu>::nextObjClk(unsigned int ndup) {
-  assert(ndup == 1);
+  if (ndup != 1) {
+    throw std::invalid_argument("Only ndup==1 is currently supported for the TkObjEmu buffers.");
+  }
 
   unsigned int nextVal = std::max(clkindex360_, clkindex240_) / 3;
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
@@ -1,93 +1,49 @@
+
+
 template <typename T>
-l1ct::tdr_regionizer::PipeObject<T>::PipeObject(const T& obj,
-                                                unsigned int phiindex,
-                                                unsigned int etaindex,
-                                                bool phioverlap,
-                                                bool etaoverlap,
-                                                int glbphi,
-                                                int glbeta,
-                                                unsigned int clk)
-    : obj_(obj),
-      phiindex_(phiindex),
-      etaindex_(etaindex),
-      phioverlap_(phioverlap),
-      etaoverlap_(etaoverlap),
-      glbphi_(glbphi),
-      glbeta_(glbeta),
-      linkobjclk_(clk) {
+l1ct::tdr_regionizer::PipeObject<T>::PipeObject(
+    const T& obj, std::vector<size_t> srIndices, int glbphi, int glbeta, unsigned int clk)
+    : obj_(obj), srIndices_(srIndices), glbeta_(glbeta), glbphi_(glbphi), linkobjclk_(clk) {
   objcount_ = 0;
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Pipe<T>::addObj(
-    T obj, unsigned int phiindex, unsigned int etaindex, bool phioverlap, bool etaoverlap, int glbphi, int glbeta) {
-  data_.emplace_back(PipeObject<T>(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, clkindex_++));
+void l1ct::tdr_regionizer::Pipe<T>::addObj(T obj, std::vector<size_t> srIndices, int glbeta, int glbphi) {
+  data_.emplace_back(obj, srIndices, glbeta, glbphi, clkindex_++);
 }
 //explicit for tracker to handle clocking
 template <>
 inline void l1ct::tdr_regionizer::Pipe<l1ct::TkObjEmu>::addObj(l1ct::TkObjEmu obj,
-                                                               unsigned int phiindex,
-                                                               unsigned int etaindex,
-                                                               bool phioverlap,
-                                                               bool etaoverlap,
-                                                               int glbphi,
-                                                               int glbeta) {
-  data_.emplace_back(
-      PipeObject<l1ct::TkObjEmu>(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, clkindex_++));
+                                                               std::vector<size_t> srIndices,
+                                                               int glbeta,
+                                                               int glbphi) {
+  data_.emplace_back(obj, srIndices, glbeta, glbphi, clkindex_++);
   if (clkindex_ % 3 == 2)
     clkindex_++;  //this is for tracker, could I get this generically maybe?
 }
 
 template <typename T>
-int l1ct::tdr_regionizer::Pipe<T>::getClosedIndexForObject(unsigned int index) {
-  switch (getCount(index)) {
-    case 0:
-      return getPhi(index) * 2 + getEta(index);
-    case 1:
-      if (getPhiOverlap(index) && !getEtaOverlap(index))
-        return ((getPhi(index) + 1) % nphi_) * 2 + getEta(index);
-      else  //eta overlap, or 4-small-region overlap
-        return getPhi(index) * 2 + getEta(index) + 1;
-    case 2:
-      return ((getPhi(index) + 1) % nphi_) * 2 + getEta(index);
-    case 3:
-      return ((getPhi(index) + 1) % nphi_) * 2 + getEta(index) + 1;
-    default:
-      dbgCout() << "Impossible object count!" << std::endl;
-      exit(0);
-  }
+size_t l1ct::tdr_regionizer::Pipe<T>::getPipeIndexForObject(unsigned int index) {
+  return getObj(index).getNextSRIndex();
 }
 
 template <typename T>
-int l1ct::tdr_regionizer::Pipe<T>::getPipeIndexForObject(unsigned int index) {
-  switch (getCount(index)) {
-    case 0:
-      return getPhi(index);
-    case 1:
-      if (getPhiOverlap(index) && !getEtaOverlap(index))
-        return (getPhi(index) + 1) % nphi_;
-      else
-        return getPhi(index);
-    case 2:
-    case 3:
-      return (getPhi(index) + 1) % nphi_;
-    default:
-      dbgCout() << "Impossible object count!" << std::endl;
-      exit(0);
-  }
-}
-
-template <typename T>
-l1ct::tdr_regionizer::Regionizer<T>::Regionizer(
-    unsigned int neta, unsigned int nregions, unsigned int maxobjects, int etaoffset, int etawidth, int nclocks)
+l1ct::tdr_regionizer::Regionizer<T>::Regionizer(unsigned int neta,
+                                                unsigned int nphi,
+                                                unsigned int nregions,
+                                                unsigned int maxobjects,
+                                                int bigRegionMin,
+                                                int bigRegionMax,
+                                                int nclocks)
     : neta_(neta),
+      nphi_(nphi),
       nregions_(nregions),
       maxobjects_(maxobjects),
       nsectors_(0),
-      etaoffset_(etaoffset),
-      etawidth_(etawidth),
+      bigRegionMin_(bigRegionMin),
+      bigRegionMax_(bigRegionMax),
       nclocks_(nclocks) {
-  smallRegionObjects_.resize(nregions);
+  smallRegionObjects_.resize(neta_ * nphi_);
 }
 
 template <typename T>
@@ -109,91 +65,116 @@ void l1ct::tdr_regionizer::Regionizer<T>::initSectors(const DetectorSector<T>& s
   pipes_.resize(nsectors_);
 }
 
+// this function is for sorting small regions first
+// in eta first, then in phi
+template <typename T>
+bool l1ct::tdr_regionizer::Regionizer<T>::sortRegionsRegular(size_t a, size_t b) const {
+  // first do eta
+  auto etaa = regions_[a].intEtaCenter();
+  auto etab = regions_[b].intEtaCenter();
+  if (etaa < etab) {
+    return true;
+  } else if (etaa > etab) {
+    return false;
+  }
+
+  // if here, then etaa == etab, move to phi
+  auto phia = regions_[a].intPhiCenter();
+  auto phib = regions_[b].intPhiCenter();
+  if (bigRegionMax_ < bigRegionMin_) {
+    // the wraparound case
+    if (phia > bigRegionMin_ && phib < bigRegionMax_) {
+      return true;
+    } else if (phib > bigRegionMin_ && phia < bigRegionMax_) {
+      return false;
+    }
+  }
+  // regular phi
+  if (phia < phib) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion>& regions) {
   regions_.resize(regions.size());
-  regionmap_.clear();
   for (unsigned int i = 0; i < regions.size(); ++i) {
     regions_[i] = regions[i].region;
-    if (etaoffset_ - etawidth_ <= regions_[i].intEtaCenter() && regions_[i].intEtaCenter() < etaoffset_ + etawidth_) {
-      regionmap_.emplace_back(i, regions_[i].intPhiCenter(), regions_[i].intEtaCenter());
+    // dbgCout() << "region eta/phi: " << regions_[i].intEtaCenter() << " " << regions_[i].intPhiCenter()
+    //                 << ", eta half width = " << regions_[i].hwEtaHalfWidth.to_int()
+    //                 << ", phi half width = " << regions_[i].hwPhiHalfWidth.to_int()
+    //                 << ", eta extra = " << regions_[i].hwEtaExtra.to_int()
+    //                 << ", phi extra = " << regions_[i].hwPhiExtra.to_int() << std::endl;
+    if (isInBigRegion(regions_[i])) {
+      regionmap_.push_back(i);
     }
   }
-  assert(regionmap_.size() == nregions_);
-  std::sort(regionmap_.begin(), regionmap_.end(), sortRegionInfo);
+  assert(regionmap_.size() == neta_ * nphi_);
+  std::sort(
+      regionmap_.begin(), regionmap_.end(), [this](size_t a, size_t b) { return this->sortRegionsRegular(a, b); });
 }
 
 template <typename T>
-bool l1ct::tdr_regionizer::Regionizer<T>::setIndicesOverlaps(const T& obj,
-                                                             unsigned int& phiindex,
-                                                             unsigned int& etaindex,
-                                                             bool& phioverlap,
-                                                             bool& etaoverlap,
-                                                             int& glbphi,
-                                                             int& glbeta,
-                                                             unsigned int index) {
-  glbphi = sectors_[index].hwGlbPhiOf(obj).to_int();
-  glbeta = sectors_[index].hwGlbEtaOf(obj).to_int();
-  phiindex = nregions_;
-  etaindex = nregions_;
-  phioverlap = false;
-  etaoverlap = false;
-  bool isset = false;
-  for (unsigned int i = 0; i < nregions_; i++) {
-    int regphi = dphi_wrap(glbphi - regionmap_[i].phi);
-    int regeta = glbeta - regionmap_[i].eta;
+bool l1ct::tdr_regionizer::Regionizer<T>::isInBigRegion(const PFRegionEmu& reg) const {
+  auto phi = reg.intPhiCenter();
+  if (bigRegionMax_ < bigRegionMin_) {
+    // the wraparound case
+    return phi > bigRegionMin_ || phi < bigRegionMax_;
+  } else {
+    // the normal case
+    return phi > bigRegionMin_ && phi < bigRegionMax_;
+  }
+}
 
-    if (regions_[regionmap_[i].index].isInside(regeta, regphi)) {
-      if (isset) {
-        if (i / neta_ != phiindex)
-          phioverlap = true;
-        if (i % neta_ != etaindex)
-          etaoverlap = true;
-      }
-      if (i / neta_ < phiindex || (i > (nregions_ - neta_) && phiindex == 0)) {
-        phiindex = i / neta_;
-      }
-      if (i % neta_ < etaindex) {
-        etaindex = i % neta_;
-        isset = true;  //only need to check eta to set since there is full coverage in each board in phi
-      }
+template <typename T>
+std::vector<size_t> l1ct::tdr_regionizer::Regionizer<T>::getSmallRegions(int glbeta, int glbphi) const {
+  std::vector<size_t> srIndices;  // the signal regions this object should go into
+
+  // only iterate over regions covered by board
+  for (size_t i = 0; i < regionmap_.size(); i++) {
+    auto regionidx = regionmap_[i];
+    int regphi = dphi_wrap(glbphi - regions_[regionidx].intPhiCenter());
+    int regeta = glbeta - regions_[regionidx].intEtaCenter();
+
+    if (regions_[regionidx].isInside(regeta, regphi)) {
+      srIndices.push_back(i);
     }
   }
-  if (isset && etaindex == 1 && etaoverlap) {
-    etaoverlap = false;
-  }
-  return isset;
+  return srIndices;
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::addToPipe(const T& obj, unsigned int index) {
-  assert(index < getSize());
-  unsigned int phiindex, etaindex;
-  bool phioverlap, etaoverlap;
-  int glbphi, glbeta;
-  bool isset = setIndicesOverlaps(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta, index);
-  if (isset) {
-    pipes_[index].addObj(obj, phiindex, etaindex, phioverlap, etaoverlap, glbphi, glbeta);
+void l1ct::tdr_regionizer::Regionizer<T>::addToPipe(const T& obj, unsigned int sector) {
+  assert(sector < getSize());
+  auto glbphi = sectors_[sector].hwGlbPhiOf(obj).to_int();
+  auto glbeta = sectors_[sector].hwGlbEtaOf(obj).to_int();
+  // get the SR indices that this object should go into
+  std::vector<size_t> srIndices = getSmallRegions(glbeta, glbphi);
+  if (!srIndices.empty()) {
+    pipes_[sector].addObj(obj, srIndices, glbeta, glbphi);
   }
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::setPipe(const std::vector<T>& objvec, unsigned int index) {
-  assert(index < getSize());
-  pipes_[index].reset();
+void l1ct::tdr_regionizer::Regionizer<T>::setPipe(const std::vector<T>& objvec, unsigned int sector) {
+  assert(sector < getSize());
+  pipes_[sector].reset();
   for (unsigned int i = 0; i < objvec.size(); i++) {
-    addToPipe(objvec[i], index);
+    addToPipe(objvec[i], sector);
   }
 }
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::setPipes(const std::vector<std::vector<T>>& objvecvec) {
   assert(getSize() == objvecvec.size());
-  for (unsigned int i = 0; i < getSize(); i++) {
-    setPipe(objvecvec[i], i);
+  for (unsigned int sector = 0; sector < getSize(); sector++) {
+    setPipe(objvecvec[sector], sector);
   }
 }
 
+// NEED TO CHECK CONSTANTS HERE
 template <typename T>
 int l1ct::tdr_regionizer::Regionizer<T>::getPipeTime(int linkIndex,
                                                      int linkTimeOfObject,
@@ -208,35 +189,28 @@ int l1ct::tdr_regionizer::Regionizer<T>::getPipeTime(int linkIndex,
 
 template <typename T>
 int l1ct::tdr_regionizer::Regionizer<T>::popLinkObject(int linkIndex, int currentTimeOfObject) {
-  pipes_[linkIndex].incCount();
-
-  //determine which object is next and at what time
-  unsigned int countToBeDone = 1;
-  if (pipes_[linkIndex].getPhiOverlap() && pipes_[linkIndex].getEtaOverlap())
-    countToBeDone = 4;
-  else if (pipes_[linkIndex].getPhiOverlap() || pipes_[linkIndex].getEtaOverlap())
-    countToBeDone = 2;
-
-  if (countToBeDone == pipes_[linkIndex].getCount()) {
-    //pop off leading object, done with it
-    pipes_[linkIndex].erase();
-
-    //get time of next object
-    if (pipes_[linkIndex].getSize())
-      return getPipeTime(linkIndex, pipes_[linkIndex].getClock(), currentTimeOfObject);
-    else  //no more objects on link
-      return -1;
-  } else {
-    //increment time for next overlapped object on this link
+  auto& obj = pipes_[linkIndex].getObj();
+  obj.incCount();
+  if (obj.getCount() < obj.getSRIndices().size()) {
+    // Continue working on the same object, since it goes in multiple SRs due to overlaps
     return currentTimeOfObject + 1;
+  } else {
+    // move on to next item in pipe
+    pipes_[linkIndex].erase();
+    //get time of next object
+    if (getPipeSize(linkIndex)) {
+      return getPipeTime(linkIndex, pipes_[linkIndex].getClock(), currentTimeOfObject);
+    } else {  //no more objects on link
+      return -1;
+    }
   }
 }
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::initTimes() {
-  for (unsigned int l = 0; l < getSize(); ++l) {
-    if (getPipeSize(l)) {
-      timeOfNextObject_.push_back(timeNextFromIndex(l, -1));
+  for (unsigned int sector = 0; sector < getSize(); ++sector) {
+    if (getPipeSize(sector)) {
+      timeOfNextObject_.push_back(timeNextFromIndex(sector, -1));
     } else {
       timeOfNextObject_.push_back(-1);
     }
@@ -245,11 +219,8 @@ void l1ct::tdr_regionizer::Regionizer<T>::initTimes() {
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::addToSmallRegion(unsigned int linkNum, unsigned int index) {
-  T theobj = pipes_[linkNum].getRawObj(index);
-  unsigned int regind = getClosedIndexForObject(linkNum);
-  theobj.hwPhi = dphi_wrap(pipes_[linkNum].getGlbPhi(index) - regionmap_[regind].phi);
-  theobj.hwEta = pipes_[linkNum].getGlbEta(index) - regionmap_[regind].eta;
-  smallRegionObjects_[regind].push_back(theobj);
+  auto pipeObj = pipes_[linkNum].getObj(index);
+  smallRegionObjects_[pipeObj.getNextSRIndex()].push_back(pipeObj.getRawObj());
 }
 
 template <typename T>
@@ -260,43 +231,50 @@ void l1ct::tdr_regionizer::Regionizer<T>::run(bool debug) {
   while (loopCount < 972) {  //this is the max allowable if nothing ever blocks
     //init min time, pipe, and link index
     //      to find the target pipe currently with action
-    int minp = -1;
-    int minl = -1;
+    int minPipeIndex = -1;
+    int minLinkIndex = -1;
     int minTime = 0;
 
     //do pipe-full handling
-    for (unsigned int l = 0; l < getSize(); ++l) {
-      if (timeOfNextObject_[l] >= 0 && smallRegionObjects_[getClosedIndexForObject(l)].size() == maxobjects_) {
+    for (unsigned int sector = 0; sector < getSize(); ++sector) {
+      if (timeOfNextObject_[sector] >= 0 && smallRegionObjects_[getPipeIndexForObject(sector)].size() == maxobjects_) {
         //pipe is full so proceed to next object
         //'remove' the selected object from its link
-        timeOfNextObject_[l] = popLinkObject(l, timeOfNextObject_[l]);
+        timeOfNextObject_[sector] = popLinkObject(sector, timeOfNextObject_[sector]);
       }  //end pipe-full handling loop
     }
 
     //do find object handling
-    for (unsigned int l = 0; l < getSize(); ++l) {
-      if (timeOfNextObject_[l] >= 0 && (minl == -1 || timeOfNextObject_[l] < minTime)) {
+    for (unsigned int sector = 0; sector < getSize(); ++sector) {
+      // dbgCout() << "secotor = " << sector << ", timeOfNextObject_[sector] = " << timeOfNextObject_[sector]
+      //   << ", minLinkIndex = " << minLinkIndex << ", minTime = " << minTime << ", minPipeIndex = " << minPipeIndex << std::endl;
+      if (timeOfNextObject_[sector] >= 0 && (minLinkIndex == -1 || timeOfNextObject_[sector] < minTime)) {
         //found new 'selected' link object and pipe
-        minp = getPipeIndexForObject(l);
-        minTime = timeOfNextObject_[l];
-        minl = l;
-      } else if (getPipeSize(l) && minl >= 0 && minp == getPipeIndexForObject(l) && timeOfNextObject_[l] == minTime) {
+        minPipeIndex = getHardwarePipeIndexForObject(sector);
+        minTime = timeOfNextObject_[sector];
+        minLinkIndex = sector;
+      } else if (getPipeSize(sector) && minLinkIndex >= 0 &&
+                 minPipeIndex == static_cast<int>(getHardwarePipeIndexForObject(sector)) &&
+                 timeOfNextObject_[sector] == minTime) {
         //have pipe conflict, so need to wait a clock
-        ++timeOfNextObject_[l];
+        ++timeOfNextObject_[sector];
       }
     }
 
-    if (minl < 0)
+    // dbgCout() << " After, minLinkIndex = " << minLinkIndex << ", minTime = " << minTime << ", minPipeIndex = " << minPipeIndex << std::endl;
+
+    if (minLinkIndex < 0)
       break;  //exit case
 
     //'put' object in small region
-    addToSmallRegion(minl);
+    addToSmallRegion(minLinkIndex);
 
     //'remove' the selected object from its link
-    int nextTime = popLinkObject(minl, timeOfNextObject_[minl]);
-    if (nextTime > nclocks_)
+    int nextTime = popLinkObject(minLinkIndex, timeOfNextObject_[minLinkIndex]);
+    if (nextTime > nclocks_) {
       break;
-    timeOfNextObject_[minl] = nextTime;
+    }
+    timeOfNextObject_[minLinkIndex] = nextTime;
     ++loopCount;
   }  //end main loop
 
@@ -306,20 +284,51 @@ void l1ct::tdr_regionizer::Regionizer<T>::run(bool debug) {
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::reset() {
-  for (unsigned int i = 0; i < getSize(); i++) {
-    pipes_[i].reset();
+  for (auto& pipe : pipes_) {
+    pipe.reset();
   }
   timeOfNextObject_.clear();
-  for (unsigned int i = 0; i < nregions_; i++) {
-    smallRegionObjects_[i].clear();
+  for (auto& smallRegionObject : smallRegionObjects_) {
+    smallRegionObject.clear();
   }
 }
 
 template <typename T>
-std::vector<T> l1ct::tdr_regionizer::Regionizer<T>::getSmallRegion(unsigned int index) {
-  for (unsigned int i = 0; i < nregions_; i++) {
-    if (regionmap_[i].index == index)
-      return smallRegionObjects_[i];
+std::map<size_t, std::vector<T>> l1ct::tdr_regionizer::Regionizer<T>::fillRegions(bool doSort) {
+  std::map<size_t, std::vector<T>> srMap;
+  for (size_t sr = 0; sr < smallRegionObjects_.size(); sr++) {
+    srMap[regionmap_[sr]] = smallRegionObjects_[sr];
+    if (doSort) {
+      std::sort(srMap[regionmap_[sr]].begin(), srMap[regionmap_[sr]].end(), std::greater<>());
+    }
   }
-  return {};
+  return srMap;
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::printDebug(int count) const {
+  dbgCout() << "PIPES, (for " << getSize() << " sectors)" << std::endl;
+  dbgCout() << count << "\tsector\titem\tpt\teta\tphi" << std::endl;
+  for (unsigned int sector = 0; sector < getSize(); sector++) {
+    for (unsigned int j = 0; j < getPipeSize(sector); j++) {
+      dbgCout() << "\t" << sector << "\t" << j << "\t" << pipes_[sector].getPt(j) << "\t" << pipes_[sector].getGlbEta(j)
+                << "\t" << pipes_[sector].getGlbPhi(j) << std::endl;
+    }
+    dbgCout() << "-------------------------------" << std::endl;
+  }
+  dbgCout() << "SMALL REGIONS" << std::endl;
+  for (unsigned int region = 0; region < neta_ * nphi_; region++) {
+    dbgCout() << count << "\tregion\titem\tpt\tloceta\tlocphi" << std::endl;
+    for (unsigned int j = 0; j < smallRegionObjects_[region].size(); j++) {
+      dbgCout() << "\t" << region << " " << j << "\t" << smallRegionObjects_[region][j].hwPt.to_int() << "\t"
+                << smallRegionObjects_[region][j].hwEta.to_int() << "\t"
+                << smallRegionObjects_[region][j].hwPhi.to_int() << std::endl;
+    }
+    dbgCout() << "-------------------------------" << std::endl;
+  }
+  dbgCout() << "TIMES" << std::endl;
+  for (unsigned int i = 0; i < timeOfNextObject_.size(); i++) {
+    dbgCout() << "  " << timeOfNextObject_[i];
+  }
+  dbgCout() << "\n-------------------------------" << std::endl;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_elements_ref.icc
@@ -1,77 +1,230 @@
 
+// PIPE ENTRY AND BUFFER
+template <typename T>
+l1ct::tdr_regionizer::PipeEntry<T> l1ct::tdr_regionizer::Pipe<T>::popEntry() {
+  assert(pipe_.size() > 0);
+  auto last = pipe_.back();
+  // shift one over
+  for (size_t i = pipe_.size() - 1; i > 0; --i) {
+    pipe_[i] = pipe_[i - 1];
+  }
+  pipe_[0].setInvalid();
+  return last;
+}
 
 template <typename T>
-l1ct::tdr_regionizer::PipeObject<T>::PipeObject(
-    const T& obj, std::vector<size_t> srIndices, int glbphi, int glbeta, unsigned int clk)
+void l1ct::tdr_regionizer::Pipe<T>::reset() {
+  for (auto& pe : pipe_) {
+    pe.setInvalid();
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Pipes<T>::reset() {
+  for (auto& pipe : pipes_) {
+    pipe.reset();
+  }
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Pipes<T>::setTaps(size_t taps) {
+  for (auto& pipe : pipes_) {
+    pipe.setTaps(taps);
+  }
+}
+
+// BUFFER ENTRY AND BUFFER
+template <typename T>
+l1ct::tdr_regionizer::BufferEntry<T>::BufferEntry(
+    const T& obj, std::vector<size_t> srIndices, int glbeta, int glbphi, unsigned int clk)
     : obj_(obj), srIndices_(srIndices), glbeta_(glbeta), glbphi_(glbphi), linkobjclk_(clk) {
   objcount_ = 0;
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Pipe<T>::addObj(T obj, std::vector<size_t> srIndices, int glbeta, int glbphi) {
-  data_.emplace_back(obj, srIndices, glbeta, glbphi, clkindex_++);
-}
-//explicit for tracker to handle clocking
-template <>
-inline void l1ct::tdr_regionizer::Pipe<l1ct::TkObjEmu>::addObj(l1ct::TkObjEmu obj,
-                                                               std::vector<size_t> srIndices,
-                                                               int glbeta,
-                                                               int glbphi) {
-  data_.emplace_back(obj, srIndices, glbeta, glbphi, clkindex_++);
-  if (clkindex_ % 3 == 2)
-    clkindex_++;  //this is for tracker, could I get this generically maybe?
+inline void l1ct::tdr_regionizer::Buffer<T>::addEntry(
+    const T& obj, std::vector<size_t> srIndices, int glbeta, int glbphi, unsigned int dupNum, unsigned int ndup) {
+  // dupNum is the duplicate number of this buffer (int range 0 to ndup_-1)
+  auto objClk = nextObjClk(ndup);
+  data_.emplace_back(obj, srIndices, glbeta, glbphi, objClk);
+  if (timeOfNextObject_ < 0) {
+    timeOfNextObject_ = objClk;
+  }
 }
 
 template <typename T>
-size_t l1ct::tdr_regionizer::Pipe<T>::getPipeIndexForObject(unsigned int index) {
-  return getObj(index).getNextSRIndex();
+void l1ct::tdr_regionizer::Buffer<T>::updateNextObjectTime(int currTime) {
+  if (data_.size() > 0) {
+    timeOfNextObject_ = std::max(front().clock(), static_cast<unsigned int>(currTime + 1));
+  } else {
+    timeOfNextObject_ = -1;
+  }
 }
 
+template <typename T>
+inline unsigned int l1ct::tdr_regionizer::Buffer<T>::nextObjClk(unsigned int ndup) {
+  unsigned int nextVal = std::max(clkindex360_, clkindex240_) / 3;
+
+  clkindex360_ += 2 * ndup;
+  clkindex240_ += 3;
+
+  return nextVal;
+}
+
+// explicit for tracks
+template <>
+inline unsigned int l1ct::tdr_regionizer::Buffer<l1ct::TkObjEmu>::nextObjClk(unsigned int ndup) {
+  assert(ndup == 1);
+
+  unsigned int nextVal = std::max(clkindex360_, clkindex240_) / 3;
+
+  clkindex360_ += 2;
+  if ((clkindex360_ - INIT360) % 6 == 4) {
+    clkindex360_ += 2;
+  }
+
+  clkindex240_ += 3;
+
+  return nextVal;
+}
+
+template <typename T>
+l1ct::tdr_regionizer::PipeEntry<T> l1ct::tdr_regionizer::Buffer<T>::popEntry(int currTime, bool debug) {
+  if (front().nextSR() < 0) {
+    // throwout
+    pop();
+    if (debug) {
+      dbgCout() << "updating time clock = " << front().clock() << ", currTime = " << currTime << std::endl;
+    }
+    updateNextObjectTime(currTime);
+    return l1ct::tdr_regionizer::PipeEntry<T>();
+  }
+
+  auto pipeEntry =
+      l1ct::tdr_regionizer::PipeEntry<T>(front().obj(), front().nextSR(), front().glbEta(), front().glbPhi());
+  front().incSR();
+  if (front().nextSR() < 0) {
+    // no more SRs for current front
+    pop();
+  } else {
+    if (debug) {
+      dbgCout() << "Remain on same object, nextSR = " << front().nextSR() << std::endl;
+    }
+    // this is a processing_stall, but throwouts that follow can still be dropped
+    // due to the pipeline have to look two ticks back
+    if (numEntries() > 1 && data_[1].nextSR() == -1 && static_cast<int>(data_[1].clock()) == currTime + 2) {
+      if (debug) {
+        dbgCout() << "removing a following throwout with time " << data_[1].clock() << std::endl;
+      }
+      data_.erase(data_.begin() + 1);
+    } else if (numEntries() > 2 && data_[2].nextSR() == -1 && static_cast<int>(data_[2].clock()) <= currTime + 2) {
+      if (debug) {
+        dbgCout() << "removing the two-back throwout with time " << data_[2].clock() << std::endl;
+      }
+      data_.erase(data_.begin() + 2);
+    }
+  }
+  if (debug) {
+    dbgCout() << "updating time clock = " << front().clock() << ", currTime = " << currTime << std::endl;
+  }
+
+  updateNextObjectTime(currTime);
+  return pipeEntry;
+}
+
+// REGIONIZER
 template <typename T>
 l1ct::tdr_regionizer::Regionizer<T>::Regionizer(unsigned int neta,
                                                 unsigned int nphi,
-                                                unsigned int nregions,
                                                 unsigned int maxobjects,
                                                 int bigRegionMin,
                                                 int bigRegionMax,
-                                                int nclocks)
+                                                unsigned int nclocks,
+                                                unsigned int ndup,
+                                                bool debug)
     : neta_(neta),
       nphi_(nphi),
-      nregions_(nregions),
       maxobjects_(maxobjects),
       nsectors_(0),
       bigRegionMin_(bigRegionMin),
       bigRegionMax_(bigRegionMax),
-      nclocks_(nclocks) {
-  smallRegionObjects_.resize(neta_ * nphi_);
-}
+      nclocks_(nclocks),
+      ndup_(ndup),
+      pipes_(neta * nphi),
+      smallRegionObjects_(neta * nphi),
+      firstEvent_(true),
+      debug_(debug) {}
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::initSectors(const std::vector<DetectorSector<T>>& sectors) {
   assert(nsectors_ == 0);
-  nsectors_ = sectors.size();
-  sectors_.resize(nsectors_);
-  pipes_.resize(nsectors_);
-  for (unsigned int i = 0; i < nsectors_; ++i) {
-    sectors_[i] = sectors[i].region;
+
+  // we need a mapping of physical (what's in the sectors variable) to logical,
+  // but it's easier to create the inverse, first
+
+  for (const auto& sector : sectors) {
+    if (isInBigRegionLoose(sector.region)) {
+      invsectormap_.push_back(sectors_.size());
+      sectors_.push_back(sector.region);
+    }
   }
+  nsectors_ = sectors_.size();
+  buffers_.resize(nsectors_ * ndup_);
+  if (debug_) {
+    dbgCout() << "Number of sectors: " << nsectors_ << std::endl;
+  }
+
+  std::sort(invsectormap_.begin(), invsectormap_.end(), [this](size_t a, size_t b) { return this->sortSectors(a, b); });
+
+  // now invert the invsectormap_
+  sectormap_.resize(invsectormap_.size());
+  for (size_t i = 0; i < invsectormap_.size(); ++i) {
+    sectormap_[invsectormap_[i]] = i;
+  }
+
+  pipes_.setTaps(nsectors_ * ndup_);
 }
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::initSectors(const DetectorSector<T>& sector) {
   assert(nsectors_ == 0);
   nsectors_ = 1;
-  sectors_.resize(1, sector.region);
-  pipes_.resize(nsectors_);
+  sectors_.push_back(sector.region);
+  sectormap_.push_back(0);
+  buffers_.resize(nsectors_ * ndup_);
+  if (debug_) {
+    dbgCout() << "Number of sectors: " << nsectors_ << std::endl;
+  }
+  pipes_.setTaps(nsectors_ * ndup_);
 }
 
-// this function is for sorting small regions first
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::fillBuffers(const std::vector<DetectorSector<T>>& sectors) {
+  setBuffers(fillLinks(sectors));
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::fillBuffers(const DetectorSector<T>& sector) {
+  setBuffers(fillLinks(sector));
+}
+
+// this function is for sorting small regions
 // in eta first, then in phi
 template <typename T>
 bool l1ct::tdr_regionizer::Regionizer<T>::sortRegionsRegular(size_t a, size_t b) const {
   // first do eta
   auto etaa = regions_[a].intEtaCenter();
   auto etab = regions_[b].intEtaCenter();
+  auto phia = regions_[a].intPhiCenter();
+  auto phib = regions_[b].intPhiCenter();
+  return sortRegionsHelper(etaa, etab, phia, phib);
+}
+
+// this function is for sorting small regions
+// in eta first, then in phi
+template <typename T>
+bool l1ct::tdr_regionizer::Regionizer<T>::sortRegionsHelper(int etaa, int etab, int phia, int phib) const {
+  // first do eta
   if (etaa < etab) {
     return true;
   } else if (etaa > etab) {
@@ -79,8 +232,6 @@ bool l1ct::tdr_regionizer::Regionizer<T>::sortRegionsRegular(size_t a, size_t b)
   }
 
   // if here, then etaa == etab, move to phi
-  auto phia = regions_[a].intPhiCenter();
-  auto phib = regions_[b].intPhiCenter();
   if (bigRegionMax_ < bigRegionMin_) {
     // the wraparound case
     if (phia > bigRegionMin_ && phib < bigRegionMax_) {
@@ -97,16 +248,30 @@ bool l1ct::tdr_regionizer::Regionizer<T>::sortRegionsRegular(size_t a, size_t b)
   }
 }
 
+// this function is for sorting the sectors
+// in eta first, then in phi
+template <typename T>
+bool l1ct::tdr_regionizer::Regionizer<T>::sortSectors(size_t a, size_t b) const {
+  // first do eta
+  auto etaa = sectors_[a].intEtaCenter();
+  auto etab = sectors_[b].intEtaCenter();
+  auto phia = sectors_[a].intPhiCenter();
+  auto phib = sectors_[b].intPhiCenter();
+  return sortRegionsHelper(etaa, etab, phia, phib);
+}
+
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::initRegions(const std::vector<PFInputRegion>& regions) {
   regions_.resize(regions.size());
   for (unsigned int i = 0; i < regions.size(); ++i) {
     regions_[i] = regions[i].region;
-    // dbgCout() << "region eta/phi: " << regions_[i].intEtaCenter() << " " << regions_[i].intPhiCenter()
-    //                 << ", eta half width = " << regions_[i].hwEtaHalfWidth.to_int()
-    //                 << ", phi half width = " << regions_[i].hwPhiHalfWidth.to_int()
-    //                 << ", eta extra = " << regions_[i].hwEtaExtra.to_int()
-    //                 << ", phi extra = " << regions_[i].hwPhiExtra.to_int() << std::endl;
+    if (debug_) {
+      dbgCout() << "region eta/phi: " << regions_[i].intEtaCenter() << " " << regions_[i].intPhiCenter()
+                << ", eta half width = " << regions_[i].hwEtaHalfWidth.to_int()
+                << ", phi half width = " << regions_[i].hwPhiHalfWidth.to_int()
+                << ", eta extra = " << regions_[i].hwEtaExtra.to_int()
+                << ", phi extra = " << regions_[i].hwPhiExtra.to_int() << std::endl;
+    }
     if (isInBigRegion(regions_[i])) {
       regionmap_.push_back(i);
     }
@@ -129,206 +294,289 @@ bool l1ct::tdr_regionizer::Regionizer<T>::isInBigRegion(const PFRegionEmu& reg) 
 }
 
 template <typename T>
+bool l1ct::tdr_regionizer::Regionizer<T>::isInBigRegionLoose(const PFRegionEmu& reg) const {
+  auto phi = reg.intPhiCenter();
+  auto brmax = phi_wrap(bigRegionMax_ + reg.hwPhiHalfWidth.to_int() + reg.hwPhiExtra.to_int());
+  auto brmin = phi_wrap(bigRegionMin_ - reg.hwPhiHalfWidth.to_int() - reg.hwPhiExtra.to_int());
+  if (brmax < brmin) {
+    // the wraparound case
+    return phi > brmin || phi < brmax;
+  } else {
+    // the normal case
+    return phi > brmin && phi < brmax;
+  }
+}
+
+template <>
+inline bool l1ct::tdr_regionizer::Regionizer<l1ct::TkObjEmu>::isInBigRegionLoose(const PFRegionEmu& reg) const {
+  auto phi = reg.intPhiCenter();
+  auto brmax = phi_wrap(bigRegionMax_ + 2 * reg.hwPhiHalfWidth.to_int());
+  auto brmin = phi_wrap(bigRegionMin_ - 2 * reg.hwPhiHalfWidth.to_int());
+  if (brmax < brmin) {
+    // the wraparound case
+    return phi > brmin || phi < brmax;
+  } else {
+    // the normal case
+    return phi > brmin && phi < brmax;
+  }
+}
+
+template <typename T>
 std::vector<size_t> l1ct::tdr_regionizer::Regionizer<T>::getSmallRegions(int glbeta, int glbphi) const {
   std::vector<size_t> srIndices;  // the signal regions this object should go into
 
   // only iterate over regions covered by board
   for (size_t i = 0; i < regionmap_.size(); i++) {
-    auto regionidx = regionmap_[i];
-    int regphi = dphi_wrap(glbphi - regions_[regionidx].intPhiCenter());
+    auto regionidx = regionIndex(i);
+    int regphi = phi_wrap(glbphi - regions_[regionidx].intPhiCenter());
     int regeta = glbeta - regions_[regionidx].intEtaCenter();
 
-    if (regions_[regionidx].isInside(regeta, regphi)) {
+    // add a special check to not have 3 eta regions
+    if (regions_[regionidx].isInside(regeta, regphi) &&
+        !((glbeta == 57 && regeta == -115) || (glbeta == -57 && regeta == 115))) {
       srIndices.push_back(i);
     }
+  }
+
+  // In a silly convention, the order of these nneds to be modified if there are 4.
+  if (srIndices.size() == 4) {
+    auto ent1 = srIndices[1];
+    srIndices[1] = srIndices[2];
+    srIndices[2] = ent1;
   }
   return srIndices;
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::addToPipe(const T& obj, unsigned int sector) {
-  assert(sector < getSize());
+void l1ct::tdr_regionizer::Regionizer<T>::addToBuffer(const T& obj, unsigned int buffer, unsigned int dupNum) {
+  assert(buffer < numBuffers());
+  const unsigned int sector = buffer / ndup_;
   auto glbphi = sectors_[sector].hwGlbPhiOf(obj).to_int();
   auto glbeta = sectors_[sector].hwGlbEtaOf(obj).to_int();
   // get the SR indices that this object should go into
-  std::vector<size_t> srIndices = getSmallRegions(glbeta, glbphi);
-  if (!srIndices.empty()) {
-    pipes_[sector].addObj(obj, srIndices, glbeta, glbphi);
+  buffers_[buffer].addEntry(obj, getSmallRegions(glbeta, glbphi), glbeta, glbphi, dupNum, ndup_);
+}
+
+template <typename T>
+void l1ct::tdr_regionizer::Regionizer<T>::setBuffer(const std::vector<T>& objvec, unsigned int buffer) {
+  assert(buffer < numBuffers());
+  buffers_[buffer].reset();
+  unsigned int dupNum = buffer % ndup_;
+  for (unsigned int i = dupNum; i < objvec.size(); i += ndup_) {
+    // if (debug_) {
+    //   dbgCout() << "Buffer " << buffer << " dupNum " << dupNum << ": add obj, index " << i << " with pt = " << objvec[i].intPt() << std::endl;
+    // }
+    addToBuffer(objvec[i], buffer, dupNum);
   }
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::setPipe(const std::vector<T>& objvec, unsigned int sector) {
-  assert(sector < getSize());
-  pipes_[sector].reset();
-  for (unsigned int i = 0; i < objvec.size(); i++) {
-    addToPipe(objvec[i], sector);
+void l1ct::tdr_regionizer::Regionizer<T>::setBuffers(const std::vector<std::vector<T>>&& objvecvec) {
+  assert(numBuffers() == objvecvec.size() * ndup_);
+  for (unsigned int buffer = 0; buffer < numBuffers(); buffer++) {
+    setBuffer(objvecvec[buffer / ndup_], buffer);
   }
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::setPipes(const std::vector<std::vector<T>>& objvecvec) {
-  assert(getSize() == objvecvec.size());
-  for (unsigned int sector = 0; sector < getSize(); sector++) {
-    setPipe(objvecvec[sector], sector);
-  }
-}
+void l1ct::tdr_regionizer::Regionizer<T>::addToSmallRegion(l1ct::tdr_regionizer::PipeEntry<T>&& pipeEntry) {
+  if (pipeEntry.valid()) {
+    auto rawObj = pipeEntry.obj();
 
-// NEED TO CHECK CONSTANTS HERE
-template <typename T>
-int l1ct::tdr_regionizer::Regionizer<T>::getPipeTime(int linkIndex,
-                                                     int linkTimeOfObject,
-                                                     int linkAlgoClockRunningTime) {
-  const int LINK_TO_ALGO_CLK_OFFSET = 2;  //13; // in units of algo clock
-  int linkObjectArrival = (nsectors_ - 1 - linkIndex) + LINK_TO_ALGO_CLK_OFFSET + linkTimeOfObject;
+    // in small region, the relative eta and phi are based on a different center, so need to update
+    auto realRegIdx = regionIndex(pipeEntry.sr());
+    auto etaC = regions_[realRegIdx].intEtaCenter();
+    auto phiC = regions_[realRegIdx].intPhiCenter();
 
-  return (linkAlgoClockRunningTime < 0 || linkObjectArrival > linkAlgoClockRunningTime + 4)
-             ? linkObjectArrival
-             : (linkAlgoClockRunningTime + 4);
-}
+    int locEta = pipeEntry.glbEta() - etaC;
+    int locPhi = phi_wrap(pipeEntry.glbPhi() - phiC);
 
-template <typename T>
-int l1ct::tdr_regionizer::Regionizer<T>::popLinkObject(int linkIndex, int currentTimeOfObject) {
-  auto& obj = pipes_[linkIndex].getObj();
-  obj.incCount();
-  if (obj.getCount() < obj.getSRIndices().size()) {
-    // Continue working on the same object, since it goes in multiple SRs due to overlaps
-    return currentTimeOfObject + 1;
-  } else {
-    // move on to next item in pipe
-    pipes_[linkIndex].erase();
-    //get time of next object
-    if (getPipeSize(linkIndex)) {
-      return getPipeTime(linkIndex, pipes_[linkIndex].getClock(), currentTimeOfObject);
-    } else {  //no more objects on link
-      return -1;
-    }
+    rawObj.hwEta = locEta;
+    rawObj.hwPhi = locPhi;
+
+    smallRegionObjects_[pipeEntry.sr()].push_back(rawObj);
   }
 }
 
 template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::initTimes() {
-  for (unsigned int sector = 0; sector < getSize(); ++sector) {
-    if (getPipeSize(sector)) {
-      timeOfNextObject_.push_back(timeNextFromIndex(sector, -1));
-    } else {
-      timeOfNextObject_.push_back(-1);
-    }
-  }
-}
+void l1ct::tdr_regionizer::Regionizer<T>::run() {
+  if (debug_)
+    printDebug(-1);
 
-template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::addToSmallRegion(unsigned int linkNum, unsigned int index) {
-  auto pipeObj = pipes_[linkNum].getObj(index);
-  smallRegionObjects_[pipeObj.getNextSRIndex()].push_back(pipeObj.getRawObj());
-}
+  // first event doesn't have a delayed start
+  int startTime = firstEvent_ ? 0 : DELAY_TO_START;
+  firstEvent_ = false;
 
-template <typename T>
-void l1ct::tdr_regionizer::Regionizer<T>::run(bool debug) {
-  unsigned int loopCount = 0;
-  if (debug)
-    printDebug(loopCount);
-  while (loopCount < 972) {  //this is the max allowable if nothing ever blocks
-    //init min time, pipe, and link index
-    //      to find the target pipe currently with action
-    int minPipeIndex = -1;
-    int minLinkIndex = -1;
-    int minTime = 0;
+  for (int currTime = startTime; currTime < 972 + startTime;
+       currTime++) {  //this is the max allowable if nothing ever blocks
+                      // not positive where 972 comes from. It seems to be 162 * 6
 
-    //do pipe-full handling
-    for (unsigned int sector = 0; sector < getSize(); ++sector) {
-      if (timeOfNextObject_[sector] >= 0 && smallRegionObjects_[getPipeIndexForObject(sector)].size() == maxobjects_) {
-        //pipe is full so proceed to next object
-        //'remove' the selected object from its link
-        timeOfNextObject_[sector] = popLinkObject(sector, timeOfNextObject_[sector]);
-      }  //end pipe-full handling loop
-    }
+    // to exit early
+    bool processedAll = true;  // to be overwritten if not the case
 
-    //do find object handling
-    for (unsigned int sector = 0; sector < getSize(); ++sector) {
-      // dbgCout() << "secotor = " << sector << ", timeOfNextObject_[sector] = " << timeOfNextObject_[sector]
-      //   << ", minLinkIndex = " << minLinkIndex << ", minTime = " << minTime << ", minPipeIndex = " << minPipeIndex << std::endl;
-      if (timeOfNextObject_[sector] >= 0 && (minLinkIndex == -1 || timeOfNextObject_[sector] < minTime)) {
-        //found new 'selected' link object and pipe
-        minPipeIndex = getHardwarePipeIndexForObject(sector);
-        minTime = timeOfNextObject_[sector];
-        minLinkIndex = sector;
-      } else if (getPipeSize(sector) && minLinkIndex >= 0 &&
-                 minPipeIndex == static_cast<int>(getHardwarePipeIndexForObject(sector)) &&
-                 timeOfNextObject_[sector] == minTime) {
-        //have pipe conflict, so need to wait a clock
-        ++timeOfNextObject_[sector];
+    // handle the fifo buffers
+    for (size_t bufIdx = 0; bufIdx < buffers_.size(); ++bufIdx) {
+      auto& buffer = buffers_[bufIdx];
+      if (buffer.timeOfNextObject() >= 0) {
+        processedAll = false;
+      }
+      if (buffer.timeOfNextObject() == currTime) {
+        // time to handle the buffer entry
+        const auto nextSR = buffer.front().nextSR();
+        if (debug_) {
+          dbgCout() << "Current time " << currTime << ", handling bufIdx " << bufIdx << " object with SR = " << nextSR
+                    << ", pt = " << buffer.pt() << ", glbeta = " << buffer.glbEta() << ", glbphi = " << buffer.glbPhi()
+                    << std::endl;
+        }
+        if (nextSR < 0 || buffer.pt() == 0 || smallRegionObjects_[nextSR].size() == maxobjects_) {
+          // throwout or SR full, just get rid of object
+          buffer.popEntry(currTime, debug_);
+        } else {
+          const auto logicBufIdx = logicBuffIndex(bufIdx);
+          if (pipes_.valid(nextSR, logicBufIdx)) {
+            // The pipe already has an entry, so wait till space is available
+            buffer.updateNextObjectTime(currTime);
+          } else {
+            // put the value in the pipe
+            pipes_.addEntry(nextSR, logicBufIdx, buffer.popEntry(currTime, debug_));
+          }
+        }
       }
     }
 
-    // dbgCout() << " After, minLinkIndex = " << minLinkIndex << ", minTime = " << minTime << ", minPipeIndex = " << minPipeIndex << std::endl;
+    if (debug_)
+      printDebug(currTime);
 
-    if (minLinkIndex < 0)
-      break;  //exit case
+    // add the small regions
+    for (size_t i = 0; i < pipes_.size(); i++) {
+      addToSmallRegion(pipes_.popEntry(i));
+    }
 
-    //'put' object in small region
-    addToSmallRegion(minLinkIndex);
-
-    //'remove' the selected object from its link
-    int nextTime = popLinkObject(minLinkIndex, timeOfNextObject_[minLinkIndex]);
-    if (nextTime > nclocks_) {
+    // check ot see if you have processed all
+    if (processedAll) {
+      // first clear the pipes
+      for (size_t tap = 0; tap < pipes_.numTaps(); tap++) {
+        // add the small regions
+        for (size_t i = 0; i < pipes_.size(); i++) {
+          addToSmallRegion(pipes_.popEntry(i));
+        }
+      }
+      if (debug_)
+        printDebug(2000);
       break;
     }
-    timeOfNextObject_[minLinkIndex] = nextTime;
-    ++loopCount;
   }  //end main loop
-
-  if (debug)
-    printDebug(loopCount);
 }
 
 template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::reset() {
-  for (auto& pipe : pipes_) {
-    pipe.reset();
+  for (auto& buffer : buffers_) {
+    buffer.reset();
   }
-  timeOfNextObject_.clear();
+  pipes_.reset();
   for (auto& smallRegionObject : smallRegionObjects_) {
     smallRegionObject.clear();
   }
+  firstEvent_ = true;
 }
 
 template <typename T>
 std::map<size_t, std::vector<T>> l1ct::tdr_regionizer::Regionizer<T>::fillRegions(bool doSort) {
   std::map<size_t, std::vector<T>> srMap;
   for (size_t sr = 0; sr < smallRegionObjects_.size(); sr++) {
-    srMap[regionmap_[sr]] = smallRegionObjects_[sr];
+    srMap[regionIndex(sr)] = smallRegionObjects_[sr];
     if (doSort) {
-      std::sort(srMap[regionmap_[sr]].begin(), srMap[regionmap_[sr]].end(), std::greater<>());
+      std::sort(srMap[regionIndex(sr)].begin(), srMap[regionIndex(sr)].end(), std::greater<>());
     }
   }
   return srMap;
 }
 
 template <typename T>
+size_t l1ct::tdr_regionizer::Regionizer<T>::logicBuffIndex(size_t bufIdx) const {
+  const unsigned int sector = bufIdx / ndup_;
+  auto logSector = sectormap_[sector];
+  return logSector * ndup_ + bufIdx % ndup_;
+}
+
+template <typename T>
 void l1ct::tdr_regionizer::Regionizer<T>::printDebug(int count) const {
-  dbgCout() << "PIPES, (for " << getSize() << " sectors)" << std::endl;
-  dbgCout() << count << "\tsector\titem\tpt\teta\tphi" << std::endl;
-  for (unsigned int sector = 0; sector < getSize(); sector++) {
-    for (unsigned int j = 0; j < getPipeSize(sector); j++) {
-      dbgCout() << "\t" << sector << "\t" << j << "\t" << pipes_[sector].getPt(j) << "\t" << pipes_[sector].getGlbEta(j)
-                << "\t" << pipes_[sector].getGlbPhi(j) << std::endl;
+  dbgCout() << "BUFFERS, (for " << numBuffers() << " buffers)" << std::endl;
+  dbgCout() << count << "\tbuffer\tlogical\titem\tpt\teta\tphi\tclock" << std::endl;
+  for (auto sector : invsectormap_) {
+    for (unsigned int dup = 0; dup < ndup_; dup++) {
+      const unsigned int buffer = sector * ndup_ + dup;
+      for (unsigned int j = 0; j < numEntries(buffer); j++) {
+        dbgCout() << "\t" << buffer << "\t" << logicBuffIndex(buffer) << "\t" << j << "\t" << buffers_[buffer].pt(j)
+                  << "\t" << buffers_[buffer].glbEta(j) << "\t" << buffers_[buffer].glbPhi(j) << "\t"
+                  << buffers_[buffer].clock(j) << std::endl;
+      }
+      dbgCout() << "-------------------------------" << std::endl;
+    }
+  }
+  dbgCout() << "PIPES, (for " << pipes_.size() << " pipes)" << std::endl;
+  dbgCout() << count << "\tpipe\ttap\tsr\tpt\teta\tphi" << std::endl;
+  for (size_t pipe = 0; pipe < pipes_.size(); pipe++) {
+    for (size_t tap = 0; tap < pipes_.numTaps(); tap++) {
+      auto entry = pipes_.entry(pipe, tap);
+      dbgCout() << "\t" << pipe << "\t" << tap << "\t" << entry.sr() << "\t" << entry.pt() << "\t" << entry.glbEta()
+                << "\t" << entry.glbPhi() << std::endl;
     }
     dbgCout() << "-------------------------------" << std::endl;
   }
+
   dbgCout() << "SMALL REGIONS" << std::endl;
   for (unsigned int region = 0; region < neta_ * nphi_; region++) {
-    dbgCout() << count << "\tregion\titem\tpt\tloceta\tlocphi" << std::endl;
+    dbgCout() << count << "\tregion\t\titem\tpt\tloceta\tlocphi" << std::endl;
+    auto realRegIdx = regionIndex(region);
+    auto etaC = regions_[realRegIdx].intEtaCenter();
+    auto phiC = regions_[realRegIdx].intPhiCenter();
     for (unsigned int j = 0; j < smallRegionObjects_[region].size(); j++) {
-      dbgCout() << "\t" << region << " " << j << "\t" << smallRegionObjects_[region][j].hwPt.to_int() << "\t"
-                << smallRegionObjects_[region][j].hwEta.to_int() << "\t"
-                << smallRegionObjects_[region][j].hwPhi.to_int() << std::endl;
+      dbgCout() << "\t" << region << " (" << etaC << ", " << phiC << ")\t" << j << "\t"
+                << smallRegionObjects_[region][j].intPt() << "\t" << smallRegionObjects_[region][j].intEta() << "\t"
+                << smallRegionObjects_[region][j].intPhi() << std::endl;
     }
     dbgCout() << "-------------------------------" << std::endl;
   }
   dbgCout() << "TIMES" << std::endl;
-  for (unsigned int i = 0; i < timeOfNextObject_.size(); i++) {
-    dbgCout() << "  " << timeOfNextObject_[i];
+  for (unsigned int i = 0; i < numBuffers(); i++) {
+    dbgCout() << "  " << buffers_[i].timeOfNextObject();
   }
   dbgCout() << "\n-------------------------------" << std::endl;
+}
+
+// returns 2D arrays, sectors (links) first dimension, objects second
+template <typename T>
+std::vector<std::vector<T>> l1ct::tdr_regionizer::Regionizer<T>::fillLinks(
+    const std::vector<DetectorSector<T>>& sectors) const {
+  std::vector<std::vector<T>> links;
+
+  if (maxobjects_ == 0) {
+    return links;
+  }
+  //one link per sector
+  for (const auto& sector : sectors) {
+    if (isInBigRegionLoose(sector.region)) {
+      links.emplace_back();
+      for (unsigned int io = 0; io < sector.size() && io < nclocks_; io++) {
+        links.back().push_back(sector[io]);
+      }
+    }
+  }
+  return links;
+}
+
+template <typename T>
+std::vector<std::vector<T>> l1ct::tdr_regionizer::Regionizer<T>::fillLinks(const DetectorSector<T>& sector) const {
+  std::vector<std::vector<T>> links;
+
+  if (maxobjects_ == 0) {
+    return links;
+  }
+
+  links.emplace_back();
+  for (unsigned int io = 0; io < sector.size() && io < nclocks_; io++) {
+    links.back().push_back(sector[io]);
+  }
+  return links;
 }

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_ref.h
@@ -11,12 +11,12 @@ namespace edm {
 namespace l1ct {
   class TDRRegionizerEmulator : public RegionizerEmulator {
   public:
-    TDRRegionizerEmulator(unsigned int netaslices,
-                          unsigned int ntk,
-                          unsigned int ncalo,
-                          unsigned int nem,
-                          unsigned int nmu,
-                          int nclocks,
+    TDRRegionizerEmulator(uint32_t ntk,
+                          uint32_t ncalo,
+                          uint32_t nem,
+                          uint32_t nmu,
+                          int32_t nclocks,
+                          std::vector<int32_t> bigRegionEdges,
                           bool dosort);
 
     // note: this one will work only in CMSSW
@@ -24,37 +24,40 @@ namespace l1ct {
 
     ~TDRRegionizerEmulator() override;
 
-    static const int NTK_SECTORS = 9, NTK_LINKS = 2;  // max objects per sector per clock cycle
-    static const int NCALO_SECTORS = 4, NCALO_LINKS = 4;
-    static const int NEMCALO_SECTORS = 4, NEMCALO_LINKS = 4;
-    static const int NMU_LINKS = 2;
-    static const int MAX_TK_EVT = 108, MAX_EMCALO_EVT = 162, MAX_CALO_EVT = 162,
-                     MAX_MU_EVT = 162;  //all at TMUX 6, per link
-    //assuming 96b for tracks, 64b for emcalo, calo, mu
-    static const int NUMBER_OF_SMALL_REGIONS = 18;
-    static const int NETA_SMALL = 2;
-
     void initSectorsAndRegions(const RegionizerDecodedInputs& in, const std::vector<PFInputRegion>& out) override;
 
-    // TODO: implement
     void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) override;
 
+  private:
     // link emulation from decoded inputs (for simulation)
     void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::TkObjEmu>>& links);
     void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::HadCaloObjEmu>>& links);
     void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::EmCaloObjEmu>>& links);
     void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::MuObjEmu>>& links);
 
-    // convert links to firmware
-    void toFirmware(const std::vector<l1ct::TkObjEmu>& emu, TkObj fw[NTK_SECTORS][NTK_LINKS]);
-    void toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu, HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
-    void toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu, EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]);
-    void toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]);
+    /// The nubmer of barrel big regions (boards)
+    uint32_t nBigRegions_;
+    /// The maximum number of objects of each type to output per small region
+    uint32_t ntk_, ncalo_, nem_, nmu_;
+    /// The number of clocks to receive all data of an event (TMUX18 = 162)
+    int32_t nclocks_;
 
-  private:
-    unsigned int netaslices_, ntk_, ncalo_, nem_, nmu_, nregions_;
-    int nclocks_;
-    bool dosort_, init_;
+    /// The phi edges of the big regions (boards); one greater than the number of boards
+    std::vector<int32_t> bigRegionEdges_;
+
+    bool dosort_;
+
+    /// The number of eta and phi small regions in a big region (board)
+    uint32_t netaInBR_, nphiInBR_;
+    /// The total number of small regions in barrel (not just in board)
+    uint32_t nregions_;
+
+    uint32_t MAX_TK_OBJ_;
+    uint32_t MAX_EMCALO_OBJ_;
+    uint32_t MAX_HADCALO_OBJ_;
+    uint32_t MAX_MU_OBJ_;
+
+    bool init_;  // has initialization happened
 
     std::vector<tdr_regionizer::Regionizer<l1ct::TkObjEmu>> tkRegionizers_;
     std::vector<tdr_regionizer::Regionizer<l1ct::HadCaloObjEmu>> hadCaloRegionizers_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/tdr_regionizer_ref.h
@@ -15,7 +15,7 @@ namespace l1ct {
                           uint32_t ncalo,
                           uint32_t nem,
                           uint32_t nmu,
-                          int32_t nclocks,
+                          uint32_t nclocks,
                           std::vector<int32_t> bigRegionEdges,
                           bool dosort);
 
@@ -29,18 +29,12 @@ namespace l1ct {
     void run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) override;
 
   private:
-    // link emulation from decoded inputs (for simulation)
-    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::TkObjEmu>>& links);
-    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::HadCaloObjEmu>>& links);
-    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::EmCaloObjEmu>>& links);
-    void fillLinks(const RegionizerDecodedInputs& in, std::vector<std::vector<l1ct::MuObjEmu>>& links);
-
     /// The nubmer of barrel big regions (boards)
     uint32_t nBigRegions_;
     /// The maximum number of objects of each type to output per small region
     uint32_t ntk_, ncalo_, nem_, nmu_;
     /// The number of clocks to receive all data of an event (TMUX18 = 162)
-    int32_t nclocks_;
+    uint32_t nclocks_;
 
     /// The phi edges of the big regions (boards); one greater than the number of boards
     std::vector<int32_t> bigRegionEdges_;
@@ -49,13 +43,6 @@ namespace l1ct {
 
     /// The number of eta and phi small regions in a big region (board)
     uint32_t netaInBR_, nphiInBR_;
-    /// The total number of small regions in barrel (not just in board)
-    uint32_t nregions_;
-
-    uint32_t MAX_TK_OBJ_;
-    uint32_t MAX_EMCALO_OBJ_;
-    uint32_t MAX_HADCALO_OBJ_;
-    uint32_t MAX_MU_OBJ_;
 
     bool init_;  // has initialization happened
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/regionizer/tdr_regionizer_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/regionizer/tdr_regionizer_ref.cpp
@@ -7,75 +7,88 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 l1ct::TDRRegionizerEmulator::TDRRegionizerEmulator(const edm::ParameterSet& iConfig)
-    : TDRRegionizerEmulator(
-          /*netaslices=*/3,
-          iConfig.getParameter<uint32_t>("nTrack"),
-          iConfig.getParameter<uint32_t>("nCalo"),
-          iConfig.getParameter<uint32_t>("nEmCalo"),
-          iConfig.getParameter<uint32_t>("nMu"),
-          iConfig.getParameter<int32_t>("nClocks"),
-          iConfig.getParameter<bool>("doSort")) {
+    : TDRRegionizerEmulator(iConfig.getParameter<uint32_t>("nTrack"),
+                            iConfig.getParameter<uint32_t>("nCalo"),
+                            iConfig.getParameter<uint32_t>("nEmCalo"),
+                            iConfig.getParameter<uint32_t>("nMu"),
+                            iConfig.getParameter<int32_t>("nClocks"),
+                            iConfig.getParameter<std::vector<int32_t>>("bigRegionEdges"),
+                            iConfig.getParameter<bool>("doSort")) {
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 }
 #endif
 
-l1ct::TDRRegionizerEmulator::TDRRegionizerEmulator(unsigned int netaslices,
-                                                   unsigned int ntk,
-                                                   unsigned int ncalo,
-                                                   unsigned int nem,
-                                                   unsigned int nmu,
-                                                   int nclocks,
+l1ct::TDRRegionizerEmulator::TDRRegionizerEmulator(uint32_t ntk,
+                                                   uint32_t ncalo,
+                                                   uint32_t nem,
+                                                   uint32_t nmu,
+                                                   int32_t nclocks,
+                                                   std::vector<int32_t> bigRegionEdges,
                                                    bool dosort)
     : RegionizerEmulator(),
-      netaslices_(netaslices),
       ntk_(ntk),
       ncalo_(ncalo),
       nem_(nem),
       nmu_(nmu),
       nclocks_(nclocks),
+      bigRegionEdges_(bigRegionEdges),
       dosort_(dosort),
+      netaInBR_(6),
+      nphiInBR_(3),
       init_(false) {
-  assert(netaslices == 3);             //the setup here only works for 3 barrel boards
-  int etaoffsets[3] = {-228, 0, 228};  //this could be made generic perhaps, hardcoding for now
-  for (unsigned int i = 0; i < netaslices_; i++) {
-    tkRegionizers_.emplace_back(
-        (unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, ntk, etaoffsets[i], 115, nclocks);
-    hadCaloRegionizers_.emplace_back(
-        (unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, ncalo, etaoffsets[i], 115, nclocks);
-    emCaloRegionizers_.emplace_back(
-        (unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, nem, etaoffsets[i], 115, nclocks);
-    muRegionizers_.emplace_back(
-        (unsigned int)NETA_SMALL, (unsigned int)NUMBER_OF_SMALL_REGIONS, nmu, etaoffsets[i], 115, nclocks);
-  }
+  nBigRegions_ = bigRegionEdges_.size() - 1;
+  MAX_TK_OBJ_ = nclocks_ * 2 / 3;  // 2 objects per 3 clocks
+  MAX_EMCALO_OBJ_ = nclocks_;      // 1 object per clock
+  MAX_HADCALO_OBJ_ = nclocks_;     // 1 object per clock
+  MAX_MU_OBJ_ = nclocks_;          // 1 object per clock
 }
 
 l1ct::TDRRegionizerEmulator::~TDRRegionizerEmulator() {}
 
 void l1ct::TDRRegionizerEmulator::initSectorsAndRegions(const RegionizerDecodedInputs& in,
                                                         const std::vector<PFInputRegion>& out) {
+  if (debug_) {
+    dbgCout() << "doing init, out_size = " << out.size() << std::endl;
+  }
   assert(!init_);
   init_ = true;
   nregions_ = out.size();
+
+  for (unsigned int i = 0; i < nBigRegions_; i++) {
+    tkRegionizers_.emplace_back(
+        netaInBR_, nphiInBR_, nregions_, ntk_, bigRegionEdges_[i], bigRegionEdges_[i + 1], nclocks_);
+    hadCaloRegionizers_.emplace_back(
+        netaInBR_, nphiInBR_, nregions_, ncalo_, bigRegionEdges_[i], bigRegionEdges_[i + 1], nclocks_);
+    emCaloRegionizers_.emplace_back(
+        netaInBR_, nphiInBR_, nregions_, nem_, bigRegionEdges_[i], bigRegionEdges_[i + 1], nclocks_);
+    muRegionizers_.emplace_back(
+        netaInBR_, nphiInBR_, nregions_, nmu_, bigRegionEdges_[i], bigRegionEdges_[i + 1], nclocks_);
+  }
+
+  dbgCout() << "in.track.size() = " << in.track.size() << std::endl;
+  dbgCout() << "in.hadcalo.size() = " << in.hadcalo.size() << std::endl;
+  dbgCout() << "in.emcalo.size() = " << in.emcalo.size() << std::endl;
+
   if (ntk_) {
-    for (unsigned int i = 0; i < netaslices_; i++) {
+    for (unsigned int i = 0; i < nBigRegions_; i++) {
       tkRegionizers_[i].initSectors(in.track);
       tkRegionizers_[i].initRegions(out);
     }
   }
   if (ncalo_) {
-    for (unsigned int i = 0; i < netaslices_; i++) {
+    for (unsigned int i = 0; i < nBigRegions_; i++) {
       hadCaloRegionizers_[i].initSectors(in.hadcalo);
       hadCaloRegionizers_[i].initRegions(out);
     }
   }
   if (nem_) {
-    for (unsigned int i = 0; i < netaslices_; i++) {
+    for (unsigned int i = 0; i < nBigRegions_; i++) {
       emCaloRegionizers_[i].initSectors(in.emcalo);
       emCaloRegionizers_[i].initRegions(out);
     }
   }
   if (nmu_) {
-    for (unsigned int i = 0; i < netaslices_; i++) {
+    for (unsigned int i = 0; i < nBigRegions_; i++) {
       muRegionizers_[i].initSectors(in.muon);
       muRegionizers_[i].initRegions(out);
     }
@@ -95,7 +108,7 @@ void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs&
     const l1ct::DetectorSector<l1ct::TkObjEmu>& sec = in.track[il];
     for (unsigned int io = 0; io < sec.size(); io++) {
       links[il].push_back(sec[io]);
-      if (links[il].size() == MAX_TK_EVT) {
+      if (links[il].size() == MAX_TK_OBJ_) {
         break;
       }
     }
@@ -115,7 +128,7 @@ void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs&
     const l1ct::DetectorSector<l1ct::HadCaloObjEmu>& sec = in.hadcalo[il];
     for (unsigned int io = 0; io < sec.size(); io++) {
       links[il].push_back(sec[io]);
-      if (links[il].size() == MAX_CALO_EVT) {
+      if (links[il].size() == MAX_HADCALO_OBJ_) {
         break;
       }
     }
@@ -135,7 +148,7 @@ void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs&
     const l1ct::DetectorSector<l1ct::EmCaloObjEmu>& sec = in.emcalo[il];
     for (unsigned int io = 0; io < sec.size(); io++) {
       links[il].push_back(sec[io]);
-      if (links[il].size() == MAX_EMCALO_EVT) {
+      if (links[il].size() == MAX_EMCALO_OBJ_) {
         break;
       }
     }
@@ -153,59 +166,22 @@ void l1ct::TDRRegionizerEmulator::fillLinks(const l1ct::RegionizerDecodedInputs&
   const l1ct::DetectorSector<l1ct::MuObjEmu>& sec = in.muon;
   for (unsigned int io = 0; io < sec.size(); io++) {
     links[0].push_back(sec[io]);
-    if (links[0].size() == MAX_MU_EVT) {
+    if (links[0].size() == MAX_MU_OBJ_) {
       break;
     }
   }
 }
 
-void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::TkObjEmu>& emu, TkObj fw[NTK_SECTORS][NTK_LINKS]) {
-  if (ntk_ == 0)
-    return;
-  assert(emu.size() == NTK_SECTORS * NTK_LINKS * netaslices_);
-  for (unsigned int is = 0, idx = 0; is < NTK_SECTORS * netaslices_; ++is) {  // tf sectors
-    for (unsigned int il = 0; il < NTK_LINKS; ++il, ++idx) {
-      fw[is][il] = emu[idx];
-    }
-  }
-}
-void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::HadCaloObjEmu>& emu,
-                                             HadCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
-  if (ncalo_ == 0)
-    return;
-  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * netaslices_);
-  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * netaslices_; ++is) {  // tf sectors
-    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
-      fw[is][il] = emu[idx];
-    }
-  }
-}
-
-void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::EmCaloObjEmu>& emu,
-                                             EmCaloObj fw[NCALO_SECTORS][NCALO_LINKS]) {
-  if (nem_ == 0)
-    return;
-  assert(emu.size() == NCALO_SECTORS * NCALO_LINKS * netaslices_);
-  for (unsigned int is = 0, idx = 0; is < NCALO_SECTORS * netaslices_; ++is) {  // tf sectors
-    for (unsigned int il = 0; il < NCALO_LINKS; ++il, ++idx) {
-      fw[is][il] = emu[idx];
-    }
-  }
-}
-
-void l1ct::TDRRegionizerEmulator::toFirmware(const std::vector<l1ct::MuObjEmu>& emu, MuObj fw[NMU_LINKS]) {
-  if (nmu_ == 0)
-    return;
-  assert(emu.size() == NMU_LINKS);
-  for (unsigned int il = 0, idx = 0; il < NMU_LINKS; ++il, ++idx) {
-    fw[il] = emu[idx];
-  }
-}
-
 void l1ct::TDRRegionizerEmulator::run(const RegionizerDecodedInputs& in, std::vector<PFInputRegion>& out) {
-  if (!init_)
-    initSectorsAndRegions(in, out);
+  if (debug_) {
+    dbgCout() << "TDRRegionizerEmulator::run called, out.size =  " << out.size() << std::endl;
+  }
 
+  if (!init_) {
+    initSectorsAndRegions(in, out);
+  }
+
+  // 2D arrays, sectors (links) first dimension, objects second
   std::vector<std::vector<l1ct::TkObjEmu>> tk_links_in;
   std::vector<std::vector<l1ct::EmCaloObjEmu>> em_links_in;
   std::vector<std::vector<l1ct::HadCaloObjEmu>> calo_links_in;
@@ -218,17 +194,19 @@ void l1ct::TDRRegionizerEmulator::run(const RegionizerDecodedInputs& in, std::ve
   fillLinks(in, mu_links_in);
   //this is overkill and could be improved, for now its ok (the sectors outside each board just wont do anything)
 
-  for (unsigned int ie = 0; ie < netaslices_; ie++) {
+  for (unsigned int ie = 0; ie < nBigRegions_; ie++) {
     //add objects from link
     tkRegionizers_[ie].reset();
     tkRegionizers_[ie].setPipes(tk_links_in);
     tkRegionizers_[ie].initTimes();
     if (debug_) {
-      dbgCout() << ie << "SECTORS/LINKS " << ie << std::endl;
-      for (unsigned int i = 0; i < tk_links_in.size(); i++) {
-        for (unsigned int j = 0; j < tk_links_in[i].size(); j++) {
-          dbgCout() << "\t" << i << " " << j << "\t" << tk_links_in[i][j].hwPt.to_int() << "\t"
-                    << tk_links_in[i][j].hwEta.to_int() << "\t" << tk_links_in[i][j].hwPhi.to_int() << std::endl;
+      dbgCout() << "Big region: " << ie << " SECTORS/LINKS " << std::endl;
+      dbgCout() << "\tsector\titem\tpt\teta\tphi" << std::endl;
+      for (unsigned int sector = 0; sector < tk_links_in.size(); sector++) {
+        for (unsigned int j = 0; j < tk_links_in[sector].size(); j++) {
+          dbgCout() << "\t" << sector << "\t" << j << "\t " << tk_links_in[sector][j].hwPt.to_int() << "\t"
+                    << tk_links_in[sector][j].hwEta.to_int() << "\t" << tk_links_in[sector][j].hwPhi.to_int()
+                    << std::endl;
         }
         dbgCout() << "-------------------------------" << std::endl;
       }
@@ -251,42 +229,22 @@ void l1ct::TDRRegionizerEmulator::run(const RegionizerDecodedInputs& in, std::ve
     muRegionizers_[ie].run();
   }
 
-  for (unsigned int ie = 0; ie < netaslices_; ie++) {
-    for (unsigned int ireg = 0; ireg < nregions_; ireg++) {
-      std::vector<l1ct::TkObjEmu> out_tks = tkRegionizers_[ie].getSmallRegion(ireg);
-      if (!out_tks.empty()) {
-        if (dosort_) {
-          std::sort(
-              out_tks.begin(), out_tks.end(), [](const l1ct::TkObjEmu a, const l1ct::TkObjEmu b) { return a > b; });
-        }
-        out[ireg].track = out_tks;
-      }
-      std::vector<l1ct::EmCaloObjEmu> out_emcalos = emCaloRegionizers_[ie].getSmallRegion(ireg);
-      if (!out_emcalos.empty()) {
-        if (dosort_) {
-          std::sort(out_emcalos.begin(), out_emcalos.end(), [](const l1ct::EmCaloObjEmu a, const l1ct::EmCaloObjEmu b) {
-            return a > b;
-          });
-        }
-        out[ireg].emcalo = out_emcalos;
-      }
-      std::vector<l1ct::HadCaloObjEmu> out_hadcalos = hadCaloRegionizers_[ie].getSmallRegion(ireg);
-      if (!out_hadcalos.empty()) {
-        if (dosort_) {
-          std::sort(out_hadcalos.begin(),
-                    out_hadcalos.end(),
-                    [](const l1ct::HadCaloObjEmu a, const l1ct::HadCaloObjEmu b) { return a > b; });
-        }
-        out[ireg].hadcalo = out_hadcalos;
-      }
-      std::vector<l1ct::MuObjEmu> out_mus = muRegionizers_[ie].getSmallRegion(ireg);
-      if (!out_mus.empty()) {
-        if (dosort_) {
-          std::sort(
-              out_mus.begin(), out_mus.end(), [](const l1ct::MuObjEmu a, const l1ct::MuObjEmu b) { return a > b; });
-        }
-        out[ireg].muon = out_mus;
-      }
+  for (unsigned int ie = 0; ie < nBigRegions_; ie++) {
+    auto regionTrackMap = tkRegionizers_[ie].fillRegions(dosort_);
+    for (auto& pr : regionTrackMap) {
+      out[pr.first].track = pr.second;
+    }
+    auto regionEmCaloMap = emCaloRegionizers_[ie].fillRegions(dosort_);
+    for (auto& pr : regionEmCaloMap) {
+      out[pr.first].emcalo = pr.second;
+    }
+    auto regionHadCaloMap = hadCaloRegionizers_[ie].fillRegions(dosort_);
+    for (auto& pr : regionHadCaloMap) {
+      out[pr.first].hadcalo = pr.second;
+    }
+    auto regionMuMap = muRegionizers_[ie].fillRegions(dosort_);
+    for (auto& pr : regionMuMap) {
+      out[pr.first].muon = pr.second;
     }
   }
 }

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -82,6 +82,18 @@ process.l1tLayer1Barrel9.boards=cms.VPSet(
             regions=cms.vuint32(*[6+9*ie+i for ie in range(3) for i in range(3)])),
     )
 
+process.l1tLayer1BarrelTDR = process.l1tLayer1Barrel.clone()
+process.l1tLayer1BarrelTDR.regionizerAlgo = cms.string("TDR")
+process.l1tLayer1BarrelTDR.regionizerAlgoParameters = cms.PSet(
+        nTrack = cms.uint32(22),
+        nCalo = cms.uint32(15),
+        nEmCalo = cms.uint32(12),
+        nMu = cms.uint32(2),
+        nClocks = cms.int32(162),
+        doSort = cms.bool(False),
+        bigRegionEdges = cms.vint32(-560, -80, 400, -560)
+    )
+
 process.l1tLayer1BarrelSerenity = process.l1tLayer1Barrel.clone()
 process.l1tLayer1BarrelSerenity.regionizerAlgo = "MultififoBarrel"
 process.l1tLayer1BarrelSerenity.regionizerAlgoParameters = cms.PSet(
@@ -117,6 +129,7 @@ process.runPF = cms.Path(
         process.l1tGTTInputProducer +
         process.l1tVertexFinderEmulator +
         process.l1tLayer1Barrel +
+        process.l1tLayer1BarrelTDR +
         process.l1tLayer1BarrelSerenity +
         process.l1tLayer1Barrel9 +
         process.l1tLayer1HGCal +
@@ -148,7 +161,7 @@ if not args.patternFilesOFF:
     process.l1tLayer2SeedConeJetWriter.maxLinesPerFile = eventsPerFile_*54
 
 if not args.dumpFilesOFF:
-  for det in "Barrel", "BarrelSerenity", "Barrel9", "HGCal", "HGCalElliptic", "HGCalNoTK", "HF":
+  for det in "Barrel", "BarrelTDR", "BarrelSerenity", "Barrel9", "HGCal", "HGCalElliptic", "HGCalNoTK", "HF":
         l1pf = getattr(process, 'l1tLayer1'+det)
         l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
 

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -89,7 +89,7 @@ process.l1tLayer1BarrelTDR.regionizerAlgoParameters = cms.PSet(
         nCalo = cms.uint32(15),
         nEmCalo = cms.uint32(12),
         nMu = cms.uint32(2),
-        nClocks = cms.int32(162),
+        nClocks = cms.uint32(162),
         doSort = cms.bool(False),
         bigRegionEdges = cms.vint32(-560, -80, 400, -560)
     )


### PR DESCRIPTION
#### PR description:

This PR updates the emulator of the "TDR" regionizer for the Barrel region of the Correlator Layer 1.

It is the forward to the CMSSW master of https://github.com/cms-l1t-offline/cmssw/pull/1134, which contains two PRs from @jmitrevs:
 * https://github.com/p2l1pfp/cmssw/pull/112
 * https://github.com/p2l1pfp/cmssw/pull/116

This emulator is not yet enabled in the default configuration of the correlator trigger, so no physics changes are expected from this PR, but is run in integration tests and comparisons with the firmware so we would like to have it integrated in CMSSW (and then we may perform the switch of the default configuration to enable this emulator in a later PR)

As a side comment, a separate PR which will add the fillDescriptions to all the Correlator Layer 1 emulators will arrive in the next weeks: it's some amount of work and for the sake of validation I'd rather keep it factorized from changes to the emulator algorithms themselves.

#### PR validation:

This PR was tested on `CMSSW_13_2_X_2023-05-31-1100` (el8)
 * standard code-checks
 * `runTheMatrix.py -l 23234.0` (runs the standard L1T config, so it does not run this emulator)
 * `L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py` (used for correlator trigger integration, runs this emulator among other custom firmware-friendly configurations)

The original code in 12_5_2_patch1 was validated against the firmware by @jmitrevs.
