### PR TITLE
Update ReweightUserHooks.h to be able to handle 13.6 TeV, backport of…

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/ReweightUserHooks.h
@@ -27,7 +27,7 @@ private:
 class PtHatEmpReweightUserHook : public Pythia8::UserHooks {
 public:
   PtHatEmpReweightUserHook(const std::string& tuneName = "") {
-    if (tuneName == "CP5")
+    if (tuneName == "CP5" || tuneName == "CP5Run3")
       p = {7377.94700788, 8.38168461349, -4.70983112392, -0.0310148108446, -0.028798537937, 925.335472326};
     //Default reweighting - works good for tune CUEPT8M1
     else
@@ -37,9 +37,10 @@ public:
            -5.1575514014931e-01,
            5.5951279807561e-02,
            3.5e+02};
-    sigma = [this](double x) -> double {
+    const double ecms = (tuneName == "CP5Run3" ? 13600. : 13000.);
+    sigma = [this, ecms](double x) -> double {
       return (p[0] * pow(x, p[2] + p[3] * log(0.01 * x) + p[4] * pow(log(0.01 * x), 2)) *
-              pow(1 - 2 * x / (13000. + p[5]), p[1])) *
+              pow(1 - 2 * x / (ecms + p[5]), p[1])) *
              x;
     };
   }


### PR DESCRIPTION
#### PR description:

Update 13000 to 13600 in ReweightUserHooks.h for Run3

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/41836, needed for run3 production using this release
