### PR TITLE
Implementation of inactive regions along partial wafer cuts 

### DIFF
--- a/SimG4CMS/Calo/interface/HGCGuardRingPartial.h
+++ b/SimG4CMS/Calo/interface/HGCGuardRingPartial.h
@@ -18,9 +18,11 @@ private:
   const HGCalDDDConstants& hgcons_;
   const HGCalGeometryMode::GeometryMode modeUV_;
   const double waferSize_, guardRingOffset_;
-  static constexpr std::array<double, 12> tan_1 = {{-sqrt3_, sqrt3_, 0.0, -sqrt3_,  sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0}};
+  static constexpr std::array<double, 12> tan_1 = {
+      {-sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0}};
   static constexpr std::array<double, 12> cos_1 = {{0.5, -0.5, -1.0, -0.5, 0.5, 1.0, -0.5, 0.5, 1.0, 0.5, -0.5, -1.0}};
-  static constexpr std::array<double, 12> cot_1 = {{sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0}};
+  static constexpr std::array<double, 12> cot_1 = {
+      {sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0}};
   double offset_, xmax_, ymax_;
 };
 

--- a/SimG4CMS/Calo/interface/HGCGuardRingPartial.h
+++ b/SimG4CMS/Calo/interface/HGCGuardRingPartial.h
@@ -1,0 +1,27 @@
+#ifndef SimG4CMS_HGCGuardRingPartial_h
+#define SimG4CMS_HGCGuardRingPartial_h
+
+#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "G4ThreeVector.hh"
+
+#include <vector>
+#include <array>
+
+class HGCGuardRingPartial {
+public:
+  HGCGuardRingPartial(const HGCalDDDConstants& hgc);
+  bool exclude(G4ThreeVector& point, int zside, int frontBack, int layer, int waferU, int waferV);
+  static bool insidePolygon(double x, double y, const std::vector<std::pair<double, double> >& xyv);
+
+private:
+  static constexpr double sqrt3_ = 1.732050807568877;  // std::sqrt(3.0) in double precision
+  const HGCalDDDConstants& hgcons_;
+  const HGCalGeometryMode::GeometryMode modeUV_;
+  const double waferSize_, guardRingOffset_;
+  static constexpr std::array<double, 12> tan_1 = {{-sqrt3_, sqrt3_, 0.0, -sqrt3_,  sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0}};
+  static constexpr std::array<double, 12> cos_1 = {{0.5, -0.5, -1.0, -0.5, 0.5, 1.0, -0.5, 0.5, 1.0, 0.5, -0.5, -1.0}};
+  static constexpr std::array<double, 12> cot_1 = {{sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0}};
+  double offset_, xmax_, ymax_;
+};
+
+#endif  // HGCGuardRing_h

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -43,7 +43,7 @@ private:
   const HGCalDDDConstants *hgcons_;
   std::unique_ptr<HGCalNumberingScheme> numberingScheme_;
   std::unique_ptr<HGCGuardRing> guardRing_;
-  std::unique_ptr<HGCGuardRing> guardRingPartial_;
+  std::unique_ptr<HGCGuardRingPartial> guardRingPartial_;
   std::unique_ptr<HGCMouseBite> mouseBite_;
   DetId::Detector mydet_;
   std::string nameX_;

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -11,7 +11,7 @@
 #include "SimG4CMS/Calo/interface/HGCalNumberingScheme.h"
 #include "SimG4CMS/Calo/interface/HGCGuardRing.h"
 #include "SimG4CMS/Calo/interface/HGCMouseBite.h"
-
+#include "SimG4CMS/Calo/interface/HGCGuardRingPartial.h"
 #include <string>
 
 class HGCalDDDConstants;
@@ -43,6 +43,7 @@ private:
   const HGCalDDDConstants *hgcons_;
   std::unique_ptr<HGCalNumberingScheme> numberingScheme_;
   std::unique_ptr<HGCGuardRing> guardRing_;
