### PR TITLE
Remove stripTrackerHVOn check for BeamSpotLegacy client

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -440,14 +440,7 @@ else:
 print("Configured frontierKey", options.runUniqueKey)
 
 #--------
-# Do no run on events with pixel or strip with HV off
-
-process.stripTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
-    DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
-    DcsStatusLabel = cms.untracked.InputTag( "scalersRawToDigi" ),
-    DebugOn = cms.untracked.bool( False ),
-    DetectorType = cms.untracked.string( "sistrip" )
-)
+# Do no run on events with pixel with HV off
 
 process.pixelTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
     DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
@@ -463,7 +456,6 @@ if (not process.runType.getRunType() == process.runType.hi_run):
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.pixelTrackerHVOn
-                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.dqmcommon
@@ -475,7 +467,6 @@ else:
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.pixelTrackerHVOn
-                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.filter_step # the only extra: pix-multi filter


### PR DESCRIPTION
#### PR description:
Recently we had an issue in [Fill 8860](https://cmsoms.cern.ch/cms/fills/report?cms_fill=8860&datetime_from=2023-06-01T20:15:33Z&datetime_to=2023-06-02T08:20:53Z&cms_run_from=368331&cms_run_to=368343) when the `TEC-` DCS bit was marked as HV OFF (see [here](https://cmsoms.cern.ch/cms/runs/lumisection?cms_run=368343&cms_run_sequence=GLOBAL-RUN)) because the ON channels were 95% as far as I understood (and the majority is set to 98% of channels).

Hence the BeamSpot was not computed by the neither of the clients for the affected runs, see [here](https://cmsoms.cern.ch/cms/fills/report/fullscreen/12657?cms_fill=8860&datetime_from=2023-06-01T20:15:33Z&datetime_to=2023-06-02T08:20:53Z&cms_run_from=368331&cms_run_to=368343).

We also realized that, since the `beam` client (BeamSpotLegacy) is only relying on pixel tracks and vertices, this check is not only useless, but actually detrimental in cases like this.

This PR removes the check on the SiStrip HV for the `beam` DQM BeamSpot client.

#### PR validation:
Running this command:
```
cmsRun DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py unitTest=True runNumber=368341 dataset=/ExpressPhysics/Run2023C-Express-v4/FEVT
```
before the fix leads to (no BeamSpot):
```
-rw-r--r--. 1 fbrivio zh    0 Jun  5 15:37 BeamFitResultsOld.txt
-rw-r--r--. 1 fbrivio zh    0 Jun  5 15:37 BeamSpotOnlineLegacy.db
```
While after this PR the BeamSpot is computed:
```
-rw-r--r--. 1 fbrivio zh  4220 Jun  2 18:28 2023-06-02_16-28-37.log
-rw-r--r--. 1 fbrivio zh   674 Jun  2 18:27 BeamFitResultsOld.txt
-rw-r--r--. 1 fbrivio zh    85 Jun  2 18:27 BeamFitResultsOld_TkStatus.txt
-rw-r--r--. 1 fbrivio zh 65536 Jun  2 18:27 BeamSpotOnlineLegacy.db
```

#### Backport:
Not a backport. Backports to 13_1_X and 13_2_X are available in:
 - 13_1_X: #41882
 - 13_0_X: #41883

FYI @mmusich @dzuolo @gennai @lguzzi