### PR TITLE
[13_0_x] PPS suppress LogErrors in Pixel unpacker

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -42,6 +42,8 @@
 #include "EventFilter/CTPPSRawToDigi/interface/ElectronicIndex.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+
 #include <cstdint>
 #include <vector>
 #include <map>
@@ -65,7 +67,7 @@ public:
 
   typedef std::unordered_map<cms_uint32_t, DetDigis> Digis;
 
-  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping);
+  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping, CTPPSPixelErrorSummary&);
 
   void setErrorStatus(bool theErrorStatus);
 
@@ -94,6 +96,8 @@ public:
     return a.id < b.id || (a.id == b.id && a.roc < b.roc);
   }
 
+  void printErrorSummary() const { m_ErrorSummary.printSummary(); }
+
 private:
   int m_WordCounter;
 
@@ -113,6 +117,7 @@ private:
   int m_allDetDigis;
   int m_hasDetDigis;
   CTPPSPixelIndices m_Indices;
+  CTPPSPixelErrorSummary& m_ErrorSummary;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h
@@ -6,8 +6,8 @@
 
 class CTPPSPixelErrorSummary {
 public:
-CTPPSPixelErrorSummary(const std::string& category, const std::string& name, bool debug = false)
-  : m_debug(debug), m_category(category), m_name(name) {}
+  CTPPSPixelErrorSummary(const std::string& category, const std::string& name, bool debug = false)
+      : m_debug(debug), m_category(category), m_name(name) {}
 
   void add(const std::string& message, const std::string& details = "");
   void printSummary() const;
@@ -18,4 +18,4 @@ private:
   std::string m_name;
   std::map<std::string, std::size_t> m_errors;
 };
-#endif 
+#endif

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h
@@ -1,0 +1,21 @@
+#ifndef EventFilter_CTPPSRawToDigi_CTPPSPixelErrorSummary
+#define EventFilter_CTPPSRawToDigi_CTPPSPixelErrorSummary
+
+#include <string>
+#include <map>
+
+class CTPPSPixelErrorSummary {
+public:
+CTPPSPixelErrorSummary(const std::string& category, const std::string& name, bool debug = false)
+  : m_debug(debug), m_category(category), m_name(name) {}
+
+  void add(const std::string& message, const std::string& details = "");
+  void printSummary() const;
+
+private:
+  bool m_debug;
+  std::string m_category;
+  std::string m_name;
+  std::map<std::string, std::size_t> m_errors;
+};
+#endif 

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
@@ -15,6 +15,7 @@
 
 #include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -30,6 +31,8 @@ public:
   /// get data, convert to digis attach againe to Event
   void produce(edm::Event&, const edm::EventSetup&) override;
 
+  void endStream() override;
+
 private:
   edm::ParameterSet config_;
 
@@ -42,6 +45,8 @@ private:
   edm::InputTag label_;
 
   std::string mappingLabel_;
+
+  CTPPSPixelErrorSummary eSummary_;
 
   bool includeErrors_;
   bool isRun3_;

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
@@ -52,6 +52,7 @@ Implementation:
 #include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelFramePosition.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -82,6 +83,7 @@ private:
   edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tCTPPSPixelDAQMapping_;
   std::vector<CTPPSPixelDataFormatter::PPSPixelIndex> v_iDdet2fed_;
   CTPPSPixelFramePosition fPos_;
+  CTPPSPixelErrorSummary eSummary_;
   bool isRun3_;
 };
 
@@ -101,7 +103,8 @@ CTPPSPixelDigiToRaw::CTPPSPixelDigiToRaw(const edm::ParameterSet& iConfig)
       allDigiCounter_(0),
       allWordCounter_(0),
       debug_(false),
-      mappingLabel_(iConfig.getParameter<std::string>("mappingLabel")) {
+      mappingLabel_(iConfig.getParameter<std::string>("mappingLabel")),
+      eSummary_("CTPPSPixelDataFormatter", "[ctppsPixelRawToDigi]", false) {
   //register your products
   tCTPPSPixelDigi_ = consumes<edm::DetSetVector<CTPPSPixelDigi>>(iConfig.getParameter<edm::InputTag>("InputLabel"));
   tCTPPSPixelDAQMapping_ = esConsumes<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd>();
@@ -145,7 +148,7 @@ void CTPPSPixelDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         p.second.iD, p.second.roc, p.first.getROC(), p.first.getFEDId(), p.first.getChannelIdx()});
   fedIds_ = mapping->fedIds();
 
