### PR TITLE
[13.1.X] Support HLT tracks in alignment validation

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -147,7 +147,8 @@ def getSequence(process, collection,
 
     if collection in ("ALCARECOTkAlMinBias", "generalTracks",
                       "ALCARECOTkAlMinBiasHI", "hiGeneralTracks",
-                      "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks"):
+                      "ALCARECOTkAlJetHT", "ALCARECOTkAlDiMuonVertexTracks",
+                      "hltMergedTracks"):
         options["TrackSelector"]["Alignment"].update({
                 "ptMin": 1.0,
                 "pMin": 8.,

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -2,6 +2,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -805,6 +806,7 @@ namespace reco {
           //check that hit is in a det belonging to a subdet where we decided to apply a S/N cut
           const std::type_info &type = typeid(*therechit);
           const SiStripCluster *cluster;
+          std::optional<const SiStripCluster *> stereo_cluster;
           if (type == typeid(SiStripRecHit2D)) {
             const SiStripRecHit2D *hit = dynamic_cast<const SiStripRecHit2D *>(therechit);
             if (hit != nullptr)
@@ -825,26 +827,64 @@ namespace reco {
                   << "(detID=" << id.rawId() << ")\n ";
               keepthishit = false;
             }
-          }
-          //the following two cases should not happen anymore since CMSSW > 2_0_X because of hit splitting in stereo modules
-          //const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(therechit);
-          //const ProjectedSiStripRecHit2D* unmatchedhit = dynamic_cast<const ProjectedSiStripRecHit2D*>(therechit);
-          else {
+          } else if (type == typeid(SiStripMatchedRecHit2D)) {
+            const SiStripMatchedRecHit2D *hit = dynamic_cast<const SiStripMatchedRecHit2D *>(therechit);
+            if (hit != nullptr) {
+              cluster = &(hit->monoCluster());
+              stereo_cluster = &(hit->stereoCluster());
+            } else {
+              edm::LogError("TrackerTrackHitFilter")
+                  << "TrackerTrackHitFilter::checkStoN : Unknown valid tracker hit in subdet " << id.subdetId()
+                  << "(detID=" << id.rawId() << ")\n ";
+              keepthishit = false;
+            }
+          } else if (type == typeid(ProjectedSiStripRecHit2D)) {
+            const ProjectedSiStripRecHit2D *hit = dynamic_cast<const ProjectedSiStripRecHit2D *>(therechit);
+            if (hit != nullptr)
+              cluster = &*(hit->cluster());
+            else {
+              edm::LogError("TrackerTrackHitFilter")
+                  << "TrackerTrackHitFilter::checkStoN : Unknown valid tracker hit in subdet " << id.subdetId()
+                  << "(detID=" << id.rawId() << ")\n ";
+              keepthishit = false;
+            }
+          } else {
             throw cms::Exception("Unknown RecHit Type")
-                << "RecHit of type " << type.name() << " not supported. (use c++filt to demangle the name)";
+                << "RecHit of type " << edm::typeDemangle(type.name()) << " not supported.";
           }
 
           if (keepthishit) {
-            siStripClusterInfo_->setCluster(*cluster, id.rawId());
-            if ((subdetStoNlowcut_[subdet_cnt - 1] > 0) &&
-                (siStripClusterInfo_->signalOverNoise() < subdetStoNlowcut_[subdet_cnt - 1]))
+            double sToNlowCut = subdetStoNlowcut_[subdet_cnt - 1];
+            double sToNhighCut = subdetStoNhighcut_[subdet_cnt - 1];
+
+            float sOverN{-1.f};
+
+            if UNLIKELY (stereo_cluster.has_value()) {
+              const auto &matched = dynamic_cast<const SiStripMatchedRecHit2D *>(therechit);
+              if (!matched) {
+                throw cms::Exception("LogicError")
+                    << "expected a SiStripMatchedRecHit2D but could not cast!" << std::endl;
+              }
+              siStripClusterInfo_->setCluster(*cluster, matched->monoId());
+              sOverN = siStripClusterInfo_->signalOverNoise();
+              // if it's matched rechit, use the average of stereo and mono clusters
+              siStripClusterInfo_->setCluster(**stereo_cluster, matched->stereoId());
+              sOverN += siStripClusterInfo_->signalOverNoise();
+              sOverN *= 0.5f;
+            } else {
+              siStripClusterInfo_->setCluster(*cluster, id.rawId());
+              sOverN = siStripClusterInfo_->signalOverNoise();
+            }
+
+            if ((sToNlowCut > 0) && (sOverN < sToNlowCut)) {
               keepthishit = false;
-            if ((subdetStoNhighcut_[subdet_cnt - 1] > 0) &&
-                (siStripClusterInfo_->signalOverNoise() > subdetStoNhighcut_[subdet_cnt - 1]))
+            }
+
+            if ((sToNhighCut > 0) && (sOverN > sToNhighCut)) {
               keepthishit = false;
+            }
             //if(!keepthishit)std::cout<<"Hit rejected because of bad S/N: "<<siStripClusterInfo_->signalOverNoise()<<std::endl;
           }
-
         }  //end if  subdetStoN_[subdet_cnt]&&...
 
       }  //end if subdet_cnt >2


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42302

#### PR description:

It is in the plans to start using `hltMergedTracks` from the `SteamHLTMonitor` PD in the tracker alignment procedure in order to minimize the drift between the derived alignment correction / validations and their actual usage in production (at the HLT).
This PR proposes a couple of minimal fixes in order to be able to run the standard setup.
There are two commits:
   *  9ade9e6c45a3930af0606c1043260e429091e2d6 supports the `hltMergedTracks` collection in the common track selection and refitting sequence
   * 1f2d6b20a79f7dd2f3836f7bb8536bae498a0517 supports the `SiStripMatchedRecHit2D` and `ProjectedSiStripRecHit2D` collections in `TrackerTrackHitFilter`. Encountering hits from either of these two collections was leading to a runtime exception of the type:
   
```   
----- Begin Fatal Exception 05-Jul-2023 19:33:49 CEST-----------------------
An exception of category 'Unknown RecHit Type' occurred while
   [0] Processing  Event run: 370102 lumi: 668 event: 1557577232 stream: 0
   [1] Running path 'p'
   [2] Calling method for module TrackerTrackHitFilter/'TrackerTrackHitFilter'
   
Exception Message:
RecHit of type 22SiStripMatchedRecHit2D not supported. (use c++filt to demangle the name)
----- End Fatal Exception -------------------------------------------------
```
These two collections (as the previously stated in the removed comment) did not happen anymore since CMSSW > 2_0_X because of hit splitting in stereo modules in offline reconstruction, but in HLT tracking stereo hit splitting is not performed.
In order to cope with the  `SiStripMatchedRecHit2D`, the cut on the S/N is performed by taking the average of the stereo and mono hits.

#### PR validation:

Tested the minimal configuration provided by @henriettepetersen (available [here](https://gist.github.com/mmusich/ff4d8ba8d9b852e67ffad514dc026cbf)).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of  https://github.com/cms-sw/cmssw/pull/42302