### PR TITLE
Small fix to DTDataIntegrityTask.cc

### DIFF
--- a/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
+++ b/DQM/DTMonitorModule/interface/DTDataIntegrityTask.h
@@ -14,9 +14,9 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
@@ -122,8 +122,3 @@ private:
 };
 
 #endif
-
-/* Local Variables: */
-/* show-trailing-whitespace: t */
-/* truncate-lines: t */
-/* End: */


### PR DESCRIPTION
#### PR description:

The Static Analyzer for DQM/DTMonitorModule/src/DTDataIntegrityTask.cc warns that at [line 669](https://github.com/cms-sw/cmssw/blob/master/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc#L669) there is a  C++ object whose pointer is potentially null

The reason is that the `uROSSummary` (as well as the `uROSStatus`) objects are only instantiated when `mode<=2`, while in that line it is accessed for every `mode != 1`.

Here the check `mode<=2` is extended also to the filling of those Monitor Elements

#### PR validation:

It builds
No changes expected: at most, the previous version could have crashed if `mode>2`
