### PR TITLE
MTD Validation: update track validation, adding TDR-like study of extrapolation at BTL surface

### DIFF
--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -3,6 +3,14 @@
 <use name="Geometry/MTDGeometryBuilder"/>
 <use name="RecoLocalFastTime/Records"/>
 <use name="RecoLocalFastTime/FTLClusterizer"/>
+<use name="RecoMTD/DetLayers"/>
+<use name="RecoMTD/Records"/>
+<use name="TrackingTools/KalmanUpdators"/>
+<use name="TrackingTools/TransientTrack"/>
+<use name="DataFormats/GeometryCommonDetAlgo"/>
+<use name="TrackPropagation/SteppingHelixPropagator"/>
+<use name="TrackingTools/Records"/>
+<use name="TrackingTools/TrajectoryState"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/TrackReco"/>

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -22,6 +22,7 @@ protected:
 
 private:
   void computeEfficiency1D(MonitorElement* num, MonitorElement* den, MonitorElement* result);
+  void normalize(MonitorElement* h, double scale);
 
   const std::string folder_;
 
@@ -49,7 +50,12 @@ private:
   MonitorElement* meTPmtdEtaSelEff_;
   MonitorElement* meTPmtdPtMatchEff_;
   MonitorElement* meTPmtdEtaMatchEff_;
-  MonitorElement* meTPAssocEff_;
+  MonitorElement* meNoTimeFraction_;
+  MonitorElement* meExtraPtEff_;
+  MonitorElement* meExtraPtEtl2Eff_;
+  MonitorElement* meExtraEtaEff_;
+  MonitorElement* meExtraEtaEtl2Eff_;
+  MonitorElement* meExtraPhiAtBTLEff_;
 };
 
 // ------------ constructor and destructor --------------
@@ -70,6 +76,17 @@ void MtdTracksHarvester::computeEfficiency1D(MonitorElement* num, MonitorElement
     }
     result->setBinContent(ibin, eff);
     result->setBinError(ibin, bin_err);
+  }
+}
+
+void MtdTracksHarvester::normalize(MonitorElement* h, double scale) {
+  double integral = h->getTH1F()->Integral();
+  double norma = (integral > 0.) ? scale / integral : 0.;
+  for (int ibin = 1; ibin <= h->getNbinsX(); ibin++) {
+    double eff = h->getBinContent(ibin) * norma;
+    double bin_err = h->getBinError(ibin) * norma;
+    h->setBinContent(ibin, eff);
+    h->setBinError(ibin, bin_err);
   }
 }
 
@@ -100,24 +117,33 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meETLTrackEffEta2MtdZpos = igetter.get(folder_ + "TrackETLEffEta2MtdZpos");
   MonitorElement* meETLTrackEffPhi2MtdZpos = igetter.get(folder_ + "TrackETLEffPhi2MtdZpos");
   MonitorElement* meETLTrackEffPt2MtdZpos = igetter.get(folder_ + "TrackETLEffPt2MtdZpos");
+  MonitorElement* meTrackPtTot = igetter.get(folder_ + "TrackPtTot");
   MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
   MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
   MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
+  MonitorElement* meExtraPtMtd = igetter.get(folder_ + "ExtraPtMtd");
+  MonitorElement* meExtraPtEtl2Mtd = igetter.get(folder_ + "ExtraPtEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
   MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
   MonitorElement* meTrackMatchedTPEffPtEtl2Mtd = igetter.get(folder_ + "MatchedTPEffPtEtl2Mtd");
   MonitorElement* meTrackMatchedTPmtdEffPtTot = igetter.get(folder_ + "MatchedTPmtdEffPtTot");
   MonitorElement* meTrackMatchedTPmtdEffPtMtd = igetter.get(folder_ + "MatchedTPmtdEffPtMtd");
+  MonitorElement* meTrackEtaTot = igetter.get(folder_ + "TrackEtaTot");
   MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
+  MonitorElement* meExtraEtaMtd = igetter.get(folder_ + "ExtraEtaMtd");
+  MonitorElement* meExtraEtaEtl2Mtd = igetter.get(folder_ + "ExtraEtaEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
   MonitorElement* meTrackMatchedTPEffEtaMtd = igetter.get(folder_ + "MatchedTPEffEtaMtd");
   MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd = igetter.get(folder_ + "MatchedTPEffEtaEtl2Mtd");
   MonitorElement* meTrackMatchedTPmtdEffEtaTot = igetter.get(folder_ + "MatchedTPmtdEffEtaTot");
   MonitorElement* meTrackMatchedTPmtdEffEtaMtd = igetter.get(folder_ + "MatchedTPmtdEffEtaMtd");
-  MonitorElement* meNTrackingParticles = igetter.get(folder_ + "NTrackingParticles");
-  MonitorElement* meUnassDeposit = igetter.get(folder_ + "UnassDeposit");
+  MonitorElement* meTrackNumHits = igetter.get(folder_ + "TrackNumHits");
+  MonitorElement* meTrackNumHitsNT = igetter.get(folder_ + "TrackNumHitsNT");
+  MonitorElement* meExtraPhiAtBTL = igetter.get(folder_ + "ExtraPhiAtBTL");
+  MonitorElement* meExtraPhiAtBTLmatched = igetter.get(folder_ + "ExtraPhiAtBTLmatched");
+  MonitorElement* meExtraBTLeneInCone = igetter.get(folder_ + "ExtraBTLeneInCone");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
@@ -130,7 +156,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
       !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd || !meTrackMatchedTPmtdEffPtTot ||
       !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaMtd ||
       !meTrackMatchedTPEffEtaEtl2Mtd || !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd ||
-      !meNTrackingParticles || !meUnassDeposit) {
+      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -257,6 +283,40 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meEtlPtEff2_[1]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffPt2MtdZpos, meETLTrackEffPtTotZpos, meEtlPtEff2_[1]);
 
+  if (meExtraPtMtd && meExtraPtEtl2Mtd && meExtraEtaMtd && meExtraEtaEtl2Mtd) {
+    meExtraPtEff_ = ibook.book1D("ExtraPtEff",
+                                 "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                                 meMVATrackEffPtTot->getNbinsX(),
+                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraPtEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
+
+    meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
+                                     "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                                     meMVATrackEffPtTot->getNbinsX(),
+                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
+
+    meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
+                                  "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
+                                  meMVATrackEffEtaTot->getNbinsX(),
+                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraEtaEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
+
+    meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
+                                      "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
+                                      meMVATrackEffEtaTot->getNbinsX(),
+                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
+  }
+
   meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
                                 "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
                                 meMVATrackEffPtTot->getNbinsX(),
@@ -295,7 +355,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
   meTPPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffPtTot, meMVATrackEffPtTot, meTPPtSelEff_);
+  computeEfficiency1D(meTrackMatchedTPEffPtTot, meTrackPtTot, meTPPtSelEff_);
 
   meTPEtaSelEff_ = ibook.book1D("TPEtaSelEff",
                                 "Track selected efficiency TP VS Eta;Eta;Efficiency",
@@ -303,7 +363,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
   meTPEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPEffEtaTot, meMVATrackEffEtaTot, meTPEtaSelEff_);
+  computeEfficiency1D(meTrackMatchedTPEffEtaTot, meTrackEtaTot, meTPEtaSelEff_);
 
   meTPPtMatchEff_ = ibook.book1D("TPPtMatchEff",
                                  "Track matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
@@ -343,7 +403,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
   meTPmtdPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffPtTot, meMVATrackEffPtTot, meTPmtdPtSelEff_);
+  computeEfficiency1D(meTrackMatchedTPmtdEffPtTot, meTrackPtTot, meTPmtdPtSelEff_);
 
   meTPmtdEtaSelEff_ = ibook.book1D("TPmtdEtaSelEff",
                                    "Track selected efficiency TPmtd hit VS Eta;Eta;Efficiency",
@@ -351,7 +411,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
   meTPmtdEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meTrackMatchedTPmtdEffEtaTot, meMVATrackEffEtaTot, meTPmtdEtaSelEff_);
+  computeEfficiency1D(meTrackMatchedTPmtdEffEtaTot, meTrackEtaTot, meTPmtdEtaSelEff_);
 
   meTPmtdPtMatchEff_ = ibook.book1D("TPmtdPtMatchEff",
                                     "Track matched to TP-mtd hit efficiency VS Pt;Pt [GeV];Efficiency",
@@ -369,14 +429,13 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meTPmtdEtaMatchEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meTrackMatchedTPmtdEffEtaMtd, meTrackMatchedTPmtdEffEtaTot, meTPmtdEtaMatchEff_);
 
-  meTPAssocEff_ =
-      ibook.book1D("TPAssocEff",
-                   "Tracking particles not associated to any MTD cell in events with at least one cell over threshold",
-                   meNTrackingParticles->getNbinsX(),
-                   meNTrackingParticles->getTH1()->GetXaxis()->GetXmin(),
-                   meNTrackingParticles->getTH1()->GetXaxis()->GetXmax());
-  meTPAssocEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meUnassDeposit, meNTrackingParticles, meTPAssocEff_);
+  meNoTimeFraction_ = ibook.book1D("NoTimeFraction",
+                                   "Fraction of tracks with MTD hits and no time associated; Num. of hits",
+                                   meTrackNumHits->getNbinsX(),
+                                   meTrackNumHits->getTH1()->GetXaxis()->GetXmin(),
+                                   meTrackNumHits->getTH1()->GetXaxis()->GetXmax());
+  meNoTimeFraction_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackNumHitsNT, meTrackNumHits, meNoTimeFraction_);
 
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
@@ -393,6 +452,52 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
   meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
   meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
