### PR TITLE
Definition of a new DQM Offline sequence to be run on Express Stream

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -13,6 +13,7 @@ from DQMOffline.RecoB.bTagMiniDQM_cff import *
 
 
 dqmHarvesting = cms.Path(DQMOffline_SecondStep*DQMOffline_Certification)
+dqmHarvestingExpress = cms.Path(DQMOffline_SecondStep_Express)
 dqmHarvestingExtraHLT = cms.Path(DQMOffline_SecondStep_ExtraHLT*DQMOffline_Certification)
 dqmHarvestingFakeHLT = cms.Path(DQMOffline_SecondStep_FakeHLT*DQMOffline_Certification)
 #dqmHarvesting = cms.Sequence(DQMOffline_SecondStep*DQMOffline_Certification)

--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -31,6 +31,11 @@ DQMOffline_SecondStepMuonDPG = cms.Sequence( dtClients *
                                              rpcTier0Client *
                                              cscOfflineCollisionsClients )
 
+DQMOffline_SecondStepMuonDPGExpress = cms.Sequence( rpcTier0Client *
+                                                    cscOfflineCollisionsClients*
+                                                    gemClients )
+
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_GEM_DQMOffline_SecondStepMuonDPG = DQMOffline_SecondStepMuonDPG.copy()
 _run3_GEM_DQMOffline_SecondStepMuonDPG += gemClients
@@ -56,10 +61,25 @@ DQMOffline_SecondStep_PreDPG = cms.Sequence(
                                              DQMOffline_SecondStepFED *
 					     DQMOffline_SecondStepL1T )
 
+
+DQMOffline_SecondStep_PreDPG_Express = cms.Sequence(
+                                             DQMOffline_SecondStepEcal *
+                                             DQMOffline_SecondStepTrackerStrip *
+                                             DQMOffline_SecondStepTrackerPixel *
+                                             DQMOffline_SecondStepMuonDPGExpress *
+                                             #DQMOffline_SecondStepHcal *
+                                             #DQMOffline_SecondStepHcal2 *
+                                             DQMOffline_SecondStepFED 
+                                             #DQMOffline_SecondStepL1T 
+)
+
 DQMOffline_SecondStepDPG = cms.Sequence(
                                          DQMOffline_SecondStep_PreDPG *
                                          DQMMessageLoggerClientSeq )
 
+DQMOffline_SecondStepDPG_Express = cms.Sequence(
+                                         DQMOffline_SecondStep_PreDPG_Express *
+                                         DQMMessageLoggerClientSeq )
 
 from DQM.TrackingMonitorClient.TrackingClientConfig_Tier0_cff import *
 from DQMOffline.Muon.muonQualityTests_cff import *
@@ -93,9 +113,22 @@ DQMOffline_SecondStep_PrePOG = cms.Sequence( DQMOffline_SecondStepTracking *
                                              DQMOffline_SecondStepBeam *
                                              DQMOffline_SecondStepJetMET )
 
+
+DQMOffline_SecondStep_PrePOG_Express = cms.Sequence( DQMOffline_SecondStepTracking *
+                                             DQMOffline_SecondStepMUO *
+                                             #DQMOffline_SecondStepEGamma *
+                                             DQMOffline_SecondStepTrigger *
+                                             DQMOffline_SecondStepBTag *
+                                             DQMOffline_SecondStepBeam 
+                                             #Dqmoffline_SecondStepJetMET 
+)
+
+
 DQMOffline_SecondStepPOG = cms.Sequence(
                                          DQMOffline_SecondStep_PrePOG *
                                          DQMMessageLoggerClientSeq )
+
+
 
 
 HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT)
@@ -107,6 +140,14 @@ DQMOffline_SecondStep = cms.Sequence(
                                       HLTMonitoringClient *
                                       DQMMessageLoggerClientSeq *
                                       dqmFastTimerServiceClient)
+
+DQMOffline_SecondStep_Express = cms.Sequence(
+                                      DQMOffline_SecondStep_PreDPG_Express *
+                                      DQMOffline_SecondStep_PrePOG_Express *
+                                      HLTMonitoringClient *
+                                      DQMMessageLoggerClientSeq *
+                                      dqmFastTimerServiceClient)
+
 
 DQMOffline_SecondStep_ExtraHLT = cms.Sequence( hltOfflineDQMClientExtra )
 

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -67,6 +67,11 @@ DQMOfflineMuonDPG = cms.Sequence( dtSources *
                                   rpcTier0Source *
                                   cscSources )
 
+
+DQMOfflineMuonDPGExpress = cms.Sequence(rpcTier0Source *
+                                        cscSources *
+                                        gemSources)
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 _run3_GEM_DQMOfflineMuonDPG = DQMOfflineMuonDPG.copy()
 _run3_GEM_DQMOfflineMuonDPG += gemSources
@@ -87,8 +92,23 @@ DQMOfflinePreDPG = cms.Sequence( DQMOfflineDCS *
                                  DQMOfflineCASTOR *
                                  DQMOfflineCTPPS )
 
