### PR TITLE
Make MessageLogger format() to be compatible with C++20, and add vformat() for runtime format string

### DIFF
--- a/FWCore/MessageLogger/interface/ErrorObj.h
+++ b/FWCore/MessageLogger/interface/ErrorObj.h
@@ -25,6 +25,8 @@
 #include "FWCore/MessageLogger/interface/ELextendedID.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 
+#include "fmt/format.h"
+
 #include <sstream>
 #include <string>
 
@@ -78,7 +80,8 @@ namespace edm {
     inline ErrorObj& operator<<(std::ostream& (*f)(std::ostream&));
     inline ErrorObj& operator<<(std::ios_base& (*f)(std::ios_base&));
     template <typename... Args>
-    inline ErrorObj& format(std::string_view fmt, Args const&... args);
+    inline ErrorObj& format(fmt::format_string<Args...> format, Args&&... args);
+    inline ErrorObj& vformat(std::string_view fmt, fmt::format_args args);
 
     virtual ErrorObj& emitToken(std::string_view txt);
 

--- a/FWCore/MessageLogger/interface/ErrorObj.icc
+++ b/FWCore/MessageLogger/interface/ErrorObj.icc
@@ -57,8 +57,15 @@ namespace edm {
   }
 
   template <typename... Args>
-  inline ErrorObj& ErrorObj::format(std::string_view fmt, Args const&... args) {
-    auto str = fmt::format(fmt, args...);
+  inline ErrorObj& ErrorObj::format(fmt::format_string<Args...> format, Args&&... args) {
+    auto str = fmt::format(std::move(format), std::forward<Args>(args)...);
+    if (!str.empty())
+      emitToken(str);
+    return *this;
+  }
+
+  inline ErrorObj& ErrorObj::vformat(std::string_view format, fmt::format_args args) {
+    auto str = fmt::vformat(format, std::move(args));
     if (!str.empty())
       emitToken(str);
     return *this;

--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -95,9 +95,15 @@ namespace edm {
     }
 
     template <typename... Args>
-    ThisLog& format(std::string_view fmt, Args const&... args) {
+    ThisLog& format(fmt::format_string<Args...> format, Args&&... args) {
       if (ap.valid())
-        ap.format(fmt, args...);
+        ap.format(std::move(format), std::forward<Args>(args)...);
+      return *this;
+    }
+
+    ThisLog& vformat(std::string_view fmt, fmt::format_args args) {
+      if (ap.valid())
+        ap.vformat(fmt, std::move(args));
       return *this;
     }
 
@@ -198,9 +204,11 @@ namespace edm {
     Suppress_LogDebug_& operator<<(std::ios_base& (*)(std::ios_base&)) { return *this; }
 
     template <typename... Args>
-    Suppress_LogDebug_& format(std::string_view fmt, Args const&... args) {
+    Suppress_LogDebug_& format(fmt::format_string<Args...> format, Args&&... args) {
       return *this;
     }
+
+    Suppress_LogDebug_& vformat(std::string_view fmt, fmt::format_args args) { return *this; }
 
     template <typename F>
     Suppress_LogDebug_& log(F&& iF) {

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -38,9 +38,16 @@ namespace edm {
     }
 
     template <typename... Args>
-    MessageSender& format(std::string_view fmt, Args const&... args) {
+    MessageSender& format(fmt::format_string<Args...> format, Args&&... args) {
       if (valid())
-        errorobj_p->format(fmt, args...);
+        errorobj_p->format(std::move(format), std::forward<Args>(args)...);
+      return *this;
+    }
+
+    template <typename... Args>
+    MessageSender& vformat(std::string_view fmt, fmt::format_args args) {
+      if (valid())
+        errorobj_p->vformat(fmt, std::move(args));
       return *this;
     }
 

--- a/FWCore/MessageService/test/UnitTestClient_C.cc
+++ b/FWCore/MessageService/test/UnitTestClient_C.cc
@@ -33,9 +33,10 @@ namespace edmtest {
     edm::LogWarning("cat_A")
         .format("Test of format fill and width: ")
         .format("The following should read ++abcdefg $$$12: {:+>9} {:$>5}", "abcdefg", 12);
-    edm::LogWarning("cat_A").format("Test of format precision: Pi with precision 12 is {:.12g}", d);
-    edm::LogWarning("cat_A").format(
-        "Test of format spacing: The following should read a b cc: {} {:+>} {:>2}", "a", "b", "cc");
+    edm::LogWarning("cat_A").vformat(std::string("Test of format precision: Pi with precision 12 is {:.12g}"),
+                                     fmt::make_format_args(d));
+    edm::LogWarning("cat_A").vformat("Test of format spacing: The following should read a b cc: {} {:+>} {:>2}",
+                                     fmt::make_format_args("a", "b", "cc"));
   }
 
 }  // namespace edmtest

--- a/FWCore/MessageService/test/fmt_test.cppunit.cpp
+++ b/FWCore/MessageService/test/fmt_test.cppunit.cpp
@@ -45,7 +45,9 @@ auto capture(const Args&... args) {
   return std::make_tuple(args...);
 }
 
-auto print_message = [](const auto&... args) { fmt::print(args...); };
+auto vprint_message = [](auto&& format, auto&&... args) {
+  fmt::vprint(format, fmt::make_format_args(std::forward<decltype(args)>(args)...));
+};
 
 void test_fmt_external::test_fmt()
 
@@ -54,11 +56,11 @@ void test_fmt_external::test_fmt()
   std::string s_check = "The date is 2012-12-9";
   CPPUNIT_ASSERT(s_check == s);
   auto args = capture("{} {}", 42, "foo");
-  std::apply(print_message, args);
+  std::apply(vprint_message, args);
   auto buf = fmt::memory_buffer();
   format_to(std::back_inserter(buf), "{}", 42);  // replaces itoa(42, buffer, 10)
-  fmt::print(to_string(buf));
+  fmt::vprint(to_string(buf), fmt::make_format_args());
   format_to(std::back_inserter(buf), "{:x}", 42);  // replaces itoa(42, buffer, 16)
-  fmt::print(to_string(buf));
+  fmt::vprint(to_string(buf), fmt::make_format_args());
 }
 #include <Utilities/Testing/interface/CppUnit_testdriver.icpp>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmsdist/pull/8233#issuecomment-1572210519 showed that the MessageLogger's `format()` doesn't compile with C++20 enabled. The reason is that both the C++20 `std::format()` as well as the fmt's `fmt::format()` when C++20 is enabled require the format string to be a constant expression, what `std::string_view` is not. This PR makes MessageLogger's `format()` to require the format string to be a constant expression, and adds `vformat()` for a runtime-defined format string with similar interface as `std::vformat()`  and `fmt::vformat()`.

For `format()` I had to use the `fmt::format_string<T...>` in the "front line" interface (that `fmt::format()` uses itself) because apparently perfect forwarding is not sufficient to provide "constant expression".


#### PR validation:

Compiles in a C++20-enabled build (as provided by https://github.com/cms-sw/cmsdist/pull/8233#issuecomment-1572210519). The `fmt_test.cppunit` test runs in the same build. I did not exercise the MessageLogger unit tests as I didn't want to build the universe and otherwise the tests fail because of a lot of code failed to build in https://github.com/cms-sw/cmsdist/pull/8233#issuecomment-1572210519. 