### PR TITLE
Replace calls to getManyByType with exception

### DIFF
--- a/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
+++ b/Alignment/LaserAlignmentSimulation/test/SimAnalyzer.cc
@@ -17,6 +17,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -334,7 +335,12 @@ void SimAnalyzer::trackerStatistics(edm::Event const &theEvent, edm::EventSetup 
 
   // get the SimHitContainers
   std::vector<edm::Handle<edm::PSimHitContainer>> theSimHitContainers;
-  theEvent.getManyByType(theSimHitContainers);
+
+  //theEvent.getManyByType(theSimHitContainers);
+  throw cms::Exception("UnsupportedFunction") << "SimAnalyzer::trackerStatistics: "
+                                              << "getManyByType has not been supported by the Framework since 2015. "
+                                              << "This module has been broken since then. Maybe it should be deleted. "
+                                              << "Another possibility is to upgrade to use GetterOfProducts instead.";
 
   LogDebug("SimAnalyzer") << " Geometry node for TrackingGeometry is  " << theTracker << "\n I have "
                           << theTracker->dets().size() << " detectors "

--- a/IORawData/CaloPatterns/src/HtrXmlPattern.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPattern.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 
 class HtrXmlPattern : public edm::one::EDAnalyzer<> {
@@ -95,7 +96,12 @@ void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   std::vector<edm::Handle<HcalTrigPrimDigiCollection> > htp;
   std::vector<edm::Handle<HcalHistogramDigiCollection> > hh;
 
-  iEvent.getManyByType(hbhe);
+  //iEvent.getManyByType(hbhe);
+  throw cms::Exception("UnsupportedFunction") << "HtrXmlPattern::analyze: "
+                                              << "getManyByType has not been supported by the Framework since 2015. "
+                                              << "This module has been broken since then. Maybe it should be deleted. "
+                                              << "Another possibility is to upgrade to use GetterOfProducts instead.";
+
   if (hbhe.empty()) {
     edm::LogPrint("HtrXmlPattern") << "No HB/HE Digis.";
   } else {
@@ -119,7 +125,12 @@ void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     }
   }
 
-  iEvent.getManyByType(hf);
+  //iEvent.getManyByType(hf);
+  throw cms::Exception("UnsupportedFunction") << "HtrXmlPattern::analyze: "
+                                              << "getManyByType has not been supported by the Framework since 2015. "
+                                              << "This module has been broken since then. Maybe it should be deleted. "
+                                              << "Another possibility is to upgrade to use GetterOfProducts instead.";
+
   if (hf.empty()) {
     edm::LogPrint("HtrXmlPattern") << "No HF Digis.";
   } else {
@@ -143,7 +154,12 @@ void HtrXmlPattern::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     }
   }
 
-  iEvent.getManyByType(ho);
+  //iEvent.getManyByType(ho);
+  throw cms::Exception("UnsupportedFunction") << "HtrXmlPattern::analyze: "
+                                              << "getManyByType has not been supported by the Framework since 2015. "
+                                              << "This module has been broken since then. Maybe it should be deleted. "
+                                              << "Another possibility is to upgrade to use GetterOfProducts instead.";
+
   if (ho.empty()) {
     edm::LogPrint("HtrXmlPattern") << "No HO Digis.";
   } else {


### PR DESCRIPTION
#### PR description:

Replace calls to getManyByType with an immediate exception.

We are trying to make it possible to delete getManyByType from the Framework without breaking compilation.

The Framework has been throwing an exception when getManyByType is called without a call to consumesMany since 2015. We've just finished a large migration where all code calling both consumesMany and getManyByType was replaced by GetterOfProducts or was removed in some other way. The function consumesMany has been deleted entirely from the Framework. The only uses of getManyByType that are left are the ones where consumeMany was not called. All these have been broken since 2015. The Framework will throw an exception if these calls to getManyByType are executed. This change moves the exception throw from the Framework directly to the module at the location of the getManyByType call.

There are two alternatives I can think of:

1. These modules have been broken since 2015. I could delete the files completely instead.

2. If we really need these modules, we could upgrade them to use GetterOfProducts. This seems unlikely, because they have been broken for so many years already (I don't want to create new tests, but if provided an otherwise working test I'll run it).

If you want me to implement one of the alternatives, ask and I will do that instead.

#### PR validation:

Nothing uses this code and it is already broken. There is nothing to test.
