### PR TITLE
[PileUpJetID] Backport of #41854 (Move average calculations outside of jet constituents loop) to 13_0_X

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -571,10 +571,10 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet* jet,
     float dphi = reco::deltaPhi(*icand, *jet);
     sum_deta += deta * weight2;
     sum_dphi += dphi * weight2;
-    if (sumW2 > 0) {
-      ave_deta = sum_deta / sumW2;
-      ave_dphi = sum_dphi / sumW2;
-    }
+  }
+  if (sumW2 > 0) {
+    ave_deta = sum_deta / sumW2;
+    ave_dphi = sum_dphi / sumW2;
   }
 
   // // Finalize all variables


### PR DESCRIPTION
Backport of #41854

####Original PR description:
This PR moves the average values calculations to outside of the jet constituents loop in `PileupJetIdAlgo.cc`.
