### PR TITLE
L1T: Add zPt to L1JetRecoTree in L1Ntuples

### DIFF
--- a/L1Trigger/L1TNtuples/interface/L1AnalysisRecoMetDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisRecoMetDataFormat.h
@@ -42,6 +42,7 @@ namespace L1Analysis {
       puppi_mHt = -999.;
       puppi_mHtPhi = -999.;
       sumEt = -999.;
+      zPt = -999.;
       ecalFlag = 0;
       hcalFlag = 0;
     }
@@ -72,6 +73,7 @@ namespace L1Analysis {
     float puppi_Ht;
     float puppi_mHt;
     float puppi_mHtPhi;
+    float zPt;
     unsigned short ecalFlag;
     unsigned short hcalFlag;
   };

--- a/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
@@ -680,7 +680,7 @@ void L1JetRecoTreeProducer::doZPt(edm::Handle<reco::MuonCollection> muons) {
   for (auto it1 = muons->begin(); it1 != muons->end(); ++it1) {
     if (!it1->isPFMuon())
       continue;
-    for (auto it2 = muons->begin(); it2 != muons->end(); ++it2) {
+    for (auto it2 = std::next(it1); it2 != muons->end(); ++it2) {
       if (!it2->isPFMuon())
         continue;
       if (it1->charge() != (-1 * it2->charge()))

--- a/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
@@ -683,8 +683,8 @@ void L1JetRecoTreeProducer::doZPt(edm::Handle<reco::MuonCollection> muons) {
     for (auto it2 = muons->begin(); it2 != muons->end(); ++it2) {
       if (!it2->isPFMuon())
         continue;
-      if (it1->charge() != (-1*it2->charge()))
-	continue;
+      if (it1->charge() != (-1 * it2->charge()))
+        continue;
 
       found2PFMuons = true;
       diMuMass = (it1->p4() + it2->p4()).M();


### PR DESCRIPTION
- Adds a new variable "zPt" to the L1JetRecoTree in the L1Ntuples
- zPt is calculated from two opposite sign muons with invariant mass closest to Z mass
- zPt is set to -999. if there are not 2 opposite signed PF muons with dM < 30 GeV