### PR TITLE
[GCC12] Split RiemannFitOnGPU.cu in multiple files to avoid build errors

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU.icc
+++ b/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU.icc
@@ -130,7 +130,3 @@ void HelixFitOnGPU<TrackerTraits>::launchRiemannKernels(const TrackingRecHitSoAC
     }
   }
 }
-
-template class HelixFitOnGPU<pixelTopology::Phase1>;
-template class HelixFitOnGPU<pixelTopology::Phase2>;
-template class HelixFitOnGPU<pixelTopology::HIonPhase1>;

--- a/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_HIonPhase1.cu
+++ b/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_HIonPhase1.cu
@@ -1,0 +1,3 @@
+#include "RiemannFitOnGPU.icc"
+
+template class HelixFitOnGPU<pixelTopology::HIonPhase1>;

--- a/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_Phase1.cu
+++ b/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_Phase1.cu
@@ -1,0 +1,3 @@
+#include "RiemannFitOnGPU.icc"
+
+template class HelixFitOnGPU<pixelTopology::Phase1>;

--- a/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_Phase2.cu
+++ b/RecoTracker/PixelSeeding/plugins/RiemannFitOnGPU_Phase2.cu
@@ -1,0 +1,3 @@
+#include "RiemannFitOnGPU.icc"
+
+template class HelixFitOnGPU<pixelTopology::Phase2>;


### PR DESCRIPTION
Compilation of `RiemannFitOnGPU.cu` for `gcc12/cuda12` fails [a] . During build stage `cicc` was using over 16G and then system killed it. The PR splits `RiemannFitOnGPU.cu` in three files (one for each `Phase1`, `Phase2` and `HIonPhase1`) which allow the `cicc` to properly build it.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_X_2023-07-19-1100/RecoTracker/PixelSeeding
```
LLVM ERROR: out of memory
nvcc error   : 'cicc' died due to signal 6 
nvcc error   : 'cicc' core dumped
```