### PR TITLE
[13_0_X] Adding cov matrix to fakeBS object

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -54,6 +54,14 @@ OnlineBeamSpotESProducer::OnlineBeamSpotESProducer(const edm::ParameterSet& p)
   fakeBS_.setSigmaZ(15.);
   fakeBS_.setPosition(0.0001, 0.0001, 0.0001);
   fakeBS_.setType(-1);
+  // Set diagonal covariance, i.e. errors on the parameters
+  fakeBS_.setCovariance(0, 0, 5e-10);
+  fakeBS_.setCovariance(1, 1, 5e-10);
+  fakeBS_.setCovariance(2, 2, 0.002);
+  fakeBS_.setCovariance(3, 3, 0.002);
+  fakeBS_.setCovariance(4, 4, 5e-11);
+  fakeBS_.setCovariance(5, 5, 5e-11);
+  fakeBS_.setCovariance(6, 6, 1e-09);
 
   bsHLTToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd>();
   bsLegacyToken_ = cc.consumesFrom<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd>();


### PR DESCRIPTION
#### PR description:

Following the changes in PR https://github.com/cms-sw/cmssw/pull/41597 a fake beam spot object is now effectively used at HLT if none of the two fits produced by the DQM client converge.
This caused crashes at HLT (see https://github.com/cms-sw/cmssw/issues/41914) because no cov matrix, and hence no errors, was assigned to the bs fake object.
This PR adds a cov matrix with non-zero diagonal elements close to the ones returned by the fit.

#### PR validation:

Minor changes: code compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/42239