### PR TITLE
L1T: add puppi jet requirement for filling zpt in L1Ntuples

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1JetRecoTreeProducer.cc
@@ -682,7 +682,7 @@ void L1JetRecoTreeProducer::doZPt(edm::Handle<reco::MuonCollection> muons,
       passPuppiJetPtCut = true;
   }
 
-  if (!passPuppiJetPtCut) {
+  if (!passPuppiJetPtCut || muons->size() < 2) {
     met_data->zPt = -999;
     return;
   }


### PR DESCRIPTION
Adds a puppi jet selection for filling the Z pt in the L1Ntuples used for offline reference in L1 MET efficiencies