### PR TITLE
Fix warnings in EcnaAnalyzer

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
@@ -177,8 +177,8 @@ private:
   Int_t fCurrentEventNumber;
   Int_t fNbOfSelectedEvents;
 
-  Int_t *fBuildEventDistribBad;
-  Int_t *fBuildEventDistribGood;
+  std::vector<Int_t> fBuildEventDistribBad;
+  std::vector<Int_t> fBuildEventDistribGood;
 
   TString fCfgAnalyzerParametersFilePath;  // absolute path for the analyzer
                                            // parameters files (/afs/etc...)
@@ -209,30 +209,30 @@ private:
   Int_t fStexIndexStop;
 
   Int_t fFedTcc;
-  Int_t *fSMFromFedTcc;
-  Int_t *fESFromFedTcc;
-  Int_t *fDeeFromFedTcc;
+  std::vector<Int_t> fSMFromFedTcc;
+  std::vector<Int_t> fESFromFedTcc;
+  // Int_t *fDeeFromFedTcc; - unused?
   Int_t fTreatedFedOrder;
-  Int_t *fFedStatusOrder;
+  std::vector<Int_t> fFedStatusOrder;
   Int_t fFedId;
-  TString *fDeeNumberString;
+  std::vector<TString> fDeeNumberString;
 
   Int_t fMaxTreatedStexCounter;
   Int_t fDeeDS5Memo1;
   Int_t fDeeDS5Memo2;
-  Int_t *fStexDigiOK;
-  Int_t *fStexNbOfTreatedEvents;
-  Int_t *fStexStatus;
+  std::vector<Int_t> fStexDigiOK;
+  std::vector<Int_t> fStexNbOfTreatedEvents;
+  std::vector<Int_t> fStexStatus;
 
   Int_t fMaxFedUnitCounter;
-  Int_t *fFedStatus;
-  Int_t *fFedDigiOK;
-  Int_t *fFedNbOfTreatedEvents;
+  std::vector<Int_t> fFedStatus;
+  std::vector<Int_t> fFedDigiOK;
+  std::vector<Int_t> fFedNbOfTreatedEvents;
 
   Int_t fMemoCutOK;
   Int_t fNbOfTreatedStexs;
-  Int_t *fNbOfTreatedFedsInDee;
-  Int_t *fNbOfTreatedFedsInStex;
+  std::vector<Int_t> fNbOfTreatedFedsInDee;
+  std::vector<Int_t> fNbOfTreatedFedsInStex;
 
   Int_t fANY_RUN;
   Int_t fPEDESTAL_STD;
@@ -241,12 +241,12 @@ private:
   Int_t fPHYSICS_GLOBAL;
   Int_t fPEDSIM;
 
-  time_t *fTimeFirst;
-  time_t *fTimeLast;
-  TString *fDateFirst;
-  TString *fDateLast;
+  std::vector<time_t> fTimeFirst;
+  std::vector<time_t> fTimeLast;
+  std::vector<TString> fDateFirst;
+  std::vector<TString> fDateLast;
 
-  Int_t *fMemoDateFirstEvent;
+  std::vector<Int_t> fMemoDateFirstEvent;
 
   TEcnaObject *fMyEcnaEBObjectManager;
   TEcnaObject *fMyEcnaEEObjectManager;
@@ -264,16 +264,16 @@ private:
   //  a given (channel,sample) Int_t*  fT1d_LastEvt;
 
   Int_t fMaxRunTypeCounter;
-  Int_t *fRunTypeCounter;
+  std::vector<Int_t> fRunTypeCounter;
 
   Int_t fMaxMgpaGainCounter;
-  Int_t *fMgpaGainCounter;
+  std::vector<Int_t> fMgpaGainCounter;
 
   Int_t fMaxFedIdCounter;
-  Int_t *fFedIdCounter;
+  std::vector<Int_t> fFedIdCounter;
 
   Int_t fMaxCounterQuad;
-  Int_t *fCounterQuad;
+  std::vector<Int_t> fCounterQuad;
 };
 
 #endif

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
@@ -211,7 +211,6 @@ private:
   Int_t fFedTcc;
   std::vector<Int_t> fSMFromFedTcc;
   std::vector<Int_t> fESFromFedTcc;
-  // Int_t *fDeeFromFedTcc; - unused?
   Int_t fTreatedFedOrder;
   std::vector<Int_t> fFedStatusOrder;
   Int_t fFedId;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
@@ -46,7 +46,6 @@ EcnaAnalyzer::EcnaAnalyzer(const edm::ParameterSet &pSet)
     : verbosity_(pSet.getUntrackedParameter("verbosity", 1U)),
       nChannels_(0),
       iEvent_(0),
-      // fDeeFromFedTcc(nullptr), - unused?
       fMyCnaEBSM(nullptr),
       fMyCnaEEDee(nullptr),
       fMyEBNumbering(nullptr),
@@ -583,8 +582,6 @@ EcnaAnalyzer::~EcnaAnalyzer() {
 
   Int_t n0 = 0;
   CheckMsg(n0);
-
-  // delete fDeeFromFedTcc;
 
   delete fMyEBNumbering;
   delete fMyEENumbering;


### PR DESCRIPTION
#### PR description:

Fix warnings in gcc12 builds ([log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_aarch64_gcc12/CMSSW_13_2_X_2023-06-29-2300/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules)):

```
.../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc: In member function '__ct_base ':
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:218:52: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   218 |   fDeeNumberString = new TString[fMaxFedUnitCounter];
      |                                                    ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:326:50: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   326 |   fDateFirst = new TString[fMaxTreatedStexCounter];
      |                                                  ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:333:49: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   333 |   fDateLast = new TString[fMaxTreatedStexCounter];
      |                                                 ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
.../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc: In member function '__ct_comp ':
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:218:52: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   218 |   fDeeNumberString = new TString[fMaxFedUnitCounter];
      |                                                    ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:326:50: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   326 |   fDateFirst = new TString[fMaxTreatedStexCounter];
      |                                                  ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
  .../src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc:333:49: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   333 |   fDateLast = new TString[fMaxTreatedStexCounter];
      |                                                 ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
```

#### PR validation:

Code compiles
