### PR TITLE
Initialize values for all members of PixelBarrelValues

### DIFF
--- a/DataFormats/TrackReco/test/testHitPattern.cpp
+++ b/DataFormats/TrackReco/test/testHitPattern.cpp
@@ -13,7 +13,15 @@ namespace test {
     int test() {
       {
         // Phase0, only for testing
-        TrackerTopology::PixelBarrelValues ttopo_pxb{16, 8, 2, 0xF, 0xFF, 0x3F};
+        TrackerTopology::PixelBarrelValues ttopo_pxb{
+            16,
+            8,
+            2,
+            0,
+            0xF,
+            0xFF,
+            0x3F,
+            0x0};  //DoubleMask is not used in Phase0, so initializing the corresponding starting bit and mask to 0
         TrackerTopology::PixelEndcapValues ttopo_pxf{23, 16, 10, 8, 2, 0x3, 0xF, 0x3F, 0x3, 0x3F};
         TrackerTopology::TECValues ttopo_tec{18, 14, 12, 8, 5, 2, 0, 0x3, 0xF, 0x3, 0xF, 0x7, 0x7, 0x3};
         TrackerTopology::TIBValues ttopo_tib{14, 12, 10, 4, 2, 0, 0x7, 0x3, 0x3, 0x7F, 0x3, 0x3};


### PR DESCRIPTION
#### PR description:

Bugfix: new data members for PixelBarrelValues added in https://github.com/cms-sw/cmssw/pull/41880 but at reported here: https://github.com/cms-sw/cmssw/pull/41880#discussion_r1233730282 this leads to issues in building the IB. Now addressed by initializing these values. They're not used for phase 0 so just initialized to 0 in this case.

FYI @smuzaffar 

#### PR validation:

Checked that compilation now works. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
