### PR TITLE
[13.1.X] clear `badPixelDetsBarrel_` and `badPixelDetsEndcap_` in `PixelInactiveAreaFinder`

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/PixelInactiveAreaFinder.cc
@@ -559,6 +559,10 @@ PixelInactiveAreaFinder::InactiveAreas PixelInactiveAreaFinder::inactiveAreas(co
 
   // assign data to instance variables
   updatePixelDets(iSetup);
+
+  // clear the list of bad pixel modules at each event!
+  badPixelDetsBarrel_.clear();
+  badPixelDetsEndcap_.clear();
   getBadPixelDets(iEvent, iSetup);
 
   //write files for plotting


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42378

#### PR description:

Title says it all, potentially fix for the issue described at https://its.cern.ch/jira/browse/CMSHLT-2881 (`Reproducibility issues with pixel-doublet-recovery iteration (GRun/V151 of 13_0_X)`).

#### PR validation:

Run the script from @missirol 10 times and always obtained same trigger decisions.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/42378