### PR TITLE
Add Phase2 HLT DQM

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -28,6 +28,10 @@ validationHarvestingNoHLT = cms.Path(postValidation*postValidation_gen)
 validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
 #validationHarvestingNoHLT = cms.Sequence(postValidation*postValidation_gen)
 #validationHarvesting = cms.Sequence(postValidation*hltpostvalidation*postValidation_gen)
+validationHarvestingPhase2 = cms.Path(hltpostvalidation)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(validationHarvesting,validationHarvestingPhase2)
 
 _validationHarvesting_fastsim = validationHarvesting.copy()
 for _entry in [hltpostvalidation]:

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -47,6 +47,9 @@ for _entry in [hltassociation]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(prevalidation,_prevalidation_fastsim)
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(prevalidation, prevalidation.copyAndExclude([cms.SequencePlaceholder("mix"),globalPrevalidation,metPreValidSeq,jetPreValidSeq]))
+
 validationNoHLT = cms.Sequence(
                                genvalid_all
                                *globaldigisanalyze
@@ -56,6 +59,9 @@ validationNoHLT = cms.Sequence(
 validationNoHLT.remove(condDataValidation) # foca d'ovatta !
 validation = cms.Sequence(validationNoHLT
                          *hltvalidation)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(validation, validation.copyAndExclude([validationNoHLT]))
 
 validationNoHLTHiMix = cms.Sequence(
                                genvalid_all_hiMix

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -39,6 +39,29 @@ hltpostvalidation = cms.Sequence(
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
+# Temporary Phase-2 configuration
+# Exclude everything except JetMET for now
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([postProcessorHLTtrackingSequence,
+                                                                                 postProcessorHLTvertexing,
+                                                                                 HLTMuonPostVal,
+                                                                                 HLTTauPostVal,
+                                                                                 EgammaPostVal,
+                                                                                 postProcessorHLTgsfTrackingSequence,
+                                                                                 postProcessorHLTmuonTrackingSequence,
+                                                                                 heavyFlavorValidationHarvestingSequence,
+                                                                                 #JetMETPostVal,
+                                                                                 #HLTAlCaPostVal,
+                                                                                 SusyExoPostVal,
+                                                                                 #ExamplePostVal,
+                                                                                 hltvalidationqt,
+                                                                                 HLTHiggsPostVal,
+                                                                                 hltExoticaPostProcessors,
+                                                                                 b2gHLTriggerValidationHarvest,
+                                                                                 HLTSMPPostVal,
+                                                                                 HltBTagPostVal])
+)
+
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -39,6 +39,16 @@ hltassociation = cms.Sequence(
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
+# Temporary Phase-2 config
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([hltMultiTrackValidation,
+                                                                           hltMultiPVValidation,
+                                                                           egammaSelectors,
+                                                                           ExoticaValidationProdSeq,
+                                                                           hltMultiTrackValidationGsfTracks,
+                                                                           hltMultiTrackValidationMuonTracks])
+)
+
 # hcal
 from DQMOffline.Trigger.HCALMonitoring_cff import *
 
@@ -60,6 +70,24 @@ hltvalidationWithMC = cms.Sequence(
     +hltbtagValidationSequence #too noisy for now
     +hltHCALdigisAnalyzer+hltHCALRecoAnalyzer+hltHCALNoiseRates # HCAL
 )
+
+# Temporary Phase-2 config
+# Exclude everything except JetMET for now
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([HLTMuonVal,
+                                                                                     HLTTauVal,
+                                                                                     egammaValidationSequence,
+                                                                                     heavyFlavorValidationSequence,
+                                                                                     #HLTJetMETValSeq,
+                                                                                     HLTSusyExoValSeq,
+                                                                                     HiggsValidationSequence,
+                                                                                     ExoticaValidationSequence,
+                                                                                     b2gHLTriggerValidation,
+                                                                                     SMPValidationSequence,
+                                                                                     hltbtagValidationSequence,
+                                                                                     hltHCALdigisAnalyzer,
+                                                                                     hltHCALRecoAnalyzer,
+                                                                                     hltHCALNoiseRates]))
 
 hltvalidationWithData = cms.Sequence(
 )

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -20,4 +20,9 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     HLTriggerResults      = cms.InputTag("TriggerResults::HLT"),
 )
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(SingleJetMetPaths,
+                       PatternJetTrg = cms.untracked.string("HLT_(AK4)?PF(NoPU|Puppi)?Jet([0-9])+(_v[0-9]+)?$")
+                       )
+
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -1,20 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-#pfjetcoll="hltAK4PFJetsCorrected"
-pfjetcoll="hltAK4PFJets"
-pfjetcollPhase2 = "hltAK4PFPuppiJetsCorrected"
-
-foldernm="HLT/HLTJETMET/"
-
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     triggerEventObject    = cms.untracked.InputTag("hltTriggerSummaryRAW","","HLT"),
-    DQMFolder             = cms.untracked.string(foldernm),
+    DQMFolder             = cms.untracked.string("HLT/HLTJETMET/"),
     PatternJetTrg         = cms.untracked.string("HLT_PF(NoPU)?Jet([0-9])+(_v[0-9]+)?$"),                                   
     PatternMetTrg         = cms.untracked.string("HLT_+[Calo|PF]+MET([0-9])+[_NotCleaned|_BeamHaloCleaned]+(_v[0-9]+)?$"),
     PatternMuTrg          = cms.untracked.string("HLT_Mu([0-9])+(_v[0-9]+)?$"),
     LogFileName           = cms.untracked.string('JetMETSingleJetValidation.log'),
-    PFJetAlgorithm        = cms.untracked.InputTag(pfjetcoll),
+    PFJetAlgorithm        = cms.untracked.InputTag("hltAK4PFJets"),
     GenJetAlgorithm       = cms.untracked.InputTag("ak4GenJets"),
     CaloMETCollection     = cms.untracked.InputTag("hltMet"),
     GenMETCollection      = cms.untracked.InputTag("genMetCalo"),
@@ -23,8 +17,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg = 'HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$',
-                       PFJetAlgorithm = cms.untracked.InputTag(pfjetcollPhase2)
+                       PatternJetTrg = "HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$",
+                       PFJetAlgorithm = "hltAK4PFPuppiJetsCorrected"
                        )
 
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #pfjetcoll="hltAK4PFJetsCorrected"
 pfjetcoll="hltAK4PFJets"
