### PR TITLE
Utilities/StaticAnalyzers: updates to address changes in number of reports with llvm 14/16

### DIFF
--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -69,12 +69,10 @@ namespace clangcms {
         os << "const qualifier was removed via a cast, this may result in thread-unsafe code.";
         std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
             std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, llvm::StringRef(os.str()), errorNode);
-        std::unique_ptr<clang::ento::BasicBugReport> R =
-            std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), PSBR->getLocation());
-        R->addRange(CE->getSourceRange());
-        if (!m_exception.reportConstCastAway(*R, C))
+        PSBR->addRange(CE->getSourceRange());
+        if (!m_exception.reportConstCastAway(*PSBR, C))
           return;
-        C.emitReport(std::move(R));
+        C.emitReport(std::move(PSBR));
         if (cname.empty())
           return;
         std::string tname = "constcastaway-checker.txt.unsorted";

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -58,12 +58,10 @@ namespace clangcms {
       os << "const_cast was used, this may result in thread-unsafe code.";
       std::unique_ptr<clang::ento::PathSensitiveBugReport> PSBR =
           std::make_unique<clang::ento::PathSensitiveBugReport>(*BT, llvm::StringRef(os.str()), errorNode);
-      std::unique_ptr<clang::ento::BasicBugReport> R =
-          std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), PSBR->getLocation());
-      R->addRange(CE->getSourceRange());
-      if (!m_exception.reportConstCast(*R, C))
+      PSBR->addRange(CE->getSourceRange());
+      if (!m_exception.reportConstCast(*PSBR, C))
         return;
