### PR TITLE
TH2Poly Tracker Maps

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -27,7 +27,6 @@
 #include "TGraph.h"
 #include "TPaletteAxis.h"
 
-
 /**********************************************************
 Allocate all the modules in a map of TmModule
 The filling of the values for each module is done later
@@ -694,23 +693,24 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
 
   //Get value and name for TH2Poly bin
   float vals = mod->value;
-  if (std::isnan(vals)) vals = 0; //Avoid nan values
+  if (std::isnan(vals))
+    vals = 0;  //Avoid nan values
   std::string nams = mod->name;
 
   //Format TH2Poly bin name = short_name_(detId)_FED
   //Original name = TOB- Layer 5 Rod 61 Module 6 r-phi (436295608) connected to 0 413/48 1 413/49 2 413/50 (3)^C
   //Bin name = TOB-_L_5_R_61_M_6_(436295608)_413
   nams.erase(std::remove_if(nams.begin(), nams.end(), [](char c) { return std::islower(c); }), nams.end());
-  size_t found = nams.find("/");
+  size_t found = nams.find('/');
   if (found != std::string::npos) {
     nams.erase(found, nams.length() - found);
   } else {
-    found = nams.find(")");
-    nams.erase(found+1, nams.length() - found);
+    found = nams.find(')');
+    nams.erase(found + 1, nams.length() - found);
   }
   found = nams.find(")   ");
   while (found != std::string::npos) {
-    nams.erase(found+1, 4);
+    nams.erase(found + 1, 4);
     found = nams.find(")   ", found);
   }
   found = nams.find(" -");
@@ -728,7 +728,8 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
     nams.erase(found, 1);
     found = nams.find("  ", found);
   }
-  std::replace_if(nams.begin(), nams.end(), [](char c) { return c == ' '; }, '_');
+  std::replace_if(
+      nams.begin(), nams.end(), [](char c) { return c == ' '; }, '_');
 
   if (mod->red < 0) {  //use count to compute color
     int color = getcolor(mod->value, palette);
@@ -741,7 +742,7 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
 
     if (mod->count > 0)
       if (temporary_file)
-	//Add TH2Poly bin name and value to temporary .coor file
+        //Add TH2Poly bin name and value to temporary .coor file
         *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
@@ -922,7 +923,7 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           int key = layer * 100000 + ring * 1000 + module;
           TmModule *mod = smoduleMap[key];
           if (mod != nullptr && !mod->notInUse()) {
-	     drawModule(mod, key, layer, print_total, savefile);
+            drawModule(mod, key, layer, print_total, savefile);
           }
         }
       }
@@ -988,7 +989,7 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
-	  colorList[colindex] = ncolor + 100;
+          colorList[colindex] = ncolor + 100;
           col = gROOT->GetColor(ncolor + 100);
           if (col)
             col->SetRGB((Double_t)(red / 255.), (Double_t)(green / 255.), (Double_t)(blue / 255.));
@@ -997,13 +998,13 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           vc.push_back(c);
           ncolor++;
         }
-	for (int i = 0; i < npoints; i++) {
+        for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
       }
 
       if (ncolor > 0 && ncolor < 10000) {
-	Int_t colors[10000];
+        Int_t colors[10000];
         for (int i = 0; i < ncolor; i++) {
           colors[i] = i + 100;
         }
@@ -1016,18 +1017,18 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
 
       //TH2Poly Tracker Map for Strip
       TH2Poly *StripMap = new TH2Poly("StripSummary", "", 775, 3600, 0, 1350);
-      StripMap->SetFloat(1);
+      StripMap->SetFloat(true);
       StripMap->GetXaxis()->SetTitle("");
       StripMap->GetYaxis()->SetTitle("");
-      StripMap->SetStats(0);
-      int siterator =0;
+      StripMap->SetStats(false);
+      int siterator = 0;
 
       while (!tempfile.eof()) {  //create polylines
         siterator++;
-	//Get TH2Poly bin name and content from temporary .coor file
+        //Get TH2Poly bin name and content from temporary .coor file
         tempfile >> named >> content >> red >> green >> blue >> npoints;
 
-	for (int i = 0; i < npoints; i++) {
+        for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
         colindex = red + green * 1000 + blue * 1000000;
@@ -1038,14 +1039,15 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           pline->SetFillColor(colorList[colindex]);
 
           TGraph *bin = new TGraph(npoints, y, x);
-	  //Fill only 15145 TH2Poly bins (Strip only), instead of 16588 bins (Pixel+Strip, old)
-	  if ( (siterator >= 1 && siterator <= 3608) || (siterator >= 4281 && siterator <= 7888) || (siterator >= 8657 && siterator <= 16588)){
-	    bin->SetName(named.c_str());
-	    StripMap->AddBin(bin);
-	    StripMap->Fill(named.c_str(), content);
-	  }
+          //Fill only 15145 TH2Poly bins (Strip only), instead of 16588 bins (Pixel+Strip, old)
+          if ((siterator >= 1 && siterator <= 3608) || (siterator >= 4281 && siterator <= 7888) ||
+              (siterator >= 8657 && siterator <= 16588)) {
+            bin->SetName(named.c_str());
+            StripMap->AddBin(bin);
+            StripMap->Fill(named.c_str(), content);
+          }
 
-	  pline->SetLineWidth(0);
+          pline->SetLineWidth(0);
           pline->Draw("f");
         }
       }
@@ -1176,7 +1178,7 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
 
       //Rainbow palette, fix pad margin and palette position
       gStyle->SetPalette(kRainBow);
-      TPaletteAxis *realPalette = (TPaletteAxis*)StripMap->GetListOfFunctions()->FindObject("palette");
+      TPaletteAxis *realPalette = (TPaletteAxis *)StripMap->GetListOfFunctions()->FindObject("palette");
       realPalette->SetX1NDC(0.92);
       realPalette->SetX2NDC(0.94);
       realPalette->SetY1NDC(0.02);
@@ -1191,8 +1193,10 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
       TLatex l2;
       l2.SetTextSize(0.06);
       std::string runnumber;
-      for (char c : title) if (std::isdigit(c)) runnumber.push_back(c);
-      std::string striptitle = "Run "+runnumber+": Strip "+outputfilename;
+      for (char c : title)
+        if (std::isdigit(c))
+          runnumber.push_back(c);
+      std::string striptitle = "Run " + runnumber + ": Strip " + outputfilename;
       l2.DrawLatex(800, 1380, striptitle.c_str());
       l2.SetTextSize(0.05);
       l2.DrawLatex(1200, 40, "-z");
@@ -1279,8 +1283,8 @@ void TrackerMap::drawApvPair(
   if (useApvPairValue) {
     if (apvPair->red < 0) {  //use count to compute color
       if (apvPair->count > 0) {
-	float vals = apvPair->value;
-	std::string nams = "nams_apv";
+        float vals = apvPair->value;
+        std::string nams = "nams_apv";
 
         color = getcolor(apvPair->value, palette);
         red = (color >> 16) & 0xFF;
@@ -1301,7 +1305,7 @@ void TrackerMap::drawApvPair(
               << " \" fill=\"rgb(" << red << "," << green << "," << blue << ")\" points=\"";
       } else {
         if (temporary_file)
-	  *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
+          *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1334,15 +1338,15 @@ void TrackerMap::drawApvPair(
   } else {
     if (apvPair->mod->red < 0) {  //use count to compute color
       if (apvPair->mod->count > 0) {
-	float vals = apvPair->mod->value;
-	std::string nams = "nams_apv2";
+        float vals = apvPair->mod->value;
+        std::string nams = "nams_apv2";
 
         color = getcolor(apvPair->mod->value, palette);
         red = (color >> 16) & 0xFF;
         green = (color >> 8) & 0xFF;
         blue = (color)&0xFF;
         if (temporary_file)
-	  *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
+          *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1354,7 +1358,7 @@ void TrackerMap::drawApvPair(
               << " \" fill=\"rgb(" << red << "," << green << "," << blue << ")\" points=\"";
       } else {
         if (temporary_file)
-	  *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
+          *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1373,7 +1377,8 @@ void TrackerMap::drawApvPair(
       if (apvPair->mod->blue > 255)
         apvPair->mod->blue = 255;
       if (temporary_file)
-	*svgfile << 0 << " " << 0 << " " << apvPair->mod->red << " " << apvPair->mod->green << " " << apvPair->mod->blue << " ";
+        *svgfile << 0 << " " << 0 << " " << apvPair->mod->red << " " << apvPair->mod->green << " " << apvPair->mod->blue
+                 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1452,7 +1457,7 @@ void TrackerMap::drawCcu(
       if (!print_total)
         ccu->value = ccu->value * ccu->count;  //restore mod->value
       if (temporary_file)
-	*svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
+        *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << ccu->idex << "\" count=\"" << ccu->count << "\" value=\"" << ccu->value
@@ -1563,7 +1568,7 @@ void TrackerMap::drawPsu(
       if (!print_total)
         psu->value = psu->value * psu->count;  //restore mod->value
       if (temporary_file)
-	*svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
+        *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->count << "\" value=\"" << psu->value
@@ -1667,7 +1672,7 @@ void TrackerMap::drawHV2(
       if (!print_total)
         psu->valueHV2 = psu->valueHV2 * psu->countHV2;  //restore mod->value
       if (temporary_file)
-	*svgfile << nams << " " << vals << " " << redHV2 << " " << greenHV2 << " " << blueHV2 << " ";
+        *svgfile << nams << " " << vals << " " << redHV2 << " " << greenHV2 << " " << blueHV2 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV2 << "\" value=\"" << psu->valueHV2
@@ -1770,7 +1775,7 @@ void TrackerMap::drawHV3(
       if (!print_total)
         psu->valueHV3 = psu->valueHV3 * psu->countHV3;  //restore mod->value
       if (temporary_file)
-	*svgfile << nams << " " << vals << " " << redHV3 << " " << greenHV3 << " " << blueHV3 << " ";
+        *svgfile << nams << " " << vals << " " << redHV3 << " " << greenHV3 << " " << blueHV3 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV3 << "\" value=\"" << psu->valueHV3
@@ -1781,7 +1786,7 @@ void TrackerMap::drawHV3(
             << "," << greenHV3 << "," << blueHV3 << ")\" points=\"";
     } else {
       if (temporary_file)
-	*svgfile << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
+        *svgfile << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV3 << "\" value=\"" << psu->valueHV3
@@ -2668,7 +2673,7 @@ void TrackerMap::save_as_psutrackermap(
           vc.push_back(c);
           ncolor++;
         }
-	for (int i = 0; i < npoints; i++) {
+        for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
       }
@@ -3190,8 +3195,8 @@ void TrackerMap::drawPalette(std::ofstream *svgfile, int xoffset, int yoffset) {
       *svgfile << "<svg:rect  x=\"3610\" y=\"" << (1550 - 6 * i) << "\" width=\"50\" height=\"6\" fill=\"rgb(" << red
                << "," << green << "," << blue << ")\" />\n";
     else
-      *svgfile << 0 << " " << 0 << " " << red << " " << green << " " << blue << " 4 " << int(step * i) + 34 << " " << xoffset - width << ". "
-               <<                                                                   //
+      *svgfile << 0 << " " << 0 << " " << red << " " << green << " " << blue << " 4 " << int(step * i) + 34 << " "
+               << xoffset - width << ". " <<                                        //
           int(step * i) + 34 << " " << xoffset << ". " <<                           //
           int(step * (i - 1)) + 34 << " " << xoffset << ". " <<                     //
           int(step * (i - 1)) + 34 << " " << xoffset - width << ". " << std::endl;  //
@@ -4382,7 +4387,7 @@ void TrackerMap::printlayers(bool print_total, float minval, float maxval, std::
         int key = layer * 100000 + ring * 1000 + module;
         TmModule *mod = smoduleMap[key];
         if (mod != nullptr && !mod->notInUse()) {
-	  drawModule(mod, key, layer, print_total, xmlfile);
+          drawModule(mod, key, layer, print_total, xmlfile);
         }
       }
     }

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -23,6 +23,10 @@
 #include "TArrow.h"
 #include "TLegend.h"
 #include "TH1F.h"
+#include "TH2Poly.h"
+#include "TGraph.h"
+#include "TPaletteAxis.h"
+
 
 /**********************************************************
 Allocate all the modules in a map of TmModule
@@ -688,6 +692,44 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
   char buffer[20];
   sprintf(buffer, "%X", mod->idex);
 
+  //Get value and name for TH2Poly bin
+  float vals = mod->value;
+  if (std::isnan(vals)) vals = 0; //Avoid nan values
+  std::string nams = mod->name;
+
+  //Format TH2Poly bin name = short_name_(detId)_FED
+  //Original name = TOB- Layer 5 Rod 61 Module 6 r-phi (436295608) connected to 0 413/48 1 413/49 2 413/50 (3)^C
+  //Bin name = TOB-_L_5_R_61_M_6_(436295608)_413
+  nams.erase(std::remove_if(nams.begin(), nams.end(), [](char c) { return std::islower(c); }), nams.end());
+  size_t found = nams.find("/");
+  if (found != std::string::npos) {
+    nams.erase(found, nams.length() - found);
+  } else {
+    found = nams.find(")");
+    nams.erase(found+1, nams.length() - found);
+  }
+  found = nams.find(")   ");
+  while (found != std::string::npos) {
+    nams.erase(found+1, 4);
+    found = nams.find(")   ", found);
+  }
+  found = nams.find(" -");
+  while (found != std::string::npos) {
+    nams.erase(found, 2);
+    found = nams.find(" -", found);
+  }
+  found = nams.find("   ");
+  while (found != std::string::npos) {
+    nams.erase(found, 2);
+    found = nams.find("   ", found);
+  }
+  found = nams.find("  ");
+  while (found != std::string::npos) {
+    nams.erase(found, 1);
+    found = nams.find("  ", found);
+  }
+  std::replace_if(nams.begin(), nams.end(), [](char c) { return c == ' '; }, '_');
+
   if (mod->red < 0) {  //use count to compute color
     int color = getcolor(mod->value, palette);
     red = (color >> 16) & 0xFF;
@@ -699,7 +741,8 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
 
     if (mod->count > 0)
       if (temporary_file)
-        *svgfile << red << " " << green << " " << blue << " ";
+	//Add TH2Poly bin name and value to temporary .coor file
+        *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << mod->idex << "\" count=\"" << mod->count << "\" value=\"" << mod->value
@@ -709,7 +752,7 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
             << mod->text << "\" POS=\"" << mod->name << " \" fill=\"rgb(" << red << "," << green << "," << blue
             << ")\" points=\"";
     else if (temporary_file)
-      *svgfile << 255 << " " << 255 << " " << 255 << " ";
+      *svgfile << nams << " " << vals << " " << 255 << " " << 255 << " " << 255 << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << mod->idex << "\" count=\"" << mod->count << "\" value=\"" << mod->value
@@ -737,7 +780,7 @@ void TrackerMap::drawModule(TmModule *mod, int key, int mlay, bool print_total, 
     if (mod->blue > 255)
       mod->blue = 255;
     if (temporary_file)
-      *svgfile << mod->red << " " << mod->green << " " << mod->blue << " ";
+      *svgfile << nams << " " << vals << " " << mod->red << " " << mod->green << " " << mod->blue << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << mod->idex << "\" count=\"" << mod->count << "\" value=\"" << mod->value
@@ -810,6 +853,11 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
     outputfilename = outputfilename.substr(0, found);
     //outputfilename.erase(outputfilename.begin()+outputfilename.find("."),outputfilename.end());
     temporary_file = true;
+
+    //Dev option to produce only one plot
+    //if(outputfilename != "StoNCorrOnTrack")
+    //  return;
+
     if (filetype == "svg")
       temporary_file = false;
     std::ostringstream outs;
@@ -874,7 +922,7 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           int key = layer * 100000 + ring * 1000 + module;
           TmModule *mod = smoduleMap[key];
           if (mod != nullptr && !mod->notInUse()) {
-            drawModule(mod, key, layer, print_total, savefile);
+	     drawModule(mod, key, layer, print_total, savefile);
           }
         }
       }
@@ -910,6 +958,10 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
     }
 
     if (temporary_file) {  // create root trackermap image
+      //Variables for TH2Poly bin content and name from temporary .coor file
+      float content;
+      std::string named;
+
       int red, green, blue, npoints, colindex, ncolor;
       double x[4], y[4];
       std::ifstream tempfile(tempfilename.c_str(), std::ios::in);
@@ -932,11 +984,11 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
       TColor *col, *c;
       std::cout << "tempfilename " << tempfilename << std::endl;
       while (!tempfile.eof()) {
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
-          colorList[colindex] = ncolor + 100;
+	  colorList[colindex] = ncolor + 100;
           col = gROOT->GetColor(ncolor + 100);
           if (col)
             col->SetRGB((Double_t)(red / 255.), (Double_t)(green / 255.), (Double_t)(blue / 255.));
@@ -945,13 +997,13 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           vc.push_back(c);
           ncolor++;
         }
-        for (int i = 0; i < npoints; i++) {
+	for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
       }
 
       if (ncolor > 0 && ncolor < 10000) {
-        Int_t colors[10000];
+	Int_t colors[10000];
         for (int i = 0; i < ncolor; i++) {
           colors[i] = i + 100;
         }
@@ -962,9 +1014,20 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
       tempfile.seekg(0, std::ios::beg);
       std::cout << "created palette with " << ncolor << " colors" << std::endl;
 
+      //TH2Poly Tracker Map for Strip
+      TH2Poly *StripMap = new TH2Poly("StripSummary", "", 775, 3600, 0, 1350);
+      StripMap->SetFloat(1);
+      StripMap->GetXaxis()->SetTitle("");
+      StripMap->GetYaxis()->SetTitle("");
+      StripMap->SetStats(0);
+      int siterator =0;
+
       while (!tempfile.eof()) {  //create polylines
-        tempfile >> red >> green >> blue >> npoints;
-        for (int i = 0; i < npoints; i++) {
+        siterator++;
+	//Get TH2Poly bin name and content from temporary .coor file
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
+
+	for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
         colindex = red + green * 1000 + blue * 1000000;
@@ -973,7 +1036,16 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
           TPolyLine *pline = new TPolyLine(npoints, y, x);
           vp.push_back(pline);
           pline->SetFillColor(colorList[colindex]);
-          pline->SetLineWidth(0);
+
+          TGraph *bin = new TGraph(npoints, y, x);
+	  //Fill only 15145 TH2Poly bins (Strip only), instead of 16588 bins (Pixel+Strip, old)
+	  if ( (siterator >= 1 && siterator <= 3608) || (siterator >= 4281 && siterator <= 7888) || (siterator >= 8657 && siterator <= 16588)){
+	    bin->SetName(named.c_str());
+	    StripMap->AddBin(bin);
+	    StripMap->Fill(named.c_str(), content);
+	  }
+
+	  pline->SetLineWidth(0);
           pline->Draw("f");
         }
       }
@@ -1093,6 +1165,67 @@ void TrackerMap::save(bool print_total, float minval, float maxval, std::string 
       MyC->Clear();
       delete MyC;
       delete MyL;
+
+      //Canvas name = MyT for both Pixel and Strip Tracker Maps
+      TCanvas *MyT = new TCanvas("MyT", "MyT", 3500, 1500);
+      //gPad->SetFillColor(38);//Fill pad
+      StripMap->SetLineColor(kBlack);
+      StripMap->SetLineWidth(0);
+      StripMap->Draw("AL COLZ");
+      MyT->Update();
+
+      //Rainbow palette, fix pad margin and palette position
+      gStyle->SetPalette(kRainBow);
+      TPaletteAxis *realPalette = (TPaletteAxis*)StripMap->GetListOfFunctions()->FindObject("palette");
+      realPalette->SetX1NDC(0.92);
+      realPalette->SetX2NDC(0.94);
+      realPalette->SetY1NDC(0.02);
+      realPalette->SetY2NDC(0.91);
+      gPad->SetRightMargin(0.08);
+      gPad->SetLeftMargin(0.01);
+      gPad->SetTopMargin(0.09);
+      gPad->SetBottomMargin(0.02);
+      gPad->Update();
+
+      //Fill pad with text and arrows
+      TLatex l2;
+      l2.SetTextSize(0.06);
+      std::string runnumber;
+      for (char c : title) if (std::isdigit(c)) runnumber.push_back(c);
+      std::string striptitle = "Run "+runnumber+": Strip "+outputfilename;
+      l2.DrawLatex(800, 1380, striptitle.c_str());
+      l2.SetTextSize(0.05);
+      l2.DrawLatex(1200, 40, "-z");
+      l2.DrawLatex(1200, 1300, "+z");
+      l2.DrawLatex(1085, 310, "TIB L1");
+      l2.DrawLatex(1085, 1000, "TIB L2");
+      l2.DrawLatex(1585, 310, "TIB L3");
+      l2.DrawLatex(1585, 1000, "TIB L4");
+      l2.DrawLatex(2085, 310, "TOB L1");
+      l2.DrawLatex(2085, 1000, "TOB L2");
+      l2.DrawLatex(2585, 310, "TOB L3");
+      l2.DrawLatex(2585, 1000, "TOB L4");
+      l2.DrawLatex(3085, 310, "TOB L5");
+      l2.DrawLatex(3085, 1000, "TOB L6");
+      l2.DrawLatex(3460, 1320, "x");
+      l2.DrawLatex(3315, 1210, "y");
+      l2.DrawLatex(3510, 667, "z");
+      l2.DrawLatex(3023, 530, "#Phi");
+      arx.SetY2(1320);
+      ary.SetX2(3320);
+      arz.SetX1(3490);
+      arz.SetX2(3490);
+      arphi.SetX1(3490);
+      arx.Draw();
+      ary.Draw();
+      arz.Draw();
+      arphi.Draw();
+      MyT->Update();
+
+      std::string filename = outputfilename + ".root";
+      MyT->Print(filename.c_str());
+      delete MyT;
+
       if (printflag)
         delete axis;
       for (std::vector<TPolyLine *>::iterator pos1 = vp.begin(); pos1 != vp.end(); pos1++) {
@@ -1146,6 +1279,9 @@ void TrackerMap::drawApvPair(
   if (useApvPairValue) {
     if (apvPair->red < 0) {  //use count to compute color
       if (apvPair->count > 0) {
+	float vals = apvPair->value;
+	std::string nams = "nams_apv";
+
         color = getcolor(apvPair->value, palette);
         red = (color >> 16) & 0xFF;
         green = (color >> 8) & 0xFF;
@@ -1153,7 +1289,7 @@ void TrackerMap::drawApvPair(
         if (!print_total)
           apvPair->value = apvPair->value * apvPair->count;  //restore mod->value
         if (temporary_file)
-          *svgfile << red << " " << green << " " << blue << " ";
+          *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1165,7 +1301,7 @@ void TrackerMap::drawApvPair(
               << " \" fill=\"rgb(" << red << "," << green << "," << blue << ")\" points=\"";
       } else {
         if (temporary_file)
-          *svgfile << 255 << " " << 255 << " " << 255 << " ";
+	  *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1184,7 +1320,7 @@ void TrackerMap::drawApvPair(
       if (apvPair->blue > 255)
         apvPair->blue = 255;
       if (temporary_file)
-        *svgfile << apvPair->red << " " << apvPair->green << " " << apvPair->blue << " ";
+        *svgfile << 0 << " " << 0 << " " << apvPair->red << " " << apvPair->green << " " << apvPair->blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1198,12 +1334,15 @@ void TrackerMap::drawApvPair(
   } else {
     if (apvPair->mod->red < 0) {  //use count to compute color
       if (apvPair->mod->count > 0) {
+	float vals = apvPair->mod->value;
+	std::string nams = "nams_apv2";
+
         color = getcolor(apvPair->mod->value, palette);
         red = (color >> 16) & 0xFF;
         green = (color >> 8) & 0xFF;
         blue = (color)&0xFF;
         if (temporary_file)
-          *svgfile << red << " " << green << " " << blue << " ";
+	  *svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1215,7 +1354,7 @@ void TrackerMap::drawApvPair(
               << " \" fill=\"rgb(" << red << "," << green << "," << blue << ")\" points=\"";
       } else {
         if (temporary_file)
-          *svgfile << 255 << " " << 255 << " " << 255 << " ";
+	  *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
         else
           *svgfile
               << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1234,7 +1373,7 @@ void TrackerMap::drawApvPair(
       if (apvPair->mod->blue > 255)
         apvPair->mod->blue = 255;
       if (temporary_file)
-        *svgfile << apvPair->mod->red << " " << apvPair->mod->green << " " << apvPair->mod->blue << " ";
+	*svgfile << 0 << " " << 0 << " " << apvPair->mod->red << " " << apvPair->mod->green << " " << apvPair->mod->blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << apvPair->idex << "\" count=\"" << apvPair->count << "\" value=\""
@@ -1303,6 +1442,9 @@ void TrackerMap::drawCcu(
 
   if (ccu->red < 0) {  //use count to compute color
     if (ccu->count > 0) {
+      float vals = ccu->value;
+      std::string nams = "nams_ccu";
+
       color = getcolor(ccu->value, palette);
       red = (color >> 16) & 0xFF;
       green = (color >> 8) & 0xFF;
@@ -1310,7 +1452,7 @@ void TrackerMap::drawCcu(
       if (!print_total)
         ccu->value = ccu->value * ccu->count;  //restore mod->value
       if (temporary_file)
-        *svgfile << red << " " << green << " " << blue << " ";
+	*svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << ccu->idex << "\" count=\"" << ccu->count << "\" value=\"" << ccu->value
@@ -1321,7 +1463,7 @@ void TrackerMap::drawCcu(
             << " \" fill=\"rgb(" << red << "," << green << "," << blue << ")\" points=\"";
     } else {
       if (temporary_file)
-        *svgfile << 255 << " " << 255 << " " << 255 << " ";
+        *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << ccu->idex << "\" count=\"" << ccu->count << "\" value=\"" << ccu->value
@@ -1340,7 +1482,7 @@ void TrackerMap::drawCcu(
     if (ccu->blue > 255)
       ccu->blue = 255;
     if (temporary_file)
-      *svgfile << ccu->red << " " << ccu->green << " " << ccu->blue << " ";
+      *svgfile << 0 << " " << 0 << " " << ccu->red << " " << ccu->green << " " << ccu->blue << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << ccu->idex << "\" count=\"" << ccu->count << "\" value=\"" << ccu->value
@@ -1411,6 +1553,9 @@ void TrackerMap::drawPsu(
 
   if (psu->red < 0) {  //use count to compute color
     if (psu->count > 0) {
+      float vals = psu->value;
+      std::string nams = "nams_psu";
+
       color = getcolor(psu->value, palette);
       red = (color >> 16) & 0xFF;
       green = (color >> 8) & 0xFF;
@@ -1418,7 +1563,7 @@ void TrackerMap::drawPsu(
       if (!print_total)
         psu->value = psu->value * psu->count;  //restore mod->value
       if (temporary_file)
-        *svgfile << red << " " << green << " " << blue << " ";
+	*svgfile << nams << " " << vals << " " << red << " " << green << " " << blue << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->count << "\" value=\"" << psu->value
@@ -1429,7 +1574,7 @@ void TrackerMap::drawPsu(
             << "," << green << "," << blue << ")\" points=\"";
     } else {
       if (temporary_file)
-        *svgfile << 255 << " " << 255 << " " << 255 << " ";
+        *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->count << "\" value=\"" << psu->value
@@ -1449,7 +1594,7 @@ void TrackerMap::drawPsu(
     if (psu->blue > 255)
       psu->blue = 255;
     if (temporary_file)
-      *svgfile << psu->red << " " << psu->green << " " << psu->blue << " ";
+      *svgfile << 0 << " " << 0 << " " << psu->red << " " << psu->green << " " << psu->blue << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->count << "\" value=\"" << psu->value
@@ -1512,6 +1657,9 @@ void TrackerMap::drawHV2(
   if (psu->redHV2 < 0) {  //use count to compute color
 
     if (psu->valueHV2 > 0) {
+      float vals = psu->valueHV2;
+      std::string nams = "nams_hv2";
+
       color = getcolor(psu->valueHV2, palette);
       redHV2 = (color >> 16) & 0xFF;
       greenHV2 = (color >> 8) & 0xFF;
@@ -1519,7 +1667,7 @@ void TrackerMap::drawHV2(
       if (!print_total)
         psu->valueHV2 = psu->valueHV2 * psu->countHV2;  //restore mod->value
       if (temporary_file)
-        *svgfile << redHV2 << " " << greenHV2 << " " << blueHV2 << " ";
+	*svgfile << nams << " " << vals << " " << redHV2 << " " << greenHV2 << " " << blueHV2 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV2 << "\" value=\"" << psu->valueHV2
@@ -1530,7 +1678,7 @@ void TrackerMap::drawHV2(
             << "," << greenHV2 << "," << blueHV2 << ")\" points=\"";
     } else {
       if (temporary_file)
-        *svgfile << 255 << " " << 255 << " " << 255 << " ";
+        *svgfile << 0 << " " << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV2 << "\" value=\"" << psu->valueHV2
@@ -1550,7 +1698,7 @@ void TrackerMap::drawHV2(
     if (psu->blueHV2 > 255)
       psu->blueHV2 = 255;
     if (temporary_file)
-      *svgfile << psu->redHV2 << " " << psu->greenHV2 << " " << psu->blueHV2 << " ";
+      *svgfile << 0 << " " << 0 << " " << psu->redHV2 << " " << psu->greenHV2 << " " << psu->blueHV2 << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV2 << "\" value=\"" << psu->valueHV2
@@ -1612,6 +1760,9 @@ void TrackerMap::drawHV3(
 
   if (psu->redHV3 < 0) {  //use count to compute color
     if (psu->valueHV3 > 0) {
+      float vals = psu->valueHV3;
+      std::string nams = "nams_hv3";
+
       color = getcolor(psu->valueHV3, palette);
       redHV3 = (color >> 16) & 0xFF;
       greenHV3 = (color >> 8) & 0xFF;
@@ -1619,7 +1770,7 @@ void TrackerMap::drawHV3(
       if (!print_total)
         psu->valueHV3 = psu->valueHV3 * psu->countHV3;  //restore mod->value
       if (temporary_file)
-        *svgfile << redHV3 << " " << greenHV3 << " " << blueHV3 << " ";
+	*svgfile << nams << " " << vals << " " << redHV3 << " " << greenHV3 << " " << blueHV3 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV3 << "\" value=\"" << psu->valueHV3
@@ -1630,7 +1781,7 @@ void TrackerMap::drawHV3(
             << "," << greenHV3 << "," << blueHV3 << ")\" points=\"";
     } else {
       if (temporary_file)
-        *svgfile << 255 << " " << 255 << " " << 255 << " ";
+	*svgfile << 0 << " " << 255 << " " << 255 << " " << 255 << " ";
       else
         *svgfile
             << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV3 << "\" value=\"" << psu->valueHV3
@@ -1650,7 +1801,7 @@ void TrackerMap::drawHV3(
     if (psu->blueHV3 > 255)
       psu->blueHV3 = 255;
     if (temporary_file)
-      *svgfile << psu->redHV3 << " " << psu->greenHV3 << " " << psu->blueHV3 << " ";
+      *svgfile << 0 << " " << 0 << " " << psu->redHV3 << " " << psu->greenHV3 << " " << psu->blueHV3 << " ";
     else
       *svgfile
           << "<svg:polygon detid=\"" << psu->idex << "\" count=\"" << psu->countHV3 << "\" value=\"" << psu->valueHV3
@@ -1851,6 +2002,8 @@ void TrackerMap::save_as_fectrackermap(
         drawPalette(savefile);
       savefile->close();
 
+      float content;
+      std::string named;
       const char *command1;
       std::string tempfilename = outputfilename + ".coor";
       int red, green, blue, npoints, colindex, ncolor;
@@ -1871,7 +2024,7 @@ void TrackerMap::save_as_fectrackermap(
       ColorList::iterator pos;
       TColor *col, *c;
       while (!tempfile.eof()) {
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
@@ -1900,7 +2053,7 @@ void TrackerMap::save_as_fectrackermap(
       tempfile.seekg(0, std::ios::beg);
       std::cout << "created palette with " << ncolor << " colors" << std::endl;
       while (!tempfile.eof()) {  //create polylines
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
@@ -2171,6 +2324,8 @@ void TrackerMap::save_as_HVtrackermap(
         drawPalette(savefile);
       savefile->close();
 
+      float content;
+      std::string named;
       const char *command1;
       std::string tempfilename = outputfilename + ".coor";
       int red, green, blue, npoints, colindex, ncolor;
@@ -2191,7 +2346,7 @@ void TrackerMap::save_as_HVtrackermap(
       ColorList::iterator pos;
       TColor *col, *c;
       while (!tempfile.eof()) {
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
@@ -2220,7 +2375,7 @@ void TrackerMap::save_as_HVtrackermap(
       tempfile.seekg(0, std::ios::beg);
       std::cout << "created palette with " << ncolor << " colors" << std::endl;
       while (!tempfile.eof()) {  //create polylines
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
@@ -2478,6 +2633,8 @@ void TrackerMap::save_as_psutrackermap(
         drawPalette(savefile, rangex - 140, rangey - 100);
       savefile->close();
 
+      float content;
+      std::string named;
       const char *command1;
       std::string tempfilename = outputfilename + ".coor";
       int red, green, blue, npoints, colindex, ncolor;
@@ -2498,7 +2655,7 @@ void TrackerMap::save_as_psutrackermap(
       ColorList::iterator pos;
       TColor *col, *c;
       while (!tempfile.eof()) {
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
@@ -2511,7 +2668,7 @@ void TrackerMap::save_as_psutrackermap(
           vc.push_back(c);
           ncolor++;
         }
-        for (int i = 0; i < npoints; i++) {
+	for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
       }
@@ -2526,7 +2683,7 @@ void TrackerMap::save_as_psutrackermap(
       tempfile.seekg(0, std::ios::beg);
       std::cout << "created palette with " << ncolor << " colors" << std::endl;
       while (!tempfile.eof()) {  //create polylines
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
@@ -2783,6 +2940,8 @@ void TrackerMap::save_as_fedtrackermap(
       savefile->close();
       delete savefile;
 
+      float content;
+      std::string named;
       const char *command1;
       std::string tempfilename = outputfilename + ".coor";
       int red, green, blue, npoints, colindex, ncolor;
@@ -2803,7 +2962,7 @@ void TrackerMap::save_as_fedtrackermap(
       ColorList::iterator pos;
       TColor *col, *c;
       while (!tempfile.eof()) {
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         colindex = red + green * 1000 + blue * 1000000;
         pos = colorList.find(colindex);
         if (pos == colorList.end()) {
@@ -2831,7 +2990,7 @@ void TrackerMap::save_as_fedtrackermap(
       tempfile.seekg(0, std::ios::beg);
       std::cout << "created palette with " << ncolor << " colors" << std::endl;
       while (!tempfile.eof()) {  //create polylines
-        tempfile >> red >> green >> blue >> npoints;
+        tempfile >> named >> content >> red >> green >> blue >> npoints;
         for (int i = 0; i < npoints; i++) {
           tempfile >> x[i] >> y[i];
         }
@@ -3002,6 +3161,7 @@ void TrackerMap::print(bool print_total, float minval, float maxval, std::string
 
 void TrackerMap::drawPalette(std::ofstream *svgfile, int xoffset, int yoffset) {
   std::cout << "preparing the palette" << std::endl;
+
   int color, red, green, blue;
   float val = minvalue;
   int paletteLength = 250;
@@ -3030,7 +3190,7 @@ void TrackerMap::drawPalette(std::ofstream *svgfile, int xoffset, int yoffset) {
       *svgfile << "<svg:rect  x=\"3610\" y=\"" << (1550 - 6 * i) << "\" width=\"50\" height=\"6\" fill=\"rgb(" << red
                << "," << green << "," << blue << ")\" />\n";
     else
-      *svgfile << red << " " << green << " " << blue << " 4 " << int(step * i) + 34 << " " << xoffset - width << ". "
+      *svgfile << 0 << " " << 0 << " " << red << " " << green << " " << blue << " 4 " << int(step * i) + 34 << " " << xoffset - width << ". "
                <<                                                                   //
           int(step * i) + 34 << " " << xoffset << ". " <<                           //
           int(step * (i - 1)) + 34 << " " << xoffset << ". " <<                     //
@@ -4222,7 +4382,7 @@ void TrackerMap::printlayers(bool print_total, float minval, float maxval, std::
         int key = layer * 100000 + ring * 1000 + module;
         TmModule *mod = smoduleMap[key];
         if (mod != nullptr && !mod->notInUse()) {
-          drawModule(mod, key, layer, print_total, xmlfile);
+	  drawModule(mod, key, layer, print_total, xmlfile);
         }
       }
     }


### PR DESCRIPTION
#### PR description:

In order to exploit jsroot with interactive tracker maps for both Strip and Pixel, need to save plots (in form of TH2Poly) inside .root files.
Changes:
- Strip: introduced TH2Poly in new canvas, saved to .root
- Pixel: already in TH2Poly format, changed bin name and saved new canvas to .root

New TH2Poly plots are being integrated into the Tracker Map website (outside CMSSW) with a [separate PR](https://github.com/CMSTrackerDPG/cmsTrackerMaps/pull/5).

#### PR validation:

1. Old format (png files) used in previous tracker map website version are not modified
2. New TH2Poly plots inside root files are as expected, examples:
- Strip: https://alaperto.web.cern.ch/htmls/strip_jsroot.html
- Pixel: https://alaperto.web.cern.ch/htmls/pixel_jsroot.html
3. [Preview of the website](https://alaperto.web.cern.ch/tkmaps/index.html?link=true&mode=compare&checkbox88=true&checkbox104=true&refRunPath=&currRunPath=&mapSelect=undefined) with interactive Strip and Pixel Maps.