### PR TITLE
Initial GT Unpacker Inspector Prototype.

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/GTUnpackerInspector.cc
+++ b/EventFilter/L1TRawToDigi/plugins/GTUnpackerInspector.cc
@@ -1,0 +1,130 @@
+// A filter designed to trigger on bad GT data
+// Currently defined as not having 5 BXs
+// It will also produce either duplicate GT data, or empty GT data
+// depending on whether or not corruption has been found
+
+// Original Author: Andrew Loeliger
+// Created: Mon, 22 May, 2023
+
+#include <memory>
+#include <string>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+
+template<class T>
+class GTUnpackerInspector : public edm::stream::EDFilter<> {
+    public:
+        explicit GTUnpackerInspector(const edm::ParameterSet&);
+        ~GTUnpackerInspector() override {};
+
+        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+        void beginStream(edm::StreamID) override {streamErrors = 0;};
+        bool filter(edm::Event&, const edm::EventSetup&) override;
+        void endStream() override;
+        bool isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle);
+
+        // member data
+        edm::EDGetTokenT<BXVector<T>> bxCollection;
+        unsigned nBXsAllowed;
+        string outputCollectionName;
+        unsigned streamErrors;
+};
+
+template<class T>
+GTUnpackerInspector<T>::GTUnpackerInspector(const edm::ParameterSet& iConfig):
+    bxCollection(consumes<BXVector<T>>(iConfig.getParameter<edm::InputTag>("objectSrc"))),
+    nBXsAllowed(iConfig.getParameter<unsigned>("nBXs")),
+    outputCollectionName(iConfig.getParameter<string>("outputCollectionName"))
+
+{
+    produces<BXVector<T>>(outputCollectionName);
+}
+
+
+template<class T>
+bool GTUnpackerInspector<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+    edm::Handle<BXVector<T>> objectHandle;
+    iEvent.getByToken(bxCollection, objectHandle);
+
+    //make a default empty BX vector that can be returned if necessary
+    int firstBX = -1*(nBXsAllowed/2);
+    int lastBX = (nBXsAllowed % 2 == 0) ? -1*firstBX + 1 : -1 * firstBX; //place the extra BX number on the positive side by default
+    std::unique_ptr<BXVector<T>> outputObject = std::make_unique<BXVector<T>>(nBXsAllowed, lastBX, firstBX);
+
+    //check the event for corruption
+    bool corrupt = isDataCorrupt(objectHandle);
+
+    // if we find corrupt data, we warn and proceed with the empty vector
+    if(corrupt)
+        edm::LogWarning("UnpackerInspectorSubstitution")<<"A GTUnpackerInspector is putting an empty collection into the event.";
+    // Otherwise, we just copy the input data and output it
+    else
+        *outputObject = *objectHandle;
+
+    iEvent.put(std::move(outputObject), outputCollectionName);
+
+    return not corrupt;
+}
+
+template<class T>
+void GTUnpackerInspector<T>::endStream()
+{
+    if(streamErrors > 0)
+        edm::LogInfo("UnpackerInspectorStreamCorruptedEvents")<<"A GTUnpackerInspector stream caught "<<streamErrors<<" corrupt data events from the GT unpacker";
+}
+
+// This is simplistic at the moment, but left modularized as a function in 
+// anticipation that it might see more complicated checks at some point in the future.
+template<class T>
+bool GTUnpackerInspector<T>::isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle)
+{
+    bool isCorrupt =  ((objectHandle->getLastBX()-objectHandle->getFirstBX()+1) == (int)nBXsAllowed);
+    if (isCorrupt)
+    {
+        ++streamErrors;
+        edm::LogError("UnpackerInspectorFoundCorruptData")<<"A GTUnpackerInspector has detected corrupted data";
+    }
+    return isCorrupt;
+}
+
+template<class T>
+void GTUnpackerInspector<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("objectSrc");
+    desc.add<unsigned>("nBXs", 5);
+    desc.add<string>("outputCollectionName"); 
+    descriptions.addDefault(desc);
+}
+
+typedef GTUnpackerInspector<l1t::Muon> GTMuonUnpackerInspector;
+typedef GTUnpackerInspector<l1t::MuonShower> GTMuonShowerUnpackerInspector;
+typedef GTUnpackerInspector<l1t::EGamma> GTEGammaUnpackerInspector;
+typedef GTUnpackerInspector<l1t::EtSum> GTEtSumUnpackerInspector;
+typedef GTUnpackerInspector<l1t::Jet> GTJetUnpackerInspector;
+typedef GTUnpackerInspector<l1t::Tau> GTTauUnpackerInspector;
+
+DEFINE_FWK_MODULE(GTMuonUnpackerInspector);
+DEFINE_FWK_MODULE(GTMuonShowerUnpackerInspector);
+DEFINE_FWK_MODULE(GTEGammaUnpackerInspector);
+DEFINE_FWK_MODULE(GTEtSumUnpackerInspector);
+DEFINE_FWK_MODULE(GTJetUnpackerInspector);
+DEFINE_FWK_MODULE(GTTauUnpackerInspector);

