### PR TITLE
RAW' workflow: rename `siStripDigisHLT` to `hltSiStripRawToDigi`

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -181,7 +181,7 @@ from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStr
 approxSiStripClusters.toModify(RAWEventContent,
                               outputCommands = RAWEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 
 #
@@ -624,7 +624,7 @@ FEVTDEBUGEventContent.outputCommands.extend(SimFastTimingFEVTDEBUG.outputCommand
 approxSiStripClusters.toModify(FEVTDEBUGEventContent,
                               outputCommands = FEVTDEBUGEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 #
 #
@@ -643,7 +643,7 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2165,7 +2165,7 @@ steps['RAWPRIMESIMHI18']={ '--scenario':'pp',
                            '--era':'Run2_2018_pp_on_AA',
                            '-n':'10',
                            '--procModifiers':'approxSiStripClusters',
-                           '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
+                           '--customise_commands':'\"process.hltSiStripRawToDigi.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                            '--process':'REHLT'
 }
 
@@ -2199,7 +2199,7 @@ steps['RAWPRIMEHI22']={ '--scenario':'pp',
                         '--eventcontent':'REPACKRAW',
                         '--era':'Run3_pp_on_PbPb_approxSiStripClusters',
                         '-n':'10',
-                        '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
+                        '--customise_commands':'\"process.hltSiStripRawToDigi.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                         '--process':'REHLT'
 }
 

--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -58,7 +58,7 @@ DigiToVirginRawRepack = cms.Sequence( DigiToVirginRawRepackTask )
 DigiToSplitRawRepack = cms.Sequence( DigiToRawRepackTask, DigiToVirginRawRepackTask )
 
 from EventFilter.SiStripRawToDigi.SiStripDigis_cfi import siStripDigis
-siStripDigisHLT = siStripDigis.clone(ProductLabel = "rawDataRepacker")
+hltSiStripRawToDigi = siStripDigis.clone(ProductLabel = "rawDataRepacker")
 
 from RecoLocalTracker.Configuration.RecoLocalTracker_cff import siStripZeroSuppressionHLT
 
@@ -66,7 +66,7 @@ from RecoLocalTracker.SiStripClusterizer.DefaultClusterizer_cff import *
 siStripClustersHLT = cms.EDProducer("SiStripClusterizer",
                                     Clusterizer = DefaultClusterizer,
                                     DigiProducersList = cms.VInputTag(
-                                        cms.InputTag('siStripDigisHLT','ZeroSuppressed'),
+                                        cms.InputTag('hltSiStripRawToDigi','ZeroSuppressed'),
                                         cms.InputTag('siStripZeroSuppressionHLT','VirginRaw'),
                                         cms.InputTag('siStripZeroSuppressionHLT','ProcessedRaw'),
                                         cms.InputTag('siStripZeroSuppressionHLT','ScopeMode')),
@@ -84,5 +84,5 @@ hltScalersRawToDigi =  cms.EDProducer( "ScalersRawToDigi",
    scalersInputTag = cms.InputTag( "rawDataRepacker" )
 )
 
-DigiToApproxClusterRawTask = cms.Task(siStripDigisHLT,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
+DigiToApproxClusterRawTask = cms.Task(hltSiStripRawToDigi,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
 DigiToApproxClusterRaw = cms.Sequence(DigiToApproxClusterRawTask)

--- a/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
@@ -29,7 +29,8 @@ phase2_tracker.toModify(siStripZeroSuppression, # FIXME
                            'simSiStripDigis:ScopeMode' ]
 )
 
+# For the HI RAW' workflow
 siStripZeroSuppressionHLT = siStripZeroSuppression.clone(
-    RawDigiProducersList =[("siStripDigisHLT","VirginRaw"), ("siStripDigisHLT","ProcessedRaw"), ("siStripDigisHLT","ScopeMode")]
+    RawDigiProducersList =[("hltSiStripRawToDigi","VirginRaw"), ("hltSiStripRawToDigi","ProcessedRaw"), ("hltSiStripRawToDigi","ScopeMode")]
 )
     

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -10,7 +10,7 @@ MeasurementTrackerEvent = _measurementTrackerEventDefault.clone(
 # take the list of inactive strip labels directly from RAW data
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 approxSiStripClusters.toModify(MeasurementTrackerEvent,
-                               inactiveStripDetectorLabels = ["siStripDigisHLT"]) 
+                               inactiveStripDetectorLabels = ["hltSiStripRawToDigi"])
 
 # This customization will be removed once we have phase2 pixel digis
 # Need this line to stop error about missing siPixelDigis
@@ -42,4 +42,4 @@ MeasurementTrackerEventPreSplitting = MeasurementTrackerEvent.clone(
 # in case of RAW' (approximated SiStrip clusters) 
 # take the list of inactive strip labels directly from RAW data 
 approxSiStripClusters.toModify(MeasurementTrackerEventPreSplitting,
-                               inactiveStripDetectorLabels = ["siStripDigisHLT"])
+                               inactiveStripDetectorLabels = ["hltSiStripRawToDigi"])


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/42475.
Since the `DetIdedmEDCollection` with the list of Strip FED errors is supposed to come from the HLT in production, the name of the collection should match the one in the Online HLT Heavy Ion menu:

https://github.com/cms-sw/cmssw/blob/f04980c79911900153373b23c402f042276160ee/HLTrigger/Configuration/test/OnLine_HLT_HIon.py#L6129

in order to consume the right collection (as it was done before for `SiStripClusters2ApproxClustersHLT` -> `hltSiStripClusters2ApproxClusters` in https://github.com/cms-sw/cmssw/pull/39863).
The change is purely technical and it's not expected to generate regressions.

#### PR validation:

Run successfully `runTheMatrix.py -l 140.58 -t 4 -j 8 --ibeos` 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but needs to be backported (along side https://github.com/cms-sw/cmssw/pull/42475) to CMSSW_13_2_X in order to be used in the 2023 HI data-taking