### PR TITLE
Add L1NANO in Prompt/Tier0 configuration [13_1_X]

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -61,14 +61,17 @@ class Reco(Scenario):
 
         miniAODStep = ''
         nanoAODStep = ''
+        if not 'customs' in	args:
+            args['customs']= []
 
         if 'outputs' in args:
-            print(args['outputs']) 
+            print(args['outputs'])
             for a in args['outputs']:
                 if a['dataTier'] == 'MINIAOD':
-                    miniAODStep = ',PAT' 
+                    miniAODStep = ',PAT'
                 if a['dataTier'] in ['NANOAOD', 'NANOEDMAOD']:
-                    nanoAODStep = ',NANO' 
+                    nanoAODStep = ',NANO'
+                    args['customs'].append('PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize')
 
         self._checkRepackedFlag(options, **args)
 


### PR DESCRIPTION
#### PR description:

Title says all
Backport of #41868 in 13_1_X: since a similar backport already exists for 13_0_X (see #41884) this will avoid holes in the release cycles

#### PR validation:

Same commit already merged in master, and going to be merged in 13_0_X as well

@vlimant 
