### PR TITLE
IsoPhotonEB RAW-RECO skim

### DIFF
--- a/DPGAnalysis/Skims/python/IsoPhotonEBSkim_cff.py
+++ b/DPGAnalysis/Skims/python/IsoPhotonEBSkim_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+import copy
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+IsoPhotonEBHLTFilter = copy.deepcopy(hltHighLevel)
+IsoPhotonEBHLTFilter.throw = cms.bool(False)
+IsoPhotonEBHLTFilter.HLTPaths = ["HLT_Photon110EB_TightID_TightIso_v*"]
+
+# run on MIONAOD
+RUN_ON_MINIAOD = False
+
+
+# cuts
+PHOTON_CUT=("pt > 110 && abs(eta)<1.4442")
+
+# single lepton selectors
+if RUN_ON_MINIAOD:
+    goodPhotons = cms.EDFilter("PATElectronRefSelector",
+                                    src = cms.InputTag("slimmedPhotons"),
+                                    cut = cms.string(PHOTON_CUT)
+                                    )
+else:
+    goodPhotons = cms.EDFilter("PhotonRefSelector",
+                                    src = cms.InputTag("gedPhotons"),
+                                    cut = cms.string(PHOTON_CUT)
+                                    )
+
+photonIDWP = cms.PSet( #first for barrel, second for endcap. 
+    full5x5_sigmaIEtaIEtaCut       = cms.vdouble(0.011 ,-1. )  , # full5x5_sigmaIEtaIEtaCut
+    hOverECut                      = cms.vdouble(0.1  ,-1. )  , # hOverECut
+    relCombIsolationWithEACut      = cms.vdouble(0.05  ,-1. )   # relCombIsolationWithEALowPtCut
+) 
+
+
+identifiedPhotons = cms.EDFilter("IsoPhotonEBSelectorAndSkim",
+                                   src    = cms.InputTag("goodPhotons"),
+                                   phID = photonIDWP, 
+                                   absEtaMin=cms.vdouble( 0.0000, 1.0000, 1.4790, 2.0000, 2.2000, 2.3000, 2.4000),
+                                   absEtaMax=cms.vdouble( 1.0000,  1.4790, 2.0000,  2.2000, 2.3000, 2.4000, 5.0000),
+                                   effectiveAreaValues=cms.vdouble( 0.1703, 0.1715, 0.1213, 0.1230, 0.1635, 0.1937, 0.2393),
+                                   rho = cms.InputTag("fixedGridRhoFastjetCentralCalo") 
+                         )
+
+identifiedPhotonsCountFilter = cms.EDFilter("CandViewCountFilter",
+                                    src = cms.InputTag("identifiedPhotons"),
+                                    minNumber = cms.uint32(1)
+                                    )
+
+
+
+#sequences
+isoPhotonEBSequence = cms.Sequence(IsoPhotonEBHLTFilter*goodPhotons*identifiedPhotons*identifiedPhotonsCountFilter )

--- a/DPGAnalysis/Skims/python/IsoPhotonEBSkim_cff.py
+++ b/DPGAnalysis/Skims/python/IsoPhotonEBSkim_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
-import copy
-from HLTrigger.HLTfilters.hltHighLevel_cfi import *
-IsoPhotonEBHLTFilter = copy.deepcopy(hltHighLevel)
-IsoPhotonEBHLTFilter.throw = cms.bool(False)
-IsoPhotonEBHLTFilter.HLTPaths = ["HLT_Photon110EB_TightID_TightIso_v*"]
+from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+IsoPhotonEBHLTFilter = hltHighLevel.clone(
+     throw = False,
+     HLTPaths = ["HLT_Photon110EB_TightID_TightIso_v*"]
+)
 
 # run on MIONAOD
 RUN_ON_MINIAOD = False

