### PR TITLE
fix `ldir.z==0` edge case in `fastProp` method of `RecHitPropagator.h`

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
@@ -19,9 +19,14 @@ public:
 // propagate from glued to mono/stereo
 inline TrajectoryStateOnSurface fastProp(const TrajectoryStateOnSurface& ts, const Plane& oPlane, const Plane& tPlane) {
   GlobalVector gdir = ts.globalMomentum();
+  LocalVector ldir = tPlane.toLocal(gdir);  // fast prop!
+
+  // if ldir.z() == 0, return an invalid TrajectoryStateOnSurface
+  if (ldir.z() == 0) {
+    return TrajectoryStateOnSurface();
+  }
 
   double delta = tPlane.localZ(oPlane.position());
-  LocalVector ldir = tPlane.toLocal(gdir);  // fast prop!
   LocalPoint lPos = tPlane.toLocal(ts.globalPosition());
   LocalPoint projectedPos = lPos - ldir * delta / ldir.z();
   // we can also patch it up as only the position-errors are used...

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -82,7 +82,8 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts,
     if LIKELY (!emptyMono) {
       // mono does require "projection" for precise estimate
       TrajectoryStateOnSurface mts = fastProp(ts, geomDet().surface(), theMonoDet->geomDet().surface());
-      theMonoDet->simpleRecHits(mts, collector.estimator(), data, monoHits);
+      if LIKELY (mts.isValid())
+        theMonoDet->simpleRecHits(mts, collector.estimator(), data, monoHits);
     }
     // print("mono", mts,ts);
     mf = monoHits.size();
@@ -96,7 +97,8 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts,
     emptyStereo = theStereoDet->empty(data);
     if LIKELY (!emptyStereo) {
       TrajectoryStateOnSurface pts = fastProp(ts, geomDet().surface(), theStereoDet->geomDet().surface());
-      theStereoDet->simpleRecHits(pts, collector.estimator(), data, stereoHits);
+      if LIKELY (pts.isValid())
+        theStereoDet->simpleRecHits(pts, collector.estimator(), data, stereoHits);
       // print("stereo", pts,ts);
     }
     sf = stereoHits.size();


### PR DESCRIPTION
#### PR description:

This PR includes a possibile solution for the issue discussed in #40174 (see that issue for details), thanks to suggestions from @cms-sw/tracking-pog-l2.

#42320 contains a different solution for the same issue. The two PRs are not mutually exclusive (in principle, both could be integrated).

In this PR, the edge case where `ldir.z() == 0` inside the `fastProp` method of `RecHitPropagator.h` is handled gracefully by returning an invalid `TrajectoryStateOnSurface`, which is then skipped in the method `TkGluedMeasurementDet::doubleMatch` (which is the only method that makes use of `fastProp`).

#### PR validation:

Manual checks with the reproducers in https://github.com/cms-sw/cmssw/issues/40174#issuecomment-1598702425 and https://github.com/cms-sw/cmssw/issues/40174#issuecomment-1625219782.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

TBD
