### PR TITLE
[13_1_X] fixed comparePayloads in LHInfo* PopCons

### DIFF
--- a/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
@@ -164,8 +164,8 @@ namespace theLHCInfoPerFillImpl {
   bool comparePayloads(const LHCInfoPerFill& rhs, const LHCInfoPerFill& lhs) {
     if (rhs.fillNumber() != lhs.fillNumber() || rhs.delivLumi() != lhs.delivLumi() || rhs.recLumi() != lhs.recLumi() ||
         rhs.instLumi() != lhs.instLumi() || rhs.instLumiError() != lhs.instLumiError() ||
-        rhs.lhcState() != rhs.lhcState() || rhs.lhcComment() != rhs.lhcComment() ||
-        rhs.ctppsStatus() != rhs.ctppsStatus()) {
+        rhs.lhcState() != lhs.lhcState() || rhs.lhcComment() != lhs.lhcComment() ||
+        rhs.ctppsStatus() != lhs.ctppsStatus()) {
       return false;
     }
     return true;

--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -562,15 +562,15 @@ namespace LHCInfoImpl {
       return false;
     if (rhs.instLumiError() != lhs.instLumiError())
       return false;
-    if (rhs.crossingAngle() != rhs.crossingAngle())
+    if (rhs.crossingAngle() != lhs.crossingAngle())
       return false;
-    if (rhs.betaStar() != rhs.betaStar())
+    if (rhs.betaStar() != lhs.betaStar())
       return false;
-    if (rhs.lhcState() != rhs.lhcState())
+    if (rhs.lhcState() != lhs.lhcState())
       return false;
-    if (rhs.lhcComment() != rhs.lhcComment())
+    if (rhs.lhcComment() != lhs.lhcComment())
       return false;
-    if (rhs.ctppsStatus() != rhs.ctppsStatus())
+    if (rhs.ctppsStatus() != lhs.ctppsStatus())
       return false;
     return true;
   }


### PR DESCRIPTION
#### PR description:

Backport of #42360

Fixed `LHCInfo` PopCon (`LHCInfoPopConSourceHandler`) and `LHCInfoPerFill` PopCon (`LHCInfoPerFillPopConAnalyzer`) skipping payloads because of bug in `comparePayload`.  It was supposed to save a payload every time one of some variables change. Because of the bug, for some variables it was not saving the payload despite the change of the vaule.


#### PR validation:

See master PR for validation description

#### Backport

Backport of #42360
