### PR TITLE
Changed 'type' to 'read_type' to avoid keyword class in UDP message [12_4]

### DIFF
--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -392,7 +392,7 @@ void StatisticsSenderService::fillUDP(const std::string &siteName,
   } else {
     os << "\"fallback\": false, ";
   }
-  os << "\"type\": ";
+  os << "\"read_type\": ";
   switch (fileinfo.m_type) {
     case edm::InputType::Primary: {
       os << "\"primary\", ";

--- a/Utilities/StorageFactory/test/test_file_statistics_sender.sh
+++ b/Utilities/StorageFactory/test/test_file_statistics_sender.sh
@@ -11,7 +11,10 @@ function testJSON {
 import json
 with open('test.json') as f:
     for line in f:
-        json.loads(line)
+        d = json.loads(line)
+        for k in d.keys():
+            if k in ['producer', 'type', 'type_prefix', 'timestamp', 'host']:
+                raise RuntimeError("Found restricted keyword %s"%k)
 EOF
     RET=$?
     if [ "x$RET" != "x0" ]; then


### PR DESCRIPTION
#### PR description:

Changed key 'type' to 'read_type' in UDP message from StatisticsSenderService. This is needed to avoid a naming clash with a 3rd party library used by the workflow system.

#### PR validation:

Code compiles.

backport of https://github.com/cms-sw/cmssw/pull/42060
