### PR TITLE
[13_1_X] Change EMTF Primitive Conversion LUT Assignment for MC

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -27,7 +27,7 @@ void SectorProcessorLUT::read(bool pc_lut_data, int pc_lut_version) {
     coord_lut_dir = "ph_lut_v3_data";  // Update in September 2017 from ReReco alignment, data only
   else if (pc_lut_version == 3 && pc_lut_data)
     coord_lut_dir = "ph_lut_Run3_2022_data";  // Update in October 2022 from Run 3 2022 alignment, data only
-  else if (pc_lut_version == 2)
+  else if (pc_lut_version >= 2)
     coord_lut_dir = "ph_lut_v2";  // MC still uses ideal CMS aligment
   else if (pc_lut_version == -1 && pc_lut_data)
     coord_lut_dir = "ph_lut_v3_data";  // September 2017 data LCT alignment, but use local CPPF LUTs for RPC


### PR DESCRIPTION
#### PR description:

This PR makes the primitive conversion LUT loading for MC inclusive for `pc_lut_version`.  In data, based on muon detector alignment we use a different version of PC LUT, but in MC we always use ideal aligment. This PR fixes this assignment for MC for all future PC LUTs.

This is a backport of https://github.com/cms-sw/cmssw/pull/41954

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested with `addOnTests.py` and the new GT `131X_mcRun3_2023_realistic_v6`. Workflow crashes without this PR, doesn't crash with the PR included.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->


<!-- Please delete the text above after you verified all points of the checklist  -->

FYI: @francescobrivio 
