### PR TITLE
[13_2_X] Change of GE21 layouts and plots, and VFAT status with VFAT mask and missing VFATs

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -48,21 +48,21 @@ protected:
     bErr = true;
   };
 
-  void FillStatusSummaryPlot(std::map<ME4IdsKey, bool> &mapChamber,
+  void FillStatusSummaryPlot(std::map<ME5IdsKey, bool> &mapChamber,
                              MonitorElement *h2Plot,
-                             std::map<ME4IdsKey, bool> *pmapSummary = nullptr) {
-    for (auto const &[key4, bFlag] : mapChamber) {  // bFlag is not used
-      ME3IdsKey key3 = key4Tokey3(key4);
-      Int_t nChamber = keyToChamber(key4);
-      h2Plot->Fill(nChamber, mapStationToIdx_[key3]);
+                             std::map<ME5IdsKey, bool> *pmapSummary = nullptr) {
+    for (auto const &[key5, bFlag] : mapChamber) {  // bFlag is not used
+      ME4IdsKey key4 = key5Tokey4(key5);
+      Int_t nChamber = keyToChamber(key5);
+      h2Plot->Fill(nChamber, mapStationToIdx_[key4]);
       if (pmapSummary != nullptr)
-        (*pmapSummary)[key4] = true;
+        (*pmapSummary)[key5] = true;
     }
   };
 
 private:
-  int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) override;
+  int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) override;
+  int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) override;
 
   void SetLabelAMC13Status(MonitorElement *h2Status);
   void SetLabelAMCStatus(MonitorElement *h2Status);
@@ -80,12 +80,12 @@ private:
 
   MonitorElement *h2AMC13Status_;
 
-  MEMap3Inf mapStatusOH_;
-  MEMap3Inf mapStatusVFAT_;
+  MEMap4Inf mapStatusOH_;
+  MEMap4Inf mapStatusVFAT_;
 
-  MEMap3Inf mapStatusWarnVFATPerLayer_;
-  MEMap3Inf mapStatusErrVFATPerLayer_;
-  MEMap4Inf mapStatusVFATPerCh_;
+  MEMap4Inf mapStatusWarnVFATPerLayer_;
+  MEMap4Inf mapStatusErrVFATPerLayer_;
+  MEMap5Inf mapStatusVFATPerCh_;
 
   MonitorElement *h2SummaryStatusAll;
   MonitorElement *h2SummaryStatusWarning;
@@ -111,11 +111,12 @@ private:
   std::map<int, std::vector<GEMDetId>> mapAMC13ToListChamber_;
   std::map<std::tuple<int, int>, std::vector<GEMDetId>> mapAMCToListChamber_;
   Int_t nAMCSlots_;
+  Bool_t useDBEMap_;
 
   int nBitAMC13_ = 10;
   int nBitAMC_ = 12;
-  int nBitOH_ = 17;
-  int nBitVFAT_ = 7;
+  int nBitOH_ = 18;
+  int nBitVFAT_ = 8;
 };
 
 #endif  // DQM_GEM_INTERFACE_GEMDAQStatusSource_h

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -334,7 +334,7 @@ public:
       return mapHist[key];
     };
 
