### PR TITLE
Fix approximated SiStrip clusters workflow by saving SiStrip FED error information 

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -180,7 +180,8 @@ RAWEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 approxSiStripClusters.toModify(RAWEventContent,
                               outputCommands = RAWEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 
 #
@@ -622,7 +623,8 @@ FEVTDEBUGEventContent.outputCommands.extend(SimCalorimetryFEVTDEBUG.outputComman
 FEVTDEBUGEventContent.outputCommands.extend(SimFastTimingFEVTDEBUG.outputCommands)
 approxSiStripClusters.toModify(FEVTDEBUGEventContent,
                               outputCommands = FEVTDEBUGEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 #
 #
@@ -640,7 +642,8 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_StripDigiSimLink_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])

--- a/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
@@ -35,6 +35,10 @@ RawToDigiTask = cms.Task(
     castorDigis,
     scalersRawToDigi)
 
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(RawToDigiTask, 
+                               RawToDigiTask.copyAndExclude(siStripDigis)) # in case of the approximate cluster wf don't run the 
+
 RawToDigi = cms.Sequence(RawToDigiTask)
 
 RawToDigiTask_woGCT = RawToDigiTask.copyAndExclude([gctDigis])

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -6,6 +6,12 @@ MeasurementTrackerEvent = _measurementTrackerEventDefault.clone(
     badPixelFEDChannelCollectionLabels = ['siPixelDigis'],
 )
 
+# in case of RAW' (approximated SiStrip clusters) 
+# take the list of inactive strip labels directly from RAW data
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(MeasurementTrackerEvent,
+                               inactiveStripDetectorLabels = ["siStripDigisHLT"]) 
+
 # This customization will be removed once we have phase2 pixel digis
 # Need this line to stop error about missing siPixelDigis
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -31,4 +37,9 @@ vectorHits.toModify(MeasurementTrackerEvent,
 
 MeasurementTrackerEventPreSplitting = MeasurementTrackerEvent.clone(
     pixelClusterProducer = 'siPixelClustersPreSplitting'
-    )
+)
+
+# in case of RAW' (approximated SiStrip clusters) 
+# take the list of inactive strip labels directly from RAW data 
+approxSiStripClusters.toModify(MeasurementTrackerEventPreSplitting,
+                               inactiveStripDetectorLabels = ["siStripDigisHLT"])


### PR DESCRIPTION
#### PR description:

It has been shown (see [talk](https://indico.cern.ch/event/1271490/contributions/5484101/attachments/2679179/4647438/DPG_RawPrime_20230705.pdf)) that events repacked in the RAW' data format and then reconstructed with the dedicated process modifier `approxSiStripClusters` have a different content in terms of tracks w.r.t. the standard reconstruction starting from RAW data (with full SiStrip ADC information). Part of that is expected from information loss intrinsic to the procedure, but dedicated checks showed that in some events few perfectly valid seeds lead to no track reconstructed when data is repacked with the RAW' data format.
This has been shown to depend on the fact the currently the RAW' data format is not saving the list of SiStrip FED errors (collection  `DetIdedmEDCollection_siStripDigisHLT_*_*`) which is used in the tracking setup to construct the list of inactive componets:

https://github.com/cms-sw/cmssw/blob/a5b91a1d0848665cc6f5d3ddb11be28272302e1c/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc#L405-L417

which is then used in trajectory building.
This PR proposed to fix this issue by keeping the missing collection (2bb7f37fdc2c5ed211c120f1e17b14b655d61d9b, supposed eventually to come from the HLT) in the repack procedure and then to use it in the `MeasurementTrackerEventProducer` (1f49f6ee100618d603f6862ebad60294f144465d).
After that is no longer necessary to run the SiStrip unpacker `siStripDigis` in the RAW2DIGI step, therefore that's excluded from execution profiting of the process modifier (6cc72b501cc8e3f44bf0e86529a539aefe729636).


#### PR validation:

Run successfully `runTheMatrix.py -l 140.58 -t 4 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to at least CMSSW_13_2_X
