### PR TITLE
TopRecoilHook: fix warning about empty if

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
@@ -33,9 +33,7 @@ namespace Pythia8 {
     }
 
     // Destructor prints histogram.
-    ~TopRecoilHook() override {
-      delete wtCorr;
-    }
+    ~TopRecoilHook() override { delete wtCorr; }
 
     // Initialise. Only use hook for simple showers with recoilToColoured = off.
     bool initAfterBeams() override {

--- a/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
@@ -34,8 +34,6 @@ namespace Pythia8 {
 
     // Destructor prints histogram.
     ~TopRecoilHook() override {
-      if (doTopRecoil)
-        ;
       delete wtCorr;
     }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the following warning (produced for all platforms in CMSSW_13_3_X_2023-07-19-2300):

```
In file included from .../CMSSW_13_3_X_2023-07-19-2300/src/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc:22:
.../CMSSW_13_3_X_2023-07-19-2300/src/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h: In destructor 'virtual Pythia8::TopRecoilHook::~TopRecoilHook()':
  .../CMSSW_13_3_X_2023-07-19-2300/src/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h:38:9: warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
    38 |         ;
      |         ^
```

As far as I can tell from the file history, this `if` block is actually not needed.