+
+  if (meExtraPtMtd && meExtraPtEtl2Mtd && meExtraEtaMtd && meExtraEtaEtl2Mtd) {
+    meExtraPtEff_ = ibook.book1D("ExtraPtEff",
+                                 "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                                 meMVATrackEffPtTot->getNbinsX(),
+                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraPtEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
+
+    meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
+                                     "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                                     meMVATrackEffPtTot->getNbinsX(),
+                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
+
+    meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
+                                  "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
+                                  meMVATrackEffEtaTot->getNbinsX(),
+                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraEtaEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
+
+    meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
+                                      "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
+                                      meMVATrackEffEtaTot->getNbinsX(),
+                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
+  }
+
+  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone) {
+    meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
+                                       "Efficiency to match hits at BTL surface",
+                                       meExtraPhiAtBTL->getNbinsX(),
+                                       meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmin(),
+                                       meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmax());
+    meExtraPhiAtBTLEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraPhiAtBTLmatched, meExtraPhiAtBTL, meExtraPhiAtBTLEff_);
+
+    normalize(meExtraBTLeneInCone, 1.);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/Common/interface/ValidHandle.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 
@@ -32,6 +33,31 @@
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
+
+#include "RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h"
+#include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h"
+#include "RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h"
+#include "RecoMTD/DetLayers/interface/MTDDetTray.h"
+#include "RecoMTD/DetLayers/interface/MTDRingForwardDoubleLayer.h"
+#include "RecoMTD/DetLayers/interface/MTDDetRing.h"
+#include "RecoMTD/Records/interface/MTDRecoGeometryRecord.h"
+
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementError.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
+#include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
+
+#include "DataFormats/Common/interface/OneToMany.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
@@ -58,12 +84,14 @@ private:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  const std::pair<bool, bool> checkAcceptance(
+      const reco::Track&, const edm::Event&, const edm::EventSetup&, size_t&, float&, float&, float&, float&);
+
   const bool mvaGenSel(const HepMC::GenParticle&, const float&);
   const bool mvaTPSel(const TrackingParticle&);
   const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&, const double&, const double&);
   const bool mvaGenRecMatch(const HepMC::GenParticle&, const double&, const reco::TrackBase&, const bool&);
