### PR TITLE
fixes uninitialized member calib in p2eg::Cluster::calib

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -835,6 +835,7 @@ namespace p2eg {
             ap_uint<15> clusterEt5x5 = 0,
             ap_uint<15> clusterEt2x5 = 0,
             ap_uint<2> clusterBrems = 0,
+	    float clusterCalib = 1.0,
             bool cluster_is_ss = false,
             bool cluster_is_looseTkss = false,
             bool cluster_is_iso = false,
@@ -845,6 +846,7 @@ namespace p2eg {
       regionIdx = clusterRegionIdx, et5x5 = clusterEt5x5;
       et2x5 = clusterEt2x5;
       brems = clusterBrems;
+      calib = clusterCalib;
       is_ss = cluster_is_ss;
       is_looseTkss = cluster_is_looseTkss;
       is_iso = cluster_is_iso;

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -835,7 +835,7 @@ namespace p2eg {
             ap_uint<15> clusterEt5x5 = 0,
             ap_uint<15> clusterEt2x5 = 0,
             ap_uint<2> clusterBrems = 0,
-	    float clusterCalib = 1.0,
+            float clusterCalib = 1.0,
             bool cluster_is_ss = false,
             bool cluster_is_looseTkss = false,
             bool cluster_is_iso = false,


### PR DESCRIPTION
#### PR description:

This PR addresses issue #42094 by initializing `calib` in the constructor at https://github.com/cms-sw/cmssw/blob/27ea50baba0a766fe0806d4961fbcd9759267aa0/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h#L829-L852
