### PR TITLE
Fix UBSAN warning in DataFormats/L1TParticleFlow

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -45,7 +45,7 @@ namespace l1ct {
     }
 
     inline std::array<uint64_t, 2> pack() const {
-      std::array<uint64_t, 2> packed;
+      std::array<uint64_t, 2> packed = {{0, 0}};
       ap_uint<BITWIDTH> bits = this->pack_ap();
       packed[0] = bits;
       //packed[1] = bits[slice]; // for when there are more than 64 bits in the word


### PR DESCRIPTION
#### PR description:

Fixes warning reported in  https://github.com/cms-sw/cmssw/issues/41774 :

```
(...)/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=110201 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DCMSSW_GIT_HASH='CMSSW_13_2_UBSAN_X_2023-05-24-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_2_UBSAN_X_2023-05-24-2300' -I(...)/src -I(...)/external/libpng/1.6.37-a2ff0f76300cbef7e51b77d816ff554a/include -I(...)/external/pcre/8.43-5dcc901acc02f624b22dd9840b2357e8/include -isystem(...)/external/boost/1.80.0-7f4aeae1bffcf24aa4723f09435633c2/include -I(...)/external/bz2lib/1.0.6-2c1f18484cb66c30aba7929f2be5e7d4/include -isystem(...)/external/clhep/2.4.6.0-a4e46555f840df7cd8747ba64c6e914f/include -I(...)/external/giflib/5.2.0-e928fbc1a732191ff28d8dfbf2e6ee63/include -I(...)/external/gsl/2.6-fcf47bcbedd800ca8386c7e2920fa474/include -isystem(...)/external/hls/2019.08-fd724004387c2a6770dc3517446d30d9/include -I(...)/external/libjpeg-turbo/2.0.2-0670ec17b6dbf72d9c70c3a287cf2ce2/include -I(...)/external/libuuid/2.34-0451b31e1b9a58c6aeefab41c18eea34/include -I(...)/external/protobuf/3.15.1-afbf0e4e62db8d179f85b9eef7a9fbab/include -isystem(...)/lcg/root/6.26.11-9720c7273eac1c892ddadde973cf1965/include -I(...)/external/sqlite/3.36.0-0f26675926fd468efdd431be2b62785e/include -isystem(...)/external/tbb/v2021.8.0-4e779f195a25a0aba119b27519937ba0/include -I(...)/external/utm/utm_0.11.2-7320d0f24d79805aa3ee736be565f1ee/include -I(...)/cms/vdt/0.4.3-b2ab7c000c16e419f85e9fb6284d3681/include -I(...)/external/xerces-c/3.1.3-96261f23c7d6fbfb7d59be544bd882f3/include -I(...)/external/xz/5.2.5-83d0a00b575efd1701e07bedf7977343/include -I(...)/external/zlib/1.2.11-3dfb2715f3608466b74431b80eb9d788/include -I(...)/external/eigen/82dd3710dac619448f50331c1d6a35da673f764a-9ac4aed18ac60d0189693c592862694d/include/eigen3 -I(...)/external/fmt/8.0.1-43b841663c2a0d6622910a1ad66d228d/include -I(...)/external/md5/1.0.0-e68283f2de2e2e709a0db99db3b53205/include -I(...)/external/OpenBLAS/0.3.15-26c67b8b638762cfd2e2bcfc936e3ec7/include -isystem(...)/external/tensorflow/2.6.4-b4f6f01138e8f0acdb49d7d3d00d3168/include -I(...)/external/tinyxml2/6.2.0-c2bad61e58f94d6db8f640afbd739be2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -g  -fPIC  -MMD -MF tmp/el8_amd64_gcc11/src/L1Trigger/Phase2L1ParticleFlow/plugins/L1TriggerPhase2L1ParticleFlowAuto/PFTrackProducerFromL1Tracks.cc.d (...)/src/L1Trigger/Phase2L1ParticleFlow/plugins/PFTrackProducerFromL1Tracks.cc -o tmp/el8_amd64_gcc11/src/L1Trigger/Phase2L1ParticleFlow/plugins/L1TriggerPhase2L1ParticleFlowAuto/PFTrackProducerFromL1Tracks.cc.o
In file included from (...)/src/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1SeedConePFJetEmulator.h:5,
                 from (...)/src/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc:20:
In member function 'std::array<long unsigned int, 2> l1ct::Jet::pack() const',
    inlined from 'L1SeedConePFJetProducer::convertHWToEDM(std::vector<L1SCJetEmu::Jet>, std::unordered_map<const l1t::PFCandidate*, edm::Ptr<l1t::PFCandidate> >) const::<lambda(L1SCJetEmu::Jet)>' at (...)/src/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc:207:25,
    inlined from '_Funct std::for_each(_IIter, _IIter, _Funct) [with _IIter = __gnu_cxx::__normal_iterator<L1SCJetEmu::Jet*, std::vector<L1SCJetEmu::Jet> >; _Funct = L1SeedConePFJetProducer::convertHWToEDM(std::vector<L1SCJetEmu::Jet>, std::unordered_map<const l1t::PFCandidate*, edm::Ptr<l1t::PFCandidate> >) const::<lambda(L1SCJetEmu::Jet)>]' at (...)/external/gcc/11.2.1-f9b9dfdd886f71cd63f5538223d8f161/include/c++/11.2.1/bits/stl_algo.h:3820:5,
    inlined from 'std::vector<l1t::PFJet> L1SeedConePFJetProducer::convertHWToEDM(std::vector<L1SCJetEmu::Jet>, std::unordered_map<const l1t::PFCandidate*, edm::Ptr<l1t::PFCandidate> >) const' at (...)/src/L1Trigger/Phase2L1ParticleFlow/plugins/L1SeedConePFJetProducer.cc:194:16:
  (...)/src/DataFormats/L1TParticleFlow/interface/jets.h:52:14: warning: 'packed' may be used uninitialized [-Wmaybe-uninitialized]
    52 |       return packed;
      |              ^~~~~~
(...)/src/DataFormats/L1TParticleFlow/interface/jets.h: In member function 'std::vector<l1t::PFJet> L1SeedConePFJetProducer::convertHWToEDM(std::vector<L1SCJetEmu::Jet>, std::unordered_map<const l1t::PFCandidate*, edm::Ptr<l1t::PFCandidate> >) const':
(...)/src/DataFormats/L1TParticleFlow/interface/jets.h:48:31: note: 'packed' declared here
   48 |       std::array<uint64_t, 2> packed;
      |                               ^~~~~~
```

#### PR validation:

No special validation
