### PR TITLE
Make churn_allocator to compile with C++20

### DIFF
--- a/TrackingTools/TrajectoryState/interface/ChurnAllocator.h
+++ b/TrackingTools/TrajectoryState/interface/ChurnAllocator.h
@@ -6,7 +6,7 @@ template <typename T>
 class churn_allocator : public std::allocator<T> {
 public:
   using Base = std::allocator<T>;
-  using pointer = typename Base::pointer;
+  using pointer = typename std::allocator_traits<std::allocator<T>>::pointer;
   using size_type = typename Base::size_type;
 
   struct Cache {
@@ -24,10 +24,10 @@ public:
     typedef churn_allocator<_Tp1> other;
   };
 
-  pointer allocate(size_type n, const void *hint = nullptr) {
+  pointer allocate(size_type n) {
     Cache &c = cache();
     if (!c.gard)
-      c.cache = std::allocator<T>::allocate(n, hint);
+      c.cache = std::allocator<T>::allocate(n);
     c.gard = false;
     return c.cache;
   }


### PR DESCRIPTION
#### PR description:

This PR makes `churn_allocator` to compile with C++ 20 (certain parts of the `std::allocator<T>` API were deprecated in C++17 and removed from C++20).

#### PR validation:

The package `TrackingTools/TrajecotryState` compiles (but does not link because of other problems) in CPP20 IB.