### PR TITLE
Get rid of useless check in TopRecoilHook

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/TopRecoilHook.h
@@ -33,11 +33,7 @@ namespace Pythia8 {
     }
 
     // Destructor prints histogram.
-    ~TopRecoilHook() override {
-      if (doTopRecoil)
-        ;
-      delete wtCorr;
-    }
+    ~TopRecoilHook() override { delete wtCorr; }
 
     // Initialise. Only use hook for simple showers with recoilToColoured = off.
     bool initAfterBeams() override {


### PR DESCRIPTION
#### PR description:

Remove an useless check in the class destructor

This also gets rid of a build warning from this package (see IBs since CMSSW_13_3_X_2023-07-19-2300)

@vslokenb this was introduced with your #42180: what was intended with that check? Please have a look.

#### PR validation:

It builds