### PR TITLE
Remove consumesMany and related code from the Framework

### DIFF
--- a/DQMServices/Components/plugins/DQMFileSaver.cc
+++ b/DQMServices/Components/plugins/DQMFileSaver.cc
@@ -64,8 +64,6 @@ private:
   // needed only for the harvesting step when saving in the endJob
   int irun_;
 
-  // We want to consume all DQMTokens for runs and jobs. But consumesMany is
-  // confused by the labels, so we sue these getters.
   edm::GetterOfProducts<DQMToken> jobmegetter_;
   edm::GetterOfProducts<DQMToken> runmegetter_;
 };

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -136,7 +136,6 @@ namespace edm {
 
       ProductResolverIndex index(unsigned int i) const;
       unsigned int numberOfMatches() const { return numberOfMatches_; }
-      bool isFullyResolved(unsigned int i) const;
       char const* moduleLabel(unsigned int i) const;
       char const* productInstanceName(unsigned int i) const;
       char const* processName(unsigned int i) const;

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -137,14 +137,6 @@ namespace edm {
     return productResolverIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].index();
   }
 
-  bool ProductResolverIndexHelper::Matches::isFullyResolved(unsigned int i) const {
-    if (i >= numberOfMatches_) {
-      throw Exception(errors::LogicError)
-          << "ProductResolverIndexHelper::Matches::isFullyResolved - Argument is out of range.\n";
-    }
-    return (productResolverIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].startInProcessNames() != 0U);
-  }
-
   char const* ProductResolverIndexHelper::Matches::processName(unsigned int i) const {
     if (i >= numberOfMatches_) {
       throw Exception(errors::LogicError)

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
@@ -126,8 +126,6 @@ void TestProductResolverIndexHelper::testOneEntry() {
   CPPUNIT_ASSERT(matches.numberOfMatches() == 2);
   CPPUNIT_ASSERT(matches.index(0) == indexEmptyProcess);
   CPPUNIT_ASSERT(matches.index(1) == indexWithProcess);
-  CPPUNIT_ASSERT(matches.isFullyResolved(0) == false);
-  CPPUNIT_ASSERT(matches.isFullyResolved(1) == true);
 
   matches = helper.relatedIndexes(PRODUCT_TYPE, typeID_EventID);
   CPPUNIT_ASSERT(matches.numberOfMatches() == 0);

--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -80,18 +80,6 @@ namespace edm {
       return m_consumer->mayConsume<B>(id, tag);
     }
 
-    template <typename ProductType, BranchType B = InEvent>
-    void consumesMany() {
-      m_consumer->consumesMany<ProductType, B>();
-    }
-
-    void consumesMany(const TypeToGet& id) { m_consumer->consumesMany(id); }
-
-    template <BranchType B>
-    void consumesMany(const TypeToGet& id) {
-      m_consumer->consumesMany<B>(id);
-    }
-
     // For consuming event-setup products
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
     auto esConsumes() {

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -97,8 +97,6 @@ namespace edm {
     ///\return true if the product corresponding to the index was registered via consumes or mayConsume call
     bool registeredToConsume(ProductResolverIndex, bool, BranchType) const;
 
-    ///\return true of TypeID corresponds to a type specified in a consumesMany call
-    bool registeredToConsumeMany(TypeID const&, BranchType) const;
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
@@ -188,19 +186,6 @@ namespace edm {
     template <BranchType B>
     EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
       return EDGetToken{recordConsumes(B, id, checkIfEmpty(tag), false)};
-    }
-
-    template <typename ProductType, BranchType B = InEvent>
-    void consumesMany() {
-      TypeToGet tid = TypeToGet::make<ProductType>();
-      consumesMany<B>(tid);
-    }
-
-    void consumesMany(const TypeToGet& id) { consumesMany<InEvent>(id); }
-
-    template <BranchType B>
-    void consumesMany(const TypeToGet& id) {
-      recordConsumes(B, id, edm::InputTag{}, true);
     }
 
     // For consuming event-setup products

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -529,11 +529,7 @@ namespace edm {
 
   template <typename PROD>
   void Event::getManyByType(std::vector<Handle<PROD>>& results) const {
-    provRecorder_.getManyByType(results, moduleCallingContext_);
-    for (typename std::vector<Handle<PROD>>::const_iterator it = results.begin(), itEnd = results.end(); it != itEnd;
-         ++it) {
-      addToGotBranchIDs(*it->provenance());
-    }
+    principal_get_adapter_detail::throwGetManyByType();
   }
 
   template <typename PROD>

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -101,9 +101,6 @@ namespace edm {
     template <typename PROD>
     PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
 
-    template <typename PROD>
-    void getManyByType(std::vector<Handle<PROD>>& results) const;
-
     Run const& getRun() const {
       if (not run_) {
         fillRun();
@@ -361,14 +358,6 @@ namespace edm {
     }
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return *convert_handle<PROD>(std::move(bh));
-  }
-
-  template <typename PROD>
-  void LuminosityBlock::getManyByType(std::vector<Handle<PROD>>& results) const {
-    if (!provRecorder_.checkIfComplete<PROD>()) {
-      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)));
-    }
-    return provRecorder_.getManyByType(results, moduleCallingContext_);
   }
 
   // Free functions to retrieve a collection from the LuminosityBlock.

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -131,12 +131,6 @@ namespace edm {
                        ServiceToken const& token,
                        ModuleCallingContext const* mcc) const;
 
-    void getManyByType(TypeID const& typeID,
-                       BasicHandleVec& results,
-                       EDConsumerBase const* consumes,
-                       SharedResourcesAcquirer* sra,
-                       ModuleCallingContext const* mcc) const;
-
     ProcessHistory const& processHistory() const { return *processHistoryPtr_; }
 
     ProcessHistoryID const& processHistoryID() const { return processHistoryID_; }
@@ -244,12 +238,6 @@ namespace edm {
     OptionalThinnedKey getThinnedKeyFrom(ProductID const& parent,
                                          unsigned int key,
                                          ProductID const& thinned) const override;
-
-    void findProducts(std::vector<ProductResolverBase const*> const& holders,
-                      TypeID const& typeID,
-                      BasicHandleVec& results,
-                      SharedResourcesAcquirer* sra,
-                      ModuleCallingContext const* mcc) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -124,9 +124,9 @@ namespace edm {
                               TypeID const& productType,
                               std::string const& moduleLabel,
                               std::string const& productInstanceName);
-    void throwOnPrematureRead(char const* principalType, TypeID const& productType);
 
     void throwOnPrematureRead(char const* principalType, TypeID const& productType, EDGetToken);
+    void throwGetManyByType();
 
   }  // namespace principal_get_adapter_detail
   class PrincipalGetAdapter {
@@ -156,9 +156,6 @@ namespace edm {
     bool checkIfComplete() const;
 
     Transition transition() const;
-
-    template <typename PROD>
-    void getManyByType(std::vector<Handle<PROD> >& results, ModuleCallingContext const* mcc) const;
 
     ProcessHistory const& processHistory() const;
 
@@ -209,8 +206,6 @@ namespace edm {
                                             std::string const& instance,
                                             std::string const& process,
                                             ModuleCallingContext const* mcc) const;
-
-    void getManyByType_(TypeID const& tid, BasicHandleVec& results, ModuleCallingContext const* mcc) const;
 
     // Also isolates the PrincipalGetAdapter class
     // from the Principal class.
@@ -315,34 +310,5 @@ namespace edm {
     return isComplete() || !detail::has_mergeProduct_function<PROD>::value;
   }
 
-  template <typename PROD>
-  inline void PrincipalGetAdapter::getManyByType(std::vector<Handle<PROD> >& results,
-                                                 ModuleCallingContext const* mcc) const {
-    BasicHandleVec bhv;
-    this->getManyByType_(TypeID(typeid(PROD)), bhv, mcc);
-
-    // Go through the returned handles; for each element,
-    //   1. create a Handle<PROD> and
-    //
-    // This function presents an exception safety difficulty. If an
-    // exception is thrown when converting a handle, the "got
-    // products" record will be wrong.
-    //
-    // Since EDProducers are not allowed to use this function,
-    // the problem does not seem too severe.
-    //
-    // Question: do we even need to keep track of the "got products"
-    // for this function, since it is *not* to be used by EDProducers?
-    std::vector<Handle<PROD> > products;
-
-    typename BasicHandleVec::iterator it = bhv.begin();
-    typename BasicHandleVec::iterator end = bhv.end();
-
-    while (it != end) {
-      products.push_back(convert_handle<PROD>(std::move(*it)));
-      ++it;
-    }
-    results.swap(products);
-  }
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -362,10 +362,7 @@ namespace edm {
 
   template <typename PROD>
   void Run::getManyByType(std::vector<Handle<PROD>>& results) const {
-    if (!provRecorder_.checkIfComplete<PROD>()) {
-      principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)));
-    }
-    return provRecorder_.getManyByType(results, moduleCallingContext_);
+    principal_get_adapter_detail::throwGetManyByType();
   }
 
   // Free functions to retrieve a collection from the Run.

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -91,13 +91,6 @@ namespace edm {
   }
 
   namespace {
-    void failedToRegisterConsumesMany(edm::TypeID const& iType) {
-      cms::Exception exception("GetManyWithoutRegistration");
-      exception << "::getManyByType called for " << iType
-                << " without a corresponding consumesMany being called for this module. \n";
-      throw exception;
-    }
-
     void failedToRegisterConsumes(KindOfType kindOfType,
                                   TypeID const& productType,
                                   std::string const& moduleLabel,
@@ -652,101 +645,6 @@ namespace edm {
     auto const& productResolver = productResolvers_.at(index);
     assert(nullptr != productResolver.get());
     productResolver->prefetchAsync(task, *this, skipCurrentProcess, token, nullptr, mcc);
-  }
-
-  void Principal::getManyByType(TypeID const& typeID,
-                                BasicHandleVec& results,
-                                EDConsumerBase const* consumer,
-                                SharedResourcesAcquirer* sra,
-                                ModuleCallingContext const* mcc) const {
-    // Not implemented for ProcessBlocks
-    assert(branchType_ != InProcess);
-
-    assert(results.empty());
-
-    if (UNLIKELY(consumer and (not consumer->registeredToConsumeMany(typeID, branchType())))) {
-      failedToRegisterConsumesMany(typeID);
-    }
-
-    // This finds the indexes to all the ProductResolver's matching the type
-    ProductResolverIndexHelper::Matches matches = productLookup().relatedIndexes(PRODUCT_TYPE, typeID);
-
-    if (matches.numberOfMatches() == 0) {
-      return;
-    }
-
-    results.reserve(matches.numberOfMatches());
-
-    // Loop over the ProductResolvers. Add the products that are actually
-    // present into the results. This will also trigger delayed reading,
-    // on demand production, and check for deleted products as appropriate.
-
-    // Over the years the code that uses getManyByType has grown to depend
-    // on the ordering of the results. The order originally was just an
-    // accident of how previous versions of the code were written, but
-    // here we have to go through some extra effort to preserve that ordering.
-
-    // We build a list of holders that match a particular label and instance.
-    // When that list is complete we call findProducts, which loops over
-    // that list in reverse order of the ProcessHistory (starts with the
-    // most recent).  Then we clear the list and repeat this until all the
-    // matching label and instance subsets have been dealt with.
-
-    // Note that the function isFullyResolved returns true for the ProductResolvers
-    // that are associated with an empty process name. Those are the ones that
-    // know how to search for the most recent process name matching
-    // a label and instance. We do not need these for getManyByType and
-    // skip them. In addition to skipping them, we make use of the fact
-    // that they mark the beginning of each subset of holders with the same
-    // label and instance. They tell us when to call findProducts.
-
-    std::vector<ProductResolverBase const*> holders;
-
-    for (unsigned int i = 0; i < matches.numberOfMatches(); ++i) {
-      ProductResolverIndex index = matches.index(i);
-
-      if (!matches.isFullyResolved(i)) {
-        if (!holders.empty()) {
-          // Process the ones with a particular module label and instance
-          findProducts(holders, typeID, results, sra, mcc);
-          holders.clear();
-        }
-      } else {
-        ProductResolverBase const* productResolver = productResolvers_.at(index).get();
-        assert(productResolver);
-        holders.push_back(productResolver);
-      }
-    }
-    // Do not miss the last subset of products
-    if (!holders.empty()) {
-      findProducts(holders, typeID, results, sra, mcc);
-    }
-    return;
-  }
-
-  void Principal::findProducts(std::vector<ProductResolverBase const*> const& holders,
-                               TypeID const&,
-                               BasicHandleVec& results,
-                               SharedResourcesAcquirer* sra,
-                               ModuleCallingContext const* mcc) const {
-    for (auto iter = processHistoryPtr_->rbegin(), iEnd = processHistoryPtr_->rend(); iter != iEnd; ++iter) {
-      std::string const& process = iter->processName();
-      for (auto productResolver : holders) {
-        BranchDescription const& bd = productResolver->branchDescription();
-        if (process == bd.processName()) {
-          // Ignore aliases to avoid matching the same product multiple times.
-          if (bd.isAnyAlias()) {
-            continue;
-          }
-
-          ProductData const* productData = productResolver->resolveProduct(*this, false, sra, mcc).data();
-          if (productData) {
-            // Skip product if not available.
-            results.emplace_back(productData->wrapper(), &(productData->provenance()));
-          }
-        }
-      }
-    }
   }
 
   ProductData const* Principal::findProductByLabel(KindOfType kindOfType,

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -64,19 +64,18 @@ namespace edm {
                              << "'.\n";
   }
 
-  void principal_get_adapter_detail::throwOnPrematureRead(char const* principalType, TypeID const& productType) {
-    //throw Exception(errors::LogicError)
-    LogWarning("LogicError") << "::getManyByType: An attempt was made to read a " << principalType
-                             << " product before end" << principalType << "() was called.\n"
-                             << "The product is of type '" << productType << "'.\n";
-  }
-
   void principal_get_adapter_detail::throwOnPrematureRead(char const* principalType,
                                                           TypeID const& productType,
                                                           EDGetToken token) {
     throw Exception(errors::LogicError) << "::getByToken: An attempt was made to read a " << principalType
                                         << " product before end" << principalType << "() was called.\n"
                                         << "The index of the token was " << token.index() << ".\n";
+  }
+
+  void principal_get_adapter_detail::throwGetManyByType() {
+    throw Exception(errors::LogicError)
+        << "The getManyByType function is no longer supported. "
+        << "Consider upgrading to use GetterOfProducts instead or delete this function call.\n";
   }
 
   size_t PrincipalGetAdapter::numberOfProductsConsumed() const { return consumer_->itemsToGetFrom(InEvent).size(); }
@@ -186,12 +185,6 @@ namespace edm {
                                                                ModuleCallingContext const* mcc) const {
     auto h = principal_.getByLabel(ELEMENT_TYPE, typeID, label, instance, process, consumer_, resourcesAcquirer_, mcc);
     return h;
-  }
-
-  void PrincipalGetAdapter::getManyByType_(TypeID const& tid,
-                                           BasicHandleVec& results,
-                                           ModuleCallingContext const* mcc) const {
-    principal_.getManyByType(tid, results, consumer_, resourcesAcquirer_, mcc);
   }
 
   ProcessHistory const& PrincipalGetAdapter::processHistory() const { return principal_.processHistory(); }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -370,10 +370,7 @@ test name="TestFWCoreFrameworkDeleteEarly" command="test_deleteEarly.sh"/>
 <test name="testFWCoreFrameworkConditionalTask_testView" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView"/>
 <test name="testFWCoreFrameworkConditionalTask_testView_testAlias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias"/>
 <test name="testFWCoreFrameworkConditionalTask_testView_testAlias_aliasWithStar" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias --aliasWithStar"/>
-<test name="testFWCoreFrameworkConditionalTask_testConsumesMany" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testConsumesMany"/>
 <test name="testFWCoreFrameworkModuleSynchLumiBoundary" command="run_module_synch_lumiboundary.sh"/>
-<test name="testFWCoreFrameworkGetByType_consumesMany" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_get_by_type_cfg.py -- --useConsumesMany"/>
-<test name="testFWCoreFrameworkGetByType_consumesMany_alias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_get_by_type_cfg.py -- --useConsumesMany --useEDAlias"/>
 <test name="testFWCoreFrameworkGetByType_getterOfProduct" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_get_by_type_cfg.py"/>
 <test name="testFWCoreFrameworkGetByType_getterOfProduct_alias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_get_by_type_cfg.py -- --useEDAlias"/>
 

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -105,7 +105,6 @@ class testEvent : public CppUnit::TestFixture {
   CPPUNIT_TEST(getByToken);
   CPPUNIT_TEST(getHandle);
   CPPUNIT_TEST(get_product);
-  CPPUNIT_TEST(getManyByType);
   CPPUNIT_TEST(printHistory);
   CPPUNIT_TEST(deleteProduct);
   CPPUNIT_TEST_SUITE_END();
@@ -130,7 +129,6 @@ public:
   void getByToken();
   void getHandle();
   void get_product();
-  void getManyByType();
   void printHistory();
   void deleteProduct();
 
@@ -971,44 +969,6 @@ void testEvent::get_product() {
   CPPUNIT_ASSERT(currentEvent_->get(modMultiInt2EarlyToken).value == 2);
 
   CPPUNIT_ASSERT(currentEvent_->get(modOneToken).value == 4);
-}
-
-void testEvent::getManyByType() {
-  typedef edmtest::IntProduct product_t;
-  typedef std::unique_ptr<product_t> ap_t;
-  typedef Handle<product_t> handle_t;
-  typedef std::vector<handle_t> handle_vec;
-
-  ap_t one(new product_t(1));
-  ap_t two(new product_t(2));
-  ap_t three(new product_t(3));
-  ap_t four(new product_t(4));
-  addProduct(std::move(one), "int1_tag", "int1");
-  addProduct(std::move(two), "int2_tag", "int2");
-  addProduct(std::move(three), "int3_tag");
-  addProduct(std::move(four), "nolabel_tag");
-
-  auto ap_vthing = std::make_unique<std::vector<edmtest::Thing>>();
-  addProduct(std::move(ap_vthing), "thing", "");
-
-  auto ap_vthing2 = std::make_unique<std::vector<edmtest::Thing>>();
-  addProduct(std::move(ap_vthing2), "thing2", "inst2");
-
-  ap_t oneHundred(new product_t(100));
-  addProduct(std::move(oneHundred), "int1_tag_late", "int1");
-
-  auto twoHundred = std::make_unique<edmtest::IntProduct>(200);
-  putProduct(std::move(twoHundred), "int1");
-
-  CPPUNIT_ASSERT(currentEvent_->size() == 8);
-
-  handle_vec handles;
-  currentEvent_->getManyByType(handles);
-  CPPUNIT_ASSERT(handles.size() == 6);
-  int sum = 0;
-  for (int k = 0; k < 6; ++k)
-    sum += handles[k]->value;
-  CPPUNIT_ASSERT(sum == 310);
 }
 
 void testEvent::printHistory() {

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -36,7 +36,6 @@ public:
   CPPUNIT_TEST_SUITE(TestEDConsumerBase);
   CPPUNIT_TEST(testRegularType);
   CPPUNIT_TEST(testViewType);
-  CPPUNIT_TEST(testMany);
   CPPUNIT_TEST(testMay);
   CPPUNIT_TEST_SUITE_END();
 
@@ -46,7 +45,6 @@ public:
 
   void testRegularType();
   void testViewType();
-  void testMany();
   void testMay();
 };
 
@@ -428,57 +426,6 @@ void TestEDConsumerBase::testViewType() {
 
       CPPUNIT_ASSERT(0 == indices.size());
     }
-  }
-}
-
-namespace {
-  class ManyEventIDConsumer : public edm::EDConsumerBase {
-  public:
-    ManyEventIDConsumer() { consumesMany<edm::EventID>(); }
-  };
-}  // namespace
-
-void TestEDConsumerBase::testMany() {
-  edm::ProductResolverIndexHelper helper;
-
-  edm::TypeID typeIDProductID(typeid(edm::ProductID));
-  edm::TypeID typeIDEventID(typeid(edm::EventID));
-  edm::TypeID typeIDVectorInt(typeid(std::vector<int>));
-  edm::TypeID typeIDSetInt(typeid(std::set<int>));
-  edm::TypeID typeIDVSimpleDerived(typeid(std::vector<edmtest::SimpleDerived>));
-
-  helper.insert(typeIDVectorInt, "labelC", "instanceC", "processC");       // 0, 1, 2
-  helper.insert(typeIDVectorInt, "label", "instance", "process");          // 3, 4, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB");         // 6, 7
-  helper.insert(typeIDEventID, "label", "instanceB", "processB");          // 8, 9
-  helper.insert(typeIDEventID, "labelX", "instanceB", "processB");         // 10, 11
-  helper.insert(typeIDEventID, "labelB", "instance", "processB");          // 12, 13
-  helper.insert(typeIDEventID, "labelB", "instanceX", "processB");         // 14, 15
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB1");        // 16, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB3");        // 17, 5
-  helper.insert(typeIDEventID, "labelB", "instanceB", "processB2");        // 18, 5
-  helper.insert(typeIDProductID, "label", "instance", "process");          // 19, 20
-  helper.insert(typeIDEventID, "label", "instance", "process");            // 21, 22
-  helper.insert(typeIDProductID, "labelA", "instanceA", "processA");       // 23, 24
-  helper.insert(typeIDSetInt, "labelC", "instanceC", "processC");          // 25, 26
-  helper.insert(typeIDVSimpleDerived, "labelC", "instanceC", "processC");  // 27, 28, 29, 30
-
-  helper.setFrozen();
-
-  edm::TypeID typeID_EventID(typeid(edm::EventID));
-
-  const auto productIndex = helper.index(edm::PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB", "processB");
-
-  {
-    ManyEventIDConsumer consumer{};
-    consumer.updateLookup(edm::InEvent, helper, false);
-
-    std::vector<edm::ProductResolverIndexAndSkipBit> indices;
-    consumer.itemsToGet(edm::InEvent, indices);
-
-    CPPUNIT_ASSERT(9 == indices.size());
-    CPPUNIT_ASSERT(indices.end() !=
-                   std::find(indices.begin(), indices.end(), edm::ProductResolverIndexAndSkipBit(productIndex, false)));
   }
 }
 

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -45,7 +45,6 @@ class test_ep : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(test_ep);
   CPPUNIT_TEST(failgetbyIdTest);
   CPPUNIT_TEST(failgetbyLabelTest);
-  CPPUNIT_TEST(failgetManybyTypeTest);
   CPPUNIT_TEST(failgetbyInvalidIdTest);
   CPPUNIT_TEST(failgetProvenanceTest);
   CPPUNIT_TEST_SUITE_END();
@@ -55,7 +54,6 @@ public:
   void tearDown();
   void failgetbyIdTest();
   void failgetbyLabelTest();
-  void failgetManybyTypeTest();
   void failgetbyInvalidIdTest();
   void failgetProvenanceTest();
 
@@ -230,15 +228,6 @@ void test_ep::failgetbyLabelTest() {
   edm::BasicHandle h(
       pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr, nullptr));
   CPPUNIT_ASSERT(h.failedToGet());
-}
-
-void test_ep::failgetManybyTypeTest() {
-  edmtest::IntProduct dummy;
-  edm::TypeID tid(dummy);
-  std::vector<edm::BasicHandle> handles;
-
-  pEvent_->getManyByType(tid, handles, nullptr, nullptr, nullptr);
-  CPPUNIT_ASSERT(handles.empty());
 }
 
 void test_ep::failgetbyInvalidIdTest() {

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -302,14 +302,17 @@ namespace edmtest {
   class ConsumingIntProducer : public edm::stream::EDProducer<> {
   public:
     explicit ConsumingIntProducer(edm::ParameterSet const& p)
-        : token_{produces<IntProduct>()}, value_(p.getParameter<int>("ivalue")) {
+        : getterOfTriggerResults_(edm::TypeMatch(), this),
+          token_{produces<IntProduct>()},
+          value_(p.getParameter<int>("ivalue")) {
       // not used, only exists to test PathAndConsumesOfModules
       consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
-      consumesMany<edm::TriggerResults>();
+      callWhenNewProductsRegistered(getterOfTriggerResults_);
     }
     void produce(edm::Event& e, edm::EventSetup const& c) override;
 
   private:
+    edm::GetterOfProducts<edm::TriggerResults> getterOfTriggerResults_;
     const edm::EDPutTokenT<IntProduct> token_;
     const int value_;
   };
@@ -487,36 +490,25 @@ namespace edmtest {
 
   class AddAllIntsProducer : public edm::global::EDProducer<> {
   public:
-    explicit AddAllIntsProducer(edm::ParameterSet const& p)
-        : putToken_{produces()}, useConsumesMany_(p.getUntrackedParameter<bool>("useConsumesMany")) {
-      if (useConsumesMany_) {
-        consumesMany<IntProduct>();
-      } else {
-        getter_ = edm::GetterOfProducts<IntProduct>(edm::TypeMatch(), this);
-        callWhenNewProductsRegistered(*getter_);
-      }
+    explicit AddAllIntsProducer(edm::ParameterSet const& p) : putToken_{produces()} {
+      getter_ = edm::GetterOfProducts<IntProduct>(edm::TypeMatch(), this);
+      callWhenNewProductsRegistered(*getter_);
     }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.addUntracked<bool>("useConsumesMany", true);
       descriptions.addDefault(desc);
     }
 
   private:
     const edm::EDPutTokenT<int> putToken_;
     std::optional<edm::GetterOfProducts<IntProduct>> getter_;
-    bool useConsumesMany_;
   };
 
   void AddAllIntsProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
     std::vector<edm::Handle<IntProduct>> ints;
-    if (useConsumesMany_) {
-      e.getManyByType(ints);
-    } else {
-      getter_->fillHandles(e, ints);
-    }
+    getter_->fillHandles(e, ints);
 
     int value = 0;
     for (auto const& i : ints) {

--- a/FWCore/Framework/test/test_conditionaltasks_cfg.py
+++ b/FWCore/Framework/test/test_conditionaltasks_cfg.py
@@ -10,7 +10,6 @@ parser.add_argument("--reverseDependencies", help="Switch the order of dependenc
 parser.add_argument("--testAlias", help="Get data from an alias", action="store_true")
 parser.add_argument("--testView", help="Get data via a view", action="store_true")
 parser.add_argument("--aliasWithStar", help="when using testAlias use '*' as type", action="store_true")
-parser.add_argument("--testConsumesMany", help="use ConsumesMany", action="store_true")
 
 argv = sys.argv[:]
 if '--' in argv:
@@ -33,9 +32,6 @@ process.d = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTa
 process.e = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d")))
 
 process.prodOnPath = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d"), cms.InputTag("e")))
-
-if args.testConsumesMany:
-  process.prodOnPath = cms.EDProducer("AddAllIntsProducer")
 
 if args.filterSucceeds:
     threshold = 1
@@ -79,7 +75,7 @@ if args.testAlias:
 process.p = cms.Path(process.f1+process.prodOnPath+process.f2+process.f3, cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e, process.f))
 
 process.tst = cms.EDAnalyzer("IntTestAnalyzer", moduleLabel = cms.untracked.InputTag("f"), valueMustMatch = cms.untracked.int32(3), 
-                                                       valueMustBeMissing = cms.untracked.bool(not args.filterSucceeds and not args.testConsumesMany))
+                                                       valueMustBeMissing = cms.untracked.bool(not args.filterSucceeds))
 
 process.endp = cms.EndPath(process.tst)
 

--- a/FWCore/Framework/test/test_get_by_type_cfg.py
+++ b/FWCore/Framework/test/test_get_by_type_cfg.py
@@ -4,7 +4,6 @@ import argparse
 import sys
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test getting many DataProducts just by type.')
-parser.add_argument("--useConsumesMany", action="store_true", help="use consumesMany instead of GetterOfProducts")
 parser.add_argument("--useEDAlias", action="store_true", help="add an EDAlias for one of the modules")
 
 argv = sys.argv[:]
@@ -27,11 +26,7 @@ if args.useEDAlias:
     process.d = cms.EDAlias(a = cms.VPSet(cms.PSet(type = cms.string('*'))))
     print("turned on useEDAlias")
 
-useConsumesMany = False
-if args.useConsumesMany:
-    useConsumesMany = True
-    print("turned on useConsumesMany")
-process.add = cms.EDProducer("AddAllIntsProducer", useConsumesMany = cms.untracked.bool(useConsumesMany))
+process.add = cms.EDProducer("AddAllIntsProducer")
 
 process.test = cms.EDAnalyzer("BuiltinIntTestAnalyzer",
                               valueMustMatch = cms.untracked.int32(111),

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -127,7 +127,7 @@ For products only read from previous processes, 'skip current process' is added
   IntProducer/'intProducerE'
   ConsumingIntProducer/'testManyConsumingProducer' consumes:
     edm::TriggerResults 'TriggerResults' '' ''
-    edm::TriggerResults '' '' ''
+    edm::TriggerResults 'TriggerResults' '' 'PROD1'
   PoolOutputModule/'out' consumes:
     edm::TriggerResults 'TriggerResults' '' 'PROD1'
     edmtest::IntProduct 'aliasForInt' '' 'PROD1'
@@ -436,7 +436,9 @@ For products only read from previous processes, 'skip current process' is added
     edmtest::IntProduct 'intProducerEndProcessBlock' '' 'COPY', processBlock
   ConsumingIntProducer/'testManyConsumingProducer' consumes:
     edm::TriggerResults 'TriggerResults' '' ''
-    edm::TriggerResults '' '' ''
+    edm::TriggerResults 'TriggerResults' '' 'COPY'
+    edm::TriggerResults 'TriggerResults' '' 'PROD1'
+    edm::TriggerResults 'TriggerResults' '' 'PROD2'
   TestOneOutput/'testOneOutput' consumes:
     edm::TriggerResults 'TriggerResults' '' 'COPY'
     edm::TriggerResults 'TriggerResults' '' 'PROD1'

--- a/FWCore/ServiceRegistry/interface/ConsumesInfo.h
+++ b/FWCore/ServiceRegistry/interface/ConsumesInfo.h
@@ -41,10 +41,6 @@ namespace edm {
     bool skipCurrentProcess() const { return skipCurrentProcess_; }
 
     // This provides information from EDConsumerBase
-    // There a couple cases that need explanation.
-    //
-    // consumesMany
-    //    The label, instance and process are all empty.
     //
     // process is empty - A get will search over processes in reverse
     //    time order (unknown which process the product will be gotten

--- a/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
+++ b/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
@@ -57,7 +57,7 @@ namespace edm {
     // they produce (they might or might not really produce) at least one
     // product in the event (not run, not lumi) that the module corresponding
     // to the moduleID argument declares it consumes (includes declarations using
-    // consumes, maybeConsumes, or consumesMany). Note that if a module declares
+    // consumes or maybeConsumes). Note that if a module declares
     // it consumes a module label that is an EDAlias, the corresponding module
     // description will be included in the returned vector (but the label in the
     // module description is not the EDAlias label).


### PR DESCRIPTION
#### PR description:

Remove consumesMany from the Framework. Also remove related code.

All uses of consumesMany outside the Framework were removed by previous PRs. This PR should not affect anything other than Framework tests which were the only thing left using consumesMany. In this PR, if a Framework unit test was using consumesMany to test something else, then the test was converted to use GetterOfProducts. Tests whose purpose was to test getManyByType and consumesMany were deleted.

Note that there is code outside of the Framework that still contains the getManyByType calls and I couldn't delete getManyByType from the Event or Run yet. I plan to do that in a future PR. All such code has been broken since 2015 when we implemented code that would detect calls to getManyByType without a consumesMany call. All of the code still containing getManyByType calls does not call consumesMany. Since 2015, it would have thrown an exception if executed. 

There is one other thing I was reminded of as I worked on this PR. This potential issue does not affect anything in this PR, but I thought it was worth mentioning. One difference between GetterOfProducts and getManyByType is that the vector of products in getManyByType is ordered (each type/label/instance group in reverse process history order) and the one from GetterOfProducts is not. It is possible some previously migrated code could have a problem with that if the same type, module label, and instance was available from difference processes. I am not aware of any such problem... The client of GetterOfProducts should deal with this possibility (that is the design). If it ever became an actual problem we could add a sorting step (maybe optional) in GetterOfProducts.

#### PR validation:

Existing tests pass. There are not any new abilities to test in this PR. This shouldn't change the output or behavior of anything in the RelVals or production.
