### PR TITLE
Make ProcessRegistryImpl to compile with C++20

### DIFF
--- a/PhysicsTools/MVAComputer/interface/ProcessRegistry.h
+++ b/PhysicsTools/MVAComputer/interface/ProcessRegistry.h
@@ -97,8 +97,7 @@ namespace PhysicsTools {
   template <class Base_t, class CalibBase_t, class Parent_t, class Instance_t, class Calibration_t>
   class ProcessRegistryImpl : public ProcessRegistry<Base_t, CalibBase_t, Parent_t> {
   public:
-    ProcessRegistryImpl<Base_t, CalibBase_t, Parent_t, Instance_t, Calibration_t>(const char *name)
-        : ProcessRegistry<Base_t, CalibBase_t, Parent_t>(name) {}
+    ProcessRegistryImpl(const char *name) : ProcessRegistry<Base_t, CalibBase_t, Parent_t>(name) {}
 
   protected:
     Base_t *instance(const char *name, const CalibBase_t *calib, Parent_t *parent) const override {


### PR DESCRIPTION
#### PR description:

This PR makes `ProcessRegistryImpl` to compile with C++20.

#### PR validation:

`PhysicsTools/MVAComputer` package compiles in CPP20 IB.