### PR TITLE
[13.2.X] Fix approximated SiStrip clusters workflow by saving SiStrip FED error information

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -180,7 +180,8 @@ RAWEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 approxSiStripClusters.toModify(RAWEventContent,
                               outputCommands = RAWEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 
 #
@@ -622,7 +623,8 @@ FEVTDEBUGEventContent.outputCommands.extend(SimCalorimetryFEVTDEBUG.outputComman
 FEVTDEBUGEventContent.outputCommands.extend(SimFastTimingFEVTDEBUG.outputCommands)
 approxSiStripClusters.toModify(FEVTDEBUGEventContent,
                               outputCommands = FEVTDEBUGEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 #
 #
@@ -640,7 +642,8 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_StripDigiSimLink_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*'
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
                               ])
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -181,7 +181,7 @@ from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStr
 approxSiStripClusters.toModify(RAWEventContent,
                               outputCommands = RAWEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 
 #
@@ -624,7 +624,7 @@ FEVTDEBUGEventContent.outputCommands.extend(SimFastTimingFEVTDEBUG.outputCommand
 approxSiStripClusters.toModify(FEVTDEBUGEventContent,
                               outputCommands = FEVTDEBUGEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 #
 #
@@ -643,7 +643,7 @@ FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIdedmEDCollection_siStripDigisHLT_*_*'
+                                  'keep DetIdedmEDCollection_hltSiStripRawToDigi_*_*'
                               ])
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2165,7 +2165,7 @@ steps['RAWPRIMESIMHI18']={ '--scenario':'pp',
                            '--era':'Run2_2018_pp_on_AA',
                            '-n':'10',
                            '--procModifiers':'approxSiStripClusters',
-                           '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
+                           '--customise_commands':'\"process.hltSiStripRawToDigi.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                            '--process':'REHLT'
 }
 
@@ -2199,7 +2199,7 @@ steps['RAWPRIMEHI22']={ '--scenario':'pp',
                         '--eventcontent':'REPACKRAW',
                         '--era':'Run3_pp_on_PbPb_approxSiStripClusters',
                         '-n':'10',
-                        '--customise_commands':'\"process.siStripDigisHLT.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
+                        '--customise_commands':'\"process.hltSiStripRawToDigi.ProductLabel=\'rawDataCollector\';process.hltScalersRawToDigi.scalersInputTag=\'rawDataCollector\'\"',
                         '--process':'REHLT'
 }
 

--- a/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_Repack_cff.py
@@ -58,7 +58,7 @@ DigiToVirginRawRepack = cms.Sequence( DigiToVirginRawRepackTask )
 DigiToSplitRawRepack = cms.Sequence( DigiToRawRepackTask, DigiToVirginRawRepackTask )
 
 from EventFilter.SiStripRawToDigi.SiStripDigis_cfi import siStripDigis
-siStripDigisHLT = siStripDigis.clone(ProductLabel = "rawDataRepacker")
+hltSiStripRawToDigi = siStripDigis.clone(ProductLabel = "rawDataRepacker")
 
 from RecoLocalTracker.Configuration.RecoLocalTracker_cff import siStripZeroSuppressionHLT
 
@@ -66,7 +66,7 @@ from RecoLocalTracker.SiStripClusterizer.DefaultClusterizer_cff import *
 siStripClustersHLT = cms.EDProducer("SiStripClusterizer",
                                     Clusterizer = DefaultClusterizer,
                                     DigiProducersList = cms.VInputTag(
-                                        cms.InputTag('siStripDigisHLT','ZeroSuppressed'),
+                                        cms.InputTag('hltSiStripRawToDigi','ZeroSuppressed'),
                                         cms.InputTag('siStripZeroSuppressionHLT','VirginRaw'),
                                         cms.InputTag('siStripZeroSuppressionHLT','ProcessedRaw'),
                                         cms.InputTag('siStripZeroSuppressionHLT','ScopeMode')),
@@ -84,5 +84,5 @@ hltScalersRawToDigi =  cms.EDProducer( "ScalersRawToDigi",
    scalersInputTag = cms.InputTag( "rawDataRepacker" )
 )
 
-DigiToApproxClusterRawTask = cms.Task(siStripDigisHLT,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
+DigiToApproxClusterRawTask = cms.Task(hltSiStripRawToDigi,siStripZeroSuppressionHLT,hltScalersRawToDigi,hltBeamSpotProducer,siStripClustersHLT,hltSiStripClusters2ApproxClusters,rawPrimeDataRepacker)
 DigiToApproxClusterRaw = cms.Sequence(DigiToApproxClusterRawTask)

--- a/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
@@ -35,6 +35,10 @@ RawToDigiTask = cms.Task(
     castorDigis,
     scalersRawToDigi)
 
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(RawToDigiTask, 
+                               RawToDigiTask.copyAndExclude(siStripDigis)) # in case of the approximate cluster wf don't run the 
+
 RawToDigi = cms.Sequence(RawToDigiTask)
 
 RawToDigiTask_woGCT = RawToDigiTask.copyAndExclude([gctDigis])

--- a/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
@@ -29,7 +29,8 @@ phase2_tracker.toModify(siStripZeroSuppression, # FIXME
                            'simSiStripDigis:ScopeMode' ]
 )
 
+# For the HI RAW' workflow
 siStripZeroSuppressionHLT = siStripZeroSuppression.clone(
-    RawDigiProducersList =[("siStripDigisHLT","VirginRaw"), ("siStripDigisHLT","ProcessedRaw"), ("siStripDigisHLT","ScopeMode")]
+    RawDigiProducersList =[("hltSiStripRawToDigi","VirginRaw"), ("hltSiStripRawToDigi","ProcessedRaw"), ("hltSiStripRawToDigi","ScopeMode")]
 )
     

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -6,6 +6,12 @@ MeasurementTrackerEvent = _measurementTrackerEventDefault.clone(
     badPixelFEDChannelCollectionLabels = ['siPixelDigis'],
 )
 
+# in case of RAW' (approximated SiStrip clusters) 
+# take the list of inactive strip labels directly from RAW data
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(MeasurementTrackerEvent,
+                               inactiveStripDetectorLabels = ["siStripDigisHLT"]) 
+
 # This customization will be removed once we have phase2 pixel digis
 # Need this line to stop error about missing siPixelDigis
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
@@ -31,4 +37,9 @@ vectorHits.toModify(MeasurementTrackerEvent,
 
 MeasurementTrackerEventPreSplitting = MeasurementTrackerEvent.clone(
     pixelClusterProducer = 'siPixelClustersPreSplitting'
-    )
+)
+
+# in case of RAW' (approximated SiStrip clusters) 
+# take the list of inactive strip labels directly from RAW data 
+approxSiStripClusters.toModify(MeasurementTrackerEventPreSplitting,
+                               inactiveStripDetectorLabels = ["siStripDigisHLT"])

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -10,7 +10,7 @@ MeasurementTrackerEvent = _measurementTrackerEventDefault.clone(
 # take the list of inactive strip labels directly from RAW data
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 approxSiStripClusters.toModify(MeasurementTrackerEvent,
-                               inactiveStripDetectorLabels = ["siStripDigisHLT"]) 
+                               inactiveStripDetectorLabels = ["hltSiStripRawToDigi"])
 
 # This customization will be removed once we have phase2 pixel digis
 # Need this line to stop error about missing siPixelDigis
@@ -42,4 +42,4 @@ MeasurementTrackerEventPreSplitting = MeasurementTrackerEvent.clone(
 # in case of RAW' (approximated SiStrip clusters) 
 # take the list of inactive strip labels directly from RAW data 
 approxSiStripClusters.toModify(MeasurementTrackerEventPreSplitting,
-                               inactiveStripDetectorLabels = ["siStripDigisHLT"])
+                               inactiveStripDetectorLabels = ["hltSiStripRawToDigi"])


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42475
backport of https://github.com/cms-sw/cmssw/pull/42480

#### PR description:

It has been shown (see [talk](https://indico.cern.ch/event/1271490/contributions/5484101/attachments/2679179/4647438/DPG_RawPrime_20230705.pdf)) that events repacked in the RAW' data format and then reconstructed with the dedicated process modifier `approxSiStripClusters` have a different content in terms of tracks w.r.t. the standard reconstruction starting from RAW data (with full SiStrip ADC information). Part of that is expected from information loss intrinsic to the procedure, but dedicated checks showed that in some events few perfectly valid seeds lead to no track reconstructed when data is repacked with the RAW' data format.
This has been shown to depend on the fact the currently the RAW' data format is not saving the list of SiStrip FED errors (collection  `DetIdedmEDCollection_siStripDigisHLT_*_*`) which is used in the tracking setup to construct the list of inactive componets:

https://github.com/cms-sw/cmssw/blob/a5b91a1d0848665cc6f5d3ddb11be28272302e1c/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc#L405-L417

which is then used in trajectory building.
This PR proposed to fix this issue by keeping the missing collection (32b79ff31e275defbbd3ca982d86a6cd2758f971, supposed eventually to come from the HLT) in the repack procedure and then to use it in the `MeasurementTrackerEventProducer` (4e3c70edf7e6496faa320850ebc556a1a4007522).
After that is no longer necessary to run the SiStrip unpacker `siStripDigis` in the RAW2DIGI step, therefore that's excluded from execution profiting of the process modifier (e6f3888992a7c17621d530a6c247053323b97488).
In addition since the `DetIdedmEDCollection` with the list of Strip FED errors is supposed to come from the HLT in production, the name of the collection should match the one in the [Online HLT Heavy Ion menu](https://github.com/cms-sw/cmssw/blob/f04980c79911900153373b23c402f042276160ee/HLTrigger/Configuration/test/OnLine_HLT_HIon.py#L6129) in order to consume the right collection (as it was done before for `SiStripClusters2ApproxClustersHLT` -> `hltSiStripClusters2ApproxClusters` in https://github.com/cms-sw/cmssw/pull/39863).
This is done in commit 6e38bd933cf0c29de1d6461248d1ef463bbf3719.
This final change is purely technical and it's not expected to generate further regressions.
#### PR validation:

Run successfully `runTheMatrix.py -l 140.58 -t 4 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/42475 and https://github.com/cms-sw/cmssw/pull/42480 to CMSSW_13_2_X for the 2023 HI data-taking.
