### PR TITLE
Fix compilation warnings in MESet*

### DIFF
--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -76,6 +76,7 @@ namespace ecaldqm {
       std::vector<float> edges;
       std::vector<std::string> labels;
       std::string title;
+      AxisSpecs() : nbins(0), low(0.), high(0.), edges(0), labels(0), title("") { ; };
     };
 
     AxisSpecs getBinning(EcalElectronicsMapping const *, ObjectType, BinningType, bool, int, unsigned);

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -73,57 +73,9 @@ namespace ecaldqm {
     struct AxisSpecs {
       int nbins;
       float low, high;
-      float *edges;
-      std::string *labels;
+      std::vector<float> edges;
+      std::vector<std::string> labels;
       std::string title;
-      AxisSpecs() : nbins(0), low(0.), high(0.), edges(nullptr), labels(nullptr), title("") {}
-      AxisSpecs(AxisSpecs const &_specs)
-          : nbins(_specs.nbins),
-            low(_specs.low),
-            high(_specs.high),
-            edges(nullptr),
-            labels(nullptr),
-            title(_specs.title) {
-        if (_specs.edges) {
-          edges = new float[nbins + 1];
-          for (int i(0); i <= nbins; i++)
-            edges[i] = _specs.edges[i];
-        }
-        if (_specs.labels) {
-          labels = new std::string[nbins];
-          for (int i(0); i < nbins; i++)
-            labels[i] = _specs.labels[i];
-        }
-      }
-      AxisSpecs &operator=(AxisSpecs const &_rhs) {
-        if (edges) {
-          delete[] edges;
-          edges = nullptr;
-        }
-        if (labels) {
-          delete[] labels;
-          labels = nullptr;
-        }
-        nbins = _rhs.nbins;
-        low = _rhs.low;
-        high = _rhs.high;
-        title = _rhs.title;
-        if (_rhs.edges) {
-          edges = new float[nbins + 1];
-          for (int i(0); i <= nbins; i++)
-            edges[i] = _rhs.edges[i];
-        }
-        if (_rhs.labels) {
-          labels = new std::string[nbins];
-          for (int i(0); i < nbins; i++)
-            labels[i] = _rhs.labels[i];
-        }
-        return *this;
-      }
-      ~AxisSpecs() {
-        delete[] edges;
-        delete[] labels;
-      }
     };
 
     AxisSpecs getBinning(EcalElectronicsMapping const *, ObjectType, BinningType, bool, int, unsigned);

--- a/DQM/EcalCommon/src/MESetBinningUtils.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils.cc
@@ -832,8 +832,7 @@ namespace ecaldqm {
       if (_axisParams.existsAs<std::vector<double>>("edges", false)) {
         std::vector<double> const &vEdges(_axisParams.getUntrackedParameter<std::vector<double>>("edges"));
         axis.nbins = vEdges.size() - 1;
-        axis.edges = new float[vEdges.size()];
-        std::copy(vEdges.begin(), vEdges.end(), axis.edges);
+        axis.edges.assign(vEdges.begin(), vEdges.end());
       } else {
         axis.nbins = _axisParams.getUntrackedParameter<int>("nbins");
         axis.low = _axisParams.getUntrackedParameter<double>("low");
@@ -852,9 +851,7 @@ namespace ecaldqm {
       if (_axisParams.existsAs<std::vector<std::string>>("labels", false)) {
         std::vector<std::string> const &labels(_axisParams.getUntrackedParameter<std::vector<std::string>>("labels"));
         if (int(labels.size()) == axis.nbins) {
-          axis.labels = new std::string[axis.nbins];
-          for (int iB(0); iB != axis.nbins; ++iB)
-            axis.labels[iB] = labels[iB];
+          axis.labels = labels;
         }
       }
 

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -349,7 +349,7 @@ namespace ecaldqm {
             break;
           case kProjEta:
             specs.nbins = nEBEtaBins + 2 * nEEEtaBins;
-            specs.edges = new float[specs.nbins + 1];
+            specs.edges = std::vector(specs.nbins + 1, 0.f);
             for (int i(0); i <= nEEEtaBins; i++)
               specs.edges[i] = -3. + (3. - etaBound) / nEEEtaBins * i;
             for (int i(1); i <= nEBEtaBins; i++)


### PR DESCRIPTION
#### PR description:

Fix warnings reported [here](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_2_X_2023-07-04-1100/DQM/EcalCommon), e.g.:

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/de71853a65d857b5c29aa52c2674d8d1/opt/cmssw/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_13_2_X_2023-07-04-1100/src/DQM/EcalCommon/src/MESetBinningUtils.cc: In function 'formAxis':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/de71853a65d857b5c29aa52c2674d8d1/opt/cmssw/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_13_2_X_2023-07-04-1100/src/DQM/EcalCommon/src/MESetBinningUtils.cc:855:51: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   855 |           axis.labels = new std::string[axis.nbins];
      |                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
```

#### PR validation:

Code compiles without warnings

