### PR TITLE
[13_0_X] Online DQM: replace the hard-coded output directory name of event display clients with an input argument, backport of 41986 and 42128

### DIFF
--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -79,7 +79,7 @@ if not unitTest:
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))
     runno = str(m.group(1))
-    outDir= '/fff/BU0/output/EvD/run'+runno+'/streamEvDOutput2'
+    outDir= options.outputBaseDir+'/EvD/run'+runno+'/streamEvDOutput2'
 else:
     runno = options.runNumber
     outDir = "./upload"

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -77,7 +77,7 @@ if not unitTest:
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))
     runno = str(m.group(1))
-    outDir= '/fff/BU0/output/EvD/run'+runno+'/streamEvDOutput'
+    outDir= options.outputBaseDir+'/EvD/run'+runno+'/streamEvDOutput'
 else:
     runno = options.runNumber
     outDir = "./upload"

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -67,6 +67,20 @@ options.register('runUniqueKey',
                  VarParsing.VarParsing.varType.string,
                  "Unique run key from RCMS for Frontier")
 
+# Parameter for output directory of the event display clients
+# visualization-live and visualization-live-secondInstance
+# this additional input argument was added in the hltd framework
+# only for the visualization clients 
+# Note, the other clients do not use this input parameter
+
+options.register('outputBaseDir',
+                 '/fff/BU0/output',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Directory where the visualization output files will appear.")
+
+
+
 options.parseArguments()
 
 # Fix to allow scram to compile

--- a/DQM/Integration/python/config/pbsource_cfi.py
+++ b/DQM/Integration/python/config/pbsource_cfi.py
@@ -60,6 +60,19 @@ options.register('runUniqueKey',
                  VarParsing.VarParsing.varType.string,
                  "Unique run key from RCMS for Frontier")
 
+# Parameter for output directory of the event display clients
+# visualization-live and visualization-live-secondInstance
+# this additional input argument was added in the hltd framework
+# only for the visualization clients 
+# Note, the other clients do not use this input parameter
+
+options.register('outputBaseDir',
+                 '/fff/BU0/output',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Directory where the visualization output files will appear.")
+
+
 options.parseArguments()
 
 # Fix to allow scram to compile


### PR DESCRIPTION
#### PR description:
This is a backport of [PR 41986](https://github.com/cms-sw/cmssw/pull/41986) and  [PR 42128](https://github.com/cms-sw/cmssw/pull/42128).

We are working on the upgrade of online DQM machines [0][1]. There will be a few months that we share the same CMSSW code between the new and the current machines. 
In the current (old) DQM machines, the disks of bu-c2f11-09-01 and bu-c2f11-13-01 are mounted on our fu machines as /fff/BU0.  Event display clients `visualization-live` and `visualization-live-secondInstance` produce output root files at /fff/BU0/output. 

However, the mount point (path) has changed in the new online DQM machines [1]. In order to use the same event display client codes for both old and new machines and also to make the path name more flexible, we replace the output path with an input argument (with a default value of `/fff/BU0/output`). The old machines will use an old hltd version and take the default value of the argument `outputBaseDir`, while the input values for the new machines will be determined by hltd and startDqmRun.sh. 


[0] [twiki about the upgrade of DQM machines](https://twiki.cern.ch/twiki/bin/view/CMS/DQMUpgradeOnlineMachines)
[1] [JIRA ticket that includes the communication with DAQ](https://its.cern.ch/jira/browse/CMSONS-14012)
[2] [JIRA ticket of the tests during TS1](https://its.cern.ch/jira/browse/CMSONS-14652)

#### PR validation:

- This PR has been tested at lxplus by running the hlt, hcal, and ecal clients standalone with `CMSSW_13_0_X_2023-06-27-1100` , `CMSSW_13_1_X_2023-06-27-1100`,  and `CMSSW_13_2_X_2023-06-26-2300` with the streamers at `/eos/cms/store/group/comm_dqm/Collisions23_tempStreamers/`. 
- This PR has been tested at the current (old) online DQM playback machines and ran all clients without problem when using the default value of the input argument. 
- This PR has been deployed/tested when we tested the data transfer during TS1 [2].
