### PR TITLE
Configure SectorProcessShower objects only once in L1TMuonEndCapShowerProducer

### DIFF
--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapShowerProducer.h
@@ -33,7 +33,6 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  const edm::ParameterSet& config_;
   edm::EDGetToken tokenCSCShower_;
   emtf::sector_array<SectorProcessorShower> sector_processors_shower_;
 };

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -1,9 +1,7 @@
 #include "L1TMuonEndCapTrackProducer.h"
 
 L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const edm::ParameterSet& iConfig)
-    : track_finder_(new TrackFinder(iConfig, consumesCollector())),
-      uGMT_converter_(new MicroGMTConverter()),
-      config_(iConfig) {
+    : track_finder_(new TrackFinder(iConfig, consumesCollector())), uGMT_converter_(new MicroGMTConverter()) {
   // Make output products
   produces<EMTFHitCollection>("");                      // All CSC LCTs and RPC clusters received by EMTF
   produces<EMTFTrackCollection>("");                    // All output EMTF tracks, in same format as unpacked data

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
@@ -36,8 +36,6 @@ private:
 private:
   std::unique_ptr<TrackFinder> track_finder_;
   std::unique_ptr<MicroGMTConverter> uGMT_converter_;
-
-  const edm::ParameterSet& config_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR makes the `L1TMuonEndCapShowerProducer` to configure `SectorProcessShower` objects only once rather than on each event in order to avoid storing the `edm::ParameterSet` from the constructor. This PR also removes an unnecessary reference to `edm::ParameterSet` from `L1TMuonEndCapTrackProducer`. These changes are needed for https://github.com/cms-sw/cmssw/pull/42503.

Resolves https://github.com/makortel/framework/issues/620

#### PR validation:

Code compiles.