### PR TITLE
Added TryToContinue exception handling to cmsRun

### DIFF
--- a/CalibTracker/SiStripChannelGain/test/testSSTGain_MultiRun_ALCAHARVEST.py
+++ b/CalibTracker/SiStripChannelGain/test/testSSTGain_MultiRun_ALCAHARVEST.py
@@ -53,10 +53,8 @@ process.source = cms.Source("PoolSource",
 )
 
 process.options = cms.untracked.PSet(
-    FailPath = cms.untracked.vstring(),
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring('ProductNotFound'),
-    SkipEvent = cms.untracked.vstring(),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),
     emptyRunLumiMode = cms.obsolete.untracked.string,

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMHarvester_cfg.py
@@ -52,10 +52,8 @@ process.source = cms.Source("DQMRootSource",
 )
 
 process.options = cms.untracked.PSet(
-    FailPath = cms.untracked.vstring(),
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring('ProductNotFound'),
-    SkipEvent = cms.untracked.vstring(),
     accelerators = cms.untracked.vstring('*'),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),

--- a/DQMOffline/Alignment/test/DiMuonTkAlDQMValidator_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonTkAlDQMValidator_cfg.py
@@ -71,10 +71,8 @@ process.source = cms.Source("PoolSource",
                             )
 
 process.options = cms.untracked.PSet(
-    FailPath = cms.untracked.vstring(),
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring(),
-    SkipEvent = cms.untracked.vstring(),
     accelerators = cms.untracked.vstring('*'),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),