-    int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1, Int_t nIdxStart = 1, Int_t nNumModules = 1) {
+    int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1, Int_t nIdxStart = 1) {
       if (!bOperating_)
         return 0;
       if (nNumBin <= 0) {
@@ -349,13 +349,7 @@ public:
       if (histCurr == nullptr)
         return -999;
       for (Int_t i = 1; i <= nNumBin; i++) {
-        Int_t nIdxCh = (nIdxStart + i - 2) / nNumModules + 1;
-        Int_t nIdxMod = (nIdxStart + i - 2) % nNumModules + 1;
-        if (nNumModules > 1) {
-          histCurr->setBinLabel(i, Form("#splitline{%i}{M%i}", nIdxCh, nIdxMod), nAxis);
-        } else {
-          histCurr->setBinLabel(i, Form("%i", nIdxStart + i - 1), nAxis);
-        }
+        histCurr->setBinLabel(i, Form("%i", nIdxStart + i - 1), nAxis);
       }
       return 0;
     };
@@ -479,6 +473,7 @@ public:
   typedef MEMapInfT<MEMap2Ids, ME2IdsKey> MEMap2Inf;
   typedef MEMapInfT<MEMap3Ids, ME3IdsKey> MEMap3Inf;
   typedef MEMapInfT<MEMap4Ids, ME4IdsKey> MEMap4Inf;
+  typedef MEMapInfT<MEMap5Ids, ME5IdsKey> MEMap5Inf;
 
   class MEStationInfo {
   public:
@@ -561,19 +556,27 @@ protected:
   virtual int ProcessWithMEMap2AbsReWithEta(BookingHelper &bh, ME3IdsKey key) { return 0; };  // must be overrided
   virtual int ProcessWithMEMap3(BookingHelper &bh, ME3IdsKey key) { return 0; };              // must be overrided
   virtual int ProcessWithMEMap4(BookingHelper &bh, ME4IdsKey key) { return 0; };              // must be overrided
-  virtual int ProcessWithMEMap3WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };   // must be overrided
+  virtual int ProcessWithMEMap5(BookingHelper &bh, ME5IdsKey key) { return 0; };              // must be overrided
+  virtual int ProcessWithMEMap4WithChamber(BookingHelper &bh, ME4IdsKey key) { return 0; };   // must be overrided
+  virtual int ProcessWithMEMap5WithChamber(BookingHelper &bh, ME5IdsKey key) { return 0; };   // must be overrided
 
   int keyToRegion(ME2IdsKey key) { return std::get<0>(key); };
   int keyToRegion(ME3IdsKey key) { return std::get<0>(key); };
   int keyToRegion(ME4IdsKey key) { return std::get<0>(key); };
+  int keyToRegion(ME5IdsKey key) { return std::get<0>(key); };
   int keyToStation(ME2IdsKey key) { return std::get<1>(key); };
   int keyToStation(ME3IdsKey key) { return std::get<1>(key); };
   int keyToStation(ME4IdsKey key) { return std::get<1>(key); };
+  int keyToStation(ME5IdsKey key) { return std::get<1>(key); };
   int keyToLayer(ME3IdsKey key) { return std::get<2>(key); };
   int keyToLayer(ME4IdsKey key) { return std::get<2>(key); };
+  int keyToLayer(ME5IdsKey key) { return std::get<2>(key); };
+  int keyToModule(ME4IdsKey key) { return std::get<3>(key); };
+  int keyToModule(ME5IdsKey key) { return std::get<3>(key); };
   int keyToChamber(ME4IdsKey key) { return std::get<3>(key); };
-  int keyToIEta(ME3IdsKey key) { return std::get<2>(key); };
+  int keyToChamber(ME5IdsKey key) { return std::get<4>(key); };
   int keyToIEta(ME4IdsKey key) { return std::get<3>(key); };
+  int keyToIEta(ME5IdsKey key) { return std::get<4>(key); };
 
   ME2IdsKey key3Tokey2(ME3IdsKey key) {
     auto keyNew = ME2IdsKey{keyToRegion(key), keyToStation(key)};
@@ -585,7 +588,12 @@ protected:
     return keyNew;
   };
 
-  int SortingLayers(std::vector<ME3IdsKey> &listLayers);
+  ME4IdsKey key5Tokey4(ME5IdsKey key) {
+    auto keyNew = ME4IdsKey{keyToRegion(key), keyToStation(key), keyToLayer(key), keyToModule(key)};
+    return keyNew;
+  };
+
+  int SortingLayers(std::vector<ME4IdsKey> &listLayers);
   dqm::impl::MonitorElement *CreateSummaryHist(DQMStore::IBooker &ibooker, TString strName);
 
   template <typename T>
@@ -605,6 +613,7 @@ protected:
   inline int getDetOccXBin(const int, const int, const int);
   inline Float_t restrictAngle(const Float_t fTheta, const Float_t fStart);
   inline std::string getNameDirLayer(ME3IdsKey key3);
+  inline std::string getNameDirLayer(ME4IdsKey key4);
 
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
@@ -616,12 +625,14 @@ protected:
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;
   std::map<ME3IdsKey, bool> MEMap2AbsReWithEtaCheck_;
   std::map<ME3IdsKey, bool> MEMap3Check_;
-  std::map<ME4IdsKey, bool> MEMap3WithChCheck_;
   std::map<ME4IdsKey, bool> MEMap4Check_;
+  std::map<ME4IdsKey, bool> MEMap4WithChCheck_;
+  std::map<ME5IdsKey, bool> MEMap5WithChCheck_;
+  std::map<ME5IdsKey, bool> MEMap5Check_;
 
   int nMaxNumCh_;
-  std::map<ME3IdsKey, int> mapStationToIdx_;
   std::map<ME3IdsKey, MEStationInfo> mapStationInfo_;
+  std::map<ME4IdsKey, int> mapStationToIdx_;
 };
 
 // Borrwed from DQM/GEM/interface/GEMOfflineDQMBase.h
@@ -719,6 +730,17 @@ inline std::string GEMDQMBase::getNameDirLayer(ME3IdsKey key3) {
   auto nStation = keyToStation(key3);
   char cRegion = (keyToRegion(key3) > 0 ? 'P' : 'M');
   auto nLayer = keyToLayer(key3);
+  return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));
+}
+
+inline std::string GEMDQMBase::getNameDirLayer(ME4IdsKey key4) {
+  auto nStation = keyToStation(key4);
+  char cRegion = (keyToRegion(key4) > 0 ? 'P' : 'M');
+  auto nLayer = keyToLayer(key4);
+  if (nStation == 2) {
+    auto nModule = keyToModule(key4);
+    return std::string(Form("GE%i1-%c-L%i-M%i", nStation, cRegion, nLayer, nModule));
+  }
   return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));
 }
 

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -46,7 +46,8 @@ private:
   int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap2(BookingHelper& bh, ME2IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+  int ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) override;
+  int ProcessWithMEMap5WithChamber(BookingHelper& bh, ME5IdsKey key) override;
 
   const static int nNumBitDigiOcc_ = 16384;
 
@@ -59,17 +60,20 @@ private:
   std::map<ME4IdsKey, Int_t> mapChamberType_;
   std::map<ME3IdsKey, Int_t> mapStripToVFAT_;
 
-  MEMap3Inf mapTotalDigi_layer_;
   MEMap3Inf mapDigiWheel_layer_;
-  MEMap3Inf mapDigiOcc_ieta_;
-  MEMap3Inf mapDigiOcc_phi_;
-  MEMap3Inf mapTotalDigiPerEvtLayer_;
+
+  MEMap4Inf mapTotalDigi_layer_;
+  MEMap4Inf mapDigiOcc_ieta_;
+  MEMap4Inf mapDigiOcc_phi_;
+  MEMap4Inf mapTotalDigiPerEvtLayer_;
   MEMap3Inf mapTotalDigiPerEvtIEta_;
   MEMap2Inf mapBX_;
 
-  MEMap4Inf mapDigiOccPerCh_;
+  MEMap5Inf mapDigiOccPerCh_;
 
   std::string strFolderMain_;
