### PR TITLE
Add ECal-component modifiers and test workflows

### DIFF
--- a/Configuration/ProcessModifiers/python/ecal_component_cff.py
+++ b/Configuration/ProcessModifiers/python/ecal_component_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+ecal_component = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/ecal_component_finely_sampled_waveforms_cff.py
+++ b/Configuration/ProcessModifiers/python/ecal_component_finely_sampled_waveforms_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+ecal_component_finely_sampled_waveforms = cms.Modifier()

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -66,6 +66,8 @@ The offsets currently in use are:
 * 0.31: Photon energy corrections with DRN architecture
 * 0.61: ECAL `phase2_ecal_devel` era, on CPU
 * 0.612: ECAL `phase2_ecal_devel` era, with automatic offload to GPU if available
+* 0.631: ECAL component-method based digis
+* 0.632: ECAL component-method based finely-sampled waveforms
 * 0.75: Phase-2 HLT
 * 0.91: Track DNN modifier
 * 0.97: Premixing stage1

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1794,6 +1794,48 @@ upgradeWFs['ecalDevelGPU'] = UpgradeWorkflow_ecalDevel(
     offset = 0.612,
 )
 
+# ECAL component
+class UpgradeWorkflow_ECalComponent(UpgradeWorkflow):
+    def __init__(self, suffix, offset, ecalMod,
+                 steps = [
+                     'GenSim',
+                     'GenSimHLBeamSpot',
+                     'GenSimHLBeamSpot14',
+                     'GenSimHLBeamSpotHGCALCloseBy',
+                     'Digi',
+                     'DigiTrigger',
+                 ],
+                 PU = [
+                     'GenSim',
+                     'GenSimHLBeamSpot',
+                     'GenSimHLBeamSpot14',
+                     'GenSimHLBeamSpotHGCALCloseBy',
+                     'Digi',
+                     'DigiTrigger',
+                 ]):
+        super(UpgradeWorkflow_ECalComponent, self).__init__(steps, PU, suffix, offset)
+        self.__ecalMod = ecalMod
+    
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Sim' in step or 'Digi' in step:
+            if self.__ecalMod is not None:
+                stepDict[stepName][k] = merge([{'--procModifiers':self.__ecalMod},stepDict[step][k]])
+
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return ('2021' in key or '2023' in key or '2026' in key)
+
+upgradeWFs['ECALComponent'] = UpgradeWorkflow_ECalComponent(
+    suffix = '_ecalComponent',
+    offset = 0.631,
+    ecalMod = 'ecal_component',
+)
+
+upgradeWFs['ECALComponentFSW'] = UpgradeWorkflow_ECalComponent(
+    suffix = '_ecalComponentFSW',
+    offset = 0.632,
+    ecalMod = 'ecal_component_finely_sampled_waveforms',
+)
+
 class UpgradeWorkflow_0T(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         myGT=stepDict[step][k]['--conditions']

--- a/SimCalorimetry/EcalSimProducers/python/componentDigiParameters_cff.py
+++ b/SimCalorimetry/EcalSimProducers/python/componentDigiParameters_cff.py
@@ -5,6 +5,9 @@ component_digi_parameters = cms.PSet(
     componentTimeTag = cms.string("Component"),
     componentSeparateDigi = cms.bool(False),
     componentAddToBarrel  = cms.bool(False),
-    componentTimePhase  = cms.double(0.),
-
+    componentTimePhase  = cms.double(0.)
 )
+
+from Configuration.ProcessModifiers.ecal_component_cff import ecal_component
+from Configuration.ProcessModifiers.ecal_component_finely_sampled_waveforms_cff import ecal_component_finely_sampled_waveforms
+(ecal_component | ecal_component_finely_sampled_waveforms).toModify(component_digi_parameters,componentSeparateDigi=True)

--- a/SimCalorimetry/EcalSimProducers/python/ecalTimeDigiParameters_cff.py
+++ b/SimCalorimetry/EcalSimProducers/python/ecalTimeDigiParameters_cff.py
@@ -8,4 +8,7 @@ ecal_time_digi_parameters = cms.PSet(
     timeLayerBarrel = cms.int32(7),
     timeLayerEndcap = cms.int32(3),
     componentWaveform = cms.bool(False)
-    )
+)
+
+from Configuration.ProcessModifiers.ecal_component_finely_sampled_waveforms_cff import ecal_component_finely_sampled_waveforms
+(ecal_component_finely_sampled_waveforms).toModify(ecal_time_digi_parameters,componentWaveform=True)

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -680,6 +680,13 @@ phase2_timing.toModify( g4SimHits, ECalSD = dict(
 )
 
 ##
+## For ECAL component study
+##
+from Configuration.ProcessModifiers.ecal_component_cff import ecal_component
+from Configuration.ProcessModifiers.ecal_component_finely_sampled_waveforms_cff import ecal_component_finely_sampled_waveforms
+(ecal_component | ecal_component_finely_sampled_waveforms).toModify(g4SimHits,ECalSD = dict(StoreLayerTimeSim = True, SlopeLightYield = 0.0))
+
+##
 ## Change CALO Thresholds
 ##
 from Configuration.Eras.Modifier_h2tb_cff import h2tb


### PR DESCRIPTION
#### PR description:
This PR adds modifiers `ecal_component` and `ecal_component_finely_sampled_waveforms` to avoid long customization, and add test workflows `.631` and `.632`.  

The customization comes from [this link](https://gitlab.cern.ch/-/snippets/2648).

#### PR validation:
Test with `20834.631` and `20834.632`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport, or we can backport to 13_0 if it makes cmsDriver look more cleaner in production.