### PR TITLE
By-pass scalers input collection for `hltScalersRawToDigi` for Heavy Ions pp-reco workflows post merge of #41815

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2136,7 +2136,7 @@ steps['RAWPRIMESIMHI18']={ '--scenario':'pp',
                            '--era':'Run2_2018_pp_on_AA',
                            '-n':'10',
                            '--procModifiers':'approxSiStripClusters',
-                           '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\'\"',
+                           '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                            '--process':'REHLT'
 }
 
@@ -2170,7 +2170,7 @@ steps['RAWPRIMEHI22']={ '--scenario':'pp',
                         '--eventcontent':'REPACKRAW',
                         '--era':'Run3_pp_on_PbPb_approxSiStripClusters',
                         '-n':'10',
-                        '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\'\"',
+                        '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                         '--process':'REHLT'
 }
 


### PR DESCRIPTION
#### PR description:

Title says it all, address https://github.com/cms-sw/cmssw/pull/41815#issuecomment-1606825744. Done similarly as previously done for `siStripDigisHLT` collection.

#### PR validation:

```
runTheMatrix.py -l 159.02,159.03,160.02,160.03
```

runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @Ksavva1021 