### PR TITLE
add L1nano NANO in Prompt/Tier0 configuration

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -61,14 +61,17 @@ class Reco(Scenario):
 
         miniAODStep = ''
         nanoAODStep = ''
+        if not 'customs' in	args:
+            args['customs']= []
 
         if 'outputs' in args:
-            print(args['outputs']) 
+            print(args['outputs'])
             for a in args['outputs']:
                 if a['dataTier'] == 'MINIAOD':
-                    miniAODStep = ',PAT' 
+                    miniAODStep = ',PAT'
                 if a['dataTier'] in ['NANOAOD', 'NANOEDMAOD']:
-                    nanoAODStep = ',NANO' 
+                    nanoAODStep = ',NANO'
+                    args['customs'].append('PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize')
 
         self._checkRepackedFlag(options, **args)
 


### PR DESCRIPTION
#### PR description:

after discussion with @drkovalskyi , we propose to add the L1NANO customisation function in DataProcessing where T0 picks up its configuration.

a 13.0.X backport is imminent for this, after agreed with Tier0 operation  https://its.cern.ch/jira/browse/CMSTZ-1046 

#### PR validation:

`python3 $CMSSW_BASE/src/Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run3 --reco --aod --miniaod --nanoaod --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias --lfn=/eos/cms/tier0/store/data/Run2023C/HLTPhysics/RAW/v1/000/368/382/00000/86a26e18-1c93-48f2-a4bd-384d1cca7dbf.root  --global-tag 130X_dataRun3_Prompt_v3`

was run successfully, and the L1 branches were located in the output dataset
