### PR TITLE
[13.0.X]  Tracker Alignment: all in one Zmumu fixes

### DIFF
--- a/Alignment/OfflineValidation/bin/Zmumumerge.cc
+++ b/Alignment/OfflineValidation/bin/Zmumumerge.cc
@@ -145,7 +145,7 @@ const TString tstring_variables_name[variables_number] = {
 void Fitting_GetMassmeanVSvariables(TString inputfile_name, TString output_path) {
   TH2D* th2d_mass_variables[variables_number];
   TFile* inputfile = TFile::Open(inputfile_name.Data());
-  TDirectoryFile* tdirectory = (TDirectoryFile*)inputfile->Get("myanalysis");
+  TDirectoryFile* tdirectory = (TDirectoryFile*)inputfile->Get("DiMuonMassValidation");
   for (int i = 0; i < variables_number; i++) {
     TString th2d_name = Form("th2d_mass_%s", tstring_variables_name[i].Data());
     th2d_mass_variables[i] = (TH2D*)tdirectory->Get(th2d_name);
@@ -238,12 +238,18 @@ void Draw_TH1D_forMultiRootFiles(const vector<TString>& file_names,
   }
   lg->Draw("same");
   c->SaveAs(output_name);
+  if (output_name.Contains(".pdf")) {
+    TString output_name_png(output_name);  // output_name is const, copy to modify
+    output_name_png.Replace(output_name_png.Index(".pdf"), 4, ".png");
+    c->SaveAs(output_name_png);
+  }
 }
 
 int Zmumumerge(int argc, char* argv[]) {
   vector<TString> vec_single_file_path;
   vector<TString> vec_single_file_name;
   vector<TString> vec_global_tag;
+  vector<TString> vec_title;
   vector<int> vec_color;
   vector<int> vec_style;
 
@@ -260,6 +266,7 @@ int Zmumumerge(int argc, char* argv[]) {
     vec_color.push_back(childTree.second.get<int>("color"));
     vec_style.push_back(childTree.second.get<int>("style"));
     vec_global_tag.push_back(childTree.second.get<std::string>("globaltag"));
+    vec_title.push_back(childTree.second.get<std::string>("title"));
 
     //Fitting_GetMassmeanVSvariables(childTree.second.get<std::string>("file") + "/Zmumu.root", childTree.second.get<std::string>("file"));
   }
@@ -278,7 +285,7 @@ int Zmumumerge(int argc, char* argv[]) {
     TString th1d_name = Form("th1d_meanmass_%s", tstring_variables_name[idx_variable].Data());
     Draw_TH1D_forMultiRootFiles(
         vec_single_fittingoutput,
-        vec_global_tag,
+        vec_title,
         vec_color,
         vec_style,
         th1d_name,
@@ -286,7 +293,7 @@ int Zmumumerge(int argc, char* argv[]) {
     TString th1d_name_entries = Form("th1d_entries_%s", tstring_variables_name[idx_variable].Data());
     Draw_TH1D_forMultiRootFiles(
         vec_single_fittingoutput,
-        vec_global_tag,
+        vec_title,
         vec_color,
         vec_style,
         th1d_name_entries,

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/Zmumu_cfg.py
@@ -1,6 +1,7 @@
 import math 
 import json
 import os
+from sys import version_info
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.PythonUtilities.LumiList as LumiList
@@ -26,7 +27,10 @@ valiMode = "StandAlone"
 # Read in AllInOne config in JSON format
 ###################################################################
 with open(options.config, "r") as configFile:
-    config = _byteify(json.load(configFile, object_hook=_byteify),ignore_dicts=True)
+    if version_info.major == 2:
+        config = _byteify(json.load(configFile, object_hook=_byteify),ignore_dicts=True)
+    else:
+        config = json.load(configFile)
 
 ###################################################################
 # Read filenames from given TXT file


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41849

#### PR description:

Several fixes for the Zmumu validation tool, including:
   * python2 to python3 (unicode strings)
   * wrong name for a directory in a rootfile
   * wrong name in legend

#### PR validation:

   * Compiled with `scram b`
   * Ran tests with `scram runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/41849 for convenience of analyzing 2023 data
