### PR TITLE
[13_0_X] Add preliminary GTs for 2023 MC and new L1T menu to relval/ideal/2024/run4 GTs and re-snapshot data GTS

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-05-10 09:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v2',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v2 but with snapshot at 2023-05-10 09:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v2',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v3 but with snapshot at 2023-05-10 09:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v2',
+    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-06-14 12:00:00 (UTC)
+    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v3',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-06-14 12:00:00 (UTC)
+    'run3_data_express'            : '130X_dataRun3_Express_frozen_v3',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-06-14 12:00:00 (UTC)
+    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v3',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20 (UTC)
     'run3_data'                    : '130X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -74,19 +74,19 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v6',
+    'phase1_2023_design'           : '130X_mcRun3_2023_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v8',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v7',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v6',
+    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v6',
+    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '130X_mcRun4_realistic_v7'
+    'phase2_realistic'             : '130X_mcRun4_realistic_v8'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2023_v1_1_0-v2_xml' , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-05-02 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2023_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-06-13 14:12:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:
Combined backport of #41947 and #41958.
 - Updates the 2023 MC realistic GTs to **preliminary** GTs for 2023 MC production, see [this CMSTalk post](https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-2023-mc/24376/10)
 - Updates the L1T menu tag to be compatible with HLT menu `v1.2` in relval/ideal/2024/run4 GTs (see [this CMSTalk post](https://cms-talk.web.cern.ch/t/update-of-the-2023-l1-menu-tag-l1menu-collisions2023-v1-2-0/25410))
 - Updates the Run3 data GTs snapshot

**GT differences** (listing here because these are 130X GTs, while in master they are 131X):
- **run3_hlt:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_frozen_v2/130X_dataRun3_HLT_frozen_v3
   - Difference wrt production GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_v2/130X_dataRun3_HLT_frozen_v3
- **run3_data_express:**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_frozen_v2/130X_dataRun3_Express_frozen_v3
   - Difference wrt production GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_v3/130X_dataRun3_Express_frozen_v3
- **run3_data_prompt:**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_frozen_v2/130X_dataRun3_Prompt_frozen_v3
   - Difference wrt production GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_v4/130X_dataRun3_Prompt_frozen_v3
- **phase1_2023_design:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_v6/130X_mcRun3_2023_design_v7
- **phase1_2023_realistic:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v8/130X_mcRun3_2023_realistic_v9
- **phase1_2023_cosmics:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v7/130X_mcRun3_2023cosmics_realistic_deco_v8
- **phase1_2023_cosmics_design:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_v6/130X_mcRun3_2023cosmics_design_deco_v7
- **phase1_2024_realistic:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v6/130X_mcRun3_2024_realistic_v7
- **phase2_realistic:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun4_realistic_v7/130X_mcRun4_realistic_v8

#### PR validation:
Tested with:
```
runTheMatrix.py -l 138.4,138.5,139.001,12434.0,12834.0,23234.0 -j 8 --ibeos
```

#### Backport:
Combined backport of #41947 and #41958.