### PR TITLE
Replace reference to ParameterSet with explicit parameter values in HcalTimeSlewEP

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.h
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTimeSlewEP.h
@@ -32,7 +32,14 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  const edm::ParameterSet& pset_;
+  struct M2Parameters {
+    float t0, m, tmaximum;
+  };
+  struct M3Parameters {
+    double cap, tspar0, tspar1, tspar2, tspar0_siPM, tspar1_siPM, tspar2_siPM;
+  };
+  std::vector<M2Parameters> m2parameters_;
+  std::vector<M3Parameters> m3parameters_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR replaces a reference to `edm::ParameterSet` with explicitly parsed data structures for the configuration parameters. This change is needed in order to avoid keeping the top level `ParameterSet` alive throughout the job (and thus saving O(10 MB) of memory).

#### PR validation:

Workflow 11834.21 reco step runs.

