### PR TITLE
Make CaloTSamples(Base) to compile with C++20

### DIFF
--- a/CalibFormats/CaloObjects/interface/CaloTSamples.h
+++ b/CalibFormats/CaloObjects/interface/CaloTSamples.h
@@ -15,10 +15,10 @@ class CaloTSamples : public CaloTSamplesBase<Ttype> {
 public:
   enum { kCapacity = Tsize };
 
-  CaloTSamples<Ttype, Tsize>();
-  CaloTSamples<Ttype, Tsize>(const CaloTSamples<Ttype, Tsize> &cs);
-  CaloTSamples<Ttype, Tsize>(const DetId &id, uint32_t size = 0, uint32_t pre = 0);
-  ~CaloTSamples<Ttype, Tsize>() override;
+  CaloTSamples();
+  CaloTSamples(const CaloTSamples<Ttype, Tsize> &cs);
+  CaloTSamples(const DetId &id, uint32_t size = 0, uint32_t pre = 0);
+  ~CaloTSamples() override;
 
   CaloTSamples<Ttype, Tsize> &operator=(const CaloTSamples<Ttype, Tsize> &cs);
 

--- a/CalibFormats/CaloObjects/interface/CaloTSamplesBase.h
+++ b/CalibFormats/CaloObjects/interface/CaloTSamplesBase.h
@@ -8,13 +8,13 @@
 template <class Ttype>
 class CaloTSamplesBase {
 public:
-  CaloTSamplesBase<Ttype>(Ttype *mydata, uint32_t size);
+  CaloTSamplesBase(Ttype *mydata, uint32_t size);
 
-  CaloTSamplesBase<Ttype>(const CaloTSamplesBase<Ttype> &cs);
+  CaloTSamplesBase(const CaloTSamplesBase<Ttype> &cs);
 
-  CaloTSamplesBase<Ttype>(Ttype *mydata, uint32_t length, const DetId &id, uint32_t size, uint32_t pre);
+  CaloTSamplesBase(Ttype *mydata, uint32_t length, const DetId &id, uint32_t size, uint32_t pre);
 
-  virtual ~CaloTSamplesBase<Ttype>();
+  virtual ~CaloTSamplesBase();
 
   void setZero();
 


### PR DESCRIPTION
#### PR description:

Title says it all

#### PR validation:

Package `CalibFormats/CaloObjects` builds in CPP20 IB.