### PR TITLE
ECAL : DB PayloadInspector correction

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
@@ -125,10 +125,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
@@ -113,10 +113,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
@@ -121,10 +121,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
@@ -118,10 +118,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
@@ -102,10 +102,10 @@ namespace {
       for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatios> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {
             if (!EEDetId::validHashIndex(cellid))

--- a/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
@@ -117,10 +117,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
@@ -123,10 +123,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
@@ -122,10 +122,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
@@ -124,10 +124,10 @@ namespace {
           if (payload->endcapItems().empty())
             return false;
 
-          // set to -1 everywhwere
+          // set to 0 everywhwere
           for (int ix = IX_MIN; ix < EEhistXMax + 1; ix++)
-            for (int iy = IY_MAX; iy < IY_MAX + 1; iy++)
-              fillWithValue(ix, iy, -1);
+            for (int iy = IY_MIN; iy < IY_MAX + 1; iy++)
+              fillWithValue(ix, iy, 0);
 
           for (int cellid = 0; cellid < EEDetId::kSizeForDenseIndexing; ++cellid) {  // loop on EE cells
             if (EEDetId::validHashIndex(cellid)) {


### PR DESCRIPTION
#### PR description:

ECAL : DB PayloadInspector : bug found in class Histo2D for EEMap, -1 added to row iY=100 (only).  Replaced by 0, on the whole MAP.  Same error in 9 files.

#### PR validation:

Tested in local with CondCore/Utilities/getPayloadData.py : OK, no more -1 added