-      C.emitReport(std::move(R));
+      C.emitReport(std::move(PSBR));
       if (cname.empty())
         return;
       std::string tname = "constcast-checker.txt.unsorted";

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -104,7 +104,12 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const static local variable '" << svname << "'.\n";
-      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D,
+                         Checker->getCheckerName(),
+                         "non-const static local variable accessed or modified",
+                         "ThreadSafety",
+                         os.str(),
+                         DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -115,7 +120,12 @@ namespace clangcms {
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const static member data variable '" << svname
          << "'.\n";
-      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D,
+                         Checker->getCheckerName(),
+                         "non-const static local variable accessed or modified",
+                         "ThreadSafety",
+                         os.str(),
+                         DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -125,7 +135,12 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const global static variable '" << svname << "'.\n";
-      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D,
+                         Checker->getCheckerName(),
+                         "non-const static local variable accessed or modified",
+                         "ThreadSafety",
+                         os.str(),
+                         DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -159,8 +174,10 @@ namespace clangcms {
         os << "function '" << dname
            << "' is in an extern \"C\" context and most likely accesses or modifies fortran variables in a "
               "'COMMONBLOCK'.\n";
-        clang::ento::PathDiagnosticLocation FDLoc = clang::ento::PathDiagnosticLocation::createBegin(FD, BR.getSourceManager());
-        BR.EmitBasicReport(FD,this->getCheckerName() , "COMMONBLOCK variable accessed or modified","ThreadSafety",os.str(), FDLoc);
+        clang::ento::PathDiagnosticLocation FDLoc =
+            clang::ento::PathDiagnosticLocation::createBegin(FD, BR.getSourceManager());
+        BR.EmitBasicReport(
+            FD, this->getCheckerName(), "COMMONBLOCK variable accessed or modified", "ThreadSafety", os.str(), FDLoc);
         std::string ostring = "function '" + dname + "' static variable 'COMMONBLOCK'.\n";
         std::string tname = "function-checker.txt.unsorted";
         support::writeLog(ostring, tname);

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -104,7 +104,7 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const static local variable '" << svname << "'.\n";
-      //		BR.EmitBasicReport(D, Checker, "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -115,7 +115,7 @@ namespace clangcms {
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const static member data variable '" << svname
          << "'.\n";
-      //		BR.EmitBasicReport(D, Checker, "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -125,7 +125,7 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       os << "function '" << dname << "' accesses or modifies non-const global static variable '" << svname << "'.\n";
-      //		BR.EmitBasicReport(D, Checker, "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
+      BR.EmitBasicReport(D, Checker->getCheckerName(), "non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
       std::string ostring = "function '" + sdname + "' static variable '" + vname + "'.\n";
       support::writeLog(ostring, tname);
       return;
@@ -159,8 +159,8 @@ namespace clangcms {
         os << "function '" << dname
            << "' is in an extern \"C\" context and most likely accesses or modifies fortran variables in a "
               "'COMMONBLOCK'.\n";
-        clang::ento::PathDiagnosticLocation::createBegin(FD, BR.getSourceManager());
-        //		BR.EmitBasicReport(FD, "COMMONBLOCK variable accessed or modified","ThreadSafety",os.str(), FDLoc);
+        clang::ento::PathDiagnosticLocation FDLoc = clang::ento::PathDiagnosticLocation::createBegin(FD, BR.getSourceManager());
+        BR.EmitBasicReport(FD,this->getCheckerName() , "COMMONBLOCK variable accessed or modified","ThreadSafety",os.str(), FDLoc);
         std::string ostring = "function '" + dname + "' static variable 'COMMONBLOCK'.\n";
         std::string tname = "function-checker.txt.unsorted";
         support::writeLog(ostring, tname);

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -33,9 +33,14 @@ namespace clangcms {
 
       std::string buf;
       llvm::raw_string_ostream os(buf);
-      os << "Non-const variable '" << t.getAsString() << " " << *D << "' is static and might be thread-unsafe";
-
-      BR.EmitBasicReport(D, this, "non-const global static variable", "ThreadSafety", os.str(), DLoc);
+      os << "Non-const variable '" << t.getAsString() << " " << D->getQualifiedNameAsString() << "' is static and might be thread-unsafe";
+      if (!BT)
+	      BT=std::make_unique<clang::ento::BugType>(this, "non-const global static variable", "ThreadSafety");
+      std::unique_ptr<clang::ento::BasicBugReport> R =
+	      std::make_unique<clang::ento::BasicBugReport>(*BT,llvm::StringRef(os.str()), DLoc);
+      R->setDeclWithIssue(D);
+      R->addRange(D->getSourceRange());
+      BR.emitReport(std::move(R));
       return;
     }
   }

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -33,11 +33,12 @@ namespace clangcms {
 
       std::string buf;
       llvm::raw_string_ostream os(buf);
-      os << "Non-const variable '" << t.getAsString() << " " << D->getQualifiedNameAsString() << "' is static and might be thread-unsafe";
+      os << "Non-const variable '" << t.getAsString() << " " << D->getQualifiedNameAsString()
+         << "' is static and might be thread-unsafe";
       if (!BT)
-	      BT=std::make_unique<clang::ento::BugType>(this, "non-const global static variable", "ThreadSafety");
+        BT = std::make_unique<clang::ento::BugType>(this, "non-const global static variable", "ThreadSafety");
       std::unique_ptr<clang::ento::BasicBugReport> R =
-	      std::make_unique<clang::ento::BasicBugReport>(*BT,llvm::StringRef(os.str()), DLoc);
+          std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       R->setDeclWithIssue(D);
       R->addRange(D->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.h
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.h
@@ -14,7 +14,7 @@
 
 namespace clangcms {
   class GlobalStaticChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::VarDecl> > {
-    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BuiltinBug> BT;
+    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
 
   public:
     void checkASTDecl(const clang::VarDecl *D, clang::ento::AnalysisManager &Mgr, clang::ento::BugReporter &BR) const;

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
@@ -18,8 +18,7 @@ namespace clangcms {
       return;
     if (D->isMutable() && D->getDeclContext()->isRecord()) {
       clang::QualType t = D->getType();
-      clang::ento::PathDiagnosticLocation DLoc =
-          clang::ento::PathDiagnosticLocation::create(D, BR.getSourceManager());
+      clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::create(D, BR.getSourceManager());
 
       if (!m_exception.reportMutableMember(t, DLoc, BR))
         return;
@@ -32,14 +31,15 @@ namespace clangcms {
       os << "Mutable member '" << D->getQualifiedNameAsString() << "' in class '" << pname
          << "', might be thread-unsafe when accessing via a const pointer.";
       if (!BT)
-	      BT = std::make_unique<clang::ento::BugType>(this,"mutable member if accessed via const pointer", "ConstThreadSafety");
+        BT = std::make_unique<clang::ento::BugType>(
+            this, "mutable member if accessed via const pointer", "ConstThreadSafety");
       std::unique_ptr<clang::ento::BasicBugReport> R =
-	      std::make_unique<clang::ento::BasicBugReport>( *BT, llvm::StringRef(os.str()), DLoc);
+          std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       R->setDeclWithIssue(D);
       R->addRange(D->getSourceRange());
       BR.emitReport(std::move(R));
       std::string tname = "mutablemember-checker.txt.unsorted";
-      std::string ostring = "flagged class '" + pname + "' mutable member '" + D->getQualifiedNameAsString() +"'";
+      std::string ostring = "flagged class '" + pname + "' mutable member '" + D->getQualifiedNameAsString() + "'";
       support::writeLog(ostring, tname);
     }
   }

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
@@ -19,7 +19,7 @@ namespace clangcms {
     if (D->isMutable() && D->getDeclContext()->isRecord()) {
       clang::QualType t = D->getType();
       clang::ento::PathDiagnosticLocation DLoc =
-          clang::ento::PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
+          clang::ento::PathDiagnosticLocation::create(D, BR.getSourceManager());
 
       if (!m_exception.reportMutableMember(t, DLoc, BR))
         return;
@@ -29,11 +29,17 @@ namespace clangcms {
       std::string buf;
       llvm::raw_string_ostream os(buf);
       std::string pname = D->getParent()->getQualifiedNameAsString();
-      os << "Mutable member '" << *D << "' in class '" << pname
+      os << "Mutable member '" << D->getQualifiedNameAsString() << "' in class '" << pname
          << "', might be thread-unsafe when accessing via a const pointer.";
-      BR.EmitBasicReport(D, this, "mutable member if accessed via const pointer", "ConstThreadSafety", os.str(), DLoc);
+      if (!BT)
+	      BT = std::make_unique<clang::ento::BugType>(this,"mutable member if accessed via const pointer", "ConstThreadSafety");
+      std::unique_ptr<clang::ento::BasicBugReport> R =
+	      std::make_unique<clang::ento::BasicBugReport>( *BT, llvm::StringRef(os.str()), DLoc);
+      R->setDeclWithIssue(D);
+      R->addRange(D->getSourceRange());
+      BR.emitReport(std::move(R));
       std::string tname = "mutablemember-checker.txt.unsorted";
-      std::string ostring = "flagged class '" + pname + "' mutable member '" + D->getQualifiedNameAsString();
+      std::string ostring = "flagged class '" + pname + "' mutable member '" + D->getQualifiedNameAsString() +"'";
       support::writeLog(ostring, tname);
     }
   }

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
@@ -16,7 +16,6 @@
 
 namespace clangcms {
   class MutableMemberChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::FieldDecl> > {
-
   public:
     CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
     void checkASTDecl(const clang::FieldDecl *D, clang::ento::AnalysisManager &Mgr, clang::ento::BugReporter &BR) const;

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.h
@@ -16,9 +16,9 @@
 
 namespace clangcms {
   class MutableMemberChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::FieldDecl> > {
-    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BuiltinBug> BT;
 
   public:
+    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
     void checkASTDecl(const clang::FieldDecl *D, clang::ento::AnalysisManager &Mgr, clang::ento::BugReporter &BR) const;
 
   private:

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -34,10 +34,15 @@ namespace clangcms {
 
       std::string buf;
       llvm::raw_string_ostream os(buf);
-      os << "Non-const variable '" << t.getAsString() << " " << *D
+      os << "Non-const variable '" << t.getAsString() << " " << D->getQualifiedNameAsString()
          << "' is static local or static member data and might be thread-unsafe";
-
-      BR.EmitBasicReport(D, this, "non-const static variable", "ThreadSafety", os.str(), DLoc);
+      if (!BT)
+        BT=std::make_unique<clang::ento::BugType>(this, "non-const static variable", "ThreadSafety");
+      std::unique_ptr<clang::ento::BasicBugReport> R =
+        std::make_unique<clang::ento::BasicBugReport>(*BT,llvm::StringRef(os.str()), DLoc);
+      R->setDeclWithIssue(D);
+      R->addRange(D->getSourceRange());
+      BR.emitReport(std::move(R));
       return;
     }
   }

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -37,9 +37,9 @@ namespace clangcms {
       os << "Non-const variable '" << t.getAsString() << " " << D->getQualifiedNameAsString()
          << "' is static local or static member data and might be thread-unsafe";
       if (!BT)
-        BT=std::make_unique<clang::ento::BugType>(this, "non-const static variable", "ThreadSafety");
+        BT = std::make_unique<clang::ento::BugType>(this, "non-const static variable", "ThreadSafety");
       std::unique_ptr<clang::ento::BasicBugReport> R =
-        std::make_unique<clang::ento::BasicBugReport>(*BT,llvm::StringRef(os.str()), DLoc);
+          std::make_unique<clang::ento::BasicBugReport>(*BT, llvm::StringRef(os.str()), DLoc);
       R->setDeclWithIssue(D);
       R->addRange(D->getSourceRange());
       BR.emitReport(std::move(R));

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.h
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.h
@@ -15,7 +15,7 @@
 
 namespace clangcms {
   class StaticLocalChecker : public clang::ento::Checker<clang::ento::check::ASTDecl<clang::VarDecl> > {
-    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BuiltinBug> BT;
+    CMS_SA_ALLOW mutable std::unique_ptr<clang::ento::BugType> BT;
 
   public:
     void checkASTDecl(const clang::VarDecl *D, clang::ento::AnalysisManager &Mgr, clang::ento::BugReporter &BR) const;


### PR DESCRIPTION
Use emitReport with BugType pointer instead of emitBasicReport. 
Enable function/class checker bug reports.
