### PR TITLE
Make EDAlias_t test to compile with C++20

### DIFF
--- a/FWCore/Integration/test/EDAlias_t.cpp
+++ b/FWCore/Integration/test/EDAlias_t.cpp
@@ -175,7 +175,7 @@ process.moduleToTest(process.test, cms.Task(process.intprod))
 }
 
 TEST_CASE("Configuration with all products of a module with a given product instance name", s_tag) {
-  const std::string baseConfig{
+  constexpr const std::string_view baseConfig{
       R"_(from FWCore.TestProcessor.TestProcess import *
 import FWCore.ParameterSet.Config as cms
 
@@ -313,7 +313,7 @@ process.moduleToTest(process.test, cms.Task(process.intprod, process.intprod2))
 
 ////////////////////////////////////////
 TEST_CASE("No products found with wildcards", s_tag) {
-  const std::string baseConfig{
+  constexpr const std::string_view baseConfig{
       R"_(from FWCore.TestProcessor.TestProcess import *
 import FWCore.ParameterSet.Config as cms
 


### PR DESCRIPTION
#### PR description:

This PR makes the `EDAlias_t` test to compile with C++20. ~~Simplest change that should with both C++17 and C++20 was to change the format "literals" to `constexpr string_view`, and make `TestProcessorConfig` constructor to accept `string_view` argument.~~

#### PR validation:

`FWCore/TestProcessor` and `FWCore/Integration`  compile in CPP20 IB.

