### PR TITLE
Final DQM plot updates for the Totem T2 in the special run 25.6, to be ready for special TOTEM release testing around 12-13.6

### DIFF
--- a/DQM/CTPPS/interface/TotemT2Segmentation.h
+++ b/DQM/CTPPS/interface/TotemT2Segmentation.h
@@ -10,24 +10,21 @@
 #define DQM_CTPPS_TotemT2Segmentation_h
 
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
-#include "Geometry/ForwardGeometry/interface/TotemGeometry.h"
 
 #include <unordered_map>
 #include <vector>
 
-class TotemGeometry;
 class TH2D;
 
 class TotemT2Segmentation {
 public:
-  explicit TotemT2Segmentation(const TotemGeometry&, size_t, size_t);
+  explicit TotemT2Segmentation(size_t, size_t);
 
   void fill(TH2D*, const TotemT2DetId&, double value = 1.);
 
 private:
   std::vector<std::pair<short, short> > computeBins(const TotemT2DetId& detid) const;
 
-  const TotemGeometry geom_;
   const size_t nbinsx_;
   const size_t nbinsy_;
 

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -112,15 +112,20 @@ TotemT2DQMSource::SectorPlots::SectorPlots(
 
   TotemT2DetId(id).armName(title, TotemT2DetId::nFull);
 
-  activePlanes = ibooker.book1D("active planes", title + " which planes are active (digi);plane number", 8, -0.5, 7.5);
+  activePlanes =
+      ibooker.book1D("active planes", title + " which planes are active (LE+TE digis);plane number", 8, -0.5, 7.5);
 
-  activePlanesCount = ibooker.book1D(
-      "number of active planes (digi)", title + " how many planes are active;number of active planes", 9, -0.5, 8.5);
+  activePlanesCount = ibooker.book1D("number of active planes",
+                                     title + " how many planes are active (LE+TE digis);number of active planes",
+                                     9,
+                                     -0.5,
+                                     8.5);
 
-  activityPerBX = ibooker.book1D("activity per BX CMS", title + " Activity per BX;Event.BX", 3600, -1.5, 3598. + 0.5);
+  activityPerBX =
+      ibooker.book1D("activity per BX CMS", title + " Activity (=LE) per BX;Event.BX", 3600, -1.5, 3598. + 0.5);
 
   triggerEmulator = ibooker.book2DD("trigger emulator",
-                                    title + " trigger emulator;arbitrary unit;arbitrary unit",
+                                    title + " trigger emulator (LE+TE digis);arbitrary unit;arbitrary unit",
                                     nbinsx,
                                     -0.5,
                                     double(nbinsx) - 0.5,
@@ -128,12 +133,15 @@ TotemT2DQMSource::SectorPlots::SectorPlots(
                                     -0.5,
                                     double(nbinsy) - 0.5);
   leadingEdge = ibooker.book1D(
-      "leading edge", title + " leading edge (DIGIs); leading edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+      "leading edge", title + " leading edge (all DIGIs); leading edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
   trailingEdge = ibooker.book1D(
-      "trailing edge", title + " trailing edge (DIGIs); trailing edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+      "trailing edge", title + " trailing edge (all DIGIs); trailing edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
 
-  timeOverTreshold = ibooker.book1D(
-      "time over threshold", title + " time over threshold (digi);time over threshold (ns)", 500, -50, 200);
+  timeOverTreshold = ibooker.book1D("time over threshold",
+                                    title + " time over threshold (digi, =0 if LE or TE=0);time over threshold (ns)",
+                                    500,
+                                    -50,
+                                    200);
 
   eventFlags = ibooker.book1D(
       "event flags", title + " event flags (digi);Event flags (TE/LE valid, TE/LE multiple)", 4, -0.5, 3.5);
@@ -152,7 +160,7 @@ TotemT2DQMSource::PlanePlots::PlanePlots(DQMStore::IBooker& ibooker,
   ibooker.setCurrentFolder(path);
 
   digisMultiplicity = ibooker.book2DD("digis multiplicity",
-                                      title + " digis multiplicity;arbitrary unit;arbitrary unit",
+                                      title + " digis multiplicity (=LE);arbitrary unit;arbitrary unit",
                                       nbinsx,
                                       -0.5,
                                       double(nbinsx) - 0.5,
@@ -182,17 +190,21 @@ TotemT2DQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, unsigne
   ibooker.setCurrentFolder(path);
 
   leadingEdgeCh = ibooker.book1D(
-      "leading edge", title + " leading edge (DIGIs); leading edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+      "leading edge", title + " leading edge (all DIGIs); leading edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
   trailingEdgeCh = ibooker.book1D(
-      "trailing edge", title + " trailing edge (DIGIs); trailing edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
+      "trailing edge", title + " trailing edge (all DIGIs); trailing edge (ns)", 25 * windowsNum, 0, 25 * windowsNum);
 
-  timeOverTresholdCh = ibooker.book1D(
-      "time over threshold", title + " time over threshold (digi);time over threshold (ns)", 500, -50, 200);
+  timeOverTresholdCh = ibooker.book1D("time over threshold",
+                                      title + " time over threshold (digi, =0 if LE or TE=0);time over threshold (ns)",
+                                      500,
+                                      -50,
+                                      200);
 
   eventFlagsCh = ibooker.book1D(
       "event flags", title + " event flags (digi);Event flags (TE/LE valid, TE/LE multiple)", 4, -0.5, 3.5);
 
-  activityPerBXCh = ibooker.book1D("activity per BX", title + " Activity per BX;Event.BX", 1000, -1.5, 998. + 0.5);
+  activityPerBXCh =
+      ibooker.book1D("activity per BX", title + " Activity (=LE) per BX;Event.BX", 1000, -1.5, 998. + 0.5);
 
   for (unsigned short flag_index = 1; flag_index <= 4; ++flag_index)
     eventFlagsCh->setBinLabel(flag_index, "Flag " + std::to_string(flag_index));
@@ -242,8 +254,9 @@ void TotemT2DQMSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       for (const auto& digi : ds_digis) {
         if (digi.hasLE()) {
           segm_->fill(planePlots_[planeId].digisMultiplicity->getTH2D(), detid);
-          fillTriggerBitset(detid);
-	}
+          if (digi.hasTE())
+            fillTriggerBitset(detid);
+        }
         fillErrorFlagsHistogram(digi, detid);
         fillEdges(digi, detid);
         fillToT(digi, detid);

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -240,8 +240,10 @@ void TotemT2DQMSource::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       const TotemT2DetId detid(ds_digis.detId());
       const TotemT2DetId planeId(detid.planeId());
       for (const auto& digi : ds_digis) {
-        segm_->fill(planePlots_[planeId].digisMultiplicity->getTH2D(), detid);
-        fillTriggerBitset(detid);
+        if (digi.hasLE()) {
+          segm_->fill(planePlots_[planeId].digisMultiplicity->getTH2D(), detid);
+          fillTriggerBitset(detid);
+	}
         fillErrorFlagsHistogram(digi, detid);
         fillEdges(digi, detid);
         fillToT(digi, detid);

--- a/DQM/CTPPS/src/TotemT2Segmentation.cc
+++ b/DQM/CTPPS/src/TotemT2Segmentation.cc
@@ -49,7 +49,7 @@ std::vector<std::pair<short, short> > TotemT2Segmentation::computeBins(const Tot
   // and going clockwise around in increments of 1h30min=45deg, we have
   // Ch0 on even planes, Ch0+odd, Ch1+even, Ch1+odd, up to Ch3+odd at 7:30PM
 
-  const float tile_angle_rad = (180 - 45. / 2 - (detid.plane() % 2 ? 0 : 45) - (detid.channel() * 90)) * M_PI / 180.;
+  const float tile_angle_rad = (180 - 45. / 2 - (detid.plane() % 2 ? 45 : 0) - (detid.channel() * 90)) * M_PI / 180.;
   // Geometric way of associating a DetId to a vector<ix, iy> of bins given the size (nx_, ny_) of
   // the TH2D('s) to be filled
   for (size_t ix = 0; ix < nbinsx_; ++ix)

--- a/DQM/CTPPS/test/totemt2_dqm_test_common_cfg.py
+++ b/DQM/CTPPS/test/totemt2_dqm_test_common_cfg.py
@@ -29,15 +29,13 @@ process.dqmEnv.eventInfoFolder = "EventInfo"
 process.dqmSaver.path = ""
 process.dqmSaver.tag = "CTPPS"
 
-# raw data source
-#alignment run without T2, TimingDiamond and TrackingStrip not affected by PR changes
-process.source = cms.Source("PoolSource",
-  fileNames = cms.untracked.vstring(
-    '/store/data/Run2023A/HLTPhysics/RAW/v1/000/366/192/00000/f277ee80-e88b-41e8-b1ba-6c18af119fbc.root'
-  )
+# raw data source, T2 + TrackingStrips test file in run 368593, not 368594 (wrong settings)
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring(
+        '/store/t0streamer/Minidaq/A/000/368/593/run368593_ls0001_streamA_StorageManager.dat',
+#        '/store/t0streamer/Minidaq/A/000/368/594/run368594_ls0001_streamA_StorageManager.dat',
+    )
 )
-
-
 process.maxEvents = cms.untracked.PSet(
   input = cms.untracked.int32(8000)
 )
@@ -45,11 +43,9 @@ process.maxEvents = cms.untracked.PSet(
 # raw-to-digi conversion
 process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_cff")
 
-# global tag - conditions for P5 cluster
-process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
-
-#from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, '130X_dataRun3_HLT_v2', '')
+#Latest PPS GT candidate
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '130X_dataRun3_Prompt_Candidate_2023_06_06_21_34_08', '')
 
 # local RP reconstruction chain with standard settings
 process.load("RecoPPS.Configuration.recoCTPPS_cff")


### PR DESCRIPTION
#### PR description:

For the TOTEM special foreseen on 25.6.2023, the new T2 telescope will be used (and removed after the run) to measure inelastic rate and veto diffractive p+p collisions, when measuring the elastic p+p cross section.
This PR is for a special TOTEM release to be ready for testing start of next week (https://github.com/cms-sw/cmssw/pull/41859#issuecomment-1584370879).

After the merging of PR #41859 and submission of backport PR #41916 , T2 Digis are successfully saved in the event and used to produce Digi-based DQM plots in common reconstruction with the rest of the PPS detectors. 
In this PR, the DQM plots that use the T2Segmentation helper (removed due to T2 RecHit and TotemGeometry dependence causing relVal issues detailed in the previous PR's) were added back with a hardcoded "geometry" mapping from channel number to (X,Y) position using the attached mapping on slide 1 (agreed with @vavati & E. Bossini to use slide 1, not slide 3), see comments here: https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:fo_nt2_dqm_final#diff-c26415cb77d83b1dbe3bdea47ca041d0e35f6ab203364c54d92c4b143b11ce47R47

[T2-map-latest-2023jun11.pdf](https://github.com/cms-sw/cmssw/files/11715483/T2-map-latest-2023jun11.pdf)

Several other T2 plots were also adjusted as to the T2 Digi demands used.

This PR is the final one needed for testing a special 13_0_X release for TOTEM, or possibly to be backported to 13_1_X too, see https://github.com/cms-sw/cmssw/pull/41916#issuecomment-1585592026

#### PR validation:

After the inclusion of PR #41916 in master, there were no other dependent packages brought in by checkdeps , so I ran successfully a PPS workflow (1044) & the DQM test file totemt2_dqm_test_common_cfg.py , which produced the expected plots.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This will hopefully be backported very soon (during the coming week) to 13_0_X, and possibly later to 13_1_X, as noted above. I will submit a backport PR later with the commits from PR #41916 and the ones from this PR.

<!-- Please delete the text above after you verified all points of the checklist  -->