-  const edm::Ref<std::vector<TrackingParticle>>* getMatchedTP(const reco::TrackBaseRef&, const double&);
-  const bool tpWithMTD(const TrackingParticle&, const std::unordered_set<unsigned long int>&);
+  const edm::Ref<std::vector<TrackingParticle>>* getMatchedTP(const reco::TrackBaseRef&);
 
   const unsigned long int uniqueId(const uint32_t x, const EncodedEventId& y) {
     const uint64_t a = static_cast<uint64_t>(x);
@@ -96,6 +124,7 @@ private:
   static constexpr double rBTL_ = 110.0;
   static constexpr double zETL_ = 290.0;
   static constexpr double etaMatchCut_ = 0.05;
+  static constexpr double cluDRradius_ = 0.05;  // to cluster rechits around extrapolated track
 
   bool optionalPlots_;
 
@@ -112,6 +141,8 @@ private:
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
   edm::EDGetTokenT<CrossingFrame<PSimHit>> btlSimHitsToken_;
   edm::EDGetTokenT<CrossingFrame<PSimHit>> etlSimHitsToken_;
+  edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
+  edm::EDGetTokenT<FTLRecHitCollection> etlRecHitsToken_;
 
   edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
@@ -128,6 +159,9 @@ private:
 
   edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
   edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> mtdlayerToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> builderToken_;
   edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> particleTableToken_;
 
   MonitorElement* meBTLTrackRPTime_;
@@ -159,20 +193,27 @@ private:
   MonitorElement* meTrackt0SafePid_;
   MonitorElement* meTrackSigmat0SafePid_;
   MonitorElement* meTrackNumHits_;
+  MonitorElement* meTrackNumHitsNT_;
   MonitorElement* meTrackMVAQual_;
   MonitorElement* meTrackPathLenghtvsEta_;
 
+  MonitorElement* meTrackPtTot_;
   MonitorElement* meMVATrackEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtMtd_;
+  MonitorElement* meExtraPtMtd_;
+  MonitorElement* meExtraPtEtl2Mtd_;
   MonitorElement* meTrackMatchedTPEffPtTot_;
   MonitorElement* meTrackMatchedTPEffPtMtd_;
   MonitorElement* meTrackMatchedTPEffPtEtl2Mtd_;
   MonitorElement* meTrackMatchedTPmtdEffPtTot_;
   MonitorElement* meTrackMatchedTPmtdEffPtMtd_;
+  MonitorElement* meTrackEtaTot_;
   MonitorElement* meMVATrackEffEtaTot_;
   MonitorElement* meMVATrackMatchedEffEtaTot_;
   MonitorElement* meMVATrackMatchedEffEtaMtd_;
+  MonitorElement* meExtraEtaMtd_;
+  MonitorElement* meExtraEtaEtl2Mtd_;
   MonitorElement* meTrackMatchedTPEffEtaTot_;
   MonitorElement* meTrackMatchedTPEffEtaMtd_;
   MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd_;
@@ -182,11 +223,9 @@ private:
   MonitorElement* meMVATrackPullTot_;
   MonitorElement* meMVATrackZposResTot_;
 
-  MonitorElement* meUnassociatedDetId_;
-  MonitorElement* meUnassCrysEnergy_;
-  MonitorElement* meUnassLgadsEnergy_;
-  MonitorElement* meUnassDeposit_;
-  MonitorElement* meNTrackingParticles_;
+  MonitorElement* meExtraPhiAtBTL_;
+  MonitorElement* meExtraPhiAtBTLmatched_;
+  MonitorElement* meExtraBTLeneInCone_;
 };
 
 // ------------ constructor and destructor --------------
@@ -209,6 +248,8 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
   btlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("btlSimHits"));
   etlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("etlSimHits"));
+  btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("btlRecHits"));
+  etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("etlRecHits"));
   trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
   tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
@@ -222,6 +263,9 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
   trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
   mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
   mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
+  mtdlayerToken_ = esConsumes<MTDDetLayerGeometry, MTDRecoGeometryRecord>();
+  magfieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
+  builderToken_ = esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
   particleTableToken_ = esConsumes<HepPDT::ParticleDataTable, edm::DefaultRecord>();
 }
 
@@ -233,19 +277,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   using namespace geant_units::operators;
   using namespace std;
 
-  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
-  const MTDGeometry* geom = geometryHandle.product();
-  auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
-  const MTDTopology* topology = topologyHandle.product();
-
-  bool topo1Dis = false;
-  bool topo2Dis = false;
-  if (MTDTopologyMode::etlLayoutFromTopoMode(topology->getMTDTopologyMode()) == ETLDetId::EtlLayout::tp) {
-    topo1Dis = true;
-  } else {
-    topo2Dis = true;
-  }
-
   auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));
 
@@ -253,6 +284,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::unordered_map<uint32_t, MTDHit> m_etlHits;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_etlTrkPerCell;
+  std::map<TrackingParticleRef, std::vector<uint32_t>> m_tp2detid;
 
   const auto& tMtd = iEvent.get(tmtdToken_);
   const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
@@ -283,31 +315,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
   r2s_ = recoToSimH.product();
 
-  // find all signal event trackId corresponding to an MTD simHit
-  std::unordered_set<unsigned long int> mtdTrackId;
-
-  std::unordered_set<unsigned long int> tpTrackId;
-  auto tpHandle = makeValid(iEvent.getHandle(trackingParticleCollectionToken_));
-  TrackingParticleCollection tpColl = *(tpHandle.product());
-  for (const auto& tp : tpColl) {
-    if (tp.eventId().bunchCrossing() == 0 && tp.eventId().event() == 0) {
-      if (!mvaTPSel(tp))
-        continue;
-      if (optionalPlots_) {
-        if (std::abs(tp.eta()) < trackMaxBtlEta_) {
-          meNTrackingParticles_->Fill(0.5);
-        } else if ((std::abs(tp.eta()) < trackMaxEtlEta_) && (std::abs(tp.eta()) > trackMinEtlEta_)) {
-          meNTrackingParticles_->Fill(1.5);
-        }
-      }
-      for (const auto& simTrk : tp.g4Tracks()) {
-        auto const thisTId = uniqueId(simTrk.trackId(), simTrk.eventId());
-        tpTrackId.insert(thisTId);
-        LogDebug("MtdTracksValidation") << "TP simTrack id : " << thisTId;
-      }
-    }
-  }
-
   //Fill maps with simhits accumulated per DetId
 
   auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
@@ -323,25 +330,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
   }
 
-  uint32_t hcount(0);
-  for (auto const& cell : m_btlTrkPerCell) {
-    bool foundAssocTP = false;
-    auto detId_key = cell.first;
-    for (auto const& simtrack : cell.second) {
-      if (tpTrackId.find(simtrack) != tpTrackId.end()) {
-        foundAssocTP = true;
-        mtdTrackId.insert(simtrack);
-      }
-    }
-    if (foundAssocTP == false) {
-      meUnassCrysEnergy_->Fill(log10(m_btlHits[detId_key].energy));
-      if (m_btlHits[detId_key].energy > depositBTLthreshold_) {
-        hcount++;
-      }
-    }
-  }
-  meUnassociatedDetId_->Fill(0.5, hcount);
-
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
   for (auto const& simHit : etlSimHits) {
@@ -356,123 +344,43 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
   }
 
