### PR TITLE
[13_0_X] Change muon shower BX assignment in EMTF

### DIFF
--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.cc
@@ -15,7 +15,7 @@ void L1TMuonEndCapShowerProducer::produce(edm::Event& iEvent, const edm::EventSe
   // Create pointers to output products
   auto out_showers = std::make_unique<l1t::RegionalMuonShowerBxCollection>();
   out_showers->clear();
-  out_showers->setBXRange(0, 0);
+  out_showers->setBXRange(-2, 2);
 
   edm::Handle<CSCShowerDigiCollection> showersH;
   iEvent.getByToken(tokenCSCShower_, showersH);

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -19,6 +19,8 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
   // reset
   std::vector<CSCShowerDigi> selected_showers;
 
+  int bx = 0;
+
   // shower selection
   auto chamber = in_showers.begin();
   auto chend = in_showers.end();
@@ -36,6 +38,7 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
 
         // shower is valid
         if (digi->isValid()) {
+          bx = digi->getBX() - CSCConstants::LCT_CENTRAL_BX;
           selected_showers.emplace_back(*digi);
         }
       }
@@ -71,7 +74,7 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
         hasOneNominalInTime, false, hasTwoLooseInTime, false, hasOneLooseInTime, hasOneTightInTime, false);
     l1t::tftype tftype = (endcap_ == 1) ? l1t::tftype::emtf_pos : l1t::tftype::emtf_neg;
     out_shower.setTFIdentifiers(sector_ - 1, tftype);
-    out_showers.push_back(0, out_shower);
+    out_showers.push_back(bx, out_shower);
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR changes the BX range for muon showers in ETMF emulator. In https://github.com/cms-sw/cmssw/pull/38941 BX assignment for muon showers in CSC unpacking/emulation changed, but the corresponding changes were not don in EMTF. 

This PR also follows the same convention used in https://github.com/cms-sw/cmssw/pull/41993, so the emulated and unpacked showers should now be aligned as it should be.

This is a backport of https://github.com/cms-sw/cmssw/pull/42176

I don't know which release will be used when LHC restarts, but this backport might be necessary for some re-emulation studies with 2023 data.


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested with L1T menu experts to see unpacked/emulated shower matches. Also validated by `runTheMatrix.py -l limited -i all --ibeos`

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
<!-- Please delete the text above after you verified all points of the checklist  -->

FYI @caruta @elfontan 
