### PR TITLE
Remove getManyByType from the Framework

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -178,9 +178,6 @@ namespace edm {
     bool getByLabel(std::string const& label, std::string const& productInstanceName, Handle<PROD>& result) const;
 
     template <typename PROD>
-    void getManyByType(std::vector<Handle<PROD>>& results) const;
-
-    template <typename PROD>
     bool getByToken(EDGetToken token, Handle<PROD>& result) const;
 
     template <typename PROD>
@@ -525,11 +522,6 @@ namespace edm {
   template <typename PROD>
   bool Event::getByLabel(std::string const& label, Handle<PROD>& result) const {
     return getByLabel(label, emptyString_, result);
-  }
-
-  template <typename PROD>
-  void Event::getManyByType(std::vector<Handle<PROD>>& results) const {
-    principal_get_adapter_detail::throwGetManyByType();
   }
 
   template <typename PROD>

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -22,9 +22,6 @@ the configuration to get all of them each time a
 different HLT trigger table was used. This class
 handles that and similar cases.
 
-This class is preferred over using getManyByType
-where it is possible to use it.
-
 This method can select by type and branch type.
 There exists a predicate (in ProcessMatch.h)
 to also select on process name.  It is possible

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -126,7 +126,6 @@ namespace edm {
                               std::string const& productInstanceName);
 
     void throwOnPrematureRead(char const* principalType, TypeID const& productType, EDGetToken);
-    void throwGetManyByType();
 
   }  // namespace principal_get_adapter_detail
   class PrincipalGetAdapter {

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -101,9 +101,6 @@ namespace edm {
     template <typename PROD>
     PROD const& get(EDGetTokenT<PROD> token) const noexcept(false);
 
-    template <typename PROD>
-    void getManyByType(std::vector<Handle<PROD>>& results) const;
-
     ///Put a new product.
     template <typename PROD>
     void put(std::unique_ptr<PROD> product) {
@@ -358,11 +355,6 @@ namespace edm {
     }
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return *convert_handle<PROD>(std::move(bh));
-  }
-
-  template <typename PROD>
-  void Run::getManyByType(std::vector<Handle<PROD>>& results) const {
-    principal_get_adapter_detail::throwGetManyByType();
   }
 
   // Free functions to retrieve a collection from the Run.

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -72,12 +72,6 @@ namespace edm {
                                         << "The index of the token was " << token.index() << ".\n";
   }
 
-  void principal_get_adapter_detail::throwGetManyByType() {
-    throw Exception(errors::LogicError)
-        << "The getManyByType function is no longer supported. "
-        << "Consider upgrading to use GetterOfProducts instead or delete this function call.\n";
-  }
-
   size_t PrincipalGetAdapter::numberOfProductsConsumed() const { return consumer_->itemsToGetFrom(InEvent).size(); }
 
   void PrincipalGetAdapter::labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {


### PR DESCRIPTION
#### PR description:

Remove getManyByType from the Framework.

This function has long been deprecated and we have finally removed all uses of this function from the CMSSW repository (except the last calls to the function are removed in PR #42310 which was just submitted, don't merge this one until after that one is merged).

#### PR validation:

Just deletions, nothing to test.