-  CTPPSPixelDataFormatter formatter(mapping->ROCMapping);
+  CTPPSPixelDataFormatter formatter(mapping->ROCMapping, eSummary_);
 
   // create product (raw data)
   auto buffers = std::make_unique<FEDRawDataCollection>();

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
@@ -22,7 +22,8 @@
 using namespace std;
 
 CTPPSPixelRawToDigi::CTPPSPixelRawToDigi(const edm::ParameterSet& conf)
-    : config_(conf)
+    : config_(conf),
+      eSummary_("CTPPSPixelDataFormatter", "[ctppsPixelRawToDigi]", edm::isDebugEnabled())
 
 {
   FEDRawDataCollection_ = consumes<FEDRawDataCollection>(config_.getParameter<edm::InputTag>("inputLabel"));
@@ -76,7 +77,7 @@ void CTPPSPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
 
     fedIds_ = mapping->fedIds();
 
-    CTPPSPixelDataFormatter formatter(mapping->ROCMapping);
+    CTPPSPixelDataFormatter formatter(mapping->ROCMapping, eSummary_);
     formatter.setErrorStatus(includeErrors_);
 
     bool errorsInEvent = false;
@@ -119,6 +120,10 @@ void CTPPSPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   if (includeErrors_) {
     ev.put(std::move(errorcollection));
   }
+}
+
+void CTPPSPixelRawToDigi::endStream() {
+  eSummary_.printSummary();
 }
 
 DEFINE_FWK_MODULE(CTPPSPixelRawToDigi);

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
@@ -122,8 +122,6 @@ void CTPPSPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   }
 }
 
-void CTPPSPixelRawToDigi::endStream() {
-  eSummary_.printSummary();
-}
+void CTPPSPixelRawToDigi::endStream() { eSummary_.printSummary(); }
 
 DEFINE_FWK_MODULE(CTPPSPixelRawToDigi);

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -41,7 +41,6 @@ CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePositio
                                                  CTPPSPixelErrorSummary& eSummary)
     : m_WordCounter(0),
       m_Mapping(mapping),
