### PR TITLE
simplify implementation of `SiPixelQualityESProducer` and use multiple instances of it

### DIFF
--- a/CalibTracker/Configuration/python/Tracker_DependentRecords_forGlobalTag_nofakes_cff.py
+++ b/CalibTracker/Configuration/python/Tracker_DependentRecords_forGlobalTag_nofakes_cff.py
@@ -36,15 +36,8 @@ siStripQualityESProducer.PrintDebugOutput = cms.bool(False)
 # Default is "False".
 siStripQualityESProducer.UseEmptyRunInfo = cms.bool(False)
 
-from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import *
-siPixelQualityESProducer.ListOfRecordToMerge = cms.VPSet(
-        cms.PSet( record = cms.string("SiPixelQualityFromDbRcd"),
-                  tag    = cms.string("")
-                  ),
-        cms.PSet( record = cms.string("SiPixelDetVOffRcd"),
-                  tag    = cms.string("")
-                  )
-        )
+from CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi import *
+from CalibTracker.SiPixelESProducers.siPixelQualityForRawToDigiESProducer_cfi import *
 
 # Multiple scattering parametrisation
 from RecoTracker.TkMSParametrization.multipleScatteringParametrisationMakerESProducer_cfi import *

--- a/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/SiPixelQualityESProducer_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi import siPixelQualityESProducer
-
-from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
-siPixelQualityRawToDigi.toModify(siPixelQualityESProducer,
-    siPixelQualityLabel_RawToDigi = 'forRawToDigi',
-)
-

--- a/CalibTracker/SiPixelESProducers/python/siPixelQualityForDigitizerESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/siPixelQualityForDigitizerESProducer_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi import siPixelQualityESProducer as _siPixelQualityESProducer
+
+siPixelQualityForDigitizerESProducer = _siPixelQualityESProducer.clone(
+    appendToDataLabel = 'forDigitizer',
+    siPixelQualityFromDbLabel = 'forDigitizer'
+)
+
+# remove siPixelQualityForDigitizerESProducer when the modifier run2_SiPixel_2018 is not enabled
+def _removeSiPixelQualityForDigitizerESProducer(process):
+    if hasattr(process, 'siPixelQualityForDigitizerESProducer'):
+        del process.siPixelQualityForDigitizerESProducer
+
+from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
+removeSiPixelQualityForDigitizerESProducer_ = (~run2_SiPixel_2018).makeProcessModifier( _removeSiPixelQualityForDigitizerESProducer )

--- a/CalibTracker/SiPixelESProducers/python/siPixelQualityForRawToDigiESProducer_cfi.py
+++ b/CalibTracker/SiPixelESProducers/python/siPixelQualityForRawToDigiESProducer_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi import siPixelQualityESProducer as _siPixelQualityESProducer
+
+siPixelQualityForRawToDigiESProducer = _siPixelQualityESProducer.clone(
+    appendToDataLabel = 'forRawToDigi',
+    siPixelQualityFromDbLabel = 'forRawToDigi'
+)
+
+# remove siPixelQualityForRawToDigiESProducer when the modifier siPixelQualityRawToDigi is not enabled
+def _removeSiPixelQualityForRawToDigiESProducer(process):
+    if hasattr(process, 'siPixelQualityForRawToDigiESProducer'):
+        del process.siPixelQualityForRawToDigiESProducer
+
+from Configuration.ProcessModifiers.siPixelQualityRawToDigi_cff import siPixelQualityRawToDigi
+removeSiPixelQualityForRawToDigiESProducer_ = (~siPixelQualityRawToDigi).makeProcessModifier( _removeSiPixelQualityForRawToDigiESProducer )

--- a/CondTools/SiPixel/test/SiPixelBadModule_ESProducer_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModule_ESProducer_cfg.py
@@ -36,7 +36,7 @@ process.load("Configuration/StandardSequences/GeometryIdeal_cff")
 process.GlobalTag.globaltag = 'START311_V1::All'
 
 ###### Quality ESProducer --- copied from SiStripESProducer
-process.load("CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi")
+process.load("CalibTracker.SiPixelESProducers.siPixelQualityESProducer_cfi")
 
 process.GlobalTag.toGet = cms.VPSet(
     cms.PSet(
@@ -66,10 +66,3 @@ process.siPixelQualityESProducer.ListOfRecordToMerge = cms.VPSet(
     )
 
 process.p = cms.Path(process.BadModuleReader)
-
-
-
-
-
-
-

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -223,6 +223,20 @@ def customizeHLTfor42514(process):
     return process
 
 
+def customizeHLTfor42497(process):
+    for producer in esproducers_by_type(process, 'SiPixelQualityESProducer'):
+        producer.siPixelQualityFromDbLabel = cms.string('')
+        producer.appendToDataLabel = cms.string('')
+        for parName in [
+            'siPixelQualityLabel',
+            'siPixelQualityLabel_RawToDigi',
+        ]:
+            if hasattr(producer, parName):
+                producer.__delattr__(parName)
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -232,5 +246,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customizeHLTfor42514(process)
+    process = customizeHLTfor42497(process)
 
     return process

--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -120,10 +120,8 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify( SiPixelSimBlock, func=_modifyPixelDigitizerForPhase1Pixel )
 
 # use Label 'forDigitizer' for years >= 2018
-from CalibTracker.SiPixelESProducers.SiPixelQualityESProducer_cfi import siPixelQualityESProducer
 from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
-run2_SiPixel_2018.toModify(siPixelQualityESProducer,siPixelQualityLabel = 'forDigitizer',)
-run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer',)
+run2_SiPixel_2018.toModify(SiPixelSimBlock, SiPixelQualityLabel = 'forDigitizer')
 
 # change the digitizer threshold for Run3
 # - new layer1 installed: expected improvement in timing alignment of L1 and L2

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -11,6 +11,9 @@ pixelDigitizer = cms.PSet(
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 premix_stage1.toModify(pixelDigitizer, makeDigiSimLinks = False)
 
+# ESProducer for SiPixelQuality with "forDigitizer" label
+from CalibTracker.SiPixelESProducers.siPixelQualityForDigitizerESProducer_cfi import *
+
 # Customize here instead of SiPixelSimBlock as the latter is imported
 # also to DataMixer configuration, and the original version is needed
 # there in stage2. Customize before phase2_tracker because this


### PR DESCRIPTION
#### PR description:

This PR includes a change tested as part of #42492.

As a way to disentangle the `SiPixelQuality` ES product used by HLT from other ones used at times in other steps (e.g. the one with label `"forDigitizer"`), the implementation of the ESProducer is simplified to return just one ES product, and separate instances of the ESProducer are added to the python configuration. In order to load the 'extra' ESProducers only when appropriate, calls to `makeProcessModifier` are used in the `cfi` files to remove the modules from the `cms.Process` when the relevant modifiers are not enabled.

Merely technical. No changes expected (in terms of physics results).

#### PR validation:

A few selected wfs of `runTheMatrix.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A