### PR TITLE
Revert "Powheg+Vincia matching"

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -29,7 +29,6 @@ using namespace Pythia8;
 // Emission Veto Hooks
 //
 #include "Pythia8Plugins/PowhegHooks.h"
-#include "Pythia8Plugins/PowhegHooksVincia.h"
 #include "GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.h"
 
 // Resonance scale hook
@@ -133,7 +132,6 @@ private:
   // Emission Veto Hooks
   //
   std::shared_ptr<PowhegHooks> fEmissionVetoHook;
-  std::shared_ptr<PowhegHooksVincia> fEmissionVetoHookVincia;
   std::shared_ptr<EmissionVetoHook1> fEmissionVetoHook1;
 
   // Resonance scale hook
@@ -386,10 +384,7 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
     (fUserHooksVector->hooks).push_back(fEmissionVetoHook1);
   }
 
-  bool VinciaShower = fMasterGen->settings.mode("PartonShowers:Model") == 2;
-
-  if ((fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) &&
-      !VinciaShower) {
+  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
     if (fJetMatchingHook.get() || fEmissionVetoHook1.get())
       throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
           << " Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible "
@@ -400,13 +395,6 @@ bool Pythia8Hadronizer::initializeForInternalPartons() {
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     (fUserHooksVector->hooks).push_back(fEmissionVetoHook);
-  }
-
-  if (fMasterGen->settings.mode("POWHEG:veto") > 0 && VinciaShower) {
-    edm::LogInfo("Pythia8Interface") << "Turning on Vincia Emission Veto Hook from pythia8 code";
-    if (!fEmissionVetoHookVincia.get())
-      fEmissionVetoHookVincia.reset(new PowhegHooksVincia());
-    (fUserHooksVector->hooks).push_back(fEmissionVetoHookVincia);
   }
 
   bool PowhegRes = fMasterGen->settings.flag("POWHEGres:calcScales");
@@ -555,10 +543,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons() {
     }
   }
 
-  bool VinciaShower = fMasterGen->settings.mode("PartonShowers:Model") == 2;
-
-  if ((fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) &&
-      !VinciaShower) {
+  if (fMasterGen->settings.mode("POWHEG:veto") > 0 || fMasterGen->settings.mode("POWHEG:MPIveto") > 0) {
     if (fJetMatchingHook.get() || fEmissionVetoHook1.get())
       throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
           << " Attempt to turn on PowhegHooks by pythia8 settings but there are incompatible hooks on \n Incompatible "
@@ -569,13 +554,6 @@ bool Pythia8Hadronizer::initializeForExternalPartons() {
 
     edm::LogInfo("Pythia8Interface") << "Turning on Emission Veto Hook from pythia8 code";
     (fUserHooksVector->hooks).push_back(fEmissionVetoHook);
-  }
-
-  if (fMasterGen->settings.mode("POWHEG:veto") > 0 && VinciaShower) {
-    edm::LogInfo("Pythia8Interface") << "Turning on Vincia Emission Veto Hook from pythia8 code";
-    if (!fEmissionVetoHookVincia.get())
-      fEmissionVetoHookVincia.reset(new PowhegHooksVincia());
-    (fUserHooksVector->hooks).push_back(fEmissionVetoHookVincia);
   }
 
   bool PowhegRes = fMasterGen->settings.flag("POWHEGres:calcScales");


### PR DESCRIPTION
This reverts commit 1c80a7d7d19ee65787d9851293032af8d237fe39.

#### PR description:

Not needed anymore for Pythia 8.309:
> The PowhegHooks now work with all three shower models and automatically switch between the simple shower, Vincia, and Dire based on the PartonShowers:model mode. In addition, the option to set POWHEG:nFinal = -1 has been ported from 8.244 to allow the use of event files with a variable number of real emissions.

https://github.com/cms-sw/cmsdist/pull/8552

#### PR validation:

Compiles, should not affect any workflow.


