### PR TITLE
update unit tests for `CondTools/SiPhase2Tracker` package to register failures and fix underlying code

### DIFF
--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
@@ -8,18 +8,31 @@ process.RandomNumberGeneratorService.prod = cms.PSet(
     engineName = cms.untracked.string('TRandom3')
 )
 
-## speciffy detector D49, as the geometry is needed (will take tracker T15)
-process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+## specify detector D88, as the geometry is needed (will take tracker T24)
+process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
 
-process.MessageLogger = cms.Service("MessageLogger",
-    cerr = cms.untracked.PSet(
-        enable = cms.untracked.bool(False)
-    ),
-    cout = cms.untracked.PSet(
-        enable = cms.untracked.bool(True),
-        threshold = cms.untracked.string('INFO')
-    )
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiPhase2BadStripChannelBuilder=dict()
+process.MessageLogger.SiStripBadStrip=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable    = cms.untracked.bool(True),
+    enableStatistics = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),
+    SiPhase2BadStripChannelBuilder = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiStripBadStrip = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
 )
 
 process.source = cms.Source("EmptyIOVSource",
@@ -39,10 +52,10 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         authenticationPath = cms.untracked.string('')
     ),
     timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:SiStripBadStripPhase2_T15_v0.db'),
+    connect = cms.string('sqlite_file:SiStripBadStripPhase2_T21_v0.db'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('SiStripBadStripRcd'),
-        tag = cms.string('SiStripBadStripPhase2_T15')
+        tag = cms.string('SiStripBadStripPhase2_T21')
     ))
 )
 

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
@@ -1,6 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing('analysis')
+options.register('algorithm',
+                 2, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Algorithm to populate output sqlite file")
+options.parseArguments()
 
 process.load("Configuration.StandardSequences.Services_cff")
 process.RandomNumberGeneratorService.prod = cms.PSet(
@@ -66,7 +75,8 @@ process.prod = cms.EDAnalyzer("SiPhase2BadStripChannelBuilder",
                               printDebug = cms.untracked.bool(False),
                               doStoreOnDB = cms.bool(True),
                               #popConAlgo = cms.uint32(1), #NAIVE
-                              popConAlgo = cms.uint32(2), #RANDOM
+                              #popConAlgo = cms.uint32(2), #RANDOM
+                              popConAlgo = cms.uint32(options.algorithm), 
                               badComponentsFraction = cms.double(0.01)  #1% of bad strips
                               #badComponentsFraction = cms.double(0.05)  #5% of bad strips
                               #badComponentsFraction = cms.double(0.1)   #10% of bad strips

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
@@ -48,13 +48,16 @@ process.source = cms.Source("EmptyIOVSource",
 # Input data
 ###################################################################
 if(options.fromESSource): 
-    process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
-    process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+    process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
+    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
     #process.load("SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff") # already included
     #process.SiPhase2OTFakeBadStripsESSource.printDebug = cms.untracked.bool(True)    # this makes it verbose 
     process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = cms.double(0.05)   # bad components fraction is 5%
 else:
-    tag = 'SiStripBadStripPhase2_T15'
+    tag = 'SiStripBadStripPhase2_T21'
     suffix = 'v0'
     inFile = tag+'_'+suffix+'.db'
     inDB = 'sqlite_file:'+inFile

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
@@ -36,7 +36,7 @@ process.source = cms.Source("EmptyIOVSource",
 ###################################################################
 # Input data
 ###################################################################
-tag = 'SiPhase2OuterTrackerLorentzAngle_T15'
+tag = 'SiPhase2OuterTrackerLorentzAngle_T21'
 suffix = 'v0'
 inFile = tag+'_'+suffix+'.db'
 inDB = 'sqlite_file:'+inFile

--- a/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
@@ -25,7 +25,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
   SiPhase2OuterTrackerLorentzAngle = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
 )
 
-tag = 'SiPhase2OuterTrackerLorentzAngle_T15'
+tag = 'SiPhase2OuterTrackerLorentzAngle_T21'
 suffix = 'v0'
 outfile = tag+'_'+suffix+'.db'
 outdb = 'sqlite_file:'+outfile
@@ -38,12 +38,12 @@ if os.path.exists(outfile):
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = cms.string(outdb)
 
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21')
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
+++ b/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
@@ -10,7 +10,8 @@ cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py || die "Failure
 
 printf "testing writing Phase2 Outer Tracker Bad Strips \n\n"
 ## need to be in order (don't read before writing)
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py algorithm=1 || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py (naive)" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py algorithm=1 || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py (random)" $?
 cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py  || die "Failure running SiPhase2BadStripChannelReader_cfg.py" $?
 cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py fromESSource=True || die "Failure running SiPhase2BadStripChannelReader_cfg.py fromESSource=True" $?
 

--- a/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
+++ b/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
@@ -1,26 +1,27 @@
  #!/bin/bash -ex
+function die { echo $1: status $2 ; exit $2; }
 TEST_DIR=$CMSSW_BASE/src/CondTools/SiPhase2Tracker/test
 echo "test dir: $TEST_DIR"
 
 printf "testing writing Phase2 Outer Tracker Lorentz Angle \n\n"
 ## need to be in order (don't read before writing)
-cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
-cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
+cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py || die "Failure running SiPhase2OuterTrackerLorentzAngleWriter_cfg.py " $?
+cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py || die "Failure running SiPhase2OuterTrackerLorentzAngleReader_cfg.py " $?
 
 printf "testing writing Phase2 Outer Tracker Bad Strips \n\n"
 ## need to be in order (don't read before writing)
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py
-cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py fromESSource=True
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py || die "Failure running SiPhase2BadStripChannelBuilder_cfg.py" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py  || die "Failure running SiPhase2BadStripChannelReader_cfg.py" $?
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py fromESSource=True || die "Failure running SiPhase2BadStripChannelReader_cfg.py fromESSource=True" $?
 
 printf "testing writing Phase2 Tracker Cabling Map (test) \n\n"
 ## need to be in order (don't read before writing)
-cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_write.py
-cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_retrieve.py
-cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_dump.py
+cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_write.py || die "Failure running DTCCablingMapTestProducer_write.py" $?
+cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_retrieve.py || die "Failure running DTCCablingMapTestProducer_retrieve.py" $?
+cmsRun ${TEST_DIR}/DTCCablingMapTestProducer_dump.py || die "Failure running DTCCablingMapTestProducer_dump.py" $?
 
 printf "testing writing Phase2 Tracker Cabling Map  \n\n"
 ## need to be in order (don't read before writing)
-cmsRun ${TEST_DIR}/DTCCablingMapProducer_write.py
-cmsRun ${TEST_DIR}/DTCCablingMapProducer_retrieve.py
-cmsRun ${TEST_DIR}/DTCCablingMapProducer_dump.py
+cmsRun ${TEST_DIR}/DTCCablingMapProducer_write.py || die "Failure running DTCCablingMapProducer_write.py" $?
+cmsRun ${TEST_DIR}/DTCCablingMapProducer_retrieve.py || die "Failure running DTCCablingMapProducer_retrieve.py " $?
+cmsRun ${TEST_DIR}/DTCCablingMapProducer_dump.py || die "Failure running DTCCablingMapProducer_dump.py" $?


### PR DESCRIPTION
#### PR description:

Unit tests for `CondTools/SiPhase2Tracker` are currently silently failing (see [logs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc11/CMSSW_13_2_X_2023-06-07-2300/unitTestLogs/CondTools/SiPhase2Tracker#/6-6), despite the test [declaring success](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc11/CMSSW_13_2_X_2023-06-07-2300/unitTestLogs/CondTools/SiPhase2Tracker#/201)). 
I modify the executable test script such that it registers the failure.
Also I update the configuration files in order to be able to run in recent releases.

#### PR validation:

Run successfully `scram b runtests_test_CondToolsSiPhase2Tracker`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.