### PR TITLE
Prevent copy construction of `TrackerGeometry`

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -55,6 +55,14 @@ public:
     Ph2SS
   };
 
+  // deleted copy constructor and copy assignment operators
+  TrackerGeometry(TrackerGeometry const&) = delete;
+  TrackerGeometry& operator=(TrackerGeometry const&) = delete;
+
+  // defaulted move constructor and move assignment operators
+  TrackerGeometry(TrackerGeometry&&) = default;
+  TrackerGeometry& operator=(TrackerGeometry&&) = default;
+
   ~TrackerGeometry() override;
 
   const DetTypeContainer& detTypes() const override { return theDetTypes; }


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/issues/41895. 
   *  `delete` the `TrackerGeometry` copy constructor and assignment operator, and default the `move` constructor and assignment operator in order to avoid undefined behaviour (double `delete`, usually leading to a crash) .

#### PR validation:

`cmssw` compiles. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, perhaps to be backported?