### PR TITLE
CSC Unpacker fix for handling of rare CSC data corruption

### DIFF
--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -193,6 +193,14 @@ void CSCDDUEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner)
         if (cscid != -1) {
           const uint16_t* pos = (const uint16_t*)csc_itr->second;
 
+          if (pos == nullptr) {
+            if (debug)
+              LogTrace("CSCDDUEventData|CSCRawToDigi")
+                  << "skip unpacking of CSC " << cscid << " due format errors (NULL pointer to chamber data)"
+                  << std::dec;
+            continue;
+          }
+
           ExaminerStatusType errors = examiner->errorsForChamber(cscid);
           if ((errors & examiner->getMask()) > 0) {
             if (debug)

--- a/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDDUEventData.cc
@@ -196,8 +196,7 @@ void CSCDDUEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner)
           if (pos == nullptr) {
             if (debug)
               LogTrace("CSCDDUEventData|CSCRawToDigi")
-                  << "skip unpacking of CSC " << cscid << " due format errors (NULL pointer to chamber data)"
-                  << std::dec;
+                  << "skip unpacking of CSC " << cscid << " due to format errors (NULL pointer to chamber data)";
             continue;
           }
 
@@ -205,7 +204,7 @@ void CSCDDUEventData::unpack_data(const uint16_t* buf, CSCDCCExaminer* examiner)
           if ((errors & examiner->getMask()) > 0) {
             if (debug)
               LogTrace("CSCDDUEventData|CSCRawToDigi")
-                  << "skip unpacking of CSC " << cscid << " due format errors: 0x" << std::hex << errors << std::dec;
+                  << "skip unpacking of CSC " << cscid << " due to format errors: 0x" << std::hex << errors << std::dec;
             continue;
           }
 


### PR DESCRIPTION
CSC Unpacker fix for handling of rare data corruption, related to invalid CSC DMB header/trailer data

#### PR description:

- related to HLT crash in run-367770 from CSCDCCUnpacker issue #41747 in CMSSW_13_0_6
- observed single HLT crash case so far
- was reproduced with supplied by HLT script and data file
- added safeguard against invalid nullptr data, caused by rare case of CSC hardware readout corruption

#### PR validation:

Ran PR validation runTheMatrix basic battery of tests.
Notes:
Supplied by the HLT test script for 13_0_6 doesn't work with 13_2_X and 13_1_X (doesn't look like CSC related issue), 
but the script passed without crashes with this code modification for 13_0_X.
For 13_2_X and 13_1_X tests was using custom minimal CSC test script to run only affected muonCSCDigis CSC unpacking sequence with corrupted data file.
Tests passed without crashes with proposed modification.

This PR would need backport for 13_1_X and 13_0_X.