--- a/DPGAnalysis/Skims/python/Skims_DPG_cff.py
+++ b/DPGAnalysis/Skims/python/Skims_DPG_cff.py
@@ -402,6 +402,20 @@ SKIMStreamZElectron = cms.FilteredStream(
 
 #####################
 
+from DPGAnalysis.Skims.IsoPhotonEBSkim_cff import *
+isoPhotonEBPath = cms.Path( isoPhotonEBSequence )
+
+SKIMStreamIsoPhotonEB = cms.FilteredStream(
+    responsible = 'L1 DPG',
+    name = 'IsoPhotonEB',
+    paths = ( isoPhotonEBPath ),
+    content = skimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################
+
 from DPGAnalysis.Skims.HighMETSkim_cff import *
 condPath = cms.Path(CondMETSelSeq)
 #pfPath = cms.Path(pfMETSelSeq)

--- a/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
+++ b/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
@@ -57,13 +57,12 @@ public:
   std::vector<double> absEtaMin_;            // low limit of the eta range
   std::vector<double> absEtaMax_;            // upper limit of the eta range
   std::vector<double> effectiveAreaValues_;  // effective area for this eta range
-  
+
   edm::ParameterSet phIDWP;
 
   vector<double> sigmaIEtaIEtaCut;
   vector<double> hOverECut;
   vector<double> relCombIso;
-
 };
 
 void IsoPhotonEBSelector::printEffectiveAreas() const {
@@ -128,8 +127,8 @@ bool IsoPhotonEBSelector::operator()(const reco::Photon& ph) const {
   const float rho = _rhoHandle.isValid() ? (float)(*_rhoHandle.product()) : 0;
   if ((ph.getPflowIsolationVariables().chargedHadronIso +
        std::max(float(0.0),
-                ph.getPflowIsolationVariables().neutralHadronIso + ph.getPflowIsolationVariables().photonIso - eA * rho)) >
-      relCombIso[ind] * pt_e)
+                ph.getPflowIsolationVariables().neutralHadronIso + ph.getPflowIsolationVariables().photonIso -
+                    eA * rho)) > relCombIso[ind] * pt_e)
     return false;
 
   return true;

