### PR TITLE
Fixing crash when accessing JetResolutionObject in CondDB

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -108,6 +108,7 @@ namespace JME {
     static const bimap<Binning, std::string> binning_to_string;
 
     std::vector<float> createVector(const std::vector<Binning>& binning) const;
+    std::vector<float> createVector(const std::vector<std::string>& binname) const;
 
   private:
     value_type m_values;
@@ -155,7 +156,7 @@ namespace JME {
 
       std::string getVariableName(size_t variable) const { return m_variables_name[variable]; }
 
-      size_t nVariables() const { return m_variables.size(); }
+      size_t nVariables() const { return m_variables_name.size(); }
 
       const std::vector<std::string>& getParametersName() const { return m_parameters_name; }
 

--- a/CondFormats/JetMETObjects/src/JetResolutionObject.cc
+++ b/CondFormats/JetMETObjects/src/JetResolutionObject.cc
@@ -420,10 +420,7 @@ namespace JME {
       return 1;
 
 #ifndef STANDALONE
-    reco::FormulaEvaluator* Formula = new reco::FormulaEvaluator(m_definition.getFormulaString());
-    if (!Formula)
-      return 1;
-    auto formula = *Formula;
+    reco::FormulaEvaluator formula = reco::FormulaEvaluator(m_definition.getFormulaString());
 #else
     // Set parameters
     auto const* pFormula = m_definition.getFormula();


### PR DESCRIPTION
#### PR description:

For the crashes found while accessing the JetResolutionObject in CondDB, it's found that the bins and variables are empty with Definiton::getBins() and Definition::getVariables(). This causes segmentation violation when calling JetResolutionObject::getRecord(). As not seen in XML dump, the formula is obtained through the formula string. Later found that Definition::nBins() is actually check from the bin-name strings. This PR changes Definition::nVariables() accordingly. Also make new function overloading on createVector to access through name strings. Minimum changes to get around the crashes.

#### PR validation:

Tested locally with getPayLoadData.py on modified PI to make sure no seg. fault. Python binding parts are not touched.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport is expected.
