### PR TITLE
MTD geometry: fix BTL numbering scheme to work with DD4hep through Geant4

### DIFF
--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -28,12 +28,17 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
     }
   }
 
+  auto bareBaseName = [&](std::string_view name) {
+    size_t ipos = name.rfind('_');
+    return (isDD4hepOK) ? name.substr(0, ipos) : name;
+  };
+
   if (nLevels == kBTLcrystalLevel || isDD4hepOK) {
-    LogDebug("MTDGeom") << baseNumber.getLevelName(0) << ", " << baseNumber.getLevelName(1) << ", "
-                        << baseNumber.getLevelName(2) << ", " << baseNumber.getLevelName(3) << ", "
-                        << baseNumber.getLevelName(4) << ", " << baseNumber.getLevelName(5) << ", "
-                        << baseNumber.getLevelName(6) << ", " << baseNumber.getLevelName(7) << ", "
-                        << baseNumber.getLevelName(8);
+    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(2)) << ", " << bareBaseName(baseNumber.getLevelName(3)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(4)) << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(6)) << ", " << bareBaseName(baseNumber.getLevelName(7)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(8));
 
     // barphiflat scenario
 
@@ -110,7 +115,7 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
         modCopy = negModCopy[modCopy - 1];
       }
 
-      modtyp = ::atoi(&baseNumber.getLevelName(2).back());
+      modtyp = ::atoi(&bareBaseName(baseNumber.getLevelName(2)).back());
 
       // error checking
 
@@ -123,7 +128,7 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
       if (1 > modtyp || 3 < modtyp) {
         edm::LogWarning("MTDGeom") << "BTLNumberingScheme::getUnitID(): "
-                                   << "****************** Bad RU name, Volume Name = " << baseNumber.getLevelName(2);
+                                   << "****************** Bad RU name, Volume Name = " << bareBaseName(baseNumber.getLevelName(2));
         return 0;
       }
 
@@ -164,10 +169,10 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   } else if (nLevels == kBTLmoduleLevel && baseNumber.getLevelName(0).find("BTLModule") != std::string_view::npos) {
     // v2 scenario, geographicalId per module
     // for tracking navigation geometry
-    LogDebug("MTDGeom") << baseNumber.getLevelName(0) << ", " << baseNumber.getLevelName(1) << ", "
-                        << baseNumber.getLevelName(2) << ", " << baseNumber.getLevelName(3) << ", "
-                        << baseNumber.getLevelName(4) << ", " << baseNumber.getLevelName(5) << ", "
-                        << baseNumber.getLevelName(6) << ", " << baseNumber.getLevelName(7);
+    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(2)) << ", " << bareBaseName(baseNumber.getLevelName(3)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(4)) << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(6)) << ", " << bareBaseName(baseNumber.getLevelName(7));
 
     modCopy = baseNumber.getCopyNumber(0);
     runitCopy = baseNumber.getCopyNumber(1);
@@ -183,13 +188,13 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
       modCopy = negModCopy[modCopy - 1];
     }
 
-    modtyp = ::atoi(&baseNumber.getLevelName(1).back());
+    modtyp = ::atoi(&bareBaseName(baseNumber.getLevelName(1)).back());
 
     // error checking
 
     if (1 > modtyp || 3 < modtyp) {
       edm::LogWarning("MTDGeom") << "BTLNumberingScheme::getUnitID(): "
-                                 << "****************** Bad RU name, Volume Name = " << baseNumber.getLevelName(1);
+                                 << "****************** Bad RU name, Volume Name = " << bareBaseName(baseNumber.getLevelName(1));
       return 0;
     }
 

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -34,11 +34,12 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   };
 
   if (nLevels == kBTLcrystalLevel || isDD4hepOK) {
-    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(2)) << ", " << bareBaseName(baseNumber.getLevelName(3)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(4)) << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(6)) << ", " << bareBaseName(baseNumber.getLevelName(7)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(8));
+    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1))
+                        << ", " << bareBaseName(baseNumber.getLevelName(2)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(3)) << ", " << bareBaseName(baseNumber.getLevelName(4))
+                        << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(6)) << ", " << bareBaseName(baseNumber.getLevelName(7))
+                        << ", " << bareBaseName(baseNumber.getLevelName(8));
 
     // barphiflat scenario
 
