### PR TITLE
Add track MVA1 to DQM tools for future studies

### DIFF
--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -63,6 +63,7 @@ public:
   MonitorElement *Track_All_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
   MonitorElement *Track_All_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
   MonitorElement *Track_All_Chi2_Probability = nullptr;  // chi2 probability
+  MonitorElement *Track_All_MVA1 = nullptr;              // MVA1 (prompt quality) distribution
 
   /// High-quality TTTracks; different depending on prompt vs displaced tracks
   // Quality cuts: chi2/dof<10, bendchi2<2.2 (Prompt), default in config
@@ -86,6 +87,7 @@ public:
   MonitorElement *Track_HQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
   MonitorElement *Track_HQ_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
   MonitorElement *Track_HQ_Chi2_Probability = nullptr;  // chi2 probability
+  MonitorElement *Track_HQ_MVA1 = nullptr;              // MVA1 (prompt quality) distribution
 
 private:
   edm::ParameterSet conf_;
@@ -142,6 +144,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
     float track_chi2dof = tempTrackPtr->chi2Red();
     float track_chi2rz = tempTrackPtr->chi2Z();
     float track_chi2rphi = tempTrackPtr->chi2XY();
+    float track_MVA1 = tempTrackPtr->trkMVA1();
     int nLayersMissed = 0;
     unsigned int hitPattern_ = (unsigned int)tempTrackPtr->hitPattern();
 
@@ -194,6 +197,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
       Track_HQ_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
       Track_HQ_Eta_ECStubs->Fill(track_eta, nECStubs);
       Track_HQ_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
+      Track_HQ_MVA1->Fill(track_MVA1);
     }
 
     // All tracks (including HQ tracks)
@@ -216,7 +220,7 @@ void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::Ev
     Track_All_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
     Track_All_Eta_ECStubs->Fill(track_eta, nECStubs);
     Track_All_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
-
+    Track_All_MVA1->Fill(track_MVA1);
   }  // End of loop over TTTracks
 
   Track_HQ_N->Fill(numHQTracks);
@@ -396,6 +400,17 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                                               psTrack_Chi2_Probability.getParameter<double>("xmax"));
   Track_All_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
   Track_All_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
+
+  // MVA1 (prompt quality)
+  edm::ParameterSet psTrack_MVA1 = conf_.getParameter<edm::ParameterSet>("TH1_Track_MVA1");
+  HistoName = "Track_All_MVA1";
+  Track_All_MVA1 = iBooker.book1D(HistoName,
+				  HistoName,
+				  psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+				  psTrack_MVA1.getParameter<double>("xmin"),
+				  psTrack_MVA1.getParameter<double>("xmax"));
+  Track_All_MVA1->setAxisTitle("MVA1", 1);
+  Track_All_MVA1->setAxisTitle("# L1 Tracks", 2);
 
   // Reduced chi2 vs #stubs
   edm::ParameterSet psTrack_Chi2R_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
@@ -604,6 +619,16 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
                                              psTrack_Chi2_Probability.getParameter<double>("xmax"));
   Track_HQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
   Track_HQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
+
+  // MVA1 (prompt quality)
+  HistoName = "Track_HQ_MVA1";
+  Track_HQ_MVA1 = iBooker.book1D(HistoName,
+				 HistoName,
+				 psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+				 psTrack_MVA1.getParameter<double>("xmin"),
+				 psTrack_MVA1.getParameter<double>("xmax"));
+  Track_HQ_MVA1->setAxisTitle("MVA1", 1);
+  Track_HQ_MVA1->setAxisTitle("# L1 Tracks", 2);
 
   // Reduced chi2 vs #stubs
   HistoName = "Track_HQ_Chi2Red_NStubs";

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -405,10 +405,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   edm::ParameterSet psTrack_MVA1 = conf_.getParameter<edm::ParameterSet>("TH1_Track_MVA1");
   HistoName = "Track_All_MVA1";
   Track_All_MVA1 = iBooker.book1D(HistoName,
-				  HistoName,
-				  psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
-				  psTrack_MVA1.getParameter<double>("xmin"),
-				  psTrack_MVA1.getParameter<double>("xmax"));
+                                  HistoName,
+                                  psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_MVA1.getParameter<double>("xmin"),
+                                  psTrack_MVA1.getParameter<double>("xmax"));
   Track_All_MVA1->setAxisTitle("MVA1", 1);
   Track_All_MVA1->setAxisTitle("# L1 Tracks", 2);
 
@@ -623,10 +623,10 @@ void OuterTrackerMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
   // MVA1 (prompt quality)
   HistoName = "Track_HQ_MVA1";
   Track_HQ_MVA1 = iBooker.book1D(HistoName,
-				 HistoName,
-				 psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
-				 psTrack_MVA1.getParameter<double>("xmin"),
-				 psTrack_MVA1.getParameter<double>("xmax"));
+                                 HistoName,
+                                 psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_MVA1.getParameter<double>("xmin"),
+                                 psTrack_MVA1.getParameter<double>("xmax"));
   Track_HQ_MVA1->setAxisTitle("MVA1", 1);
   Track_HQ_MVA1->setAxisTitle("# L1 Tracks", 2);
 

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTTrack_cfi.py
@@ -78,6 +78,13 @@ OuterTrackerMonitorTTTrack = DQMEDAnalyzer('OuterTrackerMonitorTTTrack',
         xmin = cms.double(0)
         ),
 
+#MVA1 (prompt quality) of the track
+    TH1_Track_MVA1 = cms.PSet(
+        Nbinsx = cms.int32(100),
+        xmax = cms.double(1),
+        xmin = cms.double(0)
+        ),
+
 #Chi2R of the track vs Nb of stubs
     TH2_Track_Chi2R_NStubs = cms.PSet(
         Nbinsx = cms.int32(5),


### PR DESCRIPTION
#### PR description:

These changes add the new L1 track quality variable to the DQM tools. This is in anticipation of future DQM studies which can check the track quality (called MVA1) variable among different CMSSW differences.

#### PR validation:

The changes are minimal and does not change how anything in the DQM tools are being run. I have checked that the code additions work as expected by running the DQM tools on a RelVal TTbar sample and checking the histogram outputs. All of the basic tests were run and succeeded as well.
