### PR TITLE
moved PixelThresholdClusterizer::clusterizeDetUnitT template function in separate header

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -120,80 +120,8 @@ bool PixelThresholdClusterizer::setup(const PixelGeomDetUnit* pixDet) {
 
   return true;
 }
-//----------------------------------------------------------------------------
-//!  \brief Cluster pixels.
-//!  This method operates on a matrix of pixels
-//!  and finds the largest contiguous cluster around
-//!  each seed pixel.
-//!  Input and output data stored in DetSet
-//----------------------------------------------------------------------------
-template <typename T>
-void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
-                                                   const PixelGeomDetUnit* pixDet,
-                                                   const TrackerTopology* tTopo,
-                                                   const std::vector<short>& badChannels,
-                                                   edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) {
-  typename T::const_iterator begin = input.begin();
-  typename T::const_iterator end = input.end();
 
-  // this should never happen and the raw2digi does not create empty detsets
-  if (begin == end) {
-    edm::LogError("PixelThresholdClusterizer") << "@SUB=PixelThresholdClusterizer::clusterizeDetUnitT()"
-                                               << " No digis to clusterize";
-  }
-
-  //  Set up the clusterization on this DetId.
-  if (!setup(pixDet))
-    return;
-
-  theDetid = input.detId();
-
-  // Set separate cluster threshold for L1 (needed for phase1)
-  auto clusterThreshold = theClusterThreshold;
-  theLayer = (DetId(theDetid).subdetId() == 1) ? tTopo->pxbLayer(theDetid) : 0;
-  if (theLayer == 1)
-    clusterThreshold = theClusterThreshold_L1;
-
-  //  Copy PixelDigis to the buffer array; select the seed pixels
-  //  on the way, and store them in theSeeds.
-  if (end > begin)
-    copy_to_buffer(begin, end);
-
-  assert(output.empty());
-  //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
-  for (unsigned int i = 0; i < theSeeds.size(); i++) {
-    // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
-    // so we don't want to call "make_cluster" for these cases
-    if (theBuffer(theSeeds[i]) >= theSeedThreshold) {  // Is this seed still valid?
-      //  Make a cluster around this seed
-      SiPixelCluster&& cluster = make_cluster(theSeeds[i], output);
-
-      //  Check if the cluster is above threshold
-      // (TO DO: one is signed, other unsigned, gcc warns...)
-      if (cluster.charge() >= clusterThreshold) {
-        // sort by row (x)
-        output.push_back(std::move(cluster));
-        std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
-          return cl1.minPixelRow() < cl2.minPixelRow();
-        });
-      }
-    }
-  }
-  // sort by row (x)   maybe sorting the seed would suffice....
-  std::sort_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
-    return cl1.minPixelRow() < cl2.minPixelRow();
-  });
-
-  // Erase the seeds.
-  theSeeds.clear();
-
-  //  Need to clean unused pixels from the buffer array.
-  clear_buffer(begin, end);
-
-  theFakePixels.clear();
-
-  thePixelOccurrence.clear();
-}
+#include "PixelThresholdClusterizer.icc"
 
 //----------------------------------------------------------------------------
 //!  \brief Clear the internal buffer array.

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.icc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.icc
@@ -1,0 +1,74 @@
+//----------------------------------------------------------------------------
+//!  \brief Cluster pixels.
+//!  This method operates on a matrix of pixels
+//!  and finds the largest contiguous cluster around
+//!  each seed pixel.
+//!  Input and output data stored in DetSet
+//----------------------------------------------------------------------------
+template <typename T>
+void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
+                                                   const PixelGeomDetUnit* pixDet,
+                                                   const TrackerTopology* tTopo,
+                                                   const std::vector<short>& badChannels,
+                                                   edmNew::DetSetVector<SiPixelCluster>::FastFiller& output) {
+  typename T::const_iterator begin = input.begin();
+  typename T::const_iterator end = input.end();
+
+  // this should never happen and the raw2digi does not create empty detsets
+  if (begin == end) {
+    edm::LogError("PixelThresholdClusterizer") << "@SUB=PixelThresholdClusterizer::clusterizeDetUnitT()"
+                                               << " No digis to clusterize";
+  }
+
+  //  Set up the clusterization on this DetId.
+  if (!setup(pixDet))
+    return;
+
+  theDetid = input.detId();
+
+  // Set separate cluster threshold for L1 (needed for phase1)
+  auto clusterThreshold = theClusterThreshold;
+  theLayer = (DetId(theDetid).subdetId() == 1) ? tTopo->pxbLayer(theDetid) : 0;
+  if (theLayer == 1)
+    clusterThreshold = theClusterThreshold_L1;
+
+  //  Copy PixelDigis to the buffer array; select the seed pixels
+  //  on the way, and store them in theSeeds.
+  if (end > begin)
+    copy_to_buffer(begin, end);
+
+  assert(output.empty());
+  //  Loop over all seeds.  TO DO: wouldn't using iterators be faster?
+  for (unsigned int i = 0; i < theSeeds.size(); i++) {
+    // Gavril : The charge of seeds that were already inlcuded in clusters is set to 1 electron
+    // so we don't want to call "make_cluster" for these cases
+    if (theBuffer(theSeeds[i]) >= theSeedThreshold) {  // Is this seed still valid?
+      //  Make a cluster around this seed
+      SiPixelCluster&& cluster = make_cluster(theSeeds[i], output);
+
+      //  Check if the cluster is above threshold
+      // (TO DO: one is signed, other unsigned, gcc warns...)
+      if (cluster.charge() >= clusterThreshold) {
+        // sort by row (x)
+        output.push_back(std::move(cluster));
+        std::push_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+          return cl1.minPixelRow() < cl2.minPixelRow();
+        });
+      }
+    }
+  }
+  // sort by row (x)   maybe sorting the seed would suffice....
+  std::sort_heap(output.begin(), output.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+    return cl1.minPixelRow() < cl2.minPixelRow();
+  });
+
+  // Erase the seeds.
+  theSeeds.clear();
+
+  //  Need to clean unused pixels from the buffer array.
+  clear_buffer(begin, end);
+
+  theFakePixels.clear();
+
+  thePixelOccurrence.clear();
+}

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -199,6 +199,7 @@ void SiPixelClusterProducer::run(const T& input,
   }  // end of DetUnit loop
 }
 
+#include "PixelThresholdClusterizer.icc"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/42161

[template <typename T> void PixelThresholdClusterizer::clusterizeDetUnitT](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc#L130-L135 ) is template function and it should not be in `cc` file. Moving it to a separate header file and then including it, where it is needed, fixes the ppc64le gcc12 build/link errors. 