### PR TITLE
Validation RecoEgamma h2_scl_EoEtrueVsrecOfflineVertices_Extended histogram correction

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -3433,6 +3433,10 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
             matchingMotherID = true;
           }
         }  // end of mother if test
+        if (mother != nullptr) {
+          std::cout << "Matching mc-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother Id : " << mother->pdgId() << "\n";
+          //std::cout << "Matching mc-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother : " << mother ;
+        }
       }
       if (matchingMotherID) {
         if (mcIter->pt() > maxPt_ || std::abs(mcIter->eta()) > maxAbsEta_) {
@@ -3659,8 +3663,8 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
 
     h2_scl_EoEtrueVsrecOfflineVertices->Fill((*vertexCollectionHandle).size(),
                                              bestGsfElectron.ecalEnergy() / mcIter->p());
-    h2_scl_EoEtrueVsrecOfflineVertices_Extended->Fill((*vertexCollectionHandle).size(),
-                                                      bestGsfElectron.ecalEnergy() / mcIter->p());
+    //h2_scl_EoEtrueVsrecOfflineVertices_Extended->Fill((*vertexCollectionHandle).size(),
+    //                                                  bestGsfElectron.ecalEnergy() / mcIter->p());
     if (isEBflag)
       h2_scl_EoEtrueVsrecOfflineVertices_barrel->Fill((*vertexCollectionHandle).size(),
                                                       bestGsfElectron.ecalEnergy() / mcIter->p());

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -3433,10 +3433,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
             matchingMotherID = true;
           }
         }  // end of mother if test
-        if (mother != nullptr) {
-          std::cout << "Matching mc-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother Id : " << mother->pdgId() << "\n";
-          //std::cout << "Matching mc-reco : matchingMotherID[" << i << "] : " << matchingMotherIDs_[i] << ", evt ID = " << iEvent.id() << ", mother : " << mother ;
-        }
       }
       if (matchingMotherID) {
         if (mcIter->pt() > maxPt_ || std::abs(mcIter->eta()) > maxAbsEta_) {
@@ -3663,8 +3659,6 @@ void ElectronMcSignalValidator::analyze(const edm::Event &iEvent, const edm::Eve
 
     h2_scl_EoEtrueVsrecOfflineVertices->Fill((*vertexCollectionHandle).size(),
                                              bestGsfElectron.ecalEnergy() / mcIter->p());
-    //h2_scl_EoEtrueVsrecOfflineVertices_Extended->Fill((*vertexCollectionHandle).size(),
-    //                                                  bestGsfElectron.ecalEnergy() / mcIter->p());
     if (isEBflag)
       h2_scl_EoEtrueVsrecOfflineVertices_barrel->Fill((*vertexCollectionHandle).size(),
                                                       bestGsfElectron.ecalEnergy() / mcIter->p());


### PR DESCRIPTION
#### PR description:
Small bug-fix of a precedent PR [38569](https://github.com/cms-sw/cmssw/pull/38569).
Bug-fix: one of the histograms introduced to monitor the performance of the electron reconstruction in the 2.5<|eta|<3 range wasn't actually restricting the angular region"
before correction :
![Canvas_1_std](https://github.com/cms-sw/cmssw/assets/5586847/697e79e0-bced-4ae8-a9b1-55b918f96861)
After correction : 
![Canvas_1_new](https://github.com/cms-sw/cmssw/assets/5586847/01e944fc-fa2a-48ca-a8dd-9c5161cd44ad)

#### PR validation:

scram build code-checks → OK
scram build code-format → OK

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine (47 46 45 35 22 4 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed).
here is the run-log : [runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/11789102/runall-report-step123-.log)

@beaudett 