### PR TITLE
Updates to PFClusterMatchedToPhotonsSelector for PF ECAL cluster calibration

### DIFF
--- a/RecoEgamma/EgammaMCTools/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaMCTools/plugins/BuildFile.xml
@@ -7,5 +7,6 @@
   <use name="DataFormats/Math"/>
   <use name="DataFormats/ParticleFlowReco"/>
   <use name="DataFormats/HepMCCandidate"/>
+  <use name="RecoEcal/EgammaCoreTools"/>
   <use name="SimDataFormats/TrackingAnalysis"/>
 </library>

--- a/RecoEgamma/EgammaMCTools/plugins/PFClusterMatchedToPhotonsSelector.cc
+++ b/RecoEgamma/EgammaMCTools/plugins/PFClusterMatchedToPhotonsSelector.cc
@@ -29,11 +29,13 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
@@ -52,6 +54,11 @@ private:
   edm::EDGetTokenT<reco::PFClusterCollection> particleFlowClusterECALToken_;
   edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> associationToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticleToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsEB_;
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsEE_;
+
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+
   double matchMaxDR2_;
   double matchMaxDEDR2_;
 
@@ -60,7 +67,8 @@ private:
   double volumeZ_EE_;
 };
 
-PFClusterMatchedToPhotonsSelector::PFClusterMatchedToPhotonsSelector(const edm::ParameterSet& iConfig) {
+PFClusterMatchedToPhotonsSelector::PFClusterMatchedToPhotonsSelector(const edm::ParameterSet& iConfig)
+    : ecalClusterToolsESGetTokens_{consumesCollector()} {
   //now do what ever initialization is needed
   particleFlowClusterECALToken_ =
       consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("pfClustersTag"));
@@ -69,6 +77,8 @@ PFClusterMatchedToPhotonsSelector::PFClusterMatchedToPhotonsSelector(const edm::
   trackingParticleToken_ =
       consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticleTag"));
   genParticleToken_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticleTag"));
+  recHitsEB_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsEBLabel"));
+  recHitsEE_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsEELabel"));
 
   matchMaxDR2_ = iConfig.getParameter<double>("maxDR2");
   matchMaxDEDR2_ = iConfig.getParameter<double>("maxDEDR2");
@@ -77,8 +87,10 @@ PFClusterMatchedToPhotonsSelector::PFClusterMatchedToPhotonsSelector(const edm::
   volumeZ_EE_ = iConfig.getParameter<double>("volumeZ_EE");
 
   produces<reco::PFClusterCollection>();
-  produces<reco::PFCluster::EEtoPSAssociation>();
   produces<edm::ValueMap<reco::GenParticleRef> >();
+  produces<edm::ValueMap<int> >();
+  produces<edm::ValueMap<float> >("PS1");
+  produces<edm::ValueMap<float> >("PS2");
 }
 
 void PFClusterMatchedToPhotonsSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -86,6 +98,8 @@ void PFClusterMatchedToPhotonsSelector::fillDescriptions(edm::ConfigurationDescr
   desc.add<edm::InputTag>("pfClustersTag", edm::InputTag("particleFlowClusterECAL"));
   desc.add<edm::InputTag>("trackingParticleTag", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("genParticleTag", edm::InputTag("genParticles"));
+  desc.add<edm::InputTag>("recHitsEBLabel", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("recHitsEELabel", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
   desc.add<double>("maxDR2", 0.1 * 0.1);
   desc.add<double>("maxDEDR2", 0.5 * 0.5);
   desc.add<double>("volumeZ_EB", 304.5);
@@ -99,20 +113,26 @@ void PFClusterMatchedToPhotonsSelector::produce(edm::Event& iEvent, const edm::E
   edm::Handle<reco::PFCluster::EEtoPSAssociation> associationHandle_;
   edm::Handle<TrackingParticleCollection> trackingParticleHandle_;
   edm::Handle<reco::GenParticleCollection> genParticleHandle_;
+
   iEvent.getByToken(particleFlowClusterECALToken_, particleFlowClusterECALHandle_);
   iEvent.getByToken(trackingParticleToken_, trackingParticleHandle_);
   iEvent.getByToken(genParticleToken_, genParticleHandle_);
   iEvent.getByToken(associationToken_, associationHandle_);
 
   std::unique_ptr<reco::PFClusterCollection> out = std::make_unique<reco::PFClusterCollection>();
-  std::unique_ptr<reco::PFCluster::EEtoPSAssociation> association_out =
-      std::make_unique<reco::PFCluster::EEtoPSAssociation>();
   std::unique_ptr<edm::ValueMap<reco::GenParticleRef> > genmatching_out =
       std::make_unique<edm::ValueMap<reco::GenParticleRef> >();
+  std::unique_ptr<edm::ValueMap<int> > clustersize_out = std::make_unique<edm::ValueMap<int> >();
+  std::unique_ptr<edm::ValueMap<float> > energyPS1_out = std::make_unique<edm::ValueMap<float> >();
+  std::unique_ptr<edm::ValueMap<float> > energyPS2_out = std::make_unique<edm::ValueMap<float> >();
 
   std::vector<reco::GenParticleRef> genmatching;
+  std::vector<int> clustersize;
+  std::vector<float> energyPS1;
+  std::vector<float> energyPS2;
 
-  size_t iN(0);
+  EcalClusterLazyTools lazyTool(iEvent, ecalClusterToolsESGetTokens_.get(iSetup), recHitsEB_, recHitsEE_);
+
   for (size_t iP = 0; iP < particleFlowClusterECALHandle_->size(); iP++) {
     auto&& pfCluster = particleFlowClusterECALHandle_->at(iP);
     bool isMatched = false;
@@ -129,6 +149,7 @@ void PFClusterMatchedToPhotonsSelector::produce(edm::Event& iEvent, const edm::E
       if (trackingParticle.status() != 1)
         continue;
       matchedKey = trackingParticle.genParticles().at(0).key();
+
       float dR2 = reco::deltaR2(trackingParticle, pfCluster.position());
       if (dR2 > matchMaxDR2_)
         continue;
@@ -160,23 +181,54 @@ void PFClusterMatchedToPhotonsSelector::produce(edm::Event& iEvent, const edm::E
 
     if (isMatched) {
       out->push_back(pfCluster);
-      for (size_t i = 0; i < associationHandle_.product()->size(); i++) {
-        if (associationHandle_.product()->at(i).first == iP) {
-          association_out->push_back(std::make_pair(iN, associationHandle_.product()->at(i).second));
+      double ePS1 = 0, ePS2 = 0;
+      if (!(pfCluster.layer() == PFLayer::ECAL_BARREL)) {
+        auto ee_key_val = std::make_pair(iP, edm::Ptr<reco::PFCluster>());
+        const auto clustops = std::equal_range(
+            associationHandle_.product()->begin(), associationHandle_.product()->end(), ee_key_val, sortByKey);
+        for (auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
+          edm::Ptr<reco::PFCluster> psclus(i_ps->second);
+          switch (psclus->layer()) {
+            case PFLayer::PS1:
+              ePS1 += psclus->energy();
+              break;
+            case PFLayer::PS2:
+              ePS2 += psclus->energy();
+              break;
+            default:
+              break;
+          }
         }
       }
+
       genmatching.push_back(edm::Ref<reco::GenParticleCollection>(genParticleHandle_, matchedKey));
+      clustersize.push_back(lazyTool.n5x5(pfCluster));
+      energyPS1.push_back(ePS1);
+      energyPS2.push_back(ePS2);
     }
   }
 
-  std::sort(association_out->begin(), association_out->end(), sortByKey);
   edm::OrphanHandle<reco::PFClusterCollection> pfClusterHandle = iEvent.put(std::move(out));
-  iEvent.put(std::move(association_out));
 
   edm::ValueMap<reco::GenParticleRef>::Filler mapFiller(*genmatching_out);
   mapFiller.insert(pfClusterHandle, genmatching.begin(), genmatching.end());
   mapFiller.fill();
   iEvent.put(std::move(genmatching_out));
+
+  edm::ValueMap<int>::Filler mapFiller_int(*clustersize_out);
+  mapFiller_int.insert(pfClusterHandle, clustersize.begin(), clustersize.end());
+  mapFiller_int.fill();
+  iEvent.put(std::move(clustersize_out));
+
+  edm::ValueMap<float>::Filler mapFiller_energyPS1(*energyPS1_out);
+  mapFiller_energyPS1.insert(pfClusterHandle, energyPS1.begin(), energyPS1.end());
+  mapFiller_energyPS1.fill();
+  iEvent.put(std::move(energyPS1_out), "PS1");
+
+  edm::ValueMap<float>::Filler mapFiller_energyPS2(*energyPS2_out);
+  mapFiller_energyPS2.insert(pfClusterHandle, energyPS2.begin(), energyPS2.end());
+  mapFiller_energyPS2.fill();
+  iEvent.put(std::move(energyPS2_out), "PS2");
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

Updates to PFClusterMatchedToPhotonsSelector for usage in PF ECAL cluster calibration. These changes have been used for PF cluster calibration for the Run 2 UL and Run 3 calibration [1,2] through checkout of private branch, but now trying to merge to the central CMSSW for better booking.

[1] https://codimd.web.cern.ch/IwKw1T6VQw6Q8mHpvK3Mzw?view
[2] https://twiki.cern.ch/twiki/bin/view/CMS/EGMPFClusterRegression

#### PR validation:

Made sure that they are consistent with hartakeyamak:PfclusterCalibration_12_6_X_tmp - cleaned up version used for 12_6_X round of PF cluster calibration, and it compiles under CMSSW_13_2_0_pre3. It shouldn't make any changes to regular reco outputs (only used for the PF Cluster calibration ntuple maker [3].)

[3] https://github.com/hatakeyamak/RegressionTreeProducer/tree/PFTree_12_6_X

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.

Cc: @jainshilpi @swagata87 @kdlong @akanugan @Nghazwani