### PR TITLE
fixed LHCInfo PopCon ignoring endTime parameter

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -699,6 +699,7 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
         query->filterGT("start_time", targetTime);
       }
 
+      query->filterLT("start_time", m_endTime);
       if (m_endFill)
         query->filterNotNull("end_time");
       bool foundFill = query->execute();


### PR DESCRIPTION
#### PR description:

Fixed `LHCInfo` PopCon (`LHCInfoPopConSourceHandler`) ignoring the parameter `endTime` which is the end of the period it should perform the o2o for.

This parameter is not used in production in o2o jobs but it's useful for testing and regenerating payloads.

#### PR validation:

Validated by:
1. running the PopCon scripts (`LHCInfoPopConAnalyzerEndFill.py` and `LHCInfoPopConAnalyzerStartFill.py`) with different parameters of `startTime` and `endTime` (including leaving the `endTime` empty, as it runs in production). 
2. validating if the correct fills were processed by checking the logs produced by the aforementioned Python scripts

#### Backport
It's going to be backported to CMSSW_13_1_X and CMSSW_13_0_X
