### PR TITLE
Fix error code on fallback file open error with test, 12_6_X backport

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -252,14 +252,15 @@ namespace edm {
       }
       for (std::vector<std::string>::const_iterator it = fNames.begin(); it != fNames.end(); ++it) {
         try {
+          usedFallback_ = (it != fNames.begin());
           std::unique_ptr<char[]> name(gSystem->ExpandPathName(it->c_str()));
           filePtr = std::make_shared<InputFile>(name.get(), "  Initiating request to open file ", inputType);
-          usedFallback_ = (it != fNames.begin());
           break;
         } catch (cms::Exception const& e) {
           if (!skipBadFiles && std::next(it) == fNames.end()) {
             InputFile::reportSkippedFile((*it), logicalFileName());
-            Exception ex(errors::FileOpenError, "", e);
+            errors::ErrorCodes errorCode = usedFallback_ ? errors::FallbackFileOpenError : errors::FileOpenError;
+            Exception ex(errorCode, "", e);
             ex.addContext("Calling RootInputFileSequence::initTheFile()");
             std::ostringstream out;
             out << "Input file " << (*it) << " could not be opened.";

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -12,4 +12,5 @@
  
  <test name="TestIOPoolInputRepeating" command="testRepeatingCachedRootSource.sh"/>
  <test name="TestIOPoolInputNoParentDictionary" command="testNoParentDictionary.sh"/>
+ <test name="TestFileOpenErrorExitCode" command="testFileOpenErrorExitCode.sh"/>
 </environment>

--- a/IOPool/Input/test/sitelocalconfig/noFallbackFile/local/storage.json
+++ b/IOPool/Input/test/sitelocalconfig/noFallbackFile/local/storage.json
@@ -1,0 +1,10 @@
+[
+   {  "site": "DUMMY",
+      "volume": "DummyVolume",
+      "protocols": [
+         {  "protocol": "protocolThatDoesNotExist",
+            "prefix": "abc"
+         }
+      ]
+   }
+]

--- a/IOPool/Input/test/sitelocalconfig/noFallbackFile/site-local-config.xml
+++ b/IOPool/Input/test/sitelocalconfig/noFallbackFile/site-local-config.xml
@@ -1,0 +1,7 @@
+<site-local-config>
+<site name="DUMMY">
+  <data-access>
+    <catalog volume="DummyVolume" protocol="protocolThatDoesNotExist"/>
+  </data-access>
+</site>
+</site-local-config>

--- a/IOPool/Input/test/sitelocalconfig/useFallbackFile/local/storage.json
+++ b/IOPool/Input/test/sitelocalconfig/useFallbackFile/local/storage.json
@@ -1,0 +1,18 @@
+[
+   {  "site": "DUMMY",
+      "volume": "DummyVolume1",
+      "protocols": [
+         {  "protocol": "protocolThatDoesNotExist1",
+            "prefix": "abc"
+         }
+      ]
+   },
+   {  "site": "DUMMY",
+      "volume": "DummyVolume2",
+      "protocols": [
+         {  "protocol": "protocolThatDoesNotExist2",
+            "prefix": "abc"
+         }
+      ]
+   }
+]

--- a/IOPool/Input/test/sitelocalconfig/useFallbackFile/site-local-config.xml
+++ b/IOPool/Input/test/sitelocalconfig/useFallbackFile/site-local-config.xml
@@ -1,0 +1,8 @@
+<site-local-config>
+<site name="DUMMY">
+  <data-access>
+    <catalog volume="DummyVolume1" protocol="protocolThatDoesNotExist1"/>
+    <catalog volume="DummyVolume2" protocol="protocolThatDoesNotExist2"/>
+  </data-access>
+</site>
+</site-local-config>

--- a/IOPool/Input/test/testFileOpenErrorExitCode.sh
+++ b/IOPool/Input/test/testFileOpenErrorExitCode.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+mkdir -p SITECONF
+mkdir -p SITECONF/local
+mkdir -p SITECONF/local/JobConfig
+
+export SITECONFIG_PATH=${PWD}/SITECONF/local
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/noFallbackFile/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/noFallbackFile/local/storage.json ${SITECONFIG_PATH}/
+F1=${LOCAL_TEST_DIR}/test_fileOpenErrorExitCode_cfg.py
+cmsRun -j NoFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root && die "$F1 should have failed but didn't, exit code was 0" 1
+
+CMSRUN_EXIT_CODE=$(edmFjrDump --exitCode NoFallbackFile_jobreport.xml)
+echo "Exit code after first run of test_fileOpenErrorExitCode_cfg.py is ${CMSRUN_EXIT_CODE}"
+if [ "x${CMSRUN_EXIT_CODE}" != "x8020" ]; then
+  echo "Unexpected cmsRun exit code after FileOpenError, exit code from jobReport ${CMSRUN_EXIT_CODE} which is different from the expected 8020"
+  exit 1
+fi
+
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
+cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/local/storage.json ${SITECONFIG_PATH}/
+cmsRun -j UseFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root && die "$F1 should have failed after file fallback but didn\'t, exit code was 0" 1
+
+CMSRUN_EXIT_CODE=$(edmFjrDump --exitCode UseFallbackFile_jobreport.xml)
+echo "Exit code after second run of test_fileOpenErrorExitCode_cfg.py is ${CMSRUN_EXIT_CODE}"
+if [ "x${CMSRUN_EXIT_CODE}" != "x8028" ]; then
+  echo "Unexpected cmsRun exit code after FallbackFileOpenError, exit code from jobReport ${CMSRUN_EXIT_CODE} which is different from the expected 8028"
+  exit 1
+fi

--- a/IOPool/Input/test/test_fileOpenErrorExitCode_cfg.py
+++ b/IOPool/Input/test/test_fileOpenErrorExitCode_cfg.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test FileOpenErrorExitCode")
+parser.add_argument("--input", type=str, default=[], nargs="*", help="Optional list of input files")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring("/store/"+x for x in args.input)
+)


### PR DESCRIPTION
#### PR description:

Fix error code returned by cmsRun on a FallbackFileOpenError. There was a bug where it returns FileOpenError in the fallback case.

There is more discussion and more information related to this bug in issue https://github.com/cms-sw/cmssw/issues/42040. FYI @stlammel

#### PR validation:

Includes new unit test. New unit test and existing tests pass. This should only affect the behavior after an exception occurs. It should not affect the output of successful cmsRun processes.

Backport of https://github.com/cms-sw/cmssw/pull/42249.
