### PR TITLE
Fix customiseTICLFromReco

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -642,6 +642,8 @@ approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*'
                               ])
+phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
+    outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -38,7 +38,7 @@ def customiseHGCalOnlyEventContent(process):
         outputModule.outputCommands = ['drop *_*_*_*']
         outputModule.outputCommands.extend(ticl_outputCommads)
         outputModule.outputCommands.extend(['keep *_HGCalRecHit_*_*',
-                                            'keep *_hgcalLayerClusters_*_*',
+                                            'keep *_hgcalMergeLayerClusters_*_*',
                                             'keep CaloParticles_mix_*_*',
                                             'keep SimClusters_mix_*_*',
                                             'keep recoTracks_generalTracks_*_*',

--- a/RecoHGCal/TICL/python/customiseTICLFromReco.py
+++ b/RecoHGCal/TICL/python/customiseTICLFromReco.py
@@ -1,6 +1,7 @@
 # Reconstruction
 from RecoHGCal.TICL.iterativeTICL_cff import *
-from RecoLocalCalo.HGCalRecProducers.hgcalMergeLayerClusters_cff import hgcalMergeLayerClusters
+from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff import hgcalLayerClustersEE, hgcalLayerClustersHSi, hgcalLayerClustersHSci
+from RecoLocalCalo.HGCalRecProducers.hgcalMergeLayerClusters_cfi import hgcalMergeLayerClusters
 # Validation
 from Validation.HGCalValidation.HGCalValidator_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalRecHitMapProducer_cfi import hgcalRecHitMapProducer
@@ -12,12 +13,17 @@ from RecoTracker.IterativeTracking.iterativeTk_cff import trackdnn_source
 from RecoHGCal.Configuration.RecoHGCal_EventContent_cff import customiseHGCalOnlyEventContent
 
 
-
 def customiseTICLFromReco(process):
 # TensorFlow ESSource
     process.TFESSource = cms.Task(process.trackdnn_source)
+
+    process.hgcalLayerClustersTask = cms.Task(process.hgcalLayerClustersEE,
+                                              process.hgcalLayerClustersHSi,
+                                              process.hgcalLayerClustersHSci,
+                                              process.hgcalMergeLayerClusters)
+
 # Reconstruction
-    process.TICL = cms.Path(process.hgcalMergeLayerClusters,
+    process.TICL = cms.Path(process.hgcalLayerClustersTask,
                             process.TFESSource,
                             process.ticlLayerTileTask,
                             process.ticlIterationsTask,


### PR DESCRIPTION
This PR introduces a fix for  `customiseTICLFromReco` (https://github.com/cms-sw/cmssw/blob/master/RecoHGCal/TICL/python/customiseTICLFromReco.py#L16):
- Propagates changes introduced in #41589 
- Saves additional collections needed in [PFTICLProducer](https://github.com/cms-sw/cmssw/blob/master/RecoHGCal/TICL/plugins/PFTICLProducer.cc) to FEVTDEBUGEventContent 

Additional collections size (results obtained with WF `21094.0_CloseByPGun_CE_E_Front_300um+2026D88PU`, 200PU)
```
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event)

recoMuons_muons1stStep__RECO. 82366.4 24654
recoIsoDepositedmValueMap_muons1stStep_tracker_RECO. 6453.8 3317.6
recoIsoDepositedmValueMap_muons1stStep_ecal_RECO. 3717.2 1924.4
recoIsoDepositedmValueMap_muons1stStep_jets_RECO. 3436.4 1736.2
recoMuonTimeExtraedmValueMap_muons1stStep_combined_RECO. 1820.8 1383.9
recoMuonTimeExtraedmValueMap_muons1stStep_csc_RECO. 1813.8 1362.5
recoIsoDepositedmValueMap_muons1stStep_hcal_RECO. 2604.5 1211.7
recoIsoDepositedmValueMap_muons1stStep_ho_RECO. 2250.5 881.2
recoMuonTimeExtraedmValueMap_muons1stStep_dt_RECO. 1812.4 313.3
recoCaloMuons_muons1stStep__RECO. 246.6 238.4
Total Sum bytes/event: 106522.4 37023.2
```

EDIT 21/06/23:
Only `recoMuons_muons1stStep_*_*` is needed for using `customiseTICLFromReco`, additional collection size:
```
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event)
recoMuons_muons1stStep__RECO. 82366.4 24654
```

EDIT 23/06/23:
Only `recoMuons_muons1stStep_*_*` is needed for using `customiseTICLFromReco`, affecting only Phase-2 workflows, additional collection size:
```
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event)
recoMuons_muons1stStep__RECO. 82366.4 24654
```
**Impact on file size:**
5 events of `21094.0_CloseByPGun_CE_E_Front_300um+2026D88PU` @ 200PU:
Before PR: 559425853 bytes
After PR: 559554439 bytes
File size increased by:  0.023% 

@rovere @felicepantaleo 