### PR TITLE
Fix maybe-uninitialized warnings in L1GTDeltaCut.h

### DIFF
--- a/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h
@@ -106,13 +106,13 @@ namespace l1t {
       res &= os_ ? obj1.hwCharge() != obj2.hwCharge() : true;
       res &= ss_ ? obj1.hwCharge() == obj2.hwCharge() : true;
 
-      int32_t lutCoshDEta;
+      int32_t lutCoshDEta = 0;
       if (dEta) {
         lutCoshDEta = dEta < DETA_LUT_SPLIT ? coshEtaLUT_[dEta.value()] : coshEtaLUT2_[dEta.value() - DETA_LUT_SPLIT];
       }
 
       // Optimization: (cos(x + pi) = -cos(x), x in [0, pi))
-      int32_t lutCosDPhi;
+      int32_t lutCosDPhi = 0;
       if (dPhi) {
         lutCosDPhi = dPhi >= HW_PI ? -cosPhiLUT_[dPhi.value()] : cosPhiLUT_[dPhi.value()];
       }


### PR DESCRIPTION
#### PR description:

gcc12 complains about maybe-uninitialized variables: [log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_X_2023-07-26-1100/L1Trigger/Phase2L1GT)

```
  .../CMSSW_13_3_X_2023-07-26-1100/src/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h:153:78: warning: 'lutCoshDEta' may be used uninitialized [-Wmaybe-uninitialized]
   153 |           invMassSqrDiv2 = obj1.hwPT().to_int64() * obj2.hwPT().to_int64() * lutCoshDEta;
      |                                                                              ^
.../CMSSW_13_3_X_2023-07-26-1100/src/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h:109:15: note: 'lutCoshDEta' declared here
  109 |       int32_t lutCoshDEta;
      |               ^
  .../CMSSW_13_3_X_2023-07-26-1100/src/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h:144:91: warning: 'lutCoshDEta' may be used uninitialized [-Wmaybe-uninitialized]
   144 |           invMassSqrDiv2 = obj1.hwPT().to_int64() * obj2.hwPT().to_int64() * (lutCoshDEta - lutCosDPhi);
      |                                                                                           ^
.../CMSSW_13_3_X_2023-07-26-1100/src/L1Trigger/Phase2L1GT/plugins/L1GTDeltaCut.h:109:15: note: 'lutCoshDEta' declared here
  109 |       int32_t lutCoshDEta;
      |               ^
```

Seems to be false-positive.

#### PR validation:

Code compiles w/o warnings in cmssw code

