### PR TITLE
update `testTriggerEventAnalyzers` unit test (new input, more events)

### DIFF
--- a/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
+++ b/HLTrigger/HLTcore/test/testTriggerEventAnalyzers_cfg.py
@@ -4,11 +4,11 @@ import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing('analysis')
 options.register('logLevel', 'WARNING', options.multiplicity.singleton, options.varType.string, 'value of MessageLogger.cerr.threshold')
-options.register('globalTag', '125X_mcRun3_2022_realistic_v3', options.multiplicity.singleton, options.varType.string, 'name of GlobalTag')
+options.register('globalTag', '131X_mcRun3_2023_realistic_forEGamma_v1', options.multiplicity.singleton, options.varType.string, 'name of GlobalTag')
 options.setDefault('inputFiles', [
-  '/store/mc/CMSSW_13_0_0_pre2/RelValWToLNu_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun3_2022_realistic_v5-v2/80000/155dc2cf-2b77-4797-883c-c22d6c065d59.root',
+  '/store/relval/CMSSW_13_0_11/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/131X_mcRun3_2023_realistic_forEGamma_v1_RV209-v1/2580000/0c5f48ef-554f-478b-9b58-b7bdba0d65bb.root',
 ])
-options.setDefault('maxEvents', 10)
+options.setDefault('maxEvents', 25)
 options.parseArguments()
 
 ## Process


### PR DESCRIPTION
#### PR description:

This PR changes the input file of the unit test `testTriggerEventAnalyzers`. A ttbar-MC file is used (like before #41350) to exercise more triggers compared to the current input file. The new input file was made with an HLT menu which includes the fix discussed in #41045 (see also [CMSHLT-2750](https://its.cern.ch/jira/browse/CMSHLT-2750)). The number of events used in this unit test is also increased without increasing significantly the duration of the test (a few seconds).

#### PR validation:

The unit test `testTriggerEventAnalyzers` passes in an ASAN IB.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A