### PR TITLE
AVXVec: replace 2*insertf128 with 1*_mm256_set_m128d

### DIFF
--- a/DataFormats/Math/interface/private/AVXVec.h
+++ b/DataFormats/Math/interface/private/AVXVec.h
@@ -30,8 +30,7 @@ namespace mathSSE {
     }
 
     Vec4(Vec2<double> ivec0, Vec2<double> ivec1) {
-      vec = _mm256_insertf128_pd(vec, ivec0.vec, 0);
-      vec = _mm256_insertf128_pd(vec, ivec1.vec, 1);
+      vec = _mm256_set_m128d(ivec1.vec, ivec0.vec);
     }
 
     Vec4(Vec2<double> ivec0, double f3, double f4 = 0) {

--- a/DataFormats/Math/interface/private/AVXVec.h
+++ b/DataFormats/Math/interface/private/AVXVec.h
@@ -29,9 +29,7 @@ namespace mathSSE {
       arr[3] = f4;
     }
 
-    Vec4(Vec2<double> ivec0, Vec2<double> ivec1) {
-      vec = _mm256_set_m128d(ivec1.vec, ivec0.vec);
-    }
+    Vec4(Vec2<double> ivec0, Vec2<double> ivec1) { vec = _mm256_set_m128d(ivec1.vec, ivec0.vec); }
 
     Vec4(Vec2<double> ivec0, double f3, double f4 = 0) {
       vec = _mm256_insertf128_pd(vec, ivec0.vec, 0);


### PR DESCRIPTION
#### PR description:

Fixes #36542, as suggested by @slava77  [here](https://github.com/cms-sw/cmssw/issues/36542#issuecomment-996992142)


#### PR validation:

Bot tests