### PR TITLE
Enforce const-correctness for the Getter in edmNew::DetSetVector

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -85,7 +85,7 @@ namespace edmNew {
         return *this;
       }
       mutable std::atomic<bool> m_filling;
-      std::shared_ptr<void> m_getter;
+      std::shared_ptr<void const> m_getter;
       mutable std::atomic<size_type> m_dataSize;
 
       void swap(DetSetVectorTrans& rh) {
@@ -609,7 +609,7 @@ namespace edmNew {
     class LazyGetter {
     public:
       virtual ~LazyGetter() {}
-      virtual void fill(typename DetSetVector<T>::TSFastFiller&) = 0;
+      virtual void fill(typename DetSetVector<T>::TSFastFiller&) const = 0;
     };
   }  // namespace dslv
 
@@ -642,7 +642,7 @@ namespace edmNew {
       assert(item.initializing());
       {
         TSFastFiller ff(*this, item);
-        static_cast<Getter*>(m_getter.get())->fill(ff);
+        static_cast<Getter const*>(m_getter.get())->fill(ff);
       }
       assert(item.isValid());
     }

--- a/DataFormats/Common/test/DetSetNewTS_t.cpp
+++ b/DataFormats/Common/test/DetSetNewTS_t.cpp
@@ -216,7 +216,7 @@ void TestDetSet::fillSeq() {
 struct Getter final : public DSTV::Getter {
   Getter(TestDetSet* itest) : ntot(0), test(*itest) {}
 
-  void fill(TSFF& ff) override {
+  void fill(TSFF& ff) const override {
     int n = ff.id() - 20;
     CPPUNIT_ASSERT(n >= 0);
     CPPUNIT_ASSERT(ff.size() == 0);
@@ -229,7 +229,7 @@ struct Getter final : public DSTV::Getter {
     ntot.fetch_add(1, std::memory_order_acq_rel);
   }
 
-  std::atomic<unsigned int> ntot;
+  mutable std::atomic<unsigned int> ntot;
   TestDetSet& test;
 };
 

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -8,8 +8,8 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 struct B {
   virtual ~B() {}
@@ -381,7 +381,7 @@ namespace {
   struct Getter final : public DSTV::Getter {
     Getter(TestDetSet *itest) : ntot(0), test(*itest) {}
 
-    void fill(TSFF &ff) override {
+    void fill(TSFF &ff) const override {
       aborted = false;
       try {
         const int n = ff.id() - 20;
@@ -403,8 +403,8 @@ namespace {
       }
     }
 
-    unsigned int ntot;
-    bool aborted = false;
+    mutable unsigned int ntot;
+    mutable bool aborted = false;
     TestDetSet &test;
   };
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <sstream>
@@ -109,11 +110,11 @@ namespace {
 
     ~ClusterFiller() override { printStat(); }
 
-    void fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) override;
+    void fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const override;
 
   private:
-    std::unique_ptr<sistrip::FEDBuffer> buffers[1024];
-    std::atomic<sistrip::FEDBuffer*> done[1024];
+    CMS_THREAD_GUARD(done) mutable std::unique_ptr<sistrip::FEDBuffer> buffers[1024];
+    mutable std::atomic<sistrip::FEDBuffer*> done[1024];
 
     const FEDRawDataCollection& rawColl;
 
@@ -324,7 +325,7 @@ namespace {
   };
 }  // namespace
 
-void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) {
+void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::TSFastFiller& record) const {
   try {  // edmNew::CapacityExaustedException
     incReady();
 


### PR DESCRIPTION
#### PR description:

This PR addresses the issue in the `edmNew::DetSetVector` interface that does not enforce the `LazyGetter`-derived class (provided by the user) to be thread safe (noticed in https://github.com/cms-sw/cmssw/issues/41786#issuecomment-1569139512). This PR adds the requirement for the `LazyGetter::fill()` to be `const`.

The only deriving class (beyond tests) is `ClusterFiller` defined in `RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc`. As far as I can tell, the use of `buffers` and `done` is thread safe, so I added the necessary `mutable` type specifiers there. Having the `fill()` function as `const` helps to reason about thread safety, because now nothing else there needs to be understood that well (assuming everything else used by the `fill()` function is `const`-thread-safe) to conclude the function is thread safe.

#### PR validation:

Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

