### PR TITLE
Add preliminary GTs for 2023 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -76,9 +76,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '131X_mcRun3_2023_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v5',
+    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:
This PR updates the GTs for the 2023 MC production to **preliminary** GTs, as detailed in [this CMSTalk post](https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-2023-mc/24376/10).

**Important Note:**
These GTs do not yet contain all the conditions needed for the 2023 MC production as a few of them are still work in progress, but, since most of them are already available, we decided to start adding them to the release so they can be validated via the usual release validation.

**GT differences:**
 - **phase1_2023_realistic**:  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v5/131X_mcRun3_2023_realistic_v6
 - **phase1_2023_cosmics**:  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v5/131X_mcRun3_2023cosmics_realistic_deco_v6

#### PR validation:
Successfully run:
```
runTheMatrix.py -l 12434.0,12434.7,12634.0 -j 8 --ibeos
```

#### Backport:
Not a backport.
Backports to 13_1_X and 13_0_X will be opened only after all the conditions are available.