### PR TITLE
Remove pessimizing std::move from ModuleHolder and OutputModuleCommunicatorT

### DIFF
--- a/FWCore/Framework/interface/OutputModuleCommunicatorT.h
+++ b/FWCore/Framework/interface/OutputModuleCommunicatorT.h
@@ -77,7 +77,7 @@ namespace edm {
     ModuleDescription const& description() const override;
 
     static std::unique_ptr<edm::OutputModuleCommunicator> createIfNeeded(T* iMod) {
-      return std::move(impl::createCommunicatorIfNeeded(iMod));
+      return impl::createCommunicatorIfNeeded(iMod);
     }
 
   private:

--- a/FWCore/Framework/interface/maker/ModuleHolder.h
+++ b/FWCore/Framework/interface/maker/ModuleHolder.h
@@ -72,7 +72,7 @@ namespace edm {
       }
 
       std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator() override {
-        return std::move(OutputModuleCommunicatorT<T>::createIfNeeded(m_mod.get()));
+        return OutputModuleCommunicatorT<T>::createIfNeeded(m_mod.get());
       }
 
     private:


### PR DESCRIPTION
#### PR description:

Found with the new GCC 13 IB with warnings along
```
>> Compiling edm plugin /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gcc/13.1.0-b0f6b39400dd76b4515ac385c64dcf2b/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=130100 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DCMSSW_GIT_HASH='CMSSW_13_2_X_2023-06-23-1100' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_2_X_2023-06-23-1100' -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/pcre/8.43-6fe996eae26c6972a3d852725c7e182d/include -isystem/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/boost/1.80.0-5c3cd0aed897726626e426e21e65b7de/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/bz2lib/1.0.6-8cb9e8dbf533d0372bdbc604a9f400e9/include -isystem/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/clhep/2.4.6.4-30ed17af44b742b6d6d8fc380338a39b/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/gsl/2.6-88108d20f07ca7486479b194b660cac6/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/libuuid/2.34-931b8f7cb79988cdaba47734751862b4/include -isystem/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/lcg/root/6.28.05-8ce4470129b350c5ebc134e6b0d943ba/include -isystem/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/tbb/v2021.9.0-94a0fe89dab0d3bc19a63717d807635f/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/xz/5.2.5-5a34e6e33a922c4f0999910f6083cb61/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/zlib/1.2.11-87dd6c8e075611dd56ab3458199d1d67/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-ac70e8102067cce0fddcf376940b2e33/include/eigen3 -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/fmt/8.0.1-6de1a42395399bf0a31fbef0614fa68c/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/md5/1.0.0-4f4da6cbc05619129b561fe29078775f/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/OpenBLAS/0.3.15-04ca15644bdb1c8fac3dfa4cd3c49ca5/include -I/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/el9_amd64_gcc13/external/tinyxml2/6.2.0-d8ded327101083500cb9b0b06de4c5b2/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  -MMD -MF tmp/el9_amd64_gcc13/src/EventFilter/Phase2TrackerRawToDigi/plugins/EventFilterPhase2TrackerRawToDigiPlugins/Phase2TrackerDigiProducer.cc.d /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc -o tmp/el9_amd64_gcc13/src/EventFilter/Phase2TrackerRawToDigi/plugins/EventFilterPhase2TrackerRawToDigiPlugins/Phase2TrackerDigiProducer.cc.o
In file included from /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/WorkerMaker.h:10,
                 from /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/MakerMacros.h:5,
                 from /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerCommissioningDigiProducer.cc:30:
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h: In instantiation of 'std::unique_ptr<edm::OutputModuleCommunicator> edm::maker::ModuleHolderT<T>::createOutputModuleCommunicator() [with T = edm::global::EDProducerBase]':
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:74:49:   required from here
  /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:75:83: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    75 |         return std::move(OutputModuleCommunicatorT<T>::createIfNeeded(m_mod.get()));
      |                                                                                   ^
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:75:83: note: remove 'std::move' call
In file included from /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:26:
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/OutputModuleCommunicatorT.h: In instantiation of 'static std::unique_ptr<edm::OutputModuleCommunicator> edm::OutputModuleCommunicatorT<T>::createIfNeeded(T*) [with T = edm::global::EDProducerBase]':
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:75:70:   required from 'std::unique_ptr<edm::OutputModuleCommunicator> edm::maker::ModuleHolderT<T>::createOutputModuleCommunicator() [with T = edm::global::EDProducerBase]'
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/maker/ModuleHolder.h:74:49:   required from here
  /pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/OutputModuleCommunicatorT.h:80:62: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    80 |       return std::move(impl::createCommunicatorIfNeeded(iMod));
      |                                                              ^
/pool/condor/dir_9376/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a10fc2b06258253d9a7f946e5bca0c7f/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_13_2_X_2023-06-23-1100/src/FWCore/Framework/interface/OutputModuleCommunicatorT.h:80:62: note: remove 'std::move' call
```
This PR doesn't fix any of the build errors in the GCC 13 IB, but it should reduce the number of warnings, and removing pessimizing move is useful in general.

#### PR validation:

`FWCore/Framework` compiles