@@ -128,7 +129,8 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
       if (1 > modtyp || 3 < modtyp) {
         edm::LogWarning("MTDGeom") << "BTLNumberingScheme::getUnitID(): "
-                                   << "****************** Bad RU name, Volume Name = " << bareBaseName(baseNumber.getLevelName(2));
+                                   << "****************** Bad RU name, Volume Name = "
+                                   << bareBaseName(baseNumber.getLevelName(2));
         return 0;
       }
 
@@ -169,9 +171,10 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   } else if (nLevels == kBTLmoduleLevel && baseNumber.getLevelName(0).find("BTLModule") != std::string_view::npos) {
     // v2 scenario, geographicalId per module
     // for tracking navigation geometry
-    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(2)) << ", " << bareBaseName(baseNumber.getLevelName(3)) << ", "
-                        << bareBaseName(baseNumber.getLevelName(4)) << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
+    LogDebug("MTDGeom") << bareBaseName(baseNumber.getLevelName(0)) << ", " << bareBaseName(baseNumber.getLevelName(1))
+                        << ", " << bareBaseName(baseNumber.getLevelName(2)) << ", "
+                        << bareBaseName(baseNumber.getLevelName(3)) << ", " << bareBaseName(baseNumber.getLevelName(4))
+                        << ", " << bareBaseName(baseNumber.getLevelName(5)) << ", "
                         << bareBaseName(baseNumber.getLevelName(6)) << ", " << bareBaseName(baseNumber.getLevelName(7));
 
     modCopy = baseNumber.getCopyNumber(0);
@@ -194,7 +197,8 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
     if (1 > modtyp || 3 < modtyp) {
       edm::LogWarning("MTDGeom") << "BTLNumberingScheme::getUnitID(): "
-                                 << "****************** Bad RU name, Volume Name = " << bareBaseName(baseNumber.getLevelName(1));
+                                 << "****************** Bad RU name, Volume Name = "
+                                 << bareBaseName(baseNumber.getLevelName(1));
       return 0;
     }
 

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -50,12 +50,7 @@ process.MessageLogger.files.mtdCommonDataDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
-
-process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                                     appendToDataLabel = cms.string('')
-)
+process.load('Configuration.Geometry.GeometryDD4hepExtended2026D98_cff')
 
 process.testBTL = cms.EDAnalyzer("DD4hep_TestMTDIdealGeometry",
                                  DDDetector = cms.ESInputTag('',''),

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -49,7 +49,7 @@ process.MessageLogger.files.mtdCommonDataDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryExtended2026D95_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D98_cff')
 
 process.testBTL = cms.EDAnalyzer("TestMTDIdealGeometry",
                                ddTopNodeName = cms.untracked.string('BarrelTimingLayer')

--- a/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
@@ -50,24 +50,7 @@ process.MessageLogger.files.mtdGeometryDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
-
-process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                                 appendToDataLabel = cms.string('')
-)
-
-process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                                     appendToDataLabel = cms.string('')
-)
-
-process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdParameters_cff")
-
-process.load("Geometry.MTDGeometryBuilder.mtdGeometry_cfi")
-process.mtdGeometry.applyAlignment = cms.bool(False)
+process.load("Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdGeometryDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D98_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -47,21 +47,7 @@ process.MessageLogger.files.mtdNumberingDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryDD4hep_cff')
-process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D95.xml")
-
-process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                                 appendToDataLabel = cms.string('')
-)
-
-process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                                     appendToDataLabel = cms.string('')
-)
-
-process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdParameters_cff")
+process.load("Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff")
 
 process.prod = cms.EDAnalyzer("GeometricTimingDetAnalyzer")
 

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -46,12 +46,7 @@ process.MessageLogger.files.mtdNumberingDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdParameters_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -48,18 +48,8 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2026D95_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
-
-process.load("Geometry.MTDNumberingBuilder.mtdTopology_cfi")
-process.load("Geometry.MTDGeometryBuilder.mtdParameters_cff")
-
-process.load("Geometry.MTDGeometryBuilder.mtdGeometry_cfi")
-process.mtdGeometry.applyAlignment = cms.bool(False)
-
+process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
 process.load("MagneticField.Engine.volumeBasedMagneticField_160812_cfi")
