### PR TITLE
correct the time propagation and add options in CloseByParticleGunProducer

### DIFF
--- a/IOMC/ParticleGuns/BuildFile.xml
+++ b/IOMC/ParticleGuns/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name="boost"/>
 <use name="FWCore/Framework"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="clhep"/>

--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -3,6 +3,14 @@
 
 #include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
 namespace edm {
 
   class CloseByParticleGunProducer : public BaseFlatGunProducer {
@@ -10,19 +18,25 @@ namespace edm {
     CloseByParticleGunProducer(const ParameterSet&);
     ~CloseByParticleGunProducer() override;
 
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
   private:
     void produce(Event& e, const EventSetup& es) override;
 
   protected:
     // data members
     bool fControlledByEta;
-    double fEnMin, fEnMax, fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax;
+    double fEnMin, fEnMax, fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax, fTMin, fTMax,
+        fOffsetFirst;
     int fNParticles;
     bool fMaxEnSpread = false;
     bool fPointing = false;
     bool fOverlapping = false;
     bool fRandomShoot = false;
+    bool fUseDeltaT = false;
     std::vector<int> fPartIDs;
+
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> m_fieldToken;
   };
 }  // namespace edm
 

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -1,4 +1,5 @@
 #include <ostream>
+#include <cmath>
 
 #include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
 
@@ -21,11 +22,16 @@
 using namespace edm;
 using namespace std;
 
-CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset) : BaseFlatGunProducer(pset) {
+CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
+    : BaseFlatGunProducer(pset), m_fieldToken(esConsumes()) {
   ParameterSet pgun_params = pset.getParameter<ParameterSet>("PGunParameters");
   fControlledByEta = pgun_params.getParameter<bool>("ControlledByEta");
   fEnMax = pgun_params.getParameter<double>("EnMax");
   fEnMin = pgun_params.getParameter<double>("EnMin");
+  if (fEnMin < 1)
+    LogError("CloseByParticleGunProducer") << " Please choose a minimum energy greater than 1 GeV, otherwise time "
+                                              "information may be invalid or not reliable";
+
   fMaxEnSpread = pgun_params.getParameter<bool>("MaxEnSpread");
   if (fControlledByEta) {
     fEtaMax = pgun_params.getParameter<double>("MaxEta");
@@ -47,7 +53,16 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fOverlapping = pgun_params.getParameter<bool>("Overlapping");
   fRandomShoot = pgun_params.getParameter<bool>("RandomShoot");
   fNParticles = pgun_params.getParameter<int>("NParticles");
-  fPartIDs = pgun_params.getParameter<vector<int> >("PartID");
+  fPartIDs = pgun_params.getParameter<vector<int>>("PartID");
+
+  // set dt between particles
+  fUseDeltaT = pgun_params.getParameter<bool>("UseDeltaT");
+  fTMax = pgun_params.getParameter<double>("TMax");
+  fTMin = pgun_params.getParameter<double>("TMin");
+  if (fTMax <= fTMin)
+    LogError("CloseByParticleGunProducer") << " Please fix TMin and TMax values in the configuration";
+  // set a fixed time offset for the particles
+  fOffsetFirst = pgun_params.getParameter<double>("OffsetFirst");
 
   produces<HepMCProduct>("unsmeared");
   produces<GenEventInfoProduct>();
@@ -55,6 +70,44 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
 
 CloseByParticleGunProducer::~CloseByParticleGunProducer() {
   // no need to cleanup GenEvent memory - done in HepMCProduct
+}
+
+void CloseByParticleGunProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("AddAntiParticle", false);
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<bool>("ControlledByEta", false);
+    psd0.add<double>("Delta", 10);
+    psd0.add<double>("EnMax", 200.0);
+    psd0.add<double>("EnMin", 25.0);
+    psd0.add<bool>("MaxEnSpread", false);
+    psd0.add<double>("MaxEta", 2.7);
+    psd0.add<double>("MaxPhi", 3.14159265359);
+    psd0.add<double>("MinEta", 1.7);
+    psd0.add<double>("MinPhi", -3.14159265359);
+    psd0.add<int>("NParticles", 2);
+    psd0.add<bool>("Overlapping", false);
+    psd0.add<std::vector<int>>("PartID",
+                               {
+                                   22,
+                               });
+    psd0.add<bool>("Pointing", true);
+    psd0.add<double>("RMax", 120);
+    psd0.add<double>("RMin", 60);
+    psd0.add<bool>("RandomShoot", false);
+    psd0.add<double>("ZMax", 321);
+    psd0.add<double>("ZMin", 320);
+    psd0.add<bool>("UseDeltaT", false);
+    psd0.add<double>("TMin", 0.);
+    psd0.add<double>("TMax", 0.05);
+    psd0.add<double>("OffsetFirst", 0.);
+    desc.add<edm::ParameterSetDescription>("PGunParameters", psd0);
+  }
+  desc.addUntracked<int>("Verbosity", 0);
+  desc.addUntracked<unsigned int>("firstRun", 1);
+  desc.add<std::string>("psethack", "random particles in phi and r windows");
+  descriptions.add("CloseByParticleGunProducer", desc);
 }
 
 void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
@@ -66,18 +119,27 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
   }
   fEvt = new HepMC::GenEvent();
 
