### PR TITLE
MTD validation: downgrade warning in BTL local reco validation

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -359,9 +359,9 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       meTPullvsE_->Fill(m_btlSimHits[detId.rawId()].energy, time_res / recHit.timeError());
     } else if (m_btlSimHits.count(detId.rawId()) == 0) {
       n_reco_btl_nosimhit++;
-      edm::LogWarning("BtlLocalRecoValidation")
-          << "BTL rec hit with no corresponding sim hit in crystal, DetId= " << detId.rawId()
-          << " geoId= " << geoId.rawId() << " ene= " << recHit.energy() << " time= " << recHit.time();
+      LogDebug("BtlLocalRecoValidation") << "BTL rec hit with no corresponding sim hit in crystal, DetId= "
+                                         << detId.rawId() << " geoId= " << geoId.rawId() << " ene= " << recHit.energy()
+                                         << " time= " << recHit.time();
     }
 
     n_reco_btl++;


### PR DESCRIPTION
#### PR description:

In #42257 a check on BTL recHits not corresponding to simHits was introduced, with a corresponding ```LogWarning``` message. This check is supposed to be valid if the full list of hits can be scanned, which is not the case in premixing. As a consequence, premixing processing log files are flooded with messages, that went unnoticed at the time of integration.

This PR downgrades the ```LogWarning``` to ```LogDebug```, as a plot is available to monitor anyway the counting, and should be looked at depending of the kind of process is simulated.

#### PR validation:

In wf 25034.999 step 4 warning messages disappear as expected.