### PR TITLE
[GCC13] Add include of cstdint in more places

### DIFF
--- a/CondFormats/PPSObjects/interface/TotemDAQMapping.h
+++ b/CondFormats/PPSObjects/interface/TotemDAQMapping.h
@@ -16,6 +16,7 @@
 #include "CondFormats/PPSObjects/interface/TotemSymbId.h"
 
 #include <map>
+#include <cstdint>
 
 //----------------------------------------------------------------------------------------------------
 

--- a/MagneticField/Interpolation/src/binary_ofstream.cc
+++ b/MagneticField/Interpolation/src/binary_ofstream.cc
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <cstdint>
 
 struct binary_ofstream_error {};
 

--- a/RecoLocalCalo/HcalRecAlgos/bin/generateQIEShapes.cc
+++ b/RecoLocalCalo/HcalRecAlgos/bin/generateQIEShapes.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 //
 // Pregenerate QIE Shapes using hardcoded arrays

--- a/SimG4Core/PrintGeomInfo/test/SimFileCompare.cpp
+++ b/SimG4Core/PrintGeomInfo/test/SimFileCompare.cpp
@@ -24,6 +24,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include "SimG4Core/Geometry/interface/DD4hep2DDDName.h"
 
 struct materials {

--- a/SimG4Core/PrintGeomInfo/test/SolidFileCompare.cpp
+++ b/SimG4Core/PrintGeomInfo/test/SolidFileCompare.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 std::pair<std::string, std::string> splitInto2(const std::string& list) {
   std::string list1, list2;

--- a/SimPPS/RPDigiProducer/interface/RPSimTypes.h
+++ b/SimPPS/RPDigiProducer/interface/RPSimTypes.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <vector>
 #include <set>
+#include <cstdint>
 
 #include "SimPPS/RPDigiProducer/interface/RPEnergyDepositUnit.h"
 #include "SimPPS/RPDigiProducer/interface/RPSignalPoint.h"


### PR DESCRIPTION
Added missing cstdint includes to fix the GCC build errors about

error: 'uint32_t' does not name a type

This is a technical update
