### PR TITLE
SiPixel payload inspector: add `SiPixelQualityBadFractionMap`

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelQuality_PayloadInspector.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h"
+#include "DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h"
 
 #include <memory>
 #include <sstream>
@@ -448,6 +449,89 @@ namespace {
   using SiPixelFPixQualityMapCompareTwoTags = SiPixelQualityMapComparisonBase<SiPixelPI::t_forward, SINGLE_IOV, 2>;
   using SiPixelFullQualityMapCompareTwoTags = SiPixelQualityMapComparisonBase<SiPixelPI::t_all, SINGLE_IOV, 2>;
 
+  /************************************************
+   Full Pixel Tracker Map class
+  *************************************************/
+  class SiPixelQualityBadFractionMap : public PlotImage<SiPixelQuality, SINGLE_IOV> {
+  public:
+    SiPixelQualityBadFractionMap() : PlotImage<SiPixelQuality, SINGLE_IOV>("SiPixelQuality Map") {
+      label_ = "SiPixelQualityFullPixelMap";
+      payloadString = "Quality";
+    }
+
+    bool fill() override {
+      gStyle->SetPalette(1);
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+      std::shared_ptr<SiPixelQuality> payload = this->fetchPayload(std::get<1>(iov));
+
+      if (payload.get()) {
+        Phase1PixelSummaryMap fullMap(
+            "", fmt::sprintf("%s", payloadString), fmt::sprintf("bad %s fraction [%%]", payloadString));
+        fullMap.createTrackerBaseMap();
+
+        auto theDisabledModules = payload->getBadComponentList();
+        if (this->isPhase0(theDisabledModules)) {
+          edm::LogError("SiPixelQuality_PayloadInspector")
+              << "SiPixelQuality maps are not supported for non-Phase1 Pixel geometries !";
+          TCanvas canvas("Canv", "Canv", 1200, 1000);
+          SiPixelPI::displayNotSupported(canvas, 0);
+          std::string fileName(m_imageFileName);
+          canvas.SaveAs(fileName.c_str());
+          return false;
+        }
+
+        for (const auto& mod : theDisabledModules) {
+          std::bitset<16> bad_rocs(mod.BadRocs);
+          fullMap.fillTrackerMap(mod.DetID, (bad_rocs.count() / 16.) * 100);  // 16 ROCs in a Pixel Phase-1 module!
+        }
+
+        TCanvas canvas("Canv", "Canv", 3000, 2000);
+        fullMap.printTrackerMap(canvas);
+
+        auto ltx = TLatex();
+        ltx.SetTextFont(62);
+        ltx.SetTextSize(0.025);
+        ltx.SetTextAlign(11);
+        ltx.DrawLatexNDC(gPad->GetLeftMargin() + 0.01,
+                         gPad->GetBottomMargin() + 0.01,
+                         ("#color[4]{" + tag.name + "}, IOV: #color[4]{" + std::to_string(unpacked.first) + "," +
+                          std::to_string(unpacked.second) + " }")
+                             .c_str());
+
+        std::string fileName(this->m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+      }
+      return true;
+    }
+
+  protected:
+    std::string payloadString;
+    std::string label_;
+
+  private:
+    //_________________________________________________
+    bool isPhase0(std::vector<SiPixelQuality::disabledModuleType> mods) {
+      SiPixelDetInfoFileReader reader =
+          SiPixelDetInfoFileReader(edm::FileInPath(SiPixelDetInfoFileReader::kPh0DefaultFile).fullPath());
+      const auto& p0detIds = reader.getAllDetIds();
+
+      std::vector<uint32_t> ownDetIds;
+      std::transform(mods.begin(),
+                     mods.end(),
+                     std::back_inserter(ownDetIds),
+                     [](SiPixelQuality::disabledModuleType d) -> uint32_t { return d.DetID; });
+
+      for (const auto& det : ownDetIds) {
+        // if found at least one phase-0 detId early return
+        if (std::find(p0detIds.begin(), p0detIds.end(), det) != p0detIds.end()) {
+          return true;
+        }
+      }
+      return false;
+    }
+  };
 }  // namespace
 
 // Register the classes as boost python plugin
@@ -459,6 +543,7 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelQuality) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelBPixQualityMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFPixQualityMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFullQualityMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelQualityBadFractionMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelBPixQualityMapCompareSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFPixQualityMapCompareSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFullQualityMapCompareSingleTag);

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -94,6 +94,10 @@ int main(int argc, char** argv) {
   histo9.process(connectionString, PI::mk_input(tag, start, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo9.data() << std::endl;
 
+  SiPixelQualityBadFractionMap histo9bis;
+  histo9bis.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo9bis.data() << std::endl;
+
   // SiPixelGainCalibrationOffline
 
   tag = "SiPixelGainCalibration_2009runs_express";


### PR DESCRIPTION
#### PR description:

This PR adds a `TrackerMap`-style plot for the fraction of pixel bad components from `SiPixelQuality`.
Also augmented the unit test of the package to be able to test this. 

#### PR validation:

Tested privately the following command:

```python
getPayloadData.py \
    --plugin pluginSiPixelQuality_PayloadInspector \
    --plot plot_SiPixelQualityBadFractionMap \
    --tag SiPixelQuality_byPCL_prompt_v2 \
    --time_type Lumi \
    --iovs '{"start_iov": "1594407824392193", "end_iov": "1594407824392193"}'  \
    --db Prod --test ;
```
and obtained:

![image](https://github.com/cms-sw/cmssw/assets/5082376/e6d18694-e297-47c8-bd21-e7d46a422451)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A