### PR TITLE
Run3-hcx351 Removing C-cast in favour of C++ cast in Geometry/HcalCommonData

### DIFF
--- a/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDRecConstants.cc
@@ -238,7 +238,7 @@ std::vector<HcalDDDRecConstants::HFCellParameters> HcalDDDRecConstants::getHFCel
   if (maxDepth[2] > 0) {
     for (unsigned int k = 0; k < nEta; ++k) {
       int ieta = iEtaMin[2] + k;
-      int dphi = (int)(0.001 + hcons.getPhiTableHF()[k] / (5._deg));
+      int dphi = static_cast<int>(0.001 + hcons.getPhiTableHF()[k] / (5._deg));
       int iphi = (dphi == 4) ? 3 : 1;
       int nphi = 72 / dphi;
       double rMin = hcons.getRTableHF()[nEta - k - 1] / CLHEP::cm;
@@ -254,7 +254,7 @@ std::vector<HcalDDDRecConstants::HFCellParameters> HcalDDDRecConstants::getHFCel
       for (unsigned int k = 0; k < hcons.getIdHF2QIE().size(); ++k) {
         int ieta = hcons.getIdHF2QIE()[k].ieta();
         int ind = std::abs(ieta) - iEtaMin[2];
-        int dphi = (int)(0.001 + hcons.getPhiTableHF()[ind] / (5._deg));
+        int dphi = static_cast<int>(0.001 + hcons.getPhiTableHF()[ind] / (5._deg));
         int iphi = hcons.getIdHF2QIE()[k].iphi();
         double rMin = hcons.getRTableHF()[nEta - ind - 1] / CLHEP::cm;
         double rMax = hcons.getRTableHF()[nEta - ind] / CLHEP::cm;
@@ -264,7 +264,7 @@ std::vector<HcalDDDRecConstants::HFCellParameters> HcalDDDRecConstants::getHFCel
     } else {
       for (unsigned int k = 0; k < nEta; ++k) {
         int ieta = iEtaMin[2] + k;
-        int dphi = (int)(0.001 + hcons.getPhiTableHF()[k] / (5._deg));
+        int dphi = static_cast<int>(0.001 + hcons.getPhiTableHF()[k] / (5._deg));
         int iphi = (dphi == 4) ? 3 : 1;
         int nphi = 72 / dphi;
         double rMin = hcons.getRTableHF()[nEta - k - 1] / CLHEP::cm;
@@ -307,7 +307,7 @@ int HcalDDDRecConstants::getLayerBack(const int& idet, const int& ieta, const in
   int laymax = hcons.getLastLayer(subdet, ieta);
   if (layBack < 0 && eta <= hpar->etaMax[1]) {
     for (unsigned int k = 0; k < layerGroupSize(eta - 1); ++k) {
-      if (depth + 1 == (int)layerGroup(eta - 1, k)) {
+      if ((depth + 1) == static_cast<int>(layerGroup(eta - 1, k))) {
         layBack = k - 1;
         break;
       }
@@ -333,8 +333,8 @@ int HcalDDDRecConstants::getLayerFront(const int& idet, const int& ieta, const i
       layFront = laymin;
     } else if (eta <= hpar->etaMax[1]) {
       for (unsigned int k = 0; k < layerGroupSize(eta - 1); ++k) {
-        if (depth == (int)layerGroup(eta - 1, k)) {
-          if ((int)(k) >= laymin) {
+        if (depth == static_cast<int>(layerGroup(eta - 1, k))) {
+          if (static_cast<int>(k) >= laymin) {
             layFront = k;
             break;
           }
@@ -361,7 +361,7 @@ int HcalDDDRecConstants::getMaxDepth(const int& itype, const int& ieta, const in
     if (layerGroupSize(ieta - 1) > 0) {
       if (layerGroupSize(ieta - 1) < lymax)
         lymax = layerGroupSize(ieta - 1);
-      lmax = (int)(layerGroup(ieta - 1, lymax - 1));
+      lmax = static_cast<int>(layerGroup(ieta - 1, lymax - 1));
       if (type == 0 && ieta == iEtaMax[type])
         lmax = hcons.getDepthEta16M(1);
       if (type == 1 && ieta >= hpar->noff[1])
@@ -388,7 +388,7 @@ int HcalDDDRecConstants::getMinDepth(const int& itype, const int& ieta, const in
         if (type == 1 && ieta == iEtaMin[type])
           lmin = hcons.getDepthEta16M(2);
         else
-          lmin = (int)(layerGroup(ieta - 1, 0));
+          lmin = static_cast<int>(layerGroup(ieta - 1, 0));
       }
     }
   }
@@ -455,7 +455,7 @@ double HcalDDDRecConstants::getRZ(const int& subdet, const int& ieta, const int&
 
 double HcalDDDRecConstants::getRZ(const int& subdet, const int& layer) const {
   double rz(0);
-  if (layer > 0 && layer <= (int)(layerGroupSize(0)))
+  if (layer > 0 && layer <= static_cast<int>(layerGroupSize(0)))
     rz = ((subdet == static_cast<int>(HcalBarrel)) ? (gconsHB[layer - 1].first) : (gconsHE[layer - 1].first));
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "getRZ: subdet|layer " << subdet << "|" << layer << " rz " << rz;
@@ -581,7 +581,7 @@ std::vector<HcalCellType> HcalDDDRecConstants::HcalCellTypes(HcalSubdetector sub
         }
       }
       for (unsigned int il = 0; il < etabin.layer.size(); ++il) {
-        int depth = etabin.depthStart + (int)(il);
+        int depth = etabin.depthStart + static_cast<int>(il);
         temp[il].setEta(ieta, etabin.etaMin, etabin.etaMax);
         temp[il].setDepth(depth, dmin[il], dmax[il]);
         double foff = (etabin.ieta <= iEtaMax[0]) ? hpar->phioff[0] : hpar->phioff[1];
@@ -766,7 +766,7 @@ void HcalDDDRecConstants::getOneEtaBin(HcalSubdetector subdet,
       edm::LogVerbatim("HCalGeom") << "[" << l << "] " << phis[l].first << ":" << convertRadToDeg(phis[l].second);
 #endif
     for (itr = layers.begin(); itr != layers.end(); ++itr) {
-      if (itr->first <= (int)(lymx0)) {
+      if (itr->first <= static_cast<int>(lymx0)) {
         if (itr->second == dep) {
           if (lmin == 0)
             lmin = itr->first;
@@ -790,7 +790,7 @@ void HcalDDDRecConstants::getOneEtaBin(HcalSubdetector subdet,
           lmax = lymx0;
           break;
         }
-        if (itr->first == (int)(lymx0))
+        if (itr->first == static_cast<int>(lymx0))
           lmax = lymx0;
       }
     }
@@ -825,8 +825,8 @@ void HcalDDDRecConstants::getOneEtaBin(HcalSubdetector subdet,
 
 void HcalDDDRecConstants::initialize(void) {
   //Eta grouping
-  int nEta = (int)(hpar->etagroup.size());
-  if (nEta != (int)(hpar->phigroup.size())) {
+  int nEta = static_cast<int>(hpar->etagroup.size());
+  if (nEta != static_cast<int>(hpar->phigroup.size())) {
     edm::LogError("HCalGeom") << "HcalDDDRecConstants: sizes of the vectors "
                               << " etaGroup (" << nEta << ") and phiGroup (" << hpar->phigroup.size()
                               << ") do not match";
@@ -845,7 +845,7 @@ void HcalDDDRecConstants::initialize(void) {
   for (int i = 0; i < nEta; ++i) {
     int ef = ieta + 1;
     ieta += (hpar->etagroup[i]);
-    if (ieta >= (int)(hpar->etaTable.size())) {
+    if (ieta >= static_cast<int>(hpar->etaTable.size())) {
       edm::LogError("HCalGeom") << "HcalDDDRecConstants: Going beyond the array boundary " << hpar->etaTable.size()
                                 << " at index " << i << " of etaTable from SimConstant";
       throw cms::Exception("DDException")
@@ -878,7 +878,7 @@ void HcalDDDRecConstants::initialize(void) {
   for (int i = 0; i < nEta; ++i) {
     double dphi = (hpar->phigroup[i]) * (hpar->phibin[ieta]);
     phibin.emplace_back(dphi);
-    int nphi = (int)((2._pi + 0.001) / dphi);
+    int nphi = static_cast<int>((2._pi + 0.001) / dphi);
     if (ieta <= iEtaMax[0]) {
       if (nphi > nPhiBins[0])
         nPhiBins[3] = nPhiBins[0] = nphi;
@@ -894,7 +894,7 @@ void HcalDDDRecConstants::initialize(void) {
     phiUnitS.emplace_back(unit);
   }
   for (double i : hpar->phitable) {
-    int nphi = (int)((2._pi + 0.001) / i);
+    int nphi = static_cast<int>((2._pi + 0.001) / i);
     if (nphi > nPhiBins[2])
       nPhiBins[2] = nphi;
   }

--- a/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
+++ b/Geometry/HcalCommonData/src/HcalDDDSimConstants.cc
@@ -42,7 +42,7 @@ HcalCellType::HcalCell HcalDDDSimConstants::cell(
        idet == static_cast<int>(HcalOuter) || idet == static_cast<int>(HcalForward)) &&
       etaR >= etaMn && etaR <= etaMx && depth > 0)
     ok = true;
-  if (idet == static_cast<int>(HcalEndcap) && depth > (int)(hpar->zHE.size()))
+  if (idet == static_cast<int>(HcalEndcap) && depth > static_cast<int>(hpar->zHE.size()))
     ok = false;
   else if (idet == static_cast<int>(HcalBarrel) && depth > maxLayerHB_ + 1)
     ok = false;
@@ -83,8 +83,9 @@ HcalCellType::HcalCell HcalDDDSimConstants::cell(
     } else if (etaR <= nEta) {
       int laymin(depth), laymax(depth);
       if (idet == static_cast<int>(HcalOuter)) {
-        laymin = (etaR > hpar->noff[2]) ? ((int)(hpar->zHE.size())) : ((int)(hpar->zHE.size())) - 1;
-        laymax = ((int)(hpar->zHE.size()));
+        laymin =
+            (etaR > hpar->noff[2]) ? (static_cast<int>(hpar->zHE.size())) : (static_cast<int>(hpar->zHE.size())) - 1;
+        laymax = (static_cast<int>(hpar->zHE.size()));
       }
       double d1 = 0, d2 = 0;
       if (idet == static_cast<int>(HcalEndcap)) {
@@ -127,7 +128,7 @@ unsigned int HcalDDDSimConstants::findLayer(const int& layer,
                                             const std::vector<HcalParameters::LayerItem>& layerGroup) const {
   unsigned int id = layerGroup.size();
   for (unsigned int i = 0; i < layerGroup.size(); i++) {
-    if (layer == (int)(layerGroup[i].layer)) {
+    if (layer == static_cast<int>(layerGroup[i].layer)) {
       id = i;
       break;
     }
@@ -264,12 +265,13 @@ std::pair<int, int> HcalDDDSimConstants::getEtaDepth(
   } else {
     if (lay >= 0) {
       depth = layerGroup(det, etaR, phi, zside, lay - 1);
-      if (etaR == hpar->noff[0] && lay > 1) {
-        int kphi = phi + int((hpar->phioff[3] + 0.1) / hpar->phibin[etaR - 1]);
-        kphi = (kphi - 1) % 4 + 1;
-        if (kphi == 2 || kphi == 3)
-          depth = layerGroup(det, etaR, phi, zside, lay - 2);
-      }
+      if (((det == 2) && (etaR == 18)) || ((det == 1) && (etaR == 15)))
+        if (etaR == hpar->noff[0] && lay > 1) {
+          int kphi = phi + static_cast<int>((hpar->phioff[3] + 0.1) / hpar->phibin[etaR - 1]);
+          kphi = (kphi - 1) % 4 + 1;
+          if (kphi == 2 || kphi == 3)
+            depth = layerGroup(det, etaR, phi, zside, lay - 2);
+        }
     } else if (det == static_cast<int>(HcalBarrel)) {
       if (depth > getMaxDepth(det, etaR, phi, zside, false))
         depth = getMaxDepth(det, etaR, phi, zside, false);
@@ -371,7 +373,7 @@ int HcalDDDSimConstants::getLayerFront(
     if (det == 1 || det == 2) {
       layer = 1;
       for (int l = 0; l < getLayerMax(eta, depth); ++l) {
-        if ((int)(layerGroup(eta - 1, l)) == depth) {
+        if (static_cast<int>(layerGroup(eta - 1, l)) == depth) {
           layer = l + 1;
           break;
         }
@@ -397,7 +399,8 @@ int HcalDDDSimConstants::getLayerBack(
 }
 
 int HcalDDDSimConstants::getLayerMax(const int& eta, const int& depth) const {
-  int layermx = ((eta < hpar->etaMin[1]) && depth - 1 < maxDepth[0]) ? maxLayerHB_ + 1 : (int)layerGroupSize(eta - 1);
+  int layermx = ((eta < hpar->etaMin[1]) && depth - 1 < maxDepth[0]) ? maxLayerHB_ + 1
+                                                                     : static_cast<int>(layerGroupSize(eta - 1));
   return layermx;
 }
 
@@ -442,7 +445,7 @@ int HcalDDDSimConstants::getMinDepth(
     if (ldmap_.isValid(det, phi, zside)) {
       lmin = ldmap_.getDepths(eta).first;
     } else if (layerGroupSize(eta - 1) > 0) {
-      lmin = (int)(layerGroup(eta - 1, 0));
+      lmin = static_cast<int>(layerGroup(eta - 1, 0));
       unsigned int type = (det == 1) ? 0 : 1;
       if (type == 1 && eta == hpar->etaMin[1])
         lmin = getDepthEta16(det, phi, zside);
@@ -671,7 +674,7 @@ unsigned int HcalDDDSimConstants::numberOfCells(const HcalSubdetector& subdet) c
   unsigned int num = 0;
   std::vector<HcalCellType> cellTypes = HcalCellTypes(subdet);
   for (auto& cellType : cellTypes) {
-    num += (unsigned int)(cellType.nPhiBins());
+    num += static_cast<unsigned int>(cellType.nPhiBins());
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "HcalDDDSimConstants:numberOfCells " << cellTypes.size() << " " << num
@@ -790,7 +793,7 @@ void HcalDDDSimConstants::initialize(void) {
       int layermx = getLayerMax(k + 1, i + 1);
       int ll = layermx;
       for (int l = layermx - 1; l >= 0; --l) {
-        if ((int)layerGroup(k, l) == i + 1) {
+        if (static_cast<int>(layerGroup(k, l)) == i + 1) {
           ll = l + 1;
           break;
         }
@@ -837,14 +840,14 @@ void HcalDDDSimConstants::initialize(void) {
 
   int noffsize = 7 + hpar->noff[5] + hpar->noff[6];
   int noffl(noffsize + 5);
-  if ((int)(hpar->noff.size()) > (noffsize + 3)) {
+  if (static_cast<int>(hpar->noff.size()) > (noffsize + 3)) {
     depthEta16[0] = hpar->noff[noffsize];
     depthEta16[1] = hpar->noff[noffsize + 1];
     depthEta29[0] = hpar->noff[noffsize + 2];
     depthEta29[1] = hpar->noff[noffsize + 3];
-    if ((int)(hpar->noff.size()) > (noffsize + 4)) {
+    if (static_cast<int>(hpar->noff.size()) > (noffsize + 4)) {
       noffl += (2 * hpar->noff[noffsize + 4]);
-      if ((int)(hpar->noff.size()) > noffl)
+      if (static_cast<int>(hpar->noff.size()) > noffl)
         isBH_ = (hpar->noff[noffl] > 0);
     }
   } else {
@@ -860,7 +863,7 @@ void HcalDDDSimConstants::initialize(void) {
                                << depthEta29[1] << ")";
 #endif
 
-  if ((int)(hpar->noff.size()) > (noffsize + 4)) {
+  if (static_cast<int>(hpar->noff.size()) > (noffsize + 4)) {
     int npair = hpar->noff[noffsize + 4];
     int kk = noffsize + 4;
     for (int k = 0; k < npair; ++k) {
@@ -893,16 +896,16 @@ void HcalDDDSimConstants::initialize(void) {
   }
   depthMaxSp_ = std::pair<int, int>(0, 0);
   int noffk(noffsize + 5);
-  if ((int)(hpar->noff.size()) > (noffsize + 5)) {
+  if (static_cast<int>(hpar->noff.size()) > (noffsize + 5)) {
     noffk += (2 * hpar->noff[noffsize + 4]);
-    if ((int)(hpar->noff.size()) >= noffk + 7) {
+    if (static_cast<int>(hpar->noff.size()) >= noffk + 7) {
       int dtype = hpar->noff[noffk + 1];
       int nphi = hpar->noff[noffk + 2];
       int ndeps = hpar->noff[noffk + 3];
       int ndp16 = hpar->noff[noffk + 4];
       int ndp29 = hpar->noff[noffk + 5];
       double wt = 0.1 * (hpar->noff[noffk + 6]);
-      if ((int)(hpar->noff.size()) >= (noffk + 7 + nphi + 3 * ndeps)) {
+      if (static_cast<int>(hpar->noff.size()) >= (noffk + 7 + nphi + 3 * ndeps)) {
         if (dtype == 1 || dtype == 2) {
           std::vector<int> ifi, iet, ily, idp;
           for (int i = 0; i < nphi; ++i)
@@ -931,15 +934,15 @@ void HcalDDDSimConstants::initialize(void) {
         }
       }
       int noffm = (noffk + 7 + nphi + 3 * ndeps);
-      if ((int)(hpar->noff.size()) > noffm) {
+      if (static_cast<int>(hpar->noff.size()) > noffm) {
         int ndnext = hpar->noff[noffm];
-        if (ndnext > 4 && (int)(hpar->noff.size()) >= noffm + ndnext) {
+        if (ndnext > 4 && static_cast<int>(hpar->noff.size()) >= noffm + ndnext) {
           for (int i = 0; i < 2; ++i)
             layFHB[i] = hpar->noff[noffm + i + 1];
           for (int i = 0; i < 3; ++i)
             layFHE[i] = hpar->noff[noffm + i + 3];
         }
-        if (ndnext > 11 && (int)(hpar->noff.size()) >= noffm + ndnext) {
+        if (ndnext > 11 && static_cast<int>(hpar->noff.size()) >= noffm + ndnext) {
           for (int i = 0; i < 3; ++i)
             layBHB[i] = hpar->noff[noffm + i + 6];
           for (int i = 0; i < 4; ++i)
@@ -1200,10 +1203,10 @@ void HcalDDDSimConstants::printTileHE(const int& eta, const int& phi, const int&
 unsigned int HcalDDDSimConstants::layerGroupSize(int eta) const {
   unsigned int k = 0;
   for (auto const& it : hpar->layerGroupEtaSim) {
-    if (it.layer == (unsigned int)(eta + 1)) {
+    if (it.layer == static_cast<unsigned int>(eta + 1)) {
       return it.layerGroup.size();
     }
-    if (it.layer > (unsigned int)(eta + 1))
+    if (it.layer > static_cast<unsigned int>(eta + 1))
       break;
     k = it.layerGroup.size();
   }
@@ -1213,10 +1216,10 @@ unsigned int HcalDDDSimConstants::layerGroupSize(int eta) const {
 unsigned int HcalDDDSimConstants::layerGroup(int eta, int i) const {
   unsigned int k = 0;
   for (auto const& it : hpar->layerGroupEtaSim) {
-    if (it.layer == (unsigned int)(eta + 1)) {
+    if (it.layer == static_cast<unsigned int>(eta + 1)) {
       return it.layerGroup.at(i);
     }
-    if (it.layer > (unsigned int)(eta + 1))
+    if (it.layer > static_cast<unsigned int>(eta + 1))
       break;
     k = it.layerGroup.at(i);
   }
@@ -1225,6 +1228,6 @@ unsigned int HcalDDDSimConstants::layerGroup(int eta, int i) const {
 
 unsigned int HcalDDDSimConstants::layerGroup(int det, int eta, int phi, int zside, int lay) const {
   int depth0 = findDepth(det, eta, phi, zside, lay);
-  unsigned int depth = (depth0 > 0) ? (unsigned int)(depth0) : layerGroup(eta - 1, lay);
+  unsigned int depth = (depth0 > 0) ? static_cast<unsigned int>(depth0) : layerGroup(eta - 1, lay);
   return depth;
 }


### PR DESCRIPTION
#### PR description:

Removing C-cast in favour of C++ cast in Geometry/HcalCommonData

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special