### PR TITLE
Fix `NavigationSchoolAnalyzer` and create unit tests

### DIFF
--- a/RecoTracker/TkNavigation/test/BuildFile.xml
+++ b/RecoTracker/TkNavigation/test/BuildFile.xml
@@ -10,3 +10,5 @@
 <library file="*.cc" name="RecoTrackerTkNavigationTest">
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<test name="test_NavigationSchool" command="testNavigationSchool.sh"/>

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer.cc
@@ -228,8 +228,8 @@ void printOldStyle(std::ostream& os, const NavigationSchool& nav) {
 NavigationSchoolAnalyzer::NavigationSchoolAnalyzer(const edm::ParameterSet& iConfig)
     : theNavigationSchoolName_(iConfig.getParameter<std::string>("navigationSchoolName")),
       navSchoolToken_(esConsumes(edm::ESInputTag("", theNavigationSchoolName_))),
-      tTopoTokenBR_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", theNavigationSchoolName_))),
-      navSchoolTokenBR_(esConsumes<edm::Transition::BeginRun>()) {}
+      tTopoTokenBR_(esConsumes<edm::Transition::BeginRun>()),
+      navSchoolTokenBR_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", theNavigationSchoolName_))) {}
 
 #include <sstream>
 #include <fstream>

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_Phase2_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_Phase2_cfg.py
@@ -3,12 +3,16 @@ import FWCore.ParameterSet.Config as cms
 # set the geometry and the GlobalTag
 
 process = cms.Process("NavigationSchoolAnalyzer")
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+# the following lines are kept for when the phase-2 geometry wil be moved to DB
+#process.load("Configuration.StandardSequences.GeometryDB_cff")
+#process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+
+process.load('Configuration.Geometry.GeometryExtended2026D98Reco_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T25', '')
 process.load("RecoTracker.TkNavigation.NavigationSchoolESProducer_cff")
 
 #process.MessageLogger = cms.Service("MessageLogger",
@@ -21,7 +25,9 @@ process.load("RecoTracker.TkNavigation.NavigationSchoolESProducer_cff")
 
 
 #This has to be modified in order to read the tracker + MTD structure
-process.TrackerRecoGeometryESProducer = cms.ESProducer("TrackerRecoGeometryESProducer")
+process.TrackerRecoGeometryESProducer = cms.ESProducer("TrackerMTDRecoGeometryESProducer",
+    usePhase2Stacks = cms.bool(False)
+)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -37,3 +43,4 @@ process.navigationSchoolAnalyzer = cms.EDAnalyzer("NavigationSchoolAnalyzer",
 process.muonNavigationTest = cms.EDAnalyzer("MuonNavigationTest")
 
 process.p = cms.Path(process.navigationSchoolAnalyzer+process.muonNavigationTest)
+

--- a/RecoTracker/TkNavigation/test/testNavigationSchool.sh
+++ b/RecoTracker/TkNavigation/test/testNavigationSchool.sh
@@ -1,0 +1,10 @@
+ #!/bin/bash -ex
+function die { echo $1: status $2 ; exit $2; }
+TEST_DIR=$CMSSW_BASE/src/RecoTracker/TkNavigation/test
+echo "test dir: $TEST_DIR"
+
+printf "testing navigation school for Run-3 \n\n"
+cmsRun ${TEST_DIR}/NavigationSchoolAnalyzer_cfg.py || die "Failure running NavigationSchoolAnalyzer_cfg.py" $?
+
+printf "testing navigation school for Phase-2 \n\n"
+cmsRun ${TEST_DIR}/NavigationSchoolAnalyzer_Phase2_cfg.py || die "Failure running NavigationSchoolAnalyzer_Phase2_cfg.py" $?


### PR DESCRIPTION
#### PR description:

In commit https://github.com/cms-sw/cmssw/commit/47393c900567f9665a02c56de215b3dc259a361b I have accidentally introduced a wrong `esConsumes`statement that prevents to use `NavigationSchoolAnalyzer`.
I fix it here in commit 24787a2e846966fcc27b01d30508a0333ef20a55 and well as splitting the configuration files for Run-3 and Phase-2 and introducing dedicated unit tests to avoid future issues.

#### PR validation:

`cmssw` compiles, run successfully `scram b runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc:
@bdanzi
