### PR TITLE
Phase 2 GTT Match F/W TrackVertexAssociation

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -49,7 +49,8 @@ private:
   double theTrkMVA2_;
   double theTrkMVA3_;
   int theTrackSeedType_;
-  double theBField_;  // needed for unpacking
+  double theBField_;     // needed for unpacking
+  int theGTTLinkIndex_;  // stores the position within a fiber link inside GTT
   static constexpr unsigned int Npars4 = 4;
   static constexpr unsigned int Npars5 = 5;
   static constexpr float MagConstant =
@@ -139,6 +140,11 @@ public:
   unsigned int etaSector() const { return theEtaSector_; }
   void setEtaSector(unsigned int aSector) { theEtaSector_ = aSector; }
 
+  /// GTT Link Information
+  unsigned int gttLinkID() const { return (eta() >= 0 ? 1 : 0) + (2 * phiSector()); }
+  int gttLinkIndex() const { return theGTTLinkIndex_; }
+  void setGTTLinkIndex(int idx) { theGTTLinkIndex_ = idx; }
+
   /// Track seeding (for debugging)
   unsigned int trackSeedType() const { return theTrackSeedType_; }
   void setTrackSeedType(int aSeed) { theTrackSeedType_ = aSeed; }
@@ -201,6 +207,7 @@ TTTrack<T>::TTTrack() {
   thePhiSector_ = 0;
   theEtaSector_ = 0;
   theTrackSeedType_ = 0;
+  theGTTLinkIndex_ = -1;
   theChi2_ = 0.0;
   theChi2_XY_ = 0.0;
   theChi2_Z_ = 0.0;
@@ -234,6 +241,7 @@ TTTrack<T>::TTTrack(double aRinv,
   thePhiSector_ = 0;      // must be set externally
   theEtaSector_ = 0;      // must be set externally
   theTrackSeedType_ = 0;  // must be set externally
+  theGTTLinkIndex_ = -1;  // must be set externally
   theChi2_ = aChi2;
   theTrkMVA1_ = trkMVA1;
   theTrkMVA2_ = trkMVA2;

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,7 +24,7 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      trackWords.at((track.eta() >= 0 ? 1 : 0) + (2 * track.phiSector())).push_back(encodeTrack(track));
+      trackWords.at(track.gttLinkID()).push_back(encodeTrack(track));
     }
     return trackWords;
   }
@@ -39,10 +39,9 @@ namespace l1t::demo::codecs {
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector()))
-            .push_back(encodeTrack(referenceTrack));
+        trackWords.at(referenceTrack.gttLinkID()).push_back(encodeTrack(referenceTrack));
       } else {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector())).push_back(ap_uint<96>(0));
+        trackWords.at(referenceTrack.gttLinkID()).push_back(ap_uint<96>(0));
       }
     }
     return trackWords;

--- a/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1GTTInputProducer.cc
@@ -518,6 +518,16 @@ void L1GTTInputProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
                                         << " pt/eta mismatches detected!!!";
   }
 
+  // Set the GTTLinkIndex for downstream modules
+  std::vector<int> index_counters(18, 0);
+  for (auto& track : *vTTTrackOutput) {
+    // Get the GTT Link ID (0-17) for the track
+    unsigned int gtt_link_id = track.gttLinkID();
+    // Assign the GTTLinkIndex to the converted tracks
+    track.setGTTLinkIndex(index_counters[gtt_link_id]);
+    index_counters[gtt_link_id]++;
+  }
+
   // Put the outputs into the event
   iEvent.put(std::move(vTTTrackOutput), outputCollectionName_);
   iEvent.put(std::move(vPtOutput), "L1GTTInputTrackPtExpected");


### PR DESCRIPTION
#### PR description:

This PR matches the Global Track Trigger's behavior with TrackVertexAssociation in firmware. In the current F/W, there is a restriction of associating at most 94 tracks per input link. 

Currently, the Track Finding Processors send tracks with eta >= 0 on one link, and negative eta tracks on another. There are 18 links total (2 per processor for each phi Nonant). To the TTTrack class, a method is added to get the GTT link index (0-17) indicating the fiber a track would be sent on in firmware (This is then propagated to the codecs_tracks to centralize the usage of this longstanding formula). Additionally, since the firmware behavior can best be likened to 'zeroing' un-selected tracks in the datastream, we must enumerate the tracks as they are 'processed' by the GTTInputConverter, using the added setter method. Once derived collections are processed downstream in the TrackVertexAssociation, the member variable can be checked via the getter to do a simple check on whether the Track could be associated as in the firmware.

#### PR validation:

Passes:
scram b code-checks
scram b code-format
scram b

GTT test workflow runs as expected; special variant to test the new limits (requires 6-fold duplication of tracks in the test sequence) gets 100% matching with corresponding update to GTT firmware.
https://gitlab.cern.ch/GTT/LibHLS/-/merge_requests/30

This will need to be backported to the cms-l1t-offline phase2 integration branch 