### PR TITLE
Add Phase-2 MET and Muon trigger paths to DQM

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -72,7 +72,7 @@ hltvalidationWithMC = cms.Sequence(
 )
 
 # Temporary Phase-2 config
-# Exclude everything except JetMET for now
+# Exclude everything except Muon and JetMET for now
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
                                                                                      HLTTauVal,

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -74,7 +74,7 @@ hltvalidationWithMC = cms.Sequence(
 # Temporary Phase-2 config
 # Exclude everything except JetMET for now
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([HLTMuonVal,
+phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
                                                                                      HLTTauVal,
                                                                                      egammaValidationSequence,
                                                                                      heavyFlavorValidationSequence,

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -17,8 +17,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg  = "HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$",
-                       PatternMetTrg  = "HLT_PFPuppiMET+[TypeOne140_PFPuppiMHT140]+(_v[0-9]+)?$",
+                       PatternJetTrg  = "HLT_(AK4|AK8)?PF(Puppi)?Jet[0-9]+(_v[0-9]+)?$",
+                       PatternMetTrg  = "HLT_PF(Puppi)?MET(TypeOne)?[0-9]+(_PF(Puppi)?MHT[0-9]+)?(_v[0-9]+)?$",
                        PFJetAlgorithm = "hltAK4PFPuppiJetsCorrected"
                        )
 

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -17,7 +17,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg = "HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$",
+                       PatternJetTrg  = "HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$",
+                       PatternMetTrg  = "HLT_PFPuppiMET+[TypeOne140_PFPuppiMHT140]+(_v[0-9]+)?$",
                        PFJetAlgorithm = "hltAK4PFPuppiJetsCorrected"
                        )
 

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -44,3 +44,12 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
     genMuonCut  = cms.string("abs(pdgId) == 13 && status == 1"),
     recMuonCut  = cms.string("isGlobalMuon"),
 )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(hltMuonValidator,
+                       hltPathsToCheck = cms.vstring(
+                           "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon(_v[0-9]*)?$",
+                           "HLT_Mu37_Mu27_FromL1TkMuon(_v[0-9]*)?$",
+                           "HLT_Mu50_FromL1TkMuon(_v[0-9]*)?$"
+                       )
+)

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -48,8 +48,8 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(hltMuonValidator,
                        hltPathsToCheck = cms.vstring(
-                           "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon(_v[0-9]*)?$",
-                           "HLT_Mu37_Mu27_FromL1TkMuon(_v[0-9]*)?$",
-                           "HLT_Mu50_FromL1TkMuon(_v[0-9]*)?$"
+                           "HLT_Mu[0-9]+_TrkIso[A-Z]+_Mu[0-9]+_TrkIso[A-Z]+_DZ_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_Mu[0-9]+_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
+                           "HLT_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
                        )
 )

--- a/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
+++ b/HLTriggerOffline/Muon/python/hltMuonValidator_cfi.py
@@ -47,9 +47,9 @@ hltMuonValidator = DQMEDAnalyzer('HLTMuonValidator',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(hltMuonValidator,
-                       hltPathsToCheck = cms.vstring(
+                       hltPathsToCheck = [
                            "HLT_Mu[0-9]+_TrkIso[A-Z]+_Mu[0-9]+_TrkIso[A-Z]+_DZ_FromL1TkMuon(_v[0-9]+)?$",
                            "HLT_Mu[0-9]+_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
                            "HLT_Mu[0-9]+_FromL1TkMuon(_v[0-9]+)?$",
-                       )
+                       ]
 )


### PR DESCRIPTION
#### PR description:
This PR is to add MET and Muon triggers path for Phase-2 DQM. This is a follow up PR of https://github.com/cms-sw/cmssw/pull/41898

Example of DQMs: https://tinyurl.com/238eknnf

#### PR validation:
Running 24850.0_ZMM_14+2026D98 locally, and check DQMs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: