### PR TITLE
[HGCAL trigger] Module splitting and updated seeding normalization 

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -94,7 +94,7 @@ public:
   static const int kHGCalLayerMask = 0x1F;
   static const int kHGCalTypeOffset = 19;
   static const int kHGCalTypeMask = 0x3;
-  static const int kHGCalZsideOffset = 24;
+  static const int kHGCalZsideOffset = 21;
   static const int kHGCalZsideMask = 0x1;
   static const int kHGCalTriggerSubdetOffset = 22;
   static const int kHGCalTriggerSubdetMask = 0x3;

--- a/DataFormats/ForwardDetId/src/HGCalTriggerBackendDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCalTriggerBackendDetId.cc
@@ -8,7 +8,7 @@ HGCalTriggerBackendDetId::HGCalTriggerBackendDetId(uint32_t rawid) : DetId(rawid
 
 HGCalTriggerBackendDetId::HGCalTriggerBackendDetId(int zp, int type, int sector, int label)
     : DetId(Forward, HGCTrigger) {
-  int classid = HGCalTriggerClassIdentifier::ModuleDetId;
+  int classid = HGCalTriggerClassIdentifier::BackendDetId;
   int zside = (zp < 0) ? 1 : 0;
   id_ |= (((label & kHGCalLabelMask) << kHGCalLabelOffset) | ((sector & kHGCalSectorMask) << kHGCalSectorOffset) |
           ((zside & kHGCalZsideMask) << kHGCalZsideOffset) | ((type & kHGCalTypeMask) << kHGCalTypeOffset) |

--- a/DataFormats/L1THGCal/interface/HGCalTowerID.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerID.h
@@ -28,8 +28,6 @@ namespace l1t {
 
     unsigned short rawId() const { return rawId_; }
 
-  private:
-    uint32_t rawId_;
     static const int subDetMask = 0x1;  // two for now 0 is HGC and 1 is HFNose
     static const int subDetShift = 16;
     static const int zsideMask = 0x1;
@@ -37,6 +35,9 @@ namespace l1t {
     static const int coordMask = 0x007F;
     static const int coord1Shift = 7;
     static const int coord2Shift = 0;
+
+  private:
+    uint32_t rawId_;
   };
 
   struct HGCalTowerCoord {

--- a/DataFormats/L1THGCal/interface/HGCalTowerMap.h
+++ b/DataFormats/L1THGCal/interface/HGCalTowerMap.h
@@ -22,7 +22,7 @@ namespace l1t {
 
     const HGCalTowerMap& operator+=(const HGCalTowerMap& map);
 
-    bool addEt(short bin_id, float etEm, float etHad);
+    bool addEt(const std::unordered_map<unsigned short, float>& towerIDandShares, float etEm, float etHad);
 
     unsigned nTowers() const { return towerMap_.size(); }
     const std::unordered_map<unsigned short, l1t::HGCalTower>& towers() const { return towerMap_; }

--- a/DataFormats/L1THGCal/src/HGCalTowerMap.cc
+++ b/DataFormats/L1THGCal/src/HGCalTowerMap.cc
@@ -30,12 +30,13 @@ const HGCalTowerMap& HGCalTowerMap::operator+=(const HGCalTowerMap& map) {
   return *this;
 }
 
-bool HGCalTowerMap::addEt(short bin_id, float etEm, float etHad) {
-  auto this_tower = towerMap_.find(bin_id);
-  if (this_tower == towerMap_.end())
-    return false;
-  this_tower->second.addEtEm(etEm);
-  this_tower->second.addEtHad(etHad);
-
+bool HGCalTowerMap::addEt(const std::unordered_map<unsigned short, float>& towerIDandShares, float etEm, float etHad) {
+  for (const auto& towerIDandShare : towerIDandShares) {
+    auto this_tower = towerMap_.find(towerIDandShare.first);
+    if (this_tower == towerMap_.end())
+      return false;
+    this_tower->second.addEtEm(etEm * towerIDandShare.second);
+    this_tower->second.addEtHad(etHad * towerIDandShare.second);
+  }
   return true;
 }

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerTowerGeometryHelper.h
@@ -15,6 +15,7 @@
 #include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerCell.h"
 #include "DataFormats/L1THGCal/interface/HGCalTriggerSums.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
 
 #include <vector>
 #include <unordered_map>
@@ -32,17 +33,29 @@ public:
 
   void setGeometry(const HGCalTriggerGeometryBase* const geom) { triggerTools_.setGeometry(geom); }
 
+  unsigned packLayerSubdetWaferId(int subdet, int layer, int moduleU, int moduleV) const;
+  unsigned packTowerIDandShare(int towerEta, int towerPhi, int towerShare) const;
+  void unpackTowerIDandShare(unsigned towerIDandShare, int& towerEta_raw, int& towerPhi_raw, int& towerShare) const;
+  int moveToCorrectSector(int towerPhi_raw, int sector) const;
+  void reverseXaxis(int& towerPhi) const;
+
   const std::vector<l1t::HGCalTowerCoord>& getTowerCoordinates() const;
 
   unsigned short getTriggerTowerFromEtaPhi(const float& eta, const float& phi) const;
-  unsigned short getTriggerTower(const l1t::HGCalTriggerCell&) const;
-  unsigned short getTriggerTower(const l1t::HGCalTriggerSums&) const;
+  std::unordered_map<unsigned short, float> getTriggerTower(const l1t::HGCalTriggerCell&) const;
+  std::unordered_map<unsigned short, float> getTriggerTower(const l1t::HGCalTriggerSums&) const;
 
   const bool isNose() { return doNose_; }
 
 private:
+  static const int towerShareMask = 0x7F;
+  static const int towerShareShift = 14;
+  static const int signMask = 0x1;
+  static const int sign1Shift = 21;
+  static const int sign2Shift = 22;
   std::vector<l1t::HGCalTowerCoord> tower_coords_;
   std::unordered_map<unsigned, short> cells_to_trigger_towers_;
+  std::unordered_map<unsigned, std::vector<unsigned>> modules_to_trigger_towers_;
 
   bool doNose_;
   double minEta_;
@@ -54,6 +67,13 @@ private:
 
   std::vector<double> binsEta_;
   std::vector<double> binsPhi_;
+
+  bool splitModuleSum_;
+  int splitDivisorSilic_;
+  int splitDivisorScint_;
+  int rotate180Deg_;
+  int rotate120Deg_;
+  int reverseX_;
 
   HGCalTriggerTools triggerTools_;
 };

--- a/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalHistoSeedingImpl.h
@@ -156,6 +156,9 @@ private:
   std::vector<double> neighbour_weights_;
   std::vector<double> smoothing_ecal_;
   std::vector<double> smoothing_hcal_;
+  bool seeds_norm_by_area_;
+
+  float area_10pct_;
 
   HGCalTriggerTools triggerTools_;
   Navigator navigator_;

--- a/L1Trigger/L1THGCal/python/customHistoSeeding.py
+++ b/L1Trigger/L1THGCal/python/customHistoSeeding.py
@@ -102,3 +102,9 @@ def custom_3dclustering_XYHistoMax(process,
     process.l1tHGCalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
     return process
 
+def custom_3dclustering_seedNoArea(process,
+                                   seed_threshold=cms.double(20)):
+    parameters_c3d = histoMax_C3d_seeding_params.clone(seeds_norm_by_area = False,
+                                                        threshold_histo_multicluster = seed_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
+    return process

--- a/L1Trigger/L1THGCal/python/customHistoSeeding.py
+++ b/L1Trigger/L1THGCal/python/customHistoSeeding.py
@@ -102,6 +102,14 @@ def custom_3dclustering_XYHistoMax(process,
     process.l1tHGCalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
     return process
 
+
+def custom_3dclustering_seedArea(process,
+                                   seed_threshold=cms.double(8.5)):
+    parameters_c3d = histoMax_C3d_seeding_params.clone(seeds_norm_by_area = True,
+                                                        threshold_histo_multicluster = seed_threshold)
+    process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters = parameters_c3d
+    return process
+
 def custom_3dclustering_seedNoArea(process,
                                    seed_threshold=cms.double(20)):
     parameters_c3d = histoMax_C3d_seeding_params.clone(seeds_norm_by_area = False,

--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
 import math
 
 def custom_towers_unclustered_tc(process):
@@ -35,6 +36,10 @@ def custom_towers_etaphi(process,
     parameters_towers_2d.L1TTriggerTowerConfig.binsPhi = cms.vdouble(binsPhi)
     return process
 
+def custom_towers_energySplit(process):
+    parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
+    process.hgcalTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
+    return process
 
 def custom_towers_map(process,
         towermapping='L1Trigger/L1THGCal/data/tower_mapping_hgcroc_eta-phi_v3.txt',

--- a/L1Trigger/L1THGCal/python/l1tHGCalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalBackEndLayer2Producer_cfi.py
@@ -79,13 +79,13 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                binSumsHisto=binSums,
                                kROverZMin=cms.double(0.076),
                                kROverZMax=cms.double(0.58),
-                               threshold_histo_multicluster=cms.double(10.),
+                               threshold_histo_multicluster=cms.double(20.),
                                neighbour_weights=neighbour_weights_1stOrder,
                                seed_position=cms.string("TCWeighted"),#BinCentre, TCWeighted
                                seeding_space=cms.string("RPhi"),# RPhi, XY
                                seed_smoothing_ecal=seed_smoothing_ecal,
                                seed_smoothing_hcal=seed_smoothing_hcal,
-                               seeds_norm_by_area=cms.bool(True)
+                               seeds_norm_by_area=cms.bool(False)
                               )
 
 histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
@@ -102,14 +102,6 @@ histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),
 histoMax_C3d_sorting_truncation_params = cms.PSet(AlgoName = cms.string('HGCalSortingTruncationWrapper'),
                                                   maxTCs=cms.uint32(80),
                                )
-
-# >= V9 samples have a different definition of the dEdx calibrations. To account for it
-# we rescale the thresholds of the clustering seeds
-# (see https://indico.cern.ch/event/806845/contributions/3359859/attachments/1815187/2966402/19-03-20_EGPerf_HGCBE.pdf
-# for more details)
-phase2_hgcalV10.toModify(histoMax_C3d_seeding_params,
-                        threshold_histo_multicluster=8.5,  # MipT
-                        )
 
 
 histoMaxVariableDR_C3d_params = histoMax_C3d_clustering_params.clone(

--- a/L1Trigger/L1THGCal/python/l1tHGCalBackEndLayer2Producer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalBackEndLayer2Producer_cfi.py
@@ -85,6 +85,7 @@ histoMax_C3d_seeding_params = cms.PSet(type_histoalgo=cms.string('HistoMaxC3d'),
                                seeding_space=cms.string("RPhi"),# RPhi, XY
                                seed_smoothing_ecal=seed_smoothing_ecal,
                                seed_smoothing_hcal=seed_smoothing_hcal,
+                               seeds_norm_by_area=cms.bool(True)
                               )
 
 histoMax_C3d_clustering_params = cms.PSet(dR_multicluster=cms.double(0.03),

--- a/L1Trigger/L1THGCal/python/l1tHGCalTowerMapProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalTowerMapProducer_cfi.py
@@ -10,7 +10,21 @@ L1TTriggerTowerConfig_etaphi = cms.PSet(readMappingFile=cms.bool(False),
                                         nBinsEta=cms.int32(18),
                                         nBinsPhi=cms.int32(72),
                                         binsEta=cms.vdouble(),
-                                        binsPhi=cms.vdouble())
+                                        binsPhi=cms.vdouble(),
+                                        splitModuleSum=cms.bool(False))
+
+L1TTriggerTowerConfig_energySplit = cms.PSet(readMappingFile=cms.bool(False),
+                                        doNose=cms.bool(False),
+                                        minEta=cms.double(1.305),
+                                        maxEta=cms.double(3.045),
+                                        minPhi=cms.double(-1*math.pi),
+                                        maxPhi=cms.double(math.pi),
+                                        nBinsEta=cms.int32(20),
+                                        nBinsPhi=cms.int32(72),
+                                        binsEta=cms.vdouble(),
+                                        binsPhi=cms.vdouble(),
+                                        splitModuleSum=cms.bool(True),
+                                        moduleTowerMapping=cms.FileInPath("L1Trigger/L1THGCal/data/tower_per_module_silic8_scint16.txt"))
 
 towerMap2D_parValues = cms.PSet( useLayerWeights = cms.bool(False),
                                  layerWeights = cms.vdouble(),

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -274,7 +274,7 @@ std::unordered_map<unsigned short, float> HGCalTriggerTowerGeometryHelper::getTr
     int sector = detid.sector();
     int zside = detid.zside();
     int subdet = 0;
-    int splitDivisor = splitDivisorSilic_;
+    int splitDivisor;
     if (detid.isHScintillator()) {
       subdet = 2;
       splitDivisor = splitDivisorScint_;

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -116,11 +116,11 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
                "file.\n"
             << "The incorrect line is:" << line << std::endl;
       }
-      int subdet;
-      int layer;
-      int moduleU;
-      int moduleV;
-      int numTowers;
+      int subdet = 0;
+      int layer = 0;
+      int moduleU = 0;
+      int moduleV = 0;
+      int numTowers = 0;
       std::stringstream ss(line);
       ss >> subdet >> layer >> moduleU >> moduleV >> numTowers;
       if (numOfWordsInThisRow != (numTowers * numOfWordsPerTower + minNumOfWordsPerRow)) {
@@ -132,9 +132,9 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
       unsigned packed_modID = packLayerSubdetWaferId(subdet, layer, moduleU, moduleV);
       std::vector<unsigned> towers;
       for (int itr_tower = 0; itr_tower < numTowers; itr_tower++) {
-        int iEta_raw;
-        int iPhi_raw;
-        int towerShare;
+        int iEta_raw = 0;
+        int iPhi_raw = 0;
+        int towerShare = 0;
         ss >> iEta_raw >> iPhi_raw >> towerShare;
         int splitDivisor = (subdet == 2) ? splitDivisorScint_ : splitDivisorSilic_;
         if ((towerShare > splitDivisor) || (towerShare < 1)) {

--- a/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerTowerGeometryHelper.cc
@@ -19,7 +19,8 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
       nBinsEta_(conf.getParameter<int>("nBinsEta")),
       nBinsPhi_(conf.getParameter<int>("nBinsPhi")),
       binsEta_(conf.getParameter<std::vector<double> >("binsEta")),
-      binsPhi_(conf.getParameter<std::vector<double> >("binsPhi")) {
+      binsPhi_(conf.getParameter<std::vector<double> >("binsPhi")),
+      splitModuleSum_(conf.getParameter<bool>("splitModuleSum")) {
   if (!binsEta_.empty() && ((unsigned int)(binsEta_.size()) != nBinsEta_ + 1)) {
     throw edm::Exception(edm::errors::Configuration, "Configuration")
         << "HGCalTriggerTowerGeometryHelper nBinsEta for the tower map not consistent with binsEta size" << std::endl;
@@ -79,6 +80,129 @@ HGCalTriggerTowerGeometryHelper::HGCalTriggerTowerGeometryHelper(const edm::Para
     }
     l1tTriggerTowerMappingStream.close();
   }
+
+  if (splitModuleSum_) {
+    //variables for transforming towers
+    rotate180Deg_ = int(nBinsPhi_) / 2;
+    rotate120Deg_ = int(nBinsPhi_) / 3;
+    reverseX_ = int(nBinsPhi_) / 2 - 1;
+
+    std::ifstream moduleTowerMappingStream(conf.getParameter<edm::FileInPath>("moduleTowerMapping").fullPath());
+    if (!moduleTowerMappingStream.is_open()) {
+      throw cms::Exception("MissingDataFile") << "Cannot open HGCalTowerMapProducer moduleTowerMapping file\n";
+    }
+    //get split divisors
+    std::string line;
+    std::getline(moduleTowerMappingStream, line);  //Skip row
+    std::getline(moduleTowerMappingStream, line);
+    std::stringstream ss(line);
+    ss >> splitDivisorSilic_ >> splitDivisorScint_;
+
+    //get towers and module sum shares
+    std::getline(moduleTowerMappingStream, line);  //Skip row
+    std::getline(moduleTowerMappingStream, line);  //Skip row
+    const int minNumOfWordsPerRow = 5;
+    const int numOfWordsPerTower = 3;
+    for (std::string line; std::getline(moduleTowerMappingStream, line);) {
+      int numOfWordsInThisRow = 0;
+      for (std::string::size_type i = 0; i < line.size(); i++) {
+        if (line[i] != ' ' && line[i + 1] == ' ') {
+          numOfWordsInThisRow++;
+        }
+      }
+      if (numOfWordsInThisRow < minNumOfWordsPerRow) {
+        throw edm::Exception(edm::errors::Configuration, "Configuration")
+            << "HGCalTriggerTowerGeometryHelper warning: Incorrect/incomplete values for module ID in the mapping "
+               "file.\n"
+            << "The incorrect line is:" << line << std::endl;
+      }
+      int subdet;
+      int layer;
+      int moduleU;
+      int moduleV;
+      int numTowers;
+      std::stringstream ss(line);
+      ss >> subdet >> layer >> moduleU >> moduleV >> numTowers;
+      if (numOfWordsInThisRow != (numTowers * numOfWordsPerTower + minNumOfWordsPerRow)) {
+        throw edm::Exception(edm::errors::Configuration, "Configuration")
+            << "HGCalTriggerTowerGeometryHelper warning: Incorrect/incomplete values for module ID or tower "
+               "share/eta/phi in the mapping file.\n"
+            << "The incorrect line is:" << line << std::endl;
+      }
+      unsigned packed_modID = packLayerSubdetWaferId(subdet, layer, moduleU, moduleV);
+      std::vector<unsigned> towers;
+      for (int itr_tower = 0; itr_tower < numTowers; itr_tower++) {
+        int iEta_raw;
+        int iPhi_raw;
+        int towerShare;
+        ss >> iEta_raw >> iPhi_raw >> towerShare;
+        int splitDivisor = (subdet == 2) ? splitDivisorScint_ : splitDivisorSilic_;
+        if ((towerShare > splitDivisor) || (towerShare < 1)) {
+          throw edm::Exception(edm::errors::Configuration, "Configuration")
+              << "HGCalTriggerTowerGeometryHelper warning: invalid tower share in the mapping file.\n"
+              << "Tower share must be a positive integer and less than splitDivisor. The incorrect values found for "
+                 "module ID:"
+              << std::endl
+              << "subdet=" << subdet << ", l=" << layer << ", u=" << moduleU << ", v=" << moduleV << std::endl;
+        }
+        towers.push_back(packTowerIDandShare(iEta_raw, iPhi_raw, towerShare));
+      }
+      modules_to_trigger_towers_[packed_modID] = towers;
+    }
+    moduleTowerMappingStream.close();
+  }
+}
+
+unsigned HGCalTriggerTowerGeometryHelper::packLayerSubdetWaferId(int subdet, int layer, int moduleU, int moduleV) const {
+  unsigned packed_modID = 0;
+  packed_modID |= ((subdet & HGCalTriggerModuleDetId::kHGCalTriggerSubdetMask)
+                   << HGCalTriggerModuleDetId::kHGCalTriggerSubdetOffset);
+  packed_modID |= ((layer & HGCalTriggerModuleDetId::kHGCalLayerMask) << HGCalTriggerModuleDetId::kHGCalLayerOffset);
+  packed_modID |=
+      ((moduleU & HGCalTriggerModuleDetId::kHGCalModuleUMask) << HGCalTriggerModuleDetId::kHGCalModuleUOffset);
+  packed_modID |=
+      ((moduleV & HGCalTriggerModuleDetId::kHGCalModuleVMask) << HGCalTriggerModuleDetId::kHGCalModuleVOffset);
+  return packed_modID;
+}
+
+unsigned HGCalTriggerTowerGeometryHelper::packTowerIDandShare(int iEta_raw, int iPhi_raw, int towerShare) const {
+  unsigned packed_towerIDandShare = 0;
+  unsigned iEtaAbs = std::abs(iEta_raw);
+  unsigned iEtaSign = std::signbit(iEta_raw);
+  unsigned iPhiAbs = std::abs(iPhi_raw);
+  unsigned iPhiSign = std::signbit(iPhi_raw);
+  packed_towerIDandShare |= ((iEtaAbs & l1t::HGCalTowerID::coordMask) << l1t::HGCalTowerID::coord1Shift);
+  packed_towerIDandShare |= ((iEtaSign & signMask) << sign1Shift);
+  packed_towerIDandShare |= ((iPhiAbs & l1t::HGCalTowerID::coordMask) << l1t::HGCalTowerID::coord2Shift);
+  packed_towerIDandShare |= ((iPhiSign & signMask) << sign2Shift);
+  packed_towerIDandShare |= ((towerShare & towerShareMask) << towerShareShift);
+  return packed_towerIDandShare;
+}
+
+void HGCalTriggerTowerGeometryHelper::unpackTowerIDandShare(unsigned towerIDandShare,
+                                                            int& iEta_raw,
+                                                            int& iPhi_raw,
+                                                            int& towerShare) const {
+  //eta
+  iEta_raw = (towerIDandShare >> l1t::HGCalTowerID::coord1Shift) & l1t::HGCalTowerID::coordMask;
+  unsigned iEtaSign = (towerIDandShare >> sign1Shift) & signMask;
+  iEta_raw = (iEtaSign) ? -1 * iEta_raw : iEta_raw;
+  //phi
+  iPhi_raw = (towerIDandShare >> l1t::HGCalTowerID::coord2Shift) & l1t::HGCalTowerID::coordMask;
+  unsigned iPhiSign = (towerIDandShare >> sign2Shift) & signMask;
+  iPhi_raw = (iPhiSign) ? -1 * iPhi_raw : iPhi_raw;
+  //tower share
+  towerShare = (towerIDandShare >> towerShareShift) & towerShareMask;
+}
+
+int HGCalTriggerTowerGeometryHelper::moveToCorrectSector(int iPhi_raw, int sector) const {
+  int iPhi = (iPhi_raw + sector * rotate120Deg_ + rotate180Deg_) % int(nBinsPhi_);
+  return iPhi;
+}
+
+void HGCalTriggerTowerGeometryHelper::reverseXaxis(int& iPhi) const {
+  iPhi = reverseX_ - iPhi;                          //correct x -> -x in z>0
+  iPhi = (int(nBinsPhi_) + iPhi) % int(nBinsPhi_);  // make all phi between 0 to nBinsPhi_-1
 }
 
 const std::vector<l1t::HGCalTowerCoord>& HGCalTriggerTowerGeometryHelper::getTowerCoordinates() const {
@@ -120,18 +244,76 @@ unsigned short HGCalTriggerTowerGeometryHelper::getTriggerTowerFromEtaPhi(const 
   return l1t::HGCalTowerID(doNose_, zside, bin_eta, bin_phi).rawId();
 }
 
-unsigned short HGCalTriggerTowerGeometryHelper::getTriggerTower(const l1t::HGCalTriggerCell& thecell) const {
+std::unordered_map<unsigned short, float> HGCalTriggerTowerGeometryHelper::getTriggerTower(
+    const l1t::HGCalTriggerCell& thecell) const {
+  std::unordered_map<unsigned short, float> towerIDandShares = {};
   unsigned int trigger_cell_id = thecell.detId();
   // NOTE: if the TC is not found in the map than it is mapped via eta-phi coords.
   // this can be considered dangerous (silent failure of the map) but it actually allows to save
   // memory mapping explicitly only what is actually needed
   auto tower_id_itr = cells_to_trigger_towers_.find(trigger_cell_id);
-  if (tower_id_itr != cells_to_trigger_towers_.end())
-    return tower_id_itr->second;
-
-  return getTriggerTowerFromEtaPhi(thecell.position().eta(), thecell.position().phi());
+  if (tower_id_itr != cells_to_trigger_towers_.end()) {
+    towerIDandShares.insert({tower_id_itr->second, 1.0});
+    return towerIDandShares;
+  }
+  towerIDandShares.insert({getTriggerTowerFromEtaPhi(thecell.position().eta(), thecell.position().phi()), 1.0});
+  return towerIDandShares;
 }
 
-unsigned short HGCalTriggerTowerGeometryHelper::getTriggerTower(const l1t::HGCalTriggerSums& thesum) const {
-  return getTriggerTowerFromEtaPhi(thesum.position().eta(), thesum.position().phi());
+std::unordered_map<unsigned short, float> HGCalTriggerTowerGeometryHelper::getTriggerTower(
+    const l1t::HGCalTriggerSums& thesum) const {
+  std::unordered_map<unsigned short, float> towerIDandShares = {};
+  if (!splitModuleSum_) {
+    towerIDandShares.insert({getTriggerTowerFromEtaPhi(thesum.position().eta(), thesum.position().phi()), 1.0});
+    return towerIDandShares;
+  } else {
+    HGCalTriggerModuleDetId detid(thesum.detId());
+    int moduleU = detid.moduleU();
+    int moduleV = detid.moduleV();
+    int layer = detid.layer();
+    int sector = detid.sector();
+    int zside = detid.zside();
+    int subdet = 0;
+    int splitDivisor = splitDivisorSilic_;
+    if (detid.isHScintillator()) {
+      subdet = 2;
+      splitDivisor = splitDivisorScint_;
+    } else if (detid.isEE()) {
+      subdet = 0;
+      splitDivisor = splitDivisorSilic_;
+    } else if (detid.isHSilicon()) {
+      subdet = 1;
+      splitDivisor = splitDivisorSilic_;
+    } else {  //HFNose
+      towerIDandShares.insert({getTriggerTowerFromEtaPhi(thesum.position().eta(), thesum.position().phi()), 1.0});
+      return towerIDandShares;
+    }
+
+    unsigned packed_modID = packLayerSubdetWaferId(subdet, layer, moduleU, moduleV);
+    auto module_id_itr = modules_to_trigger_towers_.find(packed_modID);
+    if (module_id_itr != modules_to_trigger_towers_.end()) {
+      //eta variables
+      int iEta = -999;
+      int iEta_raw = -999;
+      int offsetEta = 2;
+      //phi variables
+      int iPhi = -999;
+      int iPhi_raw = -999;
+      int towerShare = -999;  //the share each tower gets from module sum
+      for (auto towerIDandShare : module_id_itr->second) {
+        unpackTowerIDandShare(towerIDandShare, iEta_raw, iPhi_raw, towerShare);
+        iEta = offsetEta + iEta_raw;
+        iPhi = moveToCorrectSector(iPhi_raw, sector);
+        if (zside == 1) {
+          reverseXaxis(iPhi);
+        }
+        towerIDandShares.insert(
+            {l1t::HGCalTowerID(doNose_, zside, iEta, iPhi).rawId(), double(towerShare) / splitDivisor});
+      }
+      return towerIDandShares;
+    } else {  // for modules not found in the mapping file (currently a few partial modules) use the traditional method.
+      towerIDandShares.insert({getTriggerTowerFromEtaPhi(thesum.position().eta(), thesum.position().phi()), 1.0});
+      return towerIDandShares;
+    }
+  }
 }

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoSeedingImpl.cc
@@ -13,6 +13,7 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
       neighbour_weights_(conf.getParameter<std::vector<double>>("neighbour_weights")),
       smoothing_ecal_(conf.getParameter<std::vector<double>>("seed_smoothing_ecal")),
       smoothing_hcal_(conf.getParameter<std::vector<double>>("seed_smoothing_hcal")),
+      seeds_norm_by_area_(conf.getParameter<bool>("seeds_norm_by_area")),
       kROverZMin_(conf.getParameter<double>("kROverZMin")),
       kROverZMax_(conf.getParameter<double>("kROverZMax")) {
   if (seedingAlgoType_ == "HistoMaxC3d") {
@@ -64,6 +65,13 @@ HGCalHistoSeedingImpl::HGCalHistoSeedingImpl(const edm::ParameterSet& conf)
         << "Inconsistent size of neighbour weights vector in HGCalMulticlustering ( " << neighbour_weights_.size()
         << " ). Should be " << neighbour_weights_size_ << "\n";
   }
+
+  // compute quantities for non-normalised-by-area histoMax
+  // The 0.1 factor in bin1_10pct is an attempt to keep the same rough scale for seeds. The exact value is arbitrary.
+  int bin1_10pct = (int)0.1 * nBins1_;
+  float R1_10pct = kROverZMin_ + bin1_10pct * (kROverZMax_ - kROverZMin_) / nBins1_;
+  float R2_10pct = R1_10pct + ((kROverZMax_ - kROverZMin_) / nBins1_);
+  area_10pct_ = ((M_PI * (pow(R2_10pct, 2) - pow(R1_10pct, 2))) / nBins2_);
 }
 
 HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillHistoClusters(
@@ -166,15 +174,20 @@ HGCalHistoSeedingImpl::Histogram HGCalHistoSeedingImpl::fillSmoothPhiHistoCluste
   for (int z_side : {-1, 1}) {
     for (unsigned bin1 = 0; bin1 < nBins1_; bin1++) {
       int nBinsSide = (binSums[bin1] - 1) / 2;
-      float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_) / nBins1_;
-      float R2 = R1 + ((kROverZMax_ - kROverZMin_) / nBins1_);
       double area =
-          ((M_PI * (pow(R2, 2) - pow(R1, 2))) / nBins2_) *
           (1 +
            2.0 *
                (1 -
                 pow(0.5,
                     nBinsSide)));  // Takes into account different area of bins in different R-rings + sum of quadratic weights used
+
+      if (seeds_norm_by_area_) {
+        float R1 = kROverZMin_ + bin1 * (kROverZMax_ - kROverZMin_) / nBins1_;
+        float R2 = R1 + ((kROverZMax_ - kROverZMin_) / nBins1_);
+        area = area * ((M_PI * (pow(R2, 2) - pow(R1, 2))) / nBins2_);
+      } else {
+        area = area * area_10pct_;
+      }
 
       for (unsigned bin2 = 0; bin2 < nBins2_; bin2++) {
         const auto& bin_orig = histoClusters.at(z_side, bin1, bin2);

--- a/L1Trigger/L1THGCalUtilities/python/clustering3d.py
+++ b/L1Trigger/L1THGCalUtilities/python/clustering3d.py
@@ -48,11 +48,14 @@ class CreateHistoMax(object):
             nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
             binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
             seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            seeds_norm_by_area=histoMax_C3d_seeding_params.seeds_norm_by_area,
             shape_threshold=histoMax_C3d_clustering_params.shape_threshold,
             shape_distance=histoMax_C3d_clustering_params.shape_distance,
             ):
         self.clustering_parameters = histoMax_C3d_clustering_params.clone()
-        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone(
+                seeds_norm_by_area=seeds_norm_by_area
+                )
         set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, distance, shape_threshold, shape_distance)
 
@@ -72,13 +75,16 @@ class CreateHistoMaxVariableDr(object):
             nBins_X2=histoMax_C3d_seeding_params.nBins_X2_histo_multicluster,
             binSumsHisto=histoMax_C3d_seeding_params.binSumsHisto,
             seed_threshold=histoMax_C3d_seeding_params.threshold_histo_multicluster,
+            seeds_norm_by_area=histoMax_C3d_seeding_params.seeds_norm_by_area,
             shape_threshold=histoMaxVariableDR_C3d_params.shape_threshold,
             shape_distance=histoMaxVariableDR_C3d_params.shape_distance,
             ):
         self.clustering_parameters= histoMax_C3d_clustering_params.clone(
                 dR_multicluster_byLayer_coefficientA = distances
                 )
-        self.seeding_parameters = histoMax_C3d_seeding_params.clone()
+        self.seeding_parameters = histoMax_C3d_seeding_params.clone(
+                seeds_norm_by_area=seeds_norm_by_area
+                )
         set_histomax_seeding_params(self.seeding_parameters, nBins_X1, nBins_X2, binSumsHisto, seed_threshold)
         set_histomax_clustering_params(self.clustering_parameters, 0, shape_threshold, shape_distance)
 


### PR DESCRIPTION
**This PR depends on external cms-data/L1Trigger-L1THGCal#24**

#### PR description:
- Add possibility to split/share module energies between towers
  - Study presented in HGCAL TPG meeting [here](https://indico.cern.ch/event/1060474/#sc-8-4-stage-1-module-splittin) 
- Improve normalization used in seeding 
  - Study with jets presented [here](https://indico.cern.ch/event/1055905/#5-updates-on-cluster-seeding-s)
  - Study with e/g presented [here](https://indico.cern.ch/event/1075714/#3-study-of-seeding-normalizati)
- Fixes in Module and Backend DetIds

Associated internal PRs and reviews:
- PFCal-dev#468
- PFCal-dev#495
- PFCal-dev#501
- PFCal-dev#472
- hgc-tpg#8
- hgc-tpg#9

#### PR validation:
Tested D86, D92, D94 workflows
```
runTheMatrix.py -w upgrade -l 20034.0 --maxSteps=2 & # D86
runTheMatrix.py -w upgrade -l 22434.0 --maxSteps=2 & # D92
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 & # D94
```