+
+DQMOfflinePreDPGExpress = cms.Sequence( DQMOfflineDCS *
+                                        #DQMOfflineL1T *
+                                        DQMOfflineEcal *
+                                        #DQMOfflineHcal *
+                                        #DQMOfflineHcal2 *
+                                        DQMOfflineTrackerStrip *
+                                        DQMOfflineTrackerPixel *
+                                        DQMOfflineMuonDPGExpress *
+                                        DQMOfflineCASTOR *
+                                        DQMOfflineCTPPS )
+
 DQMOfflineDPG = cms.Sequence( DQMOfflinePreDPG *
                               DQMMessageLogger )
+
+DQMOfflineDPGExpress = cms.Sequence( DQMOfflinePreDPGExpress *
+                                     DQMMessageLogger )
 
 from DQM.TrackingMonitorSource.TrackingSourceConfig_Tier0_cff import *
 from DQMOffline.RecoB.PrimaryVertexMonitor_cff import *
@@ -137,8 +157,23 @@ DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflinePhysics )
 
 
+DQMOfflinePrePOGExpress = cms.Sequence( DQMOfflineTracking *
+                                 DQMOfflineMUO *
+                                 #DQMOfflineJetMET *
+                                 #DQMOfflineEGamma *
+                                 DQMOfflineTrigger *
+                                 DQMOfflineBTag *
+                                 DQMOfflineBeam 
+                                 #DQMOfflinePhysics 
+)
+
+
 DQMOfflinePOG = cms.Sequence( DQMOfflinePrePOG *
                               DQMMessageLogger )
+
+DQMOfflinePOGExpress = cms.Sequence( DQMOfflinePrePOGExpress *
+                                     DQMMessageLogger )
+
 
 HLTMonitoring = cms.Sequence( OfflineHLTMonitoring )
 HLTMonitoringPA = cms.Sequence( OfflineHLTMonitoringPA )
@@ -148,6 +183,12 @@ DQMOffline = cms.Sequence( DQMOfflinePreDPG *
                            DQMOfflinePrePOG *
                            HLTMonitoring *
                            DQMMessageLogger )
+
+DQMOfflineExpress = cms.Sequence( DQMOfflinePreDPGExpress *
+                                  DQMOfflinePrePOGExpress *
+                                  HLTMonitoring *
+                                  DQMMessageLogger )
+
 
 DQMOfflineExtraHLT = cms.Sequence( offlineValidationHLTSource )
 

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -219,6 +219,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                             'PostDQMOffline',
                             'dqmHarvesting'],
 
+            'standardDQMExpress': ['DQMOfflineExpress',
+                                   'PostDQMOffline',
+                                   'dqmHarvestingExpress'],
+
             'standardDQMFS': ['DQMOfflineFS',
                             'PostDQMOffline',
                             'dqmHarvesting'],


### PR DESCRIPTION
#### PR description:

The goal of this PR is to define a new sequence in DQM Offline, that should be run on the Express Stream. The new sequence  will produce a reduced number of ME (10% less) wrt the DQM sequence that is presently run on Express (the "standardDQM" sequence). 
By this way, also the number of ME that should be harvested in step3 will be reduced (thanks to a new ad-hoc harvesting sequence), and hopefully this would mitigate the memory issues observed at T0 during 2022 and 2023 collisions (discussed here https://github.com/cms-sw/cmssw/issues/38976). 

The subsystem sequences that will be run with this new configuration, are decided on the basis of the feedback received during the DQM General meeting https://indico.cern.ch/event/1259866/. Wrt the old sequence, we removed DT, EGamma, HCAL, JetMet, L1T and Physics. Additional room for improvement: remove MuonPOG (not yet done, since part of the CSC plots are produced in the MuonPOG sequence).

#### PR validation:
A generic test that mimic the offline reconstruction+ DQM steps on top of the raw express data has been performed with

cmsDriver.py step2 --conditions 130X_dataRun3_Express_v2 --data --datatier RECO,DQMIO --era Run3 --eventcontent RECO,DQM --filein file:/eos/cms/store/t0streamer/Data/Express/000/368/454/run368454_ls0134_streamExpress_StorageManager.dat --fileout file:step2_modified.root --nStreams 2 --nThreads 8 --no_exec --number 10 --process RECO,DQM --python_filename step2_modified_cfg.py --scenario pp --step RAW2DIGI,L1Reco,RECO,DQM:@standardDQMExpress

cmsDriver.py step3 --conditions 130X_dataRun3_Express_v2 --data --era Run3 --filein step2_modified_inDQM.root --fileout file:step3_modified.root --filetype DQM --nStreams 2 --no_exec --number 10 --python_filename step_3_modified_cfg.py --scenario pp --step HARVESTING:@standardDQMExpress

The DQMIO files produced from the old (standardDQM) and new (standardDQMExpress) workflow have been inspected with dqmiodumpmetadata.py and dqmiolistmes.py scripts. 


#### 
This PR should be backported to 13_0_X, because we target to have the new sequence running at T0.

