### PR TITLE
Fixes bug when SoA has not columns, only scalars [13.2.x]

### DIFF
--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -493,10 +493,17 @@
       _ITERATE_ON_ALL(_DEFINE_METADATA_MEMBERS, ~, __VA_ARGS__)                                                        \
                                                                                                                        \
       struct value_element {                                                                                           \
-        SOA_HOST_DEVICE SOA_INLINE value_element(                                                                      \
-          _ITERATE_ON_ALL_COMMA(_VALUE_ELEMENT_CTOR_ARGS, ~, __VA_ARGS__)                                              \
-        ) :                                                                                                            \
-          _ITERATE_ON_ALL_COMMA(_VALUE_ELEMENT_INITIALIZERS, ~, __VA_ARGS__)                                           \
+        SOA_HOST_DEVICE SOA_INLINE value_element                                                                       \
+          BOOST_PP_IF(                                                                                                 \
+            BOOST_PP_SEQ_SIZE(_ITERATE_ON_ALL(_VALUE_ELEMENT_CTOR_ARGS, ~, __VA_ARGS__) ),                             \
+            (_ITERATE_ON_ALL_COMMA(_VALUE_ELEMENT_CTOR_ARGS, ~, __VA_ARGS__)):,                                        \
+            ())                                                                                                        \
+          BOOST_PP_TUPLE_ENUM(BOOST_PP_IF(                                                                             \
+            BOOST_PP_SEQ_SIZE(_ITERATE_ON_ALL(_VALUE_ELEMENT_CTOR_ARGS, ~, __VA_ARGS__)),                              \
+            BOOST_PP_SEQ_TO_TUPLE(_ITERATE_ON_ALL(_VALUE_ELEMENT_INITIALIZERS, ~, __VA_ARGS__)),                       \
+            ()                                                                                                         \
+          )                                                                                                            \
+        )                                                                                                              \
         {}                                                                                                             \
                                                                                                                        \
         _ITERATE_ON_ALL(_DEFINE_VALUE_ELEMENT_MEMBERS, ~, __VA_ARGS__)                                                 \

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -67,6 +67,11 @@ GENERATE_SOA_VIEW(SoAFullDeviceConstViewTemplate,
 using SoAFullDeviceView =
     SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::enforced>;
 
+// These SoAs validate that the generating macros do not get confused in the special case where there are
+// no columns and only scalar elements in the SoA.
+GENERATE_SOA_LAYOUT(TestSoALayoutNoColumn, SOA_SCALAR(double, r))
+GENERATE_SOA_LAYOUT(TestSoALayoutNoColumn2, SOA_SCALAR(double, r), SOA_SCALAR(double, r2))
+
 // Eigen cross product kernel (on store)
 __global__ void crossProduct(SoAHostDeviceView soa, const unsigned int numElements) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -69,6 +69,11 @@ GENERATE_SOA_VIEW(SoAFullDeviceConstViewTemplate,
 using SoAFullDeviceView =
     SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::enforced>;
 
+// These SoAs validate that the generating macros do not get confused in the special case where there are
+// no columns and only scalar elements in the SoA.
+GENERATE_SOA_LAYOUT(TestSoALayoutNoColumn, SOA_SCALAR(double, r))
+GENERATE_SOA_LAYOUT(TestSoALayoutNoColumn2, SOA_SCALAR(double, r), SOA_SCALAR(double, r2))
+
 // Eigen cross product kernel (on store)
 __global__ void crossProduct(SoAHostDeviceView soa, const int numElements) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;


### PR DESCRIPTION
#### PR description:

This PR fixes and issue in macro generation of code when an SoA contains only scalars and not column. Special cases were
introduced to handle this case gracefully.

#### PR validation:

New SoAs with no columns are added. A successful compilation is enough to validate this PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42109 to 13.2.x .
