### PR TITLE
Making a new Secondary Dataset ReserveDMu

### DIFF
--- a/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
@@ -58,4 +58,5 @@ ReserveDMu.HLTPaths = cms.vstring(
 ReserveDMu.andOr = cms.bool( True )
 # we want to intentionally throw and exception
 # in case it does not match one of the HLT Paths
-ReserveDMu.throw = cms.bool( True )
+# set to False now, switch to on once matrix is updated
+ReserveDMu.throw = cms.bool( False )

--- a/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+
+#Trigger bit requirement
+import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
+ReserveDMu = hlt.hltHighLevel.clone()
+ReserveDMu.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
+ReserveDMu.HLTPaths = cms.vstring(
+    'HLT_Dimuon0_Jpsi3p5_Muon2_v*',
+    'HLT_Dimuon0_Jpsi_L1_4R_0er1p5R_v*',
+    'HLT_Dimuon0_Jpsi_L1_NoOS_v*',
+    'HLT_Dimuon0_Jpsi_NoVertexing_L1_4R_0er1p5R_v*',
+    'HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*',
+    'HLT_Dimuon0_Jpsi_NoVertexing_v*',
+    'HLT_Dimuon0_Jpsi_v*',
+    'HLT_Dimuon0_LowMass_L1_0er1p5R_v*',
+    'HLT_Dimuon0_LowMass_L1_0er1p5_v*',
+    'HLT_Dimuon0_LowMass_L1_4R_v*',
+    'HLT_Dimuon0_LowMass_L1_4_v*',
+    'HLT_Dimuon0_LowMass_L1_TM530_v*',
+    'HLT_Dimuon0_LowMass_v*',
+    'HLT_Dimuon0_Upsilon_L1_4p5_v*',
+    'HLT_Dimuon0_Upsilon_L1_4p5er2p0M_v*',
+    'HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*',
+    'HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*',
+    'HLT_Dimuon0_Upsilon_NoVertexing_v*',
+    'HLT_Dimuon12_Upsilon_y1p4_v*',
+    'HLT_Dimuon14_Phi_Barrel_Seagulls_v*',
+    'HLT_Dimuon18_PsiPrime_noCorrL1_v*',
+    'HLT_Dimuon18_PsiPrime_v*',
+    'HLT_Dimuon24_Phi_noCorrL1_v*',
+    'HLT_Dimuon24_Upsilon_noCorrL1_v*',
+    'HLT_Dimuon25_Jpsi_noCorrL1_v*',
+    'HLT_Dimuon25_Jpsi_v*',
+    'HLT_DoubleMu2_Jpsi_DoubleTrk1_Phi1p05_v*',
+    'HLT_DoubleMu3_DoubleEle7p5_CaloIdL_TrackIdL_Upsilon_v*',
+    'HLT_DoubleMu3_TkMu_DsTau3Mu_v*',
+    'HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*',
+    'HLT_DoubleMu3_Trk_Tau3mu_v*',
+    'HLT_DoubleMu4_3_Bs_v*',
+    'HLT_DoubleMu4_3_Jpsi_v*',
+    'HLT_DoubleMu4_JpsiTrkTrk_Displaced_v*',
+    'HLT_DoubleMu4_Jpsi_Displaced_v*',
+    'HLT_DoubleMu4_Jpsi_NoVertexing_v*',
+    'HLT_DoubleMu4_MuMuTrk_Displaced_v*',
+    'HLT_DoubleMu5_Upsilon_DoubleEle3_CaloIdL_TrackIdL_v*',
+    'HLT_Mu25_TkMu0_Phi_v*',
+    'HLT_Mu30_TkMu0_Psi_v*',
+    'HLT_Mu30_TkMu0_Upsilon_v*',
+    'HLT_Mu4_L1DoubleMu_v*',
+    'HLT_Mu7p5_L2Mu2_Jpsi_v*',
+    'HLT_Mu7p5_L2Mu2_Upsilon_v*',
+    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_v*',
+    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*',
+    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_v*',
+    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_v*',
+    'HLT_Trimuon5_3p5_2_Upsilon_Muon_v*',
+    'HLT_TrimuonOpen_5_3p5_2_Upsilon_Muon_v*')
+ReserveDMu.andOr = cms.bool( True )
+# we want to intentionally throw and exception
+# in case it does not match one of the HLT Paths
+ReserveDMu.throw = cms.bool( True )

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -156,6 +156,19 @@ SKIMStreamHSCPSD = cms.FilteredStream(
 
 #####################
 
+from Configuration.Skimming.PDWG_ReserveDMu_SD_cff import *
+ReserveDMuPath = cms.Path(ReserveDMu)
+SKIMStreamReserveDMu = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'ReserveDMu',
+    paths = (ReserveDMuPath),
+    content = skimRawContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW')
+    )
+
+#####################
+
 from Configuration.Skimming.PDWG_DiPhoton_SD_cff import *
 CaloIdIsoPhotonPairsPath = cms.Path(CaloIdIsoPhotonPairsFilter)
 R9IdPhotonPairsPath = cms.Path(R9IdPhotonPairsFilter)

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -17,6 +17,14 @@ autoSkim = {
  'ZeroBias' : 'LogError+LogErrorMonitor',
  'Commissioning' : 'EcalActivity+LogError+LogErrorMonitor',
  'Cosmics':'CosmicSP+CosmicTP+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass0': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass1': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass2': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass3': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass4': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass5': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass6': 'ReserveDMu+LogError+LogErrorMonitor',
+ 'ParkingDoubleMuonLowMass7': 'ReserveDMu+LogError+LogErrorMonitor',
 
  # These should be uncommented when 2022 data reprocessing
  # Dedicated skim for 2022

--- a/Configuration/Skimming/test/test_ReserveDMu_SD_cfg.py
+++ b/Configuration/Skimming/test/test_ReserveDMu_SD_cfg.py
@@ -1,0 +1,147 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: SKIM --filein file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2023/ParkingDoubleMuonLowMass0/RAW/v9121550/000/368/389/00000/fce19dd3-8384-45ce-b705-e4accb9c3ec9.root --fileout file:SD_ReservedDMu.root --nThreads 8 --no_exec --number 10 --python_filename SD_ReserveDMu_cfg.py --scenario pp --step SKIM:ReserveDMu --data --conditions 130X_dataRun3_Prompt_v3
+import FWCore.ParameterSet.Config as cms
+
+
+
+process = cms.Process('SKIM')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Skims_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2023/ParkingDoubleMuonLowMass0/RAW/v9121550/000/368/389/00000/fce19dd3-8384-45ce-b705-e4accb9c3ec9.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('SKIM nevts:10'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string(''),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:SD_ReservedDMu.root'),
+    outputCommands = process.RECOSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.SKIMStreamReserveDMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('ReserveDMuPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('RAW'),
+        filterName = cms.untracked.string('ReserveDMu')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('ReserveDMu.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep  FEDRawDataCollection_rawDataCollector_*_*',
+        'keep  FEDRawDataCollection_source_*_*',
+        'keep  FEDRawDataCollection_rawDataCollector_*_*',
+        'keep  FEDRawDataCollection_source_*_*',
+        'drop *_hlt*_*_*',
+        'keep FEDRawDataCollection_rawDataCollector_*_*',
+        'keep FEDRawDataCollection_source_*_*',
+        'keep GlobalObjectMapRecord_hltGtStage2ObjectMap_*_*',
+        'keep edmTriggerResults_*_*_*',
+        'keep triggerTriggerEvent_*_*_*',
+        'keep *_hltFEDSelectorL1_*_*',
+        'keep *_hltScoutingEgammaPacker_*_*',
+        'keep *_hltScoutingMuonPacker_*_*',
+        'keep *_hltScoutingPFPacker_*_*',
+        'keep *_hltScoutingPrimaryVertexPacker_*_*',
+        'keep *_hltScoutingTrackPacker_*_*',
+        'keep edmTriggerResults_*_*_*',
+        'drop *_MEtoEDMConverter_*_*',
+        'drop *_*_*_SKIM'
+    )
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '130X_dataRun3_Prompt_v3', '')
+
+# Path and EndPath definitions
+process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
+process.SKIMStreamReserveDMuOutPath = cms.EndPath(process.SKIMStreamReserveDMu)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.ReserveDMuPath,process.RECOSIMoutput_step,process.SKIMStreamReserveDMuOutPath)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 0
+
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
This PR is constrained at /Configuration/Skimming:

- creates Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py to make the HLT path selection for the new proposed SD. It is intended to run on the ParkingDoubleMuonLowMass PD
- creates a test file Configuration/Skimming/test/test_ReserveDMu_SD_cfg.py
- updates Configuration/Skimming/python/Skims_PDWG_cff.py with the desired data tier for the SD
- updates the Configuration/Skimming/python/autoSkim.py to be picked up automatically either in T0 or in further ReRECOS
