### PR TITLE
Add missing dependence on roothistpainter in CommonTools/TrackerMap

### DIFF
--- a/CommonTools/TrackerMap/BuildFile.xml
+++ b/CommonTools/TrackerMap/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibFormats/SiStripObjects"/>
 <use name="rootgraphics"/>
+<use name="roothistpainter"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/42036 added a dependence on `TPaletteAxis` that made UBSAN (that needs the link-time dependence) to not build
```
>> Building shared library tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/libCommonToolsTrackerMap.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -g -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TmApvPair.cc.o tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TmCcu.cc.o tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TmModule.cc.o tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TmPsu.cc.o tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TrackerMap.cc.o -o tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/libCommonToolsTrackerMap.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/470e2e8cf896f564e32c51a244fadd3f/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_UBSAN_X_2023-06-23-2300/biglib/el8_amd64_gcc11 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/470e2e8cf896f564e32c51a244fadd3f/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_UBSAN_X_2023-06-23-2300/lib/el8_amd64_gcc11 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/470e2e8cf896f564e32c51a244fadd3f/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_UBSAN_X_2023-06-23-2300/external/el8_amd64_gcc11/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/cuda/11.8.0-9f0af0f4206be7b705fe550319c49a11/lib64/stubs -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/470e2e8cf896f564e32c51a244fadd3f/opt/cmssw/el8_amd64_gcc11/cms/cmssw/CMSSW_13_2_UBSAN_X_2023-06-23-2300/static/el8_amd64_gcc11 -lCalibFormatsSiStripObjects -lCondFormatsSiStripObjects -lDataFormatsTrackerCommon -lDataFormatsSiStripCluster -lDataFormatsSiStripCommon -lDataFormatsTrajectoryState -lHeterogeneousCoreCUDACore -lDataFormatsGeometryVector -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lHeterogeneousCoreCUDAServices -lCUDADataFormatsCommon -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsMath -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lCondFormatsPhysicsToolsObjects -lDataFormatsCommon -lFWCoreParameterSet -lHeterogeneousCoreCUDAUtilities -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lTreePlayer -lGraf3d -lPostscript -lGpad -lGraf -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lThread -lMathCore -lRIO -lboost_iostreams -lboost_serialization -lCore -lboost_thread -lboost_date_time -lCLHEP -lpcre -lbz2 -lcudart -lcudadevrt -lnvToolsExt -lnvidia-ml -lgsl -luuid -ltbb -llzma -lz -lcuda -lfmt -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/bin/../lib/gcc/x86_64-redhat-linux-gnu/11.4.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el8_amd64_gcc11/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TrackerMap.cc.o:(.data.rel+0xe998): undefined reference to `typeinfo for TPaletteAxis'
 collect2: error: ld returned 1 exit status
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_13_2_UBSAN_X_2023-06-23-2300/CommonTools/TrackerMap

This PR adds the dependence.

#### PR validation:

UBSAN compiles.

