### PR TITLE
[13_0_X] fixed LHCInfo PopCon ignoring endTime parameter

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -699,6 +699,7 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
         query->filterGT("start_time", targetTime);
       }
 
+      query->filterLT("start_time", m_endTime);
       if (m_endFill)
         query->filterNotNull("end_time");
       bool foundFill = query->execute();


### PR DESCRIPTION
#### PR description:

Backport of #42207

Fixed `LHCInfo` PopCon (`LHCInfoPopConSourceHandler`) ignoring the parameter `endTime` which is the end of the period it should perform the o2o for.

#### PR validation:

See master PR for validation description

#### Backport

Backport of #42207
