### PR TITLE
[13.0.X] zeroed mono/stereo cluster counts in `SiStripMonitorTrack` at each event loop

### DIFF
--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -119,6 +119,8 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& iS
        iSubDet++) {
     iSubDet->second.totNClustersOnTrack = 0;
     iSubDet->second.totNClustersOffTrack = 0;
+    iSubDet->second.totNClustersOnTrackMono = 0;
+    iSubDet->second.totNClustersOnTrackStereo = 0;
   }
 
   trackerTopology_ = &iSetup.getData(trackerTopologyEventToken_);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/41989

#### PR description:

A trivial bug-fix follow-up PR to https://github.com/cms-sw/cmssw/pull/41725.
The mono / stereo cluster counts introduced there need to be zeroed at each event loop, otherwise it will count all the hits in the run, leading to plots like [this one](https://tinyurl.com/28tvwb7k):

![Screenshot from 2023-06-16 18-00-33](https://github.com/cms-sw/cmssw/assets/5082376/388d3ef9-30e0-4f6c-b0d1-66f2ffad9aeb)


#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/41989 for 2023 data-taking purposes.