-process.load("RecoMTD.DetLayers.mtdDetLayerGeometry_cfi")
 
 process.Timing = cms.Service("Timing")
 

--- a/SimG4CMS/Forward/plugins/PrintMTDSens.cc
+++ b/SimG4CMS/Forward/plugins/PrintMTDSens.cc
@@ -1,0 +1,179 @@
+//#define EDM_ML_DEBUG
+
+#include "SimG4Core/Notification/interface/BeginOfRun.h"
+#include "SimG4Core/Notification/interface/Observer.h"
+#include "SimG4Core/Watcher/interface/SimWatcher.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/MTDCommonData/interface/BTLNumberingScheme.h"
+#include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "DataFormats/Math/interface/Rounding.h"
+
+#include "G4Run.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4LogicalVolume.hh"
+#include "G4NavigationHistory.hh"
+#include "G4TransportationManager.hh"
+#include "G4Box.hh"
+
+#include <set>
+#include <map>
+#include <iostream>
+#include <string>
+#include <vector>
+
+class PrintMTDSens : public SimWatcher, public Observer<const BeginOfRun *> {
+public:
+  PrintMTDSens(edm::ParameterSet const &p);
+  ~PrintMTDSens() override;
+
+private:
+  void update(const BeginOfRun *run) override;
+  int dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, int ns);
+  G4VPhysicalVolume *getTopPV();
+  bool getBaseNumber();
+
+private:
+  std::vector<std::string> names_;
+  std::vector<size_t> nsens_;
+  G4NavigationHistory fHistory;
+
+  MTDBaseNumber thisN_;
+  BTLNumberingScheme btlNS_;
+  ETLNumberingScheme etlNS_;
+};
+
+PrintMTDSens::PrintMTDSens(const edm::ParameterSet &p) : thisN_(), btlNS_(), etlNS_() {
+  names_ = p.getUntrackedParameter<std::vector<std::string>>("Name");
+  nsens_.resize(names_.size());
+  for (size_t index = 0; index < nsens_.size(); index++) {
+    nsens_[index] = 0;
+  }
+  G4cout << "PrintMTDSens:: Print position of MTD Sensitive Touchables: " << G4endl;
+  for (const auto &thisName : names_) {
+    G4cout << " for name " << thisName << "\n";
+  }
+  G4cout << " Total of " << names_.size() << " sensitive volume types" << G4endl;
+}
+
+PrintMTDSens::~PrintMTDSens() {}
+
+void PrintMTDSens::update(const BeginOfRun *run) {
+  G4VPhysicalVolume *theTopPV = getTopPV();
+  int ntotal = dumpTouch(theTopPV, 0, 0);
+  G4cout << "\nTotal number of sensitive detector volumes for MTD is " << ntotal << G4endl;
+  for (size_t index = 0; index < nsens_.size(); index++) {
+    G4cout << "Sensitive volume " << names_[index] << " # copies " << nsens_[index] << G4endl;
+  }
+}
+
+using cms_rounding::roundIfNear0;
+
+int PrintMTDSens::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, int ns) {
+  if (leafDepth == 0)
+    fHistory.SetFirstEntry(pv);
+  else
+    fHistory.NewLevel(pv, kNormal, pv->GetCopyNo());
+
+  int ntotal(ns);
+  G4ThreeVector globalpoint = fHistory.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0, 0, 0));
+  G4LogicalVolume *lv = pv->GetLogicalVolume();
+
+  std::string mother = "World";
+  bool printIt(false);
+  if (pv->GetMotherLogical()) {
+    mother = pv->GetMotherLogical()->GetName();
+  }
+  size_t index(0);
+  for (const auto &thisName : names_) {
+    G4String g4name(thisName);
+    if (G4StrUtil::contains(lv->GetName(), g4name)) {
+      printIt = true;
+      break;
+    }
+    index++;
+  }
+
+  if (lv->GetSensitiveDetector() && printIt) {
+    std::stringstream sunitt;
+    ++ntotal;
+    ++nsens_[index];
+    bool isBarrel = getBaseNumber();
+    if (isBarrel) {
+      BTLDetId theId(btlNS_.getUnitID(thisN_));
+      sunitt << theId.rawId();
+#ifdef EDM_ML_DEBUG
+      G4cout << theId << G4endl;
+#endif
+    } else {
+      ETLDetId theId(etlNS_.getUnitID(thisN_));
+      sunitt << theId.rawId();
+#ifdef EDM_ML_DEBUG
+      G4cout << theId << G4endl;
+#endif
+    }
+
+    auto fround = [&](double in) {
+      std::stringstream ss;
+      ss << std::fixed << std::setw(14) << roundIfNear0(in);
+      return ss.str();
+    };
+
+    G4Box *thisSens = static_cast<G4Box *>(lv->GetSolid());
+    G4ThreeVector cn1Global = fHistory.GetTopTransform().Inverse().TransformPoint(
+        G4ThreeVector(thisSens->GetXHalfLength(), thisSens->GetYHalfLength(), thisSens->GetZHalfLength()));
+
+    sunitt << fround(globalpoint.x()) << fround(globalpoint.y()) << fround(globalpoint.z()) << fround(cn1Global.x())
+           << fround(cn1Global.y()) << fround(cn1Global.z());
+    edm::LogVerbatim("MTDG4sensUnitTest") << sunitt.str();
+  }
+
+  int NoDaughters = lv->GetNoDaughters();
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
+    if (!pvD->IsReplicated())
+      ntotal = dumpTouch(pvD, leafDepth + 1, ntotal);
+  }
+
+  if (leafDepth > 0)
+    fHistory.BackLevel();
+  return ntotal;
+}
+
+G4VPhysicalVolume *PrintMTDSens::getTopPV() {
+  return G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+}
+
+bool PrintMTDSens::getBaseNumber() {
+  bool isBTL(false);
+  thisN_.reset();
+  thisN_.setSize(fHistory.GetMaxDepth());
+  int theSize = fHistory.GetDepth() + 1;
+  if (thisN_.getCapacity() < theSize)
+    thisN_.setSize(theSize);
+  //Get name and copy numbers
+  if (theSize > 1) {
+#ifdef EDM_ML_DEBUG
+    G4cout << "Building MTD basenumber:" << G4endl;
+#endif
+    for (int ii = theSize; ii-- > 0;) {
+      thisN_.addLevel(fHistory.GetVolume(ii)->GetName(), fHistory.GetReplicaNo(ii));
+#ifdef EDM_ML_DEBUG
+      G4cout << "PrintMTDSens::getBaseNumber(): Adding level " << theSize - 1 - ii << ": "
+             << fHistory.GetVolume(ii)->GetName() << "[" << fHistory.GetReplicaNo(ii) << "]" << G4endl;
+#endif
+      if (!isBTL) {
+        isBTL = G4StrUtil::contains(fHistory.GetVolume(ii)->GetName(), "BarrelTimingLayer");
+      }
+    }
+  }
+  return isBTL;
+}
+
+#include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+
+DEFINE_SIMWATCHER(PrintMTDSens);

