### PR TITLE
No need to check into base classes of std classes in DictionaryTools.

### DIFF
--- a/FWCore/Reflection/src/DictionaryTools.cc
+++ b/FWCore/Reflection/src/DictionaryTools.cc
@@ -57,6 +57,7 @@ to have dictionaries.
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
 #include "TClass.h"
+#include "TClassEdit.h"
 #include "THashTable.h"
 
 #include <algorithm>
@@ -325,6 +326,12 @@ namespace edm {
     TypeWithDict typeWithDict(typeID.typeInfo());
 
     if (!typeWithDict.isClass()) {
+      return true;
+    }
+
+    // No need to check into base classes of standard library
+    // classes.
+    if (TClassEdit::IsStdClass(typeWithDict.name().c_str())) {
       return true;
     }
 


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/41865. By @pcanal (https://github.com/cms-sw/cmssw/issues/41865#issuecomment-1583447001).

#### PR validation:

Code compiles