### PR TITLE
[13.1.X] add DQM and Validation modules for doublet recovery tracks

### DIFF
--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
@@ -29,7 +29,7 @@ trackingForElectronsMonitorClientHLT = cms.Sequence(
 )
 
 def _modifyForRun3Default(efffromhitpattern):
-    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*"]
+    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*", "HLT/Tracking/doubletRecoveryTracks/HitEffFromHitPattern*"] #, "HLT/Tracking/iter0HP/HitEffFromHitPattern*"
 
 def _modifyForRun3EGM(efffromhitpattern):
     efffromhitpattern.subDirs = ["HLT/EGM/Tracking/GSF/HitEffFromHitPattern*"]

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -22,5 +22,5 @@ egmTrackingMonitorHLTsequence = cms.Sequence(
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(trackingMonitoringHLTsequence, cms.Sequence(pixelTracksMonitoringHLT * iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(trackingMonitoringHLTsequence, cms.Sequence(pixelTracksMonitoringHLT * iterHLTTracksMonitoringHLT * doubletRecoveryHPTracksMonitoringHLT)) # * iter0HPTracksMonitoringHLT ))
 run3_common.toReplaceWith(egmTrackingMonitorHLTsequence, cms.Sequence(gsfTracksMonitoringHLT))

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -64,7 +64,7 @@ trackEfficiencyMonitoringClientHLT = cms.Sequence(
 )
 
 def _modifyForRun3Default(efffromhitpattern):
-    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*"]
+    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*", "HLT/Tracking/doubletRecoveryTracks/HitEffFromHitPattern*"] #, "HLT/Tracking/iter0HP/HitEffFromHitPattern*"
 
 def _modifyForRun3EGM(efffromhitpattern):
     efffromhitpattern.subDirs = ["HLT/EGM/Tracking/GSF/HitEffFromHitPattern*"]

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -127,6 +127,15 @@ trackingMonitorHLTall = cms.Sequence(
 #    + iter4TracksMonitoringHLT
 )    
 
+doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/doubletRecoveryTracks',
+    TrackProducer    = 'hltDoubletRecoveryPFlowTrackSelectionHighPurity',
+    allTrackProducer = 'hltDoubletRecoveryPFlowTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
 ############
 #### EGM tracks
 # GSF: hltEgammaGsfTracks
@@ -203,6 +212,6 @@ trkHLTDQMSourceExtra = cms.Sequence(
 )
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -26,7 +26,7 @@ hltMultiTrackValidation = cms.Sequence(
 )
 
 def _modifyForRun3(trackvalidator):
-    trackvalidator.label = ["hltPixelTracks", "hltMergedTracks"]
+    trackvalidator.label = ["hltPixelTracks", "hltMergedTracks", "hltDoubletRecoveryPFlowTrackSelectionHighPurity"] #, "hltIter0PFlowTrackSelectionHighPurity"]
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42266

#### PR description:

With the inclusion of the `hltDoubletRecoveryPFlowTrackSelectionHighPurity` collection to the track reconstruction at HLT,
there is now the need of monitoring and validating it as well
This PR simply extend the already in place DQM and Validation sequences to include this collection as well
Not having the HLT menu w/ this extra collection in CMSSW, the expected output is to have empty plots, but the code will run

#### PR validation:

Relies on the master version

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

intermediate verbatim backport of https://github.com/cms-sw/cmssw/pull/42266 for 2023 data-taking