--- a/EventFilter/L1TRawToDigi/plugins/GTUnpackerInspector.cc
+++ b/EventFilter/L1TRawToDigi/plugins/GTUnpackerInspector.cc
@@ -26,93 +26,90 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 
-template<class T>
+template <class T>
 class GTUnpackerInspector : public edm::stream::EDFilter<> {
-    public:
-        explicit GTUnpackerInspector(const edm::ParameterSet&);
-        ~GTUnpackerInspector() override {};
+public:
+  explicit GTUnpackerInspector(const edm::ParameterSet&);
+  ~GTUnpackerInspector() override{};
 
-        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    private:
-        void beginStream(edm::StreamID) override {streamErrors = 0;};
-        bool filter(edm::Event&, const edm::EventSetup&) override;
-        void endStream() override;
-        bool isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle);
+private:
+  void beginStream(edm::StreamID) override { streamErrors = 0; };
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
+  bool isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle);
 
-        // member data
-        edm::EDGetTokenT<BXVector<T>> bxCollection;
-        unsigned nBXsAllowed;
-        string outputCollectionName;
-        unsigned streamErrors;
+  // member data
+  edm::EDGetTokenT<BXVector<T>> bxCollection;
+  unsigned nBXsAllowed;
+  string outputCollectionName;
+  unsigned streamErrors;
 };
 
-template<class T>
-GTUnpackerInspector<T>::GTUnpackerInspector(const edm::ParameterSet& iConfig):
-    bxCollection(consumes<BXVector<T>>(iConfig.getParameter<edm::InputTag>("objectSrc"))),
-    nBXsAllowed(iConfig.getParameter<unsigned>("nBXs")),
-    outputCollectionName(iConfig.getParameter<string>("outputCollectionName"))
+template <class T>
+GTUnpackerInspector<T>::GTUnpackerInspector(const edm::ParameterSet& iConfig)
+    : bxCollection(consumes<BXVector<T>>(iConfig.getParameter<edm::InputTag>("objectSrc"))),
+      nBXsAllowed(iConfig.getParameter<unsigned>("nBXs")),
+      outputCollectionName(iConfig.getParameter<string>("outputCollectionName"))
 
 {
-    produces<BXVector<T>>(outputCollectionName);
+  produces<BXVector<T>>(outputCollectionName);
 }
 
+template <class T>
+bool GTUnpackerInspector<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<BXVector<T>> objectHandle;
+  iEvent.getByToken(bxCollection, objectHandle);
 
-template<class T>
-bool GTUnpackerInspector<T>::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    edm::Handle<BXVector<T>> objectHandle;
-    iEvent.getByToken(bxCollection, objectHandle);
+  //make a default empty BX vector that can be returned if necessary
+  int firstBX = -1 * (nBXsAllowed / 2);
+  int lastBX = (nBXsAllowed % 2 == 0) ? -1 * firstBX + 1
+                                      : -1 * firstBX;  //place the extra BX number on the positive side by default
+  std::unique_ptr<BXVector<T>> outputObject = std::make_unique<BXVector<T>>(nBXsAllowed, lastBX, firstBX);
 
-    //make a default empty BX vector that can be returned if necessary
-    int firstBX = -1*(nBXsAllowed/2);
-    int lastBX = (nBXsAllowed % 2 == 0) ? -1*firstBX + 1 : -1 * firstBX; //place the extra BX number on the positive side by default
-    std::unique_ptr<BXVector<T>> outputObject = std::make_unique<BXVector<T>>(nBXsAllowed, lastBX, firstBX);
+  //check the event for corruption
+  bool corrupt = isDataCorrupt(objectHandle);
 
-    //check the event for corruption
-    bool corrupt = isDataCorrupt(objectHandle);
+  // if we find corrupt data, we warn and proceed with the empty vector
+  if (corrupt)
+    edm::LogWarning("UnpackerInspectorSubstitution")
+        << "A GTUnpackerInspector is putting an empty collection into the event.";
+  // Otherwise, we just copy the input data and output it
+  else
+    *outputObject = *objectHandle;
 
-    // if we find corrupt data, we warn and proceed with the empty vector
-    if(corrupt)
-        edm::LogWarning("UnpackerInspectorSubstitution")<<"A GTUnpackerInspector is putting an empty collection into the event.";
-    // Otherwise, we just copy the input data and output it
-    else
-        *outputObject = *objectHandle;
+  iEvent.put(std::move(outputObject), outputCollectionName);
 
-    iEvent.put(std::move(outputObject), outputCollectionName);
-
-    return not corrupt;
+  return not corrupt;
 }
 
