### PR TITLE
[13_1_X] EMTF Primitive Conversion LUT update for 2023

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
@@ -82,10 +82,13 @@ unsigned int ConditionHelper::get_pc_lut_version() const {
   } else if (params_->firmwareVersion_ < 1537467271) {  // From the beginning of 2017
     return 1;                                           // Corresponding to FW timestamps before Sept. 20, 2018
   } else if (params_->firmwareVersion_ <
-             1664468309) {  // Corresponds to September 29, 2022. The firmware got deployed on October 6, 2022.
+             1664468309) {  // Corresponds to September 29, 2022. The firmware was deployed on October 6, 2022.
     return 2;               // Starting September 26, 2018 with run 323556 (data only, not in MC)
+  } else if (params_->firmwareVersion_ <
+             1687686338) {  // Corresponds to June 25, 2023. The firmware was deployed on June 26, 2023.
+    return 3;               // Starting October 6, 2022 with run 359924 (data only, not in MC)
   } else {
-    return 3;  // Starting October 6, 2022 with run 359924 (data only, not in MC)
+    return 4;  // Starting July 1, 2023 with run 369675 (data only, not in MC)
   }
 }
 

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -27,6 +27,8 @@ void SectorProcessorLUT::read(bool pc_lut_data, int pc_lut_version) {
     coord_lut_dir = "ph_lut_v3_data";  // Update in September 2017 from ReReco alignment, data only
   else if (pc_lut_version == 3 && pc_lut_data)
     coord_lut_dir = "ph_lut_Run3_2022_data";  // Update in October 2022 from Run 3 2022 alignment, data only
+  else if (pc_lut_version == 4 && pc_lut_data)
+    coord_lut_dir = "ph_lut_Run3_2023_data";  // Update in June 2023 from Run 3 2023 alignment, data only
   else if (pc_lut_version >= 2)
     coord_lut_dir = "ph_lut_v2";  // MC still uses ideal CMS aligment
   else if (pc_lut_version == -1 && pc_lut_data)


### PR DESCRIPTION
#### PR description:

This PR adds options to use the new primitive conversion LUTs in the EMTF emulator. The LUTs were deployed at P5 on July 1st, but they are not used in the emulator yet. 

This PR needs the LUTs in https://github.com/cms-data/L1Trigger-L1TMuon/pull/25 to work.

We see improvement in EMTF performance at P5 with these new LUTs, so changes to muon efficiencies etc are expected when testing the re-emulation workflows from recent runs.

This is a backport of https://github.com/cms-sw/cmssw/pull/42198 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by comparing unpacked and re-emulated collections from recent runs. Also ran `runTheMatrix.py -l limited -i all --ibeos` and no failures were observed.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