+
+  Bool_t useDBEMap_;
 
   Int_t nBXMin_, nBXMax_;
   Float_t fRadiusMin_;

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -26,7 +26,7 @@ private:
   int ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey key) override;
   int ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) override;
-  int ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) override;
+  int ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey key) override;
 
   edm::EDGetToken tagRecHit_;
 

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -123,6 +123,7 @@ protected:
   const Int_t nCodeError_ = 2;
   const Int_t nCodeWarning_ = 3;
   const Int_t nCodeLowError_ = 4;
+  const Int_t nCodeMasked_ = 5;
 
   const Int_t nBitWarnVFAT_ = 7;
   const Int_t nBitErrVFAT_ = 6;
@@ -150,7 +151,6 @@ protected:
   std::vector<std::string> listLayer_;
   std::map<std::string, int> mapIdxLayer_;  // All indices in the following objects start at 1
   std::map<int, int> mapNumChPerChamber_;
-  std::map<int, int> mapNumModule_;
   std::map<int, std::map<int, int>> mapIdxToChamberInOcc_;
   std::map<int, MonitorElement *> mapHistLumiFunc_;
   Bool_t bIsStatusChambersInit_;
@@ -232,7 +232,6 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
         continue;
       listOccPlots[nIdxLayer] = h2SrcVFATOcc;
       mapIdxToChamberInOcc_[nIdxLayer] = {};
-      Int_t nNumModule = mapNumModule_[nIdxLayer];  // FIXME: Is this way to obtain the module number fully general?
       // Obtaining the bin indices of chambers from their labels
       for (Int_t i = 1; i <= h2SrcVFATOcc->getNbinsX(); i++) {
         std::string strLabel = h2SrcVFATOcc->getTH2F()->GetXaxis()->GetBinLabel(i);
@@ -257,9 +256,6 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
 
         if (listNumExtract.empty()) {  // Errneous case; but the job should not be dead
           edm::LogError("GEMDQMHarvester") << "Error: Wrong label of GEM VFAT occupancy plot: " << strLabel;
-        } else if (listNumExtract.size() > 1 && nNumModule > 1) {
-          Int_t nCh = (listNumExtract[0] - 1) * nNumModule + listNumExtract[1];
-          mapIdxToChamberInOcc_[nIdxLayer][nCh] = i;
         } else {
           mapIdxToChamberInOcc_[nIdxLayer][listNumExtract[0]] = i;
         }
@@ -307,8 +303,7 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
     if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
       continue;
     Int_t nIdxLayer = mapIdxLayer_[strSuffix];
-    auto nNumChamber = mapNumChPerChamber_[nIdxLayer] / mapNumModule_[nIdxLayer];
-    createInactiveChannelFracHist(store, strSuffix, nNumChamber);
+    createInactiveChannelFracHist(store, strSuffix, mapNumChPerChamber_[nIdxLayer]);
   }
 
   store->bookFloat("reportSummary")->Fill(fReportSummary);
@@ -364,7 +359,7 @@ void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElem
         if (strLayer.find("GE11") != std::string::npos) {
           nBinXActual = 36;
         } else if (strLayer.find("GE21") != std::string::npos) {
-          nBinXActual = 72;
+          nBinXActual = 18;
         } else if (strLayer.find("GE01") != std::string::npos) {
           nBinXActual = 36;
         }
@@ -372,7 +367,6 @@ void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElem
       listLayer_.push_back(strLayer);
       mapIdxLayer_[strLayer] = i;
       mapNumChPerChamber_[i] = nBinXActual;
