### PR TITLE
Simulation: define PSimHit track Id offset and propagate to MTD hit categories

### DIFF
--- a/SimDataFormats/TrackingHit/interface/PSimHit.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHit.h
@@ -110,9 +110,9 @@ public:
   /** In case te SimTrack ID is incremented by the k_tidOffset for hit category definition, this
    * methods returns the original theTrackId value directly.
    */
-  unsigned int originalTrackId() const { return (theTrackId > k_tidOffset) ? theTrackId % k_tidOffset : theTrackId; }
+  unsigned int originalTrackId() const { return theTrackId % k_tidOffset; }
 
-  unsigned int offsetTrackId() const { return (theTrackId > k_tidOffset) ? theTrackId / k_tidOffset : theTrackId; }
+  unsigned int offsetTrackId() const { return theTrackId / k_tidOffset; }
 
   static unsigned int addTrackIdOffset(unsigned int tId, unsigned int offset) { return offset * k_tidOffset + tId; }
 

--- a/SimDataFormats/TrackingHit/interface/PSimHit.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHit.h
@@ -14,6 +14,8 @@ class TrackingSlaveSD;  // for friend declaration only
 
 class PSimHit {
 public:
+  static constexpr unsigned int k_tidOffset = 200000000;
+
   PSimHit() : theDetUnitId(0) {}
 
   PSimHit(const Local3DPoint& entry,
@@ -104,6 +106,15 @@ public:
    *  to which the PSimHit belongs.
    */
   unsigned int trackId() const { return theTrackId; }
+
+  /** In case te SimTrack ID is incremented by the k_tidOffset for hit category definition, this
+   * methods returns the original theTrackId value directly.
+   */
+  unsigned int originalTrackId() const { return (theTrackId > k_tidOffset) ? theTrackId % k_tidOffset : theTrackId; }
+
+  unsigned int offsetTrackId() const { return (theTrackId > k_tidOffset) ? theTrackId / k_tidOffset : theTrackId; }
+
+  static unsigned int addTrackIdOffset(unsigned int tId, unsigned int offset) { return offset * k_tidOffset + tId; }
 
   EncodedEventId eventId() const { return theEventId; }
 

--- a/SimG4CMS/Forward/BuildFile.xml
+++ b/SimG4CMS/Forward/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/Math"/>
 <use name="SimDataFormats/SimHitMaker"/>
+<use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/CaloHit"/>
 <use name="Geometry/MTDCommonData"/>
 <use name="boost"/>

--- a/SimG4CMS/Forward/interface/MtdSD.h
+++ b/SimG4CMS/Forward/interface/MtdSD.h
@@ -28,9 +28,9 @@ protected:
   int getTrackID(const G4Track *) override;
 
 private:
-  static constexpr unsigned int k_idsecOffset = 100000000;
-  static constexpr unsigned int k_idloopOffset = 200000000;
-  static constexpr unsigned int k_idFromCaloOffset = 300000000;
+  static constexpr unsigned int k_idsecOffset = 1;
+  static constexpr unsigned int k_idloopOffset = 2;
+  static constexpr unsigned int k_idFromCaloOffset = 3;
 
   double energyCut;
   double energyHistoryCut;

--- a/SimG4CMS/Forward/src/MtdSD.cc
+++ b/SimG4CMS/Forward/src/MtdSD.cc
@@ -8,6 +8,7 @@
 #include "Geometry/MTDCommonData/interface/BTLNumberingScheme.h"
 #include "Geometry/MTDCommonData/interface/ETLNumberingScheme.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "G4Track.hh"
 #include "G4Step.hh"
@@ -108,11 +109,11 @@ int MtdSD::getTrackID(const G4Track* aTrack) {
     if (rname == "FastTimerRegionSensBTL") {
       theID = trkInfo->mcTruthID();
       if (trkInfo->isExtSecondary() && !trkInfo->isInTrkFromBackscattering()) {
-        theID += k_idsecOffset;
+        theID = PSimHit::addTrackIdOffset(theID, k_idsecOffset);
       } else if (trkInfo->isInTrkFromBackscattering()) {
-        theID += k_idFromCaloOffset;
+        theID = PSimHit::addTrackIdOffset(theID, k_idFromCaloOffset);
       } else if (trkInfo->isBTLlooper()) {
-        theID += k_idloopOffset;
+        theID = PSimHit::addTrackIdOffset(theID, k_idloopOffset);
       }
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("MtdSim") << "MtdSD: Track ID: " << aTrack->GetTrackID()

--- a/SimG4Core/Application/test/SimHitCaloHitDumper.cc
+++ b/SimG4Core/Application/test/SimHitCaloHitDumper.cc
@@ -371,8 +371,10 @@ void SimHitCaloHitDumper::analyze(const edm::Event& iEvent, const edm::EventSetu
     edm::LogPrint("SimHitCaloHitDumper") << (*icoll).second << " hits in the event = " << (*icoll).first;
     edm::LogPrint("SimHitCaloHitDumper") << "\n";
     for (int ihit = 0; ihit < (*icoll).first; ++ihit) {
-      edm::LogPrint("SimHitCaloHitDumper") << theMTDHits[nhit] << " Energy = " << theMTDHits[nhit].energyLoss()
-                                           << " Track Id = " << theMTDHits[nhit].trackId();
+      edm::LogPrint("SimHitCaloHitDumper")
+          << theMTDHits[nhit] << " Energy = " << theMTDHits[nhit].energyLoss()
+          << " tid orig/offset= " << theMTDHits[nhit].originalTrackId() << " " << theMTDHits[nhit].offsetTrackId()
+          << " Track Id = " << theMTDHits[nhit].trackId();
       nhit++;
     }
   }

--- a/SimG4Core/Application/test/SimHitCaloHitDumper.cc
+++ b/SimG4Core/Application/test/SimHitCaloHitDumper.cc
@@ -371,7 +371,8 @@ void SimHitCaloHitDumper::analyze(const edm::Event& iEvent, const edm::EventSetu
     edm::LogPrint("SimHitCaloHitDumper") << (*icoll).second << " hits in the event = " << (*icoll).first;
     edm::LogPrint("SimHitCaloHitDumper") << "\n";
     for (int ihit = 0; ihit < (*icoll).first; ++ihit) {
-      edm::LogPrint("SimHitCaloHitDumper") << theMTDHits[nhit] << " Track Id = " << theMTDHits[nhit].trackId();
+      edm::LogPrint("SimHitCaloHitDumper") << theMTDHits[nhit] << " Energy = " << theMTDHits[nhit].energyLoss()
+                                           << " Track Id = " << theMTDHits[nhit].trackId();
       nhit++;
     }
   }

--- a/SimG4Core/Notification/BuildFile.xml
+++ b/SimG4Core/Notification/BuildFile.xml
@@ -2,6 +2,7 @@
   <lib name="1"/>
 </export>
 <use name="SimDataFormats/Forward"/>
+<use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="DataFormats/Math"/>

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -19,6 +19,7 @@
 #include "SimG4Core/Notification/interface/TmpSimVertex.h"
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -162,6 +163,10 @@ void SimTrackManager::reallyStoreTracks() {
       }
     }
 
+    if (id >= static_cast<int>(PSimHit::k_tidOffset)) {
+      throw cms::Exception("SimTrackManager::reallyStoreTracks")
+          << " SimTrack ID " << id << " exceeds maximum allowed by PSimHit identifier" << PSimHit::k_tidOffset;
+    }
     TmpSimTrack* g4simtrack =
         new TmpSimTrack(id, trkH->particleID(), trkH->momentum(), trkH->totalEnergy(), ivertex, ig, pm, spos, smom);
     g4simtrack->copyCrossedBoundaryVars(trkH);


### PR DESCRIPTION
#### PR description:

Following the discussion about https://github.com/cms-sw/cmssw/pull/42455 at the simulation meeting https://indico.cern.ch/event/1313529/ , this PR implements:

- a default base track id offset in the ```PSimHit``` class, and methods to add and retrieve offsets and the original track id;
- propagates its use to the ```MtdSD``` class, keeping the previous logical behaviour unaltered;
- adds a protection in the ```SimTrackManager``` throwing an exception if tracks with a track Id larger than the base offset are proposed for permanent storage. 

The previous offset of 100000000 is doubled to 200000000 , in order to stay safe also in presence of Heavy Ion samples. A test with 1k events of wf. 24950 shows that track Ids close to 90k are possible in these very populated events. The chosen base offset allows anyway a large number of possible offsets to be stored, before hitting the limit of maximum size of an unsigned integer (UINT_MAX = 4294967295). 

@makortel The proposed implementation does not technically modify persistent data members or existing interfaces, and for this reason no change of class version for schema evolution is added. The track Id member meaning is potentially enlarged now, but in a way that should be backward compatible (although no mechanism prevents in principle track ids larger than the base offset for the past, they are not expected for the reasons mentioned above).

#### PR validation:

Code runs, and provides the expected track ids in BTL hits, as shown by the dump of the test class ```SimHitCaloHitDumper``` updated in this PR. e.g.

```
BTLHits hits in the event = 160


1653680716  (2.65248,0.0823182,0.866362)  4.77149 Energy = 0.00187623 Track Id = 104
1653623364  (-23.5429,0.117936,1.5)  5.13729 Energy = 0.00161607 Track Id = 104
1653623365  (-24.0755,-1.56,0.419155)  5.14377 Energy = 0.00234347 Track Id = 104
1653623365  (-24.306,-0.0968286,-1.34526)  5.15137 Energy = 0.000306122 Track Id = 104
1654395712  (-19.9635,-0.910802,0.345843)  12.8854 Energy = 0.000179942 Track Id = 400000104
1654392652  (-12.1859,-1.46623,1.02566)  12.7973 Energy = 0.000569917 Track Id = 400000104
1653999172  (13.007,1.17016,0.636569)  10.2406 Energy = 0.000445038 Track Id = 400000104
1653672524  (-4.91178,-0.848405,1.26667)  7.25785 Energy = 7.98462e-05 Track Id = 600000104
1653680719  (-9.67319,0.640687,1.5)  4.83673 Energy = 0.00299444 Track Id = 104
1653683776  (-10.1171,-1.56,0.396154)  4.84311 Energy = 0.0044181 Track Id = 104
1653680719  (-11.8098,0.169878,1.29515)  4.84187 Energy = 4.56779e-05 Track Id = 104
1658860419  (-11.4223,1.38335,-1.1103)  14.1081 Energy = 0.000175683 Track Id = 200000097
1658465159  (-1.0942,-1.36393,-0.899755)  15.5332 Energy = 0.000232008 Track Id = 600000097
1657874062  (5.81779,-0.420891,0.367464)  17.0341 Energy = 9.31307e-06 Track Id = 600000095
1657938761  (-20.3771,-0.024968,-1.10717)  16.9043 Energy = 0.000180497 Track Id = 600000095
1658477452  (20.7793,-0.806021,-1.09933)  21.7767 Energy = 8.5945e-05 Track Id = 600000095
1658855297  (18.1346,-0.17453,-1.09467)  19.5952 Energy = 0.000181718 Track Id = 600000095
1658470222  (-26.2811,-0.0460031,-1.09773)  20.8468 Energy = 9.98849e-05 Track Id = 600000095
1656816974  (1.77915,1.51598,-1.5887)  27.6375 Energy = 0.000116488 Track Id = 600000095
1657162311  (10.6521,-0.669832,-0.934452)  23.207 Energy = 7.398e-05 Track Id = 600000094
1657414280  (19.3899,-1.10402,-1.37687)  21.04 Energy = 0.000219651 Track Id = 600000094
1659064132  (16.9131,0.625088,0.0171433)  11.4986 Energy = 0.000175298 Track Id = 200000093
1654934147  (-11.4032,0.155602,-1.45387)  24.4696 Energy = 6.67964e-05 Track Id = 600000091
1654916993  (5.30227,-1.55327,-0.816225)  16.2435 Energy = 0.000136397 Track Id = 600000091
1654147467  (-8.32702,1.05475,-1.77296)  19.5695 Energy = 0.000112557 Track Id = 600000091
1654408013  (26.8781,-0.0967704,0.240067)  17.055 Energy = 6.3314e-05 Track Id = 600000091
1654408013  (26.8781,-0.0967704,0.240067)  17.055 Energy = 0.00026036 Track Id = 600000091
1654460047  (-23.8675,1.4109,-0.816348)  21.194 Energy = 0.000118696 Track Id = 600000091
1654808458  (17.9005,1.04276,-1.19358)  13.5182 Energy = 0.000903361 Track Id = 600000090
1659050564  (8.15412,-0.0136119,1.5)  4.77013 Energy = 0.0021346 Track Id = 86
1659050565  (7.92549,-1.56,0.25996)  4.77723 Energy = 0.00107187 Track Id = 86
(...)
```