### PR TITLE
SoA range checking: adds inter operability between range checked and non range checked

### DIFF
--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -52,6 +52,8 @@
 #define _VALUE_TYPE_EIGEN_COLUMN 2
 
 /* The size type need to be "hardcoded" in the template parameters for classes serialized by ROOT */
+/* In practice, using a typedef as a template parameter to the Layout or its ViewTemplateFreeParams member
+ * declaration fails ROOT dictionary generation.  */
 #define CMS_SOA_BYTE_SIZE_TYPE std::size_t
 
 namespace cms::soa {

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -132,6 +132,8 @@ namespace cms::soa {
       return reinterpret_cast<intptr_t>(addr) % alignment;
     }
 
+    TupleOrPointerType tupleOrPointer() { return addr_; }
+
   public:
     // scalar or column
     ValueType const* addr_ = nullptr;
@@ -165,6 +167,8 @@ namespace cms::soa {
       const auto& [addr, stride] = tuple;
       return reinterpret_cast<intptr_t>(addr) % alignment;
     }
+
+    TupleOrPointerType tupleOrPointer() { return {addr_, stride_}; }
 
   public:
     // address and stride
@@ -201,6 +205,8 @@ namespace cms::soa {
       return reinterpret_cast<intptr_t>(addr) % alignment;
     }
 
+    TupleOrPointerType tupleOrPointer() { return addr_; }
+
   public:
     // scalar or column
     ValueType* addr_ = nullptr;
@@ -233,6 +239,8 @@ namespace cms::soa {
       const auto& [addr, stride] = tuple;
       return reinterpret_cast<intptr_t>(addr) % alignment;
     }
+
+    TupleOrPointerType tupleOrPointer() { return {addr_, stride_}; }
 
   public:
     // address and stride

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -399,7 +399,7 @@ namespace cms::soa {
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                          \
   LOCAL_NAME(size_type _soa_impl_index) {                                                                              \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
-      if (_soa_impl_index >= base_type::elements_)                                                                     \
+      if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                              \
         SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #LOCAL_NAME "(size_type index)")                       \
     }                                                                                                                  \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
@@ -437,7 +437,7 @@ namespace cms::soa {
                 template RestrictQualifier<restrictQualify>::ParamReturnType                                           \
   LOCAL_NAME(size_type _soa_impl_index) const {                                                                        \
     if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
-      if (_soa_impl_index >= elements_)                                                                                \
+      if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                         \
         SOA_THROW_OUT_OF_RANGE("Out of range index in const " #LOCAL_NAME "(size_type index)")                         \
     }                                                                                                                  \
     return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
@@ -649,7 +649,7 @@ namespace cms::soa {
     SOA_HOST_DEVICE SOA_INLINE                                                                                         \
     element operator[](size_type _soa_impl_index) {                                                                    \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-        if (_soa_impl_index >= base_type::elements_)                                                                   \
+        if (_soa_impl_index >= base_type::elements_ or _soa_impl_index < 0)                                            \
           SOA_THROW_OUT_OF_RANGE("Out of range index in " #VIEW "::operator[]")                                        \
       }                                                                                                                \
       return element{_soa_impl_index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST)};        \
@@ -810,7 +810,7 @@ namespace cms::soa {
     SOA_HOST_DEVICE SOA_INLINE                                                                                         \
     const_element operator[](size_type _soa_impl_index) const {                                                        \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-        if (_soa_impl_index >= elements_)                                                                              \
+        if (_soa_impl_index >= elements_ or _soa_impl_index < 0)                                                       \
           SOA_THROW_OUT_OF_RANGE("Out of range index in " #CONST_VIEW "::operator[]")                                  \
       }                                                                                                                \
       return const_element{                                                                                            \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -232,6 +232,15 @@ namespace cms::soa {
   BOOST_PP_EXPAND(_DECLARE_VIEW_MEMBER_LIST_IMPL LAYOUT_MEMBER_NAME)
 
 /**
+ * Generator of view member list.
+ */
+#define _DECLARE_VIEW_OTHER_MEMBER_LIST_IMPL(LAYOUT, MEMBER, NAME) \
+  (const_cast_SoAParametersImpl(other.BOOST_PP_CAT(NAME, Parameters_)).tupleOrPointer())
+
+#define _DECLARE_VIEW_OTHER_MEMBER_LIST(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_OTHER_MEMBER_LIST_IMPL LAYOUT_MEMBER_NAME)
+
+/**
  * Generator of member initializer for copy constructor.
  */
 #define _DECLARE_VIEW_MEMBER_INITIALIZERS_FROM_OTHER_IMPL(LAYOUT, MEMBER, LOCAL_NAME, DATA) \
@@ -535,6 +544,9 @@ namespace cms::soa {
     template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
     using SoAConstValueWithConf = cms::soa::SoAConstValue<COLUMN_TYPE, C, conditionalAlignment, restrictQualify>;      \
                                                                                                                        \
+    template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                                \
+    friend struct VIEW;                                                                                                \
+                                                                                                                       \
     /**                                                                                                                \
      * Helper/friend class allowing SoA introspection.                                                                 \
      */                                                                                                                \
@@ -581,6 +593,23 @@ namespace cms::soa {
     /* Copiable */                                                                                                     \
     VIEW(VIEW const&) = default;                                                                                       \
     VIEW& operator=(VIEW const&) = default;                                                                            \
+                                                                                                                       \
+    /* Copy constructor for other parameters */                                                                        \
+    template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                             \
+              bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                   \
+              bool OTHER_RESTRICT_QUALIFY,                                                                             \
+              bool OTHER_RANGE_CHECKING>                                                                               \
+    VIEW(VIEW<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY,                          \
+              OTHER_RANGE_CHECKING> const& other): base_type{other.elements_,                                          \
+                _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_OTHER_MEMBER_LIST, BOOST_PP_EMPTY(), VALUE_LIST)                   \
+              } {}                                                                                                     \
+    /* Copy operator for other parameters */                                                                           \
+    template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                             \
+              bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                   \
+              bool OTHER_RESTRICT_QUALIFY,                                                                             \
+              bool OTHER_RANGE_CHECKING>                                                                               \
+    VIEW& operator=(VIEW<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY,               \
+              OTHER_RANGE_CHECKING> const& other) { static_cast<base_type>(*this) = static_cast<base_type>(other); }   \
                                                                                                                        \
     /* Movable */                                                                                                      \
     VIEW(VIEW &&) = default;                                                                                           \
@@ -673,6 +702,9 @@ namespace cms::soa {
     template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                                \
     friend struct VIEW;                                                                                                \
                                                                                                                        \
+    template <CMS_SOA_BYTE_SIZE_TYPE, bool, bool, bool>                                                                \
+    friend struct CONST_VIEW;                                                                                          \
+                                                                                                                       \
     /* For CUDA applications, we align to the 128 bytes of the cache lines.                                            \
      * See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-memory-3-0 this is still valid      \
      * up to compute capability 8.X.                                                                                   \
@@ -738,6 +770,23 @@ namespace cms::soa {
     /* Copiable */                                                                                                     \
     CONST_VIEW(CONST_VIEW const&) = default;                                                                           \
     CONST_VIEW& operator=(CONST_VIEW const&) = default;                                                                \
+                                                                                                                       \
+    /* Copy constructor for other parameters */                                                                        \
+    template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                             \
+              bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                   \
+              bool OTHER_RESTRICT_QUALIFY,                                                                             \
+              bool OTHER_RANGE_CHECKING>                                                                               \
+    CONST_VIEW(CONST_VIEW<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY,              \
+              OTHER_RANGE_CHECKING> const& other): CONST_VIEW{other.elements_,                                         \
+                _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_OTHER_MEMBER_LIST, BOOST_PP_EMPTY(), VALUE_LIST)                   \
+              } {}                                                                                                     \
+    /* Copy operator for other parameters */                                                                           \
+    template <CMS_SOA_BYTE_SIZE_TYPE OTHER_VIEW_ALIGNMENT,                                                             \
+              bool OTHER_VIEW_ALIGNMENT_ENFORCEMENT,                                                                   \
+              bool OTHER_RESTRICT_QUALIFY,                                                                             \
+              bool OTHER_RANGE_CHECKING>                                                                               \
+    CONST_VIEW& operator=(CONST_VIEW<OTHER_VIEW_ALIGNMENT, OTHER_VIEW_ALIGNMENT_ENFORCEMENT, OTHER_RESTRICT_QUALIFY,   \
+              OTHER_RANGE_CHECKING> const& other) { *this = other; }                                                   \
                                                                                                                        \
     /* Movable */                                                                                                      \
     CONST_VIEW(CONST_VIEW &&) = default;                                                                               \

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -37,6 +37,8 @@ GENERATE_SOA_LAYOUT(SoAHostDeviceLayoutTemplate,
 
 using SoAHostDeviceLayout = SoAHostDeviceLayoutTemplate<>;
 using SoAHostDeviceView = SoAHostDeviceLayout::View;
+using SoAHostDeviceRangeCheckingView =
+    SoAHostDeviceLayout::ViewTemplate<cms::soa::RestrictQualify::enabled, cms::soa::RangeChecking::enabled>;
 using SoAHostDeviceConstView = SoAHostDeviceLayout::ConstView;
 
 GENERATE_SOA_LAYOUT(SoADeviceOnlyLayoutTemplate,
@@ -128,6 +130,12 @@ int main(void) {
   hipCheck(hipHostMalloc((void**)&h_buf, hostDeviceSize));
   SoAHostDeviceLayout h_soahdLayout(h_buf, numElements);
   SoAHostDeviceView h_soahd(h_soahdLayout);
+
+  // Validation of range checking variants initialization
+  SoAHostDeviceRangeCheckingView h_soahdrc(h_soahdLayout);
+  [[maybe_unused]] SoAHostDeviceRangeCheckingView h_soahdrc2 = h_soahdLayout;
+  [[maybe_unused]] SoAHostDeviceRangeCheckingView h_soahdrc3{h_soahd};
+  [[maybe_unused]] SoAHostDeviceRangeCheckingView h_soahdrc4 = h_soahd;
   SoAHostDeviceConstView h_soahd_c(h_soahdLayout);
 
   // Alocate buffer, stores and views on the device (single, shared buffer).

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -258,29 +258,50 @@ int main(void) {
     }
   }
 
-  // Validation of range checking
-  try {
-    // Get a view like the default, except for range checking
-    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>
-        soa1viewRangeChecking(h_soahdLayout);
-    // This should throw an exception
-    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
-    std::cout << "Fail: expected range-check exception (operator[]) not caught on the host." << std::endl;
-    assert(false);
-  } catch (const std::out_of_range&) {
-    std::cout << "Pass: expected range-check exception (operator[]) successfully caught on the host." << std::endl;
+  {
+    // Get a view like the default, except for range checking (direct initialization from layout)
+    SoAHostDeviceRangeCheckingView soa1viewRangeChecking(h_soahdLayout);
+    try {
+      [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
+      std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host (overflow)."
+                << std::endl;
+      assert(false);
+    } catch (const std::out_of_range&) {
+    }
+    try {
+      [[maybe_unused]] auto si = soa1viewRangeChecking[-1];
+      std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host (underflow)."
+                << std::endl;
+      assert(false);
+    } catch (const std::out_of_range&) {
+    }
+    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size() - 1];
+    [[maybe_unused]] auto si2 = soa1viewRangeChecking[0];
+    std::cout << "Pass: expected range-check exceptions (view-level index access) successfully caught on the host "
+                 "(layout initialization)."
+              << std::endl;
   }
 
-  try {
-    // Get a view like the default, except for range checking
-    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>
-        soa1viewRangeChecking(h_soahdLayout);
-    // This should throw an exception
-    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
-    std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host." << std::endl;
-    assert(false);
-  } catch (const std::out_of_range&) {
-    std::cout << "Pass: expected range-check exception (view-level index access) successfully caught on the host."
+  {
+    // Validation of view initialized range checking view initialization
+    try {
+      [[maybe_unused]] auto si = h_soahdrc3[h_soahdrc3.metadata().size()];
+      std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host (overflow)."
+                << std::endl;
+      assert(false);
+    } catch (const std::out_of_range&) {
+    }
+    try {
+      [[maybe_unused]] auto si = h_soahdrc3[-1];
+      std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host (underflow)."
+                << std::endl;
+      assert(false);
+    } catch (const std::out_of_range&) {
+    }
+    [[maybe_unused]] auto si = h_soahdrc3[h_soahdrc3.metadata().size() - 1];
+    [[maybe_unused]] auto si2 = h_soahdrc3[0];
+    std::cout << "Pass: expected range-check exceptions (view-level index access) successfully caught on the host "
+                 "(view initialization)."
               << std::endl;
   }
 


### PR DESCRIPTION
#### PR description:

This PR adds copy and construction compatibility between `View`s and `ConstView`s (respectively, no const evasion was created) with different template parameters. This allows compile time switching to the range checking variant for debugging. The `View`s are usually used from the `PortableCollections` (and are non range checking). Changing the signature or a function or kernel to use the range checking variant simply requires a type definition change and the creation of a translating variable at the kernel call. The program will then half immediately on range violation.

#### PR validation:

The copy and construction are now validated in a test, as part of this PR. I addition this feature was used and validated to debug an actual out of range error during module debugging.