### PR TITLE
fix configuration of GPU Pixel unpacker in Run-3 HLT menus post-#41632

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -118,6 +118,10 @@ def customisePixelGainForRun2Input(process):
         producer.VCaltoElectronOffset_L1 = -670
 
     for producer in producers_by_type(process, "SiPixelRawToClusterCUDA"):
+        producer.VCaltoElectronGain = cms.double(1.)
+        producer.VCaltoElectronGain_L1 = cms.double(1.)
+        producer.VCaltoElectronOffset = cms.double(0.)
+        producer.VCaltoElectronOffset_L1 = cms.double(0.)
         producer.isRun2 = True
 
     return process
@@ -236,6 +240,22 @@ def customizeHLTfor41815(process):
 
     return process
 
+def customizeHLTfor41632(process):
+    for producerType in [
+        'SiPixelRawToClusterCUDA',
+        'SiPixelRawToClusterCUDAPhase1',
+        'SiPixelRawToClusterCUDAHIonPhase1',
+    ]:
+        for producer in producers_by_type(process, producerType):
+            # use explicit cms.double as parameters may not already be present, and
+            # set values to the correct Run-3 values (even when the parameters are already defined)
+            producer.VCaltoElectronGain = cms.double(1.)
+            producer.VCaltoElectronGain_L1 = cms.double(1.)
+            producer.VCaltoElectronOffset = cms.double(0.)
+            producer.VCaltoElectronOffset_L1 = cms.double(0.)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -247,5 +267,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customizeHLTfor41058(process)
     process = customizeHLTfor41495(process)
     process = customizeHLTfor41815(process)
+    process = customizeHLTfor41632(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -256,6 +256,18 @@ def customizeHLTfor41632(process):
 
     return process
 
+def customizeHLTfor42410(process):
+    for producerType in [
+        'SiPixelRawToClusterCUDA',
+        'SiPixelRawToClusterCUDAPhase1',
+        'SiPixelRawToClusterCUDAHIonPhase1',
+    ]:
+        for producer in producers_by_type(process, producerType):
+            if hasattr(producer, 'isRun2'):
+                del producer.isRun2
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -268,5 +280,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customizeHLTfor41495(process)
     process = customizeHLTfor41815(process)
     process = customizeHLTfor41632(process)
+    process = customizeHLTfor42410(process)
 
     return process

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
@@ -78,7 +78,6 @@ private:
   GPUAlgo gpuAlgo_;
   PixelDataFormatter::Errors errors_;
 
-  const bool isRun2_;
   const bool includeErrors_;
   const bool useQuality_;
   uint32_t nDigis_;
@@ -94,7 +93,6 @@ SiPixelRawToClusterCUDAT<TrackerTraits>::SiPixelRawToClusterCUDAT(const edm::Par
       gainsToken_(esConsumes<SiPixelGainCalibrationForHLTGPU, SiPixelGainCalibrationForHLTGPURcd>()),
       cablingMapToken_(esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>(
           edm::ESInputTag("", iConfig.getParameter<std::string>("CablingMapLabel")))),
-      isRun2_(iConfig.getParameter<bool>("isRun2")),
       includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),
       useQuality_(iConfig.getParameter<bool>("UseQualityInfo")),
       clusterThresholds_{iConfig.getParameter<int32_t>("clusterThreshold_layer1"),
@@ -116,7 +114,6 @@ SiPixelRawToClusterCUDAT<TrackerTraits>::SiPixelRawToClusterCUDAT(const edm::Par
 template <typename TrackerTraits>
 void SiPixelRawToClusterCUDAT<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("isRun2", true);
   desc.add<bool>("IncludeErrors", true);
   desc.add<bool>("UseQualityInfo", false);
   // Note: this parameter is obsolete: it is ignored and will have no effect.
@@ -269,8 +266,7 @@ void SiPixelRawToClusterCUDAT<TrackerTraits>::acquire(const edm::Event& iEvent,
     wordFedAppender.initializeWordFed(fedIds_[i], index[i], start[i], words[i]);
   }
 
-  gpuAlgo_.makePhase1ClustersAsync(isRun2_,
-                                   clusterThresholds_,
+  gpuAlgo_.makePhase1ClustersAsync(clusterThresholds_,
                                    gpuMap,
                                    gpuModulesToUnpack,
                                    gpuGains,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -527,7 +527,6 @@ namespace pixelgpudetails {
   // Interface to outside
   template <typename TrackerTraits>
   void SiPixelRawToClusterGPUKernel<TrackerTraits>::makePhase1ClustersAsync(
-      bool isRun2,
       const SiPixelClusterThresholds clusterThresholds,
       const SiPixelROCsStatusAndMapping *cablingMap,
       const unsigned char *modToUnp,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.h
@@ -104,8 +104,7 @@ namespace pixelgpudetails {
     SiPixelRawToClusterGPUKernel& operator=(const SiPixelRawToClusterGPUKernel&) = delete;
     SiPixelRawToClusterGPUKernel& operator=(SiPixelRawToClusterGPUKernel&&) = delete;
 
-    void makePhase1ClustersAsync(bool isRun2,
-                                 const SiPixelClusterThresholds clusterThresholds,
+    void makePhase1ClustersAsync(const SiPixelClusterThresholds clusterThresholds,
                                  const SiPixelROCsStatusAndMapping* cablingMap,
                                  const unsigned char* modToUnp,
                                  const SiPixelGainForHLTonGPU* gains,

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
@@ -28,7 +28,6 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 
 run3_common.toModify(siPixelClustersPreSplittingCUDA,
                      # use the pixel channel calibrations scheme for Run 3
-                     isRun2 = False,
                      clusterThreshold_layer1 = 4000,
                      VCaltoElectronGain      = 1,  # all gains=1, pedestals=0
                      VCaltoElectronGain_L1   = 1,


### PR DESCRIPTION
#### PR description:

#41632 made the VCal-to-NumberOfElectrons conversion factors of the GPU pixel unpacker configurable from the python interface. Since their [default values for Phase-1](https://github.com/cms-sw/cmssw/blob/193041033d0c1947b0f942d8c086a73d6954b3c6/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc#L129-L132) are valid for Run 2 (and not for Run 3), the Run-3 HLT menus became silently misconfigured as a result. This PR fixes that with a customisation function. The HLT menus will eventually be configured correctly in `ConfDB`, once HLT-menu development moves to the `13_2_X` cycle.

In addition, the configuration parameter `isRun2` is removed from the plugin template `SiPixelRawToClusterCUDAT`, as #41632 made it unnecessary.

#### PR validation:

`addOnTests.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_2_X`