+pfjetcollPhase2 = "hltAK4PFPuppiJetsCorrected"
 
 foldernm="HLT/HLTJETMET/"
 
@@ -22,7 +23,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg = cms.untracked.string("HLT_(AK4)?PF(NoPU|Puppi)?Jet([0-9])+(_v[0-9]+)?$")
+                       PatternJetTrg = 'HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$',
+                       PFJetAlgorithm = cms.untracked.InputTag(pfjetcollPhase2)
                        )
 
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -24,7 +24,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'TrackerPhase2Validation' : ['', 'trackerphase2ValidationSource', 'trackerphase2ValidationHarvesting'],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation', 'standardValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])


### PR DESCRIPTION
#### PR description:
This PR is the second attempt to include HLT validation for Phase-2. This PR starts with JetMET-only path for now.
The difference than original PR (https://github.com/cms-sw/cmssw/pull/39450) is to avoid a lot of empty histograms from HLT validation by enable one-by-one validation, starting from JetMET.

#### PR validation:
Try to run locally, to see newly produced histogram.

With this PR: we see a new folder of (`HLT_AK4PFPuppiJet520` in `HLT/HLTJETMET` from `hltvalidationWithMC`) and  (`HLT/HCAL` from `hltvalidationCommon`)
https://tinyurl.com/2xova9bl

Compare to what we have now:
https://tinyurl.com/29p9jyte

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport