### PR TITLE
fix off-by-one error in TauNNIdHW::compute

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/taus/TauNNIdHW.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/taus/TauNNIdHW.cc
@@ -89,7 +89,7 @@ result_t TauNNIdHW::compute(const l1t::PFCandidate &iSeed, std::vector<l1t::PFCa
     return (pt_t(i.pt()) > pt_t(j.pt()));
   });
   for (unsigned int i0 = 0; i0 < iParts.size(); i0++) {
-    if (i0 > fNParticles_)
+    if (i0 >= fNParticles_)
       break;
     fPt_.get()[i0] = pt_t(iParts[i0].pt());
     fEta_.get()[i0] = etaphi_t(iSeed.eta() - iParts[i0].eta());


### PR DESCRIPTION
#### PR description:

There's an off-by-one error in TauNNIdHW::compute where the loop at line 91 continues one place past the end of the arrays.  This was spotted in the ASAN builds as part of the testing of #42077.  

#### PR validation:

Verified that, with the inclusion of #42077, this fixes the remaining ASAN errors in WF 20034.0.  Purely technical fix.