### PR TITLE
Run3-alca244X Make use of PF thresholds for ECAL/HCAL in insolated tracks of hadron/muon studies

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibCorr.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibCorr.C
@@ -34,16 +34,18 @@
 //        double getCorr(entry): Entry # (in the file) dependent correction
 //        bool absent(entry) : if correction factor absent
 //        bool present(entry): or present (relevant for ML motivated)
-// CalibSelectRBX(rbx, debug)
-//      A class for selecting a given Read Out Box and provides
-//        bool isItRBX(detId): if it/they is in the chosen RBX
-//        bool isItRBX(ieta, iphi): if it is in the chosen RBX
+// CalibSelectRBX(rbxFile, debug)
+//      A class for selecting a given set of Read Out Box's and provides
+//        bool isItRBX(detId): if it/they is in the chosen RBXs
+//        bool isItRBX(ieta, iphi): if it is in the chosen RBXs
 // CalibDuplicate(infile, flag, debug)
 //      A class for either rejecting duplicate entries or giving depth
 //        dependent weight. flag is 0 for keeping a list of duplicate
-//        emtries; 1 is to keep depth dependent weight for each ieta
+//        emtries; 1 is to keep depth dependent weight for each ieta;
+//        2 is to keep a list of ieta, iphi for channels to be selected.
 //        bool isDuplicate(entry): if it is a duplicate entry
 //        double getWeight(ieta, depth): get the dependent weight
+//        bool select(int ieta, int iphi): channels to be selected
 // void CalibCorrTest(infile, flag)
 //      Tests a file which contains correction factors used by CalibCorr
 //////////////////////////////////////////////////////////////////////////////
@@ -185,6 +187,25 @@ int truncateDepth(int ieta, int depth, int truncateFlag) {
     d = ((std::abs(ieta) == 15) || (std::abs(ieta) == 16)) ? 1 : depth;
   }
   return d;
