### PR TITLE
Ensure electron mass does not go to 0 after FastSim bremsstrahlung

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
@@ -146,6 +146,7 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle & particle, const Simpl
     // Needed to rotate photons to the lab frame
     double theta = particle.momentum().Theta();
     double phi = particle.momentum().Phi();
+    double m2dontchange = particle.momentum().mass()*particle.momentum().mass();
     
     // Calculate energy of these photons and add them to the event
     for(unsigned int i=0; i<nPhotons; ++i) 
@@ -164,6 +165,9 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle & particle, const Simpl
         
         // Update the original e+/-
         particle.momentum() -= photonMom;
+        
+        // Reset mass to original, since the above codes for decay e->e+gamma, ignoring proton
+        particle.momentum().SetXYZT(particle.momentum().px(),particle.momentum().py(), particle.momentum().pz(),sqrt(pow(particle.momentum().P(),2)+m2dontchange));
     }
 }   
 


### PR DESCRIPTION
Tracked down a cause of the seg fault reported here https://github.com/cms-sw/cmssw/issues/24051, found that FastSim bremsstrahlung emissions were being treated like decays (e->e+gamma), where the 4-vector of the photon is subtracted from the electron, but this causes the electron mass to go to zero approximately once in 10k events. Fixed code to preserve electron mass to prevent it from going to 0. CMS is not really sensitive to the electron mass, so the change to physics should be negligible. 