### PR TITLE
[Backport 10_6_X] Fix EmissionVetoHook for BB4L

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
@@ -433,7 +433,7 @@ bool EmissionVetoHook1::doVetoFSREmission(int, const Pythia8::Event &e, int iSys
   if (iSys != 0) return false;
 
   // only use for outside resonance vetos in combination with bb4l:FSREmission:veto
-  if (!inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto")==1) return false;
+  if (inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto")==1) return false;
 
   // If we already have accepted 'vetoCount' emissions in a row, do nothing
   if (vetoOn && nAcceptSeq >= vetoCount) return false;


### PR DESCRIPTION
#### PR description:

Backport of #42264 (fixing the Pythia FSR hook for bb4l) to CMSSW 10_6_X for UL MC generation, as discussed with @Saptaparna.

#### PR validation:

See #42264.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

See above.
