### PR TITLE
Add initial null value for model result in calo summary

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -217,7 +217,7 @@ void L1TCaloSummary::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   }
   //Extract model output
   //Would be good to be able to configure the precision of the result
-  ap_fixed<11, 5> modelResult[1];
+  ap_fixed<11, 5> modelResult[1] = {ap_fixed<11, 5>("0.0", 10)};
   model->prepare_input(modelInput);
   model->predict();
   model->read_result(modelResult);


### PR DESCRIPTION
### PR description:

Adds an initial (null) value for the `modelResult` CICADA variable in L1TCaloSummary in response to https://github.com/cms-sw/cmssw/issues/41794

@iarspider This should(?) hopefully silence some of the warning related to `L1TCaloSummary.cc`, but I can't do anything about build warnings that may belong to the `ap_fixed` type itself. I will look at the L1TCaloLayer1 plugin soon

### PR validation:

All code compiles, passes code-checks, and has had code-formatting applied. In theory this _should_ be a trivial technical fix that again _shouldn't_ be able to mess anything else up.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, or tied into any existing workflows.