### PR TITLE
[PileUpJetID] Move average calculations outside of jet constituents loop

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -571,10 +571,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     float dphi = reco::deltaPhi(*icand, *jet);
     sum_deta += deta * weight2;
     sum_dphi += dphi * weight2;
-    if (sumW2 > 0) {
-      ave_deta = sum_deta / sumW2;
-      ave_dphi = sum_dphi / sumW2;
-    }
+  }
+  if (sumW2 > 0) {
+    ave_deta = sum_deta / sumW2;
+    ave_dphi = sum_dphi / sumW2;
   }
 
   // // Finalize all variables


### PR DESCRIPTION
#### PR description:

This PR moves the average values calculations to outside of the jet constituents loop in `PileupJetIdAlgo.cc`.

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`

#### Backport:
To be backported to `13_1_X`, `13_0_X` and `12_6_X`(in another backport PR #40802).