### PR TITLE
 Change ECAL DQM Presample and Trigger primitive plots thresholds [13_1_X]

### DIFF
--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -6,7 +6,7 @@ from DQM.EcalMonitorClient.IntegrityClient_cfi import ecalIntegrityClient
 minChannelEntries = 6
 expectedMean = 200.0
 toleranceLow = 25.0
-toleranceHigh = 40.0
+toleranceHigh = 60.0
 toleranceHighFwd = 100.0
 toleranceRMS = 6.0
 toleranceRMSFwd = 6.0

--- a/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/TrigPrimClient_cfi.py
@@ -4,7 +4,7 @@ from DQM.EcalMonitorTasks.TrigPrimTask_cfi import ecalTrigPrimTask
 from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 minEntries = 3
-errorFractionThreshold = 0.1
+errorFractionThreshold = 0.2
 TTF4MaskingAlarmThreshold = 0.1
 
 ecalTrigPrimClient = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:
This PR changes the thresholds of 

- Presample Quality plot to remove the ring of red spots observed in the Ecal endcaps
- Trigger Primitive emulator quality plot to remove the red towers at high eta in the endcaps

These are known issues due to ageing and radiation effects and the thresholds will need to be assessed and changed further, if need be.

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 13_1_X, which is next in production.
Master PR is https://github.com/cms-sw/cmssw/pull/42242.
Another backport to production version 13_0_X: https://github.com/cms-sw/cmssw/pull/42244
