### PR TITLE
Phase2-hgx341E Next step to go toward the V18 version of HGCal by adding the dd4hep version of adding passive components

### DIFF
--- a/Geometry/HGCalCommonData/data/dd4hep/testHGCalV18.xml
+++ b/Geometry/HGCalCommonData/data/dd4hep/testHGCalV18.xml
@@ -39,14 +39,13 @@
     <Include ref="Geometry/HGCalCommonData/data/hgcal/v18/hgcal.xml"/>
     <Include ref="Geometry/HGCalCommonData/data/hgcalcell/v17/hgcalcell.xml"/>
     <Include ref="Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalwafer.xml"/>
-    <Include ref="Geometry/HGCalCommonData/data/hgcalEE/v17/hgcalEE.xml"/>
-    <Include ref="Geometry/HGCalCommonData/data/hgcalHEsil/v17/hgcalHEsil.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalPassive/v18/hgcalPassive.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalEE/v18/hgcalEE.xml"/>
+    <Include ref="Geometry/HGCalCommonData/data/hgcalHEsil/v18/hgcalHEsil.xml"/>
     <Include ref="Geometry/HGCalCommonData/data/hgcalHEmix/v17/hgcalHEmix.xml"/>
     <Include ref="Geometry/HGCalCommonData/data/hgcalCons/v18/hgcalCons.xml"/>
     <Include ref="Geometry/HGCalCommonData/data/hgcalConsData/v17/hgcalConsData.xml"/>
     <Include ref="Geometry/ForwardCommonData/data/forwardshield/2026/v4/forwardshield.xml"/>
-    <Include ref="Geometry/ForwardCommonData/data/brmrotations.xml"/>
-    <Include ref="Geometry/ForwardCommonData/data/brm/2026/v1/brm.xml"/>
     <Include ref="Geometry/MuonCommonData/data/mbCommon/2021/v1/mbCommon.xml"/>
     <Include ref="Geometry/MuonCommonData/data/mb1/2015/v2/mb1.xml"/>
     <Include ref="Geometry/MuonCommonData/data/mb2/2015/v2/mb2.xml"/>
@@ -72,7 +71,6 @@
     <Include ref="Geometry/HcalSimData/data/CaloUtil.xml"/>
     <Include ref="Geometry/HGCalSimData/data/hgcsensv15.xml"/>
     <Include ref="Geometry/MuonSimData/data/PhaseII/v2/muonSens.xml"/>
-    <Include ref="Geometry/ForwardCommonData/data/brmsens.xml"/>
     <Include ref="Geometry/DTGeometryBuilder/data/dtSpecsFilter.xml"/>
     <Include ref="Geometry/CSCGeometryBuilder/data/cscSpecsFilter.xml"/>
     <Include ref="Geometry/CSCGeometryBuilder/data/cscSpecs.xml"/>

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
@@ -49,13 +49,16 @@ struct HGCalSiliconRotatedCassette {
     partialTypes_ = args.value<int>("PartialTypes");
     placeOffset_ = args.value<int>("PlaceOffset");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "Number of types of wafers: " << waferTypes_ << " passives: " << passiveTypes_ << " facings: " << facingTypes_ << " Orientations: " << orientationTypes_ << " PartialTypes: " << partialTypes_ << " PlaceOffset: " << placeOffset_;
+    edm::LogVerbatim("HGCalGeom") << "Number of types of wafers: " << waferTypes_ << " passives: " << passiveTypes_
+                                  << " facings: " << facingTypes_ << " Orientations: " << orientationTypes_
+                                  << " PartialTypes: " << partialTypes_ << " PlaceOffset: " << placeOffset_;
 #endif
     firstLayer_ = args.value<int>("FirstLayer");
     absorbMode_ = args.value<int>("AbsorberMode");
     sensitiveMode_ = args.value<int>("SensitiveMode");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "First Layer " << firstLayer_ << " and Absober:Sensitive mode " << absorbMode_ << ":" << sensitiveMode_;
+    edm::LogVerbatim("HGCalGeom") << "First Layer " << firstLayer_ << " and Absober:Sensitive mode " << absorbMode_
+                                  << ":" << sensitiveMode_;
 #endif
     zMinBlock_ = args.value<double>("zMinBlock");
     waferSize_ = args.value<double>("waferSize");
@@ -66,18 +69,22 @@ struct HGCalSiliconRotatedCassette {
     cosAlpha_ = cos(alpha_);
     rotstr_ = args.value<std::string>("LayerRotation");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "zStart " << cms::convert2mm(zMinBlock_) << " wafer width " << cms::convert2mm(waferSize_) << " separations " << cms::convert2mm(waferSepar_) << " sectors " << sectors_ << ":" << convertRadToDeg(alpha_) << ":" << cosAlpha_ << " rotation matrix " << rotstr_ << " with " << cassettes_ << " cassettes";
+    edm::LogVerbatim("HGCalGeom") << "zStart " << cms::convert2mm(zMinBlock_) << " wafer width "
+                                  << cms::convert2mm(waferSize_) << " separations " << cms::convert2mm(waferSepar_)
+                                  << " sectors " << sectors_ << ":" << convertRadToDeg(alpha_) << ":" << cosAlpha_
+                                  << " rotation matrix " << rotstr_ << " with " << cassettes_ << " cassettes";
 #endif
     waferFull_ = args.value<std::vector<std::string>>("WaferNamesFull");
     waferPart_ = args.value<std::vector<std::string>>("WaferNamesPartial");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << waferFull_.size() << " full and " << waferPart_.size() << " partial modules";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << waferFull_.size() << " full and "
+                                  << waferPart_.size() << " partial modules";
     unsigned int i1max = static_cast<unsigned int>(waferFull_.size());
     for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
       std::ostringstream st1;
       unsigned int i2 = std::min((i1 + 2), i1max);
       for (unsigned int i = i1; i < i2; ++i)
-	st1 << " [" << i << "] " << waferFull_[i];
+        st1 << " [" << i << "] " << waferFull_[i];
       edm::LogVerbatim("HGCalGeom") << st1.str();
     }
     edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Partial Modules:";
@@ -86,20 +93,21 @@ struct HGCalSiliconRotatedCassette {
       std::ostringstream st1;
       unsigned int i2 = std::min((i1 + 2), i1max);
       for (unsigned int i = i1; i < i2; ++i)
-	st1 << " [" << i << "] " << waferPart_[i];
+        st1 << " [" << i << "] " << waferPart_[i];
       edm::LogVerbatim("HGCalGeom") << st1.str();
     }
 #endif
     passiveFull_ = args.value<std::vector<std::string>>("PassiveNamesFull");
     passivePart_ = args.value<std::vector<std::string>>("PassiveNamesPartial");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << passiveFull_.size() << " full and " << passivePart_.size() << " partial passive modules";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << passiveFull_.size() << " full and "
+                                  << passivePart_.size() << " partial passive modules";
     i1max = static_cast<unsigned int>(passiveFull_.size());
     for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
       std::ostringstream st1;
       unsigned int i2 = std::min((i1 + 2), i1max);
       for (unsigned int i = i1; i < i2; ++i)
-	st1 << " [" << i << "] " << passiveFull_[i];
+        st1 << " [" << i << "] " << passiveFull_[i];
       edm::LogVerbatim("HGCalGeom") << st1.str();
     }
     edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Partial Modules:";
@@ -108,7 +116,7 @@ struct HGCalSiliconRotatedCassette {
       std::ostringstream st1;
       unsigned int i2 = std::min((i1 + 2), i1max);
       for (unsigned int i = i1; i < i2; ++i)
-	st1 << " [" << i << "] " << passivePart_[i];
+        st1 << " [" << i << "] " << passivePart_[i];
       edm::LogVerbatim("HGCalGeom") << st1.str();
     }
 #endif
