### PR TITLE
DDAlgoArguments.cc: remove redundant move in return statement

### DIFF
--- a/DetectorDescription/DDCMS/src/DDAlgoArguments.cc
+++ b/DetectorDescription/DDCMS/src/DDAlgoArguments.cc
@@ -130,7 +130,7 @@ xml_h DDAlgoArguments::rawArgument(const string& nam) const {
   for (xml_coll_t p(element, _U(star)); p; ++p) {
     string n = p.attr<string>(_U(name));
     if (n == nam) {
-      return std::move(p);
+      return p;
     }
   }
   except("DD4CMS", "+++ Attempt to access non-existing algorithm option %s[%s]", name.c_str(), nam.c_str());


### PR DESCRIPTION
#### PR description:

When building CMSSW with C++20 standard, the following warning [is emitted](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_CPP20_X_2023-07-24-1100/DetectorDescription/DDCMS):

```
.../src/DetectorDescription/DDCMS/src/DDAlgoArguments.cc: In member function 'xml_h cms::DDAlgoArguments::rawArgument(const std::string&) const':
  .../src/DetectorDescription/DDCMS/src/DDAlgoArguments.cc:133:23: warning: redundant move in return statement [-Wredundant-move]
   133 |       return std::move(p);
      |              ~~~~~~~~~^~~
.../src/DetectorDescription/DDCMS/src/DDAlgoArguments.cc:133:23: note: remove 'std::move' call
```

#### PR validation:

Bot tests
