### PR TITLE
[13_0_X] Add BX boundary checks for BXVector push_back

### DIFF
--- a/DataFormats/L1Trigger/BuildFile.xml
+++ b/DataFormats/L1Trigger/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/Concurrency"/>
+<use name="FWCore/MessageLogger"/>
 <use name="hls"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/L1Trigger/interface/BXVector.icc
+++ b/DataFormats/L1Trigger/interface/BXVector.icc
@@ -3,6 +3,8 @@
 #include <cassert>
 using namespace std;
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 template <class T>
 BXVector<T>::BXVector(unsigned size,  // number of objects per BX
                       int bxFirst,    // first BX stored
@@ -129,11 +131,17 @@ unsigned BXVector<T>::size(int bx) const {
 // add element with given BX index
 template <class T>
 void BXVector<T>::push_back(int bx, T object) {
-  data_.insert(data_.begin() + itrs_[indexFromBX(bx)] + size(bx), object);
-  for (unsigned k = 0; k < itrs_.size(); k++) {
-    if (k > indexFromBX(bx)) {
-      itrs_[k]++;
+  if (bx >= bxFirst_ && bx <= bxLast_) {
+    data_.insert(data_.begin() + itrs_[indexFromBX(bx)] + size(bx), object);
+    for (unsigned k = 0; k < itrs_.size(); k++) {
+      if (k > indexFromBX(bx)) {
+        itrs_[k]++;
+      }
     }
+  } else {
+    edm::LogWarning("BXVectorBXViolation")
+        << "Something attempted to push to a BXVector BX that does not exist. The data will be ignored. bx: " << bx
+        << " bxFirst: " << bxFirst_ << " bxLast: " << bxLast_;
   }
 }
 


### PR DESCRIPTION
#### PR description:

Original PR description:

> Quick fix requested in https://github.com/cms-sw/cmssw/issues/42185. This includes a check in `BXVector::push_back` that only includes the data if it is between `bxFirst_` and `bxLast_`, a `LogWarning` with some info is issued otherwise (I could remove that if complicating the buildfile and includes is undesirable). 

This is being backported for https://github.com/cms-sw/cmssw/pull/42321

#### PR validation:

Original PR works and prevents several BXVector related issues

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42214