### PR TITLE
Introduce autoNANO

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1792,8 +1792,6 @@ class ConfigBuilder(object):
         _nanoSeq = [seq if seq!='' else self.NANODefaultSeq for seq in _nanoSeq]    
         _nanoCustoms = [cust if cust!='' else self.NANODefaultCustom for cust in _nanoCustoms]   
         # build and inject the sequence
-        print('NANO sequence:', _nanoSeq)
-        print('NANO customizations:', _nanoCustoms)
         if len(_nanoSeq) < 1 and '@' in stepSpec:
             raise Exception(f'The specified mapping: {stepSpec} generates an empty NANO sequence. Please provide a valid mappign')
         self.scheduleSequence('+'.join(_nanoSeq), 'nanoAOD_step')

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1073,6 +1073,7 @@ class ConfigBuilder(object):
         #TODO: Check based of file input
         self.NANOGENDefaultSeq='nanogenSequence'
         self.NANODefaultSeq='nanoSequence'
+        self.NANODefaultCustom='nanoAOD_customizeCommon'
 
         self.EVTCONTDefaultCFF="Configuration/EventContent/EventContent_cff"
 
@@ -1776,9 +1777,32 @@ class ConfigBuilder(object):
         print(f"in prepare_nano {stepSpec}")
         ''' Enrich the schedule with NANO '''
         _,_nanoSeq,_nanoCff = self.loadDefaultOrSpecifiedCFF(stepSpec,self.NANODefaultCFF,self.NANODefaultSeq)
-        self.scheduleSequence(_nanoSeq,'nanoAOD_step')
-        custom = "nanoAOD_customizeCommon"
-        self._options.customisation_file.insert(0,'.'.join([_nanoCff,custom]))
+        
+        # create full specified sequence using autoNANO 
+        from PhysicsTools.NanoAOD.autoNANO import autoNANO, expandNanoMapping
+        # if not a autoNANO mapping, load an empty customization, which later will be converted into the default.
+        _nanoCustoms = _nanoSeq.split('+') if '@' in stepSpec else [''] 
+        _nanoSeq = _nanoSeq.split('+')
+        expandNanoMapping(_nanoSeq, autoNANO, 'sequence')
+        expandNanoMapping(_nanoCustoms, autoNANO, 'customize')
+        # make sure there are no duplicates while preserving the ordering
+        _nanoSeq = list(sorted(set(_nanoSeq), key=_nanoSeq.index))
+        _nanoCustoms = list(sorted(set(_nanoCustoms), key=_nanoCustoms.index))
+        # replace empty sequence with default
+        _nanoSeq = [seq if seq!='' else self.NANODefaultSeq for seq in _nanoSeq]    
+        _nanoCustoms = [cust if cust!='' else self.NANODefaultCustom for cust in _nanoCustoms]   
+        # build and inject the sequence
+        print('NANO sequence:', _nanoSeq)
+        print('NANO customizations:', _nanoCustoms)
+        if len(_nanoSeq) < 1 and '@' in stepSpec:
+            raise Exception(f'The specified mapping: {stepSpec} generates an empty NANO sequence. Please provide a valid mappign')
+        self.scheduleSequence('+'.join(_nanoSeq), 'nanoAOD_step')
+        
+        # add the customisations
+        for custom in _nanoCustoms:
+            custom_path = custom if '.' in custom else '.'.join([_nanoCff,custom]) 
+            # customization order can be important for NANO, here later specified customise take precedence
+            self._options.customisation_file.append(custom_path)
         if self._options.hltProcess:
             if len(self._options.customise_commands) > 1:
                 self._options.customise_commands = self._options.customise_commands + " \n"

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -1,0 +1,34 @@
+def expandNanoMapping(seqList, mapping, key):
+    maxLevel=30
+    level=0
+    while '@' in repr(seqList) and level<maxLevel:
+        level+=1
+        for specifiedCommand in seqList:
+            if specifiedCommand.startswith('@'):
+                location=specifiedCommand[1:]
+                if not location in mapping:
+                    raise Exception("Impossible to map "+location+" from "+repr(mapping))
+                mappedTo=mapping[location]
+                # no mapping for specified key
+                # NOTE: mising key of key=None is interpreted differently than empty string:
+                #  - An empty string recalls the default for the given key
+                #  - None is interpreted as "ignore this"
+                seqList.remove(specifiedCommand)
+                if key in mappedTo and mappedTo[key] is not None:                    
+                    seqList.extend(mappedTo[key].split('+'))
+                break;
+        if level==maxLevel:
+            raise Exception("Could not fully expand "+repr(seqList)+" from "+repr(mapping))
+
+
+autoNANO = { 
+    # PHYS is a mapping to the default NANO config, i.e. empty strings
+    'PHYS': {'sequence': '', 
+             'customize': ''},
+    # L1 flavours: add tables through customize, supposed to be combined with PHYS
+    'L1' : {'customize': 'nanoL1TrigObjCustomize'},
+    'L1FULL' : {'customize': 'nanoL1TrigObjCustomizeFull'},
+    # PromptReco config: PHYS+L1
+    'Prompt' : {'sequence': '@PHYS', 
+                'customize': '@PHYS+@L1'}
+}


### PR DESCRIPTION
#### PR description:

Introduce a new utility to configure the NANO step using a mapping technique similar to the one used by DQM to load only selected modules.

autoNANO allows one to customize the NANO step using a syntax like: `-s NANO:@PHYS+@L1Full` where the `@` is then mapped to sequences and customize function and loaded into the processing. Previously we used the standard  `-s NANO:my_cff.my_sq1+sq2` syntax to customize the NANO step, this is still supported, but the two syntaxes cannot be mixed.

We also introduce a different mapping function than the one used by DQM, mainly because the latter uses a list of lists to specify different modules (pre, main, post) while we prefer to use a dictionary to avoid ordering related bugs (we can discuss if we actually want to port the DQM implementation to use a dictionary instead of a list of lists as well).

In this PR we insert a minimal set of workflows into autoNANO, the list will be expanded soon collecting the other existing workflow that are currently configured in a different way.

#### PR validation:

Ran few test jobs for all possible combination. Successfully  reproduced PromptNano 2023 and standard NANO ntuples.

No backport foreseen at the moment.

#### Further details on the autoNANO syntax

The default NANO sequence (which includes a "default customize function") is loaded by default if no step modifer is specified (`-s NANO`) or if the mapping points to empty strings (`'PHYS': {'sequence': '',  'customize': ''},). Missing dictionary keys are instead used to specify a workflow that do not require a dedicated "sequence" or "customize".