### PR TITLE
tracking MTV: improve ability to select region in eta-phi for sim particles

### DIFF
--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -90,6 +90,7 @@ protected:
   const bool doPVAssociationPlots_;
   const bool doSeedPlots_;
   const bool doMVAPlots_;
+  const bool applyTPSelToSimMatch_;
 
   std::vector<bool> doResolutionPlots_;
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -62,6 +62,7 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset)
       doPVAssociationPlots_(pset.getUntrackedParameter<bool>("doPVAssociationPlots")),
       doSeedPlots_(pset.getUntrackedParameter<bool>("doSeedPlots")),
       doMVAPlots_(pset.getUntrackedParameter<bool>("doMVAPlots")),
+      applyTPSelToSimMatch_(pset.getParameter<bool>("applyTPSelToSimMatch")),
       simPVMaxZ_(pset.getUntrackedParameter<double>("simPVMaxZ")) {
   if (not(pset.getParameter<edm::InputTag>("cores").label().empty())) {
     cores_ = consumes<edm::View<reco::Candidate>>(pset.getParameter<edm::InputTag>("cores"));
@@ -172,7 +173,9 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset)
                                         pset.getParameter<bool>("chargedOnlyTP"),
                                         pset.getParameter<bool>("stableOnlyTP"),
                                         pset.getParameter<std::vector<int>>("pdgIdTP"),
-                                        pset.getParameter<bool>("invertRapidityCutTP"));
+                                        pset.getParameter<bool>("invertRapidityCutTP"),
+                                        pset.getParameter<double>("minPhi"),
+                                        pset.getParameter<double>("maxPhi"));
 
   cosmictpSelector = CosmicTrackingParticleSelector(pset.getParameter<double>("ptMinTP"),
                                                     pset.getParameter<double>("minRapidityTP"),
@@ -196,7 +199,9 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset)
                                           psetVsPhi.getParameter<bool>("chargedOnly"),
                                           psetVsPhi.getParameter<bool>("stableOnly"),
                                           psetVsPhi.getParameter<std::vector<int>>("pdgId"),
-                                          psetVsPhi.getParameter<bool>("invertRapidityCut"));
+                                          psetVsPhi.getParameter<bool>("invertRapidityCut"),
+                                          psetVsPhi.getParameter<double>("minPhi"),
+                                          psetVsPhi.getParameter<double>("maxPhi"));
 
   dRTrackSelector = MTVHistoProducerAlgoForTracker::makeRecoTrackSelectorFromTPSelectorParameters(psetVsPhi);
 
@@ -1065,6 +1070,8 @@ void MultiTrackValidator::dqmAnalyze(const edm::Event& event,
 
         auto tpFound = recSimColl.find(track);
         isSimMatched = tpFound != recSimColl.end();
+        if (applyTPSelToSimMatch_ && isSimMatched)
+          isSimMatched = tpSelector(*tpFound->val[0].first);
         if (isSimMatched) {
           const auto& tp = tpFound->val;
           nSimHits = tp[0].first->numberOfTrackerHits();

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -16,6 +16,7 @@ TrackingParticleSelectionForEfficiency = cms.PSet(
     invertRapidityCutTP = cms.bool(False),
     maxPhi = cms.double(3.2),
     minPhi = cms.double(-3.2),
+    applyTPSelToSimMatch = cms.bool(False)
 )
 
 def _modifyForPhase1(pset):


### PR DESCRIPTION
#### PR description:

A few changes were found necessary (and convenient to apply) in the tracking validation MTV tool while investigating a region in eta-phi with tracking problems

- actually apply phi selection to tracking particles (the parameter was there but not passed to the TPSelector constructor)
- optionally force sim matches to also pass TP selector requirements

No changes are expected in the default setup.

