### PR TITLE
add layer-1 monitoring for new slot-7 cards [13_1_0]

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -119,8 +119,8 @@ namespace CaloL1Information {
     dqm::reco::MonitorElement *hcalOccFg1Discrepancy_;
     dqm::reco::MonitorElement *hcalOccFg2Discrepancy_;
     dqm::reco::MonitorElement *hcalOccFg3Discrepancy_;
-    dqm::reco::MonitorElement *hcalOccFg4Discrepancy_;
-    dqm::reco::MonitorElement *hcalOccFg5Discrepancy_;
+    //dqm::reco::MonitorElement *hcalOccFg4Discrepancy_;
+    //dqm::reco::MonitorElement *hcalOccFg5Discrepancy_;
     dqm::reco::MonitorElement *hcalOccRecdFg0_;
     dqm::reco::MonitorElement *hcalOccRecdFg1_;
     dqm::reco::MonitorElement *hcalOccRecdFg2_;
@@ -177,6 +177,8 @@ namespace CaloL1Information {
     dqm::reco::MonitorElement *ecalOccRecdBx3_;
     dqm::reco::MonitorElement *ecalOccRecdBx4_;
     dqm::reco::MonitorElement *ecalOccRecdBx5_;
+
+    dqm::reco::MonitorElement *slot7bit_;
 
     std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, std::vector<int>>> runMismatchList;
   };

--- a/EventFilter/L1TRawToDigi/interface/Block.h
+++ b/EventFilter/L1TRawToDigi/interface/Block.h
@@ -186,6 +186,7 @@ namespace l1t {
     unsigned bx_per_l1a_;
     unsigned calo_bxid_;
     unsigned six_hcal_feature_bits_;
+    unsigned slot7_card_;
     amc::Header amcHeader_;
   };
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -21,55 +21,60 @@ namespace l1t {
       auto ctp7_phi = block.amc().getBoardID();
       const uint32_t* ptr = block.payload().data();
 
+      int amc_slot = block.amc().getAMCNumber();
+
       int N_BX = (block.header().getFlags() >> 16) & 0xf;
-      //      std::cout << " N_BX calculated " << N_BX << std::endl;
 
       int HCALFB = (block.header().getFlags() >> 15) & 0x1;
 
-      if (N_BX == 1) {
-        if (HCALFB == 0) {
-          UCTCTP7RawData ctp7Data(ptr);
-          makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-          makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-          makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-          makeRegions(ctp7_phi, ctp7Data, res->getRegions());
-        }
-        if (HCALFB == 1) {
-          UCTCTP7RawData_HCALFB ctp7Data_HCALFB(ptr);
-          makeECalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getEcalDigis());
-          makeHCalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
-          makeHFTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
-          makeRegions_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getRegions());
-        }
-      } else if (N_BX == 5) {
-        if (HCALFB == 0) {
-          UCTCTP7RawData5BX ctp7Data5BX(ptr);
-          // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
-          makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigis(), 2);
-          makeHCalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
-          makeHFTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
-          makeRegions5BX(ctp7_phi, ctp7Data5BX, res->getRegions(), 2);
-          for (int i = 0; i < 5; i++) {
-            makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigisBx(i), i);
+      if (not(amc_slot == 7)) {
+        if (N_BX == 1) {
+          if (HCALFB == 0) {
+            UCTCTP7RawData ctp7Data(ptr);
+            makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+            makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+            makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+            makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+          } else if (HCALFB == 1) {
+            UCTCTP7RawData_HCALFB ctp7Data_HCALFB(ptr);
+            makeECalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getEcalDigis());
+            makeHCalTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
+            makeHFTPGs_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getHcalDigis());
+            makeRegions_HCALFB(ctp7_phi, ctp7Data_HCALFB, res->getRegions());
           }
-        }
-        if (HCALFB == 1) {
-          UCTCTP7RawData5BX_HCALFB ctp7Data5BX_HCALFB(ptr);
-          // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
-          makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigis(), 2);
-          makeHCalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
-          makeHFTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
-          makeRegions5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getRegions(), 2);
-          for (int i = 0; i < 5; i++) {
-            makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigisBx(i), i);
+        } else if (N_BX == 5) {
+          if (HCALFB == 0) {
+            UCTCTP7RawData5BX ctp7Data5BX(ptr);
+            // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+            makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigis(), 2);
+            makeHCalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+            makeHFTPGs5BX(ctp7_phi, ctp7Data5BX, res->getHcalDigis(), 2);
+            makeRegions5BX(ctp7_phi, ctp7Data5BX, res->getRegions(), 2);
+            for (int i = 0; i < 5; i++) {
+              makeECalTPGs5BX(ctp7_phi, ctp7Data5BX, res->getEcalDigisBx(i), i);
+            }
+          } else if (HCALFB == 1) {
+            UCTCTP7RawData5BX_HCALFB ctp7Data5BX_HCALFB(ptr);
+            // BX_n = 0, 1, 2, 3, 4, where 2 is nominal
+            makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigis(), 2);
+            makeHCalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
+            makeHFTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getHcalDigis(), 2);
+            makeRegions5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getRegions(), 2);
+            for (int i = 0; i < 5; i++) {
+              makeECalTPGs5BX_HCALFB(ctp7_phi, ctp7Data5BX_HCALFB, res->getEcalDigisBx(i), i);
+            }
           }
