### PR TITLE
[13_0_X] Add EMTF unconstrained pT and dxy to unpacked EMTFTrack collections

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -115,8 +115,11 @@ namespace l1t {
         _track.set_phi_glob(L1TMuonEndCap::calc_phi_glob_deg(_track.Phi_loc(), _track.Sector()));
         _track.set_eta(L1TMuonEndCap::calc_eta(_SP.Eta_GMT()));
         _track.set_pt((_SP.Pt_GMT() - 1) * 0.5);
+        _track.set_pt_dxy((_SP.Pt_dxy_GMT() - 1));
 
         _track.set_gmt_pt(_SP.Pt_GMT());
+        _track.set_gmt_pt_dxy(_SP.Pt_dxy_GMT());
+        _track.set_gmt_dxy(_SP.Dxy_GMT());
         _track.set_gmt_phi(_SP.Phi_GMT());
         _track.set_gmt_eta(_SP.Eta_GMT());
         _track.set_gmt_quality(_SP.Quality_GMT());


### PR DESCRIPTION
#### PR description:

This PR adds vertex unconstrained pT and dxy to EMTFTrack collections produced by the EMTF unpacker. Previously these were missing from EMTFTrack. This will be useful when EMTF vertex unconstrained pT adn dxy assignment comes online.

This is a backport of https://github.com/cms-sw/cmssw/pull/42035

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by checking the pT and dxy values when unpacking recent data. Also ran `runTheMatrix.py -l limited -i all --ibeos` and saw no failures.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