--- a/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
+++ b/DPGAnalysis/Skims/src/IsoPhotonEBSelector.cc
@@ -1,0 +1,142 @@
+// -*- C++ -*-
+// Class:      ZElectronsSelector
+//
+// Original Author:  Silvia Taroni
+//         Created:  Wed, 29 Nov 2017 18:23:54 GMT
+//
+//
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+
+// system include files
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+//
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "DataFormats/Common/interface/View.h"
+
+using namespace std;
+using namespace reco;
+namespace edm {
+  class EventSetup;
+}
+
+class IsoPhotonEBSelector {
+public:
+  IsoPhotonEBSelector(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+  bool operator()(const reco::Photon&) const;
+  void newEvent(const edm::Event&, const edm::EventSetup&);
+  const float getEffectiveArea(float eta) const;
+  void printEffectiveAreas() const;
+
+  edm::EDGetTokenT<double> theRhoToken;
+  edm::EDGetTokenT<reco::PhotonCollection> thePhotonToken;
+  edm::Handle<double> _rhoHandle;
+
+  std::vector<double> absEtaMin_;            // low limit of the eta range
+  std::vector<double> absEtaMax_;            // upper limit of the eta range
+  std::vector<double> effectiveAreaValues_;  // effective area for this eta range
+  
+  edm::ParameterSet phIDWP;
+
+  vector<double> sigmaIEtaIEtaCut;
+  vector<double> hOverECut;
+  vector<double> relCombIso;
+
+};
+
+void IsoPhotonEBSelector::printEffectiveAreas() const {
+  printf("  eta_min   eta_max    effective area\n");
+  uint nEtaBins = absEtaMin_.size();
+  for (uint iEta = 0; iEta < nEtaBins; iEta++) {
+    printf("  %8.4f    %8.4f   %8.5f\n", absEtaMin_[iEta], absEtaMax_[iEta], effectiveAreaValues_[iEta]);
+  }
+}
+const float IsoPhotonEBSelector::getEffectiveArea(float eta) const {
+  float effArea = 0;
+  uint nEtaBins = absEtaMin_.size();
+  for (uint iEta = 0; iEta < nEtaBins; iEta++) {
+    if (std::abs(eta) >= absEtaMin_[iEta] && std::abs(eta) < absEtaMax_[iEta]) {
+      effArea = effectiveAreaValues_[iEta];
+      break;
+    }
+  }
+
+  return effArea;
+}
+
+IsoPhotonEBSelector::IsoPhotonEBSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : theRhoToken(iC.consumes<double>(cfg.getParameter<edm::InputTag>("rho"))) {
+  absEtaMin_ = cfg.getParameter<std::vector<double> >("absEtaMin");
+  absEtaMax_ = cfg.getParameter<std::vector<double> >("absEtaMax");
+  effectiveAreaValues_ = cfg.getParameter<std::vector<double> >("effectiveAreaValues");
+  //printEffectiveAreas();
+  phIDWP = cfg.getParameter<edm::ParameterSet>("phID");
+
+  sigmaIEtaIEtaCut = phIDWP.getParameter<std::vector<double> >("full5x5_sigmaIEtaIEtaCut");
+  hOverECut = phIDWP.getParameter<std::vector<double> >("hOverECut");
+  relCombIso = phIDWP.getParameter<std::vector<double> >("relCombIsolationWithEACut");
+}
+
+void IsoPhotonEBSelector::newEvent(const edm::Event& ev, const edm::EventSetup&) {
+  ev.getByToken(theRhoToken, _rhoHandle);
+}
+
+bool IsoPhotonEBSelector::operator()(const reco::Photon& ph) const {
+  float pt_e = ph.pt();
+  unsigned int ind = 0;
+  float abseta = fabs((ph.superCluster().get())->position().eta());
+
+  if (ph.isEB()) {
+    if (abseta > 1.479)
+      return false;  // check if it is really needed
+  }
+  if (ph.isEE()) {
+    ind = 1;
+    if (abseta < 1.479)
+      return false;  // check if it is really needed
+    if (abseta >= 2.5)
+      return false;  // check if it is really needed
+  }
+
+  if (ph.full5x5_sigmaIetaIeta() > sigmaIEtaIEtaCut[ind])
+    return false;
+  if (ph.hadronicOverEm() > hOverECut[ind])
+    return false;
+  const float eA = getEffectiveArea(abseta);
+  const float rho = _rhoHandle.isValid() ? (float)(*_rhoHandle.product()) : 0;
+  if ((ph.getPflowIsolationVariables().chargedHadronIso +
+       std::max(float(0.0),
+                ph.getPflowIsolationVariables().neutralHadronIso + ph.getPflowIsolationVariables().photonIso - eA * rho)) >
+      relCombIso[ind] * pt_e)
+    return false;
+
+  return true;
+}
+
+EVENTSETUP_STD_INIT(IsoPhotonEBSelector);
+
+typedef SingleObjectSelector<edm::View<reco::Photon>, IsoPhotonEBSelector> IsoPhotonEBSelectorAndSkim;
+
+DEFINE_FWK_MODULE(IsoPhotonEBSelectorAndSkim);


### PR DESCRIPTION
#### PR description:

This PR introduces a new skim selecting events based on the presence of a high pt well isolated/identified photon in the ECAL barrel, based on a similar HLT path (HLT_Photon110EB_TightID_TightIso). 
The saved data format is RAW-RECO. The primary purpose of the skim is to facilitate the calibration of L1 and HLT jets. 

#### PR validation:

The skim can be run with the following cmsDriver command: 

`cmsDriver.py SKIM --filein file:/afs/cern.ch/work/l/lathomas/public/SkimIsoPhotonEB/EGamma_RAW_run367902.root --fileout file:SKIM_IsoPhotonEB.root --nThreads 8 --no_exec --number 1000 --python_filename SKIM_IsoPhotonEB.py --scenario pp --step RAW2DIGI,L1Reco,RECO,SKIM:IsoPhotonEB --data --conditions 130X_dataRun3_Prompt_v3 --era Run3`

Running on 5000 events from the EGamma dataset (run 367902), I find 125 events passing the HLT path, out of which 85 pass the offline selection, resulting in 1.7% skim efficiency, comparable to what the ZElectron and ZMu skims achieve. 

