### PR TITLE
Migrate Phase-2 geometry to D98

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -117,7 +117,7 @@ The script also handles the common and forward elements of the geometry:
 
 Several detector combinations have been generated:
 * D86 = T24+C17+M10+I14+O8+F6
-* D88 = T24+C17+M10+I15+O9+F6 (Current Phase-2 baseline)
+* D88 = T24+C17+M10+I15+O9+F6
 * D91 = T30+C17+M10+I15+O9+F6
 * D92 = T24+C18+M10+I15+O9+F6
 * D93 = T24+C19+M10+I15+O9+F6
@@ -125,6 +125,6 @@ Several detector combinations have been generated:
 * D95 = T31+C17+M10+I16+O9+F6
 * D96 = T31+C18+M10+I16+O9+F6
 * D97 = T25+C17+M10+I15+O9+F6
-* D98 = T32+C17+M10+I16+O9+F6
+* D98 = T32+C17+M10+I16+O9+F6 (Current Phase-2 baseline from CMSSW_13_2_0_pre2)
 * D99 = T32+C18+M10+I16+O9+F6
 

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -16,31 +16,26 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 numWFIB = []
 numWFIB.extend([20034.0]) #2026D86
 numWFIB.extend([20834.0]) #2026D88
-numWFIB.extend([21061.97]) #2026D88 premixing stage1 (NuGun+PU)
-numWFIB.extend([20834.5,20834.9,20834.501,20834.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
-numWFIB.extend([21034.99,21034.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
-numWFIB.extend([20834.21,21034.21,21034.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
-numWFIB.extend([21034.114]) #2026D88 PU, with 10% OT ineffiency
+numWFIB.extend([20834.501,20834.502]) #2026D88 Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU (to remove when available in D98)
 numWFIB.extend([22034.0]) #2026D91
 numWFIB.extend([22434.0]) #2026D92
 numWFIB.extend([22834.0]) #2026D93
 numWFIB.extend([23234.0]) #2026D94
-numWFIB.extend([23634.0,23634.911,23634.103]) #2026D95 DDD XML, DD4hep XML, aging
-numWFIB.extend([23861.97]) #2026D95 premixing stage1 (NuGun+PU)
-numWFIB.extend([23634.5,23634.9]) #2026D95 pixelTrackingOnly, vector hits
-numWFIB.extend([23834.99,23834.999]) #2026D95 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test) 
-numWFIB.extend([23634.21,23834.21,23834.9921]) #2026D95 prodlike, prodlike PU, prodlike premix stage1+stage2
+numWFIB.extend([23634.0]) #2026D95
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
-numWFIB.extend([24834.0]) #2026D98
+numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
+numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
+numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
+numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
+numWFIB.extend([24834.21,25034.21,25034.9921]) #2026D98 prodlike, prodlike PU, prodlike premix stage1+stage2
+numWFIB.extend([25034.114]) #2026D98 PU, with 10% OT ineffiency 
 numWFIB.extend([25234.0,25234.911]) #2026D99 DDD XML, DD4hep XML
 
 #Additional sample for short matrix and IB
 #CloseByPGun for HGCAL
-numWFIB.extend([20896.0]) #CE_E_Front_120um D88
-numWFIB.extend([20900.0]) #CE_H_Coarse_Scint D88
-numWFIB.extend([23696.0]) #CE_E_Front_120um D95
-numWFIB.extend([23700.0]) #CE_H_Coarse_Scint D95
+numWFIB.extend([24896.0]) #CE_E_Front_120um D98
+numWFIB.extend([24900.0]) #CE_H_Coarse_Scint D98
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3956,6 +3956,7 @@ defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77no
 defaultDataSets['2026D88']='CMSSW_12_3_0_pre5-123X_mcRun4_realistic_v4_2026D88noPU-v'
 defaultDataSets['2026D95']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D95noPU-v'
 defaultDataSets['2026D96']='CMSSW_13_1_0_pre1-130X_mcRun4_realistic_v2_2026D96noPU-v'
+defaultDataSets['2026D98']='CMSSW_13_2_0_pre1-131X_mcRun4_realistic_v5_2026D98noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
                      12434.7, #2023 ttbar mkFit
                      24834.0, #2026D98 ttbar (Phase-2 baseline)
                      24834.911, #2026D98 ttbar DD4hep XML
-                     24834.999, #2026D98 ttbar premixing stage1+stage2, PU50
+                     25034.999, #2026D98 ttbar premixing stage1+stage2, PU50
                      24896.0, #CE_E_Front_120um D98
                      24900.0, #CE_H_Coarse_Scint D98
                      23234.0, #2026D94 ttbar (exercise with HFNose)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,11 +97,11 @@ if __name__ == '__main__':
                      13434.0, #2021 ttbar PU fastsim
                      12434.0, #2023 ttbar
                      12434.7, #2023 ttbar mkFit
-                     23634.0, #2026D95 ttbar (Phase-2 baseline)
-                     23634.911, #2026D95 ttbar DD4hep XML
-                     23834.999, #2026D95 ttbar premixing stage1+stage2, PU50
-                     23696.0, #CE_E_Front_120um D95
-                     23700.0, #CE_H_Coarse_Scint D95
+                     24834.0, #2026D98 ttbar (Phase-2 baseline)
+                     24834.911, #2026D98 ttbar DD4hep XML
+                     24834.999, #2026D98 ttbar premixing stage1+stage2, PU50
+                     24896.0, #CE_E_Front_120um D98
+                     24900.0, #CE_H_Coarse_Scint D98
                      23234.0, #2026D94 ttbar (exercise with HFNose)
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix


### PR DESCRIPTION
#### PR description:
This PR move Phase-2 baseline geometry to D98. I also use this PR to clean up old Phase-2 wfs from IB test.

#### PR validation:
Trying to dump the following workflows, and all seems to be fine:
`24834.0,24834.911,24834.103,25061.97,24834.5,24834.9,25034.99,25034.999,24834.21,25034.21,25034.9921,25034.114,24896.0,24900.0`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport