### PR TITLE
CMSSW_13_2_X_revert_PR40443

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorAsAnalyzer.cc
@@ -44,6 +44,7 @@
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
@@ -88,6 +89,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esTokenTTopo_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> esTokenGeomDet_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> esTokenPTP_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> esTokenPtitp_;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
   const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
   const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
@@ -121,6 +123,7 @@ AlignmentMonitorAsAnalyzer::AlignmentMonitorAsAnalyzer(const edm::ParameterSet& 
       esTokenTTopo_(esConsumes()),
       esTokenGeomDet_(esConsumes()),
       esTokenPTP_(esConsumes()),
+      esTokenPtitp_(esConsumes()),
       esTokenDT_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
       esTokenCSC_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
       esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForAlignmentMonitorAsAnalyzer"))),
@@ -157,8 +160,9 @@ void AlignmentMonitorAsAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
 
     const GeometricDet* geom = &iSetup.getData(esTokenGeomDet_);
     const PTrackerParameters& ptp = iSetup.getData(esTokenPTP_);
+    const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(esTokenPtitp_);
     TrackerGeomBuilderFromGeometricDet trackerBuilder;
-    std::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(geom, ptp, tTopo));
+    std::shared_ptr<TrackerGeometry> theTracker(trackerBuilder.build(geom, ptitp, ptp, tTopo));
 
     edm::ESHandle<DTGeometry> theMuonDT = iSetup.getHandle(esTokenDT_);
     edm::ESHandle<CSCGeometry> theMuonCSC = iSetup.getHandle(esTokenCSC_);

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -44,6 +44,7 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerSurveyRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurveyErrorExtendedRcd.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 #include "CondFormats/Common/interface/Time.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -59,6 +60,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
@@ -254,6 +256,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken_;
   const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken_;
   const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> gemGeomToken_;

--- a/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentProducerBase.cc
@@ -51,6 +51,7 @@ AlignmentProducerBase::AlignmentProducerBase(const edm::ParameterSet& config, ed
       ttopoToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       geomDetToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       ptpToken_(iC.esConsumes<edm::Transition::BeginRun>()),
+      ptitpToken_(iC.esConsumes<edm::Transition::BeginRun>()),
       dtGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
       cscGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
       gemGeomToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "idealForAlignmentProducerBase"))),
