### PR TITLE
Fix compilation warnings in L1TCaloLayer1FetchLUTs.cc

### DIFF
--- a/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
+++ b/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc
@@ -174,7 +174,7 @@ bool L1TCaloLayer1FetchLUTs(
   // Make ECal LUT
   for (uint32_t phiBin = 0; phiBin < numEcalPhiBins; phiBin++) {
     std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> phiLUT;
-    eLUT.push_back(phiLUT);
+
     for (uint32_t etaBin = 0; etaBin < nCalEtaBins; etaBin++) {
       for (uint32_t fb = 0; fb < nCalSideBins; fb++) {
         for (uint32_t ecalInput = 0; ecalInput <= 0xFF; ecalInput++) {
@@ -216,16 +216,17 @@ bool L1TCaloLayer1FetchLUTs(
             value |= (et_log2 << 12);
           }
           value |= (fb << 10);
-          eLUT[phiBin][etaBin][fb][ecalInput] = value;
+          phiLUT[etaBin][fb][ecalInput] = value;
         }
       }
     }
+
+    eLUT.push_back(phiLUT);
   }
 
   // Make HCal LUT
   for (uint32_t phiBin = 0; phiBin < numHcalPhiBins; phiBin++) {
     std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> phiLUT;
-    hLUT.push_back(phiLUT);
     for (uint32_t etaBin = 0; etaBin < nCalEtaBins; etaBin++) {
       int caloEta = etaBin + 1;
       int iPhi = 3;
@@ -280,16 +281,18 @@ bool L1TCaloLayer1FetchLUTs(
             value |= (et_log2 << 12);
           }
           value |= (fb << 10);
-          hLUT[phiBin][etaBin][fb][hcalInput] = value;
+          phiLUT[etaBin][fb][hcalInput] = value;
         }
       }
     }
+
+    hLUT.push_back(phiLUT);
   }
 
   // Make HF LUT
   for (uint32_t phiBin = 0; phiBin < numHFPhiBins; phiBin++) {
     std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> phiLUT;
-    hfLUT.push_back(phiLUT);
+
     for (uint32_t etaBin = 0; etaBin < nHfEtaBins; etaBin++) {
       int caloEta = etaBin + 30;
       int iPhi = 3;
@@ -348,9 +351,10 @@ bool L1TCaloLayer1FetchLUTs(
             }
           }
         }
-        hfLUT[phiBin][etaBin][etCode] = value;
+        phiLUT[etaBin][etCode] = value;
       }
     }
+    hfLUT.push_back(phiLUT);
   }
 
   // Make HCal FB LUT


### PR DESCRIPTION
#### PR description:

Fix point 3 reported [here](https://github.com/cms-sw/cmssw/issues/41794):

```
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc: In function 'L1TCaloLayer1FetchLUTs':
  .../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:177:19: warning: 'phiLUT' may be used uninitialized [-Wmaybe-uninitialized]
   177 |     eLUT.push_back(phiLUT);
      |                   ^
.../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/stl_vector.h:1276:7: note: by argument 2 of type 'const struct value_type &' to 'push_back' declared here
 1276 |       push_back(const value_type& __x)
      |       ^
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:176:86: note: 'phiLUT' declared here
  176 |     std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> phiLUT;
      |                                                                                      ^
  .../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:228:19: warning: 'phiLUT' may be used uninitialized [-Wmaybe-uninitialized]
   228 |     hLUT.push_back(phiLUT);
      |                   ^
.../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/stl_vector.h:1276:7: note: by argument 2 of type 'const struct value_type &' to 'push_back' declared here
 1276 |       push_back(const value_type& __x)
      |       ^
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:227:86: note: 'phiLUT' declared here
  227 |     std::array<std::array<std::array<uint32_t, nEtBins>, nCalSideBins>, nCalEtaBins> phiLUT;
      |                                                                                      ^
In member function 'construct',
    inlined from 'construct' at .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/alloc_traits.h:516:17,
    inlined from 'push_back' at .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/stl_vector.h:1281:30,
    inlined from 'L1TCaloLayer1FetchLUTs' at .../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:292:20:
  .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/new_allocator.h:175:11: warning: 'phiLUT' may be used uninitialized [-Wmaybe-uninitialized]
   175 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |           ^
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc: In function 'L1TCaloLayer1FetchLUTs':
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:291:59: note: 'phiLUT' declared here
  291 |     std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> phiLUT;
      |                                                           ^
In member function 'construct',
    inlined from 'construct' at .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/alloc_traits.h:516:17,
    inlined from '_M_realloc_insert' at .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/vector.tcc:462:28,
    inlined from 'push_back' at .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/stl_vector.h:1287:21,
    inlined from 'L1TCaloLayer1FetchLUTs' at .../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:292:20:
  .../external/gcc/12.2.1-59043c7bdcfa6002a8c9155ca1109454/include/c++/12.2.1/bits/new_allocator.h:175:11: warning: 'phiLUT' may be used uninitialized [-Wmaybe-uninitialized]
   175 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |           ^
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc: In function 'L1TCaloLayer1FetchLUTs':
.../CMSSW_13_2_X_2023-05-29-1100/src/L1Trigger/L1TCaloLayer1/src/L1TCaloLayer1FetchLUTs.cc:291:59: note: 'phiLUT' declared here
  291 |     std::array<std::array<uint32_t, nEtBins>, nHfEtaBins> phiLUT;
      |                                                           ^
```
#### PR validation:

Code compiles
