### PR TITLE
Remove obsolete FinalStateReconOption from Herwig7 shower settings

### DIFF
--- a/Configuration/Generator/python/Herwig7Settings/Herwig7LHEMG5aMCatNLOSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7LHEMG5aMCatNLOSettings_cfi.py
@@ -6,7 +6,6 @@ herwig7LHEMG5aMCatNLOSettingsBlock = cms.PSet(
     hw_lhe_MG5aMCatNLO_settings = cms.vstring(
         'set /Herwig/Shower/KinematicsReconstructor:InitialInitialBoostOption LongTransBoost',
         'set /Herwig/Shower/KinematicsReconstructor:ReconstructionOption General',
-        'set /Herwig/Shower/KinematicsReconstructor:FinalStateReconOption Default',
         'set /Herwig/Shower/KinematicsReconstructor:InitialStateReconOption Rapidity',
         'set /Herwig/Shower/ShowerHandler:SpinCorrelations Yes',
         'set /Herwig/Particles/t:NominalMass 172.5'


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This parameter was removed and the old default is now the only option. Specifying it prevents showering with Herwig. See https://herwig.hepforge.org/doxygen/KinematicsReconstructorInterfaces.html (bottom of the page)

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Showered a fragment in `CMSSW_10_6_29_patch1` with the updated configuration inline in the fragment. Assuming that the H7 version is the same or later as in 10_6_X, this is also needed in later versions.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) [Didn't run tests. If tests were running Herwig showering, they'd have spotted the bug.]

<!-- Please delete the text above after you verified all points of the checklist  -->