--- a/SimG4CMS/Forward/test/BuildFile.xml
+++ b/SimG4CMS/Forward/test/BuildFile.xml
@@ -10,3 +10,5 @@
   <flags EDM_PLUGIN="1"/>
   <flags REM_CXXFLAGS="-Werror=unused-variable"/>
 </library>
+
+<test name="SimG4CMSForwardTestDriver" command="runTest.sh"/>

--- a/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
@@ -1,0 +1,90 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+process = cms.Process('G4PrintGeometry',Phase2C17I13M9,dd4hep)
+
+process.load('Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')
+process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+    limit = cms.untracked.int32(0)
+)
+process.MessageLogger.cerr.G4cout = cms.untracked.PSet(
+    limit = cms.untracked.int32(-1)
+)
+process.MessageLogger.files.mtdG4sensDD4hep = cms.untracked.PSet(
+    DEBUG = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    ERROR = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    FWKINFO = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    INFO = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MTDG4sensUnitTest = cms.untracked.PSet(
+        limit = cms.untracked.int32(-1)
+    ),
+    WARNING = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string('INFO')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
+process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
+process.load('GeneratorInterface.Core.generatorSmeared_cfi')
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(13),
+        MinEta = cms.double(-2.5),
+        MaxEta = cms.double(2.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt  = cms.double(9.99),
+        MaxPt  = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+         initialSeed = cms.untracked.uint32(123456789),
+         engineName = cms.untracked.string('HepJamesRandom')
+    ),
+    VtxSmeared = cms.PSet(
+        engineName = cms.untracked.string('HepJamesRandom'),
+        initialSeed = cms.untracked.uint32(98765432)
+    ),
+    g4SimHits = cms.PSet(
+         initialSeed = cms.untracked.uint32(11),
+         engineName = cms.untracked.string('HepJamesRandom')
+    )
+)
+
+process.load('SimG4Core.Application.g4SimHits_cfi')
+
+process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmeared*process.g4SimHits)
+
+process.g4SimHits.UseMagneticField        = False
+process.g4SimHits.Physics.DefaultCutValue = 10. 
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+	Name           = cms.untracked.vstring('BTLCrystal1','BTLCrystal2','BTLCrystal3','EModule_Timingactive'),
+	type           = cms.string('PrintMTDSens')
+))

