### PR TITLE
fix how `HLTDeDxFilter` fills `TriggerFilterObjectWithRefs` output product [`13_0_X`]

### DIFF
--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -114,7 +114,6 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
     iEvent.getByToken(caloTowersToken_, caloTowersHandle);
 
   bool accept = false;
-  int NTracks = 0;
 
   // early return
   if (trackCollection.empty())
@@ -131,7 +130,6 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
     reco::TrackRef track = reco::TrackRef(trackCollectionHandle, i);
     if (pt[i] > minPT_ && fabs(eta[i]) < maxETA_ && dEdxTrack[track].numberOfMeasurements() > minNOM_ &&
         dEdxTrack[track].dEdx() > minDEDx_) {
-      NTracks++;
       if (track->numberOfValidHits() < minNumValidHits_)
         continue;
       if (track->hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::MISSING_INNER_HITS) > maxNHitMissIn_)
@@ -194,10 +192,9 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
 
   // put filter object into the Event
   if (saveTags()) {
-    edm::OrphanHandle<RecoChargedCandidateCollection> chargedCandidatesHandle =
-        iEvent.put(std::move(chargedCandidates));
-    for (int i = 0; i < NTracks; i++) {
-      filterproduct.addObject(TriggerMuon, RecoChargedCandidateRef(chargedCandidatesHandle, i));
+    auto const chargedCandidatesHandle = iEvent.put(std::move(chargedCandidates));
+    for (unsigned int i = 0; i < chargedCandidatesHandle->size(); ++i) {
+      filterproduct.addObject(trigger::TriggerMuon, reco::RecoChargedCandidateRef(chargedCandidatesHandle, i));
     }
   }
 


### PR DESCRIPTION
backport of #42000

#### PR description:

From the description of #42000:

>This PR fixes how the plugin `HLTDeDxFilter` fills its `TriggerFilterObjectWithRefs` output product.
>
>The value of `NTracks` can be larger than `chargedCandidatesHandle->size()`, and
>https://github.com/cms-sw/cmssw/blob/1e2a83230dff3d06b24a24e823012ad96b150a90/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc#L199-L201
>can lead to adding invalid references into the Event.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#42000

Bugfix to a module used in the HLT menu.
