### PR TITLE
Tracker Alignment monitoring: add unbalance histograms for pointing angle in Z events

### DIFF
--- a/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
@@ -76,6 +76,8 @@ private:
   MonitorElement *hCosPhi3D_;
   MonitorElement *hCosPhiInv_;
   MonitorElement *hCosPhiInv3D_;
+  MonitorElement *hCosPhiUnbalance_;
+  MonitorElement *hCosPhi3DUnbalance_;
   MonitorElement *hInvMass_;
   MonitorElement *hCutFlow_;
 

--- a/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
@@ -15,6 +15,7 @@
 #include <string>
 
 // user includes
+#include "DQMOffline/Alignment/interface/DiLeptonPlotHelpers.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -80,6 +81,26 @@ private:
   MonitorElement *hCosPhi3DUnbalance_;
   MonitorElement *hInvMass_;
   MonitorElement *hCutFlow_;
+
+  // 2D histograms of pointing angle vs variable
+  edm::ParameterSet CosPhi3DConfiguration_;
+  DiLepPlotHelp::PlotsVsKinematics CosPhi3DPlots_ = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
+
+  // 2D histograms of 3D PV-SV distance vs variable
+  edm::ParameterSet SVDistConfiguration_;
+  DiLepPlotHelp::PlotsVsKinematics SVDistPlots_ = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
+
+  // 2D histograms of 3D PV-SV distance significance vs variable
+  edm::ParameterSet SVDistSigConfiguration_;
+  DiLepPlotHelp::PlotsVsKinematics SVDistSigPlots_ = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
+
+  // 2D histograms of PV-SV transverse distance vs variable
+  edm::ParameterSet SVDist3DConfiguration_;
+  DiLepPlotHelp::PlotsVsKinematics SVDist3DPlots_ = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
+
+  // 2D histograms of PV-SV transverse distance significance vs variable
+  edm::ParameterSet SVDist3DSigConfiguration_;
+  DiLepPlotHelp::PlotsVsKinematics SVDist3DSigPlots_ = DiLepPlotHelp::PlotsVsKinematics(DiLepPlotHelp::MM);
 
   // impact parameters information
   MonitorElement *hdxy_;

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -164,7 +164,12 @@ ALCARECOTkAlJpsiMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiMuon
     decayMotherName = "J/#psi",
     vertices = 'offlinePrimaryVertices',
     FolderName = "AlCaReco/"+__selectionName,
-    maxSVdist = 50
+    maxSVdist = 50,
+    CosPhi3DConfig = dict(maxDeltaEta = 1.3),
+    SVDistConfig = dict(maxDeltaEta = 1.3),
+    SVDistSigConfig = dict(maxDeltaEta = 1.3),
+    SVDist3DConfig = dict(maxDeltaEta = 1.3),
+    SVDist3DSigConfig = dict(maxDeltaEta = 1.3)
 )
 
 ALCARECOTkAlJpsiMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(
@@ -234,7 +239,12 @@ ALCARECOTkAlUpsilonMuMuVtxDQM = DQMOffline.Alignment.DiMuonVertexMonitor_cfi.DiM
     decayMotherName = "#Upsilon",
     vertices = 'offlinePrimaryVertices',
     FolderName = "AlCaReco/"+__selectionName,
-    maxSVdist = 50
+    maxSVdist = 50,
+    CosPhi3DConfig = dict(maxDeltaEta = 1.6),
+    SVDistConfig = dict(maxDeltaEta = 1.6),
+    SVDistSigConfig = dict(maxDeltaEta = 1.6),
+    SVDist3DConfig = dict(maxDeltaEta = 1.6),
+    SVDist3DSigConfig = dict(maxDeltaEta = 1.6)
 )
 
 ALCARECOTkAlUpsilonMassBiasDQM = DQMOffline.Alignment.DiMuonMassBiasMonitor_cfi.DiMuonMassBiasMonitor.clone(

--- a/DQMOffline/Alignment/python/DiMuonVertexMonitor_cfi.py
+++ b/DQMOffline/Alignment/python/DiMuonVertexMonitor_cfi.py
@@ -6,4 +6,54 @@ DiMuonVertexMonitor = DQMEDAnalyzer('DiMuonVertexMonitor',
                                     decayMotherName = cms.string('Z'),
                                     vertices = cms.InputTag('offlinePrimaryVertices'),
                                     FolderName = cms.string('DiMuonVertexMonitor'),
-                                    maxSVdist = cms.double(50))
+                                    maxSVdist = cms.double(50),
+                                    CosPhi3DConfig = cms.PSet(
+                                        name = cms.string('CosPhi3D'),
+                                        title = cms.string('cos(#phi_{3D})'),
+                                        yUnits = cms.string(''),
+                                        NxBins = cms.int32(24),
+                                        NyBins = cms.int32(50),
+                                        ymin = cms.double(-1),
+                                        ymax = cms.double(1),
+                                        maxDeltaEta = cms.double(3.7)
+                                    ),
+                                    SVDistConfig = cms.PSet(
+                                        name = cms.string('SVDist'),
+                                        title = cms.string('PV-SV distance'),
+                                        yUnits = cms.string('[#mum]'),
+                                        NxBins = cms.int32(24),
+                                        NyBins = cms.int32(100),
+                                        ymin = cms.double(0),
+                                        ymax = cms.double(300),
+                                        maxDeltaEta = cms.double(3.7)
+                                    ),
+                                    SVDistSigConfig = cms.PSet(
+                                        name = cms.string('SVDistSig'),
+                                        title = cms.string('PV-SV distance significance'),
+                                        yUnits = cms.string('[#mum]'),
+                                        NxBins = cms.int32(24),
+                                        NyBins = cms.int32(100),
+                                        ymin = cms.double(0),
+                                        ymax = cms.double(5),
+                                        maxDeltaEta = cms.double(3.7)
+                                    ),
+                                    SVDist3DConfig = cms.PSet(
+                                        name = cms.string('SVDist3D'),
+                                        title = cms.string('PV-SV 3D distance'),
+                                        yUnits = cms.string('[#mum]'),
+                                        NxBins = cms.int32(24),
+                                        NyBins = cms.int32(100),
+                                        ymin = cms.double(0),
+                                        ymax = cms.double(300),
+                                        maxDeltaEta = cms.double(3.7)
+                                    ),
+                                    SVDist3DSigConfig = cms.PSet(
+                                        name = cms.string('SVDist3DSig'),
+                                        title = cms.string('PV-SV 3D distance significance'),
+                                        yUnits = cms.string('[#mum]'),
+                                        NxBins = cms.int32(24),
+                                        NyBins = cms.int32(100),
+                                        ymin = cms.double(0),
+                                        ymax = cms.double(5),
+                                        maxDeltaEta = cms.double(3.7)
+                                    ))