-      //    m_ErrorSummary("CTPPSPixelDataFormatter", "[ctppsPixelRawToDigi]", edm::isDebugEnabled())
       m_ErrorSummary(eSummary)
 
 {

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -37,8 +37,14 @@ namespace {
 
 }  // namespace
 
-CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping)
-    : m_WordCounter(0), m_Mapping(mapping) {
+CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping,
+                                                 CTPPSPixelErrorSummary& eSummary)
+    : m_WordCounter(0),
+      m_Mapping(mapping),
+      //    m_ErrorSummary("CTPPSPixelDataFormatter", "[ctppsPixelRawToDigi]", edm::isDebugEnabled())
+      m_ErrorSummary(eSummary)
+
+{
   int s32 = sizeof(Word32);
   int s64 = sizeof(Word64);
   int s8 = sizeof(char);
@@ -166,14 +172,16 @@ void CTPPSPixelDataFormatter::interpretRawData(
       if (mit == m_Mapping.end()) {
         if (nlink >= maxLinkIndex) {
           m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
-          edm::LogError("CTPPSPixelDataFormatter") << " Invalid linkId ";
+
+          m_ErrorSummary.add("Invalid linkId", "");
         } else if ((nroc - 1) >= maxRocIndex) {
           m_ErrorCheck.conversionError(fedId, iD, InvalidROCId, ww, errors);
-          edm::LogError("CTPPSPixelDataFormatter")
-              << " Invalid ROC Id " << convroc << " in nlink " << nlink << " of FED " << fedId << " in DetId " << iD;
+          m_ErrorSummary.add("Invalid ROC",
+                             fmt::format("Id {0}, in link {1}, of FED {2} in DetId {3}", convroc, nlink, fedId, iD));
+
         } else {
           m_ErrorCheck.conversionError(fedId, iD, Unknown, ww, errors);
-          edm::LogError("CTPPSPixelDataFormatter") << " Error unknown ";
+          m_ErrorSummary.add("Error unknown");
         }
         skipROC = true;  // skipping roc due to mapping errors
         continue;
@@ -201,19 +209,32 @@ void CTPPSPixelDataFormatter::interpretRawData(
     int row = (ww >> m_ROW_shift) & m_ROW_mask;
 
     if (!isRun3 && (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid)) {
-      edm::LogError("CTPPSPixelDataFormatter")
-          << " unphysical dcol and/or pxid "
-          << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc << " adc=" << adc << " dcol=" << dcol
-          << " pxid=" << pxid << " detId=" << iD;
+      m_ErrorSummary.add(
+          "unphysical dcol and/or pxid",
+          fmt::format("fedId= {0}, nllink= {1}, convroc= {2}, adc= {3}, dcol= {4}, pxid= {5}, detId= {6}",
+                      fedId,
+                      nlink,
+                      convroc,
+                      adc,
+                      dcol,
+                      pxid,
+                      iD));
 
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;
     }
     if (isRun3 && (col < min_COL || col > max_COL || row < min_ROW || row > max_ROW)) {
-      edm::LogError("CTPPSPixelDataFormatter") << " unphysical col and/or row "
-                                               << "fedId=" << fedId << " nllink=" << nlink << " convroc=" << convroc
-                                               << " adc=" << adc << " col=" << col << " row=" << row << " detId=" << iD;
+      m_ErrorSummary.add("unphysical col and/or row",
+                         fmt::format("fedId= {0}, nllink= {1}, convroc= {2}, adc= {3}, col= {4}, row= {5}, detId= {6}",
+                                     fedId,
+                                     nlink,
+                                     convroc,
+                                     adc,
+                                     col,
+                                     row,
+                                     iD));
+
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelErrorSummary.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelErrorSummary.cc
@@ -1,0 +1,31 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+#include <iostream>
+#include <algorithm>
+
+void CTPPSPixelErrorSummary::add(const std::string& message, const std::string& details) {
+  const auto eIt = m_errors.find(message);
+  if (eIt == m_errors.end()) {
+    m_errors.emplace(message, 1);
+    edm::LogError(m_category) << message << ": " << details
+                                << (m_debug ? ""
+                                            : "\nNote: further warnings of this type will be suppressed (this can be "
+                                              "changed by enabling debugging printout)");
+  } else {
+    ++(eIt->second);
+    if (m_debug) {
+      edm::LogError(m_category) << message << ": " << details;
+    }
+  }
+}
+
+void CTPPSPixelErrorSummary::printSummary() const {
+  if (!m_errors.empty()) {
+    std::stringstream message;
+    message << m_name << " errors:";
+    for (const auto& warnAndCount : m_errors) {
+      message << std::endl << warnAndCount.first << " (" << warnAndCount.second << ")";
+    }
+    edm::LogError(m_category) << message.str();
+  }
+}

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelErrorSummary.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelErrorSummary.cc
@@ -8,9 +8,9 @@ void CTPPSPixelErrorSummary::add(const std::string& message, const std::string& 
   if (eIt == m_errors.end()) {
     m_errors.emplace(message, 1);
     edm::LogError(m_category) << message << ": " << details
-                                << (m_debug ? ""
-                                            : "\nNote: further warnings of this type will be suppressed (this can be "
-                                              "changed by enabling debugging printout)");
+                              << (m_debug ? ""
+                                          : "\nNote: further warnings of this type will be suppressed (this can be "
+                                            "changed by enabling debugging printout)");
   } else {
     ++(eIt->second);
     if (m_debug) {


### PR DESCRIPTION
PR description:

Backport of PR https://github.com/cms-sw/cmssw/pull/42303

This PR is a follow up of issue https://github.com/cms-sw/cmssw/issues/41456. The same strategy used by SiStrips is followed.
LogErrors are subdivided in categories and shown only the first time they appear. A summary is printed out at the end of stream.
PR validation:

This PR has been tested with 2023 run3 data. The behaviour of the printout is as expected. No effect on data processing is seen, as expected.

@AndreaBellora