### PR TITLE
Fixed channel decoding for the timeout error in SiPixel RawToDigi

### DIFF
--- a/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
+++ b/EventFilter/SiPixelRawToDigi/interface/ErrorChecker.h
@@ -22,6 +22,10 @@ public:
 
 protected:
   cms_uint32_t errorDetId(const SiPixelFrameConverter* converter, int errorType, const Word32& word) const override;
+  cms_uint32_t errorDetIdSimple(const SiPixelFrameConverter* converter,
+                                int errorType,
+                                unsigned int channel,
+                                unsigned int roc) const;
 };
 
 #endif  // EventFilter_SiPixelRawToDigi_interface_ErrorChecker_h


### PR DESCRIPTION
#### PR description:

Making PR for Danek. This PR addresses https://github.com/cms-sw/cmssw/issues/41715

CPU code:
- Wrong channel decoding for TO (Timeout) error. All TO errors are missed.
- Reason – ErrorChecker::checkROC() skips the 1st TO word (return), PixelDataFormatter skips the 2nd one (if(link,roc)). So, none is processed.

GPU code:
- Both TO words are processed, but often ErrorChecker::errorDetId() gives a wrong DetId, the channel identification is usually wrong, so either a dummyID is returned or another (incorrect) module. 

Correction:  
- Change from errorDetId() to errorDetIdSimple() in ErrorChecker.cc .
- Modify the word select for TO errors in ErrorChecker::checkROC() (if statement).

#### PR validation:

Code compiles :)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backports to 13_1_X and 13_0_X foreseen.

@dkotlins @mmusich 
