### PR TITLE
Make RecoLocalCalo/EcalRecProducers compile with C++20

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
@@ -26,8 +26,8 @@
 template <class C>
 class EcalUncalibRecHitTimeWeightsAlgo {
 public:
-  EcalUncalibRecHitTimeWeightsAlgo<C>(){};
-  virtual ~EcalUncalibRecHitTimeWeightsAlgo<C>(){};
+  EcalUncalibRecHitTimeWeightsAlgo(){};
+  virtual ~EcalUncalibRecHitTimeWeightsAlgo(){};
 
   /// Compute time
   double time(const C &dataFrame,


### PR DESCRIPTION
#### PR description:

C++20 made it invalid to use simple-template-ids for constructors and destructors: https://eel.is/c++draft/diff.cpp17.class#2  . GCC 11 and later throw an error on this, with the unhelpful message expected `unqualified-id before ')' token.` This PR fixes the problem.

#### PR validation:

Code compiles
