### PR TITLE
P2GMT: Disable hard-coding of debug printout

### DIFF
--- a/L1Trigger/Phase2L1GMT/plugins/Isolation.h
+++ b/L1Trigger/Phase2L1GMT/plugins/Isolation.h
@@ -66,7 +66,6 @@ namespace Phase2L1GMT {
         reliso_thrT(iConfig.getParameter<double>("RelIsoThresholdT")),
         verbose_(iConfig.getParameter<int>("verbose")),
         dumpForHLS_(iConfig.getParameter<int>("IsodumpForHLS")) {
-    dumpForHLS_ = true;
     if (dumpForHLS_) {
       dumpInput.open("Isolation_Mu_Track_infolist.txt", std::ofstream::out);
       dumpOutput.open("Isolation_Mu_Isolation.txt", std::ofstream::out);


### PR DESCRIPTION
#### PR description:

This PR removes one line of code that overrides the Phase-2 GMT configuration setting to _always_ generate a dump text file with debug information probably wasn't ever supposed to be integrated in production.

Corresponds to https://github.com/cms-l1t-offline/cmssw/pull/1143

@zhenbinwu