### PR TITLE
Clean Up for Pixel Tracks - Follow-up to #41632

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from .MatrixUtil import merge, Kby, Mby
 import re
 
+U2000by1={'--relval': '2000,1'}
+
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
 
 upgradeKeys = {}
@@ -374,7 +376,7 @@ class UpgradeWorkflow_pixelTrackingOnly(UpgradeWorkflowTracking):
         elif 'ALCA' in step: stepDict[stepName][k] = None
         elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'}, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
-        return ('2017' in key or '2018' in key or '2021' in key or '2026' in key or 'HI' in key) and ('FS' not in key)
+        return ('2022' in key or '2023' in key or '2024' in key or '2026' in key or 'HI' in key) and ('FS' not in key)
 upgradeWFs['pixelTrackingOnly'] = UpgradeWorkflow_pixelTrackingOnly(
     steps = [
         'Reco',
@@ -2938,6 +2940,6 @@ upgradeFragments = OrderedDict([
     ('LbToJpsiLambda_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi',UpgradeFragment(Mby(66,660000),'LbToJpsiLambda_DGamma0_13p6TeV')), #0.3%
     ('LbToJpsiXiK0sPi_JMM_Filter_DGamma0_TuneCP5_13p6TeV-pythia8-evtgen_cfi',UpgradeFragment(Mby(50,500000),'LbToJpsiXiK0sPr_DGamma0_13p6TeV')), #0.6%
     ('OmegaMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi',UpgradeFragment(Mby(100,1000000),'OmegaMinus_13p6TeV')), #0.1%
-    ('Hydjet_Quenched_MinBias_5020GeV_cfi', UpgradeFragment(Kby(9,100),'HydjetQMinBias_5020GeV')),
-    ('Hydjet_Quenched_MinBias_5362GeV_cfi', UpgradeFragment(Kby(9,100),'HydjetQMinBias_5362GeV'))
+    ('Hydjet_Quenched_MinBias_5020GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5020GeV')),
+    ('Hydjet_Quenched_MinBias_5362GeV_cfi', UpgradeFragment(U2000by1,'HydjetQMinBias_5362GeV'))
 ])

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -139,17 +139,19 @@ from RecoTracker.PixelTrackFitting.pixelTrackProducerFromSoAHIonPhase1_cfi impor
 from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
 
 hiPixelTracksCUDA = _pixelTracksCUDA.clone(pixelRecHitSrc="siPixelRecHitsPreSplittingCUDA", idealConditions = False,
-        ptmin = 0.25, hardCurvCut = 0.0756, doPtCut = False,
+        ptmin = 0.25, z0Cut = 8.0, hardCurvCut = 0.0756, doPtCut = False,
         onGPU = True,
+        dcaCutInnerTriplet = 0.05, dcaCutOuterTriplet = 0.10,
+        CAThetaCutForward = 0.002, CAThetaCutBarrel = 0.001,
         phiCuts = cms.vint32(19*[900]), #19 pairs
         trackQualityCuts = dict(
           chi2MaxPt = 10,
           chi2Coeff = [0.9,1.8],
-          chi2Scale = 8,
-          tripletMinPt = 0.5,
+          chi2Scale = 1.8,
+          tripletMinPt = 0.1,
           tripletMaxTip = 0.3,
           tripletMaxZip = 12,
-          quadrupletMinPt = 0.3,
+          quadrupletMinPt = 0.1,
           quadrupletMaxTip = 0.5,
           quadrupletMaxZip = 12
         ))

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelPhase2DigiToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelPhase2DigiToClusterCUDA.cc
@@ -94,7 +94,7 @@ void SiPixelPhase2DigiToClusterCUDA::fillDescriptions(edm::ConfigurationDescript
   desc.add<bool>("IncludeErrors", true);
   desc.add<int32_t>("clusterThreshold_layer1", 4000);
   desc.add<int32_t>("clusterThreshold_otherLayers", 4000);
-  desc.add<double>("ElectronPerADCGain", 1500.f);
+  desc.add<double>("ElectronPerADCGain", 1500);
   desc.add<int32_t>("Phase2ReadoutMode", 3);
   desc.add<uint32_t>("Phase2DigiBaseline", 1000);
   desc.add<uint32_t>("Phase2KinkADC", 8);

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -180,8 +180,8 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::Phase1>::fillDescriptions(edm::Pa
 
   desc.add<bool>("idealConditions", true);
   desc.add<bool>("includeJumpingForwardDoublets", false);
-  desc.add<double>("z0Cut", 12.0f);
-  desc.add<double>("ptCut", 0.5f);
+  desc.add<double>("z0Cut", 12.0);
+  desc.add<double>("ptCut", 0.5);
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
@@ -213,8 +213,8 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::HIonPhase1>::fillDescriptions(edm
 
   desc.add<bool>("idealConditions", false);
   desc.add<bool>("includeJumpingForwardDoublets", false);
-  desc.add<double>("z0Cut", 10.0f);
-  desc.add<double>("ptCut", 0.0f);
+  desc.add<double>("z0Cut", 10.0);
+  desc.add<double>("ptCut", 0.0);
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
@@ -247,8 +247,8 @@ void CAHitNtupletGeneratorOnGPU<pixelTopology::Phase2>::fillDescriptions(edm::Pa
   desc.add<bool>("idealConditions", false);
   desc.add<bool>("includeFarForwards", true);
   desc.add<bool>("includeJumpingForwardDoublets", true);
-  desc.add<double>("z0Cut", 7.5f);
-  desc.add<double>("ptCut", 0.85f);
+  desc.add<double>("z0Cut", 7.5);
+  desc.add<double>("ptCut", 0.85);
 
   edm::ParameterSetDescription trackQualityCuts;
   trackQualityCuts.add<double>("maxChi2", 5.)->setComment("Max normalized chi2");
@@ -270,13 +270,13 @@ template <typename TrackerTraits>
 void CAHitNtupletGeneratorOnGPU<TrackerTraits>::fillDescriptionsCommon(edm::ParameterSetDescription& desc) {
   // 87 cm/GeV = 1/(3.8T * 0.3)
   // take less than radius given by the hardPtCut and reject everything below
-  // auto hardCurvCut = 1.f/(0.35 * 87.f);
-  desc.add<double>("ptmin", 0.9f)->setComment("Cut on minimum pt");
-  desc.add<double>("CAThetaCutBarrel", 0.002f)->setComment("Cut on RZ alignement for Barrel");
-  desc.add<double>("CAThetaCutForward", 0.003f)->setComment("Cut on RZ alignment for Forward");
-  desc.add<double>("hardCurvCut", 1.f / (0.35 * 87.f))->setComment("Cut on minimum curvature");
-  desc.add<double>("dcaCutInnerTriplet", 0.15f)->setComment("Cut on origin radius when the inner hit is on BPix1");
-  desc.add<double>("dcaCutOuterTriplet", 0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
+  // auto hardCurvCut = 1.f/(0.35 * 87.f); 
+  desc.add<double>("ptmin", 0.9)->setComment("Cut on minimum pt");
+  desc.add<double>("CAThetaCutBarrel", 0.002)->setComment("Cut on RZ alignement for Barrel");
+  desc.add<double>("CAThetaCutForward", 0.003)->setComment("Cut on RZ alignment for Forward");
+  desc.add<double>("hardCurvCut", 1. / (0.35 * 87.))->setComment("Cut on minimum curvature");
+  desc.add<double>("dcaCutInnerTriplet", 0.15)->setComment("Cut on origin radius when the inner hit is on BPix1");
+  desc.add<double>("dcaCutOuterTriplet", 0.25)->setComment("Cut on origin radius when the outer hit is on BPix1");
   desc.add<bool>("earlyFishbone", true);
   desc.add<bool>("lateFishbone", false);
   desc.add<bool>("fillStatistics", false);

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -270,7 +270,7 @@ template <typename TrackerTraits>
 void CAHitNtupletGeneratorOnGPU<TrackerTraits>::fillDescriptionsCommon(edm::ParameterSetDescription& desc) {
   // 87 cm/GeV = 1/(3.8T * 0.3)
   // take less than radius given by the hardPtCut and reject everything below
-  // auto hardCurvCut = 1.f/(0.35 * 87.f); 
+  // auto hardCurvCut = 1.f/(0.35 * 87.f);
   desc.add<double>("ptmin", 0.9)->setComment("Cut on minimum pt");
   desc.add<double>("CAThetaCutBarrel", 0.002)->setComment("Cut on RZ alignement for Barrel");
   desc.add<double>("CAThetaCutForward", 0.003)->setComment("Cut on RZ alignment for Forward");

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -778,7 +778,7 @@ trackValidatorHILowPtConformalValidator = trackValidator.clone(
     associators = ["trackingParticleHIPixelTrackAssociation"],
     vertexAssociator = "HIPixelVertexAssociatorByPositionAndTracks",
     dodEdxPlots = False,
-    cores = cms.InputTag(""),
+    cores = "" 
 )
 
 tracksValidationHIonTask = cms.Task(trackValidatorHILowPtConformalValidator) 
@@ -1090,7 +1090,7 @@ trackValidatorPixelTrackingOnly = trackValidator.clone(
     label_vertex = "pixelVertices",
     vertexAssociator = "PixelVertexAssociatorByPositionAndTracks",
     dodEdxPlots = False,
-    cores = cms.InputTag("")
+    cores = "" 
 )
 
 trackValidatorFromPVPixelTrackingOnly = trackValidatorPixelTrackingOnly.clone(


### PR DESCRIPTION
#### PR description:

This is a follow-up to #41632 taking into account the un-resolved comments (see [here](https://github.com/cms-sw/cmssw/pull/41632#issuecomment-1637005874)). 

I took the chance also to apply the changes in the cuts suggested by @CesarBernardes (see slide 5 [here](https://indico.cern.ch/event/1300029/contributions/5465602/attachments/2680232/4649242/pixelTracking_patatrackStudies_05062023_v3.pdf)). This is not strictly needed since all those parameters are tunable from the config, but I would take the chance to push it anyway here.