### PR TITLE
Add default for `FileName` in `TfGraphDefProducer::fillDescriptions()`

### DIFF
--- a/PhysicsTools/TensorFlow/plugins/TfGraphDefProducer.cc
+++ b/PhysicsTools/TensorFlow/plugins/TfGraphDefProducer.cc
@@ -54,7 +54,7 @@ TfGraphDefProducer::ReturnType TfGraphDefProducer::produce(const TfGraphRecord& 
 void TfGraphDefProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName", "tfGraphDef");
-  desc.add<edm::FileInPath>("FileName");
+  desc.add<edm::FileInPath>("FileName", edm::FileInPath());
   descriptions.add("tfGraphDefProducer", desc);
 }
 


### PR DESCRIPTION
#### PR description:

Title says it all, trivial technical PR in order to help parsing this parameter in `confDB` (needed to setup the HLT menu for 2023 Heavy Ions data-taking).

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

to be backported to CMSSW_13_2_X for integration of the HLT menu for 2023 Heavy Ion data-taking.

Cc: @vince502 @missirol 