--- a/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
+++ b/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
@@ -91,6 +91,8 @@ void DiMuonVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run co
   hCosPhi3D_ = iBooker.book1D("CosPhi3D", fmt::sprintf("%s;cos(#phi_{3D});%s", histTit, ps), 50, -1., 1.);
   hCosPhiInv_ = iBooker.book1D("CosPhiInv", fmt::sprintf("%s;inverted cos(#phi_{xy});%s", histTit, ps), 50, -1., 1.);
   hCosPhiInv3D_ = iBooker.book1D("CosPhiInv3D", fmt::sprintf("%s;inverted cos(#phi_{3D});%s", histTit, ps), 50, -1., 1.);
+  hCosPhiUnbalance_ = iBooker.book1D("CosPhiUnbalance", fmt::sprintf("%s;cos(#phi_{xy}) unbalance;#Delta%s", histTit, ps), 50, -1.,1.);
+  hCosPhi3DUnbalance_ = iBooker.book1D("CosPhi3DUnbalance", fmt::sprintf("%s;cos(#phi_{3D}) unbalance;#Delta%s", histTit, ps), 50, -1., 1.);
 
   hdxy_ = iBooker.book1D("dxy", fmt::sprintf("%s;muon track d_{xy}(PV) [#mum];muon tracks", histTit), 150, -300, 300);
   hdz_ = iBooker.book1D("dz", fmt::sprintf("%s;muon track d_{z}(PV) [#mum];muon tracks", histTit), 150, -300, 300);
@@ -252,6 +254,12 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
       // inverted
       hCosPhiInv_->Fill(-cosphi);
       hCosPhiInv3D_->Fill(-cosphi3D);
+
+      // unbalance
+      hCosPhiUnbalance_->Fill(cosphi, 1.);
+      hCosPhiUnbalance_->Fill(-cosphi, -1.);
+      hCosPhi3DUnbalance_->Fill(cosphi3D, 1.);
+      hCosPhi3DUnbalance_->Fill(-cosphi3D, -1.);
     }
   } else {
     edm::LogWarning("DiMuonVertexMonitor") << "hardest primary vertex in the event is not valid!";


### PR DESCRIPTION
#### PR description:

In order to help with spotting more easily the problem presented in this [talk](https://indico.cern.ch/event/1312617/#17-tracker-alignment-performan), we add a couple of histograms in which the backward / forward unbalance in the 3D pointing angle in Z events is graphed, in order to better spot this sort of deformations during data-taking

#### PR validation:

Run privately unit test of the package (using real run3 data) and obtained the following plot:
![Screenshot from 2023-08-03 12-04-18](https://github.com/cms-sw/cmssw/assets/5082376/938b9555-af75-40c5-adad-01ad3442e1aa)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A