### PR TITLE
Add a unit test for `SiStripHashedDetId`

### DIFF
--- a/CalibFormats/SiStripObjects/test/BuildFile.xml
+++ b/CalibFormats/SiStripObjects/test/BuildFile.xml
@@ -14,3 +14,5 @@
   <use name="CalibFormats/SiStripObjects"/>
   <use name="cppunit"/>
 </bin>
+
+<test name="testSiStripHashedDetId" command="testSiStripHashedDetId.sh"/>

--- a/CalibFormats/SiStripObjects/test/testSiStripHashedDetId.sh
+++ b/CalibFormats/SiStripObjects/test/testSiStripHashedDetId.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ function die { echo $1: status $2; exit $2; }
+
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
+
+echo -e " Tesing SiStripHashedDetId \n\n"
+
+cmsRun ${SCRAM_TEST_PATH}/testSiStripHashedDetId_cfg.py || die "Failure running testSiStripHashedDetId_cfg.py" $?

--- a/CalibFormats/SiStripObjects/test/testSiStripHashedDetId_cfg.py
+++ b/CalibFormats/SiStripObjects/test/testSiStripHashedDetId_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("testSiStripHashedDetId", Run3)
+
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = True
+process.MessageLogger.cerr.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.SiStripDqmCommon=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripDqmCommon = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(1),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1))
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.test =  cms.EDAnalyzer("testSiStripHashedDetId")
+
+process.p = cms.Path(process.test)


### PR DESCRIPTION
#### PR description:

Currently `SiStripHashedDetId` is not used by any production workflow but there is a plan to use it in the future. 
Protecting here the functionality with a unit test.

#### PR validation:

added unit tests `scram b runtests_testSiStripHashedDetId` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A