+  std::unique_ptr<HGCGuardRing> guardRingPartial_;
   std::unique_ptr<HGCMouseBite> mouseBite_;
   DetId::Detector mydet_;
   std::string nameX_;

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -27,7 +27,7 @@ bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack
     int partial = HGCalWaferType::getPartial(index, hgcons_.getParameter()->waferInfoMap_);
     int type = HGCalWaferType::getType(index, hgcons_.getParameter()->waferInfoMap_);
     if (partial == HGCalTypes::WaferFull) {
-      return(check);
+      return (check);
     } else {
       int orient = HGCalWaferType::getOrient(index, hgcons_.getParameter()->waferInfoMap_);
       int placement = HGCalCell::cellPlacementIndex(zside, frontBack, orient);
@@ -35,20 +35,28 @@ bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack
       double delY = 2 * delX / sqrt3_;
       double dx = (zside > 0) ? -point.x() : point.x();
       double dy = point.y();
-      if(type>0){
-        check = (std::abs(dy - (dx*tan_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
-        check = (std::abs(dy - (dx*tan_1[placement]) + ((HGCalTypes::c10 * delY * 0.5)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
-        check = (std::abs(dy*cot_1[placement] - (dx)) < std::abs(offset_/cos_1[placement]) || check);
-      } else{
-        check = (std::abs((dy*cot_1[placement]) - dx + ((HGCalTypes::c22 * delX)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
-        check = (std::abs(dy - (dx*tan_1[placement]) - ((HGCalTypes::c27 * delY)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
-        check = (std::abs(dy - (dx*tan_1[placement]) + ((HGCalTypes::c27 * delY)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+      if (type > 0) {
+        check = (std::abs(dy - (dx * tan_1[placement])) < std::abs(offset_ / cos_1[placement]) || check);
+        check = (std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c10 * delY * 0.5) / cos_1[placement])) <
+                     std::abs(offset_ / cos_1[placement]) ||
+                 check);
+        check = (std::abs(dy * cot_1[placement] - (dx)) < std::abs(offset_ / cos_1[placement]) || check);
+      } else {
+        check = (std::abs((dy * cot_1[placement]) - dx + ((HGCalTypes::c22 * delX) / cos_1[placement])) <
+                     std::abs(offset_ / cos_1[placement]) ||
+                 check);
+        check = (std::abs(dy - (dx * tan_1[placement]) - ((HGCalTypes::c27 * delY) / cos_1[placement])) <
+                     std::abs(offset_ / cos_1[placement]) ||
+                 check);
+        check = (std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c27 * delY) / cos_1[placement])) <
+                     std::abs(offset_ / cos_1[placement]) ||
+                 check);
       }
     }
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCSim") << "HGCGuardRingPartial:: Point " << point << " zside " << zside << " layer " << layer
-                                 << " wafer " << waferU << ":" << waferV << " partial type " << partial << ":"
-                                 << " type " << type << " check " << check;
+    edm::LogVerbatim("HGCSim") << "HGCGuardRingPartial:: Point " << point << " zside " << zside << " layer " << layer
+                               << " wafer " << waferU << ":" << waferV << " partial type " << partial << ":"
+                               << " type " << type << " check " << check;
 #endif
   }
   return check;

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -1,0 +1,55 @@
+#include "SimG4CMS/Calo/interface/HGCGuardRingPartial.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
+#include <iostream>
+
+//#define EDM_ML_DEBUG
+
+HGCGuardRingPartial::HGCGuardRingPartial(const HGCalDDDConstants& hgc)
+    : hgcons_(hgc),
+      modeUV_(hgcons_.geomMode()),
+      waferSize_(hgcons_.waferSize(false)),
+      guardRingOffset_(hgcons_.getParameter()->guardRingOffset_) {
+  offset_ = guardRingOffset_;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCSim") << "Creating HGCGuardRingPartial with wafer size " << waferSize_ << ", Offsets "
+                             << sensorSizeOffset_ << ":" << guardRingOffset_ << ":" << offset_ << ", and mode "
+                             << modeUV_;
+#endif
+}
+
+bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack, int layer, int waferU, int waferV) {
+  bool check(false);
+  if (modeUV_ == HGCalGeometryMode::Hexagon8Cassette) {
+    int index = HGCalWaferIndex::waferIndex(layer, waferU, waferV);
+    int partial = HGCalWaferType::getPartial(index, hgcons_.getParameter()->waferInfoMap_);
+    int type = HGCalWaferType::getType(index, hgcons_.getParameter()->waferInfoMap_);
+    if (partial == HGCalTypes::WaferFull) {
+      return(check);
+    } else {
+      int orient = HGCalWaferType::getOrient(index, hgcons_.getParameter()->waferInfoMap_);
+      int placement = HGCalCell::cellPlacementIndex(zside, frontBack, orient);
+      double delX = 0.5 * waferSize_;
+      double delY = 2 * delX / sqrt3_;
+      double dx = (zside > 0) ? -point.x() : point.x();
+      double dy = point.y();
+      if(type>0){
+        check = (std::abs(dy - (dx*tan_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+        check = (std::abs(dy - (dx*tan_1[placement]) + ((HGCalTypes::c10 * delY * 0.5)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+        check = (std::abs(dy*cot_1[placement] - (dx)) < std::abs(offset_/cos_1[placement]) || check);
+      } else{
+        check = (std::abs((dy*cot_1[placement]) - dx + ((HGCalTypes::c22 * delX)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+        check = (std::abs(dy - (dx*tan_1[placement]) - ((HGCalTypes::c27 * delY)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+        check = (std::abs(dy - (dx*tan_1[placement]) + ((HGCalTypes::c27 * delY)/cos_1[placement])) < std::abs(offset_/cos_1[placement]) || check);
+      }
+    }
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCSim") << "HGCGuardRingPartial:: Point " << point << " zside " << zside << " layer " << layer
+                                 << " wafer " << waferU << ":" << waferV << " partial type " << partial << ":"
+                                 << " type " << type << " check " << check;
+#endif
+  }
+  return check;
+}

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -34,22 +34,15 @@ bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack
       double delY = 2 * delX / sqrt3_;
       double dx = (zside > 0) ? -point.x() : point.x();
       double dy = point.y();
+      double tresh = std::abs(offset_ / cos_1[placement]);
       if (type > 0) {
-        check = (std::abs(dy - (dx * tan_1[placement])) < std::abs(offset_ / cos_1[placement]) || check);
-        check = (std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c10 * delY * 0.5) / cos_1[placement])) <
-                     std::abs(offset_ / cos_1[placement]) ||
-                 check);
-        check = (std::abs(dy * cot_1[placement] - (dx)) < std::abs(offset_ / cos_1[placement]) || check);
+        check |= std::abs(dy - (dx * tan_1[placement])) < tresh;
+        check |= std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c10 * delY * 0.5) / cos_1[placement])) < tresh;
+        check |= std::abs(dy * cot_1[placement] - (dx)) < tresh;
       } else {
-        check = (std::abs((dy * cot_1[placement]) - dx + ((HGCalTypes::c22 * delX) / cos_1[placement])) <
-                     std::abs(offset_ / cos_1[placement]) ||
-                 check);
-        check = (std::abs(dy - (dx * tan_1[placement]) - ((HGCalTypes::c27 * delY) / cos_1[placement])) <
-                     std::abs(offset_ / cos_1[placement]) ||
-                 check);
-        check = (std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c27 * delY) / cos_1[placement])) <
-                     std::abs(offset_ / cos_1[placement]) ||
-                 check);
+        check |= std::abs((dy * cot_1[placement]) - dx + ((HGCalTypes::c22 * delX) / cos_1[placement])) < tresh;
+        check |= std::abs(dy - (dx * tan_1[placement]) - ((HGCalTypes::c27 * delY) / cos_1[placement])) < tresh;
+        check |= std::abs(dy - (dx * tan_1[placement]) + ((HGCalTypes::c27 * delY) / cos_1[placement])) < tresh;
       }
     }
 #ifdef EDM_ML_DEBUG

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -15,8 +15,7 @@ HGCGuardRingPartial::HGCGuardRingPartial(const HGCalDDDConstants& hgc)
   offset_ = guardRingOffset_;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCSim") << "Creating HGCGuardRingPartial with wafer size " << waferSize_ << ", Offsets "
-                             << sensorSizeOffset_ << ":" << guardRingOffset_ << ":" << offset_ << ", and mode "
-                             << modeUV_;
+                             << ":" << guardRingOffset_ << ":" << offset_ << ", and mode " << modeUV_;
 #endif
 }
 
@@ -55,7 +54,7 @@ bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack
     }
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCSim") << "HGCGuardRingPartial:: Point " << point << " zside " << zside << " layer " << layer
-                               << " wafer " << waferU << ":" << waferV << " partial type " << partial << ":"
+                               << " wafer " << waferU << ":" << waferV << " partial type " << partial
                                << " type " << type << " check " << check;
 #endif
   }

--- a/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
+++ b/SimG4CMS/Calo/src/HGCGuardRingPartial.cc
@@ -54,8 +54,8 @@ bool HGCGuardRingPartial::exclude(G4ThreeVector& point, int zside, int frontBack
     }
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCSim") << "HGCGuardRingPartial:: Point " << point << " zside " << zside << " layer " << layer
-                               << " wafer " << waferU << ":" << waferV << " partial type " << partial
-                               << " type " << type << " check " << check;
+                               << " wafer " << waferU << ":" << waferV << " partial type " << partial << " type "
+                               << type << " check " << check;
 #endif
   }
   return check;

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -185,7 +185,8 @@ uint32_t HGCalSD::setDetUnitId(const G4Step* aStep) {
     if (fiducialCut_) {
       int layertype = hgcons_->layerType(layer);
       int frontBack = HGCalTypes::layerFrontBack(layertype);
-      if (guardRing_->exclude(local, iz, frontBack, layer, uv.first, uv.second) || guardRingPartial_->exclude(local, iz, frontBack, layer, uv.first, uv.second)) {
+      if (guardRing_->exclude(local, iz, frontBack, layer, uv.first, uv.second) ||
+          guardRingPartial_->exclude(local, iz, frontBack, layer, uv.first, uv.second)) {
         id = 0;
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCSim") << "Rejected by GuardRing cutoff *****";
@@ -265,9 +266,10 @@ void HGCalSD::update(const BeginOfJob* job) {
     numberingScheme_ = std::make_unique<HGCalNumberingScheme>(*hgcons_, mydet_, nameX_, missingFile_);
     if (rejectMB_)
       mouseBite_ = std::make_unique<HGCMouseBite>(*hgcons_, angles_, mouseBiteCut_, waferRot_);
-    if (fiducialCut_)
+    if (fiducialCut_) {
       guardRing_ = std::make_unique<HGCGuardRing>(*hgcons_);
       guardRingPartial_ = std::make_unique<HGCGuardRingPartial>(*hgcons_);
+    }
   } else {
     throw cms::Exception("Unknown", "HGCalSD") << "Cannot find HGCalDDDConstants for " << nameX_ << "\n";
   }

--- a/SimG4CMS/Calo/src/HGCalSD.cc
+++ b/SimG4CMS/Calo/src/HGCalSD.cc
@@ -48,6 +48,7 @@ HGCalSD::HGCalSD(const std::string& name,
       cos30deg_(std::cos(30.0 * CLHEP::deg)) {
   numberingScheme_.reset(nullptr);
   guardRing_.reset(nullptr);
+  guardRingPartial_.reset(nullptr);
   mouseBite_.reset(nullptr);
 
   edm::ParameterSet m_HGC = p.getParameter<edm::ParameterSet>("HGCSD");
@@ -184,7 +185,7 @@ uint32_t HGCalSD::setDetUnitId(const G4Step* aStep) {
     if (fiducialCut_) {
       int layertype = hgcons_->layerType(layer);
       int frontBack = HGCalTypes::layerFrontBack(layertype);
-      if (guardRing_->exclude(local, iz, frontBack, layer, uv.first, uv.second)) {
+      if (guardRing_->exclude(local, iz, frontBack, layer, uv.first, uv.second) || guardRingPartial_->exclude(local, iz, frontBack, layer, uv.first, uv.second)) {
         id = 0;
 #ifdef EDM_ML_DEBUG
         edm::LogVerbatim("HGCSim") << "Rejected by GuardRing cutoff *****";
@@ -266,6 +267,7 @@ void HGCalSD::update(const BeginOfJob* job) {
       mouseBite_ = std::make_unique<HGCMouseBite>(*hgcons_, angles_, mouseBiteCut_, waferRot_);
     if (fiducialCut_)
       guardRing_ = std::make_unique<HGCGuardRing>(*hgcons_);
+      guardRingPartial_ = std::make_unique<HGCGuardRingPartial>(*hgcons_);
   } else {
     throw cms::Exception("Unknown", "HGCalSD") << "Cannot find HGCalDDDConstants for " << nameX_ << "\n";
   }


### PR DESCRIPTION
PR description:

Implement script to reject hits from the inactive zones along partial wafer cuts of HGCAL. (only reject for partial wafers, Full wafers left unaffected)

PR validation:

Use runTheMatrix test workflows 'runTheMatrix.py -l limited -i all --ibeos'
Validation results presented in: https://indico.cern.ch/event/1297259/

if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing
