### PR TITLE
[13_0_X] Prevent producing EMTFTrack if only muon shower was unpacked

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -599,9 +599,9 @@ namespace l1t {
 
         (res->at(iOut)).push_SP(SP_);
 
-        res_track->push_back(Track_);
-
         if (Track_.Mode() != 0) {  // Mode == 0 means no track was found (only muon shower)
+          res_track->push_back(Track_);
+
           // TBIN_num can range from 0 through 7, i.e. BX = -3 through +4. - AWB 04.04.16
           res_cand->setBXRange(-3, 4);
           res_cand->push_back(SP_.TBIN() - 3, mu_);


### PR DESCRIPTION
#### PR description:

This is a quick PR to fix something I missed in https://github.com/cms-sw/cmssw/pull/41993. I should have made it so that no EMTFTrack is produced for muon shower only DAQ blocks. Now this is fixed. 

This is a backport of https://github.com/cms-sw/cmssw/pull/42172

I don't know which release will be used when LHC restarts, but this backport might be necessary for some re-emulation studies with 2023 data.  

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by running on recent data, behaves expectedly.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
