### PR TITLE
[ASAN] Fix runtime error by moving std::regex code in anonymous namespace

### DIFF
--- a/L1Trigger/Phase2L1Taus/src/L1HPSPFTauBuilder.cc
+++ b/L1Trigger/Phase2L1Taus/src/L1HPSPFTauBuilder.cc
@@ -7,9 +7,14 @@
 #include <algorithm>                               // std::max(), std::sort()
 #include <cmath>                                   // std::fabs
 
+namespace {
+  std::string getSignalConeSizeFormula(const edm::ParameterSet& cfg) {
+    return std::regex_replace(cfg.getParameter<std::string>("signalConeSize"), std::regex("pt"), "x");
+  }
+}  // namespace
+
 L1HPSPFTauBuilder::L1HPSPFTauBuilder(const edm::ParameterSet& cfg)
-    : signalConeSizeFormula_(
-          std::regex_replace(cfg.getParameter<std::string>("signalConeSize"), std::regex("pt"), "x")),
+    : signalConeSizeFormula_(getSignalConeSizeFormula(cfg)),
       minSignalConeSize_(cfg.getParameter<double>("minSignalConeSize")),
       maxSignalConeSize_(cfg.getParameter<double>("maxSignalConeSize")),
       useStrips_(cfg.getParameter<bool>("useStrips")),


### PR DESCRIPTION
This fixes https://github.com/cms-sw/cmssw/issues/42059 ASAN runtime issue. This looks like a GCC bug as reported in https://github.com/cms-sw/cmssw/issues/40902#issuecomment-1448914700 . Local tests shows that failing ASAN workflow runs after this change 