### PR TITLE
Handle case where exception is thrown in beginRun for simulation

### DIFF
--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -294,6 +294,9 @@ void GenXSecAnalyzer::globalEndRun(edm::Run const &iRun, edm::EventSetup const &
   }
 
   auto runC = runCache(iRun.index());
+  if (nullptr == runC)
+    return;
+
   std::lock_guard l{mutex_};
 
   // compute cross section for this run first


### PR DESCRIPTION

#### PR description:

If the modules are dependent upon the ExternalLHEProducer and that modules throws at begin run, these modules are not run. However, these modules are still run at end Run and they access data that was never initialized.

#### PR validation:

Code compiles. I artificially caused the exception to happen and these modules no longer have a problem.