-template<class T>
-void GTUnpackerInspector<T>::endStream()
-{
-    if(streamErrors > 0)
-        edm::LogInfo("UnpackerInspectorStreamCorruptedEvents")<<"A GTUnpackerInspector stream caught "<<streamErrors<<" corrupt data events from the GT unpacker";
+template <class T>
+void GTUnpackerInspector<T>::endStream() {
+  if (streamErrors > 0)
+    edm::LogInfo("UnpackerInspectorStreamCorruptedEvents")
+        << "A GTUnpackerInspector stream caught " << streamErrors << " corrupt data events from the GT unpacker";
 }
 
-// This is simplistic at the moment, but left modularized as a function in 
+// This is simplistic at the moment, but left modularized as a function in
 // anticipation that it might see more complicated checks at some point in the future.
-template<class T>
-bool GTUnpackerInspector<T>::isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle)
-{
-    bool isCorrupt =  ((objectHandle->getLastBX()-objectHandle->getFirstBX()+1) == (int)nBXsAllowed);
-    if (isCorrupt)
-    {
-        ++streamErrors;
-        edm::LogError("UnpackerInspectorFoundCorruptData")<<"A GTUnpackerInspector has detected corrupted data";
-    }
-    return isCorrupt;
+template <class T>
+bool GTUnpackerInspector<T>::isDataCorrupt(const edm::Handle<BXVector<T>>& objectHandle) {
+  bool isCorrupt = ((objectHandle->getLastBX() - objectHandle->getFirstBX() + 1) == (int)nBXsAllowed);
+  if (isCorrupt) {
+    ++streamErrors;
+    edm::LogError("UnpackerInspectorFoundCorruptData") << "A GTUnpackerInspector has detected corrupted data";
+  }
+  return isCorrupt;
 }
 
-template<class T>
-void GTUnpackerInspector<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
-    edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("objectSrc");
-    desc.add<unsigned>("nBXs", 5);
-    desc.add<string>("outputCollectionName"); 
-    descriptions.addDefault(desc);
+template <class T>
+void GTUnpackerInspector<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("objectSrc");
+  desc.add<unsigned>("nBXs", 5);
+  desc.add<string>("outputCollectionName");
+  descriptions.addDefault(desc);
 }
 
 typedef GTUnpackerInspector<l1t::Muon> GTMuonUnpackerInspector;

--- a/EventFilter/L1TRawToDigi/python/GTEGammaUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTEGammaUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTEGammaUnpackerInspector = cms.EDFilter(
+    "GTEGammaUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "EGamma"),
+    outputCollectionName = cms.String("inspectedGTEGammas")
+)

--- a/EventFilter/L1TRawToDigi/python/GTEtSumUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTEtSumUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTEtSumUnpackerInspector = cms.EDFilter(
+    "GTEtSumUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "EtSum"),
+    outputCollectionName = cms.String("inspectedGTEtSums")
+)

--- a/EventFilter/L1TRawToDigi/python/GTJetUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTJetUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTJetUnpackerInspector = cms.EDFilter(
+    "GTJetUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "Jet"),
+    outputCollectionName = cms.String("inspectedGTJets")
+)

--- a/EventFilter/L1TRawToDigi/python/GTMuonShowerUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTMuonShowerUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTMuonShowerUnpackerInspector = cms.EDFilter(
+    "GTMuonShowerUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "MuonShower"),
+    outputCollectionName = cms.String("inspectedGTMuonShowers")
+)

--- a/EventFilter/L1TRawToDigi/python/GTMuonUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTMuonUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTMuonUnpackerInspector = cms.EDFilter(
+    "GTMuonUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "Muon"),
+    outputCollectionName = cms.String("inspectedGTMuons")
+)

--- a/EventFilter/L1TRawToDigi/python/GTTauUnpackerInspector_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/GTTauUnpackerInspector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+GTTauUnpackerInspector = cms.EDFilter(
+    "GTTauUnpackerInspector",
+    objectSrc = cms.InputTag("gtStage2Digis", "Tau"),
+    outputCollectionName = cms.String("inspectedGTTaus")
+)


### PR DESCRIPTION
### PR description:

[Following the discovery of corrupted data out of the GT unpacker](https://github.com/cms-sw/cmssw/issues/41645#issuecomment-1547724193), [the discussed intermediate solution is a filter that checks for corruption](https://github.com/cms-sw/cmssw/issues/41645#issuecomment-1559217926) . This PR contains a prototype that checks a GT object output collection for having the correct number of BX's, and will fire the filter if this not found, and produce an empty vector for anything that might be caught by the filter (and pass through for anything else). I am calling this module/filter the GT Unpacker Inspector. 

It is my understanding that the desired longer term solution may be a change in the way CMSSW handles skippable errors?

In theory, this is at least a partial solution to https://github.com/cms-sw/cmssw/issues/41645

As of the writing of this, this is still a draft/prototype, and has not been hooked up to any of the original unpacker's clients. @mmusich @makortel Apologies for the long delay, but you were on the original thread where this solution was discussed, I wanted to tag you to understand if this is something that would meet the needs discussed there. If you have any review, I would appreciate this before I begin to start trying to insert this into the unpacking paths.

### PR validation:

[PR validation has not been possible due to the original file disappearing to tape](https://github.com/cms-sw/cmssw/issues/41645#issuecomment-1576871301), with the relvant block being 2.5 Tb (a little much to recall from tape for a single file). I would like to solicit suggestions for the testing of this module/technique.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but could be backported to reconstruction releases as necessary.