### PR TITLE
Update RPC geometry fix in 2022 and 2023 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -62,29 +62,29 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '131X_mcRun3_2022_design_v2',
+    'phase1_2022_design'           : '131X_mcRun3_2022_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v3',
+    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v3',
+    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v3',
+    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v2',
+    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v7',
+    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v6',
+    'phase1_2023_design'           : '131X_mcRun3_2023_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v6',
+    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v6',
+    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v6',
+    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v11',
+    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '131X_mcRun4_realistic_v6'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -84,7 +84,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '131X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:
This PR updates the 2022 and 2023 MC GTs with the RPC geometry fix for the issue in the RPC chambers. More details regarding the tags updated and the original CMS Talk request for the update can be found in [[1]](https://cms-talk.web.cern.ch/t/fix-for-rpc-geometry-for-run3-data-and-mc/25678). 

[1] https://cms-talk.web.cern.ch/t/fix-for-rpc-geometry-for-run3-data-and-mc/25678

**GT Differences with the last ones are here**:

- **Phase1 2022 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_design_v2/131X_mcRun3_2022_design_v3

- **Phase1 2022 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_v3/131X_mcRun3_2022_realistic_v4

- **Phase1 2022 realistic postEE**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_postEE_v3/131X_mcRun3_2022_realistic_postEE_v4

- **Phase1 2022 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_realistic_deco_v3/131X_mcRun3_2022cosmics_realistic_deco_v4

- **Phase1 2022 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_design_deco_v2/131X_mcRun3_2022cosmics_design_deco_v3

- **Phase1 2022 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v7/131X_mcRun3_2022_realistic_HI_v8

- **Phase1 2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v6/131X_mcRun3_2023_design_v7

- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v6/131X_mcRun3_2023_realistic_v7

- **Phase1 2023 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v6/131X_mcRun3_2023cosmics_realistic_deco_v7

- **Phase1 2023 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v6/131X_mcRun3_2023cosmics_design_deco_v7

- **Phase1 2023 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v11/131X_mcRun3_2023_realistic_HI_v12

#### PR validation:
GTs tested locally with `runTheMatrix.py -l 12034.0,11634.0,7.23,7.24,159.0,159.1,12434.0,160.1,12834.0  -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport but `131X` and `130X` backports coming up right after
