### PR TITLE
fix SetEntries in MESet

### DIFF
--- a/DQM/EcalCommon/src/MESet.cc
+++ b/DQM/EcalCommon/src/MESet.cc
@@ -146,7 +146,7 @@ namespace ecaldqm {
       }
       if (entries == 0.)
         entries = _entries;
-      h->SetEntries(_entries);
+      h->SetEntries(entries);
     }
   }
 


### PR DESCRIPTION
#### PR description:

The static analyzer points out a dead calculation of the local varable `entries`
I think that there is an error in how `h->SetEntries` is given as input parameter: here is the fix for that.
If this is not so, then the whole definition and calculation of `entries` can be safely removed, instead.

@cms-sw/dqm-l2 please have a look and either sign (if correct) or provide the correct fix

#### PR validation:

It builds