+}
+
+double threshold(int subdet, int depth, int form) {
+  double cutHE[7] = {0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2};
+  double cutHB[3][4] = {{0.1, 0.2, 0.3, 0.3}, {0.25, 0.25, 0.3, 0.3}, {0.4, 0.3, 0.3, 0.3}};
+  double thr(0);
+  if (form > 0) {
+    if (subdet == 2)
+      thr = cutHE[depth - 1];
+    else
+      thr = cutHB[form - 1][depth - 1];
+  }
+  return thr;
+}
+
+double threshold(unsigned int detId, int form) {
+  int subdet = ((detId >> 25) & (0x7));
+  int depth = ((detId & 0x1000000) == 0) ? ((detId >> 14) & 0x1F) : ((detId >> 20) & 0xF);
+  return threshold(subdet, depth, form);
 }
 
 double puFactor(int type, int ieta, double pmom, double eHcal, double ediff, bool debug = false) {
@@ -535,7 +556,7 @@ private:
 
 class CalibSelectRBX {
 public:
-  CalibSelectRBX(int rbx, bool debug = false);
+  CalibSelectRBX(const char* rbxFile, bool debug = false);
   ~CalibSelectRBX() {}
 
   bool isItRBX(const unsigned int);
@@ -544,8 +565,7 @@ public:
 
 private:
   bool debug_;
-  int subdet_, zside_;
-  std::vector<int> phis_;
+  std::vector<int> zsphis_;
 };
 
 class CalibDuplicate {
@@ -555,13 +575,15 @@ public:
 
   bool isDuplicate(long entry);
   double getWeight(const unsigned int);
-  bool doCorr() { return ((flag_ != 1) && ok_); }
+  bool doCorr() { return ((flag_ == 1) && ok_); }
+  bool select(int ieta, int iphi);
 
 private:
   int flag_;
   double debug_, ok_;
   std::vector<Long64_t> entries_;
   std::map<int, std::vector<double> > weights_;
+  std::vector<std::pair<int, int> > etaphi_;
 };
 
 CalibCorrFactor::CalibCorrFactor(const char* infile, int useScale, double scale, bool etamax, bool marina, bool debug)
@@ -1004,33 +1026,61 @@ unsigned int CalibCorr::correctDetId(const unsigned int& detId) {
   return id;
 }
 
-CalibSelectRBX::CalibSelectRBX(int rbx, bool debug) : debug_(debug) {
-  zside_ = (rbx > 0) ? 1 : -1;
-  subdet_ = (std::abs(rbx) / 100) % 10;
-  if (subdet_ != 1)
-    subdet_ = 2;
-  int iphis = std::abs(rbx) % 100;
-  if (iphis > 0 && iphis <= 18) {
-    for (int i = 0; i < 4; ++i) {
-      int iphi = (iphis - 2) * 4 + 3 + i;
-      if (iphi < 1)
-        iphi += 72;
-      phis_.push_back(iphi);
+CalibSelectRBX::CalibSelectRBX(const char* rbxFile, bool debug) : debug_(debug) {
+  std::cout << "Enters CalibSelectRBX for " << rbxFile << std::endl;
+  unsigned int all(0), good(0);
+  std::vector<int> rbxs;
+  std::ifstream fInput(rbxFile);
+  if (!fInput.good()) {
+    std::cout << "Cannot open file " << rbxFile << std::endl;
+  } else {
+    char buffer[1024];
+    while (fInput.getline(buffer, 1024)) {
+      ++all;
+      std::string bufferString(buffer);
+      if (bufferString.substr(0, 1) == "#") {
+        continue;  //ignore other comments
+      } else {
+        std::vector<std::string> items = splitString(bufferString);
+        if (items.size() != 1) {
+          std::cout << "Ignore  line: " << buffer << " Size " << items.size() << std::endl;
+        } else {
+          ++good;
+          int rbx = std::atoi(items[0].c_str());
+          rbxs.push_back(rbx);
+          int zside = (rbx > 0) ? 1 : -1;
+          int subdet = (std::abs(rbx) / 100) % 10;
+          if (subdet != 1)
+            subdet = 2;
+          int iphis = std::abs(rbx) % 100;
+          if (iphis > 0 && iphis <= 18) {
+            for (int i = 0; i < 4; ++i) {
+              int iphi = (iphis - 2) * 4 + 3 + i;
+              if (iphi < 1)
+                iphi += 72;
+              int zsphi = zside * (subdet * 100 + iphi);
+              zsphis_.push_back(zsphi);
+            }
+          }
+        }
+      }
     }
+    fInput.close();
   }
-  std::cout << "Select RBX " << rbx << " ==> Subdet " << subdet_ << " zside " << zside_ << " with " << phis_.size()
-            << " iphi values:";
-  for (unsigned int i = 0; i < phis_.size(); ++i)
-    std::cout << " " << phis_[i];
+  std::cout << "Select a set of RBXs " << rbxs.size() << " by reading " << all << ":" << good << " records from "
+            << rbxFile << " with " << zsphis_.size() << " iphi values:";
+  for (unsigned int i = 0; i < zsphis_.size(); ++i)
+    std::cout << " " << zsphis_[i];
   std::cout << std::endl;
 }
 
 bool CalibSelectRBX::isItRBX(const unsigned int detId) {
   bool ok(true);
-  if (phis_.size() == 4) {
+  if (zsphis_.size() > 0) {
     int subdet, ieta, zside, depth, iphi;
     unpackDetId(detId, subdet, zside, ieta, iphi, depth);
-    ok = ((subdet == subdet_) && (zside == zside_) && (std::find(phis_.begin(), phis_.end(), iphi) != phis_.end()));
+    int zsphi = zside * (subdet * 100 + iphi);
+    ok = (std::find(zsphis_.begin(), zsphis_.end(), zsphi) != zsphis_.end());
 
     if (debug_) {
       std::cout << "isItRBX:subdet|zside|iphi " << subdet << ":" << zside << ":" << iphi << " OK " << ok << std::endl;
@@ -1041,14 +1091,16 @@ bool CalibSelectRBX::isItRBX(const unsigned int detId) {
 
 bool CalibSelectRBX::isItRBX(const std::vector<unsigned int>* detId) {
   bool ok(true);
-  if (phis_.size() == 4) {
+  if (zsphis_.size() > 0) {
     ok = true;
     for (unsigned int i = 0; i < detId->size(); ++i) {
       int subdet, ieta, zside, depth, iphi;
       unpackDetId((*detId)[i], subdet, zside, ieta, iphi, depth);
-      ok = ((subdet == subdet_) && (zside == zside_) && (std::find(phis_.begin(), phis_.end(), iphi) != phis_.end()));
+      int zsphi = zside * (subdet * 100 + iphi);
+      ok = (std::find(zsphis_.begin(), zsphis_.end(), zsphi) != zsphis_.end());
       if (debug_) {
-        std::cout << "isItRBX: subdet|zside|iphi " << subdet << ":" << zside << ":" << iphi << std::endl;
+        std::cout << "isItRBX: subdet|zside|iphi " << subdet << ":" << zside << ":" << iphi << " OK " << ok
+                  << std::endl;
       }
       if (ok)
         break;
@@ -1061,12 +1113,14 @@ bool CalibSelectRBX::isItRBX(const std::vector<unsigned int>* detId) {
 
 bool CalibSelectRBX::isItRBX(const int ieta, const int iphi) {
   bool ok(true);
-  if (phis_.size() == 4) {
+  if (zsphis_.size() == 4) {
     int zside = (ieta > 0) ? 1 : -1;
     int subd1 = (std::abs(ieta) <= 16) ? 1 : 2;
     int subd2 = (std::abs(ieta) >= 16) ? 2 : 1;
-    ok = (((subd1 == subdet_) || (subd2 == subdet_)) && (zside == zside_) &&
-          (std::find(phis_.begin(), phis_.end(), iphi) != phis_.end()));
+    int zsphi1 = zside * (subd1 * 100 + iphi);
+    int zsphi2 = zside * (subd2 * 100 + iphi);
+    ok = ((std::find(zsphis_.begin(), zsphis_.end(), zsphi1) != zsphis_.end()) ||
+          (std::find(zsphis_.begin(), zsphis_.end(), zsphi2) != zsphis_.end()));
   }
   if (debug_) {
     std::cout << "isItRBX: ieta " << ieta << " iphi " << iphi << " OK " << ok << std::endl;
@@ -1075,7 +1129,7 @@ bool CalibSelectRBX::isItRBX(const int ieta, const int iphi) {
 }
 
 CalibDuplicate::CalibDuplicate(const char* fname, int flag, bool debug) : flag_(flag), debug_(debug), ok_(false) {
-  if (flag_ == 1) {
+  if (flag_ == 0) {
     if (strcmp(fname, "") != 0) {
       std::ifstream infile(fname);
       if (!infile.is_open()) {
@@ -1096,11 +1150,11 @@ CalibDuplicate::CalibDuplicate(const char* fname, int flag, bool debug) : flag_(
     } else {
       std::cout << "No duplicate events in the input file" << std::endl;
     }
-  } else {
+  } else if (flag_ == 1) {
     if (strcmp(fname, "") != 0) {
       std::ifstream infile(fname);
       if (!infile.is_open()) {
-        std::cout << "Cannot open duplicate file " << fname << std::endl;
+        std::cout << "Cannot open depth dependence file " << fname << std::endl;
       } else {
         unsigned int all(0), good(0);
         char buffer[1024];
@@ -1141,6 +1195,44 @@ CalibDuplicate::CalibDuplicate(const char* fname, int flag, bool debug) : flag_(
           ok_ = true;
       }
     }
+  } else {
+    flag_ = 2;
+    if (strcmp(fname, "") != 0) {
+      std::ifstream infile(fname);
+      if (!infile.is_open()) {
+        std::cout << "Cannot open rejection file " << fname << std::endl;
+      } else {
+        unsigned int all(0), good(0);
+        char buffer[1024];
+        while (infile.getline(buffer, 1024)) {
+          ++all;
+          std::string bufferString(buffer);
+          if (bufferString.substr(0, 1) == "#") {
+            continue;  //ignore other comments
+          } else {
+            std::vector<std::string> items = splitString(bufferString);
+            if (items.size() != 2) {
+              std::cout << "Ignore  line: " << buffer << " Size " << items.size();
+              for (unsigned int k = 0; k < items.size(); ++k)
+                std::cout << " [" << k << "] : " << items[k];
+              std::cout << std::endl;
+            } else {
+              ++good;
+              int ieta = std::atoi(items[0].c_str());
+              int iphi = std::atoi(items[1].c_str());
+              etaphi_.push_back(std::pair<int, int>(ieta, iphi));
+              if (debug_)
+                std::cout << "Select channels with iEta " << ieta << " iPhi " << iphi << std::endl;
+            }
+          }
+        }
+        infile.close();
+        std::cout << "Reads total of " << all << " and " << good << " good records of rejection candidates from "
+                  << fname << std::endl;
+        if (good > 0)
+          ok_ = true;
+      }
+    }
   }
 }
 
@@ -1166,6 +1258,15 @@ double CalibDuplicate::getWeight(unsigned int detId) {
     }
   }
   return wt;
+}
+
+bool CalibDuplicate::select(int ieta, int iphi) {
+  bool flag(false);
+  if ((ok_) && (flag_ == 2))
+    flag = (std::find(etaphi_.begin(), etaphi_.end(), std::pair<int, int>(ieta, iphi)) != etaphi_.end());
+  if (debug_)
+    std::cout << "Input " << ieta << ":" << iphi << " Flags " << ok_ << ":" << flag_ << ":" << flag << std::endl;
+  return flag;
 }
 
 void CalibCorrTest(const char* infile, int flag) {

--- a/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibFitPlots.C
@@ -12,6 +12,10 @@
 //      Defaults: numb=50, type=3, append=true, fiteta=true, iname=3,
 //                debug=false
 //
+//             Same as FitHistExtend with summary of each ieta/depth
+//  FitHistExtended2(infile, outfile, prefix, numb, append, iname, debug);
+//      Defaults: numb=50, append=true, iname=3, debug=false
+//
 //             For RBX dependence in sets of histograms from CalibMonitor
 //  FitHistRBX(infile, outfile, prefix, append, iname);
 //      Defaults: append=true, iname=2
@@ -886,6 +890,215 @@ void FitHistExtended(const char* infile,
               hists.push_back(hist3);
             }
             //            results meaner0 = fitTwoGauss(hist, debug);
+            results meaner0 = fitOneGauss(hist, true, debug);
+            value = meaner0.mean;
+            error = meaner0.errmean;
+            double rms;
+            std::pair<double, double> meaner = GetMean(hist, 0.2, 2.0, rms);
+            if (debug) {
+              std::cout << "Fit " << value << ":" << error << ":" << hist->GetMeanError() << " Mean " << meaner.first
+                        << ":" << meaner.second << std::endl;
+            }
+          }
+          hists.push_back(hist);
+        }
+      }
+    }
+    TFile* theFile(0);
+    if (append) {
+      if (debug) {
+        std::cout << "Open file " << outfile << " in append mode" << std::endl;
+      }
+      theFile = new TFile(outfile, "UPDATE");
+    } else {
+      if (debug) {
+        std::cout << "Open file " << outfile << " in recreate mode" << std::endl;
+      }
+      theFile = new TFile(outfile, "RECREATE");
+    }
+
+    theFile->cd();
+    for (unsigned int i = 0; i < hists.size(); ++i) {
+      TH1D* hnew = (TH1D*)hists[i]->Clone();
+      if (debug) {
+        std::cout << "Write Histogram " << hnew->GetTitle() << std::endl;
+      }
+      hnew->Write();
+    }
+    theFile->Close();
+    file->Close();
+  }
+}
+
+void FitHistExtended2(const char* infile,
+                      const char* outfile,
+                      std::string prefix,
+                      int numb = 50,
+                      bool append = true,
+                      int iname = 3,
+                      bool debug = false) {
+  std::string sname("ratio"), lname("Z"), wname("W"), ename("etaB");
+  double xbins[99];
+  int ixbin[99];
+  int neta = numb / 2;
+  for (int k = 0; k < neta; ++k) {
+    xbins[k] = (k - neta) - 0.5;
+    xbins[numb - k] = (neta - k) + 0.5;
+    ixbin[k] = (k - neta);
+    ixbin[numb - k] = (neta - k);
+  }
+  xbins[neta] = 0;
+  ixbin[neta] = 0;
+  TFile* file = new TFile(infile);
+  std::vector<TH1D*> hists;
+  char name[200];
+  if (debug) {
+    std::cout << infile << " " << file << std::endl;
+  }
+  if (file != nullptr) {
+    sprintf(name, "%s%s%d0", prefix.c_str(), sname.c_str(), iname);
+    TH1D* hist0 = (TH1D*)file->FindObjectAny(name);
+    bool ok = (hist0 != nullptr);
+    if (debug) {
+      std::cout << name << " Pointer " << hist0 << " " << ok << std::endl;
+    }
+    if (ok) {
+      TH1D *histo(0), *histw(0);
+      if (numb > 0) {
+        sprintf(name, "%s%s%d", prefix.c_str(), lname.c_str(), iname);
+        histo = new TH1D(name, hist0->GetTitle(), numb, xbins);
+        sprintf(name, "%s%s%d", prefix.c_str(), wname.c_str(), iname);
+        histw = new TH1D(name, hist0->GetTitle(), numb, xbins);
+        if (debug)
+          std::cout << name << " " << histo->GetNbinsX() << std::endl;
+      }
+      int nv1(100), nv2(0);
+      int jmin(numb), jmax(0);
+      for (int j = 0; j <= numb; ++j) {
+        sprintf(name, "%s%s%d%d", prefix.c_str(), sname.c_str(), iname, j);
+        TH1D* hist1 = (TH1D*)file->FindObjectAny(name);
+        if (debug) {
+          std::cout << "Get Histogram for " << name << " at " << hist1 << std::endl;
+        }
+        double value(0), error(0), total(0), width(0), werror(0);
+        if (hist1 == nullptr) {
+          value = 1.0;
+        } else {
+          TH1D* hist = (TH1D*)hist1->Clone();
+          if (debug)
+            std::cout << "Histogram " << name << ":" << (hist->GetName()) << " with " << (hist->GetEntries())
+                      << " entries" << std::endl;
+          if (hist->GetEntries() > 0) {
+            value = hist->GetMean();
+            error = hist->GetRMS();
+            for (int i = 1; i <= hist->GetNbinsX(); ++i)
+              total += hist->GetBinContent(i);
+            std::pair<double, double> rmserr = GetWidth(hist, 0.2, 2.0);
+            width = rmserr.first;
+            werror = rmserr.second;
+          }
+          if (total > 4) {
+            if (nv1 > j)
+              nv1 = j;
+            if (nv2 < j)
+              nv2 = j;
+            if (j == 0) {
+              sprintf(name, "%sOne", hist1->GetName());
+              TH1D* hist2 = (TH1D*)hist1->Clone(name);
+              fitOneGauss(hist2, true, debug);
+              hists.push_back(hist2);
+              results meaner = fitOneGauss(hist, true, debug);
+              value = meaner.mean;
+              error = meaner.errmean;
+              width = meaner.width;
+              werror = meaner.errwidth;
+            } else {
+              results meaner = fitOneGauss(hist, true, debug);
+              value = meaner.mean;
+              error = meaner.errmean;
+              width = meaner.width;
+              werror = meaner.errwidth;
+            }
+            if (j != 0) {
+              if (j < jmin)
+                jmin = j;
+              if (j > jmax)
+                jmax = j;
+            }
+            double wbyv0 = width / value;
+            double wverr0 = wbyv0 * std::sqrt((werror * werror) / (width * width) + (error * error) / (value * value));
+            if (ixbin[j] != 0)
+              std::cout << ixbin[j] << " MPV " << value << " +- " << error << " Width/MPV " << wbyv0 << " +- " << wverr0
+                        << std::endl;
+          }
+          hists.push_back(hist);
+        }
+        if (debug) {
+          std::cout << "Hist " << j << " Value " << value << " +- " << error << std::endl;
+        }
+        if (j != 0) {
+          double wbyv = width / value;
+          double wverr = wbyv * std::sqrt((werror * werror) / (width * width) + (error * error) / (value * value));
+          histo->SetBinContent(j, value);
+          histo->SetBinError(j, error);
+          histw->SetBinContent(j, wbyv);
+          histw->SetBinError(j, wverr);
+        }
+      }
+      if (histo != nullptr) {
+        if (histo->GetEntries() > 2) {
+          if (debug) {
+            std::cout << "Jmin/max " << jmin << ":" << jmax << ":" << histo->GetNbinsX() << std::endl;
+          }
+          double LowEdge = histo->GetBinLowEdge(jmin);
+          double HighEdge = histo->GetBinLowEdge(jmax) + histo->GetBinWidth(jmax);
+          TFitResultPtr Fit = histo->Fit("pol0", "+QRWLS", "", LowEdge, HighEdge);
+          if (debug) {
+            std::cout << "Fit to Pol0: " << Fit->Value(0) << " +- " << Fit->FitResult::Error(0) << " in range " << nv1
+                      << ":" << xbins[nv1] << ":" << nv2 << ":" << xbins[nv2] << std::endl;
+          }
+          histo->GetXaxis()->SetTitle("i#eta");
+          histo->GetYaxis()->SetTitle("MPV(E_{HCAL}/(p-E_{ECAL}))");
+          histo->GetYaxis()->SetRangeUser(0.4, 1.6);
+          histw->GetXaxis()->SetTitle("i#eta");
+          histw->GetYaxis()->SetTitle("MPV/Width(E_{HCAL}/(p-E_{ECAL}))");
+          histw->GetYaxis()->SetRangeUser(0.0, 0.5);
+        }
+        hists.push_back(histo);
+        hists.push_back(histw);
+      } else {
+        hists.push_back(hist0);
+      }
+
+      //Barrel,Endcap
+      for (int j = 1; j <= 4; ++j) {
+        sprintf(name, "%s%s%d%d", prefix.c_str(), ename.c_str(), iname, j);
+        TH1D* hist1 = (TH1D*)file->FindObjectAny(name);
+        if (debug) {
+          std::cout << "Get Histogram for " << name << " at " << hist1 << std::endl;
+        }
+        if (hist1 != nullptr) {
+          TH1D* hist = (TH1D*)hist1->Clone();
+          double value(0), error(0), total(0), width(0), werror(0);
+          if (hist->GetEntries() > 0) {
+            value = hist->GetMean();
+            error = hist->GetRMS();
+            for (int i = 1; i <= hist->GetNbinsX(); ++i)
+              total += hist->GetBinContent(i);
+          }
+          if (total > 4) {
+            sprintf(name, "%sOne", hist1->GetName());
+            TH1D* hist2 = (TH1D*)hist1->Clone(name);
+            results meanerr = fitOneGauss(hist2, true, debug);
+            value = meanerr.mean;
+            error = meanerr.errmean;
+            width = meanerr.width;
+            werror = meanerr.errwidth;
+            double wbyv = width / value;
+            double wverr = wbyv * std::sqrt((werror * werror) / (width * width) + (error * error) / (value * value));
+            std::cout << hist2->GetName() << " MPV " << value << " +- " << error << " Width " << width << " +- "
+                      << werror << " W/M " << wbyv << " +- " << wverr << std::endl;
+            hists.push_back(hist2);
             results meaner0 = fitOneGauss(hist, true, debug);
             value = meaner0.mean;
             error = meaner0.errmean;
@@ -3703,5 +3916,153 @@ void PlotDepthCorrFactor(char* infile,
   } else if (save < 0) {
     sprintf(name, "%s.C", pad->GetName());
     pad->Print(name);
+  }
+}
+
+void DrawHistPhiSymmetry(TH1D* hist0, bool dataMC, bool drawStatBox, bool save) {
+  char name[30], namep[30], txt1[30];
+  TH1D* hist = (TH1D*)(hist0->Clone());
+  sprintf(namep, "c_%s", hist->GetName());
+  TCanvas* pad = new TCanvas(namep, namep, 700, 500);
+  pad->SetRightMargin(0.10);
+  pad->SetTopMargin(0.10);
+  hist->GetXaxis()->SetTitleSize(0.04);
+  hist->GetXaxis()->SetTitle(hist->GetTitle());
+  hist->GetYaxis()->SetTitle("Channels");
+  hist->GetYaxis()->SetLabelOffset(0.005);
+  hist->GetYaxis()->SetTitleSize(0.04);
+  hist->GetYaxis()->SetLabelSize(0.035);
+  hist->GetYaxis()->SetTitleOffset(1.10);
+  hist->Draw();
+  pad->Update();
+  if (drawStatBox) {
+    TPaveStats* st1 = (TPaveStats*)hist->GetListOfFunctions()->FindObject("stats");
+    if (st1 != nullptr) {
+      st1->SetY1NDC(0.70);
+      st1->SetY2NDC(0.90);
+      st1->SetX1NDC(0.65);
+      st1->SetX2NDC(0.90);
+    }
+    pad->Modified();
+    pad->Update();
+  }
+  TPaveText* txt2 = new TPaveText(0.11, 0.85, 0.44, 0.89, "blNDC");
+  txt2->SetFillColor(0);
+  if (dataMC)
+    sprintf(txt1, "CMS Preliminary");
+  else
+    sprintf(txt1, "CMS Simulation Preliminary");
+  txt2->AddText(txt1);
+  txt2->Draw("same");
+  pad->Modified();
+  pad->Update();
+  if (save) {
+    sprintf(name, "%s.pdf", pad->GetName());
+    pad->Print(name);
+  }
+}
+
+void PlotPhiSymmetryResults(
+    char* infile, bool dataMC = true, bool drawStatBox = true, bool debug = false, bool save = false) {
+  const int maxDepthHB(4), maxDepthHE(7);
+  const double cfacMin(0.70), cfacMax(1.5);
+  const int nbin = (100.0 * (cfacMax - cfacMin));
+  std::vector<TH1D*> histHB, histHE;
+  char name[20], title[80];
+  for (int k = 0; k < maxDepthHB; ++k) {
+    sprintf(name, "HB%d", k);
+    sprintf(title, "Correction factor for depth %d of HB", k);
+    TH1D* h = new TH1D(name, title, nbin, cfacMin, cfacMax);
+    histHB.push_back(h);
+    if (debug)
+      std::cout << "Book " << h->GetName() << " Title " << h->GetTitle() << " range " << nbin << ":" << cfacMin << ":"
+                << cfacMax << std::endl;
+  }
+  for (int k = 0; k < maxDepthHE; ++k) {
+    sprintf(name, "HE%d", k);
+    sprintf(title, "Correction factor for depth %d of HE", k);
+    TH1D* h = new TH1D(name, title, nbin, cfacMin, cfacMax);
+    histHE.push_back(h);
+    if (debug)
+      std::cout << "Book " << h->GetName() << " Title " << h->GetTitle() << " range " << nbin << ":" << cfacMin << ":"
+                << cfacMax << std::endl;
+  }
+  std::ifstream fInput(infile);
+  if (!fInput.good()) {
+    std::cout << "Cannot open file " << infile << std::endl;
+  } else {
+    char buffer[1024];
+    int all(0), good(0);
+    std::map<int, int> kount;
+    while (fInput.getline(buffer, 1024)) {
+      ++all;
+      std::string bufferString(buffer);
+      if (bufferString.substr(0, 1) == "#") {
+        continue;  //ignore other comments
+      } else {
+        std::vector<std::string> items = splitString(bufferString);
+        if (items.size() < 5) {
+          for (unsigned int k = 0; k < items.size(); ++k)
+            std::cout << " [" << k << "] : " << items[k];
+          std::cout << std::endl;
+        } else {
+          ++good;
+          int subdet = std::atoi(items[0].c_str());
+          int ieta = std::atoi(items[1].c_str());
+          int depth = std::atoi(items[3].c_str());
+          double corrf = std::atof(items[4].c_str());
+          if ((debug) && (good % 100 == 0))
+            std::cout << "Subdet " << subdet << " Depth " << depth << " Corr " << corrf << std::endl;
+          if ((corrf < cfacMin) || (corrf > cfacMax))
+            std::cout << "Outlier: " << buffer << std::endl;
+          if (subdet == 1) {
+            if (depth <= maxDepthHB)
+              histHB[depth - 1]->Fill(corrf);
+          } else if (subdet == 2) {
+            if (depth <= maxDepthHE)
+              histHE[depth - 1]->Fill(corrf);
+          }
+          if ((subdet == 1) || (subdet == 2)) {
+            int indx = (ieta > 0) ? (ieta * 10 + depth) : (10000 + 10 * (-ieta) + depth);
+            if (kount.find(indx) == kount.end())
+              kount[indx] = 1;
+            else
+              ++kount[indx];
+          }
+        }
+      }
+    }
+    fInput.close();
+    std::cout << "Reads total of " << all << " and " << good << " good records of phi-symmetry factors from " << infile
+              << std::endl;
+    for (std::map<int, int>::iterator itr = kount.begin(); itr != kount.end(); ++itr) {
+      int depth = (itr->first) % 10;
+      int ieta = ((itr->first) / 10) % 100;
+      int nphi = itr->second;
+      bool miss = (((ieta <= 20) && (nphi != 72)) || ((ieta > 20) && (nphi != 36)));
+      if (itr->first >= 10000)
+        ieta = -ieta;
+      if (debug || miss)
+        std::cout << "Tower[" << ieta << ":" << depth << "] has " << nphi << " entries" << std::endl;
+    }
+  }
+
+  // Now plot the histograms
+  gStyle->SetCanvasBorderMode(0);
+  gStyle->SetCanvasColor(kWhite);
+  gStyle->SetPadColor(kWhite);
+  gStyle->SetFillColor(kWhite);
+  gStyle->SetOptTitle(0);
+  gStyle->SetOptStat(111110);
+  gStyle->SetOptFit(0);
+
+  // HB first
+  for (unsigned int k = 0; k < histHB.size(); ++k) {
+    DrawHistPhiSymmetry(histHB[k], dataMC, drawStatBox, save);
+  }
+
+  // Then HE
+  for (unsigned int k = 0; k < histHE.size(); ++k) {
+    DrawHistPhiSymmetry(histHE[k], dataMC, drawStatBox, save);
   }
 }

--- a/Calibration/HcalCalibAlgos/macros/CalibMain.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMain.C
@@ -10,23 +10,23 @@
 //  Other parameters for CalibMonitor:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
 //  <Truncate> <Nmax> <datamc> <numb> <usegen> <scale> <usescale> <etalo>
-//  <etahi> <runlo> <runhi> <phimin> <phimax> <zside> <nvxlo> <nvxhi> <rbx>
+//  <etahi> <runlo> <runhi> <phimin> <phimax> <zside> <nvxlo> <nvxhi>
 //  <exclude> <etamax> <append> <all> <corrfile> <rcorfile> <dupfile>
-//  <comfile> <outfile>
+//  <rbxfile> <comfile> <outfile>
 //
 //  Other parameters for CalibProperties:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
 //  <Truncate> <Nmax> <datamc> <usegen> <scale> <usescale> <etalo> <etahi>
-//  <runlo> <runhi> <phimin> <phimax> <zside> <nvxlo> <nvxhi> <rbx>
-//  <exclude> <etamax> <append> <all> <corrfile> <rcorfile> <dupfile>
+//  <runlo> <runhi> <phimin> <phimax> <zside> <nvxlo> <nvxhi> <exclude>
+//  <etamax> <append> <all> <corrfile> <rcorfile> <dupfile> <rbxfile>
 //
 //  Other parameters for CalibTree:
 //  <InputFile> <OutputFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
 //  <Truncate> <Nmax> <maxIter> <corrfile> <applyl1> <l1cut> <useiter>
 //  <useweight> <usemean> <nmin> <inverse> <ratmin> <ratmax> <ietamax>
 //  <ietatrack> <sysmode> <rcorform> <usegen> <runlo> <runhi> <phimin>
-//  <phimax> <zside> <nvxlo> <nvxhi> <rbx> <exclude> <higheta> <fraction>
-//  <writehisto> <debug> <rcorfile> <dupfile> <treename>
+//  <phimax> <zside> <nvxlo> <nvxhi> <exclude> <higheta> <fraction>
+//  <writehisto> <debug> <rcorfile> <dupfile> <rbxfile> <treename>
 //
 //  Other parameters for CalibSplit:
 //  <InputFile> <HistogramFile> <Flag> <DirectoryName> <Prefix> <PUcorr>
@@ -107,16 +107,36 @@ int main(Int_t argc, Char_t* argv[]) {
     int zside = (argc > 21) ? std::atoi(argv[21]) : 1;
     int nvxlo = (argc > 22) ? std::atoi(argv[22]) : 0;
     int nvxhi = (argc > 23) ? std::atoi(argv[23]) : 1000;
-    int rbx = (argc > 24) ? std::atoi(argv[24]) : 0;
-    bool exclude = (argc > 25) ? (std::atoi(argv[25]) > 0) : false;
-    bool etamax = (argc > 26) ? (std::atoi(argv[26]) > 0) : false;
-    bool append = (argc > 27) ? (std::atoi(argv[27]) > 0) : true;
-    bool all = (argc > 28) ? (std::atoi(argv[28]) > 0) : true;
-    const char* corrfile = (argc > 29) ? argv[29] : "";
-    const char* rcorfile = (argc > 30) ? argv[30] : "";
-    const char* dupfile = (argc > 31) ? argv[31] : "";
+    bool exclude = (argc > 24) ? (std::atoi(argv[24]) > 0) : false;
+    bool etamax = (argc > 25) ? (std::atoi(argv[25]) > 0) : false;
+    bool append = (argc > 26) ? (std::atoi(argv[26]) > 0) : true;
+    bool all = (argc > 27) ? (std::atoi(argv[27]) > 0) : true;
+    const char* corrfile = (argc > 28) ? argv[28] : "";
+    const char* rcorfile = (argc > 29) ? argv[29] : "";
+    const char* dupfile = (argc > 30) ? argv[30] : "";
+    const char* rbxfile = (argc > 31) ? argv[31] : "";
     const char* comfile = (argc > 32) ? argv[32] : "";
     const char* outfile = (argc > 33) ? argv[33] : "";
+    if (strcmp(corrfile, "junk.txt") == 0)
+      corrfile = "";
+    if (strcmp(rcorfile, "junk.txt") == 0)
+      rcorfile = "";
+    if (strcmp(dupfile, "junk.txt") == 0)
+      dupfile = "";
+    if (strcmp(comfile, "junk.txt") == 0)
+      comfile = "";
+    if (strcmp(rbxfile, "junk.txt") == 0)
+      rbxfile = "";
+
+    std::cout << "Execute CalibMonitor with infile:" << infile << " dirName: " << dirname << " dupFile: " << dupfile
+              << " comFile:" << comfile << " outFile:" << outfile << " prefix: " << prefix << " corrFile: " << corrfile
+              << " rcoFile:" << rcorfile << " puCorr:" << pucorr << " Flag:" << flag << " Numb:" << numb
+              << " dataMC:" << datamc << " truncate:" << truncate << " useGen:" << usegen << " Scale:" << scale
+              << " useScale:" << usescale << " etaRange:" << etalo << ":" << etahi << " runRange:" << runlo << ":"
+              << runhi << " phiRange:" << phimin << ":" << phimax << " zside:" << zside << " nvxRange:" << nvxlo << ":"
+              << nvxhi << " rbxFile:" << rbxfile << " exclude:" << exclude << " etaMax:" << etamax
+              << " histFile:" << histfile << " append:" << append << " all:" << all << " nmax:" << nmax << std::endl;
+
     CalibMonitor c1(infile,
                     dirname,
                     dupfile,
@@ -142,7 +162,7 @@ int main(Int_t argc, Char_t* argv[]) {
                     zside,
                     nvxlo,
                     nvxhi,
-                    rbx,
+                    rbxfile,
                     exclude,
                     etamax);
     c1.Loop(nmax);
@@ -162,15 +182,24 @@ int main(Int_t argc, Char_t* argv[]) {
     int zside = (argc > 20) ? std::atoi(argv[20]) : 1;
     int nvxlo = (argc > 21) ? std::atoi(argv[21]) : 0;
     int nvxhi = (argc > 22) ? std::atoi(argv[22]) : 1000;
-    int rbx = (argc > 23) ? std::atoi(argv[23]) : 0;
-    bool exclude = (argc > 24) ? (std::atoi(argv[24]) > 0) : false;
-    bool etamax = (argc > 25) ? (std::atoi(argv[25]) > 0) : false;
-    bool append = (argc > 26) ? (std::atoi(argv[26]) > 0) : true;
-    bool all = (argc > 27) ? (std::atoi(argv[27]) > 0) : true;
-    const char* corrfile = (argc > 28) ? argv[28] : "";
-    const char* rcorfile = (argc > 29) ? argv[29] : "";
-    const char* dupfile = (argc > 30) ? argv[30] : "";
+    bool exclude = (argc > 23) ? (std::atoi(argv[23]) > 0) : false;
+    bool etamax = (argc > 24) ? (std::atoi(argv[24]) > 0) : false;
+    bool append = (argc > 25) ? (std::atoi(argv[25]) > 0) : true;
+    bool all = (argc > 26) ? (std::atoi(argv[26]) > 0) : true;
+    const char* corrfile = (argc > 27) ? argv[27] : "";
+    const char* rcorfile = (argc > 28) ? argv[28] : "";
+    const char* dupfile = (argc > 29) ? argv[29] : "";
+    const char* rbxfile = (argc > 30) ? argv[30] : "";
+    if (strcmp(corrfile, "junk.txt") == 0)
+      corrfile = "";
+    if (strcmp(rcorfile, "junk.txt") == 0)
+      rcorfile = "";
+    if (strcmp(dupfile, "junk.txt") == 0)
+      dupfile = "";
+    if (strcmp(rbxfile, "junk.txt") == 0)
+      rbxfile = "";
     bool debug(false);
+
     CalibPlotProperties c1(infile,
                            dirname,
                            dupfile,
@@ -193,7 +222,7 @@ int main(Int_t argc, Char_t* argv[]) {
                            zside,
                            nvxlo,
                            nvxhi,
-                           rbx,
+                           rbxfile,
                            exclude,
                            etamax);
     c1.Loop(nmax);
@@ -223,20 +252,29 @@ int main(Int_t argc, Char_t* argv[]) {
     int zside = (argc > 30) ? std::atoi(argv[30]) : 0;
     int nvxlo = (argc > 31) ? std::atoi(argv[31]) : 0;
     int nvxhi = (argc > 32) ? std::atoi(argv[32]) : 1000;
-    int rbx = (argc > 33) ? std::atoi(argv[33]) : 0;
-    bool exclude = (argc > 34) ? (std::atoi(argv[34]) > 0) : false;
-    int higheta = (argc > 35) ? std::atoi(argv[35]) : 1;
-    double fraction = (argc > 36) ? std::atof(argv[36]) : 1.0;
-    bool writehisto = (argc > 37) ? (std::atoi(argv[37]) > 0) : false;
-    bool debug = (argc > 38) ? (std::atoi(argv[38]) > 0) : false;
-    const char* rcorfile = (argc > 39) ? argv[39] : "";
-    const char* dupfile = (argc > 40) ? argv[40] : "";
-    const char* treename = (argc > 41) ? argv[41] : "CalibTree";
+    bool exclude = (argc > 33) ? (std::atoi(argv[33]) > 0) : false;
+    int higheta = (argc > 34) ? std::atoi(argv[34]) : 1;
+    double fraction = (argc > 35) ? std::atof(argv[35]) : 1.0;
+    bool writehisto = (argc > 36) ? (std::atoi(argv[36]) > 0) : false;
+    double pmin = (argc > 37) ? std::atof(argv[37]) : 40.0;
+    double pmax = (argc > 38) ? std::atof(argv[38]) : 60.0;
+    bool debug = (argc > 39) ? (std::atoi(argv[39]) > 0) : false;
+    const char* rcorfile = (argc > 40) ? argv[40] : "";
+    const char* dupfile = (argc > 41) ? argv[41] : "";
+    const char* rbxfile = (argc > 42) ? argv[42] : "";
+    const char* treename = (argc > 43) ? argv[43] : "CalibTree";
+    if (strcmp(rcorfile, "junk.txt") == 0)
+      rcorfile = "";
+    if (strcmp(dupfile, "junk.txt") == 0)
+      dupfile = "";
+    if (strcmp(rbxfile, "junk.txt") == 0)
+      rbxfile = "";
 
     char name[500];
     sprintf(name, "%s/%s", dirname, treename);
     TChain* chain = new TChain(name);
     std::cout << "Create a chain for " << name << " from " << infile << std::endl;
+
     if (!fillChain(chain, infile)) {
       std::cout << "*****No valid tree chain can be obtained*****" << std::endl;
     } else {
@@ -249,6 +287,12 @@ int main(Int_t argc, Char_t* argv[]) {
       std::cout << "Tree " << name << " " << chain << " in directory " << dirname << " from file " << infile
                 << " with nentries (tracks): " << nentries << std::endl;
       unsigned int k(0), kmax(maxIter);
+      std::cout << "Proceed using CalibTree with dupFile:" << dupfile << " rcorFile:" << rcorfile
+                << " trunCate:" << truncate << " useIter:" << useiter << " useMean:" << usemean << " runRange:" << runlo
+                << ":" << runhi << " phiRange:" << phimin << ":" << phimax << "zSide:" << zside << " nvxRange:" << nvxlo
+                << ":" << nvxhi << " sysMode:" << sysmode << " rbxFile:" << rbxfile << " puCorr:" << pucorr
+                << " rcorForm:" << rcorform << " useGen:" << usegen << " exclude:" << exclude << " highEta:" << higheta
+                << " pRange:" << pmin << ":" << pmax << std::endl;
       CalibTree t(dupfile,
                   rcorfile,
                   truncate,
@@ -262,12 +306,14 @@ int main(Int_t argc, Char_t* argv[]) {
                   nvxlo,
                   nvxhi,
                   sysmode,
-                  rbx,
+                  rbxfile,
                   pucorr,
                   rcorform,
                   usegen,
                   exclude,
                   higheta,
+                  pmin,
+                  pmax,
                   chain);
       t.h_pbyE = new TH1D("pbyE", "pbyE", 100, -1.0, 9.0);
       t.h_Ebyp_bfr = new TProfile("Ebyp_bfr", "Ebyp_bfr", 60, -30, 30, 0, 10);

--- a/Calibration/IsolatedParticles/interface/eECALMatrix.h
+++ b/Calibration/IsolatedParticles/interface/eECALMatrix.h
@@ -29,6 +29,7 @@ Created: August 2009
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 
 #include "Calibration/IsolatedParticles/interface/MatrixECALDetIds.h"
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
@@ -128,6 +129,18 @@ namespace spr {
                                       double eeThr = -100,
                                       double tMin = -500,
                                       double tMax = 500,
+                                      bool debug = false);
+
+  std::pair<double, bool> eECALmatrix(const DetId& detId,
+                                      edm::Handle<EcalRecHitCollection>& hitsEB,
+                                      edm::Handle<EcalRecHitCollection>& hitsEE,
+                                      const EcalChannelStatus& chStatus,
+                                      const CaloGeometry* geo,
+                                      const CaloTopology* caloTopology,
+                                      const EcalSeverityLevelAlgo* sevlv,
+                                      const EcalPFRecHitThresholds* eThr,
+                                      int ieta,
+                                      int iphi,
                                       bool debug = false);
 
   // returns vector of hits in NxN matrix


### PR DESCRIPTION
#### PR description:

Make use of PF thresholds for ECAL/HCAL in insolated tracks of hadron/muon studies

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special