### PR TITLE
EMTF NNv16 Implementation

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/Common.h
+++ b/L1Trigger/L1TMuonEndCap/interface/Common.h
@@ -65,7 +65,7 @@ namespace emtf {
   using zone_array = std::array<T, NUM_ZONES>;
 
   // NN features and predictions
-  constexpr int NUM_FEATURES = 23;    // NN features
+  constexpr int NUM_FEATURES = 29;    // NN features
   constexpr int NUM_PREDICTIONS = 2;  // NN outputs
 
   using Feature = std::array<float, NUM_FEATURES>;

--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -126,7 +126,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
         PromoteMode7    = cms.bool(False), # Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
         ModeQualVer     = cms.int32(2),    # Version 2 contains modified mode-quality mapping for 2018
 
-        ProtobufFileName = cms.string('model_graph.displ.10.1.pb'), # Protobuf file name to be used by NN based pT assignment
+        ProtobufFileName = cms.string('model_graph.displ.16.pb'), # Protobuf file name to be used by NN based pT assignment NNv16 is online since 26.06.2023
     ),
 
 )

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignment.cc
@@ -113,7 +113,7 @@ void PtAssignment::process(EMTFTrackCollection& best_tracks) {
 
     pt_assign_engine_dxy_->calculate_pt_dxy(track, feature, prediction);
 
-    pt_dxy = std::abs(1.0 / prediction.at(0));
+    pt_dxy = std::abs(prediction.at(0));
     dxy = prediction.at(1);
 
     gmt_pt_dxy = aux().getGMTPtDxy(pt_dxy);

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineAux.cc
@@ -25,11 +25,11 @@ int PtAssignmentEngineAux::getGMTPtDxy(float pt) const {
 
 int PtAssignmentEngineAux::getGMTDxy(float dxy) const {
   int gmt_dxy = 0;
-  if (std::abs(dxy) < 25.) {
+  if (std::abs(dxy) < 32.) {
     gmt_dxy = 0;
-  } else if (std::abs(dxy) < 50.) {
+  } else if (std::abs(dxy) < 64.) {
     gmt_dxy = 1;
-  } else if (std::abs(dxy) < 75.) {
+  } else if (std::abs(dxy) < 96.) {
     gmt_dxy = 2;
   } else {
     gmt_dxy = 3;

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
@@ -61,37 +61,25 @@ void PtAssignmentEngineDxy::preprocessing_dxy(const EMTFTrack& track, emtf::Feat
   // 4 RPC bits indicating if ME or RE hit was used in each station (S1, S2, S3, S4)
   // Total: 23 variables
   std::array<float, 6> x_dphi;
+  std::array<float, 6> x_dphi_sign;
   std::array<float, 6> x_dtheta;
-  std::array<float, 4> x_bend_emtf;
-  std::array<float, 1> x_fr_emtf;
+  std::array<float, 6> x_dtheta_sign;
   std::array<float, 1> x_trk_theta;
-  std::array<float, 1> x_me11ring;
-  std::array<float, 4> x_rpcbit;
+  std::array<float, 4> x_csc_pattern;
 
   // Initialize to zeros
   x_dphi.fill(0);
+  x_dphi_sign.fill(0);
   x_dtheta.fill(0);
+  x_dtheta_sign.fill(0);
   //
-  x_bend_emtf.fill(0);
-  x_fr_emtf.fill(0);
   x_trk_theta.fill(0);
-  x_me11ring.fill(0);
-  x_rpcbit.fill(0);
+  x_csc_pattern.fill(0);
 
   EMTFPtLUT data = track.PtLUT();
 
   const int invalid_dtheta = 127;
   const int invalid_dphi = 8191;
-
-  // // Variables to extract from the PtLUT
-  int dPhi_12, dPhi_13, dPhi_14, dPhi_23, dPhi_24, dPhi_34;
-  int dTh_12, dTh_13, dTh_14, dTh_23, dTh_24, dTh_34;
-  int fr_1;
-  int bend_1, bend_2, bend_3, bend_4;
-  int rpc_1, rpc_2, rpc_3, rpc_4;
-  int St1_ring2 = data.st1_ring2;
-
-  int pat1 = -99, pat2 = -99, pat3 = -99, pat4 = -99;
 
   // // Which stations have hits
   int st1 = (track.Mode() >= 8);
@@ -101,140 +89,93 @@ void PtAssignmentEngineDxy::preprocessing_dxy(const EMTFTrack& track, emtf::Feat
 
   // Get valid pattern values
   if (st1)
-    pat1 = data.cpattern[0];
+    x_csc_pattern[0] = data.cpattern[0];
   if (st2)
-    pat2 = data.cpattern[1];
+    x_csc_pattern[1] = data.cpattern[1];
   if (st3)
-    pat3 = data.cpattern[2];
+    x_csc_pattern[2] = data.cpattern[2];
   if (st4)
-    pat4 = data.cpattern[3];
-
-  // F/R bit
-  fr_1 = data.fr[0];
-
-  // RPC hit in station
-  rpc_1 = (st1 ? (pat1 == 0) : 0);
-  rpc_2 = (st2 ? (pat2 == 0) : 0);
-  rpc_3 = (st3 ? (pat3 == 0) : 0);
-  rpc_4 = (st4 ? (pat4 == 0) : 0);
-
-  // Calculate bends from patterns
-  bend_1 = aux().calcBendFromPattern(pat1, track.Endcap());
-  bend_2 = aux().calcBendFromPattern(pat2, track.Endcap());
-  bend_3 = aux().calcBendFromPattern(pat3, track.Endcap());
-  bend_4 = aux().calcBendFromPattern(pat4, track.Endcap());
-
-  // Invalid bend value is 0 in the NN
-  if (bend_1 == -99)
-    bend_1 = 0;
-  if (bend_2 == -99)
-    bend_2 = 0;
-  if (bend_3 == -99)
-    bend_3 = 0;
-  if (bend_4 == -99)
-    bend_4 = 0;
-
-  // In the emulator RPCs get assigned abs(bend) = 5. This needs to be 0 for the NN.
-  if (std::abs(bend_1) == 5 && rpc_1 == 1)
-    bend_1 = 0;
-  if (std::abs(bend_2) == 5 && rpc_2 == 1)
-    bend_2 = 0;
-  if (std::abs(bend_3) == 5 && rpc_3 == 1)
-    bend_3 = 0;
-  if (std::abs(bend_4) == 5 && rpc_4 == 1)
-    bend_4 = 0;
+    x_csc_pattern[3] = data.cpattern[3];
 
   // Calculate delta phi
-  dPhi_12 = (data.delta_ph[0] != invalid_dphi) ? data.delta_ph[0] * (data.sign_ph[0] ? 1 : -1) : 0;
-  dPhi_13 = (data.delta_ph[1] != invalid_dphi) ? data.delta_ph[1] * (data.sign_ph[1] ? 1 : -1) : 0;
-  dPhi_14 = (data.delta_ph[2] != invalid_dphi) ? data.delta_ph[2] * (data.sign_ph[2] ? 1 : -1) : 0;
-  dPhi_23 = (data.delta_ph[3] != invalid_dphi) ? data.delta_ph[3] * (data.sign_ph[3] ? 1 : -1) : 0;
-  dPhi_24 = (data.delta_ph[4] != invalid_dphi) ? data.delta_ph[4] * (data.sign_ph[4] ? 1 : -1) : 0;
-  dPhi_34 = (data.delta_ph[5] != invalid_dphi) ? data.delta_ph[5] * (data.sign_ph[5] ? 1 : -1) : 0;
+  x_dphi[0] = (data.delta_ph[0] != invalid_dphi) ? data.delta_ph[0] : 0;
+  x_dphi[1] = (data.delta_ph[1] != invalid_dphi) ? data.delta_ph[1] : 0;
+  x_dphi[2] = (data.delta_ph[2] != invalid_dphi) ? data.delta_ph[2] : 0;
+  x_dphi[3] = (data.delta_ph[3] != invalid_dphi) ? data.delta_ph[3] : 0;
+  x_dphi[4] = (data.delta_ph[4] != invalid_dphi) ? data.delta_ph[4] : 0;
+  x_dphi[5] = (data.delta_ph[5] != invalid_dphi) ? data.delta_ph[5] : 0;
 
   // Calculate delta theta
-  dTh_12 = (data.delta_th[0] != invalid_dtheta) ? data.delta_th[0] * (data.sign_th[0] ? 1 : -1) : 0;
-  dTh_13 = (data.delta_th[1] != invalid_dtheta) ? data.delta_th[1] * (data.sign_th[1] ? 1 : -1) : 0;
-  dTh_14 = (data.delta_th[2] != invalid_dtheta) ? data.delta_th[2] * (data.sign_th[2] ? 1 : -1) : 0;
-  dTh_23 = (data.delta_th[3] != invalid_dtheta) ? data.delta_th[3] * (data.sign_th[3] ? 1 : -1) : 0;
-  dTh_24 = (data.delta_th[4] != invalid_dtheta) ? data.delta_th[4] * (data.sign_th[4] ? 1 : -1) : 0;
-  dTh_34 = (data.delta_th[5] != invalid_dtheta) ? data.delta_th[5] * (data.sign_th[5] ? 1 : -1) : 0;
+  x_dtheta[0] = (data.delta_th[0] != invalid_dtheta) ? data.delta_th[0] : 0;
+  x_dtheta[1] = (data.delta_th[1] != invalid_dtheta) ? data.delta_th[1] : 0;
+  x_dtheta[2] = (data.delta_th[2] != invalid_dtheta) ? data.delta_th[2] : 0;
+  x_dtheta[3] = (data.delta_th[3] != invalid_dtheta) ? data.delta_th[3] : 0;
+  x_dtheta[4] = (data.delta_th[4] != invalid_dtheta) ? data.delta_th[4] : 0;
+  x_dtheta[5] = (data.delta_th[5] != invalid_dtheta) ? data.delta_th[5] : 0;
+
+  // Get delta phi and theta signs
+  x_dphi_sign[0] = data.sign_ph[0];
+  x_dphi_sign[1] = data.sign_ph[1];
+  x_dphi_sign[2] = data.sign_ph[2];
+  x_dphi_sign[3] = data.sign_ph[3];
+  x_dphi_sign[4] = data.sign_ph[4];
+  x_dphi_sign[5] = data.sign_ph[5];
+
+  x_dtheta_sign[0] = data.sign_th[0];
+  x_dtheta_sign[1] = data.sign_th[1];
+  x_dtheta_sign[2] = data.sign_th[2];
+  x_dtheta_sign[3] = data.sign_th[3];
+  x_dtheta_sign[4] = data.sign_th[4];
+  x_dtheta_sign[5] = data.sign_th[5];
 
   // Set dPhi and dTheta values to 0 if there was no hit in the station
   if (!st1) {
-    dPhi_12 = 0;
-    dPhi_13 = 0;
-    dPhi_14 = 0;
+    x_dphi[0] = 0;
+    x_dphi[1] = 0;
+    x_dphi[2] = 0;
 
-    dTh_12 = 0;
-    dTh_13 = 0;
-    dTh_14 = 0;
+    x_dtheta[0] = 0;
+    x_dtheta[1] = 0;
+    x_dtheta[2] = 0;
   }
   if (!st2) {
-    dPhi_12 = 0;
-    dPhi_23 = 0;
-    dPhi_24 = 0;
+    x_dphi[0] = 0;
+    x_dphi[3] = 0;
+    x_dphi[4] = 0;
 
-    dTh_12 = 0;
-    dTh_23 = 0;
-    dTh_24 = 0;
+    x_dtheta[0] = 0;
+    x_dtheta[3] = 0;
+    x_dtheta[4] = 0;
   }
   if (!st3) {
-    dPhi_13 = 0;
-    dPhi_23 = 0;
-    dPhi_34 = 0;
+    x_dphi[1] = 0;
+    x_dphi[3] = 0;
+    x_dphi[5] = 0;
 
-    dTh_13 = 0;
-    dTh_23 = 0;
-    dTh_34 = 0;
+    x_dtheta[1] = 0;
+    x_dtheta[3] = 0;
+    x_dtheta[5] = 0;
   }
   if (!st4) {
-    dPhi_14 = 0;
-    dPhi_24 = 0;
-    dPhi_34 = 0;
+    x_dphi[2] = 0;
+    x_dphi[4] = 0;
+    x_dphi[5] = 0;
 
-    dTh_14 = 0;
-    dTh_24 = 0;
-    dTh_34 = 0;
+    x_dtheta[2] = 0;
+    x_dtheta[4] = 0;
+    x_dtheta[5] = 0;
   }
 
-  // Set NN inputs
-
-  // NN was trained with the wrong sign convention. TO BE CHANGED LATER!
-  x_dphi[0] = dPhi_12;
-  x_dphi[1] = dPhi_13;
-  x_dphi[2] = dPhi_14;
-  x_dphi[3] = dPhi_23;
-  x_dphi[4] = dPhi_24;
-  x_dphi[5] = dPhi_34;
-
-  // NN was trained with the wrong sign convention. TO BE CHANGED LATER!
-  x_dtheta[0] = dTh_12;
-  x_dtheta[1] = dTh_13;
-  x_dtheta[2] = dTh_14;
-  x_dtheta[3] = dTh_23;
-  x_dtheta[4] = dTh_24;
-  x_dtheta[5] = dTh_34;
-
-  // NN was trained with the wrong sign convention. TO BE CHANGED LATER!
-  x_bend_emtf[0] = bend_1;
-  x_bend_emtf[1] = bend_2;
-  x_bend_emtf[2] = bend_3;
-  x_bend_emtf[3] = bend_4;
-
-  x_fr_emtf[0] = fr_1;
   x_trk_theta[0] = track.Theta_fp();
-  x_me11ring[0] = St1_ring2;
 
-  x_rpcbit[0] = rpc_1;
-  x_rpcbit[1] = rpc_2;
-  x_rpcbit[2] = rpc_3;
-  x_rpcbit[3] = rpc_4;
+  // Set NN inputs
+  feature = {{x_dphi[0],        x_dphi[1],        x_dphi[2],        x_dphi[3],        x_dphi[4],
+              x_dphi[5],        x_dphi_sign[0],   x_dphi_sign[1],   x_dphi_sign[2],   x_dphi_sign[3],
+              x_dphi_sign[4],   x_dphi_sign[5],   x_dtheta[0],      x_dtheta[1],      x_dtheta[2],
+              x_dtheta[3],      x_dtheta[4],      x_dtheta[5],      x_dtheta_sign[0], x_dtheta_sign[1],
+              x_dtheta_sign[2], x_dtheta_sign[3], x_dtheta_sign[4], x_dtheta_sign[5], x_csc_pattern[0],
+              x_csc_pattern[1], x_csc_pattern[2], x_csc_pattern[3], x_trk_theta[0]}};
 
-  feature = {{x_dphi[0],      x_dphi[1],      x_dphi[2],      x_dphi[3],      x_dphi[4],    x_dphi[5],
-              x_dtheta[0],    x_dtheta[1],    x_dtheta[2],    x_dtheta[3],    x_dtheta[4],  x_dtheta[5],
-              x_bend_emtf[0], x_bend_emtf[1], x_bend_emtf[2], x_bend_emtf[3], x_fr_emtf[0], x_trk_theta[0],
-              x_me11ring[0],  x_rpcbit[0],    x_rpcbit[1],    x_rpcbit[2],    x_rpcbit[3]}};
   return;
 }
 
@@ -249,14 +190,8 @@ void PtAssignmentEngineDxy::call_tensorflow_dxy(const emtf::Feature& feature, em
   emtf_assert(outputs.size() == 1);
   emtf_assert(prediction.size() == emtf::NUM_PREDICTIONS);
 
-  const float reg_pt_scale = 100.0;  // a scale factor applied to regression during training
-  const float reg_dxy_scale = 1.0;   // a scale factor applied to regression during training
-
   prediction.at(0) = outputs[0].matrix<float>()(0, 0);
   prediction.at(1) = outputs[0].matrix<float>()(0, 1);
 
-  // Remove scale factor used during training
-  prediction.at(0) /= reg_pt_scale;
-  prediction.at(1) /= reg_dxy_scale;
   return;
 }


### PR DESCRIPTION
#### PR description:

This PR reworks the EMTF displaced pT assignment blocks to implement NNv16. Any other version of NN before this was merely experimental on software side and never worked at P5. After talking with @perrotta , I decided to remove the support for previous versions completely since they should never be used.

- Most of the rework is in `PtAssignmentEngineDxy.cc` to implement the new input/output for the NNv16. 
- `Common.h` changes since the NN input features have different size now
- `PtAssignment.cc` change due to NN output now being pT instead of 1/pT
- `PtAssignmentEngineAux.cc` change due to new `dxy` binning in firmware
- `simEmtfDigis.py` change for the new NN version.

This PR requires https://github.com/cms-data/L1Trigger-L1TMuon/pull/24 for tests.

This PR will be backported to 13_1_X and 13_0_X to make emulator agree with online firmware. 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by checking firmware/emulator comparisons. Also ran `runTheMatrix.py -l limited -i all --ibeos` no failures (other than a fail due to input file) were seen.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

FYI @caruta @elfontan 

<!-- Please delete the text above after you verified all points of the checklist  -->
