### PR TITLE
MTD reconstruction and validation: validation and debugging information for track - MTD matching studies

### DIFF
--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
@@ -19,6 +19,9 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
 class MTDTrackingRecHitProducer : public edm::global::EDProducer<> {
 public:
   explicit MTDTrackingRecHitProducer(const edm::ParameterSet& ps);
@@ -92,6 +95,16 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
       MTDTrackingDetSetVector::FastFiller recHitsOnDet(theoutputhits, detid);
 
       LogDebug("MTDTrackingRecHitProducer") << "MTD cluster DetId " << detid << " # cluster " << DSVit.size();
+#ifdef EDM_ML_DEBUG
+      const auto& Hit = MTDDetId(detid);
+      if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 1)) {
+        const auto& btlHit = BTLDetId(detid);
+        LogDebug("MTDTrackingRecHitProducer") << btlHit;
+      } else if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
+        const auto& etlHit = ETLDetId(detid);
+        LogDebug("MTDTrackingRecHitProducer") << etlHit;
+      }
+#endif
 
       for (const auto& clustIt : DSVit) {
         LogDebug("MTDTrackingRecHitProducer") << "Cluster: size " << clustIt.size() << " " << clustIt.x() << ","

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -725,6 +725,9 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     const Trajectory& trajs = *trjtrk.key;
     const reco::TrackRef& track = trjtrk.val;
 
+    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: extrapolating track " << itrack
+                                     << " p/pT = " << track->p() << " " << track->pt() << " eta = " << track->eta();
+
     float trackVtxTime = 0.f;
     if (useVertex_) {
       float dz;
@@ -806,8 +809,8 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
     for (const auto& trj : trajwithmtd) {
       const auto& thetrj = (updateTraj_ ? trj : trajs);
       float pathLength = 0.f, tmtd = 0.f, sigmatmtd = -1.f, tofpi = 0.f, tofk = 0.f, tofp = 0.f;
-      LogTrace("TrackExtenderWithMTD") << "Refit track " << itrack << " p/pT = " << track->p() << " " << track->pt()
-                                       << " eta = " << track->eta();
+      LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: refit track " << itrack << " p/pT = " << track->p()
+                                       << " " << track->pt() << " eta = " << track->eta();
       reco::Track result = buildTrack(track,
                                       thetrj,
                                       trj,
@@ -860,9 +863,9 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         }
         npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
-        LogTrace("TrackExtenderWithMTD") << "tmtd " << tmtdMap << " +/- " << sigmatmtdMap << " t0 " << t0Map << " +/- "
-                                         << sigmat0Map << " tof pi/K/p " << tofpiMap << " " << tofkMap << " "
-                                         << tofpMap;
+        LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap
+                                         << " t0 " << t0Map << " +/- " << sigmat0Map << " tof pi/K/p " << tofpiMap
+                                         << " " << tofkMap << " " << tofpMap;
       } else {
         LogTrace("TrackExtenderWithMTD") << "Error in the MTD track refitting. This should not happen";
       }
@@ -935,15 +938,22 @@ namespace {
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, *prop, *estimator);
     if (comp.first) {
       const vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, *prop, *estimator);
+      LogTrace("TrackExtenderWithMTD") << "Hit search: Compatible dets " << compDets.size();
       if (!compDets.empty()) {
         for (const auto& detWithState : compDets) {
           auto range = hits.equal_range(detWithState.first->geographicalId(), cmp_for_detset);
-          if (range.first == range.second)
+          if (range.first == range.second) {
+            LogTrace("TrackExtenderWithMTD")
+                << "Hit search: no hit in DetId " << detWithState.first->geographicalId().rawId();
             continue;
+          }
 
           auto pl = prop->propagateWithPath(tsos, detWithState.second.surface());
-          if (pl.second == 0.)
+          if (pl.second == 0.) {
+            LogTrace("TrackExtenderWithMTD")
+                << "Hit search: no propagation to DetId " << detWithState.first->geographicalId().rawId();
             continue;
+          }
 
           const float t_vtx = useVtxConstraint ? vtxTime : 0.f;
 
@@ -955,16 +965,23 @@ namespace {
           for (auto detitr = range.first; detitr != range.second; ++detitr) {
             for (const auto& hit : *detitr) {
               auto est = estimator->estimate(detWithState.second, hit);
-              if (!est.first)
+              if (!est.first) {
+                LogTrace("TrackExtenderWithMTD")
+                    << "Hit search: no compatible estimate in DetId " << detWithState.first->geographicalId().rawId()
+                    << " for hit at pos (" << std::fixed << std::setw(14) << hit.globalPosition().x() << ","
+                    << std::fixed << std::setw(14) << hit.globalPosition().y() << "," << std::fixed << std::setw(14)
+                    << hit.globalPosition().z() << ")";
                 continue;
+              }
 
               LogTrace("TrackExtenderWithMTD")
-                  << "Spatial compatibility DetId " << detWithState.first->geographicalId().rawId() << " TSOS dx/dy "
-                  << std::fixed << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().xx())
-                  << " " << std::fixed << std::setw(14)
-                  << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy " << std::fixed
-                  << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed << std::setw(14)
-                  << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed << std::setw(14) << est.second;
+                  << "Hit search: spatial compatibility DetId " << detWithState.first->geographicalId().rawId()
+                  << " TSOS dx/dy " << std::fixed << std::setw(14)
+                  << std::sqrt(detWithState.second.localError().positionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(detWithState.second.localError().positionError().yy()) << " hit dx/dy "
+                  << std::fixed << std::setw(14) << std::sqrt(hit.localPositionError().xx()) << " " << std::fixed
+                  << std::setw(14) << std::sqrt(hit.localPositionError().yy()) << " chi2 " << std::fixed
+                  << std::setw(14) << est.second;
 
               TrackTofPidInfo tof = computeTrackTofPidInfo(lastpmag2,
                                                            std::abs(pl.second),
@@ -1098,6 +1115,8 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
   if (!hitsInLayer.empty()) {
     //check hits to pass minimum quality matching requirements
     auto const& firstHit = *hitsInLayer.begin();
+    LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: estChi2= " << firstHit.estChi2
+                                     << " timeChi2= " << firstHit.timeChi2;
     if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
       hitMatched = true;
       output.push_back(hitbuilder_->build(firstHit.hit));
@@ -1112,6 +1131,8 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
     find_hits(0, false);
     if (!hitsInLayer.empty()) {
       auto const& firstHit = *hitsInLayer.begin();
+      LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: estChi2= " << firstHit.estChi2
+                                       << " timeChi2= " << firstHit.timeChi2;
       if (firstHit.timeChi2 < timeChi2Cut) {
         if (firstHit.estChi2 < spaceChi2Cut) {
           hitMatched = true;
@@ -1240,10 +1261,11 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
             thiterror = 1.f / (err1 + err2);
             thit = (tofInfo.dt * err1 + mtdhit2->time() * err2) * thiterror;
             thiterror = std::sqrt(thiterror);
-            LogDebug("TrackExtenderWithMTD") << "p trk = " << p.mag() << " ETL hits times/errors: " << mtdhit1->time()
-                                             << " +/- " << mtdhit1->timeError() << " , " << mtdhit2->time() << " +/- "
-                                             << mtdhit2->timeError() << " extrapolated time1: " << tofInfo.dt << " +/- "
-                                             << tofInfo.dterror << " average = " << thit << " +/- " << thiterror;
+            LogDebug("TrackExtenderWithMTD")
+                << "TrackExtenderWithMTD: p trk = " << p.mag() << " ETL hits times/errors: " << mtdhit1->time()
+                << " +/- " << mtdhit1->timeError() << " , " << mtdhit2->time() << " +/- " << mtdhit2->timeError()
+                << " extrapolated time1: " << tofInfo.dt << " +/- " << tofInfo.dterror << " average = " << thit
+                << " +/- " << thiterror;
             validmtd = true;
           }
         }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -122,6 +122,7 @@ private:
 
   MonitorElement* meTPullvsE_;
   MonitorElement* meTPullvsEta_;
+  MonitorElement* meUnmatchedRecHit_;
 
   MonitorElement* meNclusters_;
 
@@ -289,6 +290,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   // --- Loop over the BTL RECO hits
   unsigned int n_reco_btl = 0;
+  unsigned int n_reco_btl_nosimhit = 0;
   for (const auto& recHit : *btlRecHitsHandle) {
     BTLDetId detId = recHit.id();
     DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
@@ -330,6 +332,8 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitTvsZ_->Fill(global_point.z(), recHit.time());
 
     // Resolution histograms
+    LogDebug("BtlLocalRecoValidation") << "RecoHit DetId= " << detId.rawId()
+                                       << " sim hits in id= " << m_btlSimHits.count(detId.rawId());
     if (m_btlSimHits.count(detId.rawId()) == 1 && m_btlSimHits[detId.rawId()].energy > hitMinEnergy_) {
       float longpos_res = recHit.position() - convertMmToCm(m_btlSimHits[detId.rawId()].x);
       float time_res = recHit.time() - m_btlSimHits[detId.rawId()].time;
@@ -353,14 +357,25 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       meTPullvsEta_->Fill(std::abs(global_point_sim.eta()), time_res / recHit.timeError());
       meTPullvsE_->Fill(m_btlSimHits[detId.rawId()].energy, time_res / recHit.timeError());
+    } else if (m_btlSimHits.count(detId.rawId()) == 0) {
+      n_reco_btl_nosimhit++;
+      edm::LogWarning("BtlLocalRecoValidation")
+          << "BTL rec hit with no corresponding sim hit in crystal, DetId= " << detId.rawId()
+          << " geoId= " << geoId.rawId() << " ene= " << recHit.energy() << " time= " << recHit.time();
     }
 
     n_reco_btl++;
 
   }  // recHit loop
 
-  if (n_reco_btl > 0)
-    meNhits_->Fill(log10(n_reco_btl));
+  if (n_reco_btl > 0) {
+    meNhits_->Fill(std::log10(n_reco_btl));
+  }
+  if (n_reco_btl_nosimhit == 0) {
+    meUnmatchedRecHit_->Fill(-1.5);
+  } else {
+    meUnmatchedRecHit_->Fill(std::log10(n_reco_btl_nosimhit));
+  }
 
   // --- Loop over the BTL RECO clusters ---
   unsigned int n_clus_btl(0);
@@ -749,6 +764,9 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     -5.,
                                     5.,
                                     "S");
+
+  meUnmatchedRecHit_ = ibook.book1D(
+      "UnmatchedRecHit", "log10(#BTL crystals with rechits but no simhit);log10(#BTL rechits)", 80, -2., 6.);
 
   meNclusters_ = ibook.book1D("BtlNclusters", "Number of BTL RECO clusters;log_{10}(N_{RECO})", 100, 0., 5.25);
   meCluTime_ = ibook.book1D("BtlCluTime", "BTL cluster time ToA;ToA [ns]", 250, 0, 25);

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -56,6 +56,8 @@ private:
   MonitorElement* meExtraEtaEff_;
   MonitorElement* meExtraEtaEtl2Eff_;
   MonitorElement* meExtraPhiAtBTLEff_;
+  MonitorElement* meExtraBTLfailExtenderEtaEff_;
+  MonitorElement* meExtraBTLfailExtenderPtEff_;
 };
 
 // ------------ constructor and destructor --------------
@@ -144,6 +146,8 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meExtraPhiAtBTL = igetter.get(folder_ + "ExtraPhiAtBTL");
   MonitorElement* meExtraPhiAtBTLmatched = igetter.get(folder_ + "ExtraPhiAtBTLmatched");
   MonitorElement* meExtraBTLeneInCone = igetter.get(folder_ + "ExtraBTLeneInCone");
+  MonitorElement* meExtraBTLfailExtenderEta = igetter.get(folder_ + "ExtraBTLfailExtenderEta");
+  MonitorElement* meExtraBTLfailExtenderPt = igetter.get(folder_ + "ExtraBTLfailExtenderPt");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
@@ -487,7 +491,8 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
   }
 
-  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone) {
+  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone && meExtraBTLfailExtenderEta &&
+      meExtraBTLfailExtenderPt) {
     meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
                                        "Efficiency to match hits at BTL surface",
                                        meExtraPhiAtBTL->getNbinsX(),
@@ -497,6 +502,24 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     computeEfficiency1D(meExtraPhiAtBTLmatched, meExtraPhiAtBTL, meExtraPhiAtBTLEff_);
 
     normalize(meExtraBTLeneInCone, 1.);
+
+    meExtraBTLfailExtenderEtaEff_ =
+        ibook.book1D("ExtraBTLfailExtenderEtaEff",
+                     "Track extrapolated at BTL surface no extender efficiency VS Eta;Eta;Efficiency",
+                     meTrackMatchedTPEffEtaTot->getNbinsX(),
+                     meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                     meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraBTLfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraBTLfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraBTLfailExtenderEtaEff_);
+
+    meExtraBTLfailExtenderPtEff_ =
+        ibook.book1D("ExtraBTLfailExtenderPtEff",
+                     "Track extrapolated at BTL surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
+                     meTrackMatchedTPEffPtTot->getNbinsX(),
+                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
+    meExtraBTLfailExtenderPtEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraBTLfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraBTLfailExtenderPtEff_);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -226,6 +226,8 @@ private:
   MonitorElement* meExtraPhiAtBTL_;
   MonitorElement* meExtraPhiAtBTLmatched_;
   MonitorElement* meExtraBTLeneInCone_;
+  MonitorElement* meExtraBTLfailExtenderEta_;
+  MonitorElement* meExtraBTLfailExtenderPt_;
 };
 
 // ------------ constructor and destructor --------------
@@ -442,9 +444,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
         meTrackNumHits_->Fill(numMTDBtlvalidhits);
-        if (isBTL && Sigmat0Safe[trackref] < 0.) {
-          meTrackNumHitsNT_->Fill(numMTDBtlvalidhits);
-        }
 
         // --- keeping only tracks with last hit in MTD ---
         if (MTDBtl == true) {
@@ -454,6 +453,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           meBTLTrackEffPtMtd_->Fill(track.pt());
           meBTLTrackRPTime_->Fill(track.t0());
           meBTLTrackPtRes_->Fill((trackGen.pt() - track.pt()) / trackGen.pt());
+        }
+        if (isBTL && Sigmat0Safe[trackref] < 0.) {
+          meTrackNumHitsNT_->Fill(numMTDBtlvalidhits);
         }
       }  //loop over (geometrical) BTL tracks
 
@@ -606,6 +608,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meExtraEtaMtd_->Fill(std::abs(trackGen.eta()));
             if (nlayers == 2) {
               meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
+            }
+            if (accept.first && accept.second && !isBTL) {
+              meExtraBTLfailExtenderEta_->Fill(std::abs(trackGen.eta()));
+              if (noCrack) {
+                meExtraBTLfailExtenderPt_->Fill(trackGen.pt());
+              }
             }
           }
         }
@@ -986,6 +994,19 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                      180.);
     meExtraBTLeneInCone_ = ibook.book1D(
         "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
+    meExtraBTLfailExtenderEta_ =
+        ibook.book1D("ExtraBTLfailExtenderEta",
+                     "Eta of tracks extrapolated to BTL with no track extender match to hits; track eta",
+                     66,
+                     0.,
+                     3.3);
+    ;
+    meExtraBTLfailExtenderPt_ =
+        ibook.book1D("ExtraBTLfailExtenderPt",
+                     "Pt of tracks extrapolated to BTL with no track extender match to hits; track pt [GeV] ",
+                     110,
+                     0.,
+                     11.);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -610,6 +610,9 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
             }
             if (accept.first && accept.second && !isBTL) {
+              edm::LogWarning("MtdTracksValidation")
+                  << "MtdTracksValidation: extender fail in " << iEvent.id().run() << " " << iEvent.id().event()
+                  << " pt= " << trackGen.pt() << " eta= " << trackGen.eta();
               meExtraBTLfailExtenderEta_->Fill(std::abs(trackGen.eta()));
               if (noCrack) {
                 meExtraBTLfailExtenderPt_->Fill(trackGen.pt());
@@ -708,7 +711,8 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
   auto btlRecHitsHandle = makeValid(iEvent.getHandle(btlRecHitsToken_));
   auto etlRecHitsHandle = makeValid(iEvent.getHandle(etlRecHitsToken_));
 
-  edm::LogVerbatim("MtdTracksValidation") << "New Track, pt= " << track.pt() << " eta= " << track.eta();
+  edm::LogVerbatim("MtdTracksValidation")
+      << "MtdTracksValidation: extrapolating track, pt= " << track.pt() << " eta= " << track.eta();
 
   //try BTL
   bool inBTL = false;
@@ -723,8 +727,8 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       extrho = comp.second.globalPosition().perp();
       exteta = comp.second.globalPosition().eta();
       extphi = comp.second.globalPosition().phi();
-      edm::LogVerbatim("MtdTracksValidation")
-          << "Extrapolation at BTL surface, rho= " << extrho << " eta= " << exteta << " phi= " << extphi;
+      edm::LogVerbatim("MtdTracksValidation") << "MtdTracksValidation: extrapolation at BTL surface, rho= " << extrho
+                                              << " eta= " << exteta << " phi= " << extphi;
     }
     std::vector<DetLayer::DetWithState> compDets = ilay->compatibleDets(tsos, prop, *theEstimator);
     for (const auto& detWithState : compDets) {
@@ -733,9 +737,9 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       // loop on compatible rechits and check energy in a fixed size cone around the extrapolation point
 
       edm::LogVerbatim("MtdTracksValidation")
-          << "DetId= " << det->geographicalId().rawId() << " gp= " << detWithState.second.globalPosition().x() << " "
-          << detWithState.second.globalPosition().y() << " " << detWithState.second.globalPosition().z()
-          << " rho= " << detWithState.second.globalPosition().perp()
+          << "MtdTracksValidation: DetId= " << det->geographicalId().rawId()
+          << " gp= " << detWithState.second.globalPosition().x() << " " << detWithState.second.globalPosition().y()
+          << " " << detWithState.second.globalPosition().z() << " rho= " << detWithState.second.globalPosition().perp()
           << " eta= " << detWithState.second.globalPosition().eta()
           << " phi= " << detWithState.second.globalPosition().phi();
 
@@ -754,7 +758,7 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
           local_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
           const auto& global_point = thedet->toGlobal(local_point);
           edm::LogVerbatim("MtdTracksValidation")
-              << "Hit id= " << detId.rawId() << " ene= " << recHit.energy()
+              << "MtdTracksValidation: Hit id= " << detId.rawId() << " ene= " << recHit.energy()
               << " dr= " << reco::deltaR(global_point, detWithState.second.globalPosition());
           if (reco::deltaR(global_point, detWithState.second.globalPosition()) < cluDRradius_) {
             eneSum += recHit.energy();
@@ -769,7 +773,8 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       nlayers++;
       selvar = eneSum;
       isMatched = true;
-      edm::LogVerbatim("MtdTracksValidation") << "BTL matched, energy= " << eneSum << " #layers= " << nlayers;
+      edm::LogVerbatim("MtdTracksValidation")
+          << "MtdTracksValidation: BTL matched, energy= " << eneSum << " #layers= " << nlayers;
     }
   }
   if (inBTL) {
@@ -794,8 +799,8 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       exteta = comp.second.globalPosition().eta();
       extphi = comp.second.globalPosition().phi();
     }
-    edm::LogVerbatim("MtdTracksValidation")
-        << "Extrapolation at ETL surface, rho= " << extrho << " eta= " << exteta << " phi= " << extphi;
+    edm::LogVerbatim("MtdTracksValidation") << "MtdTracksValidation: extrapolation at ETL surface, rho= " << extrho
+                                            << " eta= " << exteta << " phi= " << extphi;
     std::vector<DetLayer::DetWithState> compDets = ilay->compatibleDets(tsos, prop, *theEstimator);
     for (const auto& detWithState : compDets) {
       const auto& det = detWithState.first;
@@ -803,9 +808,9 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       // loop on compatible rechits and check hits in a fixed size cone around the extrapolation point
 
       edm::LogVerbatim("MtdTracksValidation")
-          << "DetId= " << det->geographicalId().rawId() << " gp= " << detWithState.second.globalPosition().x() << " "
-          << detWithState.second.globalPosition().y() << " " << detWithState.second.globalPosition().z()
-          << " rho= " << detWithState.second.globalPosition().perp()
+          << "MtdTracksValidation: DetId= " << det->geographicalId().rawId()
+          << " gp= " << detWithState.second.globalPosition().x() << " " << detWithState.second.globalPosition().y()
+          << " " << detWithState.second.globalPosition().z() << " rho= " << detWithState.second.globalPosition().perp()
           << " eta= " << detWithState.second.globalPosition().eta()
           << " phi= " << detWithState.second.globalPosition().phi();
 
@@ -823,7 +828,7 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
           Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
           const auto& global_point = thedet->toGlobal(local_point);
           edm::LogVerbatim("MtdTracksValidation")
-              << "Hit id= " << detId.rawId() << " time= " << recHit.time()
+              << "MtdTracksValidation: Hit id= " << detId.rawId() << " time= " << recHit.time()
               << " dr= " << reco::deltaR(global_point, detWithState.second.globalPosition());
           if (reco::deltaR(global_point, detWithState.second.globalPosition()) < cluDRradius_) {
             hcount++;
@@ -840,14 +845,16 @@ const std::pair<bool, bool> MtdTracksValidation::checkAcceptance(const reco::Tra
       nlayers++;
       selvar = (float)hcount;
       isMatched = true;
-      edm::LogVerbatim("MtdTracksValidation") << "ETL matched, counts= " << hcount << " #layers= " << nlayers;
+      edm::LogVerbatim("MtdTracksValidation")
+          << "MtdTracksValidation: ETL matched, counts= " << hcount << " #layers= " << nlayers;
     }
   }
 
   if (!inBTL && !inETL) {
     edm::LogVerbatim("MtdTracksValidation")
-        << "Track not extrapolating to MTD: pt= " << track.pt() << " eta= " << track.eta() << " phi= " << track.phi()
-        << " vz= " << track.vz() << " vxy= " << std::sqrt(track.vx() * track.vx() + track.vy() * track.vy());
+        << "MtdTracksValidation: track not extrapolating to MTD: pt= " << track.pt() << " eta= " << track.eta()
+        << " phi= " << track.phi() << " vz= " << track.vz()
+        << " vxy= " << std::sqrt(track.vx() * track.vx() + track.vy() * track.vy());
   }
   return std::make_pair(inETL, isMatched);
 }

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -610,7 +610,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
             }
             if (accept.first && accept.second && !isBTL) {
-              edm::LogWarning("MtdTracksValidation")
+              edm::LogInfo("MtdTracksValidation")
                   << "MtdTracksValidation: extender fail in " << iEvent.id().run() << " " << iEvent.id().event()
                   << " pt= " << trackGen.pt() << " eta= " << trackGen.eta();
               meExtraBTLfailExtenderEta_->Fill(std::abs(trackGen.eta()));


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #42178 , it adds a few histograms to MTD validation and improves several debugging printouts, to analyse in detail events where the ```TrackExtenderWithMTD``` fails to find MTD hits, that are found in a cone around a simple track extrapolation to BTL surface.

#### PR validation:

Code compiles, runs, and provide detailed debugging printout being actively use for investigation. A few added prolts are shown in https://indico.cern.ch/event/1306288/contributions/5493532/attachments/2683819/4656070/MTDDPG-BTLmatching_20230714.pdf slide 13.