### PR TITLE
Use make_unique in tau modules

### DIFF
--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -72,18 +72,19 @@ namespace reco {
     private:
       edm::InputTag vertexTag_;
       bool vxTrkFiltering_;
-      StringCutObjectSelector<reco::Vertex>* vertexSelector_;
+      std::unique_ptr<StringCutObjectSelector<reco::Vertex>> vertexSelector_;
       std::vector<reco::VertexRef> selectedVertices_;
       std::string algorithm_;
       Algorithm algo_;
       //PJ adding quality cuts
-      RecoTauQualityCuts* qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
       bool recoverLeadingTrk_;
       enum { kLeadTrack, kLeadPFCand, kMinLeadTrackOrPFCand, kFirstTrack };
       int leadingTrkOrPFCandOption_;
       edm::EDGetTokenT<reco::VertexCollection> vxToken_;
       // containers for holding vertices associated to jets
-      std::map<const reco::Jet*, reco::VertexRef>* jetToVertexAssociation_;
+      typedef std::map<const reco::Jet*, reco::VertexRef> JetToVtxAssoc;
+      std::unique_ptr<JetToVtxAssoc> jetToVertexAssociation_;
       edm::EventNumber_t lastEvent_;
       int verbosity_;
     };

--- a/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
+++ b/RecoTauTag/RecoTau/interface/RecoTauVertexAssociator.h
@@ -52,7 +52,7 @@ namespace reco {
       enum Algorithm { kHighestPtInEvent, kClosestDeltaZ, kHighestWeigtForLeadTrack, kCombined };
 
       RecoTauVertexAssociator(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC);
-      virtual ~RecoTauVertexAssociator();
+      virtual ~RecoTauVertexAssociator(){};
       /// Get the primary vertex associated to a given jet.
       /// Returns a null Ref if no vertex is found.
       reco::VertexRef associatedVertex(const Jet& jet) const;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1242,6 +1242,10 @@ public:
   void produce(edm::Event& event, const edm::EventSetup& es) override {
     edm::Handle<TauCollection> taus;
     event.getByToken(tausToken_, taus);
+    // do nothing if tau collection is empty
+    if (taus->empty())
+      return;
+
     edm::ProductID tauProductID = taus.id();
 
     // load prediscriminators

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1242,9 +1242,13 @@ public:
   void produce(edm::Event& event, const edm::EventSetup& es) override {
     edm::Handle<TauCollection> taus;
     event.getByToken(tausToken_, taus);
-    // do nothing if tau collection is empty
-    if (taus->empty())
+
+    // store empty output collection(s) if tau collection is empty
+    if (taus->empty()) {
+      const tensorflow::Tensor emptyPrediction(tensorflow::DT_FLOAT, {0, deep_tau::NumberOfOutputs});
+      createOutputs(event, emptyPrediction, taus);
       return;
+    }
 
     edm::ProductID tauProductID = taus.id();
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromGenericTrackPlugin.cc
@@ -69,7 +69,7 @@ namespace reco {
 
       RecoTauVertexAssociator vertexAssociator_;
 
-      RecoTauQualityCuts* qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
 
       edm::InputTag srcTracks_;
       edm::EDGetTokenT<std::vector<TrackClass> > Tracks_token;
@@ -99,7 +99,7 @@ namespace reco {
           qcuts_(nullptr),
           magneticFieldToken_(iC.esConsumes()) {
       edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      qcuts_ = std::make_unique<RecoTauQualityCuts>(qcuts_pset);
 
       srcTracks_ = pset.getParameter<edm::InputTag>("srcTracks");
       Tracks_token = iC.consumes<std::vector<TrackClass> >(srcTracks_);
@@ -113,9 +113,7 @@ namespace reco {
     }
 
     template <class TrackClass>
-    PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::~PFRecoTauChargedHadronFromGenericTrackPlugin() {
-      delete qcuts_;
-    }
+    PFRecoTauChargedHadronFromGenericTrackPlugin<TrackClass>::~PFRecoTauChargedHadronFromGenericTrackPlugin() {}
 
     // Update the primary vertex
     template <class TrackClass>
@@ -261,8 +259,8 @@ namespace reco {
         if (vertexAssociator_.associatedVertex(jet).isNonnull())
           vtx = vertexAssociator_.associatedVertex(jet)->position();
 
-        std::unique_ptr<PFRecoTauChargedHadron> chargedHadron(
-            new PFRecoTauChargedHadron(trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack));
+        auto chargedHadron = std::make_unique<PFRecoTauChargedHadron>(
+            trackCharge_int, chargedPionP4, vtx, 0, true, PFRecoTauChargedHadron::kTrack);
 
         setChargedHadronTrack(*chargedHadron, edm::Ptr<TrackClass>(tracks, iTrack));
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -43,7 +43,7 @@ namespace reco {
     class PFRecoTauChargedHadronFromPFCandidatePlugin : public PFRecoTauChargedHadronBuilderPlugin {
     public:
       explicit PFRecoTauChargedHadronFromPFCandidatePlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
-      ~PFRecoTauChargedHadronFromPFCandidatePlugin() override;
+      ~PFRecoTauChargedHadronFromPFCandidatePlugin() override{};
       // Return type is unique_ptr<ChargedHadronVector>
       return_type operator()(const reco::Jet&) const override;
       // Hook to update PV information
@@ -109,8 +109,6 @@ namespace reco {
 
       verbosity_ = pset.getParameter<int>("verbosity");
     }
-
-    PFRecoTauChargedHadronFromPFCandidatePlugin::~PFRecoTauChargedHadronFromPFCandidatePlugin() {}
 
     // Update the primary vertex
     void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent() {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronFromPFCandidatePlugin.cc
@@ -54,7 +54,7 @@ namespace reco {
 
       RecoTauVertexAssociator vertexAssociator_;
 
-      RecoTauQualityCuts* qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
 
       std::vector<int> inputParticleIds_;  // type of candidates to clusterize
 
@@ -87,7 +87,7 @@ namespace reco {
           qcuts_(nullptr),
           bFieldToken_(iC.esConsumes()) {
       edm::ParameterSet qcuts_pset = pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts");
-      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      qcuts_ = std::make_unique<RecoTauQualityCuts>(qcuts_pset);
 
       inputParticleIds_ = pset.getParameter<std::vector<int> >("chargedHadronCandidatesParticleIds");
 
@@ -110,7 +110,7 @@ namespace reco {
       verbosity_ = pset.getParameter<int>("verbosity");
     }
 
-    PFRecoTauChargedHadronFromPFCandidatePlugin::~PFRecoTauChargedHadronFromPFCandidatePlugin() { delete qcuts_; }
+    PFRecoTauChargedHadronFromPFCandidatePlugin::~PFRecoTauChargedHadronFromPFCandidatePlugin() {}
 
     // Update the primary vertex
     void PFRecoTauChargedHadronFromPFCandidatePlugin::beginEvent() {

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -113,7 +113,7 @@ public:
            ++cfgFootprintCorrection) {
         std::string selection = cfgFootprintCorrection->getParameter<std::string>("selection");
         std::string offset = cfgFootprintCorrection->getParameter<std::string>("offset");
-        std::unique_ptr<FootprintCorrection> footprintCorrection(new FootprintCorrection(selection, offset));
+        auto footprintCorrection(std::make_unique<FootprintCorrection>(selection, offset));
         footprintCorrections_.push_back(std::move(footprintCorrection));
       }
     }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolationContainer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolationContainer.cc
@@ -149,7 +149,7 @@ public:
            ++cfgFootprintCorrection) {
         std::string selection = cfgFootprintCorrection->getParameter<std::string>("selection");
         std::string offset = cfgFootprintCorrection->getParameter<std::string>("offset");
-        std::unique_ptr<FootprintCorrection> footprintCorrection(new FootprintCorrection(selection, offset));
+        auto footprintCorrection = std::make_unique<FootprintCorrection>(selection, offset);
         footprintCorrections_.push_back(std::move(footprintCorrection));
       }
     }

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderCombinatoricPlugin.cc
@@ -61,7 +61,8 @@ namespace reco {
     RecoTauBuilderCombinatoricPlugin::RecoTauBuilderCombinatoricPlugin(const edm::ParameterSet& pset,
                                                                        edm::ConsumesCollector&& iC)
         : RecoTauBuilderPlugin(pset, std::move(iC)),
-          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
+          qcuts_(std::make_unique<RecoTauQualityCuts>(
+              pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           isolationConeSize_(pset.getParameter<double>("isolationConeSize")),
           signalConeSize_(pset.getParameter<std::string>("signalConeSize")),
           minAbsPhotonSumPt_insideSignalCone_(pset.getParameter<double>("minAbsPhotonSumPt_insideSignalCone")),

--- a/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauBuilderConePlugin.cc
@@ -76,7 +76,8 @@ namespace reco {
     // ctor - initialize all of our variables
     RecoTauBuilderConePlugin::RecoTauBuilderConePlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : RecoTauBuilderPlugin(pset, std::move(iC)),
-          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
+          qcuts_(std::make_unique<RecoTauQualityCuts>(
+              pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           usePFLeptonsAsChargedHadrons_(pset.getParameter<bool>("usePFLeptons")),
           leadObjecPtThreshold_(pset.getParameter<double>("leadObjectPt")),
           matchingCone_(pset.getParameter<std::string>("matchingCone")),

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroCombinatoricPlugin.cc
@@ -78,8 +78,8 @@ namespace reco {
       // Find all possible combinations
       for (ComboGenerator::iterator combo = generator.begin(); combo != generator.end(); ++combo) {
         const Candidate::LorentzVector totalP4;
-        std::unique_ptr<RecoTauPiZero> piZero(
-            new RecoTauPiZero(0, totalP4, Candidate::Point(0, 0, 0), 111, 10001, true, RecoTauPiZero::kCombinatoric));
+        auto piZero = std::make_unique<RecoTauPiZero>(
+            0, totalP4, Candidate::Point(0, 0, 0), 111, 10001, true, RecoTauPiZero::kCombinatoric);
         // Add our daughters from this combination
         for (auto candidate = combo->combo_begin(); candidate != combo->combo_end(); ++candidate) {
           piZero->addDaughter(*candidate);

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin.cc
@@ -67,7 +67,8 @@ namespace reco {
 
     RecoTauPiZeroStripPlugin::RecoTauPiZeroStripPlugin(const edm::ParameterSet& pset, edm::ConsumesCollector&& iC)
         : RecoTauPiZeroBuilderPlugin(pset, std::move(iC)),
-          qcuts_(new RecoTauQualityCuts(pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
+          qcuts_(std::make_unique<RecoTauQualityCuts>(
+              pset.getParameterSet("qualityCuts").getParameterSet("signalQualityCuts"))),
           vertexAssociator_(pset.getParameter<edm::ParameterSet>("qualityCuts"), std::move(iC)) {
       inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
       etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -64,7 +64,7 @@ namespace reco {
 
       RecoTauVertexAssociator vertexAssociator_;
 
-      RecoTauQualityCuts* qcuts_;
+      std::unique_ptr<RecoTauQualityCuts> qcuts_;
       bool applyElecTrackQcuts_;
       double minGammaEtStripSeed_;
       double minGammaEtStripAdd_;
@@ -113,7 +113,7 @@ namespace reco {
       }
       //-------------------------------------------------------------------------------
       qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-      qcuts_ = new RecoTauQualityCuts(qcuts_pset);
+      qcuts_ = std::make_unique<RecoTauQualityCuts>(qcuts_pset);
 
       inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
       etaAssociationDistance_ = pset.getParameter<double>("stripEtaAssociationDistance");
@@ -131,7 +131,7 @@ namespace reco {
       verbosity_ = pset.getParameter<int>("verbosity");
     }
 
-    RecoTauPiZeroStripPlugin2::~RecoTauPiZeroStripPlugin2() { delete qcuts_; }
+    RecoTauPiZeroStripPlugin2::~RecoTauPiZeroStripPlugin2() {}
 
     // Update the primary vertex
     void RecoTauPiZeroStripPlugin2::beginEvent() { vertexAssociator_.setEvent(*evt()); }
@@ -254,7 +254,7 @@ namespace reco {
         seedCandIdsCurrentStrip.clear();
         addCandIdsCurrentStrip.clear();
 
-        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        auto strip = std::make_unique<RecoTauPiZero>(*seedCands[idxSeed], RecoTauPiZero::kStrips);
         strip->addDaughter(seedCands[idxSeed]);
         seedCandIdsCurrentStrip.insert(idxSeed);
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin3.cc
@@ -95,7 +95,7 @@ namespace reco {
       std::unique_ptr<TFormula> makeFunction(const std::string& functionName, const edm::ParameterSet& pset) {
         TString formula = pset.getParameter<std::string>("function");
         formula = formula.ReplaceAll("pT", "x");
-        std::unique_ptr<TFormula> function(new TFormula(functionName.data(), formula.Data()));
+        auto function = std::make_unique<TFormula>(functionName.data(), formula.Data());
         int numParameter = function->GetNpar();
         for (int idxParameter = 0; idxParameter < numParameter; ++idxParameter) {
           std::string parameterName = Form("par%i", idxParameter);
@@ -133,9 +133,6 @@ namespace reco {
       }
       //-------------------------------------------------------------------------------
       qcuts_pset.addParameter<double>("minGammaEt", std::min(minGammaEtStripSeed_, minGammaEtStripAdd_));
-      //qcuts_ = new RecoTauQualityCuts(qcuts_pset);
-      //std::unique_ptr<RecoTauQualityCuts> qcuts_(new RecoTauQualityCuts(qcuts_pset));
-
       qcuts_ = std::make_unique<RecoTauQualityCuts>(qcuts_pset);
 
       inputParticleIds_ = pset.getParameter<std::vector<int> >("stripCandidatesParticleIds");
@@ -285,7 +282,7 @@ namespace reco {
         seedCandIdsCurrentStrip.clear();
         addCandIdsCurrentStrip.clear();
 
-        std::unique_ptr<RecoTauPiZero> strip(new RecoTauPiZero(*seedCands[idxSeed], RecoTauPiZero::kStrips));
+        auto strip = std::make_unique<RecoTauPiZero>(*seedCands[idxSeed], RecoTauPiZero::kStrips);
         strip->addDaughter(seedCands[idxSeed]);
         seedCandIdsCurrentStrip.insert(idxSeed);
 

--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroTrivialPlugin.cc
@@ -41,8 +41,8 @@ namespace reco::tau {
     output.reserve(pfGammaCands.size());
 
     for (auto const& gamma : pfGammaCands) {
-      std::unique_ptr<RecoTauPiZero> piZero(
-          new RecoTauPiZero(0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true, RecoTauPiZero::kTrivial));
+      auto piZero =
+          std::make_unique<RecoTauPiZero>(0, (*gamma).p4(), (*gamma).vertex(), 22, 1000, true, RecoTauPiZero::kTrivial);
       piZero->addDaughter(gamma);
       output.push_back(std::move(piZero));
     }

--- a/RecoTauTag/RecoTau/plugins/TauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/TauDiscriminantCutMultiplexer.cc
@@ -210,7 +210,7 @@ TauDiscriminantCutMultiplexerT<TauType, TauTypeRef, ParentClass>::TauDiscriminan
       else
         workingPoints = cfg.getParameter<VDouble>("workingPoints");
       for (auto const& wp : workingPoints) {
-        std::unique_ptr<DiscriminantCutEntry> cut{new DiscriminantCutEntry()};
+        auto cut = std::make_unique<DiscriminantCutEntry>();
         cut->cutValue_ = wp;
         cut->mode_ = DiscriminantCutEntry::kFixedCut;
         cutWPs.push_back(std::move(cut));
@@ -222,7 +222,7 @@ TauDiscriminantCutMultiplexerT<TauType, TauTypeRef, ParentClass>::TauDiscriminan
       else
         workingPoints = cfg.getParameter<VString>("workingPoints");
       for (auto const& wp : workingPoints) {
-        std::unique_ptr<DiscriminantCutEntry> cut{new DiscriminantCutEntry()};
+        auto cut = std::make_unique<DiscriminantCutEntry>();
         cut->cutName_ = categoryname + wp;
         if (loadMVAfromDB_) {
           cut->cutToken_ = this->esConsumes(edm::ESInputTag{"", cut->cutName_});

--- a/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
+++ b/RecoTauTag/RecoTau/src/RecoTauVertexAssociator.cc
@@ -233,8 +233,6 @@ namespace reco {
       verbosity_ = (pset.exists("verbosity")) ? pset.getParameter<int>("verbosity") : 0;
     }
 
-    RecoTauVertexAssociator::~RecoTauVertexAssociator() {}
-
     void RecoTauVertexAssociator::setEvent(const edm::Event& evt) {
       edm::Handle<reco::VertexCollection> vertices;
       evt.getByToken(vxToken_, vertices);
@@ -386,7 +384,7 @@ namespace reco {
       const Jet* jetPtr = &jet;
 
       // check if jet-vertex association has been determined for this jet before
-      JetToVtxAssoc::iterator vertexPtr = jetToVertexAssociation_->find(jetPtr);
+      auto vertexPtr = jetToVertexAssociation_->find(jetPtr);
       if (vertexPtr != jetToVertexAssociation_->end()) {
         jetVertex = vertexPtr->second;
       } else {
@@ -422,7 +420,7 @@ namespace reco {
           }
         }
 
-        jetToVertexAssociation_->insert(std::make_pair(jetPtr, jetVertex));
+        jetToVertexAssociation_->insert({jetPtr, jetVertex});
       }
 
       if (verbosity_ >= 1) {


### PR DESCRIPTION
#### PR description:

Technical PR which consistently introduces usage of `std::unique_ptr` in tau modules, namely:
* bare C pointers replaced by `std::unique_ptr` in places overlooked in previous developments,
* `std::unique_ptr` consequently initialized with `std::make_unique` rather than with `new` operator.

In addition, `DeepTauId::produce` method is now explicitly ended when the processed tau collection is empty which prevents of handling other collections, building TF objects, etc. and hopefully will avoid throwing exceptions in events without taus (https://github.com/cms-sw/cmssw/issues/40437, https://github.com/cms-sw/cmssw/issues/42444).

Those changes are not expected to modify outputs.

Will it be useful to backport this PR to 13_0/1/2?

#### PR validation:

Successfully tested with a custom tau@miniAOD workflow (10k events) and with `runTheMatrix.py -l limited -i all --ibeos`
