### PR TITLE
[13_1_X] EMTF muon shower unpacker update

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTF/ME.h
+++ b/DataFormats/L1TMuon/interface/EMTF/ME.h
@@ -39,10 +39,10 @@ namespace l1t {
             eighth_strip(-99),
             slope(-99),
             run3_pattern(-99),
-            // Run 3 HMT data
-            hmv(-99),
-            hmt_inTime(-99),
-            hmt_outOfTime(-99),
+            // Run 3 muon shower data
+            musv(-99),
+            mus_inTime(-99),
+            mus_outOfTime(-99),
             // metadata
             stub_num(-99),
             format_errors(0),
@@ -76,10 +76,10 @@ namespace l1t {
       void set_eighth_strip(int bits) { eighth_strip = bits; }
       void set_slope(int bits) { slope = bits; }
       void set_run3_pattern(int bits) { run3_pattern = bits; }
-      // Run 3 HMT
-      void set_hmv(int bits) { hmv = bits; }
-      void set_hmt_inTime(int bits) { hmt_inTime = bits; }
-      void set_hmt_outOfTime(int bits) { hmt_outOfTime = bits; }
+      // Run 3 muon shower
+      void set_musv(int bits) { musv = bits; }
+      void set_mus_inTime(int bits) { mus_inTime = bits; }
+      void set_mus_outOfTime(int bits) { mus_outOfTime = bits; }
       // meta data
       void set_stub_num(int bits) { stub_num = bits; }
       void add_format_error() { format_errors += 1; }
@@ -111,10 +111,10 @@ namespace l1t {
       int Eighth_strip() const { return eighth_strip; }
       int Slope() const { return slope; }
       int Run3_pattern() const { return run3_pattern; }
-      // Run 3 HMT
-      int HMV() const { return hmv; }
-      int HMT_inTime() const { return hmt_inTime; }
-      int HMT_outOfTime() const { return hmt_outOfTime; }
+      // Run 3 muon shower
+      int MUSV() const { return musv; }
+      int MUS_inTime() const { return mus_inTime; }
+      int MUS_outOfTime() const { return mus_outOfTime; }
       // metadata
       int Stub_num() const { return stub_num; }
       int Format_errors() const { return format_errors; }
@@ -147,10 +147,10 @@ namespace l1t {
       int eighth_strip;
       int slope;
       int run3_pattern;
-      // Run 3 HMT
-      int hmv;
-      int hmt_inTime;
-      int hmt_outOfTime;
+      // Run 3 muon shower
+      int musv;
+      int mus_inTime;
+      int mus_outOfTime;
       // metadata
       int stub_num;
       int format_errors;

--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -23,7 +23,7 @@ namespace l1t {
             quality_GMT(-99),
             phi_GMT(-99),
             bx(-99),
-            hmt(-99),
+            mus(-99),
             mode(-99),
             eta_GMT(-99),
             pt_GMT(-99),
@@ -60,7 +60,7 @@ namespace l1t {
       void set_quality_GMT(int bits) { quality_GMT = bits; }
       void set_phi_GMT(int bits) { phi_GMT = bits; }
       void set_bx(int bits) { bx = bits; }
-      void set_hmt(int bits) { hmt = bits; }
+      void set_mus(int bits) { mus = bits; }
       void set_mode(int bits) { mode = bits; }
       void set_eta_GMT(int bits) { eta_GMT = bits; }
       void set_pt_GMT(int bits) { pt_GMT = bits; }
@@ -118,7 +118,7 @@ namespace l1t {
       unsigned long Pt_LUT_addr() const { return pt_LUT_addr; }
       int Format_errors() const { return format_errors; }
       uint64_t Dataword() const { return dataword; }
-      int HMT() const { return hmt; }
+      int MUS() const { return mus; }
 
     private:
       int hl;
@@ -131,7 +131,7 @@ namespace l1t {
       int quality_GMT;
       int phi_GMT;
       int bx;
-      int hmt;
+      int mus;
       int mode;
       int eta_GMT;
       int pt_GMT;

--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -14,6 +14,7 @@
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
@@ -49,10 +50,13 @@ namespace l1t {
           strip(-99),
           strip_hi(-99),
           strip_low(-99),
-          strip_quart(-99),       // Run 3
-          strip_eighth(-99),      // Run 3
-          strip_quart_bit(-99),   // Run 3
-          strip_eighth_bit(-99),  // Run 3
+          strip_quart(-99),            // Run 3
+          strip_eighth(-99),           // Run 3
+          strip_quart_bit(-99),        // Run 3
+          strip_eighth_bit(-99),       // Run 3
+          muon_shower_valid(-99),      // Run 3 muon shower
+          muon_shower_inTime(-99),     // Run 3 muon shower
+          muon_shower_outOfTime(-99),  // Run 3 muon shower
           track_num(-99),
           quality(-99),
           pattern(-99),
@@ -95,6 +99,8 @@ namespace l1t {
 
     // void ImportCSCCorrelatedLCTDigi (const CSCCorrelatedLCTDigi& _digi);
     CSCCorrelatedLCTDigi CreateCSCCorrelatedLCTDigi(const bool isRun3) const;
+    // Run 3 muon shower
+    CSCShowerDigi CreateCSCShowerDigi() const;
     // void ImportRPCDigi (const RPCDigi& _digi);
     // RPCDigi CreateRPCDigi() const;
     // void ImportCPPFDigi (const CPPFDigi& _digi);
@@ -154,10 +160,13 @@ namespace l1t {
     void set_strip(int bits) { strip = bits; }
     void set_strip_hi(int bits) { strip_hi = bits; }
     void set_strip_low(int bits) { strip_low = bits; }
-    void set_strip_quart(int bits) { strip_quart = bits; }            // Run 3
-    void set_strip_eighth(int bits) { strip_eighth = bits; }          // Run 3
-    void set_strip_quart_bit(int bits) { strip_quart_bit = bits; }    // Run 3
-    void set_strip_eighth_bit(int bits) { strip_eighth_bit = bits; }  // Run 3
+    void set_strip_quart(int bits) { strip_quart = bits; }                      // Run 3
+    void set_strip_eighth(int bits) { strip_eighth = bits; }                    // Run 3
+    void set_strip_quart_bit(int bits) { strip_quart_bit = bits; }              // Run 3
+    void set_strip_eighth_bit(int bits) { strip_eighth_bit = bits; }            // Run 3
+    void set_muon_shower_valid(int bits) { muon_shower_valid = bits; }          // Run 3 muon shower
+    void set_muon_shower_inTime(int bits) { muon_shower_inTime = bits; }        // Run 3 muon shower
+    void set_muon_shower_outOfTime(int bits) { muon_shower_outOfTime = bits; }  // Run 3 muon shower
     void set_track_num(int bits) { track_num = bits; }
     void set_quality(int bits) { quality = bits; }
     void set_pattern(int bits) { pattern = bits; }
@@ -222,10 +231,13 @@ namespace l1t {
     int Strip() const { return strip; }
     int Strip_hi() const { return strip_hi; }
     int Strip_low() const { return strip_low; }
-    int Strip_quart() const { return strip_quart; }            // Run 3
-    int Strip_eighth() const { return strip_eighth; }          // Run 3
-    int Strip_quart_bit() const { return strip_quart_bit; }    // Run 3
-    int Strip_eighth_bit() const { return strip_eighth_bit; }  // Run 3
+    int Strip_quart() const { return strip_quart; }                      // Run 3
+    int Strip_eighth() const { return strip_eighth; }                    // Run 3
+    int Strip_quart_bit() const { return strip_quart_bit; }              // Run 3
+    int Strip_eighth_bit() const { return strip_eighth_bit; }            // Run 3
+    int Muon_shower_valid() const { return muon_shower_valid; }          // Run 3 muon shower
+    int Muon_shower_inTime() const { return muon_shower_inTime; }        // Run 3 muon shower
+    int Muon_shower_outOfTime() const { return muon_shower_outOfTime; }  // Run 3 muon shower
     int Track_num() const { return track_num; }
     int Quality() const { return quality; }
     int Pattern() const { return pattern; }
@@ -313,26 +325,29 @@ namespace l1t {
     int roll;           ///<  1 -  3.  For RPCs only, sub-division of ring. (Range? - AWB 02.03.17)
     int neighbor;       ///<  0 or 1.  Filled in EMTFBlock(ME|GEM|RPC).cc
     int mpc_link;       ///<  1 -  3.  Filled in EMTFHit.cc from CSCCorrelatedLCTDigi
-    int pc_sector;         ///<  1 -  6.  EMTF sector that received the LCT, even those sent from neighbor sectors.
-    int pc_station;        ///<  0 -  5.  0 for ME1 subsector 1, 5 for neighbor hits.
-    int pc_chamber;        ///<  0 -  8.
-    int pc_segment;        ///<  0 -  3.
-    int wire;              ///<  0 - 111  For CSCs only.
-    int strip;             ///<  0 - 158  For CSCs only.
-    int strip_hi;          ///<  ? -  ?.  For RPCs only, highest strip in a cluster.  (Range? - AWB 02.03.17)
-    int strip_low;         ///<  ? -  ?.  For RPCs only, lowest strip in a cluster.  (Range? - AWB 02.03.17)
-    int strip_quart;       ///< Run 3 CSC parameters
-    int strip_eighth;      ///< Run 3 CSC parameters
-    int strip_quart_bit;   ///< Run 3 CSC parameters
-    int strip_eighth_bit;  ///< Run 3 CSC parameters
-    int track_num;         ///<  ? -  ?.  For CSCs only.  (Range? - AWB 02.03.17)
-    int quality;           ///<  0 - 15.  For CSCs only.
-    int pattern;           ///<  0 - 10.  For CSCs only.
-    int pattern_run3;      ///< Run 3 For CSC only.
-    int bend;              ///<  0 or 1.  For CSCs only.
-    int slope;             ///<  Run 3 For CSC only.
-    int valid;             ///<  0 or 1.  For CSCs only (for now; could use to flag failing clusters? - AWB 02.03.17)
-    int sync_err;          ///<  0 or 1.  For CSCs only.
+    int pc_sector;              ///<  1 -  6.  EMTF sector that received the LCT, even those sent from neighbor sectors.
+    int pc_station;             ///<  0 -  5.  0 for ME1 subsector 1, 5 for neighbor hits.
+    int pc_chamber;             ///<  0 -  8.
+    int pc_segment;             ///<  0 -  3.
+    int wire;                   ///<  0 - 111  For CSCs only.
+    int strip;                  ///<  0 - 158  For CSCs only.
+    int strip_hi;               ///<  ? -  ?.  For RPCs only, highest strip in a cluster.  (Range? - AWB 02.03.17)
+    int strip_low;              ///<  ? -  ?.  For RPCs only, lowest strip in a cluster.  (Range? - AWB 02.03.17)
+    int strip_quart;            ///< Run 3 CSC parameters
+    int strip_eighth;           ///< Run 3 CSC parameters
+    int strip_quart_bit;        ///< Run 3 CSC parameters
+    int strip_eighth_bit;       ///< Run 3 CSC parameters
+    int muon_shower_valid;      ///< Run 3 muon shower
+    int muon_shower_inTime;     ///< Run 3 muon shower
+    int muon_shower_outOfTime;  ///< Run 3 muon shower
+    int track_num;              ///<  ? -  ?.  For CSCs only.  (Range? - AWB 02.03.17)
+    int quality;                ///<  0 - 15.  For CSCs only.
+    int pattern;                ///<  0 - 10.  For CSCs only.
+    int pattern_run3;           ///< Run 3 For CSC only.
+    int bend;                   ///<  0 or 1.  For CSCs only.
+    int slope;                  ///<  Run 3 For CSC only.
+    int valid;     ///<  0 or 1.  For CSCs only (for now; could use to flag failing clusters? - AWB 02.03.17)
+    int sync_err;  ///<  0 or 1.  For CSCs only.
     // GEM specific
     int layer;  ///<  0 -   1.  For GEMs only, superchamber detector layer (1 or 2).
     // END GEM specific

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -101,6 +101,16 @@ namespace l1t {
     // trknmb and bx0 are unused in the EMTF emulator code. mpclink = 0 (after bx) indicates unsorted.
   }
 
+  CSCShowerDigi EMTFHit::CreateCSCShowerDigi() const {
+    CSCShowerDigi shower = CSCShowerDigi(muon_shower_inTime == -99 ? 0 : muon_shower_inTime,
+                                         muon_shower_outOfTime == -99 ? 0 : muon_shower_outOfTime,
+                                         csc_ID,
+                                         bx + CSCConstants::LCT_CENTRAL_BX,
+                                         CSCShowerDigi::ShowerType::kEMTFShower);
+
+    return shower;
+  }
+
   // // Not yet implemented - AWB 15.03.17
   // RPCDigi EMTFHit::CreateRPCDigi() const {
   //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + CSCConstants::LCT_CENTRAL_BX );

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -27,6 +27,11 @@ namespace l1t {
         _hit.set_slope(_ME.Slope());
         _hit.set_pattern_run3(_ME.Run3_pattern());
 
+        // Run 3 muon shower
+        _hit.set_muon_shower_inTime(_ME.MUS_inTime());
+        _hit.set_muon_shower_outOfTime(_ME.MUS_outOfTime());
+        _hit.set_muon_shower_valid(_ME.MUSV());
+
         _hit.set_ring(L1TMuonEndCap::calc_ring(_hit.Station(), _hit.CSC_ID(), _hit.Strip()));
         _hit.set_chamber(
             L1TMuonEndCap::calc_chamber(_hit.Station(), _hit.Sector(), _hit.Subsector(), _hit.Ring(), _hit.CSC_ID()));


### PR DESCRIPTION
#### PR description:

This PR fixes a bunch of things in muon shower unpacking in EMTF. It's not critical for data taking, but it will be good to backport it so we can improve monitoring of this trigger for 2023.

The changes are as follows:

- Changed the internal name of the trigger from HMT to "muon shower" or "MUS". This is done for consistency with other L1T trigger producers
- Added a proper way of creating `CSCShowerDigi` in EMTF unpacker. This was mostly done to adjust the `BX` value associated with the shower (but also follows the same pattern with other EMTF inputs)
- Added support for new loose shower bit in unpacked EMTF outputs
- Removed pure muon shower objects from EMTF hit and track collections. This should fix the unnecessary LogWarning messages originating from EMTF unpacker or emulator

There will be a PR to include the BX value in EMTF emulator (and potentially uGMT as well) in the future, but for now I wanted to keep these separate.

This is a backport of https://github.com/cms-sw/cmssw/pull/41993  

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by `runTheMatrix.py -l limited -i all --ibeos` as well as unpacking a recent run and validating that the correct shower bits are being unpacked at each stage.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->

FYI: @elfontan @fmanteca @kakwok 
