### PR TITLE
Add isAvailable() function to RefToBaseProd

### DIFF
--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -149,6 +149,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const;
 
     /// Checks if this Ptr is transient (i.e. not persistable).

--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -257,6 +257,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const;
 
     /// Checks if this ref is transient (i.e. not persistable).
@@ -404,6 +406,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const;
 
     /// Checks if this ref is transient (i.e. not persistable).

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -88,7 +88,8 @@ namespace edm {
 
     // Checks if collection is in memory or available
     // in the Event. No type checking is done.
-
+    // This function is potentially costly as it might cause a disk
+    // read (note that it does not cause the data to be cached locally)
     bool isAvailable() const { return toRefCore().isAvailable(); }
 
     //Convert to an equivalent RefCore. Needed for Ref specialization.

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -134,6 +134,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const { return product_.isAvailable(); }
 
     /// Checks if this RefProd is transient (i.e. not persistable).

--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -116,6 +116,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const { return holder_ ? holder_->isAvailable() : false; }
 
     bool isTransient() const { return holder_ ? holder_->isTransient() : false; }

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -68,6 +68,8 @@ namespace edm {
 
     /// Checks if collection is in memory or available
     /// in the Event. No type checking is done.
+    /// This function is potentially costly as it might cause a disk
+    /// read (note that it does not cause the data to be cached locally)
     bool isAvailable() const { return product_.isAvailable(); }
 
     /// Checks for null

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -66,6 +66,10 @@ namespace edm {
     /// Checks for non-null
     bool isNonnull() const { return product_.isNonnull(); }
 
+    /// Checks if collection is in memory or available
+    /// in the Event. No type checking is done.
+    bool isAvailable() const { return product_.isAvailable(); }
+
     /// Checks for null
     bool operator!() const { return isNull(); }
 

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -93,11 +93,13 @@ void testRefToBaseProd::constructTest() {
   CPPUNIT_ASSERT(!nulled);
   CPPUNIT_ASSERT(nulled.isNull());
   CPPUNIT_ASSERT(!nulled.isNonnull());
+  CPPUNIT_ASSERT(!nulled.isAvailable());
 
   RefToBaseProd<Dummy> nulledP;
   CPPUNIT_ASSERT(!nulledP);
   CPPUNIT_ASSERT(nulledP.isNull());
   CPPUNIT_ASSERT(!nulledP.isNonnull());
+  CPPUNIT_ASSERT(!nulledP.isAvailable());
 
   ProductID const pid(1, 1);
 
@@ -110,6 +112,9 @@ void testRefToBaseProd::constructTest() {
     OrphanHandle<DummyCollection> handle(&dummyContainer, pid);
     RefToBaseProd<Dummy> dummyPtr(handle);
 
+    CPPUNIT_ASSERT(!dummyPtr.isNull());
+    CPPUNIT_ASSERT(dummyPtr.isNonnull());
+    CPPUNIT_ASSERT(dummyPtr.isAvailable());
     CPPUNIT_ASSERT(dummyPtr.id() == pid);
     compareTo(dummyPtr, dummyContainer);
   }
@@ -218,9 +223,15 @@ void testRefToBaseProd::getTest() {
 
     RefCore core(pid, nullptr, &tester, false);
     RefToBaseProd<IntValue>& prod = reinterpret_cast<RefToBaseProd<IntValue>&>(core);
+    CPPUNIT_ASSERT(!prod.isNull());
+    CPPUNIT_ASSERT(prod.isNonnull());
+    CPPUNIT_ASSERT(prod.isAvailable());
 
     //previously making a copy before reading back would cause seg fault
     RefToBaseProd<IntValue> prodCopy(prod);
+    CPPUNIT_ASSERT(!prodCopy.isNull());
+    CPPUNIT_ASSERT(prodCopy.isNonnull());
+    CPPUNIT_ASSERT(prodCopy.isAvailable());
 
     CPPUNIT_ASSERT(!prod.hasCache());
 


### PR DESCRIPTION
#### PR description:

The `isAvailable()` member function is available in
* `edm::RefProd`
* `edm::Ref`
* `edm::Ptr`
* `edm::RefToBase`

but not in `edm::RefToBaseProd`, as was noticed in https://github.com/cms-sw/cmssw/issues/41843#issuecomment-1574078890. This PR adds the `isAvailable()` to `edm::RefToBaseProd`.

#### PR validation:

Unit tests pass

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Potentially to be backported to 13_0_X (and 13_1_X).