### PR TITLE
Convert also DOMException to cms::Exception in TotemDAQMappingESSourceXML

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -371,9 +371,11 @@ TotemDAQMappingESSourceXML::produce(const TotemReadoutRcd &) {
     cms::concurrency::xercesTerminate();
   } catch (const XMLException &e) {
     throw cms::Exception("XMLDocument") << "cms::concurrency::xercesInitialize failed because of "
-                                        << to_string(e.getMessage()) << std::endl;
+                                        << to_string(e.getMessage());
   } catch (const SAXException &e) {
-    throw cms::Exception("XMLDocument") << "XML parser reported: " << to_string(e.getMessage()) << "." << std::endl;
+    throw cms::Exception("XMLDocument") << "XML parser (SAX) reported: " << to_string(e.getMessage()) << ".";
+  } catch (const DOMException &e) {
+    throw cms::Exception("XMLDocument") << "XML parser (DOM) reported: " << to_string(e.getMessage()) << ".";
   }
 
   // commit the products


### PR DESCRIPTION
#### PR description:

Hopefully resolves https://github.com/cms-sw/cmssw/issues/41846, builds on https://github.com/cms-sw/cmssw/pull/41329. The code uses the `XercesDOMParser`, and (without knowing much of Xerces) I'd imagine it to throw `DOMException` exception. I still kept the `SAXException` handler for completeness (e.g. if anyone in the future adds additional SAX parser or changes the DOM parser to SAX parser).

#### PR validation:

Code compiles.