### PR TITLE
Run3-sim145 Add a procedure to dump all touchables from a G4 geometry setup

### DIFF
--- a/SimG4Core/PrintGeomInfo/plugins/BuildFile.xml
+++ b/SimG4Core/PrintGeomInfo/plugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>
+<use name="SimG4Core/Geometry"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Watcher"/>
 <use name="FWCore/ParameterSet"/>

--- a/SimG4Core/PrintGeomInfo/plugins/PrintG4Touch.cc
+++ b/SimG4Core/PrintGeomInfo/plugins/PrintG4Touch.cc
@@ -1,0 +1,182 @@
+#include "SimG4Core/Notification/interface/BeginOfRun.h"
+#include "SimG4Core/Notification/interface/Observer.h"
+#include "SimG4Core/Watcher/interface/SimWatcher.h"
+#include "SimG4Core/Geometry/interface/DD4hep2DDDName.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Math/interface/angle_units.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "G4LogicalVolumeStore.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VSolid.hh"
+#include "G4Material.hh"
+#include "G4NavigationHistory.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4Region.hh"
+#include "G4RegionStore.hh"
+#include "G4Run.hh"
+#include "G4Track.hh"
+#include "G4TransportationManager.hh"
+#include "G4UserLimits.hh"
+#include "G4VisAttributes.hh"
+#include "G4VPhysicalVolume.hh"
+
+#include <algorithm>
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+using angle_units::operators::convertRadToDeg;
+
+class PrintG4Touch : public SimWatcher, public Observer<const BeginOfRun *> {
+public:
+  PrintG4Touch(edm::ParameterSet const &p);
+  ~PrintG4Touch() override = default;
+
+private:
+  void update(const BeginOfRun *run) override;
+  void dumpSummary(std::ostream &out = G4cout);
+  int countNoTouchables();
+  void add1touchable(G4LogicalVolume *lv, int &nTouch);
+  void dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, std::ostream &out = G4cout);
+  void getTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, unsigned int copym, std::vector<std::string> &touches);
+  G4VPhysicalVolume *getTopPV();
+  G4LogicalVolume *getTopLV();
+
+private:
+  bool dd4hep_, verbosity_;
+  G4VPhysicalVolume *theTopPV_;
+  G4NavigationHistory fHistory_;
+};
+
+PrintG4Touch::PrintG4Touch(const edm::ParameterSet &p) {
+  dd4hep_ = p.getUntrackedParameter<bool>("DD4hep", false);
+  verbosity_ = p.getUntrackedParameter<bool>("Verbosity", false);
+  G4cout << "PrintG4Touch:: initialised for dd4hep " << dd4hep_ << " with verbosity levels:"
+         << verbosity_ << G4endl;
+}
+
+void PrintG4Touch::update(const BeginOfRun *run) {
+  //Now take action
+  theTopPV_ = getTopPV();
+
+  dumpSummary(G4cout);
+
+  std::vector<std::string> touches;
+  getTouch(theTopPV_, 0, 1, touches);
+  std::sort(touches.begin(), touches.end());
+  for (const auto &touch : touches)
+    G4cout << touch << G4endl;
+
+  //---------- Dump LV and PV information
+  if (verbosity_)
+    dumpTouch(theTopPV_, 0, G4cout);
+}
+
+void PrintG4Touch::dumpSummary(std::ostream &out) {
+  //---------- Dump number of objects of each class
+  out << " @@@@@@@@@@@@@@@@@@ Dumping G4 geometry objects Summary " << G4endl;
+  if (theTopPV_ == nullptr) {
+    out << " No volume created " << G4endl;
+    return;
+  }
+  out << " @@@ Geometry built inside world volume: " << DD4hep2DDDName::namePV(static_cast<std::string>(theTopPV_->GetName()), dd4hep_) << G4endl;
+  // Get number of solids (< # LV if several LV share a solid)
+  const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();
+  std::vector<G4LogicalVolume *>::const_iterator lvcite;
+  std::set<G4VSolid *> theSolids;
+  for (lvcite = lvs->begin(); lvcite != lvs->end(); lvcite++)
+    theSolids.insert((*lvcite)->GetSolid());
+  out << " Number of G4VSolid's: " << theSolids.size() << G4endl;
+  out << " Number of G4LogicalVolume's: " << lvs->size() << G4endl;
+  const G4PhysicalVolumeStore *pvs = G4PhysicalVolumeStore::GetInstance();
+  out << " Number of G4VPhysicalVolume's: " << pvs->size() << G4endl;
+  out << " Number of Touchable's: " << countNoTouchables() << G4endl;
+  const G4MaterialTable *matTab = G4Material::GetMaterialTable();
+  out << " Number of G4Material's: " << matTab->size() << G4endl;
+  const G4RegionStore *regs = G4RegionStore::GetInstance();
+  out << " Number of G4Region's: " << regs->size() << G4endl;
+}
+
+int PrintG4Touch::countNoTouchables() {
+  int nTouch = 0;
+  G4LogicalVolume *lv = getTopLV();
+  add1touchable(lv, nTouch);
+  return nTouch;
+}
+
+void PrintG4Touch::add1touchable(G4LogicalVolume *lv, int &nTouch) {
+  int siz = lv->GetNoDaughters();
+  for (int ii = 0; ii < siz; ii++)
+    add1touchable(lv->GetDaughter(ii)->GetLogicalVolume(), ++nTouch);
+}
+
+void PrintG4Touch::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, std::ostream &out) {
+  if (leafDepth == 0)
+    fHistory_.SetFirstEntry(pv);
+  else
+    fHistory_.NewLevel(pv, kNormal, pv->GetCopyNo());
+
+  G4LogicalVolume *lv = pv->GetLogicalVolume();
+
+  G4ThreeVector globalpoint = fHistory_.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0, 0, 0));
+  std::string mother = (pv->GetMotherLogical()) ? (DD4hep2DDDName::nameSolid(static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_)) : "World";
+  std::string lvname = DD4hep2DDDName::nameSolid(static_cast<std::string>(lv->GetName()), dd4hep_);
+  out << leafDepth << "### VOLUME = " << lvname << " Copy No " << pv->GetCopyNo() << " in " << mother << " global position of centre " << globalpoint << " (r = " << globalpoint.perp() << ", phi = " << convertRadToDeg(globalpoint.phi()) << ")" << G4endl;
+
+  int NoDaughters = lv->GetNoDaughters();
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
+    if (!pvD->IsReplicated())
+      dumpTouch(pvD, leafDepth + 1, out);
+  }
+
+  if (leafDepth > 0)
+    fHistory_.BackLevel();
+}
+
+void PrintG4Touch::getTouch(G4VPhysicalVolume *pv,
+			    unsigned int leafDepth,
+			    unsigned int copym,
+			    std::vector<std::string> &touches) {
+  if (leafDepth == 0)
+    fHistory_.SetFirstEntry(pv);
+  else
+    fHistory_.NewLevel(pv, kNormal, pv->GetCopyNo());
+
+  std::string mother = (pv->GetMotherLogical()) ? (DD4hep2DDDName::nameSolid(static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_)) : "World";
+
+  G4LogicalVolume *lv = pv->GetLogicalVolume();
+  std::string lvname = DD4hep2DDDName::nameSolid(static_cast<std::string>(lv->GetName()), dd4hep_);
+  unsigned int copy = static_cast<unsigned int>(pv->GetCopyNo());
+
+  std::string type = static_cast<std::string>(lv->GetSolid()->GetEntityType());
+
+  std::string name = lvname + ":" + std::to_string(copy) + "_" + mother + ":" + std::to_string(copym) + ":" + type;
+  touches.emplace_back(name);
+
+  int NoDaughters = lv->GetNoDaughters();
+  while ((NoDaughters--) > 0) {
+    G4VPhysicalVolume *pvD = lv->GetDaughter(NoDaughters);
+    if (!pvD->IsReplicated())
+      getTouch(pvD, leafDepth + 1, copy, touches);
+  }
+
+  if (leafDepth > 0)
+    fHistory_.BackLevel();
+}
+
+G4VPhysicalVolume *PrintG4Touch::getTopPV() {
+  return G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+}
+
+G4LogicalVolume *PrintG4Touch::getTopLV() { return theTopPV_->GetLogicalVolume(); }
+
+#include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+
+DEFINE_SIMWATCHER(PrintG4Touch);

