### PR TITLE
(DAQ) Fix early too file deletion for error stream 13_2_X

### DIFF
--- a/EventFilter/Utilities/interface/DAQSource.h
+++ b/EventFilter/Utilities/interface/DAQSource.h
@@ -159,7 +159,6 @@ private:
   std::list<std::pair<int, std::unique_ptr<InputFile>>> filesToDelete_;
   std::mutex fileDeleteLock_;
   std::vector<int> streamFileTracker_;
-  unsigned int nStreams_ = 0;
   unsigned int checkEvery_ = 10;
 
   //supervisor thread wakeup

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -168,7 +168,6 @@ private:
   std::list<std::pair<int, std::string>> fileNamesToDelete_;
   std::mutex fileDeleteLock_;
   std::vector<int> streamFileTracker_;
-  unsigned int nStreams_ = 0;
   unsigned int checkEvery_ = 10;
 
   //supervisor thread wakeup

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -556,7 +556,7 @@ void DAQSource::read(edm::EventPrincipal& eventPrincipal) {
     auto it = filesToDelete_.begin();
     while (it != filesToDelete_.end()) {
       bool fileIsBeingProcessed = false;
-      for (unsigned int i = 0; i < nStreams_; i++) {
+      for (unsigned int i = 0; i < streamFileTracker_.size(); i++) {
         if (it->first == streamFileTracker_.at(i)) {
           fileIsBeingProcessed = true;
           break;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -685,7 +685,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
     auto it = filesToDelete_.begin();
     while (it != filesToDelete_.end()) {
       bool fileIsBeingProcessed = false;
-      for (unsigned int i = 0; i < nStreams_; i++) {
+      for (unsigned int i = 0; i < streamFileTracker_.size(); i++) {
         if (it->first == streamFileTracker_.at(i)) {
           fileIsBeingProcessed = true;
           break;


### PR DESCRIPTION
#### PR description:

Use correct vector to loop over tracking of files opened for each stream.
Fixed for FedRawDataInputSource and DAQSource

#### PR validation:

Fixed and tested in DAQ test setup.