--- a/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
@@ -1,0 +1,89 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process('G4PrintGeometry',Phase2C17I13M9)
+
+process.load('Configuration.Geometry.GeometryExtended2026D98Reco_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')
+process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+    limit = cms.untracked.int32(0)
+)
+process.MessageLogger.cerr.G4cout = cms.untracked.PSet(
+    limit = cms.untracked.int32(-1)
+)
+process.MessageLogger.files.mtdG4sensDDD = cms.untracked.PSet(
+    DEBUG = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    ERROR = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    FWKINFO = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    INFO = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    MTDG4sensUnitTest = cms.untracked.PSet(
+        limit = cms.untracked.int32(-1)
+    ),
+    WARNING = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    ),
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string('INFO')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
+process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
+process.load('GeneratorInterface.Core.generatorSmeared_cfi')
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(13),
+        MinEta = cms.double(-2.5),
+        MaxEta = cms.double(2.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt  = cms.double(9.99),
+        MaxPt  = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+    generator = cms.PSet(
+         initialSeed = cms.untracked.uint32(123456789),
+         engineName = cms.untracked.string('HepJamesRandom')
+    ),
+    VtxSmeared = cms.PSet(
+        engineName = cms.untracked.string('HepJamesRandom'),
+        initialSeed = cms.untracked.uint32(98765432)
+    ),
+    g4SimHits = cms.PSet(
+         initialSeed = cms.untracked.uint32(11),
+         engineName = cms.untracked.string('HepJamesRandom')
+    )
+)
+
+process.load('SimG4Core.Application.g4SimHits_cfi')
+
+process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmeared*process.g4SimHits)
+
+process.g4SimHits.UseMagneticField        = False
+process.g4SimHits.Physics.DefaultCutValue = 10. 
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+	Name           = cms.untracked.vstring('BTLCrystal1','BTLCrystal2','BTLCrystal3','EModule_Timingactive'),
+	type           = cms.string('PrintMTDSens')
+))