-      mapNumModule_[i] = (strLayer.find("GE21") != std::string::npos ? 4 : 1);
     }
   } else {  // For others (validation and...?)
     listLayer_.push_back("");
@@ -423,6 +417,8 @@ void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
 
 Int_t GEMDQMHarvester::assessOneBin(
     std::string strName, Int_t nIdxX, Int_t nIdxY, Float_t fAll, Float_t fNumOcc, Float_t fNumErr, Float_t fNumWarn) {
+  if (fNumErr < 0)
+    return nCodeMasked_;
   if (fNumErr > fCutErr_ * fAll)  // The error status criterion
     return nCodeError_;
   else if (fNumErr > fCutLowErr_ * fAll)  // The low-error status criterion
@@ -629,15 +625,8 @@ void GEMDQMHarvester::createLumiFuncHist(edm::Service<DQMStore> &store,
 
     h2Summary->setXTitle("Luminosity block");
     h2Summary->setYTitle("Chamber");
-    Int_t nNumModule = mapNumModule_[nIdxLayer];
     for (Int_t i = 1; i <= nNumCh; i++) {
-      if (nNumModule <= 1) {
-        h2Summary->setBinLabel(i, Form("%i", i), 2);
-      } else {
-        Int_t nCh = (i - 1) / nNumModule + 1;
-        Int_t nModule = (i - 1) / nNumModule + 1;
-        h2Summary->setBinLabel(i, Form("%i M%i", nCh, nModule), 2);
-      }
+      h2Summary->setBinLabel(i, Form("%i", i), 2);
     }
   } else {
     h2Summary = mapHistLumiFunc_[nIdxLayer];
@@ -718,6 +707,7 @@ std::string getNameChamberOccGE21(std::string strSuffix, Int_t nIdxCh) {
   char cRegion;
   char cChType = (nIdxCh % 2 == 0 ? 'L' : 'S');
   Int_t nLayer;
+  Int_t nModule;
 
   if (strSuffix.find("-M-") != std::string::npos)
     cRegion = 'M';
@@ -733,8 +723,34 @@ std::string getNameChamberOccGE21(std::string strSuffix, Int_t nIdxCh) {
   else
     return "";
 
-  return Form(
-      "GEM/Digis/occupancy_GE21-%c-L%i/occ_GE21-%c-%02iL%i-%c", cRegion, nLayer, cRegion, nIdxCh, nLayer, cChType);
+  if (strSuffix.find("-M1") != std::string::npos)
+    nModule = 1;
+  else if (strSuffix.find("-M2") != std::string::npos)
+    nModule = 2;
+  else if (strSuffix.find("-M3") != std::string::npos)
+    nModule = 3;
+  else if (strSuffix.find("-M4") != std::string::npos)
+    nModule = 4;
+  else if (strSuffix.find("-M5") != std::string::npos)
+    nModule = 5;
+  else if (strSuffix.find("-M6") != std::string::npos)
+    nModule = 6;
+  else if (strSuffix.find("-M7") != std::string::npos)
+    nModule = 7;
+  else if (strSuffix.find("-M8") != std::string::npos)
+    nModule = 8;
+  else
+    return "";
+
+  return Form("GEM/Digis/occupancy_GE21-%c-L%i-M%i/occ_GE21-%c-%02iL%i-M%i-%c",
+              cRegion,
+              nLayer,
+              nModule,
+              cRegion,
+              nIdxCh,
+              nLayer,
+              nModule,
+              cChType);
 }
 
 std::string getNameChamberOccNull(std::string strSuffix, Int_t nIdxChamber) {

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -10,6 +10,7 @@ GEMDigiSource::GEMDigiSource(const edm::ParameterSet& cfg)
       cfg.getUntrackedParameter<edm::InputTag>("lumiCollection", edm::InputTag("scalersRawToDigi")));
   nBXMin_ = cfg.getParameter<int>("bxMin");
   nBXMax_ = cfg.getParameter<int>("bxMax");
+  useDBEMap_ = cfg.getParameter<bool>("useDBEMap");
 }
 
 void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -19,12 +20,12 @@ void GEMDigiSource::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<std::string>("logCategory", "GEMDigiSource");
   desc.add<int>("bxMin", -10);
   desc.add<int>("bxMax", 10);
+  desc.add<bool>("useDBEMap", true);
   descriptions.add("GEMDigiSource", desc);
 }
 
 void GEMDigiSource::LoadROMap(edm::EventSetup const& iSetup) {
-  //if (useDBEMap_)
-  if (true) {
+  if (useDBEMap_) {
     const auto& chMap = iSetup.getData(gemChMapToken_);
     auto gemChMap = std::make_unique<GEMChMap>(chMap);
 
@@ -60,15 +61,21 @@ void GEMDigiSource::LoadROMap(edm::EventSetup const& iSetup) {
       for (Int_t ieta = 1; ieta <= 24; ieta++) {
         if (!gemChMap->isValidStrip(dc.chamberType, ieta, 1))
           continue;
-        mapChamberType_[{gemChId.station(), gemChId.layer(), gemChId.chamber(), ieta}] = dc.chamberType;
-        if (mapCheckedType[dc.chamberType])
+        Int_t nChamberType = dc.chamberType;
+        if (gemChId.station() == 1) {
+          nChamberType = 13 - gemChId.layer();
+        } else if (gemChId.station() == 2) {
+          nChamberType = 24 - (ieta - 1) / 4;
+        }
+        mapChamberType_[{gemChId.station(), gemChId.layer(), gemChId.chamber(), ieta}] = nChamberType;
+        if (mapCheckedType[nChamberType])
           continue;
-        mapCheckedType[dc.chamberType] = true;
+        mapCheckedType[nChamberType] = true;
         for (Int_t strip = 0; strip <= 3 * 128; strip++) {
-          if (!gemChMap->isValidStrip(dc.chamberType, ieta, strip))
+          if (!gemChMap->isValidStrip(nChamberType, ieta, strip))
             continue;
-          auto& stripInfo = gemChMap->getChannel(dc.chamberType, ieta, strip);
-          mapStripToVFAT_[{dc.chamberType, ieta, strip}] = stripInfo.vfatAdd;
+          auto& stripInfo = gemChMap->getChannel(nChamberType, ieta, strip);
+          mapStripToVFAT_[{nChamberType, ieta, strip}] = stripInfo.vfatAdd;
         }
       }
     }
@@ -89,13 +96,13 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   float radS = -5.0 / 180 * M_PI;
   float radL = 355.0 / 180 * M_PI;
 
-  mapTotalDigi_layer_ = MEMap3Inf(this, "occ", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
+  mapTotalDigi_layer_ = MEMap4Inf(this, "occ", "Digi Occupancy", 36, 0.5, 36.5, 24, -0.5, 24 - 0.5, "Chamber", "VFAT");
   mapDigiWheel_layer_ = MEMap3Inf(
       this, "occ_rphi", "Digi R-Phi Occupancy", 360, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
-  mapDigiOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
+  mapDigiOcc_ieta_ = MEMap4Inf(this, "occ_ieta", "Digi iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of fired digis");
   mapDigiOcc_phi_ =
-      MEMap3Inf(this, "occ_phi", "Digi Phi Occupancy", 72, -5, 355, "#phi (degree)", "Number of fired digis");
-  mapTotalDigiPerEvtLayer_ = MEMap3Inf(this,
+      MEMap4Inf(this, "occ_phi", "Digi Phi Occupancy", 72, -5, 355, "#phi (degree)", "Number of fired digis");
+  mapTotalDigiPerEvtLayer_ = MEMap4Inf(this,
                                        "digis_per_layer",
                                        "Total number of digis per event for each layers",
                                        50,
@@ -116,7 +123,7 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
 
   mapBX_ = MEMap2Inf(this, "bx", "Digi Bunch Crossing", 21, nBXMin_ - 0.5, nBXMax_ + 0.5, "Bunch crossing");
 
-  mapDigiOccPerCh_ = MEMap4Inf(this, "occ", "Digi Occupancy", 1, -0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
+  mapDigiOccPerCh_ = MEMap5Inf(this, "occ", "Digi Occupancy", 1, -0.5, 1.5, 1, 0.5, 1.5, "Digi", "iEta");
 
   if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
     mapDigiWheel_layer_.TurnOff();
@@ -159,27 +166,32 @@ int GEMDigiSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
 int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
-  Int_t nNewNumCh = stationInfo.nMaxIdxChamber_ - stationInfo.nMinIdxChamber_ + 1;
-  Int_t nNewMinIdxChamber = stationInfo.nNumModules_ * (stationInfo.nMinIdxChamber_ - 1) + 1;
-  Int_t nNewMaxIdxChamber = stationInfo.nNumModules_ * stationInfo.nMaxIdxChamber_;
-
-  nNewNumCh *= stationInfo.nNumModules_;
-
-  Int_t nNumVFATPerModule = stationInfo.nMaxVFAT_ / stationInfo.nNumModules_;
-
   int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
-
-  mapTotalDigi_layer_.SetBinConfX(nNewNumCh, nNewMinIdxChamber - 0.5, nNewMaxIdxChamber + 0.5);
-  mapTotalDigi_layer_.SetBinConfY(nNumVFATPerModule, -0.5);
-  mapTotalDigi_layer_.bookND(bh, key);
-  mapTotalDigi_layer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber, stationInfo.nNumModules_);
-  mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
   mapDigiWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
   mapDigiWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
   mapDigiWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
   mapDigiWheel_layer_.bookND(bh, key);
+
+  return 0;
+}
+
+int GEMDigiSource::ProcessWithMEMap4(BookingHelper& bh, ME4IdsKey key) {
+  ME3IdsKey key3 = key4Tokey3(key);
+  MEStationInfo& stationInfo = mapStationInfo_[key3];
+
+  Int_t nNewNumCh = stationInfo.nMaxIdxChamber_ - stationInfo.nMinIdxChamber_ + 1;
+  Int_t nNewMinIdxChamber = (stationInfo.nMinIdxChamber_ - 1) + 1;
+  Int_t nNewMaxIdxChamber = stationInfo.nMaxIdxChamber_;
+
+  Int_t nNumVFATPerModule = stationInfo.nMaxVFAT_ / stationInfo.nNumModules_;
+
+  mapTotalDigi_layer_.SetBinConfX(nNewNumCh, nNewMinIdxChamber - 0.5, nNewMaxIdxChamber + 0.5);
+  mapTotalDigi_layer_.SetBinConfY(nNumVFATPerModule, -0.5);
+  mapTotalDigi_layer_.bookND(bh, key);
+  mapTotalDigi_layer_.SetLabelForChambers(key, 1, -1, nNewMinIdxChamber);
+  mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapDigiOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapDigiOcc_ieta_.bookND(bh, key);
@@ -193,17 +205,18 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   return 0;
 }
 
-int GEMDigiSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) {
-  ME3IdsKey key3 = key4Tokey3(key);
+int GEMDigiSource::ProcessWithMEMap5WithChamber(BookingHelper& bh, ME5IdsKey key) {
+  ME4IdsKey key4 = key5Tokey4(key);
+  ME3IdsKey key3 = key4Tokey3(key4);
   MEStationInfo& stationInfo = mapStationInfo_[key3];
 
-  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/occupancy_" + getNameDirLayer(key3));
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/occupancy_" + getNameDirLayer(key4));
 
   int nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
   int nNumCh = stationInfo.nNumDigi_;
 
   mapDigiOccPerCh_.SetBinConfX(nNumCh * nNumVFATPerEta, stationInfo.nFirstStrip_ - 0.5);
-  mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
+  mapDigiOccPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_ / stationInfo.nNumModules_);
   mapDigiOccPerCh_.bookND(bh, key);
   mapDigiOccPerCh_.SetLabelForIEta(key, 2);
 
@@ -218,7 +231,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
   edm::Handle<LumiScalersCollection> lumiScalers;
   event.getByToken(lumiScalers_, lumiScalers);
 
-  std::map<ME3IdsKey, Int_t> total_digi_layer;
+  std::map<ME4IdsKey, Int_t> total_digi_layer;
   std::map<ME3IdsKey, Int_t> total_digi_eta;
   for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
@@ -228,8 +241,6 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     bTagVFAT.clear();
     MEStationInfo& stationInfo = mapStationInfo_[key3];
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
-    if (total_digi_layer.find(key3) == total_digi_layer.end())
-      total_digi_layer[key3] = 0;
     for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
@@ -238,29 +249,36 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
       const auto& digis_in_det = gemDigis->get(eId);
       auto nChamberType = mapChamberType_[{gid.station(), gid.layer(), gid.chamber(), eId.ieta()}];
       Int_t nIdxModule = getIdxModule(gid.station(), nChamberType);
-      Int_t nCh = (gid.chamber() - 1) * stationInfo.nNumModules_ + nIdxModule;
+      ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), nIdxModule};
+      ME5IdsKey key5Ch{gid.region(), gid.station(), gid.layer(), nIdxModule, gid.chamber()};
+      if (total_digi_layer.find(key4) == total_digi_layer.end())
+        total_digi_layer[key4] = 0;
       for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
         // Filling of digi occupancy
         Int_t nIdxVFAT = mapStripToVFAT_[{nChamberType, eId.ieta(), d->strip()}];
-        mapTotalDigi_layer_.Fill(key3, nCh, nIdxVFAT);
+        mapTotalDigi_layer_.Fill(key4, gid.chamber(), nIdxVFAT);
 
         // Filling of digi
-        mapDigiOcc_ieta_.Fill(key3, eId.ieta());  // Eta (partition)
+        mapDigiOcc_ieta_.Fill(key4, eId.ieta());  // Eta (partition)
 
         GlobalPoint digi_global_pos = surface.toGlobal(iEta->centreOfStrip(d->strip()));
         Float_t fPhi = (Float_t)digi_global_pos.phi();
         Float_t fPhiShift = restrictAngle(fPhi, stationInfo.fMinPhi_);
         Float_t fPhiDeg = fPhiShift * 180.0 / M_PI;
-        mapDigiOcc_phi_.Fill(key3, fPhiDeg);  // Phi
+        mapDigiOcc_phi_.Fill(key4, fPhiDeg);  // Phi
 
         // Filling of R-Phi occupancy
         Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
         mapDigiWheel_layer_.Fill(key3, fPhiShift, fR);
 
-        mapDigiOccPerCh_.Fill(key4Ch, d->strip(), eId.ieta());  // Per chamber
+        Int_t nIEtaInMod = eId.ieta();
+        if (gid.station() == 2) {
+          nIEtaInMod = (eId.ieta() - 1) % stationInfo.nNumModules_ + 1;
+        }
+        mapDigiOccPerCh_.Fill(key5Ch, d->strip(), nIEtaInMod);  // Per chamber
 
         // For total digis
-        total_digi_layer[key3]++;
+        total_digi_layer[key4]++;
         total_digi_eta[key3IEta]++;
 
         // Filling of bx

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -184,7 +184,7 @@ int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   return 0;
 }
 
-int GEMRecHitSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey key) {
+int GEMRecHitSource::ProcessWithMEMap4WithChamber(BookingHelper& bh, ME4IdsKey key) {
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo& stationInfo = mapStationInfo_[key3];
 

--- a/DQM/GEM/python/GEMDQM_cff.py
+++ b/DQM/GEM/python/GEMDQM_cff.py
@@ -19,3 +19,5 @@ GEMDQMForRelval = cms.Sequence(
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 phase2_GEM.toModify(GEMDigiSource, digisInputLabel = "simMuonGEMDigis")
+phase2_GEM.toModify(GEMDigiSource, useDBEMap = False)
+phase2_GEM.toModify(GEMDAQStatusSource, useDBEMap = False)

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -89,7 +89,7 @@ int GEMDQMBase::loadChambers() {
       const int strip1st = (station_number == 2 ? 1 : 0);   // the index of the first strip
       const int num_digi = GEMeMap::maxChan_;               // the number of digis (channels) per VFAT
 
-      nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers * num_mod);
+      nMaxNumCh_ = std::max(nMaxNumCh_, num_superchambers);
 
       Int_t nMinIdxChamber = 1048576;
       Int_t nMaxIdxChamber = -1048576;
@@ -126,17 +126,19 @@ int GEMDQMBase::loadChambers() {
   return 0;
 }
 
-int GEMDQMBase::SortingLayers(std::vector<ME3IdsKey>& listLayers) {
-  std::sort(listLayers.begin(), listLayers.end(), [](ME3IdsKey key1, ME3IdsKey key2) {
-    Int_t re1 = std::get<0>(key1), st1 = std::get<1>(key1), la1 = std::get<2>(key1);
-    Int_t re2 = std::get<0>(key2), st2 = std::get<1>(key2), la2 = std::get<2>(key2);
+int GEMDQMBase::SortingLayers(std::vector<ME4IdsKey>& listLayers) {
+  std::sort(listLayers.begin(), listLayers.end(), [](ME4IdsKey key1, ME4IdsKey key2) {
+    Int_t re1 = std::get<0>(key1), re2 = std::get<0>(key2);
+    Int_t st1 = std::get<1>(key1), st2 = std::get<1>(key2);
+    Int_t la1 = std::get<2>(key1), la2 = std::get<2>(key2);
+    Int_t mo1 = std::get<3>(key1), mo2 = std::get<3>(key2);
     if (re1 < 0 && re2 > 0)
       return false;
     if (re1 > 0 && re2 < 0)
       return true;
     Bool_t bRes = (re1 < 0);  // == re2 < 0
-    Int_t sum1 = 256 * std::abs(re1) + 16 * st1 + 1 * la1;
-    Int_t sum2 = 256 * std::abs(re2) + 16 * st2 + 1 * la2;
+    Int_t sum1 = 4096 * std::abs(re1) + 256 * st1 + 16 * la1 + mo1;
+    Int_t sum2 = 4096 * std::abs(re2) + 256 * st2 + 16 * la2 + mo2;
     if (sum1 <= sum2)
       return bRes;
     return !bRes;
@@ -146,10 +148,13 @@ int GEMDQMBase::SortingLayers(std::vector<ME3IdsKey>& listLayers) {
 }
 
 dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& ibooker, TString strName) {
-  std::vector<ME3IdsKey> listLayers;
-  listLayers.reserve(mapStationInfo_.size());
-  for (auto const& [key, stationInfo] : mapStationInfo_)
-    listLayers.push_back(key);
+  std::vector<ME4IdsKey> listLayers;
+  for (auto const& [key3, stationInfo] : mapStationInfo_) {
+    for (int module_number = 1; module_number <= stationInfo.nNumModules_; module_number++) {
+      ME4IdsKey key4{keyToRegion(key3), keyToStation(key3), keyToLayer(key3), module_number};
+      listLayers.push_back(key4);  // Note: Not only count layers but also modules
+    }
+  }
   SortingLayers(listLayers);
   for (Int_t i = 0; i < (Int_t)listLayers.size(); i++)
     mapStationToIdx_[listLayers[i]] = i + 1;
@@ -166,12 +171,21 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
     h2Res->setBinLabel(i, Form("%i", i), 1);
   for (Int_t i = 1; i <= (Int_t)listLayers.size(); i++) {
     auto key = listLayers[i - 1];
-    auto strInfo = GEMUtils::getSuffixName(key);  // NOTE: It starts with '_'
+    ME3IdsKey key3 = key4Tokey3(key);
+
     auto region = keyToRegion(key);
-    auto label =
-        Form("GE%+i1-%cL%i;%s", region * keyToStation(key), (region > 0 ? 'P' : 'M'), keyToLayer(key), strInfo.Data());
+    auto strInfo = GEMUtils::getSuffixName(key3);  // NOTE: It starts with '_'
+    if (mapStationInfo_[key3].nNumModules_ > 1) {
+      strInfo += Form("-M%i", keyToModule(key));
+    }
+    auto label = Form("GE%+i1-%cL%i-M%i;%s",
+                      region * keyToStation(key),
+                      (region > 0 ? 'P' : 'M'),
+                      keyToLayer(key),
+                      keyToModule(key),
+                      strInfo.Data());
     h2Res->setBinLabel(i, label, 2);
-    Int_t nNumCh = mapStationInfo_[key].nNumChambers_ * mapStationInfo_[key].nNumModules_;
+    Int_t nNumCh = mapStationInfo_[key3].nNumChambers_;
     h2Res->setBinContent(0, i, nNumCh);
   }
 
@@ -180,64 +194,96 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
 
 int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap2Check_.clear();
+  MEMap3Check_.clear();
+  MEMap4Check_.clear();
+  MEMap5Check_.clear();
   MEMap2WithEtaCheck_.clear();
   MEMap2AbsReWithEtaCheck_.clear();
-  MEMap3Check_.clear();
-  MEMap3WithChCheck_.clear();
-  MEMap4Check_.clear();
+  MEMap4WithChCheck_.clear();
+  MEMap5WithChCheck_.clear();
   for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
-    ME4IdsKey key3WithChamber{gid.region(), gid.station(), gid.layer(), gid.chamber()};
-    if (!MEMap2Check_[key2]) {
-      auto strSuffixName = GEMUtils::getSuffixName(key2);
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2);
-      BookingHelper bh2(ibooker, strSuffixName, strSuffixTitle);
-      ProcessWithMEMap2(bh2, key2);
-      MEMap2Check_[key2] = true;
-    }
-    if (!MEMap3Check_[key3]) {
-      auto strSuffixName = GEMUtils::getSuffixName(key3);
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key3);
-      BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
-      ProcessWithMEMap3(bh3, key3);
-      MEMap3Check_[key3] = true;
-    }
-    if (!MEMap3WithChCheck_[key3WithChamber]) {
-      Int_t nCh = gid.chamber();
-      Int_t nLa = gid.layer();
-      char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
-      auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
-      auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-%02iL%i-%c", nCh, nLa, cLS);
-      BookingHelper bh3Ch(ibooker, strSuffixName, strSuffixTitle);
-      ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
-      MEMap3WithChCheck_[key3WithChamber] = true;
-    }
-    for (auto iEta : mapEtaPartition_[gid]) {
-      GEMDetId eId = iEta->id();
-      ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), eId.ieta()};
-      ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};
-      ME3IdsKey key2AbsReWithEta{std::abs(gid.region()), gid.station(), eId.ieta()};
+    const auto num_mod = mapStationInfo_[key3].nNumModules_;
+    for (int module_number = 1; module_number <= num_mod; module_number++) {
+      ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), module_number};
+      ME4IdsKey key4WithChamber{gid.region(), gid.station(), gid.layer(), gid.chamber()};
+      ME5IdsKey key5WithChamber{gid.region(), gid.station(), gid.layer(), module_number, gid.chamber()};
+      if (!MEMap2Check_[key2]) {
+        auto strSuffixName = GEMUtils::getSuffixName(key2);
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2);
+        BookingHelper bh2(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap2(bh2, key2);
+        MEMap2Check_[key2] = true;
+      }
+      if (!MEMap3Check_[key3]) {
+        auto strSuffixName = GEMUtils::getSuffixName(key3);
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3);
+        BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap3(bh3, key3);
+        MEMap3Check_[key3] = true;
+      }
       if (!MEMap4Check_[key4]) {
-        auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("-E%02i", eId.ieta());
-        auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form("-E%02i", eId.ieta());
+        Int_t nLa = gid.layer();
+        TString strSuffixCh = Form("-L%i", nLa);
+        if (mapStationInfo_[key3].nNumModules_ > 1)
+          strSuffixCh = Form("-L%i-M%i", nLa, module_number);
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + strSuffixCh;
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + strSuffixCh;
         BookingHelper bh4(ibooker, strSuffixName, strSuffixTitle);
         ProcessWithMEMap4(bh4, key4);
         MEMap4Check_[key4] = true;
       }
-      if (!MEMap2WithEtaCheck_[key2WithEta]) {
-        auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-E%02i", eId.ieta());
-        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-E%02i", eId.ieta());
-        BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
-        ProcessWithMEMap2WithEta(bh3, key2WithEta);
-        MEMap2WithEtaCheck_[key2WithEta] = true;
+      if (!MEMap4WithChCheck_[key4WithChamber]) {
+        Int_t nCh = gid.chamber();
+        Int_t nLa = gid.layer();
+        char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
+        TString strSuffixCh = Form("-%02iL%i-%c", nCh, nLa, cLS);
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + strSuffixCh;
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + strSuffixCh;
+        BookingHelper bh4Ch(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap4WithChamber(bh4Ch, key4WithChamber);
+        MEMap4WithChCheck_[key4WithChamber] = true;
       }
-      if (!MEMap2AbsReWithEtaCheck_[key2AbsReWithEta]) {
-        auto strSuffixName = Form("_GE%d1-E%02i", gid.station(), eId.ieta());
-        auto strSuffixTitle = Form(" GE%d1-E%02i", gid.station(), eId.ieta());
-        BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
-        ProcessWithMEMap2AbsReWithEta(bh3, key2AbsReWithEta);
-        MEMap2AbsReWithEtaCheck_[key2AbsReWithEta] = true;
+      if (!MEMap5WithChCheck_[key5WithChamber]) {
+        Int_t nCh = gid.chamber();
+        Int_t nLa = gid.layer();
+        char cLS = (nCh % 2 == 0 ? 'L' : 'S');  // FIXME: Is it general enough?
+        TString strSuffixCh = Form("-%02iL%i-%c", nCh, nLa, cLS);
+        if (mapStationInfo_[key3].nNumModules_ > 1)
+          strSuffixCh = Form("-%02iL%i-M%i-%c", nCh, nLa, module_number, cLS);
+        auto strSuffixName = GEMUtils::getSuffixName(key2) + strSuffixCh;
+        auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + strSuffixCh;
+        BookingHelper bh5Ch(ibooker, strSuffixName, strSuffixTitle);
+        ProcessWithMEMap5WithChamber(bh5Ch, key5WithChamber);
+        MEMap5WithChCheck_[key5WithChamber] = true;
+      }
+      for (auto iEta : mapEtaPartition_[gid]) {
+        GEMDetId eId = iEta->id();
+        ME5IdsKey key5{gid.region(), gid.station(), gid.layer(), module_number, eId.ieta()};
+        ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};
+        ME3IdsKey key2AbsReWithEta{std::abs(gid.region()), gid.station(), eId.ieta()};
+        if (!MEMap5Check_[key5]) {
+          auto strSuffixName = GEMUtils::getSuffixName(key3) + Form("-E%02i", eId.ieta());
+          auto strSuffixTitle = GEMUtils::getSuffixTitle(key3) + Form("-E%02i", eId.ieta());
+          BookingHelper bh5(ibooker, strSuffixName, strSuffixTitle);
+          ProcessWithMEMap5(bh5, key5);
+          MEMap5Check_[key5] = true;
+        }
+        if (!MEMap2WithEtaCheck_[key2WithEta]) {
+          auto strSuffixName = GEMUtils::getSuffixName(key2) + Form("-E%02i", eId.ieta());
+          auto strSuffixTitle = GEMUtils::getSuffixTitle(key2) + Form("-E%02i", eId.ieta());
+          BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
+          ProcessWithMEMap2WithEta(bh3, key2WithEta);
+          MEMap2WithEtaCheck_[key2WithEta] = true;
+        }
+        if (!MEMap2AbsReWithEtaCheck_[key2AbsReWithEta]) {
+          auto strSuffixName = Form("_GE%d1-E%02i", gid.station(), eId.ieta());
+          auto strSuffixTitle = Form(" GE%d1-E%02i", gid.station(), eId.ieta());
+          BookingHelper bh3(ibooker, strSuffixName, strSuffixTitle);
+          ProcessWithMEMap2AbsReWithEta(bh3, key2AbsReWithEta);
+          MEMap2AbsReWithEtaCheck_[key2AbsReWithEta] = true;
+        }
       }
     }
   }

--- a/Validation/MuonGEMHits/interface/GEMValidationUtils.h
+++ b/Validation/MuonGEMHits/interface/GEMValidationUtils.h
@@ -18,11 +18,14 @@ class TProfile;
 typedef std::tuple<Int_t, Int_t> ME2IdsKey;
 typedef std::tuple<Int_t, Int_t, Int_t> ME3IdsKey;
 typedef std::tuple<Int_t, Int_t, Int_t, Int_t> ME4IdsKey;
+typedef std::tuple<Int_t, Int_t, Int_t, Int_t, Int_t>
+    ME5IdsKey;  // 0: region, 1: station, 2: later, 3: module, 4: chamber or iEta
 
 typedef std::map<Int_t, dqm::impl::MonitorElement*> MEMap1Ids;
 typedef std::map<ME2IdsKey, dqm::impl::MonitorElement*> MEMap2Ids;
 typedef std::map<ME3IdsKey, dqm::impl::MonitorElement*> MEMap3Ids;
 typedef std::map<ME4IdsKey, dqm::impl::MonitorElement*> MEMap4Ids;
+typedef std::map<ME5IdsKey, dqm::impl::MonitorElement*> MEMap5Ids;
 
 namespace GEMUtils {
   TString getSuffixName(Int_t region_id);


### PR DESCRIPTION
#### PR description:

In this PR, plots for GE21 have been divided into modules (+layers). In the same manner, the cells for GE21 in the summary plot have been rearranged by module(+layer).

Also, masked VFATs and error/warning status of missing VFATs are now being displayed.

This is a backport of #41915 to 13_2_X.

#### PR validation:

Tests are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True runNumber=362760 dataset=/ExpressPhysics/Run2022G-Express-v1/FEVT minLumi=19 maxLumi=21` and `runTheMatrix.py -l limited -i all --ibeos` since it makes effects on P5

@jshlee @watson-ij @seungjin-yang @yeckang 
