### PR TITLE
Re-enable nb*AK8PuppiSoftDrop in PAT step

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -97,9 +97,8 @@ def applySubstructure( process, postfix="" ) :
 
     #too slow now ==> disable
     from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
-    from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
-    for e in [pp_on_XeXe_2017, phase2_common]:
+    for e in [pp_on_XeXe_2017]:
         e.toModify(getattr(process,'nb1AK8PuppiSoftDrop'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
         e.toModify(getattr(process,'nb2AK8PuppiSoftDrop'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
 
@@ -114,7 +113,7 @@ def applySubstructure( process, postfix="" ) :
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN2','nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN3']
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['NjettinessAK8Subjets'+postfix+':tau1','NjettinessAK8Subjets'+postfix+':tau2','NjettinessAK8Subjets'+postfix+':tau3','NjettinessAK8Subjets'+postfix+':tau4']
 
-    for e in [pp_on_XeXe_2017, phase2_common]:
+    for e in [pp_on_XeXe_2017]:
         e.toModify(getattr(process,'nb1AK8PuppiSoftDropSubjets'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
         e.toModify(getattr(process,'nb2AK8PuppiSoftDropSubjets'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
 


### PR DESCRIPTION
#### PR description:
This PR follows the measurement of time/event spent in `nb*AK8PuppiSoftDrop` in PAT step.
The issue was six years old, https://github.com/cms-sw/cmssw/issues/20558

The most recent measurement comes from CMSSW_13_2_0_pre2, and it confirms the [last report](https://github.com/cms-sw/cmssw/issues/20558#issuecomment-1055287306) on much reduction  ([compare to 9_4](https://github.com/cms-sw/cmssw/issues/20558#issuecomment-1057052418), original of the issue) of time/event after enable the module.

(Default)
```
<Metric Name="AvgEventTime" Value="8.58059"/>
<Metric Name="MaxEventTime" Value="49.3242"/>
<Metric Name="MinEventTime" Value="1.66604"/>
TimeModule> 7798 1 nb1AK8PuppiSoftDropSubjets ECFAdder 2.5781e-05
TimeModule> 7798 1 nb2AK8PuppiSoftDropSubjets ECFAdder 1.3812e-05
TimeModule> 7798 1 nb1AK8PuppiSoftDrop ECFAdder 1.9545e-05
TimeModule> 7798 1 nb2AK8PuppiSoftDrop ECFAdder 9.763e-06
```

(Enable)
```
<Metric Name="AvgEventTime" Value="8.86463"/>
<Metric Name="MaxEventTime" Value="51.3121"/>
<Metric Name="MinEventTime" Value="2.62571"/>
TimeModule> 7798 1 nb2AK8PuppiSoftDrop ECFAdder 0.00156764
TimeModule> 7798 1 nb1AK8PuppiSoftDrop ECFAdder 0.00193106
TimeModule> 7798 1 nb2AK8PuppiSoftDropSubjets ECFAdder 0.00669256
TimeModule> 7798 1 nb1AK8PuppiSoftDropSubjets ECFAdder 0.00762409
```



#### PR validation:
Run `PAT` step from `23634.21`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.