### PR TITLE
Preserve electron mass after FastSim Bremsstrahlung emmision

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
@@ -137,7 +137,7 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
   // Needed to rotate photons to the lab frame
   double theta = particle.momentum().Theta();
   double phi = particle.momentum().Phi();
-  double m2dontchange = particle.momentum().mass()*particle.momentum().mass();
+  double m2dontchange = particle.momentum().mass() * particle.momentum().mass();
 
   // Calculate energy of these photons and add them to the event
   for (unsigned int i = 0; i < nPhotons; ++i) {
@@ -156,7 +156,10 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
 
     // Update the original e+/-
     particle.momentum() -= photonMom;
-    particle.momentum().SetXYZT(particle.momentum().px(),particle.momentum().py(),particle.momentum().pz(),sqrt(pow(particle.momentum().P(),2)+m2dontchange));
+    particle.momentum().SetXYZT(particle.momentum().px(),
+                                particle.momentum().py(),
+                                particle.momentum().pz(),
+                                sqrt(pow(particle.momentum().P(), 2) + m2dontchange));
   }
 }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
@@ -137,6 +137,7 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
   // Needed to rotate photons to the lab frame
   double theta = particle.momentum().Theta();
   double phi = particle.momentum().Phi();
+  double m2dontchange = particle.momentum().mass()*particle.momentum().mass();
 
   // Calculate energy of these photons and add them to the event
   for (unsigned int i = 0; i < nPhotons; ++i) {
@@ -155,6 +156,7 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
 
     // Update the original e+/-
     particle.momentum() -= photonMom;
+    particle.momentum().SetXYZT(particle.momentum().px(),particle.momentum().py(),particle.momentum().pz(),sqrt(pow(particle.momentum().P(),2)+m2dontchange));
   }
 }
 


### PR DESCRIPTION
Tracked down a cause of the seg fault reported here https://github.com/cms-sw/cmssw/issues/24051, found that FastSim bremsstrahlung emissions were being treated like decays (e->e+gamma), where the 4-vector of the photon is subtracted from the electron, but this causes the electron mass to go to zero approximately once in 10k events. Fixed code to preserve electron mass to prevent it from going to 0. CMS is not really sensitive to the electron mass, so the change to physics should be negligible. This should be percolated through the various active releases.