-  hcount = 0;
-  for (auto const& cell : m_etlTrkPerCell) {
-    bool foundAssocTP = false;
-    auto detId_key = cell.first;
-    for (auto const& simtrack : cell.second) {
-      if (tpTrackId.find(simtrack) != tpTrackId.end()) {
-        foundAssocTP = true;
-        mtdTrackId.insert(simtrack);
-      }
-    }
-    if (foundAssocTP == false) {
-      meUnassLgadsEnergy_->Fill(log10(m_etlHits[detId_key].energy));
-      if (m_etlHits[detId_key].energy > depositETLthreshold_) {
-        hcount++;
+  //Fill map of DetId per ref to TP
+
+  auto tpHandle = makeValid(iEvent.getHandle(trackingParticleCollectionToken_));
+  TrackingParticleCollection tpColl = *(tpHandle.product());
+  size_t tpindex(0);
+  for (auto tp = tpColl.begin(); tp != tpColl.end(); tp++, ++tpindex) {
+    TrackingParticleRef tpref(iEvent.getHandle(trackingParticleCollectionToken_), tpindex);
+    if (tp->eventId().bunchCrossing() == 0 && tp->eventId().event() == 0) {
+      if (!mvaTPSel(*tp))
+        continue;
+      for (const auto& simTrk : tp->g4Tracks()) {
+        auto const thisTId = uniqueId(simTrk.trackId(), simTrk.eventId());
+        for (auto const& cell : m_btlTrkPerCell) {
+          if (m_btlHits[cell.first].energy < depositBTLthreshold_) {
+            continue;
+          }
+          for (auto const& simtrack : cell.second) {
+            if (thisTId == simtrack) {
+              m_tp2detid[tpref].emplace_back(cell.first);
+              break;
+            }
+          }
+        }
+        for (auto const& cell : m_etlTrkPerCell) {
+          if (m_etlHits[cell.first].energy < depositETLthreshold_) {
+            continue;
+          }
+          for (auto const& simtrack : cell.second) {
+            if (thisTId == simtrack) {
+              m_tp2detid[tpref].emplace_back(cell.first);
+              break;
+            }
+          }
+        }
       }
     }
   }
-  meUnassociatedDetId_->Fill(1.5, hcount);
-
-  // Search for TP without associated hits and unassociated DetIds above threshold
-  if (optionalPlots_) {
-    for (const auto& tp : tpColl) {
-      if (tp.eventId().bunchCrossing() == 0 && tp.eventId().event() == 0) {
-        if (!mvaTPSel(tp)) {
-          continue;
-        }
-
-        // test BTL crystals for association
-
-        if (std::abs(tp.eta()) < trackMaxBtlEta_) {
-          bool tpIsAssoc = false;
-          bool goodCell = false;
-          for (auto const& cell : m_btlTrkPerCell) {
-            auto detId_key = cell.first;
-            if (m_btlHits[detId_key].energy < depositBTLthreshold_) {
-              continue;
-            }
-
-            BTLDetId detId(detId_key);
-            DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
-            const MTDGeomDet* thedet = geom->idToDet(geoId);
-            if (thedet == nullptr)
-              throw cms::Exception("MtdTracksValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                          << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-            const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-            const RectangularMTDTopology& topo =
-                static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
-
-            Local3DPoint local_point(convertMmToCm(m_btlHits[detId_key].x),
-                                     convertMmToCm(m_btlHits[detId_key].y),
-                                     convertMmToCm(m_btlHits[detId_key].z));
-
-            local_point =
-                topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
-            const auto& global_point = thedet->toGlobal(local_point);
-
-            if (std::abs(tp.eta() - global_point.eta()) > etaMatchCut_) {
-              continue;
-            }
-            goodCell = true;
-            for (auto const& simtrack : cell.second) {
-              for (auto const& TPsimtrack : tp.g4Tracks()) {
-                auto const testId = uniqueId(TPsimtrack.trackId(), TPsimtrack.eventId());
-                if (simtrack == testId) {
-                  tpIsAssoc = true;
-                  break;
-                }
-              }
-            }
-          }  //cell Loop
-          if (!tpIsAssoc && goodCell) {
-            meUnassDeposit_->Fill(0.5);
-          }
-
-        } else {
-          // test ETL LGADs for association
-          bool tpIsAssoc = false;
-          bool goodCell = false;
-          for (auto const& cell : m_etlTrkPerCell) {
-            auto detId_key = cell.first;
-            if (m_etlHits[detId_key].energy < depositETLthreshold_) {
-              continue;
-            }
-
-            ETLDetId detId(detId_key);
-            DetId geoId = detId.geographicalId();
-            const MTDGeomDet* thedet = geom->idToDet(geoId);
-            if (thedet == nullptr)
-              throw cms::Exception("MtdTracksValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                          << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-
-            Local3DPoint local_point(convertMmToCm(m_etlHits[detId_key].x),
-                                     convertMmToCm(m_etlHits[detId_key].y),
-                                     convertMmToCm(m_etlHits[detId_key].z));
-            const auto& global_point = thedet->toGlobal(local_point);
-
-            if (std::abs(tp.eta() - global_point.eta()) > etaMatchCut_) {
-              continue;
-            }
-            goodCell = true;
-            for (auto const& simtrack : cell.second) {
-              for (auto const& TPsimtrack : tp.g4Tracks()) {
-                auto const testId = uniqueId(TPsimtrack.trackId(), TPsimtrack.eventId());
-                if (simtrack == testId) {
-                  tpIsAssoc = true;
-                  break;
-                }
-              }
-            }
-          }  //cell Loop
-          if (!tpIsAssoc && goodCell) {
-            meUnassDeposit_->Fill(1.5);
-          }
-        }  // tp BTL/ETL acceptance selection
-      }
-    }  //tp Loop
-  }    //optionalPlots
 
   unsigned int index = 0;
 
@@ -493,7 +401,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     const reco::Track& track = *mtdTrackref;
 
     bool isBTL = false;
+    bool isETL = false;
     bool twoETLdiscs = false;
+    bool noCrack = std::abs(trackGen.eta()) < trackMaxBtlEta_ || std::abs(trackGen.eta()) > trackMinEtlEta_;
 
     if (track.pt() >= trackMinPt_ && std::abs(track.eta()) <= trackMaxEtlEta_) {
       meTracktmtd_->Fill(tMtd[trackref]);
@@ -532,6 +442,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
         meTrackNumHits_->Fill(numMTDBtlvalidhits);
+        if (isBTL && Sigmat0Safe[trackref] < 0.) {
+          meTrackNumHitsNT_->Fill(numMTDBtlvalidhits);
+        }
 
         // --- keeping only tracks with last hit in MTD ---
         if (MTDBtl == true) {
@@ -568,50 +481,39 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             continue;
           MTDDetId Hit = hit->geographicalId();
           if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
+            isETL = true;
             ETLDetId ETLHit = hit->geographicalId();
 
-            if (topo2Dis) {
-              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
-                MTDEtlZnegD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
-                MTDEtlZnegD2 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
-                MTDEtlZposD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
-              if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
-                MTDEtlZposD2 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
-                numMTDEtlvalidhits++;
-              }
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
+              MTDEtlZnegD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+              numMTDEtlvalidhits++;
             }
-
-            if (topo1Dis) {
-              if (ETLHit.zside() == -1) {
-                MTDEtlZnegD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                numMTDEtlvalidhits++;
-              }
-              if (ETLHit.zside() == 1) {
-                MTDEtlZposD1 = true;
-                meETLTrackRPTime_->Fill(track.t0());
-                numMTDEtlvalidhits++;
-              }
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
+              MTDEtlZnegD2 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+              numMTDEtlvalidhits++;
+            }
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
+              MTDEtlZposD1 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+              numMTDEtlvalidhits++;
+            }
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
+              MTDEtlZposD2 = true;
+              meETLTrackRPTime_->Fill(track.t0());
+              meETLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+              numMTDEtlvalidhits++;
             }
           }
         }
         meTrackNumHits_->Fill(-numMTDEtlvalidhits);
+        if (isETL && Sigmat0Safe[trackref] < 0.) {
+          meTrackNumHitsNT_->Fill(-numMTDEtlvalidhits);
+        }
 
         // --- keeping only tracks with last hit in MTD ---
         if ((track.eta() < -trackMinEtlEta_) && (track.eta() > -trackMaxEtlEta_)) {
@@ -641,10 +543,77 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
       }
+
+      // TrackingParticle based matching
+
+      const reco::TrackBaseRef trkrefb(trackref);
+      auto tp_info = getMatchedTP(trkrefb);
+
+      meTrackPtTot_->Fill(trackGen.pt());
+      meTrackEtaTot_->Fill(std::abs(trackGen.eta()));
+      if (tp_info != nullptr && mvaTPSel(**tp_info)) {
+        const bool withMTD = (m_tp2detid.find(*tp_info) != m_tp2detid.end());
+        if (noCrack) {
+          meTrackMatchedTPEffPtTot_->Fill(trackGen.pt());
+          if (withMTD) {
+            meTrackMatchedTPmtdEffPtTot_->Fill(trackGen.pt());
+          }
+        }
+        meTrackMatchedTPEffEtaTot_->Fill(std::abs(trackGen.eta()));
+        if (withMTD) {
+          meTrackMatchedTPmtdEffEtaTot_->Fill(std::abs(trackGen.eta()));
+        }
+        if (isBTL || isETL) {
+          if (noCrack) {
+            meTrackMatchedTPEffPtMtd_->Fill(trackGen.pt());
+            if (isBTL || twoETLdiscs) {
+              meTrackMatchedTPEffPtEtl2Mtd_->Fill(trackGen.pt());
+            }
+            if (withMTD) {
+              meTrackMatchedTPmtdEffPtMtd_->Fill(trackGen.pt());
+            }
+          }
+          meTrackMatchedTPEffEtaMtd_->Fill(std::abs(trackGen.eta()));
+          if (isBTL || twoETLdiscs) {
+            meTrackMatchedTPEffEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
+          }
+          if (withMTD) {
+            meTrackMatchedTPmtdEffEtaMtd_->Fill(std::abs(trackGen.eta()));
+          }
+        }
+
+        if (optionalPlots_) {
+          size_t nlayers(0);
+          float extrho(0.);
+          float exteta(0.);
+          float extphi(0.);
+          float selvar(0.);
+          auto accept = checkAcceptance(trackGen, iEvent, iSetup, nlayers, extrho, exteta, extphi, selvar);
+          if (accept.first && std::abs(exteta) < trackMaxBtlEta_) {
+            meExtraPhiAtBTL_->Fill(angle_units::operators::convertRadToDeg(extphi));
+            meExtraBTLeneInCone_->Fill(selvar);
+          }
+          if (accept.second) {
+            if (std::abs(exteta) < trackMaxBtlEta_) {
+              meExtraPhiAtBTLmatched_->Fill(angle_units::operators::convertRadToDeg(extphi));
+            }
+            if (noCrack) {
+              meExtraPtMtd_->Fill(trackGen.pt());
+              if (nlayers == 2) {
+                meExtraPtEtl2Mtd_->Fill(trackGen.pt());
+              }
+            }
+            meExtraEtaMtd_->Fill(std::abs(trackGen.eta()));
+            if (nlayers == 2) {
+              meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
+            }
+          }
+        }
+
+      }  // TP matching
     }
 
     if (isGoodVtx) {
-      bool noCrack = std::abs(trackGen.eta()) < trackMaxBtlEta_ || std::abs(trackGen.eta()) > trackMinEtlEta_;
       const bool vtxFake = primRecoVtx.isFake();
 
       if (mvaRecSel(trackGen, primRecoVtx, t0Safe[trackref], Sigmat0Safe[trackref])) {
@@ -675,7 +644,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 meMVATrackMatchedEffPtTot_->Fill(trackGen.pt());
               }
               meMVATrackMatchedEffEtaTot_->Fill(std::abs(trackGen.eta()));
-              if (pullT > -9999.) {
+              if (isBTL || isETL) {
                 meMVATrackResTot_->Fill(dT);
                 meMVATrackPullTot_->Fill(pullT);
                 if (noCrack) {
@@ -687,46 +656,192 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             }
           }
         }
+      }
+    }  // MC truth matich analysis for good PV
+  }    //RECO tracks loop
+}
 
