### PR TITLE
[13.1.X] add protection to `ParticleNetJetTagMonitor`, removed unused struct

### DIFF
--- a/DQMOffline/Trigger/plugins/ParticleNetJetTagMonitor.cc
+++ b/DQMOffline/Trigger/plugins/ParticleNetJetTagMonitor.cc
@@ -57,12 +57,6 @@ protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
 
-  struct JetRefCompare {
-    inline bool operator()(const edm::RefToBase<reco::Jet>& j1, const edm::RefToBase<reco::Jet>& j2) const {
-      return (j1.id() < j2.id()) || ((j1.id() == j2.id()) && (j1.key() < j2.key()));
-    }
-  };
-
 private:
   // folder for output histograms
   const std::string folderName_;
@@ -843,6 +837,14 @@ void ParticleNetJetTagMonitor::analyze(edm::Event const& iEvent, edm::EventSetup
 
     std::vector<float> jetPNETScoreValuesHLT;
     std::vector<reco::JetBaseRef> jetHLTRefs;
+
+    // protect for wrong event content
+    if (not jetPNETScoreHLTHandle->keyProduct().isAvailable()) {
+      edm::LogWarning("ParticleNetJetTagMonitor")
+          << "Collection used as a key by HLT Jet tags collection is not available, will skip event";
+      return;
+    }
+
     for (const auto& jtag : *jetPNETScoreHLTHandle) {
       jetPNETScoreValuesHLT.push_back(jtag.second);
       jetHLTRefs.push_back(jtag.first);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41930

#### PR description:

Addresses https://github.com/cms-sw/cmssw/issues/41843#issuecomment-1574074328 now that https://github.com/cms-sw/cmssw/pull/41931 is merged. Should avoid further issue with mismatched event content in the StreamHLTMonitor PD.
Profit to remove some (apparently) dead code.

#### PR validation:

`cmssw` compiles 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Intermediate verbatim backport of https://github.com/cms-sw/cmssw/pull/41930 