### PR TITLE
Tighten pixel pair loose and tight MVA selection for pp_on_AA eras

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -382,7 +382,7 @@ trackdnn.toReplaceWith(pixelPairStep, trackTfClassifier.clone(
 ))
 
 highBetaStar_2018.toModify(pixelPairStep,qualityCuts = [-0.95,0.0,0.3])
-pp_on_AA.toModify(pixelPairStep, qualityCuts = [-0.2, 0.0, 0.98])
+pp_on_AA.toModify(pixelPairStep, qualityCuts = [0.85, 0.95, 0.98])
 fastSim.toModify(pixelPairStep, vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
 # For LowPU and Phase2PU140


### PR DESCRIPTION
#### PR description:

The 2022 heavy-ion test data showed a large fake rate coming from the pixel pair steps before the `highPurity` track selection was applied. 
This PR loosens the `loose` working point that defines which tracks are kept, as well as the `tight` one, which is not used for anything at the moment.  
The performance was shown [here](https://indico.cern.ch/event/1300027/contributions/5465589/attachments/2672626/4633403/slides_pixelPairStep_23Jun2023.pdf)
Note that the track MVA selection was tuned in #41698 but only for the 6 iterations that were migrated from the BDT track selection. 

#### PR validation:

compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

No backport is needed.

<!-- Please delete the text above after you verified all points of the checklist  -->

@CesarBernardes 
