### PR TITLE
[12_4_X] Removal of StringCutObjectSelector from Muon trigger DQM

### DIFF
--- a/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
+++ b/DQMOffline/Trigger/interface/HLTMuonMatchAndPlot.h
@@ -35,8 +35,6 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-
 #include <vector>
 #include "TFile.h"
 #include "TNtuple.h"
@@ -83,18 +81,9 @@ private:
   // Internal Methods
   void book1D(DQMStore::IBooker &, std::string, const std::string &, std::string);
   void book2D(DQMStore::IBooker &, const std::string &, const std::string &, const std::string &, const std::string &);
-  reco::MuonCollection selectedMuons(const reco::MuonCollection &,
-                                     const reco::BeamSpot &,
-                                     bool,
-                                     const StringCutObjectSelector<reco::Muon> &,
-                                     double,
-                                     double);
-
-  trigger::TriggerObjectCollection selectedTriggerObjects(
-      const trigger::TriggerObjectCollection &,
-      const trigger::TriggerEvent &,
-      bool hasTriggerCuts,
-      const StringCutObjectSelector<trigger::TriggerObject> &triggerSelector);
+  reco::MuonCollection selectedMuons(const reco::MuonCollection &, const reco::BeamSpot &, bool);
+  trigger::TriggerObjectCollection selectedTriggerObjects(const trigger::TriggerObjectCollection &,
+                                                          const trigger::TriggerEvent &);
 
   // Input from Configuration File
   std::string hltProcessName_;
@@ -113,21 +102,20 @@ private:
   bool isLastFilter_;
   std::map<std::string, MonitorElement *> hists_;
 
-  // Selectors
-  bool hasTargetRecoCuts;
-  bool hasProbeRecoCuts;
-
-  StringCutObjectSelector<reco::Muon> targetMuonSelector_;
+  double targetMuonEtaMax_;
+  double targetMuonEtaMin_;
+  bool targetIsMuonGlb_;
   double targetZ0Cut_;
   double targetD0Cut_;
   double targetptCutZ_;
   double targetptCutJpsi_;
-  StringCutObjectSelector<reco::Muon> probeMuonSelector_;
+  double probeMuonEtaMax_;
+  double probeMuonEtaMin_;
+  bool probeIsMuonGlb_;
   double probeZ0Cut_;
   double probeD0Cut_;
-
-  StringCutObjectSelector<trigger::TriggerObject> triggerSelector_;
-  bool hasTriggerCuts_;
+  double triggerEtaMaxCut_;
+  double triggerEtaMinCut_;
 };
 
 #endif

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cff.py
@@ -5,8 +5,11 @@ from DQMOffline.Trigger.HLTMuonOfflineAnalyzer_cfi import hltMuonOfflineAnalyzer
 globalMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(2.0),
     z0Cut = cms.untracked.double(25.0),
-    recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-    hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+    recoMaxEtaCut = cms.untracked.double(2.4),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(True),
+    hltMaxEtaCut  = cms.untracked.double(2.4),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 globalAnalyzerTnP = hltMuonOfflineAnalyzer.clone()

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -90,8 +90,11 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
         d0Cut = cms.untracked.double(2.0),
         z0Cut = cms.untracked.double(25.0),
         ## cuts
-        recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-        hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+        recoMaxEtaCut = cms.untracked.double(2.4),
+        recoMinEtaCut = cms.untracked.double(0.0),
+        recoGlbMuCut = cms.untracked.bool(True),
+        hltMaxEtaCut  = cms.untracked.double(2.4),
+        hltMinEtaCut  = cms.untracked.double(0.0),
     ),
 
     ## If this PSet is empty, then no "tag and probe" plots are produced;
@@ -102,8 +105,11 @@ hltMuonOfflineAnalyzer = DQMEDAnalyzer('HLTMuonOfflineAnalyzer',
         d0Cut = cms.untracked.double(2.0),
         z0Cut = cms.untracked.double(25.0),
         ## cuts
-        recoCuts = cms.untracked.string("isGlobalMuon && abs(eta) < 2.4"),
-        hltCuts  = cms.untracked.string("abs(eta) < 2.4"),
+        recoMaxEtaCut = cms.untracked.double(2.4),
+        recoMinEtaCut = cms.untracked.double(0.0),
+        recoGlbMuCut = cms.untracked.bool(True),        
+        hltMaxEtaCut  = cms.untracked.double(2.4),
+        hltMinEtaCut  = cms.untracked.double(0.0),
     ),
 
 )

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
@@ -5,23 +5,31 @@ from DQMOffline.Trigger.HLTMuonOfflineAnalyzer_cfi import hltMuonOfflineAnalyzer
 barrelMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) < 0.9"),
