### PR TITLE
[JME@Phase2HLT] Removal of unnecessary modules

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFPuppiMETv0_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFPuppiMETv0_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-hltPFPuppiMETv0 = cms.EDProducer("PFMETProducer",
-    applyWeight = cms.bool(True),
-    calculateSignificance = cms.bool(False),
-    globalThreshold = cms.double(0.0),
-    src = cms.InputTag("particleFlowTmp"),
-    srcWeights = cms.InputTag("hltPFPuppi")
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFSoftKillerMET_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPFSoftKillerMET_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-hltPFSoftKillerMET = cms.EDProducer("PFMETProducer",
-    calculateSignificance = cms.bool(False),
-    globalThreshold = cms.double(0.0),
-    src = cms.InputTag("hltParticleFlowSoftKiller")
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSoftKiller_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSoftKiller_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-hltParticleFlowSoftKiller = cms.EDProducer("SoftKillerProducer",
-    PFCandidates = cms.InputTag("particleFlowTmp"),
-    Rho_EtaMax = cms.double(5.0),
-    rParam = cms.double(0.4)
-)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTJMESequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTJMESequence_cfi.py
@@ -7,7 +7,6 @@ from ..sequences.HLTPFClusterJMEReconstruction_cfi import *
 from ..sequences.HLTPFJetsCHSReconstruction_cfi import *
 from ..sequences.HLTPFMETsReconstruction_cfi import *
 from ..sequences.HLTPFPuppiJMEReconstruction_cfi import *
-from ..sequences.HLTPFSoftKillerMETReconstruction_cfi import *
 
 HLTJMESequence = cms.Sequence(
     HLTCaloMETReconstruction +
@@ -16,6 +15,5 @@ HLTJMESequence = cms.Sequence(
     HLTAK8PFJetsReconstruction +
     HLTPFJetsCHSReconstruction +
     HLTPFMETsReconstruction +
-    HLTPFSoftKillerMETReconstruction +
     HLTPFPuppiJMEReconstruction
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPFPuppiJMEReconstruction_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPFPuppiJMEReconstruction_cfi.py
@@ -16,7 +16,6 @@ from ..modules.hltPFPuppi_cfi import *
 from ..modules.hltPFPuppiMET_cfi import *
 from ..modules.hltPFPuppiMETTypeOne_cfi import *
 from ..modules.hltPFPuppiMETTypeOneCorrector_cfi import *
-from ..modules.hltPFPuppiMETv0_cfi import *
 from ..modules.hltPFPuppiNoLep_cfi import *
 from ..modules.hltPixelClustersMultiplicity_cfi import *
 
@@ -26,7 +25,6 @@ HLTPFPuppiJMEReconstruction = cms.Sequence(
     hltPFPuppiMET +
     hltPixelClustersMultiplicity +
     hltPFPuppi +
-    hltPFPuppiMETv0 +
     hltAK4PFPuppiJets +
     hltAK4PFPuppiJetCorrectorL1 +
     hltAK4PFPuppiJetCorrectorL2 +

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPFSoftKillerMETReconstruction_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPFSoftKillerMETReconstruction_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from ..modules.hltParticleFlowSoftKiller_cfi import *
-from ..modules.hltPFSoftKillerMET_cfi import *
-
-HLTPFSoftKillerMETReconstruction = cms.Sequence(
-    hltParticleFlowSoftKiller +
-    hltPFSoftKillerMET
-)


### PR DESCRIPTION
#### PR description:

This PR is for removal of modules in Phase2 HLT menu, that are not needed anymore for JME Trigger and corresponding studies.
These are the METv0 and SoftKiller modules. 

#### PR validation:

The modified HLT configuration works with cmsRun and the counts in TriggerReport remain unchanged.

@beaucero @SohamBhattacharya 
