### PR TITLE
Revert BeamSpot fallback logic

### DIFF
--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -116,7 +116,7 @@ void OnlineBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker,
   ibooker.setCurrentFolder(monitorName_ + "Validation");
   //Book histograms
   bsChoice_ = ibooker.bookProfile("bsChoice",
-                                  "BS Choice (+1): HLT - (-1): Legacy - (-10): Fake BS - (0): No Transient ",
+                                  "BS Choice: +1=HLT / -1=Legacy / -10=Fake (fallback to PCL) / 0=No Transient ",
                                   lastLumi - firstLumi + 1,
                                   firstLumi - 0.5,
                                   lastLumi + 0.5,

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -103,39 +103,39 @@ void BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   bool fallBackToDB = false;
   if (useTransientRecord_) {
     auto const& spotDB = iSetup.getData(beamTransientToken_);
-
     if (spotDB.beamType() != 2) {
       if (shoutMODE && beamTransientRcdESWatcher_.check(iSetup)) {
-        edm::LogWarning("BeamSpotFromDB") << "Online Beam Spot producer writes a fake beamspot value because the "
-                                             "ESProducer returned a fake beamspot!";
+        edm::LogWarning("BeamSpotFromDB")
+            << "Online Beam Spot producer falls back to DB value because the ESProducer returned a fake beamspot ";
       }
-    }
+      fallBackToDB = true;
+    } else {
+      // translate from BeamSpotObjects to reco::BeamSpot
+      // in case we need to switch to LHC reference frame
+      // ignore for the moment rotations, and translations
+      double f = 1.;
+      if (changeFrame_)
+        f = -1.;
+      reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
 
-    // translate from BeamSpotObjects to reco::BeamSpot
-    // in case we need to switch to LHC reference frame
-    // ignore for the moment rotations, and translations
-    double f = 1.;
-    if (changeFrame_)
-      f = -1.;
-    reco::BeamSpot::Point apoint(f * spotDB.x(), f * spotDB.y(), f * spotDB.z());
-
-    reco::BeamSpot::CovarianceMatrix matrix;
-    for (int i = 0; i < 7; ++i) {
-      for (int j = 0; j < 7; ++j) {
-        matrix(i, j) = spotDB.covariance(i, j);
+      reco::BeamSpot::CovarianceMatrix matrix;
+      for (int i = 0; i < 7; ++i) {
+        for (int j = 0; j < 7; ++j) {
+          matrix(i, j) = spotDB.covariance(i, j);
+        }
       }
-    }
-    double sigmaZ = spotDB.sigmaZ();
-    if (theSetSigmaZ > 0)
-      sigmaZ = theSetSigmaZ;
+      double sigmaZ = spotDB.sigmaZ();
+      if (theSetSigmaZ > 0)
+        sigmaZ = theSetSigmaZ;
 
-    // this assume beam width same in x and y
-    aSpot = reco::BeamSpot(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
-    aSpot.setBeamWidthY(spotDB.beamWidthY());
-    aSpot.setEmittanceX(spotDB.emittanceX());
-    aSpot.setEmittanceY(spotDB.emittanceY());
-    aSpot.setbetaStar(spotDB.betaStar());
-    aSpot.setType(static_cast<reco::BeamSpot::BeamType>(spotDB.beamType()));
+      // this assume beam width same in x and y
+      aSpot = reco::BeamSpot(apoint, sigmaZ, spotDB.dxdz(), spotDB.dydz(), spotDB.beamWidthX(), matrix);
+      aSpot.setBeamWidthY(spotDB.beamWidthY());
+      aSpot.setEmittanceX(spotDB.emittanceX());
+      aSpot.setEmittanceY(spotDB.emittanceY());
+      aSpot.setbetaStar(spotDB.betaStar());
+      aSpot.setType(reco::BeamSpot::Tracker);
+    }
   } else {
     // get scalar collection
     Handle<BeamSpotOnlineCollection> handleScaler;

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -97,22 +97,23 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
   // 3. If both are newer than the limit threshold return the BS that
   //     passes isGoodBS and has larger sigmaZ
   if (diffBStime1 > limitTime && diffBStime2 > limitTime) {
-    edm::LogInfo("OnlineBeamSpotESProducer") << "Defaulting to fake because both payloads are too old.";
+    edm::LogWarning("OnlineBeamSpotESProducer")
+        << "Defaulting to fake (fallback to PCL) because both payloads are too old.";
     return nullptr;
   } else if (diffBStime2 > limitTime) {
     if (isGoodBS(bs1)) {
       return bs1;
     } else {
-      edm::LogInfo("OnlineBeamSpotESProducer")
-          << "Defaulting to fake because the legacy Beam Spot is not suitable and HLT one is too old.";
+      edm::LogWarning("OnlineBeamSpotESProducer") << "Defaulting to fake (fallback to PCL) because the legacy Beam "
+                                                     "Spot is not suitable and HLT one is too old.";
       return nullptr;
     }
   } else if (diffBStime1 > limitTime) {
     if (isGoodBS(bs2)) {
       return bs2;
     } else {
-      edm::LogInfo("OnlineBeamSpotESProducer")
-          << "Defaulting to fake because the HLT Beam Spot is not suitable and the legacy one too old.";
+      edm::LogWarning("OnlineBeamSpotESProducer") << "Defaulting to fake (fallback to PCL) because the HLT Beam Spot "
+                                                     "is not suitable and the legacy one too old.";
       return nullptr;
     }
   } else {
@@ -121,8 +122,8 @@ const BeamSpotOnlineObjects* OnlineBeamSpotESProducer::compareBS(const BeamSpotO
     } else if (bs2->sigmaZ() >= bs1->sigmaZ() && isGoodBS(bs2)) {
       return bs2;
     } else {
-      edm::LogInfo("OnlineBeamSpotESProducer")
-          << "Defaulting to fake because despite both payloads are young enough, none has passed the fit sanity checks";
+      edm::LogWarning("OnlineBeamSpotESProducer") << "Defaulting to fake (fallback to PCL) because despite both "
+                                                     "payloads are young enough, none has passed the fit sanity checks";
       return nullptr;
     }
   }
@@ -161,7 +162,8 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   auto legacyRec = iRecord.tryToGetRecord<BeamSpotOnlineLegacyObjectsRcd>();
   auto hltRec = iRecord.tryToGetRecord<BeamSpotOnlineHLTObjectsRcd>();
   if (not legacyRec and not hltRec) {
-    edm::LogInfo("OnlineBeamSpotESProducer") << "None of the Beam Spots in ES are available! \n returning a fake one.";
+    edm::LogWarning("OnlineBeamSpotESProducer")
+        << "None of the Beam Spots in ES are available! \n returning a fake one (fallback to PCL).";
     return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
   }
 
@@ -177,8 +179,8 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
     return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
   } else {
     return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
-    edm::LogInfo("OnlineBeamSpotESProducer")
-        << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one. ";
+    edm::LogWarning("OnlineBeamSpotESProducer")
+        << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one(fallback to PCL).";
   }
 };
 


### PR DESCRIPTION
#### PR description:
After discussion at the [Tracking POG meeting on 17<sup>th</sup> July 2023](https://indico.cern.ch/event/1302649/#9-updates-on-the-online-beamsp), it was decided to revert the changes of the online BeamSpot fallback logic (used in HLT and Express) introduced in #41597. 
This PR:
 - Reverts commit 4b35c951a64f79cf4ad68b741b15eb7ccc57ce75 so that, when the ESProducer produces a fake BeamSpot, the framework will fallback to the DB, ie. to consuming the last result produced by the PCL
 - Promotes the `LogInfo`(s) in `OnlineBeamSpotESProducer.cc` to `LogWarning`(s) in order to better debug why sometimes HLT picks up the fake BeamSpot (see discussion in #41914)
 - Change in the `bsChoice` plot title to improve clarity

#### PR validation:
Code compiles +  run successfully:
```
cmsRun DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py unitTest=True
```

#### Backport:
Not a backport, but backports to the data-taking releases will be provided soon.

FYI @gennai @dzuolo @lguzzi