-        // TrackingParticle based matching
+const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Track& track,
+                                                                 const edm::Event& iEvent,
+                                                                 edm::EventSetup const& iSetup,
+                                                                 size_t& nlayers,
+                                                                 float& extrho,
+                                                                 float& exteta,
+                                                                 float& extphi,
+                                                                 float& selvar) {
+  bool isMatched(false);
+  nlayers = 0;
+  extrho = 0.;
+  exteta = -999.;
+  extphi = -999.;
+  selvar = 0.;
 
-        const reco::TrackBaseRef trkrefb(trackref);
-        auto tp_info = getMatchedTP(trkrefb, zsim);
+  auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
+  const MTDGeometry* geom = geometryHandle.product();
+  auto topologyHandle = iSetup.getTransientHandle(mtdtopoToken_);
+  const MTDTopology* topology = topologyHandle.product();
 
-        if (tp_info != nullptr && mvaTPSel(**tp_info)) {
-          const bool withMTD = tpWithMTD(**tp_info, mtdTrackId);
-          if (noCrack) {
-            meTrackMatchedTPEffPtTot_->Fill(trackGen.pt());
-            if (withMTD) {
-              meTrackMatchedTPmtdEffPtTot_->Fill(trackGen.pt());
-            }
+  auto layerHandle = iSetup.getTransientHandle(mtdlayerToken_);
+  const MTDDetLayerGeometry* layerGeo = layerHandle.product();
+
+  auto magfieldHandle = iSetup.getTransientHandle(magfieldToken_);
+  const MagneticField* mfield = magfieldHandle.product();
+
+  auto ttrackBuilder = iSetup.getTransientHandle(builderToken_);
+
+  auto tTrack = ttrackBuilder->build(track);
+  TrajectoryStateOnSurface tsos = tTrack.outermostMeasurementState();
+  float theMaxChi2 = 500.;
+  float theNSigma = 10.;
+  std::unique_ptr<MeasurementEstimator> theEstimator =
+      std::make_unique<Chi2MeasurementEstimator>(theMaxChi2, theNSigma);
+  SteppingHelixPropagator prop(mfield, anyDirection);
+
+  auto btlRecHitsHandle = makeValid(iEvent.getHandle(btlRecHitsToken_));
+  auto etlRecHitsHandle = makeValid(iEvent.getHandle(etlRecHitsToken_));
+
+  edm::LogVerbatim("MtdTracksValidation") << "New Track, pt= " << track.pt() << " eta= " << track.eta();
+
+  //try BTL
+  bool inBTL = false;
+  float eneSum(0.);
+  const std::vector<const DetLayer*>& layersBTL = layerGeo->allBTLLayers();
+  for (const DetLayer* ilay : layersBTL) {
+    std::pair<bool, TrajectoryStateOnSurface> comp = ilay->compatible(tsos, prop, *theEstimator);
+    if (!comp.first)
+      continue;
+    if (!inBTL) {
+      inBTL = true;
+      extrho = comp.second.globalPosition().perp();
+      exteta = comp.second.globalPosition().eta();
+      extphi = comp.second.globalPosition().phi();
+      edm::LogVerbatim("MtdTracksValidation")
+          << "Extrapolation at BTL surface, rho= " << extrho << " eta= " << exteta << " phi= " << extphi;
+    }
+    std::vector<DetLayer::DetWithState> compDets = ilay->compatibleDets(tsos, prop, *theEstimator);
+    for (const auto& detWithState : compDets) {
+      const auto& det = detWithState.first;
+
+      // loop on compatible rechits and check energy in a fixed size cone around the extrapolation point
+
+      edm::LogVerbatim("MtdTracksValidation")
+          << "DetId= " << det->geographicalId().rawId() << " gp= " << detWithState.second.globalPosition().x() << " "
+          << detWithState.second.globalPosition().y() << " " << detWithState.second.globalPosition().z()
+          << " rho= " << detWithState.second.globalPosition().perp()
+          << " eta= " << detWithState.second.globalPosition().eta()
+          << " phi= " << detWithState.second.globalPosition().phi();
+
+      for (const auto& recHit : *btlRecHitsHandle) {
+        BTLDetId detId = recHit.id();
+        DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
+        const MTDGeomDet* thedet = geom->idToDet(geoId);
+        if (thedet == nullptr)
+          throw cms::Exception("MtdTracksValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                      << detId.rawId() << ") is invalid!" << std::dec << std::endl;
+        if (geoId == det->geographicalId()) {
+          const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+          const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+          Local3DPoint local_point(0., 0., 0.);
+          local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
+          const auto& global_point = thedet->toGlobal(local_point);
+          edm::LogVerbatim("MtdTracksValidation")
+              << "Hit id= " << detId.rawId() << " ene= " << recHit.energy()
+              << " dr= " << reco::deltaR(global_point, detWithState.second.globalPosition());
+          if (reco::deltaR(global_point, detWithState.second.globalPosition()) < cluDRradius_) {
+            eneSum += recHit.energy();
+            //extrho = detWithState.second.globalPosition().perp();
+            //exteta = detWithState.second.globalPosition().eta();
+            //extphi = detWithState.second.globalPosition().phi();
           }
-          meTrackMatchedTPEffEtaTot_->Fill(std::abs(trackGen.eta()));
-          if (withMTD) {
-            meTrackMatchedTPmtdEffEtaTot_->Fill(std::abs(trackGen.eta()));
-          }
-          if (pullT > -9999.) {
-            if (noCrack) {
-              meTrackMatchedTPEffPtMtd_->Fill(trackGen.pt());
-              if (isBTL || twoETLdiscs) {
-                meTrackMatchedTPEffPtEtl2Mtd_->Fill(trackGen.pt());
-              }
-              if (withMTD) {
-                meTrackMatchedTPmtdEffPtMtd_->Fill(trackGen.pt());
-              }
-            }
-            meTrackMatchedTPEffEtaMtd_->Fill(std::abs(trackGen.eta()));
-            if (isBTL || twoETLdiscs) {
-              meTrackMatchedTPEffEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
-            }
-            if (withMTD) {
-              meTrackMatchedTPmtdEffEtaMtd_->Fill(std::abs(trackGen.eta()));
+        }
+      }
+    }
+    if (eneSum > depositBTLthreshold_) {
+      nlayers++;
+      selvar = eneSum;
+      isMatched = true;
+      edm::LogVerbatim("MtdTracksValidation") << "BTL matched, energy= " << eneSum << " #layers= " << nlayers;
+    }
+  }
+  if (inBTL) {
+    return std::make_pair(inBTL, isMatched);
+  }
+
+  //try ETL
+  bool inETL = false;
+  const std::vector<const DetLayer*>& layersETL = layerGeo->allETLLayers();
+  for (const DetLayer* ilay : layersETL) {
+    size_t hcount(0);
+    const BoundDisk& disk = static_cast<const MTDRingForwardDoubleLayer*>(ilay)->specificSurface();
+    const double diskZ = disk.position().z();
+    if (tsos.globalPosition().z() * diskZ < 0)
+      continue;  // only propagate to the disk that's on the same side
+    std::pair<bool, TrajectoryStateOnSurface> comp = ilay->compatible(tsos, prop, *theEstimator);
+    if (!comp.first)
+      continue;
+    if (!inETL) {
+      inETL = true;
+      extrho = comp.second.globalPosition().perp();
+      exteta = comp.second.globalPosition().eta();
+      extphi = comp.second.globalPosition().phi();
+    }
+    edm::LogVerbatim("MtdTracksValidation")
+        << "Extrapolation at ETL surface, rho= " << extrho << " eta= " << exteta << " phi= " << extphi;
+    std::vector<DetLayer::DetWithState> compDets = ilay->compatibleDets(tsos, prop, *theEstimator);
+    for (const auto& detWithState : compDets) {
+      const auto& det = detWithState.first;
+
+      // loop on compatible rechits and check hits in a fixed size cone around the extrapolation point
+
+      edm::LogVerbatim("MtdTracksValidation")
+          << "DetId= " << det->geographicalId().rawId() << " gp= " << detWithState.second.globalPosition().x() << " "
+          << detWithState.second.globalPosition().y() << " " << detWithState.second.globalPosition().z()
+          << " rho= " << detWithState.second.globalPosition().perp()
+          << " eta= " << detWithState.second.globalPosition().eta()
+          << " phi= " << detWithState.second.globalPosition().phi();
+
+      for (const auto& recHit : *etlRecHitsHandle) {
+        ETLDetId detId = recHit.id();
+        DetId geoId = detId.geographicalId();
+        const MTDGeomDet* thedet = geom->idToDet(geoId);
+        if (thedet == nullptr)
+          throw cms::Exception("MtdTracksValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                      << detId.rawId() << ") is invalid!" << std::dec << std::endl;
+        if (geoId == det->geographicalId()) {
+          const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+          const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+          Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
+          const auto& global_point = thedet->toGlobal(local_point);
+          edm::LogVerbatim("MtdTracksValidation")
+              << "Hit id= " << detId.rawId() << " time= " << recHit.time()
+              << " dr= " << reco::deltaR(global_point, detWithState.second.globalPosition());
+          if (reco::deltaR(global_point, detWithState.second.globalPosition()) < cluDRradius_) {
+            hcount++;
+            if (hcount == 1) {
+              //extrho = detWithState.second.globalPosition().perp();
+              //exteta = detWithState.second.globalPosition().eta();
+              //extphi = detWithState.second.globalPosition().phi();
             }
           }
         }
       }
-    }  // MC truth matich analysis for good PV
-  }    //RECO tracks loop
+    }
+    if (hcount > 0) {
+      nlayers++;
+      selvar = (float)hcount;
+      isMatched = true;
+      edm::LogVerbatim("MtdTracksValidation") << "ETL matched, counts= " << hcount << " #layers= " << nlayers;
+    }
+  }
+
+  if (!inBTL && !inETL) {
+    edm::LogVerbatim("MtdTracksValidation")
+        << "Track not extrapolating to MTD: pt= " << track.pt() << " eta= " << track.eta() << " phi= " << track.phi()
+        << " vz= " << track.vz() << " vxy= " << std::sqrt(track.vx() * track.vx() + track.vy() * track.vy());
+  }
+  return std::make_pair(inETL, isMatched);
 }
 
 // ------------ method for histogram booking ------------
@@ -796,6 +911,8 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackSigmat0SafePid_ =
       ibook.book1D("TrackSigmat0SafePID", "Sigmat0 Safe as stored in TofPid; #sigma_{t0} [ns]", 100, 0, 0.1);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
+  meTrackNumHitsNT_ = ibook.book1D(
+      "TrackNumHitsNT", "Number of valid MTD hits per track no time associated; Number of hits", 10, -5, 5);
   meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
@@ -806,25 +923,24 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffPtMtd_ = ibook.book1D(
       "MVAMatchedEffPtMtd", "Pt of tracks associated to LV matched to GEN with time; track pt [GeV] ", 110, 0., 11.);
 
-  meTrackMatchedTPEffPtTot_ =
-      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtMtd_ = ibook.book1D(
-      "MatchedTPEffPtMtd", "Pt of tracks associated to LV matched to TP with time; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPEffPtEtl2Mtd_ =
-      ibook.book1D("MatchedTPEffPtEtl2Mtd",
-                   "Pt of tracks associated to LV matched to TP with time, 2 ETL hits; track pt [GeV] ",
-                   110,
-                   0.,
-                   11.);
+  if (optionalPlots_) {
+    meExtraPtMtd_ = ibook.book1D("ExtraPtMtd", "Pt of tracks extrapolated to hits; track pt [GeV] ", 110, 0., 11.);
+    meExtraPtEtl2Mtd_ = ibook.book1D(
+        "ExtraPtEtl2Mtd", "Pt of tracks extrapolated to hits, 2 ETL layers; track pt [GeV] ", 110, 0., 11.);
+  }
 
-  meTrackMatchedTPmtdEffPtTot_ = ibook.book1D(
-      "MatchedTPmtdEffPtTot", "Pt of tracks associated to LV matched to TP-mtd hit; track pt [GeV] ", 110, 0., 11.);
-  meTrackMatchedTPmtdEffPtMtd_ =
-      ibook.book1D("MatchedTPmtdEffPtMtd",
-                   "Pt of tracks associated to LV matched to TP-mtd hit with time; track pt [GeV] ",
-                   110,
-                   0.,
-                   11.);
+  meTrackPtTot_ = ibook.book1D("TrackPtTot", "Pt of tracks ; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtTot_ =
+      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks  matched to TP; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtMtd_ =
+      ibook.book1D("MatchedTPEffPtMtd", "Pt of tracks  matched to TP with time; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtEtl2Mtd_ = ibook.book1D(
+      "MatchedTPEffPtEtl2Mtd", "Pt of tracks  matched to TP with time, 2 ETL hits; track pt [GeV] ", 110, 0., 11.);
+
+  meTrackMatchedTPmtdEffPtTot_ =
+      ibook.book1D("MatchedTPmtdEffPtTot", "Pt of tracks  matched to TP-mtd hit; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPmtdEffPtMtd_ = ibook.book1D(
+      "MatchedTPmtdEffPtMtd", "Pt of tracks  matched to TP-mtd hit with time; track pt [GeV] ", 110, 0., 11.);
 
   meMVATrackEffEtaTot_ = ibook.book1D("MVAEffEtaTot", "Eta of tracks associated to LV; track eta ", 66, 0., 3.3);
   meMVATrackMatchedEffEtaTot_ =
@@ -832,25 +948,25 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Eta of tracks associated to LV matched to GEN with time; track eta ", 66, 0., 3.3);
 
-  meTrackMatchedTPEffEtaTot_ =
-      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaMtd_ = ibook.book1D(
-      "MatchedTPEffEtaMtd", "Eta of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
-  meTrackMatchedTPEffEtaEtl2Mtd_ =
-      ibook.book1D("MatchedTPEffEtaEtl2Mtd",
-                   "Eta of tracks associated to LV matched to TP with time, 2 ETL hits; track eta ",
-                   66,
-                   0.,
-                   3.3);
+  if (optionalPlots_) {
+    meExtraEtaMtd_ = ibook.book1D("ExtraEtaMtd", "Eta of tracks extrapolated to hits; track eta ", 66, 0., 3.3);
+    meExtraEtaEtl2Mtd_ =
+        ibook.book1D("ExtraEtaEtl2Mtd", "Eta of tracks extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
+  }
 
-  meTrackMatchedTPmtdEffEtaTot_ = ibook.book1D(
-      "MatchedTPmtdEffEtaTot", "Eta of tracks associated to LV matched to TP-mtd hit; track eta ", 66, 0., 3.3);
+  meTrackEtaTot_ = ibook.book1D("TrackEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaTot_ =
+      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks  matched to TP; track eta ", 66, 0., 3.3);
+  meMVATrackEffEtaTot_ = ibook.book1D("MVAEffEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaMtd_ =
+      ibook.book1D("MatchedTPEffEtaMtd", "Eta of tracks  matched to TP with time; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaEtl2Mtd_ = ibook.book1D(
+      "MatchedTPEffEtaEtl2Mtd", "Eta of tracks  matched to TP with time, 2 ETL hits; track eta ", 66, 0., 3.3);
+
+  meTrackMatchedTPmtdEffEtaTot_ =
+      ibook.book1D("MatchedTPmtdEffEtaTot", "Eta of tracks  matched to TP-mtd hit; track eta ", 66, 0., 3.3);
   meTrackMatchedTPmtdEffEtaMtd_ =
-      ibook.book1D("MatchedTPmtdEffEtaMtd",
-                   "Eta of tracks associated to LV matched to TP-mtd hit with time; track eta ",
-                   66,
-                   0.,
-                   3.3);
+      ibook.book1D("MatchedTPmtdEffEtaMtd", "Eta of tracks  matched to TP-mtd hit with time; track eta ", 66, 0., 3.3);
 
   meMVATrackResTot_ = ibook.book1D(
       "MVATrackRes", "t_{rec} - t_{sim} for LV associated tracks; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
@@ -859,26 +975,18 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackZposResTot_ = ibook.book1D(
       "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for associated tracks;Z_{PCA} - Z_{sim} [cm] ", 100, -0.1, 0.1);
 
-  meUnassociatedDetId_ = ibook.bookProfile(
-      "UnassociatedDetId", "Number of MTD cell not associated to any TP per event", 2, 0., 2., 0., 100000., "S");
-  meNTrackingParticles_ = ibook.book1D("NTrackingParticles", "Total #Tracking particles", 2, 0, 2);
-  meUnassDeposit_ =
-      ibook.book1D("UnassDeposit",
-                   "#Tracking particles with deposit over threshold in MTD cell, but with no cell associated to TP;",
-                   2,
-                   0,
-                   2);
-  meUnassCrysEnergy_ =
-      ibook.book1D("UnassCrysEnergy",
-                   "Energy deposit in BTL crystal with no associated SimTracks;log_{10}(Energy [MeV]) ",
-                   100,
-                   -3.5,
-                   1.5);
-  meUnassLgadsEnergy_ = ibook.book1D("UnassLgadsEnergy",
-                                     "Energy deposit in ETL LGADs with no associated SimTracks;log_{10}(Energy [MeV]) ",
-                                     100,
-                                     -3.5,
-                                     1.5);
+  if (optionalPlots_) {
+    meExtraPhiAtBTL_ =
+        ibook.book1D("ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks; phi [deg]", 720, -180., 180.);
+    meExtraPhiAtBTLmatched_ =
+        ibook.book1D("ExtraPhiAtBTLmatched",
+                     "Phi at BTL surface of extrapolated tracksi matched with BTL hits; phi [deg]",
+                     720,
+                     -180.,
+                     180.);
+    meExtraBTLeneInCone_ = ibook.book1D(
+        "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -895,6 +1003,8 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
   desc.add<edm::InputTag>("btlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<edm::InputTag>("etlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
+  desc.add<edm::InputTag>("btlRecHits", edm::InputTag("mtdRecHits", "FTLBarrel"));
+  desc.add<edm::InputTag>("etlRecHits", edm::InputTag("mtdRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
   desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
   desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
@@ -965,36 +1075,21 @@ const bool MtdTracksValidation::mvaGenRecMatch(const HepMC::GenParticle& genP,
   return match;
 }
 
-const edm::Ref<std::vector<TrackingParticle>>* MtdTracksValidation::getMatchedTP(const reco::TrackBaseRef& recoTrack,
-                                                                                 const double& zsim) {
+const edm::Ref<std::vector<TrackingParticle>>* MtdTracksValidation::getMatchedTP(const reco::TrackBaseRef& recoTrack) {
   auto found = r2s_->find(recoTrack);
 
   // reco track not matched to any TP
   if (found == r2s_->end())
     return nullptr;
 
-  //matched TP equal to any TP associated to signal sim vertex
+  //matched TP equal to any TP associated to in time events
   for (const auto& tp : found->val) {
-    if (tp.first->eventId().bunchCrossing() == 0 && tp.first->eventId().event() == 0 &&
-        std::abs(tp.first->parentVertex()->position().z() - zsim) < deltaZcut_) {
+    if (tp.first->eventId().bunchCrossing() == 0)
       return &tp.first;
-    }
   }
 
   // reco track not matched to any TP from vertex
   return nullptr;
-}
-
-const bool MtdTracksValidation::tpWithMTD(const TrackingParticle& tp,
-                                          const std::unordered_set<unsigned long int>& trkList) {
-  for (const auto& simTrk : tp.g4Tracks()) {
-    for (const auto& mtdTrk : trkList) {
-      if (uniqueId(simTrk.trackId(), simTrk.eventId()) == mtdTrk) {
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 DEFINE_FWK_MODULE(MtdTracksValidation);


### PR DESCRIPTION
#### PR description:

This PR proposes a reorganization of the ```MtdTracksValidation``` class in ```Validation/MtdValidation``` aiming at:

- simplify the code for matching ```TrackingParticle``` and ```PSimHit``` from MTD;
- add a dedicated test to extrapolation of tracks to the BTL surface, parallel to the studies proposed in the TDR, for direct comparison.

This update serves also as a basis for a private backport to the original TDR release 10_4_0_mtd5, for direct comparison with TDR results.

#### PR validation:

The code has been extensively tested on large (100k events) samples of muon and pion guns.
