### PR TITLE
Miscellaneous improvements to `SimBeamSpotObjects` handling utilities

### DIFF
--- a/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
+++ b/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
@@ -92,19 +92,22 @@ namespace beamSpotPI {
    */
   template <class PayloadType>
   class BSParamsHelper {
-    typedef std::array<double, 8> bshelpdata;
+    typedef std::array<double, parameters::lastLumi> bshelpdata;
 
   public:
     BSParamsHelper(const std::shared_ptr<PayloadType>& bs) {
       // fill in the central values
-      m_values[0] = bs->x(), m_values[1] = bs->y(), m_values[2] = bs->z();
-      m_values[3] = bs->beamWidthX(), m_values[4] = bs->beamWidthY(), m_values[5] = bs->sigmaZ();
-      m_values[6] = bs->dxdz(), m_values[7] = bs->dydz();
+      m_values[parameters::X] = bs->x(), m_values[parameters::Y] = bs->y(), m_values[parameters::Z] = bs->z();
+      m_values[parameters::sigmaX] = bs->beamWidthX(), m_values[parameters::sigmaY] = bs->beamWidthY(),
+      m_values[parameters::sigmaZ] = bs->sigmaZ();
+      m_values[parameters::dxdz] = bs->dxdz(), m_values[parameters::dydz] = bs->dydz();
 
       // fill in the errors
-      m_errors[0] = bs->xError(), m_errors[1] = bs->yError(), m_errors[2] = bs->zError();
-      m_errors[3] = bs->beamWidthXError(), m_errors[4] = bs->beamWidthYError(), m_errors[5] = bs->sigmaZError();
-      m_errors[6] = bs->dxdzError(), m_errors[7] = bs->dydzError();
+      m_errors[parameters::X] = bs->xError(), m_errors[parameters::Y] = bs->yError(),
+      m_errors[parameters::Z] = bs->zError();
+      m_errors[parameters::sigmaX] = bs->beamWidthXError(), m_errors[parameters::sigmaY] = bs->beamWidthYError(),
+      m_errors[parameters::sigmaZ] = bs->sigmaZError();
+      m_errors[parameters::dxdz] = bs->dxdzError(), m_errors[parameters::dydz] = bs->dydzError();
     }
 
     void printDebug(std::stringstream& ss) {
@@ -685,15 +688,17 @@ namespace simBeamSpotPI {
    */
   template <class PayloadType>
   class SimBSParamsHelper {
-    typedef std::array<double, 10> bshelpdata;
+    typedef std::array<double, parameters::END_OF_TYPES> bshelpdata;
 
   public:
     SimBSParamsHelper(const std::shared_ptr<PayloadType>& bs) {
       // fill in the values
-      m_values[0] = bs->x(), m_values[1] = bs->y(), m_values[2] = bs->z();
-      m_values[3] = bs->sigmaZ(), m_values[4] = bs->betaStar(), m_values[5] = bs->emittance();
-      m_values[6] = (1 / std::sqrt(2)) * std::sqrt(bs->emittance() * bs->betaStar()) * 10000.f;
-      m_values[7] = bs->phi(), m_values[8] = bs->alpha(), m_values[9] = bs->timeOffset();
+      m_values[parameters::X] = bs->x(), m_values[parameters::Y] = bs->y(), m_values[parameters::Z] = bs->z();
+      m_values[parameters::sigmaZ] = bs->sigmaZ(), m_values[parameters::betaStar] = bs->betaStar(),
+      m_values[parameters::emittance] = bs->emittance();
+      m_values[parameters::expTransWidth] = (1 / std::sqrt(2)) * std::sqrt(bs->emittance() * bs->betaStar()) * 10000.f;
+      m_values[parameters::phi] = bs->phi(), m_values[parameters::alpha] = bs->alpha(),
+      m_values[parameters::timeOffset] = bs->timeOffset();
     }
 
     void printDebug(std::stringstream& ss) {

--- a/CondCore/BeamSpotPlugins/plugins/SimBeamSpot_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/SimBeamSpot_PayloadInspector.cc
@@ -6,21 +6,19 @@
 
 namespace {
 
-  using namespace simBeamSpotPI;
-
   /************************************************
     Display of Sim Beam Spot parameters
   *************************************************/
 
-  typedef DisplayParameters<SimBeamSpotObjects> SimBeamSpotParameters;
+  typedef simBeamSpotPI::DisplayParameters<SimBeamSpotObjects> SimBeamSpotParameters;
 
   /************************************************
     Display of Sim Beam Spot parameters Differences
   *************************************************/
 
-  typedef DisplayParametersDiff<SimBeamSpotObjects, cond::payloadInspector::MULTI_IOV, 1>
+  typedef simBeamSpotPI::DisplayParametersDiff<SimBeamSpotObjects, cond::payloadInspector::MULTI_IOV, 1>
       SimBeamSpotParametersDiffSingleTag;
-  typedef DisplayParametersDiff<SimBeamSpotObjects, cond::payloadInspector::SINGLE_IOV, 2>
+  typedef simBeamSpotPI::DisplayParametersDiff<SimBeamSpotObjects, cond::payloadInspector::SINGLE_IOV, 2>
       SimBeamSpotParametersDiffTwoTags;
 
 }  // namespace

--- a/CondCore/BeamSpotPlugins/test/testBeamSpotPayloadInspector.cpp
+++ b/CondCore/BeamSpotPlugins/test/testBeamSpotPayloadInspector.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/BeamSpotPlugins/plugins/SimBeamSpot_PayloadInspector.cc"
 #include "CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc"
 #include "CondCore/BeamSpotPlugins/plugins/BeamSpotOnline_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -49,6 +50,7 @@ int main(int argc, char** argv) {
 
   edm::LogPrint("testBeamSpotPayloadInspector") << "## Exercising BeamSpotOnline plots " << std::endl;
 
+  // BeamSpotOnline
   tag = "BeamSpotOnlineTestLegacy";
   start = static_cast<unsigned long long>(1443392479297557);
   end = static_cast<unsigned long long>(1470910334763033);
@@ -78,6 +80,31 @@ int main(int argc, char** argv) {
   BeamSpotOnlineParametersDiffTwoTags histoOnlineParametersDiffTwoTags;
   histoOnlineParametersDiffTwoTags.process(connectionString, PI::mk_input(tag1, start, start, tag2, start, start));
   edm::LogPrint("testBeamSpotPayloadInspector") << histoOnlineParametersDiffTwoTags.data() << std::endl;
+
+  // SimBeamSpot
+  std::string prepConnectionString("frontier://FrontierPrep/CMS_CONDITIONS");
+
+  tag = "SimBeamSpotObjects_Realistic25ns13p6TeVEOY2022Collision_v0_mc";
+  start = static_cast<unsigned long long>(1);
+  end = static_cast<unsigned long long>(1);
+
+  edm::LogPrint("testBeamSpotPayloadInspector") << "## Exercising SimBeamSpot plots " << std::endl;
+
+  SimBeamSpotParameters histoSimParameters;
+  histoSimParameters.process(prepConnectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimParameters.data() << std::endl;
+
+  SimBeamSpotParametersDiffSingleTag histoSimParametersDiff;
+  histoSimParametersDiff.process(prepConnectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimParametersDiff.data() << std::endl;
+
+  tag1 = "SimBeamSpotObjects_Realistic25ns13p6TeVEOY2022Collision_v0_mc";
+  tag2 = "SimBeamSpotObjects_Realistic25ns13p6TeVEarly2023Collision_v0_mc";
+  start = static_cast<unsigned long long>(1);
+
+  SimBeamSpotParametersDiffTwoTags histoSimParametersDiffTwoTags;
+  histoSimParametersDiffTwoTags.process(prepConnectionString, PI::mk_input(tag1, start, start, tag2, start, start));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimParametersDiffTwoTags.data() << std::endl;
 
   Py_Finalize();
 }

--- a/CondTools/BeamSpot/plugins/BeamProfile2DBReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamProfile2DBReader.cc
@@ -44,7 +44,7 @@
 class BeamProfile2DBReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit BeamProfile2DBReader(const edm::ParameterSet&);
-  ~BeamProfile2DBReader() override;
+  ~BeamProfile2DBReader() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -88,8 +88,6 @@ BeamProfile2DBReader::BeamProfile2DBReader(const edm::ParameterSet& iConfig)
     }
   }
 }
-
-BeamProfile2DBReader::~BeamProfile2DBReader() = default;
 
 //
 // member functions
@@ -146,7 +144,7 @@ void BeamProfile2DBReader::analyze(const edm::Event& iEvent, const edm::EventSet
   if (output_.get())
     *output_ << output.str();
   else
-    edm::LogInfo("") << output.str();
+    edm::LogInfo("BeamProfile2DBReader") << output.str();
 }
 
 // ------------ method called once each job just before starting event loop  ------------
@@ -169,11 +167,9 @@ void BeamProfile2DBReader::beginJob() {
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void BeamProfile2DBReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.addUntracked<std::string>("rawFileName", {});
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/CondTools/BeamSpot/plugins/BeamProfile2DBWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamProfile2DBWriter.cc
@@ -48,13 +48,15 @@ private:
   void endJob() override;
 
   // ----------member data ---------------------------
+  const std::string recordName_;
   SimBeamSpotObjects beamSpot_;
 };
 
 //
 // constructors and destructor
 //
-BeamProfile2DBWriter::BeamProfile2DBWriter(const edm::ParameterSet& iConfig) {
+BeamProfile2DBWriter::BeamProfile2DBWriter(const edm::ParameterSet& iConfig)
+    : recordName_(iConfig.getParameter<std::string>("recordName")) {
   beamSpot_.setX(iConfig.getParameter<double>("X0"));
   beamSpot_.setY(iConfig.getParameter<double>("Y0"));
   beamSpot_.setZ(iConfig.getParameter<double>("Z0"));
@@ -76,7 +78,7 @@ void BeamProfile2DBWriter::analyze(edm::StreamID, const edm::Event& iEvent, cons
 // ------------ method called once each job just after ending the event loop  ------------
 void BeamProfile2DBWriter::endJob() {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  poolDbService->createOneIOV<SimBeamSpotObjects>(beamSpot_, poolDbService->beginOfTime(), "SimBeamSpotObjectsRcd");
+  poolDbService->createOneIOV<SimBeamSpotObjects>(beamSpot_, poolDbService->beginOfTime(), recordName_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -84,6 +86,8 @@ void BeamProfile2DBWriter::fillDescriptions(edm::ConfigurationDescriptions& desc
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
+  desc.add<std::string>("recordName", "SimBeamSpotObjectsRcd")
+      ->setComment("name of the record to use for the PoolDBOutputService");
   desc.add<double>("X0")->setComment("in cm");
   desc.add<double>("Y0")->setComment("in cm");
   desc.add<double>("Z0")->setComment("in cm");

--- a/CondTools/BeamSpot/plugins/BeamProfile2DBWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamProfile2DBWriter.cc
@@ -39,7 +39,7 @@
 class BeamProfile2DBWriter : public edm::global::EDAnalyzer<> {
 public:
   explicit BeamProfile2DBWriter(const edm::ParameterSet&);
-  ~BeamProfile2DBWriter() override;
+  ~BeamProfile2DBWriter() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -65,8 +65,6 @@ BeamProfile2DBWriter::BeamProfile2DBWriter(const edm::ParameterSet& iConfig) {
   beamSpot_.setEmittance(iConfig.getParameter<double>("Emittance"));
   beamSpot_.setTimeOffset(iConfig.getParameter<double>("TimeOffset"));
 }
-
-BeamProfile2DBWriter::~BeamProfile2DBWriter() = default;
 
 //
 // member functions

--- a/CondTools/BeamSpot/plugins/BeamSpotRcdReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotRcdReader.cc
@@ -48,7 +48,7 @@
 class BeamSpotRcdReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit BeamSpotRcdReader(const edm::ParameterSet&);
-  ~BeamSpotRcdReader() override;
+  ~BeamSpotRcdReader() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -94,8 +94,6 @@ BeamSpotRcdReader::BeamSpotRcdReader(const edm::ParameterSet& iConfig)
     }
   }
 }
-
-BeamSpotRcdReader::~BeamSpotRcdReader() = default;
 
 //
 // member functions
@@ -150,7 +148,7 @@ void BeamSpotRcdReader::analyze(const edm::Event& iEvent, const edm::EventSetup&
   if (output_.get())
     *output_ << output.str();
   else
-    edm::LogInfo("") << output.str();
+    edm::LogInfo("BeamSpotRcdReader") << output.str();
 }
 
 // ------------ method called once each job just before starting event loop  ------------
@@ -171,11 +169,9 @@ void BeamSpotRcdReader::beginJob() {
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void BeamSpotRcdReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.addUntracked<std::string>("rawFileName", {});
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/CondTools/BeamSpot/python/BeamProfile2DBRead_cfi.py
+++ b/CondTools/BeamSpot/python/BeamProfile2DBRead_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-BeamProfile2DBRead = cms.EDAnalyzer("BeamProfile2DBReader",
-                                    rawFileName = cms.untracked.string("")
-                                    )

--- a/CondTools/BeamSpot/python/BeamSpotRcdRead_cfi.py
+++ b/CondTools/BeamSpot/python/BeamSpotRcdRead_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-BeamSpotRead = cms.EDAnalyzer("BeamSpotRcdReader",
-                              rawFileName = cms.untracked.string("")
-                              )

--- a/CondTools/BeamSpot/test/BeamProfile2DBReader_cfg.py
+++ b/CondTools/BeamSpot/test/BeamProfile2DBReader_cfg.py
@@ -79,12 +79,11 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     ))
 )
 
-
 ####################################################################
 # Load and configure analyzer
 ####################################################################
-process.load("CondTools.BeamSpot.BeamProfile2DBRead_cfi")
-process.BeamProfile2DBRead.rawFileName = 'reference_SimBeamSpotObjects.txt'
+from CondTools.BeamSpot.beamProfile2DBReader_cfi import beamProfile2DBReader
+process.BeamProfile2DBRead = beamProfile2DBReader.clone(rawFileName = 'reference_SimBeamSpotObjects.txt')
 
 ####################################################################
 # Output file

--- a/CondTools/BeamSpot/test/BeamProfile2DBWriterAll_cfg.py
+++ b/CondTools/BeamSpot/test/BeamProfile2DBWriterAll_cfg.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("writeBeamProfile2DB")
+
+options = VarParsing.VarParsing()
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "are we running the unit test?")
+options.register('inputTag',
+                 "myTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "output tag name")
+options.parseArguments()
+
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+from CondCore.CondDB.CondDB_cfi import *
+
+if options.unitTest :
+    tag_name = 'simBS_tag'
+else:
+    tag_name = options.inputTag
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+from CondTools.BeamSpot.beamProfile2DBWriter_cfi import beamProfile2DBWriter
+process.load("IOMC.EventVertexGenerators.VtxSmearedParameters_cfi")
+
+# Get the PSets that have BetaStar as a parameter
+psets_with_BetaStar = []
+psets_names = []
+for psetName in process.__dict__:
+    pset = getattr(process, psetName)
+    if isinstance(pset, cms.PSet) and "BetaStar" in pset.parameterNames_():
+        print(psetName)
+        psets_names.append(psetName)
+        psets_with_BetaStar.append(pset)
+
+# Create a VPSet to store the parameter sets
+myVPSet = cms.VPSet()
+
+for i, pset in enumerate(psets_with_BetaStar):
+    cloneName = 'BeamProfile2DBWriter_' + str(i+1)  # Unique clone name
+    setattr(process, cloneName, beamProfile2DBWriter.clone(pset,
+                                                           recordName = cms.string(psets_names[i])))
+
+    # Create a path for each clone and add the clone to it
+    pathName = 'Path_' + str(i+1)  # Unique path name
+    setattr(process, pathName, cms.Path(getattr(process, cloneName)))
+
+    myPSet = cms.PSet(
+        record =  cms.string(psets_names[i]),
+        tag = cms.string(psets_names[i])
+    )
+    
+    myVPSet.append(myPSet)
+
+#################################
+# Produce a SQLITE FILE
+#################################
+CondDBSimBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % tag_name)) # choose an output name
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBSimBeamSpotObjects,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = myVPSet,
+                                          loadBlobStreamer = cms.untracked.bool(False))
+
+# Add an end path
+process.end = cms.EndPath()
+
+process.schedule = cms.Schedule()
+for i, pset in enumerate(psets_with_BetaStar):
+    pathName = 'Path_' + str(i+1)  # Unique path name
+    process.schedule.append(getattr(process, pathName))
+process.schedule.append(process.end)
+
+

--- a/CondTools/BeamSpot/test/BeamProfile2DBWriter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamProfile2DBWriter_cfg.py
@@ -41,12 +41,12 @@ process.source = cms.Source("EmptySource")
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
-process.load("CondTools.BeamSpot.beamProfile2DBWriter_cfi")
-process.beamProfile2DBWriter.X0        = 0.0458532
-process.beamProfile2DBWriter.Y0        = -0.016966
-process.beamProfile2DBWriter.Z0        = -0.074992
-process.beamProfile2DBWriter.SigmaZ    = 3.6
-process.beamProfile2DBWriter.BetaStar  = 30.0
-process.beamProfile2DBWriter.Emittance = 3.931e-8
+from CondTools.BeamSpot.beamProfile2DBWriter_cfi import beamProfile2DBWriter
+process.BeamProfile2DBWriter = beamProfile2DBWriter.clone(X0        = 0.0458532,
+                                                          Y0        = -0.016966,
+                                                          Z0        = -0.074992,
+                                                          SigmaZ    = 3.6,
+                                                          BetaStar  = 30.0,
+                                                          Emittance = 3.931e-8,)
 
-process.p = cms.Path(process.beamProfile2DBWriter)
+process.p = cms.Path(process.BeamProfile2DBWriter)

--- a/CondTools/BeamSpot/test/extractAndUploadAll.py
+++ b/CondTools/BeamSpot/test/extractAndUploadAll.py
@@ -1,0 +1,56 @@
+import sqlite3
+import json
+import subprocess
+import shutil
+
+# Open the SQLite database file
+conn = sqlite3.connect('test_myTagName.db')
+cursor = conn.cursor()
+
+# Execute the SELECT query
+cursor.execute('SELECT * FROM IOV')
+
+# Fetch all the results from the query
+results = cursor.fetchall()
+
+# Create an empty list to store the extracted values
+extracted_values = []
+
+# Extract the desired part of the string and add it to the list
+for row in results:
+    value = row[0].split('|')[0].strip()
+    extracted_values.append(value)
+
+# Close the database connection
+conn.close()
+
+# Generate the JSON file and execute the command for each extracted value
+for value in extracted_values:
+    print("uploading",value)
+    # Create the dictionary for the JSON structure
+    data = {
+        "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS",
+        "destinationTags": {
+            "SimBeamSpot_" + value + "_v0_mc": {}
+        },
+        "inputTag": value,
+        "since": None,
+        "userText": value
+    }
+    
+    # Generate the JSON file
+    filename = "test_myTagName.txt"
+    with open(filename, 'w') as file:
+        json.dump(data, file, indent=4)
+    
+    # Execute the command to upload conditions
+    subprocess.call(["uploadConditions.py", "test_myTagName.db"])
+
+    # Generate the new filename
+    new_filename = "test_" + value + ".txt"
+    
+    # Move the file to the new name
+    shutil.move(filename, new_filename)
+
+    # Print a success message
+    print("Uploaded conditions for value:", value)

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -1,4 +1,3 @@
-
 /*
 ________________________________________________________________________
 
@@ -39,7 +38,7 @@ BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet& p) : B
     fSigmaZ = p.getParameter<double>("SigmaZ") * cm;
     fbetastar = p.getParameter<double>("BetaStar") * cm;
     femittance = p.getParameter<double>("Emittance") * cm;              // this is not the normalized emittance
-    fTimeOffset = p.getParameter<double>("TimeOffset") * ns * c_light;  // HepMC time units are mm
+    fTimeOffset = p.getParameter<double>("TimeOffset") * ns * c_light;  // HepMC distance units are mm
 
     setBoost(p.getParameter<double>("Alpha") * radian, p.getParameter<double>("Phi") * radian);
     if (fSigmaZ <= 0) {
@@ -63,12 +62,11 @@ void BetafuncEvtVtxGenerator::beginLuminosityBlock(edm::LuminosityBlock const&, 
 void BetafuncEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   if (readDB_ && parameterWatcher_.check(iEventSetup)) {
     edm::ESHandle<SimBeamSpotObjects> beamhandle = iEventSetup.getHandle(beamToken_);
-
     fX0 = beamhandle->x() * cm;
     fY0 = beamhandle->y() * cm;
     fZ0 = beamhandle->z() * cm;
     fSigmaZ = beamhandle->sigmaZ() * cm;
-    fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC time units are mm
+    fTimeOffset = beamhandle->timeOffset() * ns * c_light;  // HepMC distance units are in mm
     fbetastar = beamhandle->betaStar() * cm;
     femittance = beamhandle->emittance() * cm;
     setBoost(beamhandle->alpha() * radian, beamhandle->phi() * radian);


### PR DESCRIPTION
#### PR description:

This is a follow-up PR to https://github.com/cms-sw/cmssw/pull/41918.
Miscellaneous improvements to `SimBeamSpotObjects` handling utilities, including:
   * add expected transverse width to the payload inspector
   * add `CondCore/BeamSpotPlugins` unit tests for the exercise the plots introduced in https://github.com/cms-sw/cmssw/pull/41918
   * miscellaneous clean-up of the plugins to create and read  `SimBeamSpotObjects` payloads
   * usage of auto-generated configuration fragments from `fillDescriptions` whenever possible
   * introduce some utilities to directly dump to sqlite and consequently upload to DB all vertex smearing PSets from `IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py`

#### PR validation:

Relies on the existing (and augmented) unit tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
