### PR TITLE
Update `PrimaryVertexMonitor`

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -226,17 +226,17 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
   double EtaMin = config.getParameter<double>("EtaMin");
   double EtaMax = config.getParameter<double>("EtaMax");
 
-  IP_ = iBooker.book1D(fmt::format("d{}", varname_),
+  IP_ = iBooker.book1D(fmt::format("d{}_pt{}", varname_, pTcut_),
                        fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} (#mum)", pTcut_, varname_),
                        VarBin,
                        VarMin,
                        VarMax);
 
-  IPErr_ = iBooker.book1D(fmt::format("d{}Err", varname_),
+  IPErr_ = iBooker.book1D(fmt::format("d{}Err_pt{}", varname_, pTcut_),
                           fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_),
                           100,
                           0.,
-                          2000.);
+                          (varname_.find("xy") != std::string::npos) ? 2000. : 10000.);
 
   IPVsPhi_ = iBooker.bookProfile(fmt::format("d{}VsPhi_pt{}", varname_, pTcut_),
                                  fmt::format("PV tracks (p_{{T}} > {}) d_{{{}}} VS track #phi", pTcut_, varname_),
@@ -270,7 +270,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                           PhiMax,
                           VarBin,
                           0.,
-                          100.,
+                          (varname_.find("xy") != std::string::npos) ? 100. : 200.,
                           "");
   IPErrVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 1);
   IPErrVsPhi_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
@@ -283,7 +283,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
                           EtaMax,
                           VarBin,
                           0.,
-                          100.,
+                          (varname_.find("xy") != std::string::npos) ? 100. : 200.,
                           "");
   IPErrVsEta_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   IPErrVsEta_->setAxisTitle(fmt::format("PV tracks (p_{{T}} > {} GeV) d_{{{}}} error (#mum)", pTcut_, varname_), 2);
@@ -316,7 +316,7 @@ void PrimaryVertexMonitor::IPMonitoring::bookIPMonitor(DQMStore::IBooker& iBooke
       PhiMax,
       VarBin,
       0.,
-      100.,
+      (varname_.find("xy") != std::string::npos) ? 100. : 200.,
       "");
   IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #eta", 1);
   IPErrVsEtaVsPhi_->setAxisTitle("PV track (p_{T} > 1 GeV) #phi", 2);

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -32,6 +32,17 @@ public:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
+  struct IPMonitoring {
+    std::string varname_;
+    float pTcut_;
+    dqm::reco::MonitorElement *IP_, *IPErr_;
+    dqm::reco::MonitorElement *IPVsPhi_, *IPVsEta_;
+    dqm::reco::MonitorElement *IPErrVsPhi_, *IPErrVsEta_;
+    dqm::reco::MonitorElement *IPVsEtaVsPhi_, *IPErrVsEtaVsPhi_;
+
+    void bookIPMonitor(DQMStore::IBooker &, const edm::ParameterSet &);
+  };
+
 private:
   void pvTracksPlots(const reco::Vertex &v);
   void vertexPlots(const reco::Vertex &v, const reco::BeamSpot &beamSpot, int i);
@@ -66,15 +77,17 @@ private:
   MonitorElement *bsX, *bsY, *bsZ, *bsSigmaZ, *bsDxdz, *bsDydz, *bsBeamWidthX, *bsBeamWidthY, *bsType;
 
   MonitorElement *sumpt, *ntracks, *weight, *chi2ndf, *chi2prob;
-  MonitorElement *dxy, *dxy2, *dz, *dxyErr, *dzErr;
   MonitorElement *phi_pt1, *eta_pt1;
   MonitorElement *phi_pt10, *eta_pt10;
-  MonitorElement *dxyVsPhi_pt1, *dzVsPhi_pt1;
-  MonitorElement *dxyVsEta_pt1, *dzVsEta_pt1;
-  MonitorElement *dxyVsEtaVsPhi_pt1, *dzVsEtaVsPhi_pt1;
-  MonitorElement *dxyVsPhi_pt10, *dzVsPhi_pt10;
-  MonitorElement *dxyVsEta_pt10, *dzVsEta_pt10;
-  MonitorElement *dxyVsEtaVsPhi_pt10, *dzVsEtaVsPhi_pt10;
+
+  MonitorElement *dxy2;
+
+  // IP monitoring structs
+  IPMonitoring dxy_pt1;
+  IPMonitoring dxy_pt10;
+
+  IPMonitoring dz_pt1;
+  IPMonitoring dz_pt10;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to rationalize the code of `PrimaryVertexMonitor` in order to avoid unnecessary repetitions, also I am adding profile plots of the transverse and longitudinal impact parameter errors as a function of track eta and phi.

#### PR validation:

Privately checked `runTheMatrix.py -l 140.063 -t 4 -j 8 --ibeos` output.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but to be backported.