### PR TITLE
[13_0_X] Removal of StringCutObjectSelector from Muon trigger DQM

### DIFF
--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
@@ -35,8 +35,6 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-
 #include <vector>
 #include "TFile.h"
 #include "TNtuple.h"
@@ -83,18 +81,9 @@ private:
   // Internal Methods
   void book1D(DQMStore::IBooker &, std::string, const std::string &, std::string);
   void book2D(DQMStore::IBooker &, const std::string &, const std::string &, const std::string &, const std::string &);
-  reco::MuonCollection selectedMuons(const reco::MuonCollection &,
-                                     const reco::BeamSpot &,
-                                     bool,
-                                     const StringCutObjectSelector<reco::Muon> &,
-                                     double,
-                                     double);
-
-  trigger::TriggerObjectCollection selectedTriggerObjects(
-      const trigger::TriggerObjectCollection &,
-      const trigger::TriggerEvent &,
-      bool hasTriggerCuts,
-      const StringCutObjectSelector<trigger::TriggerObject> &triggerSelector);
+  reco::MuonCollection selectedMuons(const reco::MuonCollection &, const reco::BeamSpot &, bool);
+  trigger::TriggerObjectCollection selectedTriggerObjects(const trigger::TriggerObjectCollection &,
+                                                          const trigger::TriggerEvent &);
 
   // Input from Configuration File
   std::string hltProcessName_;
@@ -113,21 +102,20 @@ private:
   bool isLastFilter_;
   std::map<std::string, MonitorElement *> hists_;
 
-  // Selectors
-  bool hasTargetRecoCuts;
-  bool hasProbeRecoCuts;
-
-  StringCutObjectSelector<reco::Muon> targetMuonSelector_;
+  double targetMuonEtaMax_;
+  double targetMuonEtaMin_;
+  bool targetIsMuonGlb_;
   double targetZ0Cut_;
   double targetD0Cut_;
   double targetptCutZ_;
   double targetptCutJpsi_;
-  StringCutObjectSelector<reco::Muon> probeMuonSelector_;
+  double probeMuonEtaMax_;
+  double probeMuonEtaMin_;
+  bool probeIsMuonGlb_;
   double probeZ0Cut_;
   double probeD0Cut_;
-
-  StringCutObjectSelector<trigger::TriggerObject> triggerSelector_;
-  bool hasTriggerCuts_;
+  double triggerEtaMaxCut_;
+  double triggerEtaMinCut_;
 };
 
 #endif

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -5,8 +5,11 @@ from DQMOffline.Trigger.HLTMuonOfflineAnalyzer_cfi import hltMuonOfflineAnalyzer
 globalMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(2.0),
     z0Cut = cms.untracked.double(25.0),
-    recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-    hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+    recoMaxEtaCut = cms.untracked.double(2.4),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(True),
+    hltMaxEtaCut  = cms.untracked.double(2.4),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 globalAnalyzerTnP = hltMuonOfflineAnalyzer.clone()

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -94,8 +94,11 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
         d0Cut = cms.untracked.double(2.0),
         z0Cut = cms.untracked.double(25.0),
         ## cuts
-        recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-        hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+        recoMaxEtaCut = cms.untracked.double(2.4),
+        recoMinEtaCut = cms.untracked.double(0.0),
+        recoGlbMuCut = cms.untracked.bool(True),
+        hltMaxEtaCut  = cms.untracked.double(2.4),
+        hltMinEtaCut  = cms.untracked.double(0.0),
     ),
 
     ## If this PSet is empty, then no "tag and probe" plots are produced;
@@ -106,8 +109,11 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
         d0Cut = cms.untracked.double(2.0),
         z0Cut = cms.untracked.double(25.0),
         ## cuts
-        recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-        hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+        recoMaxEtaCut = cms.untracked.double(2.4),
+        recoMinEtaCut = cms.untracked.double(0.0),
+        recoGlbMuCut = cms.untracked.bool(True),        
+        hltMaxEtaCut  = cms.untracked.double(2.4),
+        hltMinEtaCut  = cms.untracked.double(0.0),
     ),
 
 )

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
@@ -5,23 +5,31 @@ from DQMOffline.Trigger.HLTMuonOfflineAnalyzer_cfi import hltMuonOfflineAnalyzer
 barrelMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) < 0.9"),
-    hltCuts  = cms.untracked.string("abs(eta) < 0.9"),
+    recoMaxEtaCut = cms.untracked.double(0.9),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(0.9),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 endcapMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) > 1.4 && "
-                                    "abs(eta) < 2.0"),
-    hltCuts  = cms.untracked.string("abs(eta) > 1.4 && abs(eta) < 2.0"),
+    recoMaxEtaCut = cms.untracked.double(2.0),
+    recoMinEtaCut = cms.untracked.double(1.4),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(2.0),
+    hltMinEtaCut  = cms.untracked.double(1.4),
 )
 
 allMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) < 2.0"),
-    hltCuts  = cms.untracked.string("abs(eta) < 2.0"),
+    recoMaxEtaCut = cms.untracked.double(2.0),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(2.0),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 barrelAnalyzer = hltMuonOfflineAnalyzer.clone(


### PR DESCRIPTION
#### PR description: Backport of [#42348](https://github.com/cms-sw/cmssw/pull/42348)

This PR removes the "StringCutObjectSelector" from the Muon trigger DQM, with the aim of solving the memory issues faced during the 2022 rereco. The cuts on the reco muons and trigger objects are now applied explicitly, since they are few and identical for all trigger paths.

#### PR validation:

See master PR for validation description

#### Backport of [#42348](https://github.com/cms-sw/cmssw/pull/42348)
