### PR TITLE
Fix EmissionVetoHook for BB4L

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
@@ -442,7 +442,7 @@ bool EmissionVetoHook1::doVetoFSREmission(int, const Pythia8::Event &e, int iSys
     return false;
 
   // only use for outside resonance vetos in combination with bb4l:FSREmission:veto
-  if (!inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto") == 1)
+  if (inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto") == 1)
     return false;
 
   // If we already have accepted 'vetoCount' emissions in a row, do nothing


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the Pythia showering hook specific to the bb4l generator, described in #40459.
bb4l generates up to three real emissions at the LHE level - one from the initial state, and one each from two possible top quarks. This requires a special shower hook to handle, implemented in CMSSW in PowhegHooksBB4L.h. The showering is set up in such a way that emissions that are outside a resonance, i.e. do not come from top quarks, are handled by the normal EmissionVetoHook1.cc hook, while PowhegHooksBB4L.h handles emissions that are inside a resonance.

Looking at the single changed line, it can be clearly seen that the condition in the code needs to be changed for this to happen correctly - if the emission is in resonance, the EmissionVetoHook should not consider it (i.e. return false to not proceed to the actual vetoing), and leave it up to PowhegHooksBB4L.

Due to the second part of the if condition, it is clear that only bb4l is affected.

#### PR validation:

I tested this change against a standalone pythia setup that uses a hook provided by the bb4l authors. Changes are only minimal, and only in variables that are very sensitive to FSR. There is a small change due to the fix in the number of jets, seen [here](https://www.desy.de/~lauridsj/bb4l_evhook/CMS_2018_I1703993_d187-x01-y01.pdf) as well as angular variables between jets, e.g. dR of the first two light jets [here](https://www.desy.de/~lauridsj/bb4l_evhook/MC_TTBAR_twolep_jetl_1_jetl_2_dR.pdf). In both cases the fixed version agrees with the standalone setup. Lepton observables seem unaffected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will need to be backported to CMSSW 10 for UL event generation and, eventually, to CMSSW 12 for Run 3 event generation.
