### PR TITLE
Automated thread control with ensemble models

### DIFF
--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -343,6 +343,11 @@ edit_model(){
 	NUMINSTANCES=$2
 	
 	cp -r $MODELNAME $TMPDIR/$LOCALMODELREPO/
+	COPY_EXIT=$?
+	if [ "$COPY_EXIT" -ne 0 ]; then
+		echo "Could not copy $MODELNAME into $TMPDIR/$LOCALMODELREPO/"
+		exit "$COPY_EXIT"
+	fi
 	IFS='/' read -ra ADDR <<< "$MODELNAME"
 	CONFIG=$TMPDIR/$LOCALMODELREPO/${ADDR[-1]}/config.pbtxt
 
@@ -357,7 +362,7 @@ edit_model(){
 			edit_model $SUBMODEL "$INSTANCES"
 		done
 	else
-		#This is not an emsemble model, so we should edit the config file
+		#This is not an ensemble model, so we should edit the config file
 		cat <<EOF >> $CONFIG
 instance_group [
   {
@@ -392,7 +397,12 @@ list_models(){
 			#Want to start with a fresh copy of model files in case this directory already exists with local edits
 			rm -rf $TMPDIR/$LOCALMODELREPO
 		fi
-		mkdir $TMPDIR/$LOCALMODELREPO
+		$DRYRUN mkdir $TMPDIR/$LOCALMODELREPO
+		MKMODELDIR_EXIT=$?
+		if [ "$MKMODELDIR_EXIT" -ne 0 ]; then
+			echo "Could not create local_model_repo dir: $TMPDIR/$LOCALMODELREPO"
+			exit "$MKMODELDIR_EXIT"
+		fi
 	fi
 
 	for MODEL in ${MODELS[@]}; do

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -10,7 +10,6 @@ SERVER=triton_server_instance
 RETRIES=3
 REPOS=()
 MODELS=()
-ENSEMBLEMODELS=()
 FORCE=""
 CLEANUP=true
 TMPDIR=""
@@ -355,13 +354,11 @@ edit_model(){
 		SUBNAME=$(grep "model_name:" "$CONFIG")
 		for s in ${SUBNAME}; do
 			if ! [[ $s == *"model_name"* ]]; then
-				submodel=$(echo $s | tr -d '"')
-				ENSEMBLEMODELS+=($(echo ${MODELLOC}/$s | tr -d '"'))
+				SUBMODEL=$(echo ${MODELLOC}/$s | tr -d '"')
+				edit_model $SUBMODEL "$INSTANCES"
 			fi
 		done
-	fi
-
-	if ! [[ $PLATFORM == *"ensemble"* ]]; then	
+	else
 		cat <<EOF >> $CONFIG
 
 instance_group [
@@ -410,17 +407,6 @@ list_models(){
 			edit_model $MODEL "$INSTANCES"
 		else
 			REPOS+=("$(dirname "$MODEL")")
-		fi
-	done
-	for ENSEMBLEMODEL in ${ENSEMBLEMODELS[@]}; do
-		# check if file was provided rather than directory
-		if [ -f "$ENSEMBLEMODEL" ]; then
-			ENSEMBLEMODEL="$(dirname "$ENSEMBLEMODEL")"
-		fi
-		if [ "$INSTANCES" -gt 0 ]; then
-			edit_model $ENSEMBLEMODEL "$INSTANCES"
-		else
-			REPOS+=("$(dirname "$ENSEMBLEMODEL")")
 		fi
 	done
 	if [ "$INSTANCES" -gt 0 ]; then

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -351,6 +351,7 @@ edit_model(){
 	PLATFORM=$(grep -m 1 "^platform:" "$CONFIG")
 
 	if [[ $PLATFORM == *"ensemble"* ]]; then
+		#recurse over submodels of ensemble model
 		SUBNAME=$(grep "model_name:" "$CONFIG")
 		for s in ${SUBNAME}; do
 			if ! [[ $s == *"model_name"* ]]; then
@@ -359,8 +360,8 @@ edit_model(){
 			fi
 		done
 	else
+		#This is not an emsemble model, so we should edit the config file
 		cat <<EOF >> $CONFIG
-
 instance_group [
   {
     count: $NUMINSTANCES
@@ -369,21 +370,20 @@ instance_group [
 ]
 
 EOF
-	fi
-
-	if [[ $PLATFORM == *"onnx"* ]]; then
-		cat <<EOF >> $CONFIG
+		if [[ $PLATFORM == *"onnx"* ]]; then
+			cat <<EOF >> $CONFIG
 parameters { key: "intra_op_thread_count" value: { string_value: "1" } }
 parameters { key: "inter_op_thread_count" value: { string_value: "1" } }
 EOF
-	elif [[ $PLATFORM == *"tensorflow"* ]]; then
-		cat <<EOF >> $CONFIG
+		elif [[ $PLATFORM == *"tensorflow"* ]]; then
+			cat <<EOF >> $CONFIG
 parameters { key: "TF_NUM_INTRA_THREADS" value: { string_value: "1" } }
 parameters { key: "TF_NUM_INTER_THREADS" value: { string_value: "1" } }
 parameters { key: "TF_USE_PER_SESSION_THREADS" value: { string_value: "1" } }
 EOF
-	else
-		echo "Warning: thread (instance) control not implemented for $PLATFORM"
+		else
+			echo "Warning: thread (instance) control not implemented for $PLATFORM"
+		fi
 	fi
 }
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -606,15 +606,6 @@ elif [ "$OP" == start ]; then
 	PORT_EXIT=$?
 	if [ "$PORT_EXIT" -ne 0 ]; then exit $PORT_EXIT; fi
 
-	make_tmp
-
-	list_models
-
-	# after make_tmp because this may create file in tmp dir
-	check_drivers
-	DRIVER_EXIT=$?
-	if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
-
 	# if parent PID is provided, automatically stop server when finished
 	# do this before actually trying to start the server in case of ctrl+c
 	if [ -n "$PARENTPID" ]; then
@@ -623,14 +614,12 @@ elif [ "$OP" == start ]; then
 
 	START_EXIT=0
 	for ((counter=0; counter < ${RETRIES}; counter++)); do
-		if [ "$START_EXIT" -ne 0 ]; then
-			make_tmp
-			#If we plan on editing model configs, must repull files into /tmp/local_model_repo, which was deleted
-			if [ "$INSTANCES" -gt 0 ]; then list_models; fi
-			check_drivers
-			DRIVER_EXIT=$?
-			if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
-		fi
+		make_tmp
+		#If we plan on editing model configs, must repull files into /tmp/local_model_repo, which is deleted upon retry
+		if [ "$counter" -eq 0 ] || [ "$INSTANCES" -gt 0 ]; then list_models; fi
+		check_drivers
+		DRIVER_EXIT=$?
+		if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
 
 		$START_FN
 		START_EXIT=$?

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -623,7 +623,14 @@ elif [ "$OP" == start ]; then
 
 	START_EXIT=0
 	for ((counter=0; counter < ${RETRIES}; counter++)); do
-		if [ "$START_EXIT" -ne 0 ]; then make_tmp; fi
+		if [ "$START_EXIT" -ne 0 ]; then
+			make_tmp
+			#If we plan on editing model configs, must repull files into /tmp/local_model_repo, which was deleted
+			if [ "$INSTANCES" -gt 0 ]; then list_models; fi
+			check_drivers
+			DRIVER_EXIT=$?
+			if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
+		fi
 
 		$START_FN
 		START_EXIT=$?

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -345,19 +345,16 @@ edit_model(){
 	cp -r $MODELNAME $TMPDIR/$LOCALMODELREPO/
 	IFS='/' read -ra ADDR <<< "$MODELNAME"
 	CONFIG=$TMPDIR/$LOCALMODELREPO/${ADDR[-1]}/config.pbtxt
-	
-	MODELLOC=$(echo ""${ADDR[@]:0:${#ADDR[@]}-1} | sed "s/ /\//g")
 
 	PLATFORM=$(grep -m 1 "^platform:" "$CONFIG")
 
 	if [[ $PLATFORM == *"ensemble"* ]]; then
 		#recurse over submodels of ensemble model
-		SUBNAME=$(grep "model_name:" "$CONFIG")
-		for s in ${SUBNAME}; do
-			if ! [[ $s == *"model_name"* ]]; then
-				SUBMODEL=$(echo ${MODELLOC}/$s | tr -d '"')
-				edit_model $SUBMODEL "$INSTANCES"
-			fi
+		MODELLOC=$(echo ""${ADDR[@]:0:${#ADDR[@]}-1} | sed "s/ /\//g")
+		SUBNAME=$(grep "model_name:" "$CONFIG" | sed 's/model_name://; s/"//g')
+		for SUBMODEL in ${SUBNAME}; do
+			SUBMODEL=${MODELLOC}/${SUBMODEL}
+			edit_model $SUBMODEL "$INSTANCES"
 		done
 	else
 		#This is not an emsemble model, so we should edit the config file

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -10,6 +10,7 @@ SERVER=triton_server_instance
 RETRIES=3
 REPOS=()
 MODELS=()
+ENSEMBLEMODELS=()
 FORCE=""
 CLEANUP=true
 TMPDIR=""
@@ -346,9 +347,22 @@ edit_model(){
 	IFS='/' read -ra ADDR <<< "$MODELNAME"
 	CONFIG=$TMPDIR/$LOCALMODELREPO/${ADDR[-1]}/config.pbtxt
 	
+	MODELLOC=$(echo ""${ADDR[@]:0:${#ADDR[@]}-1} | sed "s/ /\//g")
+
 	PLATFORM=$(grep -m 1 "^platform:" "$CONFIG")
-	
-	cat <<EOF >> $CONFIG
+
+	if [[ $PLATFORM == *"ensemble"* ]]; then
+		SUBNAME=$(grep "model_name:" "$CONFIG")
+		for s in ${SUBNAME}; do
+			if ! [[ $s == *"model_name"* ]]; then
+				submodel=$(echo $s | tr -d '"')
+				ENSEMBLEMODELS+=($(echo ${MODELLOC}/$s | tr -d '"'))
+			fi
+		done
+	fi
+
+	if ! [[ $PLATFORM == *"ensemble"* ]]; then	
+		cat <<EOF >> $CONFIG
 
 instance_group [
   {
@@ -358,6 +372,7 @@ instance_group [
 ]
 
 EOF
+	fi
 
 	if [[ $PLATFORM == *"onnx"* ]]; then
 		cat <<EOF >> $CONFIG
@@ -395,6 +410,17 @@ list_models(){
 			edit_model $MODEL "$INSTANCES"
 		else
 			REPOS+=("$(dirname "$MODEL")")
+		fi
+	done
+	for ENSEMBLEMODEL in ${ENSEMBLEMODELS[@]}; do
+		# check if file was provided rather than directory
+		if [ -f "$ENSEMBLEMODEL" ]; then
+			ENSEMBLEMODEL="$(dirname "$ENSEMBLEMODEL")"
+		fi
+		if [ "$INSTANCES" -gt 0 ]; then
+			edit_model $ENSEMBLEMODEL "$INSTANCES"
+		else
+			REPOS+=("$(dirname "$ENSEMBLEMODEL")")
 		fi
 	done
 	if [ "$INSTANCES" -gt 0 ]; then


### PR DESCRIPTION
#### PR description:

This is a follow up to https://github.com/cms-sw/cmssw/pull/41876.  This is needed in the case of ensemble models, such as the pytorch-based ECAL DRN.  This update pulls the component models of the overall ensemble model locally in order to edit them.  Previously, the ensemble model was pulled locally, but the component models were not, so the server could not start.

#### PR validation:

Local tests performed to validated that files are pulled and edited as expected, that fallback servers can start, and that a workflow with the ECAL DRN can run to completion

Tagging @kpedro88 