### PR TITLE
Make CondFormats' portable_{i,o}archive compile with CPP20

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -112,19 +112,8 @@
 #endif
 
 // endian and fpclassify
-#if BOOST_VERSION < 103600
-#include <boost/integer/endian.hpp>
-#include <boost/math/fpclassify.hpp>
-#elif BOOST_VERSION < 104800
-#include <boost/spirit/home/support/detail/integer/endian.hpp>
-#include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#elif BOOST_VERSION >= 106900
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/endian/conversion.hpp>
-#else
-#include <boost/spirit/home/support/detail/endian/endian.hpp>
-#include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#endif
 
 // namespace alias
 #if BOOST_VERSION < 103800
@@ -133,15 +122,6 @@ namespace fp = boost::math;
 namespace fp = boost::math;
 #else
 namespace fp = boost::spirit::math;
-#endif
-
-// namespace alias endian
-#if BOOST_VERSION < 104800
-namespace endian = boost::detail;
-#elif BOOST_VERSION >= 106900
-namespace endian = boost::endian;
-#else
-namespace endian = boost::spirit::detail;
 #endif
 
 #if BOOST_VERSION >= 104500 && !defined BOOST_NO_STD_WSTRING
@@ -357,11 +337,7 @@ namespace eos {
 
 // load the value from little endian - it is then converted
 // to the target type T and fits it because size <= sizeof(T)
-#if BOOST_VERSION >= 106900
-        t = endian::little_to_native(temp);
-#else
-        t = endian::load_little_endian<T, sizeof(T)>(&temp);
-#endif
+        t = boost::endian::little_to_native(temp);
       }
 
       else

--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -335,8 +335,8 @@ namespace eos {
         T temp = size < 0 ? -1 : 0;
         load_binary(&temp, abs(size));
 
-// load the value from little endian - it is then converted
-// to the target type T and fits it because size <= sizeof(T)
+        // load the value from little endian - it is then converted
+        // to the target type T and fits it because size <= sizeof(T)
         t = boost::endian::little_to_native(temp);
       }
 

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -316,8 +316,8 @@ namespace eos {
         save_signed_char(t > 0 ? size : -size);
         BOOST_ASSERT(t > 0 || boost::is_signed<T>::value);
 
-// we choose to use little endian because this way we just
-// save the first size bytes to the stream and skip the rest
+        // we choose to use little endian because this way we just
+        // save the first size bytes to the stream and skip the rest
         temp = boost::endian::native_to_little(t);
         save_binary(&temp, size);
       }

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -120,19 +120,8 @@
 #endif
 
 // endian and fpclassify
-#if BOOST_VERSION < 103600
-#include <boost/integer/endian.hpp>
-#include <boost/math/fpclassify.hpp>
-#elif BOOST_VERSION < 104800
-#include <boost/spirit/home/support/detail/integer/endian.hpp>
-#include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#elif BOOST_VERSION >= 106900
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/endian/conversion.hpp>
-#else
-#include <boost/spirit/home/support/detail/endian/endian.hpp>
-#include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#endif
 
 // namespace alias fp_classify
 #if BOOST_VERSION < 103800
@@ -141,15 +130,6 @@ namespace fp = boost::math;
 namespace fp = boost::math;
 #else
 namespace fp = boost::spirit::math;
-#endif
-
-// namespace alias endian
-#if BOOST_VERSION < 104800
-namespace endian = boost::detail;
-#elif BOOST_VERSION >= 106900
-namespace endian = boost::endian;
-#else
-namespace endian = boost::spirit::detail;
 #endif
 
 #if BOOST_VERSION >= 104500 && !defined BOOST_NO_STD_WSTRING
@@ -338,11 +318,7 @@ namespace eos {
 
 // we choose to use little endian because this way we just
 // save the first size bytes to the stream and skip the rest
-#if BOOST_VERSION >= 106900
-        temp = endian::native_to_little(t);
-#else
-        endian::store_little_endian<T, sizeof(T)>(&temp, t);
-#endif
+        temp = boost::endian::native_to_little(t);
         save_binary(&temp, size);
       }
       // zero optimization


### PR DESCRIPTION
#### PR description:

Title says it all. Not 100% sure if this is the best fix, but (IMO) maintaining backwards compatibility with older BOOST versions will make the code less readable.

#### PR validation:

Code builds