--- a/FWCore/Framework/interface/ExceptionActions.h
+++ b/FWCore/Framework/interface/ExceptionActions.h
@@ -8,7 +8,7 @@
 
 namespace edm {
   namespace exception_actions {
-    enum ActionCodes { IgnoreCompletely = 0, Rethrow, SkipEvent, FailPath, LastCode };
+    enum ActionCodes { IgnoreCompletely = 0, Rethrow, TryToContinue, LastCode };
 
     const char* actionName(ActionCodes code);
   }  // namespace exception_actions

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -122,11 +122,8 @@ namespace edm {
 
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
-    bool handleWorkerFailure(cms::Exception& e,
+    void handleWorkerFailure(cms::Exception& e,
                              int nwrwue,
-                             bool isEvent,
-                             bool begin,
-                             BranchType branchType,
                              ModuleDescription const&,
                              std::string const& id);
     static void exceptionContext(cms::Exception& ex,
@@ -136,7 +133,7 @@ namespace edm {
                                  ModuleDescription const&,
                                  std::string const& id,
                                  PathContext const&);
-    void threadsafe_setFailedModuleInfo(int nwrwue, std::exception_ptr);
+    void threadsafe_setFailedModuleInfo(int nwrwue, bool iExceptionHappened);
     void recordStatus(int nwrwue, hlt::HLTState state);
     void updateCounters(hlt::HLTState state);
 

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -122,10 +122,7 @@ namespace edm {
 
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
-    void handleWorkerFailure(cms::Exception& e,
-                             int nwrwue,
-                             ModuleDescription const&,
-                             std::string const& id);
+    void handleWorkerFailure(cms::Exception& e, int nwrwue, ModuleDescription const&, std::string const& id);
     static void exceptionContext(cms::Exception& ex,
                                  bool isEvent,
                                  bool begin,

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -53,7 +53,6 @@ namespace edm {
          ExceptionToActionTable const& actions,
          std::shared_ptr<ActivityRegistry> reg,
          StreamContext const* streamContext,
-         std::atomic<bool>* stopProcessEvent,
          PathContext::PathType pathType);
 
     Path(Path const&);
@@ -99,6 +98,7 @@ namespace edm {
     int timesFailed_;
     int timesExcept_;
     //int abortWorker_;
+    std::atomic<bool> printedException_ = false;
     //When an exception happens, it is possible for multiple modules in a path to fail
     // and then try to change the state concurrently.
     std::atomic<bool> stateLock_ = false;
@@ -115,7 +115,6 @@ namespace edm {
 
     PathContext pathContext_;
     WaitingTaskList waitingTasks_;
-    std::atomic<bool>* const stopProcessingEvent_;
     std::atomic<unsigned int> modulesToRun_;
 
     PathStatusInserter* pathStatusInserter_;
@@ -129,7 +128,7 @@ namespace edm {
                              bool begin,
                              BranchType branchType,
                              ModuleDescription const&,
-                             std::string const& id) const;
+                             std::string const& id);
     static void exceptionContext(cms::Exception& ex,
                                  bool isEvent,
                                  bool begin,

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -382,7 +382,6 @@ namespace edm {
 
     StreamID streamID_;
     StreamContext streamContext_;
-    std::atomic<bool> skippingEvent_;
   };
 
   void inline StreamSchedule::reportSkipped(EventPrincipal const& ep) const {

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -321,7 +321,7 @@ namespace edm {
 
     virtual TaskQueueAdaptor serializeRunModule() = 0;
 
-    bool shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent) const;
+    bool shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool isCatch) const;
 
     template <bool IS_EVENT>
     bool setPassed() {
@@ -1062,7 +1062,8 @@ namespace edm {
                                                          typename T::Context const* context) {
     std::exception_ptr exceptionPtr;
     if (iEPtr) {
-      if (shouldRethrowException(iEPtr, parentContext, T::isEvent_)) {
+        //TODO have to deal with 'cms.catch'
+      if (shouldRethrowException(iEPtr, parentContext, T::isEvent_, false)) {
         exceptionPtr = iEPtr;
         setException<T::isEvent_>(exceptionPtr);
       } else {
@@ -1166,7 +1167,7 @@ namespace edm {
       });
     } catch (cms::Exception& ex) {
       edm::exceptionContext(ex, moduleCallingContext_);
-      if (shouldRethrowException(std::current_exception(), parentContext, T::isEvent_)) {
+      if (shouldRethrowException(std::current_exception(), parentContext, T::isEvent_, false)) {
         assert(not cached_exception_);
         setException<T::isEvent_>(std::current_exception());
         std::rethrow_exception(cached_exception_);

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -321,7 +321,8 @@ namespace edm {
 
     virtual TaskQueueAdaptor serializeRunModule() = 0;
 
-    bool shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool isCatch) const;
+    bool shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool isTryToContinue) const;
+    void checkForShouldTryToContinue(ModuleDescription const&);
 
     template <bool IS_EVENT>
     bool setPassed() {
@@ -619,6 +620,7 @@ namespace edm {
     std::atomic<bool> workStarted_;
     bool ranAcquireWithoutException_;
     bool moduleValid_ = true;
+    bool shouldTryToContinue_ = false;
   };
 
   namespace {
@@ -1061,20 +1063,27 @@ namespace edm {
                                                          ParentContext const& parentContext,
                                                          typename T::Context const* context) {
     std::exception_ptr exceptionPtr;
+    bool shouldRun = true;
     if (iEPtr) {
         //TODO have to deal with 'cms.catch'
-      if (shouldRethrowException(iEPtr, parentContext, T::isEvent_, false)) {
+      if (shouldRethrowException(iEPtr, parentContext, T::isEvent_, shouldTryToContinue_)) {
         exceptionPtr = iEPtr;
         setException<T::isEvent_>(exceptionPtr);
+        shouldRun = false;
       } else {
-        setPassed<T::isEvent_>();
+        if (not shouldTryToContinue_) {
+          setPassed<T::isEvent_>();
+          shouldRun = false;
+        }
       }
-      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
-    } else {
+    }
+    if (shouldRun) {
       // Caught exception is propagated via WaitingTaskList
       CMS_SA_ALLOW try { runModule<T>(transitionInfo, streamID, parentContext, context); } catch (...) {
         exceptionPtr = std::current_exception();
       }
+    } else {
+      moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     }
     waitingTasks_.doneWaiting(exceptionPtr);
     return exceptionPtr;
@@ -1167,7 +1176,7 @@ namespace edm {
       });
     } catch (cms::Exception& ex) {
       edm::exceptionContext(ex, moduleCallingContext_);
-      if (shouldRethrowException(std::current_exception(), parentContext, T::isEvent_, false)) {
+      if (shouldRethrowException(std::current_exception(), parentContext, T::isEvent_, shouldTryToContinue_)) {
         assert(not cached_exception_);
         setException<T::isEvent_>(std::current_exception());
         std::rethrow_exception(cached_exception_);

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -1068,7 +1068,6 @@ namespace edm {
     std::exception_ptr exceptionPtr;
     bool shouldRun = true;
     if (iEPtr) {
-      //TODO have to deal with 'cms.catch'
       if (shouldRethrowException(iEPtr, parentContext, T::isEvent_, shouldTryToContinue_)) {
         exceptionPtr = iEPtr;
         setException<T::isEvent_>(exceptionPtr);

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -321,7 +321,10 @@ namespace edm {
 
     virtual TaskQueueAdaptor serializeRunModule() = 0;
 
-    bool shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool isTryToContinue) const;
+    bool shouldRethrowException(std::exception_ptr iPtr,
+                                ParentContext const& parentContext,
+                                bool isEvent,
+                                bool isTryToContinue) const;
     void checkForShouldTryToContinue(ModuleDescription const&);
 
     template <bool IS_EVENT>
@@ -1065,7 +1068,7 @@ namespace edm {
     std::exception_ptr exceptionPtr;
     bool shouldRun = true;
     if (iEPtr) {
-        //TODO have to deal with 'cms.catch'
+      //TODO have to deal with 'cms.catch'
       if (shouldRethrowException(iEPtr, parentContext, T::isEvent_, shouldTryToContinue_)) {
         exceptionPtr = iEPtr;
         setException<T::isEvent_>(exceptionPtr);

--- a/FWCore/Framework/src/ExceptionActions.cc
+++ b/FWCore/Framework/src/ExceptionActions.cc
@@ -13,8 +13,7 @@ namespace edm {
         std::array<char const*, LastCode> table{};
         table[IgnoreCompletely] = "IgnoreCompletely";
         table[Rethrow] = "Rethrow";
-        table[SkipEvent] = "SkipEvent";
-        table[FailPath] = "FailPath";
+        table[TryToContinue] = "TryToContinue";
         return table;
       }();
       return static_cast<unsigned int>(code) < tab.size() ? tab[code] : "UnknownAction";
@@ -50,10 +49,9 @@ namespace edm {
   ExceptionToActionTable::ExceptionToActionTable(ParameterSet const& pset) : map_() {
     addDefaults();
 
-    install(exception_actions::SkipEvent, map_, pset);
+    install(exception_actions::TryToContinue, map_, pset);
     install(exception_actions::Rethrow, map_, pset);
     install(exception_actions::IgnoreCompletely, map_, pset);
-    install(exception_actions::FailPath, map_, pset);
   }
 
   void ExceptionToActionTable::addDefaults() {

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -65,10 +65,7 @@ namespace edm {
     modulesToRun_ = workers_.size();
   }
 
-  void Path::handleWorkerFailure(cms::Exception& e,
-                                 int nwrwue,
-                                 ModuleDescription const& desc,
-                                 std::string const& id) {
+  void Path::handleWorkerFailure(cms::Exception& e, int nwrwue, ModuleDescription const& desc, std::string const& id) {
     if (e.context().empty()) {
       exceptionContext(e, true /*isEvent*/, true /*begin*/, InEvent /*branchType*/, desc, id, pathContext_);
     }
@@ -263,10 +260,7 @@ namespace edm {
         ost << iEP.id();
         ModuleDescription const* desc = worker.getWorker()->description();
         assert(desc != nullptr);
-        handleWorkerFailure(*pEx,
-                            iModuleIndex,
-                            *desc,
-                            ost.str());
+        handleWorkerFailure(*pEx, iModuleIndex, *desc, ost.str());
         //If we didn't rethrow, then we effectively skipped
         worker.skipWorker(iEP);
       } catch (...) {

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -863,14 +863,8 @@ namespace edm {
 
     // an empty path will cause an extra bit that is not used
     if (!tmpworkers.empty()) {
-      trig_paths_.emplace_back(bitpos,
-                               name,
-                               tmpworkers,
-                               trptr,
-                               actionTable(),
-                               actReg_,
-                               &streamContext_,
-                               PathContext::PathType::kPath);
+      trig_paths_.emplace_back(
+          bitpos, name, tmpworkers, trptr, actionTable(), actReg_, &streamContext_, PathContext::PathType::kPath);
     } else {
       empty_trig_paths_.push_back(bitpos);
     }
@@ -1276,9 +1270,7 @@ namespace edm {
     for_all(allWorkers(), std::bind(&Worker::clearCounters, _1));
   }
 
-  void StreamSchedule::resetAll() {
-    results_->reset();
-  }
+  void StreamSchedule::resetAll() { results_->reset(); }
 
   void StreamSchedule::addToAllWorkers(Worker* w) { workerManager_.addToAllWorkers(w); }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -103,8 +103,8 @@ namespace edm {
         earlyDeleteHelper_(nullptr),
         workStarted_(false),
         ranAcquireWithoutException_(false) {
-          checkForShouldTryToContinue(iMD);
-        }
+    checkForShouldTryToContinue(iMD);
+  }
 
   Worker::~Worker() {}
 
@@ -117,7 +117,10 @@ namespace edm {
     }
   }
 
-  bool Worker::shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool shouldTryToContinue) const {
+  bool Worker::shouldRethrowException(std::exception_ptr iPtr,
+                                      ParentContext const& parentContext,
+                                      bool isEvent,
+                                      bool shouldTryToContinue) const {
     // NOTE: the warning printed as a result of ignoring or failing
     // a module will only be printed during the full true processing
     // pass of this module

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -107,7 +107,7 @@ namespace edm {
 
   void Worker::setActivityRegistry(std::shared_ptr<ActivityRegistry> areg) { actReg_ = areg; }
 
-  bool Worker::shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent) const {
+  bool Worker::shouldRethrowException(std::exception_ptr iPtr, ParentContext const& parentContext, bool isEvent, bool isCatch) const {
     // NOTE: the warning printed as a result of ignoring or failing
     // a module will only be printed during the full true processing
     // pass of this module
@@ -125,19 +125,8 @@ namespace edm {
       if (action == exception_actions::Rethrow) {
         return true;
       }
-
-      ModuleCallingContext tempContext(description(), ModuleCallingContext::State::kInvalid, parentContext, nullptr);
-
-      // If we are processing an endpath and the module was scheduled, treat SkipEvent or FailPath
-      // as IgnoreCompletely, so any subsequent OutputModules are still run.
-      // For unscheduled modules only treat FailPath as IgnoreCompletely but still allow SkipEvent to throw
-      ModuleCallingContext const* top_mcc = tempContext.getTopModuleCallingContext();
-      if (top_mcc->type() == ParentContext::Type::kPlaceInPath &&
-          top_mcc->placeInPathContext()->pathContext()->isEndPath()) {
-        if ((action == exception_actions::SkipEvent && tempContext.type() == ParentContext::Type::kPlaceInPath) ||
-            action == exception_actions::FailPath) {
-          action = exception_actions::IgnoreCompletely;
-        }
+      if (action == exception_actions::TryToContinue) {
+        return not isCatch;
       }
       if (action == exception_actions::IgnoreCompletely) {
         edm::printCmsExceptionWarning("IgnoreCompletely", ex);
@@ -383,7 +372,7 @@ namespace edm {
       convertException::wrap([&]() { this->implDoAcquire(info, &moduleCallingContext_, holder); });
     } catch (cms::Exception& ex) {
       edm::exceptionContext(ex, moduleCallingContext_);
-      if (shouldRethrowException(std::current_exception(), parentContext, true)) {
+      if (shouldRethrowException(std::current_exception(), parentContext, true, false)) {
         timesRun_.fetch_add(1, std::memory_order_relaxed);
         throw;
       }
@@ -397,7 +386,8 @@ namespace edm {
     ranAcquireWithoutException_ = false;
     std::exception_ptr exceptionPtr;
     if (iEPtr) {
-      if (shouldRethrowException(iEPtr, parentContext, true)) {
+      //TODO should deal with cms.catch
+      if (shouldRethrowException(iEPtr, parentContext, true, false)) {
         exceptionPtr = iEPtr;
       }
       moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -404,7 +404,6 @@ namespace edm {
     ranAcquireWithoutException_ = false;
     std::exception_ptr exceptionPtr;
     if (iEPtr) {
-      //TODO should deal with cms.catch
       if (shouldRethrowException(iEPtr, parentContext, true, shouldTryToContinue_)) {
         exceptionPtr = iEPtr;
       }

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -50,8 +50,11 @@ namespace edmtest {
     class StreamIntAnalyzer : public edm::global::EDAnalyzer<edm::StreamCache<UnsafeCache>> {
     public:
       explicit StreamIntAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
-        callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
-          std::cout << "global::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
+        bool verbose = p.getUntrackedParameter<bool>("verbose", true);
+        callWhenNewProductsRegistered([verbose](edm::BranchDescription const& desc) {
+          if ( verbose ) {
+            std::cout << "global::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
+          }
         });
       }
       const unsigned int trans_;
@@ -116,7 +119,7 @@ namespace edmtest {
         }
       }
 
-      ~StreamIntAnalyzer() {
+      void endJob () override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "StreamIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
@@ -150,7 +153,7 @@ namespace edmtest {
         }
       }
 
-      ~RunIntAnalyzer() {
+      void endJob() override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "RunIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
@@ -192,7 +195,7 @@ namespace edmtest {
         }
       }
 
-      ~LumiIntAnalyzer() {
+      void endJob() override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
@@ -241,7 +244,7 @@ namespace edmtest {
         }
       }
 
-      ~RunSummaryIntAnalyzer() {
+      void endJob() override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "RunSummaryIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
@@ -302,7 +305,7 @@ namespace edmtest {
         }
       }
 
-      ~LumiSummaryIntAnalyzer() {
+      void endJob() override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiSummaryIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -52,7 +52,7 @@ namespace edmtest {
       explicit StreamIntAnalyzer(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
         bool verbose = p.getUntrackedParameter<bool>("verbose", true);
         callWhenNewProductsRegistered([verbose](edm::BranchDescription const& desc) {
-          if ( verbose ) {
+          if (verbose) {
             std::cout << "global::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
           }
         });
@@ -119,7 +119,7 @@ namespace edmtest {
         }
       }
 
-      void endJob () override {
+      void endJob() override {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "StreamIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;

--- a/FWCore/Framework/test/test_InputTag_cache_failure_cfg.py
+++ b/FWCore/Framework/test/test_InputTag_cache_failure_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 #we want to continue processing after a 'ProductNotFound' exception in order
 # to test what happens to the cache held by the InputTag
 process.options = cms.untracked.PSet(
-    SkipEvent = cms.untracked.vstring('ProductNotFound')
+    TryToContinue = cms.untracked.vstring('ProductNotFound')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/Integration/python/test/unscheduled_fail_on_output_SkipEvent_cfg.py
+++ b/FWCore/Integration/python/test/unscheduled_fail_on_output_SkipEvent_cfg.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from FWCore.Integration.test.unscheduled_fail_on_output_cfg import process
-process.options.SkipEvent = cms.untracked.vstring('NotFound')

--- a/FWCore/Integration/python/test/unscheduled_fail_on_output_TryToContinue_cfg.py
+++ b/FWCore/Integration/python/test/unscheduled_fail_on_output_TryToContinue_cfg.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from FWCore.Integration.test.unscheduled_fail_on_output_cfg import process
-process.options.FailPath = cms.untracked.vstring('NotFound')
+process.options.TryToContinue = cms.untracked.vstring('NotFound')

--- a/FWCore/Integration/python/test/unscheduled_fail_on_output_cfg.py
+++ b/FWCore/Integration/python/test/unscheduled_fail_on_output_cfg.py
@@ -13,8 +13,6 @@ process.t = cms.Task(process.failing)
 process.o = cms.EndPath(process.out, process.t)
 process.p = cms.Path(process.i)
 
-#process.options = cms.untracked.PSet()
-
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(10)
         )

--- a/FWCore/Integration/python/test/unscheduled_fail_on_output_cfg.py
+++ b/FWCore/Integration/python/test/unscheduled_fail_on_output_cfg.py
@@ -13,7 +13,7 @@ process.t = cms.Task(process.failing)
 process.o = cms.EndPath(process.out, process.t)
 process.p = cms.Path(process.i)
 
-process.options = cms.untracked.PSet()
+#process.options = cms.untracked.PSet()
 
 process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(10)

--- a/FWCore/Integration/python/test/unscheduled_fail_on_output_no_dependency_TryToContinue_cfg.py
+++ b/FWCore/Integration/python/test/unscheduled_fail_on_output_no_dependency_TryToContinue_cfg.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.Integration.test.unscheduled_fail_on_output_cfg import process
+process.options.TryToContinue = ['NotFound']
+
+process.out.outputCommands = cms.untracked.vstring('keep *', 'drop *_failing_*_*')
+process.failGet = cms.EDAnalyzer('IntTestAnalyzer', moduleLabel = cms.untracked.InputTag('failing'), valueMustMatch = cms.untracked.int32(0))
+process.failingEnd = cms.EndPath(process.failGet)

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -114,6 +114,8 @@
   <test name="TestFrameworkExceptionHandling" command="run_TestFrameworkExceptionHandling.sh ${value}" for="1,9"/>
   <test name="TestFWCoreIntegrationTryToContinuePath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py"/>
   <test name="TestFWCoreIntegrationTryToContinueTask" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --useTask"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinue" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueIndirect" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --indirect"/>
 
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -113,10 +113,21 @@
 
   <test name="TestFrameworkExceptionHandling" command="run_TestFrameworkExceptionHandling.sh ${value}" for="1,9"/>
   <test name="TestFWCoreIntegrationTryToContinuePath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py"/>
+  <test name="TestFWCoreIntegrationTryToContinuePathMessage" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py 2>&amp;1 | fgrep 'applying TryToContinue on Exception'"/>
   <test name="TestFWCoreIntegrationTryToContinueTask" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --useTask"/>
+  <test name="TestFWCoreIntegrationTryToContinueRun" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --inRun 2>&amp;1 | fgrep 'exception for testing purposes'"/>
+  <test name="TestFWCoreIntegrationTryToContinueLumi" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --inLumi 2>&amp;1 | fgrep 'exception for testing purposes'"/>
   <test name="TestFWCoreIntegrationShouldTryToContinue" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueMessage" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py 2>&amp;1 | fgrep 'Begin TryToContinue Exception'"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueRun" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --inRun 2>&amp;1 | fgrep 'exception for testing purposes'"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueLumi" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --inLumi 2>&amp;1 | fgrep 'exception for testing purposes'"/>
   <test name="TestFWCoreIntegrationShouldTryToContinueIndirect" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --indirect"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueIndirectRun" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --indirect --inRun 2>&amp;1 | fgrep 'exception for testing purposes'"/>
+  <test name="TestFWCoreIntegrationShouldTryToContinueIndirectLumi" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --indirect --inLumi 2>&amp;1 | fgrep 'exception for testing purposes'"/>
   <test name="TestFWCoreIntegrationTryToContinueExceptionOutput" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py"/>
+  <test name="TestFWCoreIntegrationTryToContinueExceptionOutput" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_source_cfg.py"/>
+  <test name="TestFWCoreIntegrationTryToContinueESProducer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py"/>
+  <test name="TestFWCoreIntegrationTryToContinueESProducerContinue" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py -- --continueAnalyzer"/>
 
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -116,6 +116,7 @@
   <test name="TestFWCoreIntegrationTryToContinueTask" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --useTask"/>
   <test name="TestFWCoreIntegrationShouldTryToContinue" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py"/>
   <test name="TestFWCoreIntegrationShouldTryToContinueIndirect" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_shouldTryToContinue_cfg.py -- --indirect"/>
+  <test name="TestFWCoreIntegrationTryToContinueExceptionOutput" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py"/>
 
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -112,6 +112,8 @@
   <test name="TestFWCoreIntegrationDelayedReaderTest" command="delayedreader_throw_test.sh"/>
 
   <test name="TestFrameworkExceptionHandling" command="run_TestFrameworkExceptionHandling.sh ${value}" for="1,9"/>
+  <test name="TestFWCoreIntegrationTryToContinuePath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py"/>
+  <test name="TestFWCoreIntegrationTryToContinueTask" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py -- --useTask"/>
 
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>

--- a/FWCore/Integration/test/run_unscheduledFailOnOutput.sh
+++ b/FWCore/Integration/test/run_unscheduledFailOnOutput.sh
@@ -11,10 +11,10 @@ function die { echo Failure $1: status $2 ; exit $2 ; }
   cmsRun ${CFG_DIR}/${test}IgnoreCompletely_cfg.py || die "cmsRun ${test}IgnoreCompletely_cfg.py" $?
   cmsRun ${CFG_DIR}/${test}read_found_events.py || die "cmsRun ${test}read_found_events.py for IgnoreCompletely" $?
 
-  cmsRun -p ${CFG_DIR}/${test}FailPath_cfg.py || die "cmsRun ${test}FailPath_cfg.py" $?
-  cmsRun ${CFG_DIR}/${test}read_found_events.py || die "cmsRun ${test}read_found_events.py for FailPath" $?
-
-  cmsRun -p ${CFG_DIR}/${test}SkipEvent_cfg.py || die "cmsRun ${test}SkipEvent_cfg.py" $?
+  cmsRun -p ${CFG_DIR}/${test}TryToContinue_cfg.py || die "cmsRun ${test}TryToComplete_cfg.py" $?
   cmsRun ${CFG_DIR}/${test}read_no_events.py || die "cmsRun ${test}read_no_events.py" $?
+
+  cmsRun -p ${CFG_DIR}/${test}no_dependency_TryToContinue_cfg.py || die "cmsRun ${test}no_dependency_TryToComplete_cfg.py" $?
+  cmsRun ${CFG_DIR}/${test}read_found_events.py || die "cmsRun ${test}read_found_events.py for TryToComplete" $?
 
 exit 0

--- a/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_ESProducer_cfg.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test TryToContinue exception handling wrt ESProducer.')
+
+parser.add_argument("--continueAnalyzer", help="Apply shouldTryToContinue to module dependent on module that fails.", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("Demo")
+
+process.MessageLogger = cms.Service("MessageLogger")
+
+process.maxEvents.input = 2
+
+if args.continueAnalyzer:
+    process.options.TryToContinue = ['StdException', 'MakeDataException']
+    process.options.modulesToCallForTryToContinue = ['demo']
+else:
+    process.options.TryToContinue = ['StdException']
+
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(3)
+)
+
+#stuck something into the EventSetup
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+process.DoodadESProducer = cms.ESProducer("DoodadESProducer",
+    throwException = cms.untracked.bool(True)
+)
+
+process.demo = cms.EDAnalyzer("WhatsItAnalyzer",
+    expectedValues = cms.untracked.vint32(0)
+)
+
+process.bad = cms.ESSource("EmptyESSource",
+    recordName = cms.string('GadgetRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+process.p = cms.Path(process.demo)

--- a/FWCore/Integration/test/test_TryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test TryToContinue exception handling.')
+
+parser.add_argument("--useTask", help="Have filter succeed", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.options.TryToContinue = ['NotFound']
+process.maxEvents.input = 3
+
+process.fail = cms.EDProducer("FailingProducer")
+
+process.shouldRun1 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6+3), verbose = cms.untracked.bool(False))
+process.shouldRun2 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6+3), verbose = cms.untracked.bool(False))
+process.shouldNotRun = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6), verbose = cms.untracked.bool(False))
+process.dependentFilter = cms.EDFilter("IntProductFilter",
+   label = cms.InputTag("fail"),
+   threshold = cms.int32(0),
+   shouldProduce = cms.bool(False)
+)
+
+process.intProd = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+process.addInts = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProd"))
+
+process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("fail"), cms.InputTag("addInts") ),
+  expectedSum = cms.untracked.int32(0)
+)
+
+process.independentAnalyzer = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("addInts") ),
+  expectedSum = cms.untracked.int32(30)
+)
+
+
+process.seq = cms.Sequence()
+process.t = cms.Task(process.intProd,process.addInts)
+if args.useTask:
+    process.t.add(process.fail)
+else:
+    process.seq = cms.Sequence(process.fail)
+process.errorPath = cms.Path(process.seq+process.shouldRun1+process.dependentFilter+process.shouldNotRun,process.t)
+process.goodPath = cms.Path(process.shouldRun2)
+
+
+process.errorEndPath = cms.EndPath(process.dependentAnalyzer)
+process.goodEndPath = cms.EndPath(process.independentAnalyzer)
+
+

--- a/FWCore/Integration/test/test_TryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_cfg.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+import sys
 import argparse
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test TryToContinue exception handling.')

--- a/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
@@ -17,6 +17,7 @@ process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
 
 process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
 
+#no direct or indirect dependency on the failed data product means no need for shouldTryToContinue
 process.out = cms.OutputModule("SewerModule",
     name=cms.string("out"),
     shouldPass = cms.int32(3),
@@ -24,6 +25,20 @@ process.out = cms.OutputModule("SewerModule",
     outputCommands = cms.untracked.vstring("drop *", "keep *_intProd_*_*")
 )
 
-process.out.shouldTryToContinue()
+process.outContinueDirect = cms.OutputModule("SewerModule",
+    name=cms.string("outNoContinueDirect"),
+    shouldPass = cms.int32(3),
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("exception@p")),
+    outputCommands = cms.untracked.vstring("drop *", "keep *_fail_*_*")
+)
+process.outContinueDirect.shouldTryToContinue()
 
-#process.add_(cms.Service("Tracer"))
+process.outNoContinueDirect = cms.OutputModule("SewerModule",
+    name=cms.string("outNoContinueDirect"),
+    shouldPass = cms.int32(0),
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("exception@p")),
+    outputCommands = cms.untracked.vstring("drop *", "keep *_fail_*_*")
+)
+
+process.e = cms.EndPath(process.out+process.outContinueDirect+process.outNoContinueDirect)
+

--- a/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
@@ -17,7 +17,8 @@ process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
 
 process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
 
-#no direct or indirect dependency on the failed data product means no need for shouldTryToContinue
+#no direct or indirect dependency on the failed data product means no need to add to
+#  modulesToCallForTryToContinue
 process.out = cms.OutputModule("SewerModule",
     name=cms.string("out"),
     shouldPass = cms.int32(3),
@@ -31,7 +32,9 @@ process.outContinueDirect = cms.OutputModule("SewerModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("exception@p")),
     outputCommands = cms.untracked.vstring("drop *", "keep *_fail_*_*")
 )
-process.outContinueDirect.shouldTryToContinue()
+
+
+process.options.modulesToCallForTryToContinue = [process.outContinueDirect.label_(), "dummy"]
 
 process.outNoContinueDirect = cms.OutputModule("SewerModule",
     name=cms.string("outNoContinueDirect"),

--- a/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_exception_output_cfg.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.options.TryToContinue = ['NotFound']
+process.maxEvents.input = 3
+
+process.fail = cms.EDProducer("FailingProducer")
+process.intProd = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    inputTagsNotFound = cms.untracked.VInputTag( cms.InputTag("fail")),
+    expectedSum = cms.untracked.int32(0)
+)
+
+process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
+
+process.out = cms.OutputModule("SewerModule",
+    name=cms.string("out"),
+    shouldPass = cms.int32(3),
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("exception@p")),
+    outputCommands = cms.untracked.vstring("drop *", "keep *_intProd_*_*")
+)
+
+process.out.shouldTryToContinue()
+
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
@@ -27,11 +27,25 @@ process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
     expectedSum = cms.untracked.int32(30)
 )
 
+process.dependent2 = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    inputTagsNotFound = cms.untracked.VInputTag( cms.InputTag("fail")),
+    expectedSum = cms.untracked.int32(30)
+)
+
+process.independent = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    expectedSum = cms.untracked.int32(30)
+)
+
+process.f = cms.EDFilter("IntProductFilter", label = cms.InputTag("intProd"))
+
 if args.indirect:
     process.dependentAnalyzer.shouldTryToContinue()
+    process.dependent2.shouldTryToContinue()
 else:
     process.fail.shouldTryToContinue()
 
 process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
-
-process.add_(cms.Service("Tracer"))
+process.p2 = cms.Path(cms.wait(process.dependent2)+process.f+process.independent)
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
@@ -41,10 +41,9 @@ process.independent = cms.EDAnalyzer("TestFindProduct",
 process.f = cms.EDFilter("IntProductFilter", label = cms.InputTag("intProd"))
 
 if args.indirect:
-    process.dependentAnalyzer.shouldTryToContinue()
-    process.dependent2.shouldTryToContinue()
+    process.options.modulesToCallForTryToContinue = [process.dependentAnalyzer.label_(), process.dependent2.label_()]
 else:
-    process.fail.shouldTryToContinue()
+    process.options.modulesToCallForTryToContinue = [process.fail.label_()]
 
 process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
 process.p2 = cms.Path(cms.wait(process.dependent2)+process.f+process.independent)

--- a/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_shouldTryToContinue_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test TryToContinue exception handling.')
+
+parser.add_argument("--indirect", help="Apply shouldTryToContinue to module dependent on module that fails. Else apply to failing module.", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.options.TryToContinue = ['NotFound']
+process.maxEvents.input = 3
+
+process.fail = cms.EDProducer("FailingProducer")
+process.intProd = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    inputTagsNotFound = cms.untracked.VInputTag( cms.InputTag("fail")),
+    expectedSum = cms.untracked.int32(30)
+)
+
+if args.indirect:
+    process.dependentAnalyzer.shouldTryToContinue()
+else:
+    process.fail.shouldTryToContinue()
+
+process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.fail,process.intProd))
+
+process.add_(cms.Service("Tracer"))

--- a/FWCore/Integration/test/test_shouldTryToContinue_source_cfg.py
+++ b/FWCore/Integration/test/test_shouldTryToContinue_source_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("DelayedReaderThrowingSource", labels = cms.untracked.vstring("fail"))
+
+process.options.TryToContinue = ['TEST']
+process.maxEvents.input = 3
+
+process.intProd = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+process.dependentAnalyzer = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    inputTagsNotFound = cms.untracked.VInputTag( cms.InputTag("fail")),
+    expectedSum = cms.untracked.int32(30)
+)
+
+process.dependent2 = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    inputTagsNotFound = cms.untracked.VInputTag( cms.InputTag("fail")),
+    expectedSum = cms.untracked.int32(30)
+)
+
+process.independent = cms.EDAnalyzer("TestFindProduct",
+    inputTags = cms.untracked.VInputTag(["intProd"]),
+    expectedSum = cms.untracked.int32(30)
+)
+
+process.f = cms.EDFilter("IntProductFilter", label = cms.InputTag("intProd"))
+
+process.options.modulesToCallForTryToContinue = [process.dependentAnalyzer.label_(), process.dependent2.label_()]
+
+process.p = cms.Path(process.dependentAnalyzer, cms.Task(process.intProd))
+process.p2 = cms.Path(cms.wait(process.dependent2)+process.f+process.independent)
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -258,8 +258,7 @@ class Process(object):
                               deleteNonConsumedUnscheduledModules = untracked.bool(True),
                               sizeOfStackForThreadsInKB = optional.untracked.uint32,
                               Rethrow = untracked.vstring(),
-                              SkipEvent = untracked.vstring(),
-                              FailPath = untracked.vstring(),
+                              TryToContinue = untracked.vstring(),
                               IgnoreCompletely = untracked.vstring(),
                               canDeleteEarly = untracked.vstring(),
                               holdsReferencesToDeleteEarly = untracked.VPSet(),
@@ -2454,10 +2453,9 @@ process.maxLuminosityBlocks = cms.untracked.PSet(
 )
 
 process.options = cms.untracked.PSet(
-    FailPath = cms.untracked.vstring(),
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring(),
-    SkipEvent = cms.untracked.vstring(),
+    TryToContinue = cms.untracked.vstring(),
     accelerators = cms.untracked.vstring('*'),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),
@@ -4647,10 +4645,9 @@ process.maxLuminosityBlocks = cms.untracked.PSet(
 )
 
 process.options = cms.untracked.PSet(
-    FailPath = cms.untracked.vstring(),
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring(),
-    SkipEvent = cms.untracked.vstring(),
+    TryToContinue = cms.untracked.vstring(),
     accelerators = cms.untracked.vstring('*'),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -260,6 +260,7 @@ class Process(object):
                               Rethrow = untracked.vstring(),
                               TryToContinue = untracked.vstring(),
                               IgnoreCompletely = untracked.vstring(),
+                              modulesToCallForTryToContinue = untracked.vstring(),
                               canDeleteEarly = untracked.vstring(),
                               holdsReferencesToDeleteEarly = untracked.VPSet(),
                               modulesToIgnoreForDeleteEarly = untracked.vstring(),
@@ -1464,6 +1465,14 @@ class Process(object):
         all_modules.update(self.filters_())
         all_modules.update(self.analyzers_())
         all_modules.update(self.outputModules_())
+        if hasattr(self.options,"modulesToCallForTryToContinue") :
+            shouldTryToContinue = set(self.options.modulesToCallForTryToContinue)
+            for m in all_modules:
+                if m in shouldTryToContinue:
+                    setattr(getattr(self,m),"@shouldTryToContinue",untracked.bool(True))
+            missing = shouldTryToContinue.difference(all_modules)
+            if missing:
+                print("Warning: The following modules appear in options.modulesToCallForTryToContinue but are not in the Process: {} ".format(",".join(missing)))
         adaptor = TopLevelPSetAcessorAdaptor(processPSet,self)
         self._insertInto(adaptor, self.psets_())
         self._insertInto(adaptor, self.vpsets_())
@@ -2472,6 +2481,7 @@ process.options = cms.untracked.PSet(
     forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
     holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
     makeTriggerResults = cms.obsolete.untracked.bool,
+    modulesToCallForTryToContinue = cms.untracked.vstring(),
     modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
     numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
     numberOfConcurrentRuns = cms.untracked.uint32(1),
@@ -4664,6 +4674,7 @@ process.options = cms.untracked.PSet(
     forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
     holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
     makeTriggerResults = cms.obsolete.untracked.bool,
+    modulesToCallForTryToContinue = cms.untracked.vstring(),
     modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
     numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
     numberOfConcurrentRuns = cms.untracked.uint32(1),

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -151,13 +151,6 @@ class _Module(_ConfigureComponent,_TypedParameterizable,_Labelable,_SequenceLeaf
     def setPrerequisites(self, *libs):
         self.__dict__["libraries_"] = libs
 
-    def shouldTryToContinue(self):
-        """C++ exceptions thrown from this module will be ignored by the framework.
-           If a dependent module throws an exception in the 'TryToContinue' handler list
-          this module will still be run."""
-        from .Types import untracked
-        setattr(self, "@shouldTryToContinue", untracked.bool(True))
-    
     def insertInto(self, parameterSet, myname):
         if "libraries_" in self.__dict__:
             from ctypes import LibraryLoader, CDLL

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -151,6 +151,13 @@ class _Module(_ConfigureComponent,_TypedParameterizable,_Labelable,_SequenceLeaf
     def setPrerequisites(self, *libs):
         self.__dict__["libraries_"] = libs
 
+    def shouldTryToContinue(self):
+        """C++ exceptions thrown from this module will be ignored by the framework.
+           If a dependent module throws an exception in the 'TryToContinue' handler list
+          this module will still be run."""
+        from .Types import untracked
+        setattr(self, "@shouldTryToContinue", untracked.bool(True))
+    
     def insertInto(self, parameterSet, myname):
         if "libraries_" in self.__dict__:
             from ctypes import LibraryLoader, CDLL

--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -85,7 +85,7 @@ namespace edm {
 
     std::vector<std::string> parameterNames = pset.getParameterNames();
     if (validatedLabels.size() != parameterNames.size()) {
-      // Three labels will be magically inserted into the top level
+      // These labels will be magically inserted into the top level
       // of a module ParameterSet even though they are not in the
       // python configuration files.  If these are present, then
       // assume they are OK and count them as validated.

--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -110,6 +110,12 @@ namespace edm {
         validatedLabels.insert(service_type);
       }
 
+      {
+        std::string tryToContinue("@shouldTryToContinue");
+        if (pset.exists(tryToContinue)) {
+          validatedLabels.insert(tryToContinue);
+        }
+      }
       // Try again
       if (validatedLabels.size() != parameterNames.size()) {
         if (IllegalParameters::throwAnException() && !anythingAllowed()) {

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -84,8 +84,7 @@ namespace edm {
     std::vector<std::string> emptyVector;
 
     description.addUntracked<std::vector<std::string>>("Rethrow", emptyVector);
-    description.addUntracked<std::vector<std::string>>("SkipEvent", emptyVector);
-    description.addUntracked<std::vector<std::string>>("FailPath", emptyVector);
+    description.addUntracked<std::vector<std::string>>("TryToContinue", emptyVector);
     description.addUntracked<std::vector<std::string>>("IgnoreCompletely", emptyVector);
 
     description.addUntracked<std::vector<std::string>>("canDeleteEarly", emptyVector)

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -87,6 +87,9 @@ namespace edm {
     description.addUntracked<std::vector<std::string>>("TryToContinue", emptyVector);
     description.addUntracked<std::vector<std::string>>("IgnoreCompletely", emptyVector);
 
+    description.addUntracked<std::vector<std::string>>("modulesToCallForTryToContinue", emptyVector)
+        ->setComment("Labels of modules which should still be called when an exception in TryToContinue list happens.");
+
     description.addUntracked<std::vector<std::string>>("canDeleteEarly", emptyVector)
         ->setComment("Branch names of products that the Framework can try to delete before the end of the Event");
 

--- a/RecoEcal/EgammaClusterProducers/test/DRNTest_cfg.py
+++ b/RecoEcal/EgammaClusterProducers/test/DRNTest_cfg.py
@@ -11,7 +11,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.options.numberOfThreads = cms.untracked.uint32(4)
 process.options.numberOfStreams = cms.untracked.uint32(4)
-process.options.SkipEvent = cms.untracked.vstring('ProductNotFound')
+process.options.TryToContinue = cms.untracked.vstring('ProductNotFound')
 
 process.TritonService.verbose = False
 process.TritonService.fallback.verbose = False


### PR DESCRIPTION
#### PR description:

Removed SkipEvent and FailPath exception handling in favor of TryToContinue. The new handling option will cause a job to continue on event processing if an exception associated to TryToContinue is thrown. For the event which had the exception, 
- If a module is marked as `shouldTryToContinue()` in the configuration, it will be eligible to be run even if a TryToContinue exception happens. Marked modules will also not propagate a TryToContinue exception to the rest of the system whether the exception happened during prefetching or while running the module. If a marked module  is on a Path, it will not propagate the exception to the Path. However, if another module on the Path is dependent on the throwing module and is not marked then the Path will still fail (see next item).
- all Paths with a module that is directly or indirectly dependent on the module which threw will be marked as having an exception. Any modules on the Path which are directly or indirectly dependent upon the throwing module will not be run, unless the dependent module is marked `shouldTryToContinue()`. Any modules on the Path not already scheduled will not be run, including those marked as `shouldTryToContinue()`. Those which were scheduled and independent of the thrown module will still be run.
- Unscheduled modules which depend on the throwing module will not be run, unless they are marked as `shouldTryToContinue()`. Unscheduled modules which are independent may still be run if their data is requested.

#### PR validation:

All the framework unit tests (including the newly added ones) pass.