### PR TITLE
Move events/LS counter to LuminosityBlockCache in DTDataIntegrityTask

### DIFF
--- a/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
@@ -30,14 +30,16 @@
 #include <list>
 
 namespace dtdi {
-  struct Void {};
+  struct LumiCache {
+    int nEventsLS = 0;
+  };
 }  // namespace dtdi
 
 class DTuROSROSData;
 class DTuROSFEDData;
 class DTTimeEvolutionHisto;
 
-class DTDataIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<dtdi::Void>> {
+class DTDataIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<dtdi::LumiCache>> {
 public:
   DTDataIntegrityTask(const edm::ParameterSet& ps);
 
@@ -48,8 +50,8 @@ public:
   void processuROS(DTuROSROSData& data, int fed, int uRos);
   void processFED(DTuROSFEDData& data, int fed);
 
-  std::shared_ptr<dtdi::Void> globalBeginLuminosityBlock(const edm::LuminosityBlock& ls,
-                                                         const edm::EventSetup& es) const override;
+  std::shared_ptr<dtdi::LumiCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& ls,
+                                                              const edm::EventSetup& es) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& ls, const edm::EventSetup& es) override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
@@ -97,13 +99,13 @@ private:
   std::map<unsigned int, DTTimeEvolutionHisto*> urosTimeHistos;
   //key =  (fed-minFED)#*100 + (uROS-minuROS)#
 
-  mutable int nEventsLS;
-
+#ifdef EDM_ML_DEBUG
   int neventsFED;
   int neventsuROS;
+#endif
 
-  int FEDIDmin;
-  int FEDIDmax;
+  const int FEDIDmin;
+  const int FEDIDmax;
 
   int errorX[6][12][5] = {{{0}}};  //5th is notOK flag and 6th is TDC Fatal; Second index is ROS. Last index is wheel
   int nLinksForFatal;  //Minumum number of Links/wheel with notOKFlag or TDC fatal errors to consider a FEDfatal event


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/37163. It makes `DTDataIntegrityTask` concurrent-lumi-safe (as far as I can tell) by moving the counter for the number of events per lumi to LuminosityBlockCache. Earlier the counter could have counted events from other lumis and being reset to 0 in the middle of a lumi when concurrent lumis are enabled.

#### PR validation:

Code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

If this DQM module is used in offline DQM run in Tier0, I'd backport to 13_0_X.