### PR TITLE
Layer processing v2 -- preview

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
@@ -198,7 +198,7 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
   DetId detid = det->geographicalId();
 
   float xy[4][2];
-  float dz;
+  float half_length, dz;
   const Bounds *b = &((det->surface()).bounds());
 
   if (const TrapezoidalPlaneBounds *b2 = dynamic_cast<const TrapezoidalPlaneBounds *>(b)) {
@@ -212,6 +212,7 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
     xy[2][1] = par[3];
     xy[3][0] = par[0];
     xy[3][1] = -par[3];
+    half_length = par[3];
     dz = par[2];
 
 #ifdef DUMP_MKF_GEO
@@ -229,6 +230,7 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
     xy[2][1] = dy;
     xy[3][0] = dx;
     xy[3][1] = -dy;
+    half_length = dy;
     dz = b2->thickness() * 0.5;  // half thickness
 
 #ifdef DUMP_MKF_GEO
@@ -280,7 +282,7 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
   const auto &p = det->position();
   auto z = det->rotation().z();
   auto x = det->rotation().x();
-  layer_info.register_module({{p.x(), p.y(), p.z()}, {z.x(), z.y(), z.z()}, {x.x(), x.y(), x.z()}, detid.rawId()});
+  layer_info.register_module({{p.x(), p.y(), p.z()}, {z.x(), z.y(), z.z()}, {x.x(), x.y(), x.z()}, half_length, detid.rawId()});
   // Set some layer parameters (repeatedly, would require hard-coding otherwise)
   layer_info.set_subdet(detid.subdetId());
   layer_info.set_is_pixel(detid.subdetId() <= 2);

--- a/RecoTracker/MkFitCore/interface/HitStructures.h
+++ b/RecoTracker/MkFitCore/interface/HitStructures.h
@@ -82,8 +82,17 @@ namespace mkfit {
 
     bool isBinDead(bin_index_t pi, bin_index_t qi) const { return m_dead_bins[qi * m_ax_phi.size_of_N() + pi]; }
 
-    float hit_q(unsigned int i) const { return m_hit_qs[i]; }
-    float hit_phi(unsigned int i) const { return m_hit_phis[i]; }
+    struct HitInfo {
+      float phi;
+      float q;
+      float q_half_length;
+      float qbar;
+    };
+    const HitInfo& hit_info(unsigned int i) const { return m_hit_infos[i]; }
+    float hit_phi(unsigned int i) const { return m_hit_infos[i].phi; }
+    float hit_q(unsigned int i) const { return m_hit_infos[i].q; }
+    float hit_q_half_length(unsigned int i) const { return m_hit_infos[i].q_half_length; }
+    float hit_qbar(unsigned int i) const { return m_hit_infos[i].qbar; }
 
     // Use this to map original indices to sorted internal ones. m_ext_idcs needs to be initialized.
     unsigned int getHitIndexFromOriginal(unsigned int i) const { return m_ext_idcs[i - m_min_ext_idx]; }
@@ -146,19 +155,11 @@ namespace mkfit {
     // Bin information for dead regions
     std::vector<bool> m_dead_bins;
 
-    // Cached hit phi and q values to minimize Hit memory access
-    std::vector<float> m_hit_phis;
-    std::vector<float> m_hit_qs;
-
     // Geometry / q-binning constants - initialized in setupLayer()
     const LayerInfo* m_layer_info = nullptr;
     bool m_is_barrel;
 
-    // Data needed during setup
-    struct HitInfo {
-      float phi;
-      float q;
-    };
+    // Cached hit phi, q  and qbar values to minimize Hit memory access
     std::vector<HitInfo> m_hit_infos;
   };
 

--- a/RecoTracker/MkFitCore/interface/TrackerInfo.h
+++ b/RecoTracker/MkFitCore/interface/TrackerInfo.h
@@ -6,6 +6,7 @@
 #include "RecoTracker/MkFitCore/interface/Config.h"
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace mkfit {
 
@@ -30,10 +31,11 @@ namespace mkfit {
     SVector3 pos;
     SVector3 zdir;
     SVector3 xdir;
+    float    half_length;
     unsigned int detid;
 
     ModuleInfo() = default;
-    ModuleInfo(SVector3 p, SVector3 zd, SVector3 xd, unsigned int id) : pos(p), zdir(zd), xdir(xd), detid(id) {}
+    ModuleInfo(SVector3 p, SVector3 zd, SVector3 xd, float hl, unsigned int id) : pos(p), zdir(zd), xdir(xd), half_length(hl), detid(id) {}
   };
 
   //==============================================================================


### PR DESCRIPTION
Contains the following changes:
1. Add half_length member to `ModuleInfo`, fill it in `MkFitGeometryESProducer.cc`
2. Extend `HitInfo` with half-strip-length, add qbar (the other of r/z variables). Store fast-access arrays as `std::vector<HitInfo>`.

Initially, the idea was that strip half-length from ModuleInfo would be filled into the fast-access structure HitInfo. Then I realized that for strips the same thing can be obtained as `sqrt(12 * (exx + eyy)/2` (for endcaps) and `sqrt(12 * ezz)/2 (for barrel). This is now used while filling up the hits.

I still need to think which is better and what this means for pixel detectors (and, if the calculation of clusters "long" direction should be different there).

Next step is to use this information in MkFinder::selectHitIndicies() to pre-select hits with compatible q coordinate -- along with zeroth or first order of track position propagation to actual qbar coordinate (r for barrel, z for endcap) of the hit.