### PR TITLE
HLTTauDQMOffline_cfi: commented out obsolete discriminators

### DIFF
--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -10,9 +10,6 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             PFTauDiscriminatorContainerWPs  = cms.untracked.vstring(),
                             PFTauDiscriminators = cms.untracked.VInputTag(
                                     cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
-                                    #cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
-                                    #cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"),
-                                    #cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection")
                             ),
                             doPFTaus = cms.untracked.bool(True),
                             ptMin = cms.untracked.double(15.0),

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -9,10 +9,10 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             PFTauDiscriminatorContainers  = cms.untracked.VInputTag(),
                             PFTauDiscriminatorContainerWPs  = cms.untracked.vstring(),
                             PFTauDiscriminators = cms.untracked.VInputTag(
-                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding"),
-                                    cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
-                                    cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"),
-                                    cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection")
+                                    cms.InputTag("hpsPFTauDiscriminationByDecayModeFinding")
+                                    #cms.InputTag("hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr3Hits"),
+                                    #cms.InputTag("hpsPFTauDiscriminationByLooseMuonRejection3"),
+                                    #cms.InputTag("hpsPFTauDiscriminationByMVA6TightElectronRejection")
                             ),
                             doPFTaus = cms.untracked.bool(True),
                             ptMin = cms.untracked.double(15.0),


### PR DESCRIPTION
#### PR description:
HLTTauDQM offline reference object selection contained obsolete discriminators not available in RAW-RECO any more. Commented them out.

Expected change: DQM plots made with fake taus, instead of just being empty.
