### PR TITLE
Maybe remove build warning in TrackerMap, but at least clean it up

### DIFF
--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -484,8 +484,8 @@ void TrackerMap::init() {
   gminvalue = 0.;
   gmaxvalue = 0.;  //default global range for online rendering
 
-  ndet = 3;   // number of detectors: pixel, inner silicon, outer silicon
-  npart = 3;  // number of detector parts: endcap -z, barrel, endcap +z
+  int constexpr ndet = 3;   // number of detectors: pixel, inner silicon, outer silicon
+  int constexpr npart = 3;  // number of detector parts: endcap -z, barrel, endcap +z
 
   //allocate module map
   for (int subdet = 1; subdet < ndet + 1; subdet++) {        //loop on subdetectors


### PR DESCRIPTION
#### PR description:

The possibility to return -1 from function `nlayer(int det, int part, int lay)` (which will never happen in practice, given its fixed input parameters) is generating build warnings in the IBs.

I imagine that if we return a non-negative number in that anyhow impossible case, those warnings can disappear.

**EDIT**: triggered by comment https://github.com/cms-sw/cmssw/pull/42373#issuecomment-1650605894 I reverted the modification of the return value in the `nlayer` function. I am not sure any more that the other change applied here, i.e. the loop boundaries defined as `constexpr` instead of being variables, will be enough to shut up the build warning: in any case I didn't want to add further useless checks in the caller code.
While doing so, I could not resist and applied a few very simple clean ups to the code. Therefore, l don't close this PR, but admittently it has a rather low priority...

#### PR validation:

It builds. No changes expected