### PR TITLE
declare the storage type of the L1GtObject to workaround a ROOT problem

### DIFF
--- a/DataFormats/L1GlobalTrigger/interface/L1GtObject.h
+++ b/DataFormats/L1GlobalTrigger/interface/L1GtObject.h
@@ -25,7 +25,7 @@
 
 /// L1 GT objects
 ///    ObjNull catch all errors
-enum L1GtObject {
+enum L1GtObject : unsigned int {
   Mu,
   NoIsoEG,
   IsoEG,


### PR DESCRIPTION
#### PR description:

ROOT has a sometimes issue with enums that don't declare the storage type.  When these are referenced in a DataFormat, ROOT stores the default storage type (unsigned int) in the dictionary (it needs to have some explicit declaration of the size).  When these are referenced from different dictionaries, ROOT can generate a (bogus) type error between its inferred type and the implicitly type enum declaration.  Details in #42234.

#### PR validation:

Compiles, trivial technical fix.  Does not change any storage formats, as it just makes explicit the type that ROOT was already inferring.