+  auto const& field = es.getData(m_fieldToken);
+
   int barcode = 1;
   unsigned int numParticles = fRandomShoot ? CLHEP::RandFlat::shoot(engine, 1, fNParticles) : fNParticles;
 
   double phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
   double fZ = CLHEP::RandFlat::shoot(engine, fZMin, fZMax);
   double fR;
+  double fT;
 
   if (!fControlledByEta) {
     fR = CLHEP::RandFlat::shoot(engine, fRMin, fRMax);
   } else {
     double fEta = CLHEP::RandFlat::shoot(engine, fEtaMin, fEtaMax);
     fR = (fZ / sinh(fEta));
+  }
+
+  if (fUseDeltaT) {
+    fT = CLHEP::RandFlat::shoot(engine, fTMin, fTMax);
+  } else {
+    fT = 0.;
   }
 
   double tmpPhi = phi;
@@ -114,9 +176,6 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
     // Compute Vertex Position
     double x = fR * cos(phi);
     double y = fR * sin(phi);
-    constexpr double c = 2.99792458e+1;  // cm/ns
-    double timeOffset = sqrt(x * x + y * y + fZ * fZ) / c * ns * c_light;
-    HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x * cm, y * cm, fZ * cm, timeOffset));
 
     HepMC::FourVector p(px, py, pz, energy);
     // If we are requested to be pointing to (0,0,0), correct the momentum direction
@@ -127,6 +186,26 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
       p.setY(momentum.y());
       p.setZ(momentum.z());
     }
+
+    // compute correct path assuming uniform magnetic field in CMS
+    double pathLength = 0.;
+    const double speed = p.pz() / p.e() * c_light / cm;
+    if (PData->charge()) {
+      // Radius [cm] = P[GeV/c] * 10^9 / (c[mm/ns] * 10^6 * q[C] * B[T]) * 100[cm/m]
+      const double radius = std::sqrt(p.px() * p.px() + p.py() * p.py()) * std::pow(10, 5) /
+                            (c_light * field.inTesla({0.f, 0.f, 0.f}).z());  // cm
+      const double arc = 2 * asinf(std::sqrt(x * x + y * y) / (2 * radius)) * radius;
+      pathLength = std::sqrt(arc * arc + fZ * fZ);
+    } else {
+      pathLength = std::sqrt(x * x + y * y + fZ * fZ);
+    }
+
+    // if not pointing time doesn't mean a lot, keep the old way
+    const double pathTime = fPointing ? (pathLength / speed) : (std::sqrt(x * x + y * y + fZ * fZ) / speed);
+    double timeOffset = fOffsetFirst + (pathTime + ip * fT) * ns * c_light;
+
+    HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x * cm, y * cm, fZ * cm, timeOffset));
+
     HepMC::GenParticle* Part = new HepMC::GenParticle(p, PartID, 1);
     Part->suggest_barcode(barcode);
     barcode++;


### PR DESCRIPTION
#### PR description:
Before this PR the time was propagated back to the vertex in a straight line at the speed of light.
These changes propagate the time back at the speed of the particle and following a curved path if the particle is charged.
In addition to that, two options have been added:
- the first one is a fixed offset with respect to 0
- the second one is a dt between the particles, configurable in a range.
By default both the offset and the dt are set to 0.
The `fillDescriptions` method has been added as well.

All of this is used in studies regarding timing in HGCAL.

#### PR validation:
Tested on CloseBy photons and pions.

@waredjeb @felicepantaleo @rovere 