### PR TITLE
Add FatJet Trigger objects and filters

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -213,11 +213,14 @@ triggerObjectTable = triggerObjectTableProducer.clone(
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
             qualityBits = cms.VPSet(
-                mksel("coll('hltAK8PFJetsCorrected')"),
-                mksel("coll('hltAK8PFSoftDropJets230')"),
-                mksel("filter('hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35"),
-                mksel("filter('hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35"),
-                mksel("filter('hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35"),
+                mksel("coll('hltAK8PFJetsCorrected')"),    #1, always present
+                mksel(["hltAK8SingleCaloJet200"]),         #2, always present
+                mksel("coll('hltAK8PFSoftDropJets230')"),  #4, present if nothing else below is fired, otherwise 12, 20, 28, 52, 60
+                mksel(["hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35",
+                       "hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35",
+                       "hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35"]), # 12 if nothing below is fired, #28 if also "hltAK8DoublePFJetSDModMass30", #60 if also "hltAK8DoublePFJetSDModMass50" 
+                mksel(["hltAK8DoublePFJetSDModMass30"]), # 16 if onthing else (except #1), 20 if also #4, 28 if also #12
+                mksel(["hltAK8DoublePFJetSDModMass50"]), # 48 if also (obviously) "hltAK8DoublePFJetSDModMass30", 52 if also #4, #60 if all above
                 )
         ),
         MET = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -208,24 +208,16 @@ triggerObjectTable = triggerObjectTableProducer.clone(
         ),
         FatJet = cms.PSet(
             id = cms.int32(6),
-            sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"),
+            sel = cms.string("type(85) && pt > 120),
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
             qualityBits = cms.VPSet(
-                mksel(["hltAK8SingleCaloJet200"]), # 0
-                mksel(["hltAK8DoublePFJet250"]), # 1
-                mksel(["hltAK8DoublePFJet270"]), # 2
-                mksel(["hltAK8DoublePFJetSDModMass30"]), # 3
-                mksel(["hltAK8DoublePFJetSDModMass50"]), # 4
-                mksel(["hltAK8PFJetsCorrectedMatchedToCaloJets200"]), # 5
-                mksel(["hltSingleAK8PFJet220","hltSingleAK8PFJet230"]), # 6
-                mksel(["hltAK8PFSoftDropJets220","hltAK8PFSoftDropJets230"]), # 8
-                mksel(["hltAK8SinglePFJets220SoftDropMass40","hltAK8SinglePFJets230SoftDropMass40"]), # 9
-                mksel(["hltAK8PFJets220SoftDropMass40"]), # 10
-                mksel(["hltAK8SinglePFJets220SoftDropMass40PNetBBTag0p06"]), # 11
-                mksel(["hltAK8SinglePFJets230SoftDropMass40PNetTauTauTag0p03"]), # 12
-                
+                mksel("coll('hltAK8PFJetsCorrected')"),
+                mksel("coll('hltAK8PFSoftDropJets230')"),
+                mksel("filter('hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35"),
+                mksel("filter('hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35"),
+                mksel("filter('hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35')","hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35"),
                 )
         ),
         MET = cms.PSet(


### PR DESCRIPTION
#### PR description:

Added new FatJet trigger Filters with ParticleNet BBTag
Some unnecessary collections and filters were removed to make filterBits more understandable.
In particular:

mksel(["hltAK8SingleCaloJet200"]), # 0 # kept

mksel(["hltAK8DoublePFJet250"]), # 1 # not needed as hltAK8PFJetsCorrected is stored

mksel(["hltAK8DoublePFJet270"]), # 2 # not needed as hltAK8PFJetsCorrected is stored

mksel(["hltAK8DoublePFJetSDModMass30"]), # 3 kept

mksel(["hltAK8DoublePFJetSDModMass50"]), # 4 kept

mksel(["hltAK8PFJetsCorrectedMatchedToCaloJets200"]), # 5 # no need as both "hltAK8PFJetsCorrected" and "hltAK8SingleCaloJet200" are stored

mksel(["hltSingleAK8PFJet220","hltSingleAK8PFJet230"]), # 6 # no need as both "hltAK8PFJetsCorrected" and "hltAK8SingleCaloJet200" (hence hltAK8PFJetsCorrectedMatchedToCaloJets200) are stored.

mksel(["hltAK8PFSoftDropJets220","hltAK8PFSoftDropJets230"]), # kept

mksel(["hltAK8SinglePFJets220SoftDropMass40","hltAK8SinglePFJets230SoftDropMass40"]), # the same as above, this is the only filter which uses the collection above, so removed

mksel(["hltAK8PFJets220SoftDropMass40"]), # could be reached with the filter PNet filters which are added

mksel(["hltAK8SinglePFJets220SoftDropMass40PNetBBTag0p06"]), # 11 # kept

mksel(["hltAK8SinglePFJets230SoftDropMass40PNetTauTauTag0p03"]), # worth to move to boosted Tau

#### PR validation:
Validated with CMSSW_12_6_0, on TTbar MiniAOD samples
