### PR TITLE
Extend `convertToRaw` to support different input collection names [13.2.x]

### DIFF
--- a/HLTrigger/Tools/python/convertToRaw.py
+++ b/HLTrigger/Tools/python/convertToRaw.py
@@ -6,6 +6,7 @@
 #           [lumiNumber=NNNN] \
 #           [eventsPerFile=50] \
 #           [eventsPerLumi=11650] \
+#           [rawDataCollection=rawDataCollector] \
 #           [outputPath=output_directory]
 #
 # The output files will appear as output_directory/runNNNNNN/runNNNNNN_lumiNNNN_indexNNNNNN.raw .
@@ -41,7 +42,7 @@ process.EvFDaqDirector = cms.Service( "EvFDaqDirector",
 )
 
 process.writer = cms.OutputModule("RawStreamFileWriterForBU",
-    source = cms.InputTag('rawDataCollector'),
+    source = cms.InputTag('rawDataCollector'),                      # to be overwritten after parsing the command line options
     numEventsPerFile = cms.uint32(0)                                # to be overwritten after parsing the command line options
 )
 
@@ -91,6 +92,12 @@ options.register('eventsPerFile',
                  VarParsing.VarParsing.varType.int,
                  "Split the output into files with at most this number of events")
 
+options.register('rawDataCollection',
+                 'rawDataCollector',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "FEDRawDataCollection to be repacked into RAW format")
+
 options.register('outputPath',
                  os.getcwd(),
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -125,6 +132,7 @@ if options.lumiNumber is not None:
 process.EvFDaqDirector.runNumber = options.runNumber
 process.EvFDaqDirector.baseDir = options.outputPath
 process.EvFDaqDirector.buBaseDir = options.outputPath
+process.writer.source = options.rawDataCollection
 process.writer.numEventsPerFile = options.eventsPerFile
 process.MessageLogger.cerr.FwkReport.reportEvery = options.eventsPerFile
 

--- a/HLTrigger/Tools/scripts/convertToRaw
+++ b/HLTrigger/Tools/scripts/convertToRaw
@@ -74,16 +74,17 @@ class LuminosityBlockRange:
 # default values
 events_per_file = 100
 events_per_lumi = 11655
-output_directory = ''
+output_directory = os.getcwd()
 
 parser = argparse.ArgumentParser(description='Convert RAW data from .root format to .raw format.', formatter_class = argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('files', type=str, metavar='FILES', nargs='+', help='input files in .root format')
-parser.add_argument('-o', '--output', type=str, dest='output_directory', metavar='PATH', default='', help='base path to store the output files; subdirectories based on the run number are automatically created')
+parser.add_argument('-s', '--source', type=str, dest='raw_data_collection', metavar='TAG', default='rawDataCollector', help='name of the FEDRawDataCollection to be repacked into RAW format')
+parser.add_argument('-o', '--output', type=str, dest='output_directory', metavar='PATH', default=os.getcwd(), help='base path to store the output files; subdirectories based on the run number are automatically created')
 parser.add_argument('-f', '--events_per_file', type=int, dest='events_per_file', metavar='EVENTS', default=events_per_file, help='split the output into files with at most EVENTS events')
 parser.add_argument('-l', '--events_per_lumi', type=int, dest='events_per_lumi', metavar='EVENTS', default=events_per_lumi, help='process at most EVENTS events in each lumisection')
 parser.add_argument('-r', '--range', type=LuminosityBlockRange, dest='range', metavar='[RUN:LUMI-RUN:LUMI]', default='all', help='process only the runs and lumisections in the given range')
 parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', default=False, help='print additional information while processing the input files')
-parser.add_argument('--one-file-per-lumi', action='store_true', dest='one_file_per_lumi', default=False, help='assume that lumisections are not split across files (and disable --events_per_lumi)')
+parser.add_argument('-1', '--one-file-per-lumi', action='store_true', dest='one_file_per_lumi', default=False, help='assume that lumisections are not split across files (and disable --events_per_lumi)')
 
 # parse the command line arguments and options
 args = parser.parse_args()
@@ -107,10 +108,9 @@ for f in files:
 
     # run edmFileUtil --eventsInLumis ...
     print(f'preprocessing input file {f}')
+    output = subprocess.run(['edmFileUtil', '--eventsInLumis', f], capture_output=True, text=True)
     if args.verbose:
-        output = subprocess.run(['edmFileUtil', '--eventsInLumis', f], stdout=None, stderr=None)
-    else:
-        output = subprocess.run(['edmFileUtil', '--eventsInLumis', f], capture_output=True, text=True)
+        print(output.stdout)
 
     # handle error conditions
     if output.returncode < 0:
@@ -195,7 +195,7 @@ for run in sorted(content):
         # process the whole run
         lumis = sorted(content[run])
         print('found run %d, lumis %d-%d, with %d events' % (run, min(lumis), max(lumis), sum(content[run][lumi].events for lumi in lumis)))
-        cmsRun(config_py, args.verbose, inputFiles = ','.join(files), runNumber = run, eventsPerFile = args.events_per_file, outputPath = args.output_directory)
+        cmsRun(config_py, args.verbose, inputFiles = ','.join(files), runNumber = run, eventsPerFile = args.events_per_file, rawDataCollection = args.raw_data_collection, outputPath = args.output_directory)
         converted_files = glob.glob(run_path + f'/run{run:06d}_ls{lumi:04d}_*.raw')
 
     else:
@@ -213,7 +213,7 @@ for run in sorted(content):
             lumi_path = args.output_directory + f'/run{run:06d}_ls{lumi:04d}'
             shutil.rmtree(lumi_path, ignore_errors=True)
             os.makedirs(lumi_path)
-            cmsRun(config_py, args.verbose, inputFiles = ','.join(content[run][lumi].files), runNumber = run, lumiNumber = lumi, eventsPerLumi = args.events_per_lumi, eventsPerFile = args.events_per_file, outputPath = lumi_path)
+            cmsRun(config_py, args.verbose, inputFiles = ','.join(content[run][lumi].files), runNumber = run, lumiNumber = lumi, eventsPerLumi = args.events_per_lumi, eventsPerFile = args.events_per_file, rawDataCollection = args.raw_data_collection, outputPath = lumi_path)
 
             # merge all lumisetions data
 


### PR DESCRIPTION
#### PR description:

The Heavy Ions data use a different collection name for the RAW data, because of the repacking done at HLT.

This PR extends the `convertToRaw` script and its underlying CMSSW configuration to support different input collection names.

#### PR validation:

Tested converting to raw format a Heavy Ions data file from 2018.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42457 to 13.2.x to support the studies for the Heavy Ions data taking.