### PR TITLE
[13_0_X] Remove stripTrackerHVOn check for BeamSpotLegacy client

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -440,14 +440,7 @@ else:
 print("Configured frontierKey", options.runUniqueKey)
 
 #--------
-# Do no run on events with pixel or strip with HV off
-
-process.stripTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
-    DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
-    DcsStatusLabel = cms.untracked.InputTag( "scalersRawToDigi" ),
-    DebugOn = cms.untracked.bool( False ),
-    DetectorType = cms.untracked.string( "sistrip" )
-)
+# Do no run on events with pixel with HV off
 
 process.pixelTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
     DCSRecordLabel = cms.untracked.InputTag( "onlineMetaDataDigis" ),
@@ -463,7 +456,6 @@ if (not process.runType.getRunType() == process.runType.hi_run):
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.pixelTrackerHVOn
-                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.dqmcommon
@@ -475,7 +467,6 @@ else:
                        * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.pixelTrackerHVOn
-                       * process.stripTrackerHVOn
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
                        * process.filter_step # the only extra: pix-multi filter


### PR DESCRIPTION
#### PR description:
Backport of #41875 

Removes the useless check on SiStrip HV status in the BeamSpotLegacy (`beam`) DQM client - see master PR for further details.

#### PR validation:
See master PR for validation details

#### Backport:
Backport of #41875 