--- a/SimG4Core/PrintGeomInfo/plugins/PrintG4Touch.cc
+++ b/SimG4Core/PrintGeomInfo/plugins/PrintG4Touch.cc
@@ -56,8 +56,7 @@ private:
 PrintG4Touch::PrintG4Touch(const edm::ParameterSet &p) {
   dd4hep_ = p.getUntrackedParameter<bool>("DD4hep", false);
   verbosity_ = p.getUntrackedParameter<bool>("Verbosity", false);
-  G4cout << "PrintG4Touch:: initialised for dd4hep " << dd4hep_ << " with verbosity levels:"
-         << verbosity_ << G4endl;
+  G4cout << "PrintG4Touch:: initialised for dd4hep " << dd4hep_ << " with verbosity levels:" << verbosity_ << G4endl;
 }
 
 void PrintG4Touch::update(const BeginOfRun *run) {
@@ -84,7 +83,8 @@ void PrintG4Touch::dumpSummary(std::ostream &out) {
     out << " No volume created " << G4endl;
     return;
   }
-  out << " @@@ Geometry built inside world volume: " << DD4hep2DDDName::namePV(static_cast<std::string>(theTopPV_->GetName()), dd4hep_) << G4endl;
+  out << " @@@ Geometry built inside world volume: "
+      << DD4hep2DDDName::namePV(static_cast<std::string>(theTopPV_->GetName()), dd4hep_) << G4endl;
   // Get number of solids (< # LV if several LV share a solid)
   const G4LogicalVolumeStore *lvs = G4LogicalVolumeStore::GetInstance();
   std::vector<G4LogicalVolume *>::const_iterator lvcite;
@@ -124,9 +124,14 @@ void PrintG4Touch::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, std:
   G4LogicalVolume *lv = pv->GetLogicalVolume();
 
   G4ThreeVector globalpoint = fHistory_.GetTopTransform().Inverse().TransformPoint(G4ThreeVector(0, 0, 0));
-  std::string mother = (pv->GetMotherLogical()) ? (DD4hep2DDDName::nameSolid(static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_)) : "World";
+  std::string mother = (pv->GetMotherLogical())
+                           ? (DD4hep2DDDName::nameSolid(
+                                 static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_))
+                           : "World";
   std::string lvname = DD4hep2DDDName::nameSolid(static_cast<std::string>(lv->GetName()), dd4hep_);
-  out << leafDepth << "### VOLUME = " << lvname << " Copy No " << pv->GetCopyNo() << " in " << mother << " global position of centre " << globalpoint << " (r = " << globalpoint.perp() << ", phi = " << convertRadToDeg(globalpoint.phi()) << ")" << G4endl;
+  out << leafDepth << "### VOLUME = " << lvname << " Copy No " << pv->GetCopyNo() << " in " << mother
+      << " global position of centre " << globalpoint << " (r = " << globalpoint.perp()
+      << ", phi = " << convertRadToDeg(globalpoint.phi()) << ")" << G4endl;
 
   int NoDaughters = lv->GetNoDaughters();
   while ((NoDaughters--) > 0) {
@@ -140,15 +145,18 @@ void PrintG4Touch::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDepth, std:
 }
 
 void PrintG4Touch::getTouch(G4VPhysicalVolume *pv,
-			    unsigned int leafDepth,
-			    unsigned int copym,
-			    std::vector<std::string> &touches) {
+                            unsigned int leafDepth,
+                            unsigned int copym,
+                            std::vector<std::string> &touches) {
   if (leafDepth == 0)
     fHistory_.SetFirstEntry(pv);
   else
     fHistory_.NewLevel(pv, kNormal, pv->GetCopyNo());
 
-  std::string mother = (pv->GetMotherLogical()) ? (DD4hep2DDDName::nameSolid(static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_)) : "World";
+  std::string mother = (pv->GetMotherLogical())
+                           ? (DD4hep2DDDName::nameSolid(
+                                 static_cast<std::string>(pv->GetMotherLogical()->GetSolid()->GetName()), dd4hep_))
+                           : "World";
 
   G4LogicalVolume *lv = pv->GetLogicalVolume();
   std::string lvname = DD4hep2DDDName::nameSolid(static_cast<std::string>(lv->GetName()), dd4hep_);

--- a/SimG4Core/PrintGeomInfo/test/python/runPrintG4Touch_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runPrintG4Touch_cfg.py
@@ -1,0 +1,108 @@
+###############################################################################
+# Way to use this:
+#   cmsRun grunPrintG4Touch_cfg.py geometry=D98 dd4hep=False
+#
+#   Options for geometry D88, D91, D92, D93, D94, D95, D96, D98, D99, D100,
+#                        D101
+#   Options for type DDD, DD4hep
+#
+###############################################################################
+import FWCore.ParameterSet.Config as cms
+import os, sys, imp, re
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "D88",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "geometry of operations: D88, D91, D92, D93, D94, D95, D96, D98, D99, D100, D101")
+options.register('type',
+                 "DDD",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "type of operations: DDD, DD4hep")
+
+### get and parse the command line arguments
+options.parseArguments()
+
+print(options)
+
+####################################################################
+# Use the options
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+if (options.type == "DD4hep"):
+    geomFile = "Configuration.Geometry.GeometryDD4hepExtended2026" + options.geometry + "Reco_cff"
+    if (options.geometry == "D94"):
+        from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
+        process = cms.Process('PrintG4Solids',Phase2C20I13M9,dd4hep)
+    else:
+        from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+        process = cms.Process('PrintG4Solids',Phase2C17I13M9,dd4hep)
+else:
+    geomFile = "Configuration.Geometry.GeometryExtended2026" + options.geometry + "Reco_cff"
+    if (options.geometry == "D94"):
+        from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
+        process = cms.Process('PrintG4Solids',Phase2C20I13M9)
+    else:
+        from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+        process = cms.Process('PrintG4Solids',Phase2C17I13M9)
+
+print("Geometry file Name: ", geomFile)
+
+process.load(geomFile)
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('SimGeneral.HepPDTESSource.pdt_cfi')
+process.load('IOMC.RandomEngine.IOMC_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedFlat_cfi')
+process.load('GeneratorInterface.Core.generatorSmeared_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('SimG4Core.Application.g4SimHits_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.G4cerr=dict()
+    process.MessageLogger.G4cout=dict()
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+                                   PGunParameters = cms.PSet(
+                                       PartID = cms.vint32(14),
+                                       MinEta = cms.double(-3.5),
+                                       MaxEta = cms.double(3.5),
+                                       MinPhi = cms.double(-3.14159265359),
+                                       MaxPhi = cms.double(3.14159265359),
+                                       MinE   = cms.double(9.99),
+                                       MaxE   = cms.double(10.01)
+                                   ),
+                                   AddAntiParticle = cms.bool(False),
+                                   Verbosity       = cms.untracked.int32(0),
+                                   firstRun        = cms.untracked.uint32(1)
+                               )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+
+process.g4SimHits.UseMagneticField = False
+process.g4SimHits.Physics.type = 'SimG4Core/Physics/DummyPhysics'
+process.g4SimHits.Physics.DummyEMPhysics = True
+process.g4SimHits.Physics.DefaultCutValue = 10. 
+process.g4SimHits.LHCTransport = False
+
+if (options.type == "DD4hep"):
+    dd4hep = True
+else:
+    dd4hep = False
+
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    dd4hep         = cms.untracked.bool(dd4hep),
+    verbosity      = cms.untracked.bool(False),
+    type           = cms.string('PrintG4Touch')
+))
+
+process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmeared*process.g4SimHits)


### PR DESCRIPTION
#### PR description:

Add a procedure to dump all touchables from a G4 geometry setup

#### PR validation:

Use the scripts to understand the differences between DDD and DD4hep geometry definitions in HGCal geometry

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special