### PR TITLE
Update muon (un)packer with support for fixed uGMT firmware

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -84,13 +84,21 @@ namespace l1t {
           shower = muonShowerCollection_->at(bx, 0);
           muonShowerCollection_->erase(bx, 0);
         }
-        if (linkID ==
-            0) {  // OneNominal and TwoLoose showers are embedded in the first and second muons of the first link
+        if (linkID == 0) {  // OneNominal shower is embedded in the first muon of the first link
           shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
-          shower.setTwoLooseDiffSectorsInTime(
-              l1t::MuonRawDigiTranslator::showerFired(payload[i + 3], fed_, getAlgoVersion()));
-        } else if (linkID == 1) {  // OneTight shower is embedded in the first muon of the second link
+          // The intial 2023 uGMT firmware put the TwoLoose shower on the wrong link, so we have to do it there.
+          if (fed_ == 1402 && getAlgoVersion() == l1t::MuonRawDigiTranslator::kUgmtFwVersionShowersFrom2023) {
+            shower.setTwoLooseDiffSectorsInTime(
+                l1t::MuonRawDigiTranslator::showerFired(payload[i + 3], fed_, getAlgoVersion()));
+          }
+        } else if (linkID ==
+                   1) {  // OneTight and TwoLoose showers are embedded in the first and second muons of the second link
           shower.setOneTightInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
+          // Set the two loose showers from this link in all cases except if we're using the faulty uGMT bitfile
+          if (!(fed_ == 1402 && getAlgoVersion() == l1t::MuonRawDigiTranslator::kUgmtFwVersionShowersFrom2023)) {
+            shower.setTwoLooseDiffSectorsInTime(
+                l1t::MuonRawDigiTranslator::showerFired(payload[i + 3], fed_, getAlgoVersion()));
+          }
         }
 
         if (shower.isValid()) {

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -72,6 +72,8 @@ namespace l1t {
     static constexpr int kUgmtFwVersionFirstWithShowers = 0x7000000;
     static constexpr int kUgtFwVersionFirstWithShowers = 0x113B;
     static constexpr int kUgmtFwVersionShowersFrom2023 = 0x8000000;
+    static constexpr int kUgmtFwVersionShowersFrom2023_patched =
+        0x8000001;  // This fixed a miscommunication wrt the link used for the two loose shower bit
     static constexpr int kUgtFwVersionShowersFrom2023 = 0x1150;
 
   private:

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -279,9 +279,15 @@ std::array<std::array<uint32_t, 4>, 2> l1t::MuonRawDigiTranslator::getPackedShow
     res.at(0).at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
     res.at(0).at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
   }
-  if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionShowersFrom2023) ||
+  if ((fedId == kUgmtFedId && fwId >= kUgmtFwVersionShowersFrom2023_patched) ||
       (fedId == kUgtFedId && fwId >= kUgtFwVersionShowersFrom2023)) {
-    res.at(1).at(0) = shower.isTwoLooseDiffSectorsInTime() ? (1 << showerShift_) : 0;
+    res.at(1).at(1) = shower.isTwoLooseDiffSectorsInTime()
+                          ? (1 << showerShift_)
+                          : 0;  // The two loose shower is on the second link in the second muon word.
+  } else if (fedId == kUgmtFedId && fwId >= kUgmtFwVersionShowersFrom2023) {
+    res.at(1).at(0) = shower.isTwoLooseDiffSectorsInTime()
+                          ? (1 << showerShift_)
+                          : 0;  // uGMT was briefly transmitting it on the first link instead.
   }
   return res;
 }


### PR DESCRIPTION
#### PR description:
Update to the muon unpacker to support a coming uGMT firmware version that places the two loose muon shower bit on a different link. The change is necessary due to a miscommunication between uGT and uGMT teams.

This should go to P5, so I plan on making a backport to 13_0_X, however could you let me know if a packport to 13_1_X is also necessary?

#### PR validation:
Ran standard tests.
