### PR TITLE
[13_1] Preserve electron mass after FastSim Bremsstrahlung emmision

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/Bremsstrahlung.cc
@@ -137,6 +137,7 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
   // Needed to rotate photons to the lab frame
   double theta = particle.momentum().Theta();
   double phi = particle.momentum().Phi();
+  double m2dontchange = particle.momentum().mass() * particle.momentum().mass();
 
   // Calculate energy of these photons and add them to the event
   for (unsigned int i = 0; i < nPhotons; ++i) {
@@ -155,6 +156,10 @@ void fastsim::Bremsstrahlung::interact(fastsim::Particle& particle,
 
     // Update the original e+/-
     particle.momentum() -= photonMom;
+    particle.momentum().SetXYZT(particle.momentum().px(),
+                                particle.momentum().py(),
+                                particle.momentum().pz(),
+                                sqrt(pow(particle.momentum().P(), 2) + m2dontchange));
   }
 }
 


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/42250