### PR TITLE
Make EZArrayFL and EZMgrFL compile with C++20

### DIFF
--- a/Geometry/CaloGeometry/interface/EZArrayFL.h
+++ b/Geometry/CaloGeometry/interface/EZArrayFL.h
@@ -27,11 +27,11 @@ public:
   typedef typename MgrType::size_type size_type;
   typedef typename MgrType::value_type value_type;
 
-  EZArrayFL<T>() : m_begin(), m_mgr() {}
+  EZArrayFL() : m_begin(), m_mgr() {}
 
-  EZArrayFL<T>(MgrType* mgr) : m_begin(), m_mgr(mgr) {}
+  EZArrayFL(MgrType* mgr) : m_begin(), m_mgr(mgr) {}
 
-  EZArrayFL<T>(MgrType* mgr, const_iterator start, const_iterator finis)
+  EZArrayFL(MgrType* mgr, const_iterator start, const_iterator finis)
       : m_begin(0 == finis - start ? iterator() : mgr->assign()), m_mgr(mgr) {
     assert((finis - start) == m_mgr->subSize());
     iterator i(begin());
@@ -39,8 +39,6 @@ public:
       (*i) = (*ic);
     }
   }
-
-  virtual ~EZArrayFL<T>() {}
 
   void resize() { assign(); }
 

--- a/Geometry/CaloGeometry/interface/EZMgrFL.h
+++ b/Geometry/CaloGeometry/interface/EZMgrFL.h
@@ -15,14 +15,12 @@ public:
   typedef typename VecType::value_type value_type;
   typedef typename VecType::size_type size_type;
 
-  EZMgrFL<T>(size_type vecSize, size_type subSize) : m_vecSize(vecSize), m_subSize(subSize) {
+  EZMgrFL(size_type vecSize, size_type subSize) : m_vecSize(vecSize), m_subSize(subSize) {
     m_vec.resize(0);
     assert(subSize > 0);
     assert(vecSize > 0);
     assert(0 == m_vec.capacity());
   }
-
-  virtual ~EZMgrFL<T>() {}
 
   iterator reserve() { return assign(); }
   iterator resize() { return assign(); }


### PR DESCRIPTION
#### PR description:

This PR makes `Geometry/CaloGeometry` package to compile with C++20. I didn't anything inheriting from these two classes, so removing the `virtual` from the destructors should be safe, and on the same go I removed the explicit destructor completely to leave them to be generated  by the compiler.

#### PR validation:

The `Geometry/CaloGeometry` code compiles in CPP20 IB.