@@ -119,14 +127,17 @@ struct HGCalSiliconRotatedCassette {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << materials_.size() << " types of volumes";
     for (unsigned int i = 0; i < names_.size(); ++i)
-      edm::LogVerbatim("HGCalGeom") << "Volume [" << i << "] " << names_[i] << " of thickness " << cms::convert2mm(thick_[i]) << " filled with " << materials_[i] << " first copy number " << copyNumber_[i];
+      edm::LogVerbatim("HGCalGeom") << "Volume [" << i << "] " << names_[i] << " of thickness "
+                                    << cms::convert2mm(thick_[i]) << " filled with " << materials_[i]
+                                    << " first copy number " << copyNumber_[i];
 #endif
     layers_ = args.value<std::vector<int>>("Layers");
     layerThick_ = args.value<std::vector<double>>("LayerThick");
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "There are " << layers_.size() << " blocks";
     for (unsigned int i = 0; i < layers_.size(); ++i)
-      edm::LogVerbatim("HGCalGeom") << "Block [" << i << "] of thickness " << cms::convert2mm(layerThick_[i]) << " with " << layers_[i] << " layers";
+      edm::LogVerbatim("HGCalGeom") << "Block [" << i << "] of thickness " << cms::convert2mm(layerThick_[i])
+                                    << " with " << layers_[i] << " layers";
 #endif
     layerType_ = args.value<std::vector<int>>("LayerType");
     layerSense_ = args.value<std::vector<int>>("LayerSense");
@@ -139,13 +150,14 @@ struct HGCalSiliconRotatedCassette {
 #endif
     if (firstLayer_ > 0) {
       for (unsigned int i = 0; i < layerType_.size(); ++i) {
-	if (layerSense_[i] > 0) {
-	  int ii = layerType_[i];
-	  copyNumber_[ii] = (layerSense_[i] == 1) ? firstLayer_ : (firstLayer_ + 1);
+        if (layerSense_[i] > 0) {
+          int ii = layerType_[i];
+          copyNumber_[ii] = (layerSense_[i] == 1) ? firstLayer_ : (firstLayer_ + 1);
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HGCalGeom") << "First copy number for layer type " << i << ":" << ii << " with " << materials_[ii] << " changed to " << copyNumber_[ii];
+          edm::LogVerbatim("HGCalGeom") << "First copy number for layer type " << i << ":" << ii << " with "
+                                        << materials_[ii] << " changed to " << copyNumber_[ii];
 #endif
-	}
+        }
       }
     } else {
       firstLayer_ = 1;
@@ -153,7 +165,8 @@ struct HGCalSiliconRotatedCassette {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HGCalGeom") << "There are " << layerType_.size() << " layers";
     for (unsigned int i = 0; i < layerType_.size(); ++i)
-      edm::LogVerbatim("HGCalGeom") << "Layer [" << i << "] with material type " << layerType_[i] << " sensitive class " << layerSense_[i];
+      edm::LogVerbatim("HGCalGeom") << "Layer [" << i << "] with material type " << layerType_[i] << " sensitive class "
+                                    << layerSense_[i];
 #endif
     slopeB_ = args.value<std::vector<double>>("SlopeBottom");
     zFrontB_ = args.value<std::vector<double>>("ZFrontBottom");
@@ -163,27 +176,37 @@ struct HGCalSiliconRotatedCassette {
     rMaxFront_ = args.value<std::vector<double>>("RMaxFront");
 #ifdef EDM_ML_DEBUG
     for (unsigned int i = 0; i < slopeB_.size(); ++i)
-      edm::LogVerbatim("HGCalGeom") << "Bottom Block [" << i << "] Zmin " << cms::convert2mm(zFrontB_[i]) << " Rmin " << cms::convert2mm(rMinFront_[i]) << " Slope " << slopeB_[i];
+      edm::LogVerbatim("HGCalGeom") << "Bottom Block [" << i << "] Zmin " << cms::convert2mm(zFrontB_[i]) << " Rmin "
+                                    << cms::convert2mm(rMinFront_[i]) << " Slope " << slopeB_[i];
     for (unsigned int i = 0; i < slopeT_.size(); ++i)
-      edm::LogVerbatim("HGCalGeom") << "Top Block [" << i << "] Zmin " << cms::convert2mm(zFrontT_[i]) << " Rmax " << cms::convert2mm(rMaxFront_[i]) << " Slope " << slopeT_[i];
+      edm::LogVerbatim("HGCalGeom") << "Top Block [" << i << "] Zmin " << cms::convert2mm(zFrontT_[i]) << " Rmax "
+                                    << cms::convert2mm(rMaxFront_[i]) << " Slope " << slopeT_[i];
 #endif
     waferIndex_ = args.value<std::vector<int>>("WaferIndex");
     waferProperty_ = args.value<std::vector<int>>("WaferProperties");
     waferLayerStart_ = args.value<std::vector<int>>("WaferLayerStart");
     cassetteShift_ = args.value<std::vector<double>>("CassetteShift");
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "waferProperties with " << waferIndex_.size() << " entries in " << waferLayerStart_.size() << " layers";
+    edm::LogVerbatim("HGCalGeom") << "waferProperties with " << waferIndex_.size() << " entries in "
+                                  << waferLayerStart_.size() << " layers";
     for (unsigned int k = 0; k < waferLayerStart_.size(); ++k)
       edm::LogVerbatim("HGCalGeom") << "LayerStart[" << k << "] " << waferLayerStart_[k];
     for (unsigned int k = 0; k < waferIndex_.size(); ++k)
-      edm::LogVerbatim("HGCalGeom") << "Wafer[" << k << "] " << waferIndex_[k] << " (" << HGCalWaferIndex::waferLayer(waferIndex_[k]) << ", " << HGCalWaferIndex::waferU(waferIndex_[k]) << ", " << HGCalWaferIndex::waferV(waferIndex_[k]) << ") : (" << HGCalProperty::waferThick(waferProperty_[k]) << ":" << HGCalProperty::waferPartial(waferProperty_[k]) << ":" << HGCalProperty::waferOrient(waferProperty_[k]) << ")";
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << cassetteShift_.size() << " elements for cassette shifts";
+      edm::LogVerbatim("HGCalGeom") << "Wafer[" << k << "] " << waferIndex_[k] << " ("
+                                    << HGCalWaferIndex::waferLayer(waferIndex_[k]) << ", "
+                                    << HGCalWaferIndex::waferU(waferIndex_[k]) << ", "
+                                    << HGCalWaferIndex::waferV(waferIndex_[k]) << ") : ("
+                                    << HGCalProperty::waferThick(waferProperty_[k]) << ":"
+                                    << HGCalProperty::waferPartial(waferProperty_[k]) << ":"
+                                    << HGCalProperty::waferOrient(waferProperty_[k]) << ")";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << cassetteShift_.size()
+                                  << " elements for cassette shifts";
     unsigned int j1max = cassetteShift_.size();
     for (unsigned int j1 = 0; j1 < j1max; j1 += 6) {
       std::ostringstream st1;
       unsigned int j2 = std::min((j1 + 6), j1max);
       for (unsigned int j = j1; j < j2; ++j)
-	st1 << " [" << j << "] " << std::setw(9) << cms::convert2mm(cassetteShift_[j]);
+        st1 << " [" << j << "] " << std::setw(9) << cms::convert2mm(cassetteShift_[j]);
       edm::LogVerbatim("HGCalGeom") << st1.str();
     }
 #endif
@@ -203,101 +226,117 @@ struct HGCalSiliconRotatedCassette {
       double zz = zi;
       double thickTot(0);
       for (int ly = laymin; ly < laymax; ++ly) {
-	int ii = layerType_[ly];
-	int copy = copyNumber_[ii];
-	double hthick = 0.5 * thick_[ii];
-	double rinB = HGCalGeomTools::radius(zo - tol1, zFrontB_, rMinFront_, slopeB_);
-	zz += hthick;
-	thickTot += thick_[ii];
+        int ii = layerType_[ly];
+        int copy = copyNumber_[ii];
+        double hthick = 0.5 * thick_[ii];
+        double rinB = HGCalGeomTools::radius(zo - tol1, zFrontB_, rMinFront_, slopeB_);
+        zz += hthick;
+        thickTot += thick_[ii];
 
-	std::string name = names_[ii] + std::to_string(copy);
+        std::string name = names_[ii] + std::to_string(copy);
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Layer " << ly << ":" << ii << " Front " << cms::convert2mm(zi) << ", " << cms::convert2mm(routF) << " Back " << cms::convert2mm(zo) << ", " << cms::convert2mm(rinB) << " superlayer thickness " << cms::convert2mm(layerThick_[i]);
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Layer " << ly << ":" << ii << " Front "
+                                      << cms::convert2mm(zi) << ", " << cms::convert2mm(routF) << " Back "
+                                      << cms::convert2mm(zo) << ", " << cms::convert2mm(rinB)
+                                      << " superlayer thickness " << cms::convert2mm(layerThick_[i]);
 #endif
-	dd4hep::Material matter = ns.material(materials_[ii]);
-	dd4hep::Volume glog;
-	if (layerSense_[ly] == 0) {
-	  std::vector<double> pgonZ, pgonRin, pgonRout;
-	  double rmax = routF * cosAlpha_ - tol1;
-	  HGCalGeomTools::radius(zz - hthick,
-				 zz + hthick,
-				 zFrontB_,
-				 rMinFront_,
-				 slopeB_,
-				 zFrontT_,
-				 rMaxFront_,
-				 slopeT_,
-				 -layerSense_[ly],
-				 pgonZ,
-				 pgonRin,
-				 pgonRout);
-	  for (unsigned int isec = 0; isec < pgonZ.size(); ++isec) {
-	    pgonZ[isec] -= zz;
-	    if (layerSense_[ly] == 0 || absorbMode_ == 0)
-	      pgonRout[isec] = rmax;
-	    else
-	      pgonRout[isec] = pgonRout[isec] * cosAlpha_ - tol1;
-	  }
-	  dd4hep::Solid solid = dd4hep::Polyhedra(sectors_, -alpha_, 2._pi, pgonZ, pgonRin, pgonRout);
+        dd4hep::Material matter = ns.material(materials_[ii]);
+        dd4hep::Volume glog;
+        if (layerSense_[ly] == 0) {
+          std::vector<double> pgonZ, pgonRin, pgonRout;
+          double rmax = routF * cosAlpha_ - tol1;
+          HGCalGeomTools::radius(zz - hthick,
+                                 zz + hthick,
+                                 zFrontB_,
+                                 rMinFront_,
+                                 slopeB_,
+                                 zFrontT_,
+                                 rMaxFront_,
+                                 slopeT_,
+                                 -layerSense_[ly],
+                                 pgonZ,
+                                 pgonRin,
+                                 pgonRout);
+          for (unsigned int isec = 0; isec < pgonZ.size(); ++isec) {
+            pgonZ[isec] -= zz;
+            if (layerSense_[ly] == 0 || absorbMode_ == 0)
+              pgonRout[isec] = rmax;
+            else
+              pgonRout[isec] = pgonRout[isec] * cosAlpha_ - tol1;
+          }
+          dd4hep::Solid solid = dd4hep::Polyhedra(sectors_, -alpha_, 2._pi, pgonZ, pgonRin, pgonRout);
           ns.addSolidNS(ns.prepend(name), solid);
           glog = dd4hep::Volume(solid.name(), solid, matter);
           ns.addVolumeNS(glog);
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " polyhedra of " << sectors_ << " sectors covering " << convertRadToDeg(-alpha_) << ":" << convertRadToDeg(-alpha_ + 2._pi) << " with " << pgonZ.size() << " sections and filled with " << matter.name();
-	  for (unsigned int k = 0; k < pgonZ.size(); ++k)
-	    edm::LogVerbatim("HGCalGeom") << "[" << k << "] z " << cms::convert2mm(pgonZ[k]) << " R " << cms::convert2mm(pgonRin[k]) << ":" << cms::convert2mm(pgonRout[k]);
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " polyhedra of "
+                                        << sectors_ << " sectors covering " << convertRadToDeg(-alpha_) << ":"
+                                        << convertRadToDeg(-alpha_ + 2._pi) << " with " << pgonZ.size()
+                                        << " sections and filled with " << matter.name();
+          for (unsigned int k = 0; k < pgonZ.size(); ++k)
+            edm::LogVerbatim("HGCalGeom") << "[" << k << "] z " << cms::convert2mm(pgonZ[k]) << " R "
+                                          << cms::convert2mm(pgonRin[k]) << ":" << cms::convert2mm(pgonRout[k]);
 #endif
-	} else {
-	  int mode = (layerSense_[ly] > 0) ? sensitiveMode_ : absorbMode_;
-	  double rins = (mode < 1) ? rinB : HGCalGeomTools::radius(zz + hthick - tol1, zFrontB_, rMinFront_, slopeB_);
-	  double routs = (mode < 1) ? routF : HGCalGeomTools::radius(zz - hthick, zFrontT_, rMaxFront_, slopeT_);
-	  dd4hep::Solid solid = dd4hep::Tube(rins, routs, hthick, 0.0, 2._pi);
+        } else {
+          int mode = (layerSense_[ly] > 0) ? sensitiveMode_ : absorbMode_;
+          double rins = (mode < 1) ? rinB : HGCalGeomTools::radius(zz + hthick - tol1, zFrontB_, rMinFront_, slopeB_);
+          double routs = (mode < 1) ? routF : HGCalGeomTools::radius(zz - hthick, zFrontT_, rMaxFront_, slopeT_);
+          dd4hep::Solid solid = dd4hep::Tube(rins, routs, hthick, 0.0, 2._pi);
           ns.addSolidNS(ns.prepend(name), solid);
           glog = dd4hep::Volume(solid.name(), solid, matter);
           ns.addVolumeNS(glog);
 #ifdef EDM_ML_DEBUG
-	  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " Tubs made of " << matter.name() << " of dimensions " << cms::convert2mm(rinB) << ":" << cms::convert2mm(rins) << ", " << cms::convert2mm(routF) << ":" << cms::convert2mm(routs) << ", " << cms::convert2mm(hthick) << ", 0.0, 360.0 and position " << glog.name() << " number " << copy << ":" << layerOrient_[copy - firstLayer_] << " Z " << cms::convert2mm(zz);
+          edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " Tubs made of "
+                                        << matter.name() << " of dimensions " << cms::convert2mm(rinB) << ":"
+                                        << cms::convert2mm(rins) << ", " << cms::convert2mm(routF) << ":"
+                                        << cms::convert2mm(routs) << ", " << cms::convert2mm(hthick)
+                                        << ", 0.0, 360.0 and position " << glog.name() << " number " << copy << ":"
+                                        << layerOrient_[copy - firstLayer_] << " Z " << cms::convert2mm(zz);
 #endif
-	  if (layerSense_[ly] > 0)
-	    positionSensitive(ctxt, e, glog, (copy - firstLayer_));
-	  else
-	    positionPassive(ctxt, e, glog, (copy - firstLayer_), -layerSense_[ly]);
-	}
-	dd4hep::Position r1(0, 0, zz);
-	dd4hep::Rotation3D rot;
+          if (layerSense_[ly] > 0)
+            positionSensitive(ctxt, e, glog, (copy - firstLayer_));
+          else
+            positionPassive(ctxt, e, glog, (copy - firstLayer_), -layerSense_[ly]);
+        }
+        dd4hep::Position r1(0, 0, zz);
+        dd4hep::Rotation3D rot;
 #ifdef EDM_ML_DEBUG
-	std::string rotName("Null");
+        std::string rotName("Null");
 #endif
-	if ((layerSense_[ly] != 0) && (layerOrient_[copy - firstLayer_] == HGCalTypes::WaferCenterR)) {
+        if ((layerSense_[ly] != 0) && (layerOrient_[copy - firstLayer_] == HGCalTypes::WaferCenterR)) {
           rot = ns.rotation(rotstr_);
 #ifdef EDM_ML_DEBUG
-	  rotName = rotstr_;
+          rotName = rotstr_;
 #endif
-	}
+        }
         mother.placeVolume(glog, copy, dd4hep::Transform3D(rot, r1));
-	int inc = ((layerSense_[ly] > 0) && (facingTypes_ > 1)) ? 2 : 1;
-	copyNumber_[ii] = copy + inc;
+        int inc = ((layerSense_[ly] > 0) && (facingTypes_ > 1)) ? 2 : 1;
+        copyNumber_[ii] = copy + inc;
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << " number " << copy << " positioned in " << mother.name() << " at (0,0," << cms::convert2mm(zz) << ") with " << rotName << " rotation";
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << " number " << copy
+                                      << " positioned in " << mother.name() << " at (0,0," << cms::convert2mm(zz)
+                                      << ") with " << rotName << " rotation";
 #endif
-	zz += hthick;
+        zz += hthick;
       }  // End of loop over layers in a block
       zi = zo;
       laymin = laymax;
       // Make consistency check of all the partitions of the block
       if (std::abs(thickTot - layerThick_[i]) >= tol2) {
-	if (thickTot > layerThick_[i]) {
-	  edm::LogError("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i]) << " is smaller than " << cms::convert2mm(thickTot)
-                                   << ": thickness of all its components **** ERROR ****";
-	} else {
-	  edm::LogWarning("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i]) << " does not match with "
-				       << cms::convert2mm(thickTot) << " of the components";
-	}
+        if (thickTot > layerThick_[i]) {
+          edm::LogError("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i])
+                                     << " is smaller than " << cms::convert2mm(thickTot)
+                                     << ": thickness of all its components **** ERROR ****";
+        } else {
+          edm::LogWarning("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i])
+                                       << " does not match with " << cms::convert2mm(thickTot) << " of the components";
+        }
       }
     }  // End of loop over blocks
 
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << copies_.size() << " different wafer copy numbers";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << copies_.size()
+                                  << " different wafer copy numbers";
     int k(0);
     for (std::unordered_set<int>::const_iterator itr = copies_.begin(); itr != copies_.end(); ++itr, ++k) {
       edm::LogVerbatim("HGCalGeom") << "Copy [" << k << "] : " << (*itr);
@@ -314,7 +353,7 @@ struct HGCalSiliconRotatedCassette {
     int layertype = (layerOrient_[layer] == HGCalTypes::WaferCenterB) ? 1 : 0;
     int firstWafer = waferLayerStart_[layer];
     int lastWafer = ((layer + 1 < static_cast<int>(waferLayerStart_.size())) ? waferLayerStart_[layer + 1]
-		     : static_cast<int>(waferIndex_.size()));
+                                                                             : static_cast<int>(waferIndex_.size()));
     double delx = 0.5 * (waferSize_ + waferSepar_);
     double dely = 2.0 * delx / sqrt3;
     double dy = 0.75 * dely;
@@ -322,7 +361,12 @@ struct HGCalSiliconRotatedCassette {
 #ifdef EDM_ML_DEBUG
     int ium(0), ivm(0), kount(0);
     std::vector<int> ntype(3, 0);
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx) << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift " << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second) << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index " << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":" << layertype;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx)
+                                  << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift "
+                                  << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second)
+                                  << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index "
+                                  << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":"
+                                  << layertype;
 #endif
     for (int k = firstWafer; k < lastWafer; ++k) {
       int u = HGCalWaferIndex::waferU(waferIndex_[k]);
@@ -345,45 +389,67 @@ struct HGCalSiliconRotatedCassette {
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":" << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v << " type|part|orient|place " << type << ":" << part << ":" << orien << ":" << place;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Wafer: layer " << layer + 1 << " cassette "
+                                    << cassette << " Shift " << cms::convert2mm(cshift.first) << ":"
+                                    << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":"
+                                    << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final "
+                                    << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v
+                                    << " type|part|orient|place " << type << ":" << part << ":" << orien << ":"
+                                    << place;
 #endif
       std::string wafer;
       int i(999);
       if (part == HGCalTypes::WaferFull) {
-	i = type * facingTypes_ * orientationTypes_ + place - placeOffset_;
-	wafer = waferFull_[i];
+        i = type * facingTypes_ * orientationTypes_ + place - placeOffset_;
+        wafer = waferFull_[i];
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":" << placeOffset_ << ":" << facingTypes_ << ":" << orientationTypes_ << " wafer " << i << ":" << wafer;
+        edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":"
+                                      << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":"
+                                      << placeOffset_ << ":" << facingTypes_ << ":" << orientationTypes_ << " wafer "
+                                      << i << ":" << wafer;
 #endif
       } else {
-	int partoffset = (part >= HGCalTypes::WaferHDTop) ? HGCalTypes::WaferPartHDOffset : HGCalTypes::WaferPartLDOffset;
-	i = (part - partoffset) * facingTypes_ * orientationTypes_ +
-          HGCalTypes::WaferTypeOffset[type] * facingTypes_ * orientationTypes_ + place - placeOffset_;
+        int partoffset =
+            (part >= HGCalTypes::WaferHDTop) ? HGCalTypes::WaferPartHDOffset : HGCalTypes::WaferPartLDOffset;
+        i = (part - partoffset) * facingTypes_ * orientationTypes_ +
+            HGCalTypes::WaferTypeOffset[type] * facingTypes_ * orientationTypes_ + place - placeOffset_;
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":" << partoffset << ":" << HGCalTypes::WaferTypeOffset[type] << ":" << i << ":" << waferPart_.size();
+        edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":"
+                                      << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":"
+                                      << partoffset << ":" << HGCalTypes::WaferTypeOffset[type] << ":" << i << ":"
+                                      << waferPart_.size();
 #endif
-	wafer = waferPart_[i];
+        wafer = waferPart_[i];
       }
       int copy = HGCalTypes::packTypeUV(type, u, v);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer " << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Wafer " << wafer << " number " << copy << " type:part:orien:place:ind " << type << ":" << part << ":" << orien << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_) << ":" << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos);
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer "
+                                    << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Wafer " << wafer << " number "
+                                    << copy << " type:part:orien:place:ind " << type << ":" << part << ":" << orien
+                                    << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_) << ":"
+                                    << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":"
+                                    << cms::convert2mm(ypos);
       if (iu > ium)
-	ium = iu;
+        ium = iu;
       if (iv > ivm)
-	ivm = iv;
+        ivm = iv;
       kount++;
       if (copies_.count(copy) == 0)
-	copies_.insert(copy);
+        copies_.insert(copy);
 #endif
       dd4hep::Position tran(xpos, ypos, 0.0);
       glog.placeVolume(ns.volume(wafer), copy, tran);
 #ifdef EDM_ML_DEBUG
       ++ntype[type];
-      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << wafer << " number " << copy << " type " << layertype << ":" << type << " positioned in " << glog.name() << " at (" << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << wafer << " number " << copy << " type "
+                                    << layertype << ":" << type << " positioned in " << glog.name() << " at ("
+                                    << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
 #endif
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm << " and " << kount << " passives (" << ntype[0] << ":" << ntype[1] << ":" << ntype[2] << ") for " << glog.name();
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm
+                                  << " and " << kount << " passives (" << ntype[0] << ":" << ntype[1] << ":" << ntype[2]
+                                  << ") for " << glog.name();
 #endif
   }
 
@@ -394,14 +460,19 @@ struct HGCalSiliconRotatedCassette {
     int layertype = (layerOrient_[layer] == HGCalTypes::WaferCenterB) ? 1 : 0;
     int firstWafer = waferLayerStart_[layer];
     int lastWafer = ((layer + 1 < static_cast<int>(waferLayerStart_.size())) ? waferLayerStart_[layer + 1]
-		     : static_cast<int>(waferIndex_.size()));
+                                                                             : static_cast<int>(waferIndex_.size()));
     double delx = 0.5 * (waferSize_ + waferSepar_);
     double dely = 2.0 * delx / sqrt3;
     double dy = 0.75 * dely;
     const auto& xyoff = geomTools_.shiftXY(layercenter, (waferSize_ + waferSepar_));
 #ifdef EDM_ML_DEBUG
     int ium(0), ivm(0), kount(0);
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx) << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift " << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second) << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index " << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":" << layertype;
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx)
+                                  << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift "
+                                  << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second)
+                                  << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index "
+                                  << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":"
+                                  << layertype;
 #endif
     for (int k = firstWafer; k < lastWafer; ++k) {
       int u = HGCalWaferIndex::waferU(waferIndex_[k]);
@@ -424,44 +495,63 @@ struct HGCalSiliconRotatedCassette {
       double xorig = xyoff.first + nc * delx;
       double yorig = xyoff.second + nr * dy;
       double angle = std::atan2(yorig, xorig);
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Passive: layer " << layer + 1 << " cassette " << cassette << " Shift " << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":" << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v << " type|part|orient" << type << ":" << part << ":" << orien;
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Passive: layer " << layer + 1 << " cassette "
+                                    << cassette << " Shift " << cms::convert2mm(cshift.first) << ":"
+                                    << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":"
+                                    << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final "
+                                    << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v
+                                    << " type|part|orient" << type << ":" << part << ":" << orien;
 #endif
       std::string passive;
       int i(999);
       if (part == HGCalTypes::WaferFull) {
-	i = absType - 1;
-	passive = passiveFull_[i];
+        i = absType - 1;
+        passive = passiveFull_[i];
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:offsets:ind " << layertype << ":" << absType << ":" << part << ":" << orien << ":" << cassette << ":" << ":" << partialTypes_ << ":" << orientationTypes_ << " passive " << i << ":" << passive;
+        edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:offsets:ind " << layertype << ":"
+                                      << absType << ":" << part << ":" << orien << ":" << cassette << ":"
+                                      << ":" << partialTypes_ << ":" << orientationTypes_ << " passive " << i << ":"
+                                      << passive;
 #endif
-    } else {
-	int partoffset = (part >= HGCalTypes::WaferHDTop)
-	  ? HGCalTypes::WaferPartHDOffset
-	  : (HGCalTypes::WaferPartLDOffset - HGCalTypes::WaferTypeOffset[1]);
-	i = (part - partoffset) * facingTypes_ * orientationTypes_ +
-          (absType - 1) * facingTypes_ * orientationTypes_ * partialTypes_ + place - placeOffset_;
+      } else {
+        int partoffset = (part >= HGCalTypes::WaferHDTop)
+                             ? HGCalTypes::WaferPartHDOffset
+                             : (HGCalTypes::WaferPartLDOffset - HGCalTypes::WaferTypeOffset[1]);
+        i = (part - partoffset) * facingTypes_ * orientationTypes_ +
+            (absType - 1) * facingTypes_ * orientationTypes_ * partialTypes_ + place - placeOffset_;
 #ifdef EDM_ML_DEBUG
-	edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:3Types:offset:ind " << layertype << ":" << absType << ":" << part << ":" << orien << ":" << cassette << ":" << partialTypes_ << ":" << facingTypes_ << ":" << orientationTypes_ << ":" << partoffset << ":" << i << ":" << passivePart_.size();
+        edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:3Types:offset:ind " << layertype << ":"
+                                      << absType << ":" << part << ":" << orien << ":" << cassette << ":"
+                                      << partialTypes_ << ":" << facingTypes_ << ":" << orientationTypes_ << ":"
+                                      << partoffset << ":" << i << ":" << passivePart_.size();
 #endif
-	passive = passivePart_[i];
+        passive = passivePart_[i];
       }
       int copy = HGCalTypes::packTypeUV(absType, u, v);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer " << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Passive " << passive << " number " << copy << " type:part:orien:place:ind " << type << ":" << part << ":" << orien << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_) << ":" << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos);
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer "
+                                    << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Passive " << passive
+                                    << " number " << copy << " type:part:orien:place:ind " << type << ":" << part << ":"
+                                    << orien << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_)
+                                    << ":" << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":"
+                                    << cms::convert2mm(ypos);
       if (iu > ium)
-	ium = iu;
+        ium = iu;
       if (iv > ivm)
-	ivm = iv;
+        ivm = iv;
       kount++;
 #endif
       dd4hep::Position tran(xpos, ypos, 0.0);
       glog.placeVolume(ns.volume(passive), copy, tran);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << passive << " number " << copy << " type " << layertype << ":" << type << " positioned in " << glog.name() << " at (" << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << passive << " number " << copy << " type "
+                                    << layertype << ":" << type << " positioned in " << glog.name() << " at ("
+                                    << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
 #endif
     }
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm << " and " << kount << " passives for " << glog.name();
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm
+                                  << " and " << kount << " passives for " << glog.name();
 #endif
   }
 

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalSiliconRotatedCassette.cc
@@ -1,0 +1,519 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: DDHGCalSiliconRotatedCassette.cc
+// Description: Geometry factory class for HGCal (EE and HESil) using
+//              information from the file for dd4hep
+///////////////////////////////////////////////////////////////////////////////
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCassette.h"
+#include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
+#include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
+#include "Geometry/HGCalCommonData/interface/HGCalProperty.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferType.h"
+#include "DD4hep/DetFactoryHelper.h"
+#include "DataFormats/Math/interface/angle_units.h"
+#include "DetectorDescription/DDCMS/interface/DDPlugins.h"
+#include "DetectorDescription/DDCMS/interface/DDutils.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#define EDM_ML_DEBUG
+using namespace angle_units::operators;
+
+struct HGCalSiliconRotatedCassette {
+  HGCalSiliconRotatedCassette() {
+    throw cms::Exception("HGCalGeom") << "Wrong initialization to HGCalSiliconRotatedCassette";
+  }
+  HGCalSiliconRotatedCassette(cms::DDParsingContext& ctxt, xml_h e) {
+    cms::DDNamespace ns(ctxt, e, true);
+    cms::DDAlgoArguments args(ctxt, e);
+
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Creating an instance";
+#endif
+    static constexpr double tol1 = 0.01 * dd4hep::mm;
+    static constexpr double tol2 = 0.00001 * dd4hep::mm;
+
+    dd4hep::Volume mother = ns.volume(args.parentName());
+    waferTypes_ = args.value<int>("WaferTypes");
+    passiveTypes_ = args.value<int>("PassiveTypes");
+    facingTypes_ = args.value<int>("FacingTypes");
+    orientationTypes_ = args.value<int>("OrientationTypes");
+    partialTypes_ = args.value<int>("PartialTypes");
+    placeOffset_ = args.value<int>("PlaceOffset");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "Number of types of wafers: " << waferTypes_ << " passives: " << passiveTypes_ << " facings: " << facingTypes_ << " Orientations: " << orientationTypes_ << " PartialTypes: " << partialTypes_ << " PlaceOffset: " << placeOffset_;
+#endif
+    firstLayer_ = args.value<int>("FirstLayer");
+    absorbMode_ = args.value<int>("AbsorberMode");
+    sensitiveMode_ = args.value<int>("SensitiveMode");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "First Layer " << firstLayer_ << " and Absober:Sensitive mode " << absorbMode_ << ":" << sensitiveMode_;
+#endif
+    zMinBlock_ = args.value<double>("zMinBlock");
+    waferSize_ = args.value<double>("waferSize");
+    waferSepar_ = args.value<double>("SensorSeparation");
+    sectors_ = args.value<int>("Sectors");
+    cassettes_ = args.value<int>("Cassettes");
+    alpha_ = (1._pi) / sectors_;
+    cosAlpha_ = cos(alpha_);
+    rotstr_ = args.value<std::string>("LayerRotation");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "zStart " << cms::convert2mm(zMinBlock_) << " wafer width " << cms::convert2mm(waferSize_) << " separations " << cms::convert2mm(waferSepar_) << " sectors " << sectors_ << ":" << convertRadToDeg(alpha_) << ":" << cosAlpha_ << " rotation matrix " << rotstr_ << " with " << cassettes_ << " cassettes";
+#endif
+    waferFull_ = args.value<std::vector<std::string>>("WaferNamesFull");
+    waferPart_ = args.value<std::vector<std::string>>("WaferNamesPartial");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << waferFull_.size() << " full and " << waferPart_.size() << " partial modules";
+    unsigned int i1max = static_cast<unsigned int>(waferFull_.size());
+    for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
+      std::ostringstream st1;
+      unsigned int i2 = std::min((i1 + 2), i1max);
+      for (unsigned int i = i1; i < i2; ++i)
+	st1 << " [" << i << "] " << waferFull_[i];
+      edm::LogVerbatim("HGCalGeom") << st1.str();
+    }
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Partial Modules:";
+    i1max = static_cast<unsigned int>(waferPart_.size());
+    for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
+      std::ostringstream st1;
+      unsigned int i2 = std::min((i1 + 2), i1max);
+      for (unsigned int i = i1; i < i2; ++i)
+	st1 << " [" << i << "] " << waferPart_[i];
+      edm::LogVerbatim("HGCalGeom") << st1.str();
+    }
+#endif
+    passiveFull_ = args.value<std::vector<std::string>>("PassiveNamesFull");
+    passivePart_ = args.value<std::vector<std::string>>("PassiveNamesPartial");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << passiveFull_.size() << " full and " << passivePart_.size() << " partial passive modules";
+    i1max = static_cast<unsigned int>(passiveFull_.size());
+    for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
+      std::ostringstream st1;
+      unsigned int i2 = std::min((i1 + 2), i1max);
+      for (unsigned int i = i1; i < i2; ++i)
+	st1 << " [" << i << "] " << passiveFull_[i];
+      edm::LogVerbatim("HGCalGeom") << st1.str();
+    }
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Partial Modules:";
+    i1max = static_cast<unsigned int>(passivePart_.size());
+    for (unsigned int i1 = 0; i1 < i1max; i1 += 2) {
+      std::ostringstream st1;
+      unsigned int i2 = std::min((i1 + 2), i1max);
+      for (unsigned int i = i1; i < i2; ++i)
+	st1 << " [" << i << "] " << passivePart_[i];
+      edm::LogVerbatim("HGCalGeom") << st1.str();
+    }
+#endif
+    materials_ = args.value<std::vector<std::string>>("MaterialNames");
+    names_ = args.value<std::vector<std::string>>("VolumeNames");
+    thick_ = args.value<std::vector<double>>("Thickness");
+    copyNumber_.resize(materials_.size(), 1);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << materials_.size() << " types of volumes";
+    for (unsigned int i = 0; i < names_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "Volume [" << i << "] " << names_[i] << " of thickness " << cms::convert2mm(thick_[i]) << " filled with " << materials_[i] << " first copy number " << copyNumber_[i];
+#endif
+    layers_ = args.value<std::vector<int>>("Layers");
+    layerThick_ = args.value<std::vector<double>>("LayerThick");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "There are " << layers_.size() << " blocks";
+    for (unsigned int i = 0; i < layers_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "Block [" << i << "] of thickness " << cms::convert2mm(layerThick_[i]) << " with " << layers_[i] << " layers";
+#endif
+    layerType_ = args.value<std::vector<int>>("LayerType");
+    layerSense_ = args.value<std::vector<int>>("LayerSense");
+    layerOrient_ = args.value<std::vector<int>>("LayerTypes");
+    for (unsigned int k = 0; k < layerOrient_.size(); ++k)
+      layerOrient_[k] = HGCalTypes::layerType(layerOrient_[k]);
+#ifdef EDM_ML_DEBUG
+    for (unsigned int i = 0; i < layerOrient_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "LayerTypes [" << i << "] " << layerOrient_[i];
+#endif
+    if (firstLayer_ > 0) {
+      for (unsigned int i = 0; i < layerType_.size(); ++i) {
+	if (layerSense_[i] > 0) {
+	  int ii = layerType_[i];
+	  copyNumber_[ii] = (layerSense_[i] == 1) ? firstLayer_ : (firstLayer_ + 1);
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("HGCalGeom") << "First copy number for layer type " << i << ":" << ii << " with " << materials_[ii] << " changed to " << copyNumber_[ii];
+#endif
+	}
+      }
+    } else {
+      firstLayer_ = 1;
+    }
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "There are " << layerType_.size() << " layers";
+    for (unsigned int i = 0; i < layerType_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "Layer [" << i << "] with material type " << layerType_[i] << " sensitive class " << layerSense_[i];
+#endif
+    slopeB_ = args.value<std::vector<double>>("SlopeBottom");
+    zFrontB_ = args.value<std::vector<double>>("ZFrontBottom");
+    rMinFront_ = args.value<std::vector<double>>("RMinFront");
+    slopeT_ = args.value<std::vector<double>>("SlopeTop");
+    zFrontT_ = args.value<std::vector<double>>("ZFrontTop");
+    rMaxFront_ = args.value<std::vector<double>>("RMaxFront");
+#ifdef EDM_ML_DEBUG
+    for (unsigned int i = 0; i < slopeB_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "Bottom Block [" << i << "] Zmin " << cms::convert2mm(zFrontB_[i]) << " Rmin " << cms::convert2mm(rMinFront_[i]) << " Slope " << slopeB_[i];
+    for (unsigned int i = 0; i < slopeT_.size(); ++i)
+      edm::LogVerbatim("HGCalGeom") << "Top Block [" << i << "] Zmin " << cms::convert2mm(zFrontT_[i]) << " Rmax " << cms::convert2mm(rMaxFront_[i]) << " Slope " << slopeT_[i];
+#endif
+    waferIndex_ = args.value<std::vector<int>>("WaferIndex");
+    waferProperty_ = args.value<std::vector<int>>("WaferProperties");
+    waferLayerStart_ = args.value<std::vector<int>>("WaferLayerStart");
+    cassetteShift_ = args.value<std::vector<double>>("CassetteShift");
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "waferProperties with " << waferIndex_.size() << " entries in " << waferLayerStart_.size() << " layers";
+    for (unsigned int k = 0; k < waferLayerStart_.size(); ++k)
+      edm::LogVerbatim("HGCalGeom") << "LayerStart[" << k << "] " << waferLayerStart_[k];
+    for (unsigned int k = 0; k < waferIndex_.size(); ++k)
+      edm::LogVerbatim("HGCalGeom") << "Wafer[" << k << "] " << waferIndex_[k] << " (" << HGCalWaferIndex::waferLayer(waferIndex_[k]) << ", " << HGCalWaferIndex::waferU(waferIndex_[k]) << ", " << HGCalWaferIndex::waferV(waferIndex_[k]) << ") : (" << HGCalProperty::waferThick(waferProperty_[k]) << ":" << HGCalProperty::waferPartial(waferProperty_[k]) << ":" << HGCalProperty::waferOrient(waferProperty_[k]) << ")";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << cassetteShift_.size() << " elements for cassette shifts";
+    unsigned int j1max = cassetteShift_.size();
+    for (unsigned int j1 = 0; j1 < j1max; j1 += 6) {
+      std::ostringstream st1;
+      unsigned int j2 = std::min((j1 + 6), j1max);
+      for (unsigned int j = j1; j < j2; ++j)
+	st1 << " [" << j << "] " << std::setw(9) << cms::convert2mm(cassetteShift_[j]);
+      edm::LogVerbatim("HGCalGeom") << st1.str();
+    }
+#endif
+    cassette_.setParameter(cassettes_, cassetteShift_);
+
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "==>> Constructing DDHGCalSiliconRotatedCassette...";
+    copies_.clear();
+#endif
+
+    double zi(zMinBlock_);
+    int laymin(0);
+    for (unsigned int i = 0; i < layers_.size(); i++) {
+      double zo = zi + layerThick_[i];
+      double routF = HGCalGeomTools::radius(zi, zFrontT_, rMaxFront_, slopeT_);
+      int laymax = laymin + layers_[i];
+      double zz = zi;
+      double thickTot(0);
+      for (int ly = laymin; ly < laymax; ++ly) {
+	int ii = layerType_[ly];
+	int copy = copyNumber_[ii];
+	double hthick = 0.5 * thick_[ii];
+	double rinB = HGCalGeomTools::radius(zo - tol1, zFrontB_, rMinFront_, slopeB_);
+	zz += hthick;
+	thickTot += thick_[ii];
+
+	std::string name = names_[ii] + std::to_string(copy);
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Layer " << ly << ":" << ii << " Front " << cms::convert2mm(zi) << ", " << cms::convert2mm(routF) << " Back " << cms::convert2mm(zo) << ", " << cms::convert2mm(rinB) << " superlayer thickness " << cms::convert2mm(layerThick_[i]);
+#endif
+	dd4hep::Material matter = ns.material(materials_[ii]);
+	dd4hep::Volume glog;
+	if (layerSense_[ly] == 0) {
+	  std::vector<double> pgonZ, pgonRin, pgonRout;
+	  double rmax = routF * cosAlpha_ - tol1;
+	  HGCalGeomTools::radius(zz - hthick,
+				 zz + hthick,
+				 zFrontB_,
+				 rMinFront_,
+				 slopeB_,
+				 zFrontT_,
+				 rMaxFront_,
+				 slopeT_,
+				 -layerSense_[ly],
+				 pgonZ,
+				 pgonRin,
+				 pgonRout);
+	  for (unsigned int isec = 0; isec < pgonZ.size(); ++isec) {
+	    pgonZ[isec] -= zz;
+	    if (layerSense_[ly] == 0 || absorbMode_ == 0)
+	      pgonRout[isec] = rmax;
+	    else
+	      pgonRout[isec] = pgonRout[isec] * cosAlpha_ - tol1;
+	  }
+	  dd4hep::Solid solid = dd4hep::Polyhedra(sectors_, -alpha_, 2._pi, pgonZ, pgonRin, pgonRout);
+          ns.addSolidNS(ns.prepend(name), solid);
+          glog = dd4hep::Volume(solid.name(), solid, matter);
+          ns.addVolumeNS(glog);
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " polyhedra of " << sectors_ << " sectors covering " << convertRadToDeg(-alpha_) << ":" << convertRadToDeg(-alpha_ + 2._pi) << " with " << pgonZ.size() << " sections and filled with " << matter.name();
+	  for (unsigned int k = 0; k < pgonZ.size(); ++k)
+	    edm::LogVerbatim("HGCalGeom") << "[" << k << "] z " << cms::convert2mm(pgonZ[k]) << " R " << cms::convert2mm(pgonRin[k]) << ":" << cms::convert2mm(pgonRout[k]);
+#endif
+	} else {
+	  int mode = (layerSense_[ly] > 0) ? sensitiveMode_ : absorbMode_;
+	  double rins = (mode < 1) ? rinB : HGCalGeomTools::radius(zz + hthick - tol1, zFrontB_, rMinFront_, slopeB_);
+	  double routs = (mode < 1) ? routF : HGCalGeomTools::radius(zz - hthick, zFrontT_, rMaxFront_, slopeT_);
+	  dd4hep::Solid solid = dd4hep::Tube(rins, routs, hthick, 0.0, 2._pi);
+          ns.addSolidNS(ns.prepend(name), solid);
+          glog = dd4hep::Volume(solid.name(), solid, matter);
+          ns.addVolumeNS(glog);
+#ifdef EDM_ML_DEBUG
+	  edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << solid.name() << " Tubs made of " << matter.name() << " of dimensions " << cms::convert2mm(rinB) << ":" << cms::convert2mm(rins) << ", " << cms::convert2mm(routF) << ":" << cms::convert2mm(routs) << ", " << cms::convert2mm(hthick) << ", 0.0, 360.0 and position " << glog.name() << " number " << copy << ":" << layerOrient_[copy - firstLayer_] << " Z " << cms::convert2mm(zz);
+#endif
+	  if (layerSense_[ly] > 0)
+	    positionSensitive(ctxt, e, glog, (copy - firstLayer_));
+	  else
+	    positionPassive(ctxt, e, glog, (copy - firstLayer_), -layerSense_[ly]);
+	}
+	dd4hep::Position r1(0, 0, zz);
+	dd4hep::Rotation3D rot;
+#ifdef EDM_ML_DEBUG
+	std::string rotName("Null");
+#endif
+	if ((layerSense_[ly] != 0) && (layerOrient_[copy - firstLayer_] == HGCalTypes::WaferCenterR)) {
+          rot = ns.rotation(rotstr_);
+#ifdef EDM_ML_DEBUG
+	  rotName = rotstr_;
+#endif
+	}
+        mother.placeVolume(glog, copy, dd4hep::Transform3D(rot, r1));
+	int inc = ((layerSense_[ly] > 0) && (facingTypes_ > 1)) ? 2 : 1;
+	copyNumber_[ii] = copy + inc;
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << " number " << copy << " positioned in " << mother.name() << " at (0,0," << cms::convert2mm(zz) << ") with " << rotName << " rotation";
+#endif
+	zz += hthick;
+      }  // End of loop over layers in a block
+      zi = zo;
+      laymin = laymax;
+      // Make consistency check of all the partitions of the block
+      if (std::abs(thickTot - layerThick_[i]) >= tol2) {
+	if (thickTot > layerThick_[i]) {
+	  edm::LogError("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i]) << " is smaller than " << cms::convert2mm(thickTot)
+                                   << ": thickness of all its components **** ERROR ****";
+	} else {
+	  edm::LogWarning("HGCalGeom") << "Thickness of the partition " << cms::convert2mm(layerThick_[i]) << " does not match with "
+				       << cms::convert2mm(thickTot) << " of the components";
+	}
+      }
+    }  // End of loop over blocks
+
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << copies_.size() << " different wafer copy numbers";
+    int k(0);
+    for (std::unordered_set<int>::const_iterator itr = copies_.begin(); itr != copies_.end(); ++itr, ++k) {
+      edm::LogVerbatim("HGCalGeom") << "Copy [" << k << "] : " << (*itr);
+    }
+    copies_.clear();
+    edm::LogVerbatim("HGCalGeom") << "<<== End of DDHGCalSiliconRotatedCassette construction...";
+#endif
+  }
+
+  void positionSensitive(cms::DDParsingContext& ctxt, xml_h e, const dd4hep::Volume& glog, int layer) {
+    cms::DDNamespace ns(ctxt, e, true);
+    static const double sqrt3 = std::sqrt(3.0);
+    int layercenter = layerOrient_[layer];
+    int layertype = (layerOrient_[layer] == HGCalTypes::WaferCenterB) ? 1 : 0;
+    int firstWafer = waferLayerStart_[layer];
+    int lastWafer = ((layer + 1 < static_cast<int>(waferLayerStart_.size())) ? waferLayerStart_[layer + 1]
+		     : static_cast<int>(waferIndex_.size()));
+    double delx = 0.5 * (waferSize_ + waferSepar_);
+    double dely = 2.0 * delx / sqrt3;
+    double dy = 0.75 * dely;
+    const auto& xyoff = geomTools_.shiftXY(layercenter, (waferSize_ + waferSepar_));
+#ifdef EDM_ML_DEBUG
+    int ium(0), ivm(0), kount(0);
+    std::vector<int> ntype(3, 0);
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx) << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift " << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second) << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index " << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":" << layertype;
+#endif
+    for (int k = firstWafer; k < lastWafer; ++k) {
+      int u = HGCalWaferIndex::waferU(waferIndex_[k]);
+      int v = HGCalWaferIndex::waferV(waferIndex_[k]);
+#ifdef EDM_ML_DEBUG
+      int iu = std::abs(u);
+      int iv = std::abs(v);
+#endif
+      int nr = 2 * v;
+      int nc = -2 * u + v;
+      int type = HGCalProperty::waferThick(waferProperty_[k]);
+      int part = HGCalProperty::waferPartial(waferProperty_[k]);
+      int orien = HGCalProperty::waferOrient(waferProperty_[k]);
+      int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
+      int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
+      auto cshift = cassette_.getShift(layer + 1, -1, cassette);
+      double xpos = xyoff.first - cshift.first + nc * delx;
+      double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+      double xorig = xyoff.first + nc * delx;
+      double yorig = xyoff.second + nr * dy;
+      double angle = std::atan2(yorig, xorig);
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Wafer: layer " << layer + 1 << " cassette " << cassette << " Shift " << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":" << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v << " type|part|orient|place " << type << ":" << part << ":" << orien << ":" << place;
+#endif
+      std::string wafer;
+      int i(999);
+      if (part == HGCalTypes::WaferFull) {
+	i = type * facingTypes_ * orientationTypes_ + place - placeOffset_;
+	wafer = waferFull_[i];
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":" << placeOffset_ << ":" << facingTypes_ << ":" << orientationTypes_ << " wafer " << i << ":" << wafer;
+#endif
+      } else {
+	int partoffset = (part >= HGCalTypes::WaferHDTop) ? HGCalTypes::WaferPartHDOffset : HGCalTypes::WaferPartLDOffset;
+	i = (part - partoffset) * facingTypes_ * orientationTypes_ +
+          HGCalTypes::WaferTypeOffset[type] * facingTypes_ * orientationTypes_ + place - placeOffset_;
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << " layertype:type:part:orien:cassette:place:offsets:ind " << layertype << ":" << type << ":" << part << ":" << orien << ":" << cassette << ":" << place << ":" << partoffset << ":" << HGCalTypes::WaferTypeOffset[type] << ":" << i << ":" << waferPart_.size();
+#endif
+	wafer = waferPart_[i];
+      }
+      int copy = HGCalTypes::packTypeUV(type, u, v);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer " << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Wafer " << wafer << " number " << copy << " type:part:orien:place:ind " << type << ":" << part << ":" << orien << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_) << ":" << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos);
+      if (iu > ium)
+	ium = iu;
+      if (iv > ivm)
+	ivm = iv;
+      kount++;
+      if (copies_.count(copy) == 0)
+	copies_.insert(copy);
+#endif
+      dd4hep::Position tran(xpos, ypos, 0.0);
+      glog.placeVolume(ns.volume(wafer), copy, tran);
+#ifdef EDM_ML_DEBUG
+      ++ntype[type];
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << wafer << " number " << copy << " type " << layertype << ":" << type << " positioned in " << glog.name() << " at (" << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
+#endif
+    }
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm << " and " << kount << " passives (" << ntype[0] << ":" << ntype[1] << ":" << ntype[2] << ") for " << glog.name();
+#endif
+  }
+
+  void positionPassive(cms::DDParsingContext& ctxt, xml_h e, const dd4hep::Volume& glog, int layer, int absType) {
+    cms::DDNamespace ns(ctxt, e, true);
+    static const double sqrt3 = std::sqrt(3.0);
+    int layercenter = layerOrient_[layer];
+    int layertype = (layerOrient_[layer] == HGCalTypes::WaferCenterB) ? 1 : 0;
+    int firstWafer = waferLayerStart_[layer];
+    int lastWafer = ((layer + 1 < static_cast<int>(waferLayerStart_.size())) ? waferLayerStart_[layer + 1]
+		     : static_cast<int>(waferIndex_.size()));
+    double delx = 0.5 * (waferSize_ + waferSepar_);
+    double dely = 2.0 * delx / sqrt3;
+    double dy = 0.75 * dely;
+    const auto& xyoff = geomTools_.shiftXY(layercenter, (waferSize_ + waferSepar_));
+#ifdef EDM_ML_DEBUG
+    int ium(0), ivm(0), kount(0);
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: " << glog.name() << "  r " << cms::convert2mm(delx) << " R " << cms::convert2mm(dely) << " dy " << cms::convert2mm(dy) << " Shift " << cms::convert2mm(xyoff.first) << ":" << cms::convert2mm(xyoff.second) << " WaferSize " << cms::convert2mm(waferSize_ + waferSepar_) << " index " << firstWafer << ":" << (lastWafer - 1) << " Layer Center " << layercenter << ":" << layertype;
+#endif
+    for (int k = firstWafer; k < lastWafer; ++k) {
+      int u = HGCalWaferIndex::waferU(waferIndex_[k]);
+      int v = HGCalWaferIndex::waferV(waferIndex_[k]);
+#ifdef EDM_ML_DEBUG
+      int iu = std::abs(u);
+      int iv = std::abs(v);
+#endif
+      int nr = 2 * v;
+      int nc = -2 * u + v;
+      int type = HGCalProperty::waferThick(waferProperty_[k]);
+      int part = HGCalProperty::waferPartial(waferProperty_[k]);
+      int orien = HGCalProperty::waferOrient(waferProperty_[k]);
+      int cassette = HGCalProperty::waferCassette(waferProperty_[k]);
+      int place = HGCalCell::cellPlacementIndex(1, layertype, orien);
+      auto cshift = cassette_.getShift(layer + 1, -1, cassette);
+      double xpos = xyoff.first - cshift.first + nc * delx;
+      double ypos = xyoff.second + cshift.second + nr * dy;
+#ifdef EDM_ML_DEBUG
+      double xorig = xyoff.first + nc * delx;
+      double yorig = xyoff.second + nr * dy;
+      double angle = std::atan2(yorig, xorig);
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette::Passive: layer " << layer + 1 << " cassette " << cassette << " Shift " << cms::convert2mm(cshift.first) << ":" << cms::convert2mm(cshift.second) << " Original " << cms::convert2mm(xorig) << ":" << cms::convert2mm(yorig) << ":" << convertRadToDeg(angle) << " Final " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos) << " u|v " << u << ":" << v << " type|part|orient" << type << ":" << part << ":" << orien;
+#endif
+      std::string passive;
+      int i(999);
+      if (part == HGCalTypes::WaferFull) {
+	i = absType - 1;
+	passive = passiveFull_[i];
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:offsets:ind " << layertype << ":" << absType << ":" << part << ":" << orien << ":" << cassette << ":" << ":" << partialTypes_ << ":" << orientationTypes_ << " passive " << i << ":" << passive;
+#endif
+    } else {
+	int partoffset = (part >= HGCalTypes::WaferHDTop)
+	  ? HGCalTypes::WaferPartHDOffset
+	  : (HGCalTypes::WaferPartLDOffset - HGCalTypes::WaferTypeOffset[1]);
+	i = (part - partoffset) * facingTypes_ * orientationTypes_ +
+          (absType - 1) * facingTypes_ * orientationTypes_ * partialTypes_ + place - placeOffset_;
+#ifdef EDM_ML_DEBUG
+	edm::LogVerbatim("HGCalGeom") << " layertype:abstype:part:orien:cassette:3Types:offset:ind " << layertype << ":" << absType << ":" << part << ":" << orien << ":" << cassette << ":" << partialTypes_ << ":" << facingTypes_ << ":" << orientationTypes_ << ":" << partoffset << ":" << i << ":" << passivePart_.size();
+#endif
+	passive = passivePart_[i];
+      }
+      int copy = HGCalTypes::packTypeUV(absType, u, v);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: Layer " << HGCalWaferIndex::waferLayer(waferIndex_[k]) << " Passive " << passive << " number " << copy << " type:part:orien:place:ind " << type << ":" << part << ":" << orien << ":" << place << ":" << i << " layer:u:v:indx " << (layer + firstLayer_) << ":" << u << ":" << v << " pos " << cms::convert2mm(xpos) << ":" << cms::convert2mm(ypos);
+      if (iu > ium)
+	ium = iu;
+      if (iv > ivm)
+	ivm = iv;
+      kount++;
+#endif
+      dd4hep::Position tran(xpos, ypos, 0.0);
+      glog.placeVolume(ns.volume(passive), copy, tran);
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << " DDHGCalSiliconRotatedCassette: " << passive << " number " << copy << " type " << layertype << ":" << type << " positioned in " << glog.name() << " at (" << cms::convert2mm(xpos) << "," << cms::convert2mm(ypos) << ",0) with no rotation";
+#endif
+    }
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalSiliconRotatedCassette: Maximum # of u " << ium << " # of v " << ivm << " and " << kount << " passives for " << glog.name();
+#endif
+  }
+
+  //Required data members to cache the values from XML file
+  HGCalGeomTools geomTools_;
+  HGCalCassette cassette_;
+
+  int waferTypes_;                        // Number of wafer types
+  int passiveTypes_;                      // Number of passive types
+  int facingTypes_;                       // Types of facings of modules toward IP
+  int orientationTypes_;                  // Number of wafer orienations
+  int partialTypes_;                      // Number of partial types
+  int placeOffset_;                       // Offset for placement
+  int firstLayer_;                        // Copy # of the first sensitive layer
+  int absorbMode_;                        // Absorber mode
+  int sensitiveMode_;                     // Sensitive mode
+  double zMinBlock_;                      // Starting z-value of the block
+  double waferSize_;                      // Width of the wafer
+  double waferSepar_;                     // Sensor separation
+  int sectors_;                           // Sectors
+  int cassettes_;                         // Cassettes
+  std::string rotstr_;                    // Rotation matrix (if needed)
+  std::vector<std::string> waferFull_;    // Names of full wafer modules
+  std::vector<std::string> waferPart_;    // Names of partial wafer modules
+  std::vector<std::string> passiveFull_;  // Names of full passive modules
+  std::vector<std::string> passivePart_;  // Names of partial passive modules
+  std::vector<std::string> materials_;    // names of materials
+  std::vector<std::string> names_;        // Names of volumes
+  std::vector<double> thick_;             // Thickness of the material
+  std::vector<int> copyNumber_;           // Initial copy numbers
+  std::vector<int> layers_;               // Number of layers in a section
+  std::vector<double> layerThick_;        // Thickness of each section
+  std::vector<int> layerType_;            // Type of the layer
+  std::vector<int> layerSense_;           // Content of a layer (sensitive?)
+  std::vector<double> slopeB_;            // Slope at the lower R
+  std::vector<double> zFrontB_;           // Starting Z values for the slopes
+  std::vector<double> rMinFront_;         // Corresponding rMin's
+  std::vector<double> slopeT_;            // Slopes at the larger R
+  std::vector<double> zFrontT_;           // Starting Z values for the slopes
+  std::vector<double> rMaxFront_;         // Corresponding rMax's
+  std::vector<int> layerOrient_;          // Layer orientation (Centering, rotations..)
+  std::vector<int> waferIndex_;           // Wafer index for the types
+  std::vector<int> waferProperty_;        // Wafer property
+  std::vector<int> waferLayerStart_;      // Index of wafers in each layer
+  std::vector<double> cassetteShift_;     // Shifts of the cassetes
+  std::unordered_set<int> copies_;        // List of copy #'s
+  double alpha_, cosAlpha_;
+};
+
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
+  HGCalSiliconRotatedCassette siliconRotatedCassetteAlgo(ctxt, e);
+  return cms::s_executed;
+}
+
+DECLARE_DDCMS_DETELEMENT(DDCMS_hgcal_DDHGCalSiliconRotatedCassette, algorithm)

--- a/Geometry/HGCalCommonData/test/python/dumpHGCalDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/dumpHGCalDDD_cfg.py
@@ -2,7 +2,7 @@
 # Way to use this:
 #   cmsRun dumpHGCalDDD_cfg.py type=V17
 #
-#   Options for type V16, V17, V17n
+#   Options for type V16, V17, V17n, V17ng, V18
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -10,13 +10,13 @@ import os, sys, imp, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################
-### SETUP OPTIONS
+### SETUP OPTIONS 
 options = VarParsing.VarParsing('standard')
 options.register('type',
                  "V17",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "type of operations: V16, V17, V17n")
+                  "type of operations: V16, V17, V17n, V17ng,V18")
 
 ### get and parse the command line arguments
 options.parseArguments()


### PR DESCRIPTION
#### PR description:

Next step to go toward the V18 version of HGCal by adding the dd4hep version of adding passive components

#### PR validation:

Use the dumping scripts in Geometry/HGCalCommonData/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special