### PR TITLE
[13.2.X] Support HLT tracks in alignment validation

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -147,7 +147,8 @@ def getSequence(process, collection,
 
     if collection in ("ALCARECOTkAlMinBias", "generalTracks",
                       "ALCARECOTkAlMinBiasHI", "hiGeneralTracks",
-                      "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks"):
+                      "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks",
+                      "hltMergedTracks"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42302

#### PR description:

It is in the plans to start using `hltMergedTracks` from the `SteamHLTMonitor` PD in the tracker alignment procedure in order to minimize the drift between the derived alignment correction / validations and their actual usage in production (at the HLT).
This PR proposes a couple of minimal fixes in order to be able to run the standard setup.
There are two commits:
   * 829f1889b48542c214776307227222d19696565e supports the `hltMergedTracks` collection in the common track selection and refitting sequence
   * 7a12d5f50922c0100da7372db5f5bda068c41f48 supports the `SiStripMatchedRecHit2D` and `ProjectedSiStripRecHit2D` collections in `TrackerTrackHitFilter`. Encountering hits from either of these two collections was leading to a runtime exception of the type:
   
```   
----- Begin Fatal Exception 05-Jul-2023 19:33:49 CEST-----------------------
An exception of category 'Unknown RecHit Type' occurred while
   [0] Processing  Event run: 370102 lumi: 668 event: 1557577232 stream: 0
   [1] Running path 'p'
   [2] Calling method for module TrackerTrackHitFilter/'TrackerTrackHitFilter'
   
Exception Message:
RecHit of type 22SiStripMatchedRecHit2D not supported. (use c++filt to demangle the name)
----- End Fatal Exception -------------------------------------------------
```
These two collections (as the previously stated in the removed comment) did not happen anymore since CMSSW > 2_0_X because of hit splitting in stereo modules in offline reconstruction, but in HLT tracking stereo hit splitting is not performed.
In order to cope with the  `SiStripMatchedRecHit2D`, the cut on the S/N is performed by taking the average of the stereo and mono hits.

#### PR validation:

Tested the minimal configuration provided by @henriettepetersen (available [here](https://gist.github.com/mmusich/ff4d8ba8d9b852e67ffad514dc026cbf)).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of  https://github.com/cms-sw/cmssw/pull/42302