### PR TITLE
[13.0.X] fix assignment of `PVValHelper::phase` in `PrimaryVertexValidation`

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -2613,6 +2613,7 @@ void PrimaryVertexValidation::beginRun(edm::Run const& iRun, edm::EventSetup con
 
   } else if ((pDD->isThere(GeomDetEnumerators::P1PXB)) || (pDD->isThere(GeomDetEnumerators::P1PXEC))) {
     // switch on the phase-1
+    phase_ = PVValHelper::phase1;
     if (debug_) {
       edm::LogInfo("PrimaryVertexValidation")
           << " pixel phase1 setup, nLadders: " << nLadders_ << " nModules:" << nModZ_;
@@ -2637,7 +2638,7 @@ void PrimaryVertexValidation::beginRun(edm::Run const& iRun, edm::EventSetup con
       etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase2);
       break;
     default:
-      edm::LogWarning("LogicError") << "Unknown detector phase: " << phase_;
+      throw cms::Exception("LogicError") << "Unknown detector phase: " << phase_;
   }
 
   if (h_etaMax->GetEntries() == 0.) {


### PR DESCRIPTION
backport of #42203

#### PR description:

Minor fix, to avoid having randomly assigned values of the `phase_` variable at runtime. Also instead of emitting a warning, throw in case the `phase_` is not defined properly.

#### PR validation:

Private checks.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of #42203 for data analysis purposes.