@@ -431,8 +432,9 @@ void AlignmentProducerBase::createGeometries(const edm::EventSetup& iSetup, cons
   if (doTracker_) {
     const GeometricDet* geometricDet = &iSetup.getData(geomDetToken_);
     const PTrackerParameters* ptp = &iSetup.getData(ptpToken_);
+    const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
     TrackerGeomBuilderFromGeometricDet trackerBuilder;
-    trackerGeometry_ = std::shared_ptr<TrackerGeometry>(trackerBuilder.build(geometricDet, *ptp, tTopo));
+    trackerGeometry_ = std::shared_ptr<TrackerGeometry>(trackerBuilder.build(geometricDet, ptitp, *ptp, tTopo));
   }
 
   if (doMuon_) {

--- a/Alignment/LaserAlignment/plugins/LaserAlignment.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.cc
@@ -23,6 +23,7 @@ LaserAlignment::LaserAlignment(edm::ParameterSet const& theConf)
       geomToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       gprToken_(esConsumes()),
       stripPedestalsToken_(esConsumes()),
       theEvents(0),
@@ -300,9 +301,10 @@ void LaserAlignment::produce(edm::Event& theEvent, edm::EventSetup const& theSet
       // the AlignableTracker object is initialized with the ideal geometry
       const GeometricDet* theGeometricDet = &theSetup.getData(geomDetToken_);
       const PTrackerParameters* ptp = &theSetup.getData(ptpToken_);
+      const PTrackerAdditionalParametersPerDet* ptitp = &theSetup.getData(ptitpToken_);
 
       TrackerGeomBuilderFromGeometricDet trackerBuilder;
-      TrackerGeometry* theRefTracker = trackerBuilder.build(&*theGeometricDet, *ptp, tTopo);
+      TrackerGeometry* theRefTracker = trackerBuilder.build(&*theGeometricDet, &*ptitp, *ptp, tTopo);
 
       theAlignableTracker = new AlignableTracker(&(*theRefTracker), tTopo);
     } else {

--- a/Alignment/LaserAlignment/plugins/LaserAlignment.h
+++ b/Alignment/LaserAlignment/plugins/LaserAlignment.h
@@ -132,6 +132,7 @@ private:
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
   const edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> stripPedestalsToken_;
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -29,6 +29,7 @@ MillePedeDQMModule ::MillePedeDQMModule(const edm::ParameterSet& config)
     : tTopoToken_(esConsumes<edm::Transition::BeginRun>()),
       gDetToken_(esConsumes<edm::Transition::BeginRun>()),
       ptpToken_(esConsumes<edm::Transition::BeginRun>()),
+      ptitpToken_(esConsumes<edm::Transition::BeginRun>()),
       aliThrToken_(esConsumes<edm::Transition::BeginRun>()),
       geomToken_(esConsumes<edm::Transition::BeginRun>()),
       mpReaderConfig_(config.getParameter<edm::ParameterSet>("MillePedeFileReader")),
@@ -166,6 +167,7 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
   const TrackerTopology* const tTopo = &setup.getData(tTopoToken_);
   const GeometricDet* geometricDet = &setup.getData(gDetToken_);
   const PTrackerParameters* ptp = &setup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &setup.getData(ptitpToken_);
   const TrackerGeometry* geom = &setup.getData(geomToken_);
 
   pixelTopologyMap_ = std::make_shared<PixelTopologyMap>(geom, tTopo);
@@ -179,7 +181,7 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
 
   TrackerGeomBuilderFromGeometricDet builder;
 
-  const auto trackerGeometry = builder.build(geometricDet, *ptp, tTopo);
+  const auto trackerGeometry = builder.build(geometricDet, ptitp, *ptp, tTopo);
   tracker_ = std::make_unique<AlignableTracker>(trackerGeometry, tTopo);
 
   const std::string labelerPlugin{"PedeLabeler"};

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -41,6 +41,7 @@
 /*** Records for ESWatcher ***/
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
@@ -97,6 +98,7 @@ private:  //===================================================================
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> gDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<AlignPCLThresholdsHG, AlignPCLThresholdsHGRcd> aliThrToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -58,6 +58,7 @@ TrackerGeometryCompare::TrackerGeometryCompare(const edm::ParameterSet& cfg)
       topoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       pixQualityToken_(esConsumes()),
       stripQualityToken_(esConsumes()),
       referenceTracker(nullptr),
@@ -391,10 +392,11 @@ void TrackerGeometryCompare::createROOTGeometry(const edm::EventSetup& iSetup) {
 
   const GeometricDet* theGeometricDet = &iSetup.getData(geomDetToken_);
   const PTrackerParameters* ptp = &iSetup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
 
   //reference tracker
-  TrackerGeometry* theRefTracker = trackerBuilder.build(theGeometricDet, *ptp, tTopo);
+  TrackerGeometry* theRefTracker = trackerBuilder.build(theGeometricDet, ptitp, *ptp, tTopo);
   if (inputFilename1_ != "IDEAL") {
     GeometryAligner aligner1;
     aligner1.applyAlignments<TrackerGeometry>(
@@ -434,7 +436,7 @@ void TrackerGeometryCompare::createROOTGeometry(const edm::EventSetup& iSetup) {
   }
 
   //currernt tracker
-  TrackerGeometry* theCurTracker = trackerBuilder.build(&*theGeometricDet, *ptp, tTopo);
+  TrackerGeometry* theCurTracker = trackerBuilder.build(&*theGeometricDet, ptitp, *ptp, tTopo);
   if (inputFilename2_ != "IDEAL") {
     GeometryAligner aligner2;
     aligner2.applyAlignments<TrackerGeometry>(

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
@@ -91,6 +91,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixQualityToken_;
   const edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
 

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
@@ -47,7 +47,9 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
 
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
@@ -87,6 +89,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
   const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrorToken_;
   const edm::ESGetToken<AlignmentSurfaceDeformations, TrackerSurfaceDeformationRcd> surfDefToken_;
@@ -134,6 +137,7 @@ TrackerGeometryIntoNtuples::TrackerGeometryIntoNtuples(const edm::ParameterSet& 
     : topoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       aliToken_(esConsumes()),
       aliErrorToken_(esConsumes()),
       surfDefToken_(esConsumes()),
@@ -195,10 +199,11 @@ void TrackerGeometryIntoNtuples::analyze(const edm::Event& iEvent, const edm::Ev
   //accessing the initial geometry
   const GeometricDet* theGeometricDet = &iSetup.getData(geomDetToken_);
   const PTrackerParameters* ptp = &iSetup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
   //currernt tracker
-  TrackerGeometry* theCurTracker = trackerBuilder.build(theGeometricDet, *ptp, tTopo);
+  TrackerGeometry* theCurTracker = trackerBuilder.build(theGeometricDet, ptitp, *ptp, tTopo);
 
   //build the tracker
   const Alignments* alignments = &iSetup.getData(aliToken_);

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.cc
@@ -19,6 +19,7 @@ CreateSurveyRcds::CreateSurveyRcds(const edm::ParameterSet& cfg)
     : tTopoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       aliToken_(esConsumes()),
       aliErrToken_(esConsumes()) {
   m_inputGeom = cfg.getUntrackedParameter<std::string>("inputGeom");
@@ -32,7 +33,8 @@ void CreateSurveyRcds::analyze(const edm::Event& event, const edm::EventSetup& s
   const TrackerTopology* const tTopo = &setup.getData(tTopoToken_);
   const GeometricDet* geom = &setup.getData(geomDetToken_);
   const PTrackerParameters& ptp = setup.getData(ptpToken_);
-  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptp, tTopo);
+  const PTrackerAdditionalParametersPerDet* ptitp = &setup.getData(ptitpToken_);
+  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptitp, ptp, tTopo);
 
   //take geometry from DB or randomly generate geometry
   if (m_inputGeom == "sqlite") {

--- a/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
+++ b/Alignment/SurveyAnalysis/plugins/CreateSurveyRcds.h
@@ -20,6 +20,9 @@
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
+
 #include "Alignment/CommonAlignment/interface/SurveyDet.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
 
@@ -53,6 +56,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
   const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrToken_;
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.cc
@@ -24,6 +24,7 @@ SurveyInputTrackerFromDB::SurveyInputTrackerFromDB(const edm::ParameterSet& cfg)
     : tTopoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       textFileName(cfg.getParameter<std::string>("textFileName")) {}
 
 void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup& setup) {
@@ -40,7 +41,8 @@ void SurveyInputTrackerFromDB::analyze(const edm::Event&, const edm::EventSetup&
 
     const GeometricDet* geom = &setup.getData(geomDetToken_);
     const PTrackerParameters& ptp = setup.getData(ptpToken_);
-    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptp, tTopo);
+    const PTrackerAdditionalParametersPerDet* ptitp = &setup.getData(ptitpToken_);
+    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptitp, ptp, tTopo);
 
     addComponent(new AlignableTracker(tracker, tTopo));
     addSurveyInfo(detector());

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputTrackerFromDB.h
@@ -30,6 +30,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
 
   std::string textFileName;
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.cc
@@ -21,6 +21,7 @@ SurveyMisalignmentInput::SurveyMisalignmentInput(const edm::ParameterSet& cfg)
     : tTopoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       aliToken_(esConsumes()),
       textFileName(cfg.getParameter<std::string>("textFileName")) {}
 
@@ -30,7 +31,8 @@ void SurveyMisalignmentInput::analyze(const edm::Event&, const edm::EventSetup& 
     const TrackerTopology* const tTopo = &setup.getData(tTopoToken_);
     const GeometricDet* geom = &setup.getData(geomDetToken_);
     const PTrackerParameters& ptp = setup.getData(ptpToken_);
-    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptp, tTopo);
+    const PTrackerAdditionalParametersPerDet* ptitp = &setup.getData(ptitpToken_);
+    TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptitp, ptp, tTopo);
 
     addComponent(new AlignableTracker(tracker, tTopo));
 

--- a/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
+++ b/Alignment/SurveyAnalysis/plugins/SurveyMisalignmentInput.h
@@ -29,6 +29,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
 
   SurveyInputTextReader::MapType uIdMap;

--- a/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
+++ b/Alignment/TrackerAlignment/plugins/CreateTrackerAlignmentRcds.cc
@@ -51,6 +51,7 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
@@ -59,6 +60,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 
 #include "CLHEP/Vector/RotationInterfaces.h"
 
@@ -88,6 +90,7 @@ private:
 
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
   const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrorToken_;
@@ -109,6 +112,7 @@ private:
 CreateIdealTkAlRecords::CreateIdealTkAlRecords(const edm::ParameterSet& iConfig)
     : geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       topoToken_(esConsumes()),
       aliToken_(esConsumes()),
       aliErrorToken_(esConsumes()),
@@ -251,11 +255,12 @@ void CreateIdealTkAlRecords::clearAlignmentInfos() {
 std::unique_ptr<TrackerGeometry> CreateIdealTkAlRecords::retrieveGeometry(const edm::EventSetup& iSetup) {
   const GeometricDet* geometricDet = &iSetup.getData(geomDetToken_);
   const PTrackerParameters& ptp = iSetup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
   const TrackerTopology* tTopo = &iSetup.getData(topoToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
 
-  return std::unique_ptr<TrackerGeometry>{trackerBuilder.build(geometricDet, ptp, tTopo)};
+  return std::unique_ptr<TrackerGeometry>{trackerBuilder.build(geometricDet, ptitp, ptp, tTopo)};
 }
 
 void CreateIdealTkAlRecords::addAlignmentInfo(const GeomDet& det) {

--- a/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
+++ b/Alignment/TrackerAlignment/plugins/MCMisalignmentScaler.cc
@@ -42,6 +42,7 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -52,6 +53,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 
 //
 // class declaration
@@ -69,6 +71,7 @@ private:
   const edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
   using ScalerMap = std::unordered_map<unsigned int, std::unordered_map<int, double> >;
@@ -91,6 +94,7 @@ MCMisalignmentScaler::MCMisalignmentScaler(const edm::ParameterSet& iConfig)
       stripQualityToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       topoToken_(esConsumes()),
       aliToken_(esConsumes()),
       scalers_{decodeSubDetectors(iConfig.getParameter<edm::VParameterSet>("scalers"))},
@@ -114,10 +118,11 @@ void MCMisalignmentScaler::analyze(const edm::Event&, const edm::EventSetup& iSe
   // get the tracker geometry
   const GeometricDet* geometricDet = &iSetup.getData(geomDetToken_);
   const PTrackerParameters& ptp = iSetup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
   const TrackerTopology* topology = &iSetup.getData(topoToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
-  auto tracker = std::unique_ptr<TrackerGeometry>{trackerBuilder.build(geometricDet, ptp, topology)};
+  auto tracker = std::unique_ptr<TrackerGeometry>{trackerBuilder.build(geometricDet, ptitp, ptp, topology)};
 
   auto dets = tracker->dets();
   std::sort(dets.begin(), dets.end(), [](const auto& a, const auto& b) {

--- a/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
+++ b/Alignment/TrackerAlignment/plugins/MisalignedTrackerESProducer.cc
@@ -48,6 +48,7 @@ public:
 private:
   edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
 
   const bool theSaveToDB;  /// whether or not writing to DB
@@ -71,6 +72,7 @@ MisalignedTrackerESProducer::MisalignedTrackerESProducer(const edm::ParameterSet
   auto cc = setWhatProduced(this);
   geomDetToken_ = cc.consumes();
   ptpToken_ = cc.consumes();
+  ptitpToken_ = cc.consumes();
   topoToken_ = cc.consumes();
 }
 
@@ -87,9 +89,10 @@ std::unique_ptr<TrackerGeometry> MisalignedTrackerESProducer::produce(const Trac
   // Create the tracker geometry from ideal geometry
   const GeometricDet* gD = &iRecord.get(geomDetToken_);
   const PTrackerParameters& ptp = iRecord.get(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iRecord.get(ptitpToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
-  std::unique_ptr<TrackerGeometry> theTracker(trackerBuilder.build(gD, ptp, tTopo));
+  std::unique_ptr<TrackerGeometry> theTracker(trackerBuilder.build(gD, ptitp, ptp, tTopo));
 
   // Create the alignable hierarchy
   auto theAlignableTracker = std::make_unique<AlignableTracker>(&(*theTracker), tTopo);

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.cc
@@ -60,6 +60,7 @@ private:
 
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
   const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrorToken_;
@@ -99,6 +100,7 @@ private:
 TrackerSystematicMisalignments::TrackerSystematicMisalignments(const edm::ParameterSet& cfg)
     : geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       topoToken_(esConsumes()),
       aliToken_(esConsumes()),
       aliErrorToken_(esConsumes()),
@@ -171,9 +173,10 @@ void TrackerSystematicMisalignments::analyze(const edm::Event& event, const edm:
   //Retrieve tracker topology from geometry
   const GeometricDet* geom = &setup.getData(geomDetToken_);
   const PTrackerParameters& ptp = setup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &setup.getData(ptitpToken_);
   const TrackerTopology* tTopo = &setup.getData(topoToken_);
 
-  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptp, tTopo);
+  TrackerGeometry* tracker = TrackerGeomBuilderFromGeometricDet().build(geom, ptitp, ptp, tTopo);
 
   //take geometry from DB or randomly generate geometry
   if (m_fromDBGeom) {

--- a/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
+++ b/Alignment/TrackerAlignment/plugins/TrackerTreeGenerator.cc
@@ -48,6 +48,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
@@ -74,6 +75,7 @@ private:
   // ----------member data ---------------------------
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
 
   const bool createEntryForDoubleSidedModule_;
@@ -95,6 +97,7 @@ private:
 TrackerTreeGenerator::TrackerTreeGenerator(const edm::ParameterSet& config)
     : geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptitpToken_(esConsumes()),
       topoToken_(esConsumes()),
       createEntryForDoubleSidedModule_(config.getParameter<bool>("createEntryForDoubleSidedModule")),
       config_(config) {
@@ -110,10 +113,11 @@ void TrackerTreeGenerator::analyze(const edm::Event& iEvent, const edm::EventSet
   // now try to take directly the ideal geometry independent of used geometry in Global Tag
   const GeometricDet* geometricDet = &iSetup.getData(geomDetToken_);
   const PTrackerParameters& ptp = iSetup.getData(ptpToken_);
+  const PTrackerAdditionalParametersPerDet* ptitp = &iSetup.getData(ptitpToken_);
   const TrackerTopology* tTopo = &iSetup.getData(topoToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
-  const TrackerGeometry* tkGeom = trackerBuilder.build(geometricDet, ptp, tTopo);
+  const TrackerGeometry* tkGeom = trackerBuilder.build(geometricDet, ptitp, ptp, tTopo);
   AlignableTracker alignableTracker{tkGeom, tTopo};
   const auto& ns = alignableTracker.trackerNameSpace();
 

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -6,6 +6,7 @@
 // for creation of TrackerGeometry
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
@@ -28,6 +29,7 @@ TrackerGeometryAnalyzer ::TrackerGeometryAnalyzer(const edm::ParameterSet& confi
     : tTopoToken_(esConsumes()),
       geomDetToken_(esConsumes()),
       ptpToken_(esConsumes()),
+      ptapToken_(esConsumes()),
       analyzeAlignables_(config.getParameter<bool>("analyzeAlignables")),
       printTrackerStructure_(config.getParameter<bool>("printTrackerStructure")),
       maxPrintDepth_(config.getParameter<int>("maxPrintDepth")),
@@ -71,9 +73,11 @@ void TrackerGeometryAnalyzer ::setTrackerTopology(const edm::EventSetup& setup) 
 void TrackerGeometryAnalyzer ::setTrackerGeometry(const edm::EventSetup& setup) {
   edm::ESHandle<GeometricDet> geometricDet = setup.getHandle(geomDetToken_);
   edm::ESHandle<PTrackerParameters> trackerParams = setup.getHandle(ptpToken_);
+  edm::ESHandle<PTrackerAdditionalParametersPerDet> trackerGeometricDetExtra = setup.getHandle(ptapToken_);
 
   TrackerGeomBuilderFromGeometricDet trackerGeometryBuilder;
-  trackerGeometry = trackerGeometryBuilder.build(&(*geometricDet), *trackerParams, trackerTopology);
+  trackerGeometry =
+      trackerGeometryBuilder.build(&(*geometricDet), &(*trackerGeometricDetExtra), *trackerParams, trackerTopology);
   alignableObjectId_ = AlignableObjectId{trackerGeometry, nullptr, nullptr, nullptr};
 }
 

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.h
@@ -19,6 +19,7 @@
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
@@ -73,6 +74,7 @@ private:  //==================================================================
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptapToken_;
 
   // config-file parameters
   const bool analyzeAlignables_;

--- a/CondTools/Geometry/plugins/PTrackerAdditionalParametersPerDetDBBuilder.cc
+++ b/CondTools/Geometry/plugins/PTrackerAdditionalParametersPerDetDBBuilder.cc
@@ -1,0 +1,52 @@
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+
+class PTrackerAdditionalParametersPerDetDBBuilder : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+public:
+  PTrackerAdditionalParametersPerDetDBBuilder(const edm::ParameterSet&);
+
+  void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
+  void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {}
+
+private:
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+};
+
+PTrackerAdditionalParametersPerDetDBBuilder::PTrackerAdditionalParametersPerDetDBBuilder(
+    const edm::ParameterSet& iConfig)
+    : geomDetToken_(esConsumes<edm::Transition::BeginRun>()) {}
+
+void PTrackerAdditionalParametersPerDetDBBuilder::beginRun(const edm::Run&, edm::EventSetup const& es) {
+  PTrackerAdditionalParametersPerDet ptitp;
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+  if (!mydbservice.isAvailable()) {
+    edm::LogError("PTrackerAdditionalParametersPerDetDBBuilder") << "PoolDBOutputService unavailable";
+    return;
+  }
+
+  const GeometricDet* gd = &es.getData(geomDetToken_);
+
+  std::vector<const GeometricDet*> comp;
+  gd->deepComponents(comp);
+
+  for (auto& i : comp) {
+    ptitp.setGeographicalId(i->geographicalId());
+  }
+
+  if (mydbservice->isNewTagRequest("PTrackerAdditionalParametersPerDetRcd")) {
+    mydbservice->createOneIOV(ptitp, mydbservice->beginOfTime(), "PTrackerAdditionalParametersPerDetRcd");
+  } else {
+    edm::LogError("PTrackerAdditionalParametersPerDetDBBuilder")
+        << "PTrackerAdditionalParametersPerDet and PTrackerAdditionalParametersPerDetRcd Tag already present";
+  }
+}
+
+DEFINE_FWK_MODULE(PTrackerAdditionalParametersPerDetDBBuilder);

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2017Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2017Reco_cff.py
@@ -4,6 +4,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2017DD4hep_cff import *
 
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2018Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2018Reco_cff.py
@@ -4,6 +4,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2018DD4hep_cff import *
 
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021FlatMinus05Percent_cff imp
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatMinus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021FlatMinus10Percent_cff imp
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021FlatPlus05Percent_cff impo
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021FlatPlus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021FlatPlus10Percent_cff impo
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2021ZeroMaterial_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatMinus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023FlatMinus05Percent_cff imp
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatMinus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023FlatMinus10Percent_cff imp
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatPlus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023FlatPlus05Percent_cff impo
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023FlatPlus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023FlatPlus10Percent_cff impo
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2023ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2023ZeroMaterialReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2023ZeroMaterial_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D100Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D100Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D100_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D101Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D101Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D101_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D86Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D86Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D86_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D88Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D88Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D88_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D91Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D91Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D91_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D92Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D92Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D92_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D93Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D93Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D93_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D94Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D94Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D94_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D95Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D95Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D95_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D96Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D96Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D96_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D97Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D97Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D97_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D98Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D98Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D98_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D99Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D99Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryDD4hepExtended2026D99_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2017DDDReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017DDDReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan0Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan0Reco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1FlatMinus05PercentReco_cff.py
@@ -9,6 +9,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1FlatMinus10PercentReco_cff.py
@@ -9,6 +9,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1FlatPlus05PercentReco_cff.py
@@ -9,6 +9,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1FlatPlus10PercentReco_cff.py
@@ -9,6 +9,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1Reco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Plan1ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Plan1ZeroMaterialReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2017Reco_cff.py
@@ -9,6 +9,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018DDDReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018DDDReco_cff.py
@@ -11,6 +11,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018FlatMinus05PercentReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018FlatMinus10PercentReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018FlatPlus05PercentReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018FlatPlus10PercentReco_cff.py
@@ -10,6 +10,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018Plan36Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018Plan36Reco_cff.py
@@ -11,6 +11,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018Reco_cff.py
@@ -11,6 +11,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2018ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2018ZeroMaterialReco_cff.py
@@ -11,6 +11,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryExtended2021FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatMinus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021FlatMinus05Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatMinus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021FlatMinus10Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatPlus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021FlatPlus05Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021FlatPlus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021FlatPlus10Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021ZeroMaterialReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2021ZeroMaterial_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023FlatMinus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023FlatMinus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023FlatMinus05Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023FlatMinus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023FlatMinus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023FlatMinus10Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023FlatPlus05PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023FlatPlus05PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023FlatPlus05Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023FlatPlus10PercentReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023FlatPlus10PercentReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023FlatPlus10Percent_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2023ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2023ZeroMaterialReco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2023ZeroMaterial_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D100Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D100Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D100_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D101Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D101Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D101_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D86Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D86Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D86_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D88Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D88Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D88_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D91Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D91Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D91_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D92Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D92Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D92_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D93Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D93Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D93_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D94Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D94Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D94_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D95Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D95Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D95_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D96Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D96Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D96_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D97Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D97Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D97_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D98Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D98Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D98_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D99Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D99Reco_cff.py
@@ -8,6 +8,7 @@ from Configuration.Geometry.GeometryExtended2026D99_cff import *
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended_cff.py
@@ -9,6 +9,8 @@ import FWCore.ParameterSet.Config as cms
 # Ideal geometry, needed for simulation
 from Geometry.CMSCommonData.cmsExtendedGeometryXML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+# TrackerAdditionalParametersPerDet contains only default values, needed for consistency with Phase 2
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryIdealAPD1_cff.py
+++ b/Configuration/Geometry/python/GeometryIdealAPD1_cff.py
@@ -12,6 +12,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 
 #Muon
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryIdealNoAPD_cff.py
+++ b/Configuration/Geometry/python/GeometryIdealNoAPD_cff.py
@@ -12,6 +12,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 
 #Muon
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryNoCastor_cff.py
+++ b/Configuration/Geometry/python/GeometryNoCastor_cff.py
@@ -12,6 +12,7 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 
 #Muon
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryRecoDB_cff.py
+++ b/Configuration/Geometry/python/GeometryRecoDB_cff.py
@@ -5,6 +5,8 @@ from Geometry.CommonTopologies.globalTrackingGeometryDB_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+# TrackerAdditionalParametersPerDet contains only default values, needed for consistency with Phase 2
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 #Muon

--- a/Configuration/Geometry/python/GeometryRecoTracker_cff.py
+++ b/Configuration/Geometry/python/GeometryRecoTracker_cff.py
@@ -6,6 +6,8 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 # Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+# TrackerAdditionalParametersPerDet contains only default values, needed for consistency with Phase 2
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 
 # Alignment
 from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryReco_cff.py
+++ b/Configuration/Geometry/python/GeometryReco_cff.py
@@ -6,6 +6,8 @@ from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+# TrackerAdditionalParametersPerDet contains only default values, needed for consistency with Phase 2
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerGeometryBuilder.trackerParameters_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 

--- a/Configuration/Geometry/python/GeometrySLHCRecoDB_cff.py
+++ b/Configuration/Geometry/python/GeometrySLHCRecoDB_cff.py
@@ -5,6 +5,7 @@ from Geometry.CommonTopologies.globalTrackingGeometryDB_cfi import *
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometryDB_cfi import *
 trackerGeometryDB.applyAlignment = cms.bool(False)
 #

--- a/Configuration/Geometry/python/GeometrySLHCReco_cff.py
+++ b/Configuration/Geometry/python/GeometrySLHCReco_cff.py
@@ -10,6 +10,7 @@ trackerGeometry.applyAlignment = cms.bool(False)
 
 #Tracker
 from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *
 
 #Muon
 from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *

--- a/Configuration/Geometry/python/dict2021Geometry.py
+++ b/Configuration/Geometry/python/dict2021Geometry.py
@@ -290,6 +290,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -492,6 +493,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -695,6 +697,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -898,6 +901,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -1101,6 +1105,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -1304,6 +1309,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -93,6 +93,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -128,6 +129,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -163,6 +165,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -199,6 +202,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -235,6 +239,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
@@ -270,6 +275,7 @@ trackerDict = {
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
             'from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *',
+            'from Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi import *',
             'from Geometry.TrackerGeometryBuilder.trackerParameters_cff import *',
             'from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *',
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',

--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h
@@ -7,6 +7,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PlaneBuilderFromGeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 
 class TrackerGeometry;
 class TrackerTopology;
@@ -16,10 +17,14 @@ class PTrackerParameters;
 
 class TrackerGeomBuilderFromGeometricDet {
 public:
-  TrackerGeometry* build(const GeometricDet* gd, const PTrackerParameters& ptp, const TrackerTopology* tTopo);
+  TrackerGeometry* build(const GeometricDet* gd,
+                         const PTrackerAdditionalParametersPerDet* ptitp,
+                         const PTrackerParameters& ptp,
+                         const TrackerTopology* tTopo);
 
 private:
   void buildPixel(std::vector<const GeometricDet*> const&,
+                  const PTrackerAdditionalParametersPerDet* const&,
                   TrackerGeometry*,
                   GeomDetType::SubDetector det,
                   bool upgradeGeometry,

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerAdditionalParametersPerDetESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerAdditionalParametersPerDetESModule.cc
@@ -1,0 +1,65 @@
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
+
+#include <memory>
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+class PTrackerAdditionalParametersPerDet;
+class PTrackerAdditionalParametersPerDetRcd;
+
+class TrackerAdditionalParametersPerDetESModule : public edm::ESProducer {
+public:
+  TrackerAdditionalParametersPerDetESModule(const edm::ParameterSet&);
+
+  using ReturnType = std::unique_ptr<PTrackerAdditionalParametersPerDet>;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  ReturnType produce(const PTrackerAdditionalParametersPerDetRcd&);
+
+private:
+  edm::ESGetToken<GeometricDet, IdealGeometryRecord> geometricDetToken_;
+};
+
+TrackerAdditionalParametersPerDetESModule::TrackerAdditionalParametersPerDetESModule(const edm::ParameterSet& ps) {
+  auto cc = setWhatProduced(this);
+  geometricDetToken_ = cc.consumesFrom<GeometricDet, IdealGeometryRecord>(edm::ESInputTag());
+}
+
+void TrackerAdditionalParametersPerDetESModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("TrackerAdditionalParametersPerDet", desc);
+}
+
+TrackerAdditionalParametersPerDetESModule::ReturnType TrackerAdditionalParametersPerDetESModule::produce(
+    const PTrackerAdditionalParametersPerDetRcd& iRecord) {
+  edm::LogInfo("TrackerAdditionalParametersPerDet")
+      << "TrackerAdditionalParametersPerDetESModule::produce(const PTrackerAdditionalParametersPerDetRcd& iRecord)";
+
+  auto ptitp = std::make_unique<PTrackerAdditionalParametersPerDet>();
+
+  edm::ESTransientHandle<GeometricDet> gd = iRecord.getTransientHandle(geometricDetToken_);
+
+  std::vector<const GeometricDet*> comp;
+  gd->deepComponents(comp);
+
+  for (auto& i : comp) {
+    ptitp->setGeographicalId(i->geographicalId());
+  }
+
+  return ptitp;
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(TrackerAdditionalParametersPerDetESModule);

--- a/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/TrackerDigiGeometryESModule.cc
@@ -15,10 +15,12 @@
 #include "CondFormats/AlignmentRecord/interface/TrackerAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/TrackerSurfaceDeformationRcd.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/Records/interface/PTrackerParametersRcd.h"
+#include "Geometry/Records/interface/PTrackerAdditionalParametersPerDetRcd.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
@@ -44,6 +46,8 @@ private:
   edm::ESGetToken<GeometricDet, IdealGeometryRecord> geometricDetToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
   edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> trackerParamsToken_;
+  edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd>
+      trackerGeometricDetExtraToken_;
 
   edm::ESGetToken<Alignments, GlobalPositionRcd> globalAlignmentToken_;
   edm::ESGetToken<Alignments, TrackerAlignmentRcd> trackerAlignmentToken_;
@@ -64,6 +68,8 @@ TrackerDigiGeometryESModule::TrackerDigiGeometryESModule(const edm::ParameterSet
     geometricDetToken_ = cc.consumesFrom<GeometricDet, IdealGeometryRecord>(kEmptyTag);
     trackerTopoToken_ = cc.consumesFrom<TrackerTopology, TrackerTopologyRcd>(kEmptyTag);
     trackerParamsToken_ = cc.consumesFrom<PTrackerParameters, PTrackerParametersRcd>(kEmptyTag);
+    trackerGeometricDetExtraToken_ =
+        cc.consumesFrom<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd>(kEmptyTag);
 
     if (applyAlignment_) {
       const edm::ESInputTag kAlignTag{"", alignmentsLabel_};
@@ -109,8 +115,10 @@ std::unique_ptr<TrackerGeometry> TrackerDigiGeometryESModule::produce(const Trac
 
   auto const& ptp = iRecord.get(trackerParamsToken_);
 
+  auto const& ptitp = iRecord.get(trackerGeometricDetExtraToken_);
+
   TrackerGeomBuilderFromGeometricDet builder;
-  std::unique_ptr<TrackerGeometry> tracker(builder.build(&gD, ptp, &tTopo));
+  std::unique_ptr<TrackerGeometry> tracker(builder.build(&gD, &ptitp, ptp, &tTopo));
 
   if (applyAlignment_) {
     // Since fake is fully working when checking for 'empty', we should get rid of applyAlignment_!

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -12,6 +12,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripTopologyBuilder.h"
 #include "CondFormats/GeometryObjects/interface/PTrackerParameters.h"
+#include "CondFormats/GeometryObjects/interface/PTrackerAdditionalParametersPerDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/GeometrySurface/interface/MediumProperties.h"
@@ -42,6 +43,7 @@ namespace {
 }  // namespace
 
 TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* gd,
+                                                           const PTrackerAdditionalParametersPerDet* ptitpx,
                                                            const PTrackerParameters& ptp,
                                                            const TrackerTopology* tTopo) {
   if (ptp.vpars.size() != 6) {
@@ -101,26 +103,23 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
   // now building the Pixel-like subdetectors
   for (unsigned int i = 0; i < 6; ++i) {
     if (gdsubdetmap[i] == GeometricDet::PixelBarrel)
-      buildPixel(
-          dets[i], tracker, GeomDetEnumerators::SubDetector::PixelBarrel, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::PixelBarrel, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase1Barrel)
-      buildPixel(dets[i], tracker, GeomDetEnumerators::SubDetector::P1PXB, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P1PXB, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     // Phase2 case
     if (gdsubdetmap[i] == GeometricDet::PixelPhase2Barrel)
-      buildPixel(dets[i], tracker, GeomDetEnumerators::SubDetector::P2PXB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     //
     if (gdsubdetmap[i] == GeometricDet::PixelEndCap)
-      buildPixel(
-          dets[i], tracker, GeomDetEnumerators::SubDetector::PixelEndcap, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::PixelEndcap, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase1EndCap)
-      buildPixel(
-          dets[i], tracker, GeomDetEnumerators::SubDetector::P1PXEC, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P1PXEC, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase2EndCap)
-      buildPixel(dets[i], tracker, GeomDetEnumerators::SubDetector::P2PXEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::OTPhase2Barrel)
-      buildPixel(dets[i], tracker, GeomDetEnumerators::SubDetector::P2OTB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::OTPhase2EndCap)
-      buildPixel(dets[i], tracker, GeomDetEnumerators::SubDetector::P2OTEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
   }
   //now building Strips
   for (unsigned int i = 0; i < 6; ++i) {
@@ -152,6 +151,7 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
 
 void TrackerGeomBuilderFromGeometricDet::buildPixel(
     std::vector<const GeometricDet*> const& gdv,
+    const PTrackerAdditionalParametersPerDet* const& ptitp,
     TrackerGeometry* tracker,
     GeomDetType::SubDetector det,
     bool upgradeGeometry,

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -103,23 +103,46 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
   // now building the Pixel-like subdetectors
   for (unsigned int i = 0; i < 6; ++i) {
     if (gdsubdetmap[i] == GeometricDet::PixelBarrel)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::PixelBarrel, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i],
+                 ptitpx,
+                 tracker,
+                 GeomDetEnumerators::SubDetector::PixelBarrel,
+                 false,
+                 BIG_PIX_PER_ROC_X,
+                 BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase1Barrel)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P1PXB, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(
+          dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P1PXB, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     // Phase2 case
     if (gdsubdetmap[i] == GeometricDet::PixelPhase2Barrel)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(
+          dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     //
     if (gdsubdetmap[i] == GeometricDet::PixelEndCap)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::PixelEndcap, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i],
+                 ptitpx,
+                 tracker,
+                 GeomDetEnumerators::SubDetector::PixelEndcap,
+                 false,
+                 BIG_PIX_PER_ROC_X,
+                 BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase1EndCap)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P1PXEC, false, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(dets[i],
+                 ptitpx,
+                 tracker,
+                 GeomDetEnumerators::SubDetector::P1PXEC,
+                 false,
+                 BIG_PIX_PER_ROC_X,
+                 BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::PixelPhase2EndCap)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(
+          dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2PXEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::OTPhase2Barrel)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(
+          dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTB, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
     if (gdsubdetmap[i] == GeometricDet::OTPhase2EndCap)
-      buildPixel(dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
+      buildPixel(
+          dets[i], ptitpx, tracker, GeomDetEnumerators::SubDetector::P2OTEC, true, BIG_PIX_PER_ROC_X, BIG_PIX_PER_ROC_Y);
   }
   //now building Strips
   for (unsigned int i = 0; i < 6; ++i) {

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerMap_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerMap_cfg.py
@@ -8,6 +8,7 @@ process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerTopology_cfi")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
 process.load("Geometry.TrackerSimData.trackerSimGeometryXML_cfi")
 
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDD4hep_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDD4hep_cfg.py
@@ -15,6 +15,8 @@ process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModu
 
 process.es_prefer_geomdet = cms.ESPrefer("TrackerGeometricDetESModule","")
 
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
+
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
 

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerModuleInfoDDD_cfg.py
@@ -16,6 +16,8 @@ process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModu
 
 process.es_prefer_geomdet = cms.ESPrefer("TrackerGeometricDetESModule","")
 
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
+
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
 


### PR DESCRIPTION
#### PR description:

This PR is the first step towards the description of the so-called big pixels for the phase-2 InnerTracker as proposed in 

https://indico.cern.ch/event/1242584/contributions/5517916/attachments/2691752/4671198/em20230728.pdf

The plan is to describe the phase-2 big pixels in the file pixelStructureTopology.xml or by using the TrackerAdditionalParametersPerDet rcd for geometries loaded from DB.

The goal of this PR is to put back the changes of the infrastructure needed for using the TrackerAdditionalParametersPerDet rcd, introduced for the bricked pixels and then removed with PR#40443 (but without reintroducing the functions related to bricked pixels).

#### PR validation:

- compilation ok after git cms-checkdeps -a
- scram b code-checks, code-format
- checked on ph-2 w/f 25610

#### 

This PR is not a backport and no backport needed

@tvami @mmusich @adewit @gbardell



