### PR TITLE
Add 2023 HI scenarios

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb.py
@@ -2,7 +2,7 @@
 """
 _ppEra_Run3_pp_on_PbPb_
 
-Scenario supporting proton collisions
+Scenario supporting heavy ions collisions
 
 """
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2023.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_2023_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_pp_on_PbPb_2023_cff import Run3_pp_on_PbPb_2023
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_2023(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_2023
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2023' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2023' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_2023' ]
+    """
+    _ppEra_Run3_pp_on_PbPb_2023_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3
+
+    """

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_2023.py
@@ -2,7 +2,7 @@
 """
 _ppEra_Run3_pp_on_PbPb_2023_
 
-Scenario supporting proton collisions
+Scenario supporting heavy ions collisions
 
 """
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters.py
@@ -2,7 +2,7 @@
 """
 _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_
 
-Scenario supporting proton collisions
+Scenario supporting heavy ions collisions
 
 """
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023.py
@@ -2,7 +2,7 @@
 """
 _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023_
 
-Scenario supporting proton collisions
+Scenario supporting heavy ions collisions
 
 """
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+from Configuration.Eras.Era_Run3_pp_on_PbPb_approxSiStripClusters_2023_cff import Run3_pp_on_PbPb_approxSiStripClusters_2023
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_pp_on_PbPb_approxSiStripClusters_2023
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2023' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2023' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2023' ]
+
+    """
+    _ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023_
+
+    Implement configuration building for data processing for pp-like processing of HI
+    collision data taking for Run3 with approxSiStripClusters (rawprime format)
+
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -109,10 +109,17 @@ def customisePostEra_Run3_pp_on_PbPb(process):
     customisePostEra_Run3(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_2023(process):
+    customisePostEra_Run3_2023(process)
+    return process
+
 def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters(process):
     customisePostEra_Run3_pp_on_PbPb(process)
     return process
 
+def customisePostEra_Run3_pp_on_PbPb_approxSiStripClusters_2023(process):
+    customisePostEra_Run3_pp_on_PbPb_2023(process)
+    return process
 
 ##############################################################################
 def customisePPData(process):

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -37,7 +37,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:
This PR adds the HI scenarios to be used in Tier0 for 2023 HI data-taking.
The new scenarios are based on the "2023" Eras introduced by @mandrenguyen in #41571.

| Era | Scenario | 
| --- | --- |
| `Run3_pp_on_PbPb_2023` | `ppEra_Run3_pp_on_PbPb_2023` |
| `Run3_pp_on_PbPb_approxSiStripClusters_2023` | `ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023` |


#### PR validation:
Code compiles and I also run:
```
scram b runtests_TestConfigDP
```
As far as I know we don't have streamer files on which the usual `RunPromptReco.py` command can be tested.

#### Backport:
Not a backport, but a 13_2_X backport will be provided soon

---
FYI @cms-sw/alca-l2 @cms-sw/ppd-l2 @mandrenguyen @icali @mmusich 

