### PR TITLE
Use TCMalloc instead of JeMalloc for cmsRun

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -30,7 +30,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc"/>
+  <use name="tcmalloc_minimal"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
As discussed during [Core SW meeting](https://indico.cern.ch/event/1312682/)  (and suggested here : https://github.com/cms-sw/cmssw/issues/40437#issuecomment-1659802873 ) , this PR proposs to use `TCMalloc` instead of `JeMalloc` for `cmsRun`

FYI @makortel @VinInn 