### PR TITLE
sort by pt only good-quality tracks

### DIFF
--- a/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -175,8 +175,12 @@ void PixelTrackProducerFromSoAT<TrackerTraits>::produce(edm::StreamID streamID,
   //sort index by pt
   std::vector<int32_t> sortIdxs(nTracks);
   std::iota(sortIdxs.begin(), sortIdxs.end(), 0);
+  //sort good-quality tracks by pt, keep bad-quality tracks in the bottom
   std::sort(sortIdxs.begin(), sortIdxs.end(), [&](int32_t const i1, int32_t const i2) {
-    return tsoa.view()[i1].pt() > tsoa.view()[i2].pt();
+    if (quality[i1] >= minQuality_ && quality[i2] >= minQuality_)
+      return tsoa.view()[i1].pt() > tsoa.view()[i2].pt();
+    else
+      return quality[i1] > quality[i2];
   });
 
   //store the index of the SoA: indToEdm[index_SoAtrack] -> index_edmTrack (if it exists)


### PR DESCRIPTION
#### PR description:

Solve https://github.com/cms-sw/cmssw/issues/42374 (@slava77 @mmusich @Dr15Jones).
In `RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc` tracks are sorted by pT in the attempt to improve the reproducibility of the GPU results #38065.
However, track with bad quality (< minQuality) might have pT undefined. Bad-quality tracks are discarded later on ( https://github.com/cms-sw/cmssw/blob/CMSSW_13_1_0_pre2/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc#L190 )
This PR sorts by pT only tracks with good quality. 
This should avoid the risk of crash due to sorting tracks with uninitialized parameters.

As bad-quality tracks are discarded, this PR should have no effects on physics results.

#### PR validation:

Added a debug printout in `storeTracks(iEvent, tracks, httopo);` and no changes are observed, as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

I'm not sure if a backport is necessary. Perhaps it would good to have it for 13_2_X (HIon).