+        } else {
+          LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX
+                                         << std::endl;
+          return false;
         }
+        return true;
       } else {
-        LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
-        return false;
+        // slot-7 card payload data have 6 32-bit words only
+        // we read from FED raw data collection for DQM directly
+        return true;
       }
-
-      return true;
     }
 
     void CaloLayer1Unpacker::makeECalTPGs(uint32_t lPhi,

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -212,6 +212,7 @@ namespace l1t {
     calo_bxid_ = *data_ & 0xfff;
     capId_ = 0;
     six_hcal_feature_bits_ = (*data_ >> 15) & 0x1;
+    slot7_card_ = (*data_ >> 14) & 0x1;
     if (bx_per_l1a_ > 1) {
       edm::LogInfo("L1T") << "CTP7 block with multiple bunch crossings:" << bx_per_l1a_;
     }
@@ -226,8 +227,9 @@ namespace l1t {
     // CTP7 header contains number of BX in payload and the bunch crossing ID
     // Not sure how to map to generic BlockHeader variables, so just packing
     // it all in flags variable
-    unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff) | ((six_hcal_feature_bits_ & 0x1) << 15);
-    unsigned blockSize = (192 + (int)six_hcal_feature_bits_ * 28) * (int)bx_per_l1a_;
+    unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff) | ((six_hcal_feature_bits_ & 0x1) << 15) |
+                          ((slot7_card_ & 0x1) << 14);
+    unsigned blockSize = (slot7_card_ == 1) ? 6 : ((192 + (int)six_hcal_feature_bits_ * 28) * (int)bx_per_l1a_);
     return BlockHeader(blockId, blockSize, capId_, blockFlags, CTP7);
   }
 


### PR DESCRIPTION
#### PR description:
This PR modifies Calo-Layer1 unpacker to adapt the additions of a new CTP7 card in slot-7 in each of the three layer-1 crates (FEDs 1354, 1356, 1358), where each card sends the same payload header and trailer as all other existing calo cards, but with a fixed payload data size of 6 32-bit words, regardless of normal or FAT events being sent. New monitoring elements are added to layer-1 DQM for the 3x6x32 bits. The modification is done in such a way that it works before and after the card addition.

Note that the monitoring elements for HCAL FB4-5 are commented out, we will put them back once HCAL fixes them (FB4-5 are reserved bits and not used for LLP, but they are sending unphysical data there which layer-1 could not read out, causing discrepancies seen when comparing them).

#### PR validation:
Validated by running offline DQM on past commissioning runs, it works as expected for current production firmware. Tested with online DQM at P5 with new firmware.

This is a backport of https://github.com/cms-sw/cmssw/pull/42048