### PR TITLE
[13_0_X] Update 2023 MC GTs with the fixed L1T tag and re-snapshot the data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-06-14 12:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v3',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-06-14 12:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v3',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-06-14 12:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v3',
+    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-07-25 12:00:00 (UTC)
+    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v4',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-07-25 12:00:00 (UTC)
+    'run3_data_express'            : '130X_dataRun3_Express_frozen_v4',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-07-25 12:00:00 (UTC)
+    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v4',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20 (UTC)
     'run3_data'                    : '130X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -76,9 +76,9 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '130X_mcRun3_2023_design_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v11',
+    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v12',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v10',
+    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/42358 

This PR updates the:
 - 2023 MC production GTs with the fixed L1T tag `L1TMuonGlobalParams_Stage2v0_2023_mc_v2` to resolve the discrepancy observed in [1]. Also, see [CMS Talk post](https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-2023-mc/24376/23) [2] for the relevant tag details.
 - Run3 data GTs with updated snapshot time

[1] https://cms-pdmv.cern.ch/relmon/1688568203___CMSSW_13_2_0_pre2_2023vsCMSSW_13_1_0_pre4_2023/FullSimReport_HLT/RelValWToLNu_14TeV_131X_mcRun3_2023_realistic_v4_2023/7fdc3f5aa9.html
[2] https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-2023-mc/24376/23

**GT Differences with respect to the last ones**:
- See master PR for data GT diffs
- **Phase1 2023 realistic**:
   https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v11/130X_mcRun3_2023_realistic_v12

- **Phase1 2023 cosmics realistic**:
   https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_realistic_deco_v10/130X_mcRun3_2023cosmics_realistic_deco_v11
	

#### PR validation:
GTs tested locally with 
- `runTheMatrix.py -l 138.2,138.4,139.001,140.106,140.111,141.031,141.032,141.036,141.038,12434.0,12434.7,12634.0,12634.99 -j 8 --ibeos` 
- `runTheMatrix.py -l 12400.0,12430.0,12440.0,12627.0,12643.0 --what upgrade -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/42358