-    hltCuts  = cms.untracked.string("abs(eta) < 0.9"),
+    recoMaxEtaCut = cms.untracked.double(0.9),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(0.9),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 endcapMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) > 1.4 && "
-                                    "abs(eta) < 2.0"),
-    hltCuts  = cms.untracked.string("abs(eta) > 1.4 && abs(eta) < 2.0"),
+    recoMaxEtaCut = cms.untracked.double(2.0),
+    recoMinEtaCut = cms.untracked.double(1.4),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(2.0),
+    hltMinEtaCut  = cms.untracked.double(1.4),
 )
 
 allMuonParams = cms.PSet(
     d0Cut = cms.untracked.double(1000.0),
     z0Cut = cms.untracked.double(1000.0),
-    recoCuts = cms.untracked.string("isStandAloneMuon && abs(eta) < 2.0"),
-    hltCuts  = cms.untracked.string("abs(eta) < 2.0"),
+    recoMaxEtaCut = cms.untracked.double(2.0),
+    recoMinEtaCut = cms.untracked.double(0.0),
+    recoGlbMuCut = cms.untracked.bool(False), #is a SA muon
+    hltMaxEtaCut  = cms.untracked.double(2.0),
+    hltMinEtaCut  = cms.untracked.double(0.0),
 )
 
 barrelAnalyzer = hltMuonOfflineAnalyzer.clone(

--- a/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
+++ b/DQMOffline/Trigger/src/HLTMuonMatchAndPlot.cc
@@ -43,18 +43,20 @@ HLTMuonMatchAndPlot::HLTMuonMatchAndPlot(const ParameterSet& pset, string hltPat
       hltPath_(std::move(hltPath)),
       moduleLabel_(std::move(moduleLabel)),
       isLastFilter_(islastfilter),
-      hasTargetRecoCuts(targetParams_.exists("recoCuts")),
-      hasProbeRecoCuts(probeParams_.exists("recoCuts")),
-      targetMuonSelector_(targetParams_.getUntrackedParameter<string>("recoCuts", "")),
+      targetMuonEtaMax_(targetParams_.getUntrackedParameter<double>("recoMaxEtaCut", 0.)),
+      targetMuonEtaMin_(targetParams_.getUntrackedParameter<double>("recoMinEtaCut", 0.)),
+      targetIsMuonGlb_(targetParams_.getUntrackedParameter<bool>("recoGlbMuCut", false)),
       targetZ0Cut_(targetParams_.getUntrackedParameter<double>("z0Cut", 0.)),
       targetD0Cut_(targetParams_.getUntrackedParameter<double>("d0Cut", 0.)),
       targetptCutZ_(targetParams_.getUntrackedParameter<double>("ptCut_Z", 20.)),
       targetptCutJpsi_(targetParams_.getUntrackedParameter<double>("ptCut_Jpsi", 20.)),
-      probeMuonSelector_(probeParams_.getUntrackedParameter<string>("recoCuts", "")),
+      probeMuonEtaMax_(probeParams_.getUntrackedParameter<double>("recoMaxEtaCut", 0.)),
+      probeMuonEtaMin_(probeParams_.getUntrackedParameter<double>("recoMinEtaCut", 0.)),
+      probeIsMuonGlb_(probeParams_.getUntrackedParameter<bool>("recoGlbMuCut", false)),
       probeZ0Cut_(probeParams_.getUntrackedParameter<double>("z0Cut", 0.)),
       probeD0Cut_(probeParams_.getUntrackedParameter<double>("d0Cut", 0.)),
-      triggerSelector_(targetParams_.getUntrackedParameter<string>("hltCuts", "")),
-      hasTriggerCuts_(targetParams_.exists("hltCuts")) {
+      triggerEtaMaxCut_(targetParams_.getUntrackedParameter<double>("hltMaxEtaCut", 0.)),
+      triggerEtaMinCut_(targetParams_.getUntrackedParameter<double>("hltMinEtaCut", 0.)) {
   // Create std::map<string, T> from ParameterSets.
   fillMapFromPSet(binParams_, pset, "binParams");
   fillMapFromPSet(plotCuts_, pset, "plotCuts");
@@ -170,13 +172,10 @@ void HLTMuonMatchAndPlot::analyze(Handle<MuonCollection>& allMuons,
   */
 
   // Select objects based on the configuration.
-  MuonCollection targetMuons =
-      selectedMuons(*allMuons, *beamSpot, hasTargetRecoCuts, targetMuonSelector_, targetD0Cut_, targetZ0Cut_);
-  MuonCollection probeMuons =
-      selectedMuons(*allMuons, *beamSpot, hasProbeRecoCuts, probeMuonSelector_, probeD0Cut_, probeZ0Cut_);
+  MuonCollection targetMuons = selectedMuons(*allMuons, *beamSpot, true);
+  MuonCollection probeMuons = selectedMuons(*allMuons, *beamSpot, false);
   TriggerObjectCollection allTriggerObjects = triggerSummary->getObjects();
-  TriggerObjectCollection hltMuons =
-      selectedTriggerObjects(allTriggerObjects, *triggerSummary, hasTriggerCuts_, triggerSelector_);
+  TriggerObjectCollection hltMuons = selectedTriggerObjects(allTriggerObjects, *triggerSummary);
   // Fill plots for HLT muons.
 
   // Find the best trigger object matches for the targetMuons.
@@ -375,47 +374,41 @@ vector<size_t> HLTMuonMatchAndPlot::matchByDeltaR(const vector<T1>& collection1,
 
 MuonCollection HLTMuonMatchAndPlot::selectedMuons(const MuonCollection& allMuons,
                                                   const BeamSpot& beamSpot,
-                                                  bool hasRecoCuts,
-                                                  const StringCutObjectSelector<reco::Muon>& selector,
-                                                  double d0Cut,
-                                                  double z0Cut) {
-  // If there is no selector (recoCuts does not exists), return an empty collection.
-  if (!hasRecoCuts)
-    return MuonCollection();
-
+                                                  bool isTargetMuons) {
   MuonCollection reducedMuons;
+  double RecoMuonEtaMax = isTargetMuons ? targetMuonEtaMax_ : probeMuonEtaMax_;
+  double RecoMuonEtaMin = isTargetMuons ? targetMuonEtaMin_ : probeMuonEtaMin_;
+  bool IsMuonGlb = isTargetMuons ? targetIsMuonGlb_ : probeIsMuonGlb_;
+  double d0Cut = isTargetMuons ? targetD0Cut_ : probeD0Cut_;
+  double z0Cut = isTargetMuons ? targetZ0Cut_ : probeZ0Cut_;
+
   for (auto const& mu : allMuons) {
     const Track* track = nullptr;
     if (mu.isTrackerMuon())
       track = &*mu.innerTrack();
     else if (mu.isStandAloneMuon())
       track = &*mu.outerTrack();
-    if (track && selector(mu) && fabs(track->dxy(beamSpot.position())) < d0Cut &&
-        fabs(track->dz(beamSpot.position())) < z0Cut)
+    // minimun ID (requested for cosmics) is being a StandAlone muon
+    bool muID = IsMuonGlb ? mu.isGlobalMuon() : mu.isStandAloneMuon();
+    if (track && muID && abs(mu.eta()) < RecoMuonEtaMax && abs(mu.eta()) >= RecoMuonEtaMin &&
+        fabs(track->dxy(beamSpot.position())) < d0Cut && fabs(track->dz(beamSpot.position())) < z0Cut)
       reducedMuons.push_back(mu);
   }
 
   return reducedMuons;
 }
 
-TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(
-    const TriggerObjectCollection& triggerObjects,
-    const TriggerEvent& triggerSummary,
-    bool hasTriggerCuts,
-    const StringCutObjectSelector<TriggerObject>& triggerSelector) {
-  if (!hasTriggerCuts)
-    return TriggerObjectCollection();
-
+TriggerObjectCollection HLTMuonMatchAndPlot::selectedTriggerObjects(const TriggerObjectCollection& triggerObjects,
+                                                                    const TriggerEvent& triggerSummary) {
   InputTag filterTag(moduleLabel_, "", hltProcessName_);
   size_t filterIndex = triggerSummary.filterIndex(filterTag);
 
   TriggerObjectCollection selectedObjects;
-
   if (filterIndex < triggerSummary.sizeFilters()) {
     const Keys& keys = triggerSummary.filterKeys(filterIndex);
     for (unsigned short key : keys) {
       TriggerObject foundObject = triggerObjects[key];
-      if (triggerSelector(foundObject))
+      if (abs(foundObject.eta()) < triggerEtaMaxCut_ && abs(foundObject.eta()) >= triggerEtaMinCut_)
         selectedObjects.push_back(foundObject);
     }
   }


### PR DESCRIPTION
#### PR description: Backport of [#42437](https://github.com/cms-sw/cmssw/pull/42437)

This PR removes the "StringCutObjectSelector" from the Muon trigger DQM, with the aim of solving the memory issues faced during the 2022 rereco. The cuts on the reco muons and trigger objects are now applied explicitly, since they are few and identical for all trigger paths.

#### PR validation:

See master PR for validation description

#### Backport 
Backport of [#42437](https://github.com/cms-sw/cmssw/pull/42437)
