### PR TITLE
Release ProcessDesc in main() to release some memory

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -306,6 +306,12 @@ int main(int argc, char* argv[]) {
         alwaysAddContext = false;
         context = "Calling beginJob";
         proc->beginJob();
+        // EventSetupsController uses pointers to the ParameterSet
+        // owned by ProcessDesc while it is dealing with sharing of
+        // ESProducers among the top-level process and the
+        // SubProcesses. Therefore the ProcessDesc needs to be kept
+        // alive until the beginJob transition has finished.
+        processDesc.reset();
 
         alwaysAddContext = false;
         context =


### PR DESCRIPTION
#### PR description:

Profiling the live memory of https://github.com/cms-sw/cmssw/issues/40437#issuecomment-1630699980 showed that the `edm::ProcessDesc` was taking about 40 MB
https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/issue40437/reco_07.5_live/496

The `ProcessDesc` is not really needed in `main()` after the `EventProcessor` is constructed, so this PR releases the ownership of `ProcessDesc` in `main()`, so that the object will be destructed in the `EventProcessor` constructor.

This change implies that the modules may no longer hold the `edm::ParameterSet`, that is given to their constructor, by reference/pointer (while testing the change I came across with https://github.com/cms-sw/cmssw/pull/42502, but there may be more).

Resolves https://github.com/makortel/framework/issues/616

#### PR validation:

Workflow 11834.21 reco step runs with https://github.com/cms-sw/cmssw/pull/42502

The IgProf MEM_LIVE in 11834.21 reco step in 13_2_0_pre3
* without this PR: https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/1320pre3/11834.21/step3_reco_07.5_live/598
* with this PR https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/1320pre3/11834.21/step3_reco_17.5_live/1551

There is residual ~1.7 MB contribution from `PyBind11ProcessDesc` that look like memory leaks in python itself(?).