--- a/SimG4CMS/Forward/test/runTest.sh
+++ b/SimG4CMS/Forward/test/runTest.sh
@@ -1,0 +1,56 @@
+#!/bin/sh -e
+
+function die { echo $1: status $2 ; exit $2; }
+function checkDiff {
+    FSIZE=$(stat -c%s "$1")
+    echo "The output diff is $FSIZE:"
+    cat $1;
+    if [ $FSIZE -gt 0 ]
+    then
+      exit -1;
+    fi
+}
+
+TEST_DIR=$CMSSW_BASE/src/SimG4CMS/Forward/test/python
+
+F1=${TEST_DIR}/runMTDSens_cfg.py
+F2=${TEST_DIR}/runMTDSens_DD4hep_cfg.py
+
+REF_FILE="Geometry/TestReference/data/mtdCommonDataRef.log.gz"
+REF=""
+for d in $(echo $CMSSW_SEARCH_PATH | tr ':' '\n') ; do
+  if [ -e "${d}/${REF_FILE}" ] ; then
+    REF="${d}/${REF_FILE}"
+      break
+  fi
+done
+[ -z $REF ] && exit 1
+
+zcat $REF > ./mtdCommonDataRef.log
+sort -n ./mtdCommonDataRef.log > ./tmplog; mv ./tmplog ./mtdCommonDataRef.log
+gzip ./mtdCommonDataRef.log
+REF=${PWD}/mtdCommonDataRef.log.gz
+
+FILE1=mtdG4sensDDD.log
+FILE2=mtdG4sensDD4hep.log
+LOG=mtdg4sdlog
+DIF=mtdg4sdif
+
+echo " testing SimG4CMS/Forward"
+
+echo "===== Test \"cmsRun runMTDSens_cfg.py\" ===="
+rm -f $LOG $DIF $FILE1
+
+cmsRun $F1 >& $LOG || die "Failure using cmsRun $F1" $?
+sort -n $FILE1 > tmpF1; mv tmpF1 $FILE1
+gzip -f $FILE1 || die "$FILE1 compression fail" $?
+(zdiff $FILE1.gz $REF >& $DIF || [ -s $DIF ] && checkDiff $DIF || echo "OK") || die "Failure in comparison for $FILE1" $?
+
+rm -f $LOG $DIF $FILE2
+echo "===== Test \"cmsRun runMTDSens_DD4hep_cfg.py\" ===="
+
+cmsRun $F2 >& $LOG || die "Failure using cmsRun $F2" $?
+sort -n $FILE2 > tmpF2; mv tmpF2 $FILE2
+gzip -f $FILE2 || die "$FILE2 compression fail" $?
+(zdiff $FILE2.gz $REF >& $DIF || [ -s $DIF ] && checkDiff $DIF || echo "OK") || die "Failure in comparison for $FILE2" $?
+


### PR DESCRIPTION
#### PR description:

This PR addresses the failure of the validation of BTL simulation and reconstruction when comparing DDD and DD4hep versions, see 
https://cms-talk.web.cern.ch/t/valdb-13-2-0-pre1-phase2-d99-dd4hep-reconstruction-fullsim-mtd-reports-status-has-been-changed/26069/3
The problem is observed in the global z coordinate of the BTL SimHits, and it is given by incorrect ```BTLDetId``` being filled for the DD4hep version, as shown by debugging dumps.

Unit tests are showing agreement between the two versions of geometry since 2020, but the way the BTL ```BaseNumber``` object is filled in the ```MtdSD``` interface to Geant4 does not clean the DD4hep output for the appended version number in the name of the volume, as instead is done in the geometry test code. Such a cleaning is now done inside the BTL numbering scheme natively, causing the unit test and Geant4-based simulation to behave in the same way.

At the same time, all MTD geometry unit tests have been updated to scenario 2026D98 (identical to D95 as far as MTD is concerned, no need to update external references).

#### PR validation:

Unit tests run without issue, the debugging printout of the numbering scheme and ```MtdSD``` is the same for 100 single muons tracked by Geant4. 