### PR TITLE
Correct validity test in edmNew::DetSet data() method

### DIFF
--- a/DataFormats/Common/interface/DetSetNew.h
+++ b/DataFormats/Common/interface/DetSetNew.h
@@ -82,7 +82,7 @@ namespace edmNew {
     DataContainer const &container() const { return *m_data; }
 
     data_type const *data() const {
-      if (m_offset | m_size)
+      if (isValid() || !empty())
         assert(m_data);
       return m_data ? (&((*m_data)[m_offset])) : nullptr;
     }


### PR DESCRIPTION
#### PR description:

This PR corrects a test for the validity of the data buffer in edmNew::DetSet.  Currently the code does a bitwise 'or' of m_offset and m_size, where m_offset is initialized to -1.  This corrects that test to use the already defined `isValid()` and `empty()` member functions.  Related to

https://github.com/cms-sw/cmssw/issues/41786#issuecomment-1578652689

where we are seeing possible race conditions in edmNew::DetSet, which this PR may help us isolate.

#### PR validation:

Ran an arbitrary selection of the `limited` WFs, with no failures.