### PR TITLE
Moved creating SiPixelTemplateStore from DB to an ESProducer

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -391,6 +391,10 @@ def getSequence(process, collection,
         modules.append(getattr(process, src))
 
     moduleSum = process.offlineBeamSpot        # first element of the sequence
+    tasks = []
+    if usePixelQualityFlag:
+        process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
+        tasks =[process.SiPixelTemplateStoreESProducer]
     if g4Refitting:
         # g4Refitter needs measurements
         moduleSum += getattr(process,"MeasurementTrackerEvent")
@@ -421,6 +425,8 @@ def getSequence(process, collection,
 
         moduleSum += module # append the other modules
 
+    if tasks:
+        return cms.Sequence(moduleSum, cms.Task(*tasks))
     return cms.Sequence(moduleSum)
 
 ###############################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -289,16 +289,19 @@ process.TFileService = cms.Service("TFileService",
                                    )
 
 
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 if (triggerFilter == "nothing" or triggerFilter == ""):
     process.p = cms.Path(process.offlineBeamSpot                        + 
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
-                         process.jetHTAnalyzer)
+                         process.jetHTAnalyzer,
+                         cms.Task(process.SiPixelTemplateStoreESProducer))
 else:
     process.p = cms.Path(process.HLTFilter                              +
                          process.offlineBeamSpot                        + 
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
-                         process.jetHTAnalyzer)
+                         process.jetHTAnalyzer,
+                         cms.Task(process.SiPixelTemplateStoreESProducer))
 
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -196,10 +196,13 @@ process.TFileService = cms.Service("TFileService",
                                    )
 print("Saving the output at %s" % process.TFileService.fileName.value())
 
+
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.theValidSequence = cms.Sequence(process.offlineBeamSpot                        +
                                         process.TrackRefitter                          +
                                         process.offlinePrimaryVerticesFromRefittedTrks +
-                                        process.PrimaryVertexResolution)
+                                        process.PrimaryVertexResolution,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
 
 HLTSel = config["validation"].get("HLTselection", False)
 

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -228,10 +228,12 @@ process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 ####################################################################
 # Sequence
 ####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                         # in case NavigatioSchool is set !=''
                                         #process.MeasurementTrackerEvent*
-                                        process.TrackRefitter)
+                                        process.TrackRefitter,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
 
 ####################################################################
 # Re-do vertices

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -150,8 +150,10 @@ process.TFileService = cms.Service("TFileService",
 ####################################################################
 # Path
 ####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.p = cms.Path(process.MeasurementTrackerEvent*
                      process.offlineBeamSpot*
                      process.AlignmentTrackSelector*
                      process.TrackRefitter*
-                     process.energyOverMomentumTree)
+                     process.energyOverMomentumTree,
+                     cms.Task(process.SiPixelTemplateStoreESProducer))

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngleMCS_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngleMCS_cff.py
@@ -26,6 +26,7 @@ from RecoTracker.IterativeTracking.InitialStep_cff import *
 from RecoTracker.Configuration.RecoTrackerP5_cff import *
 from RecoTracker.TrackProducer.TrackRefitter_cfi import *
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 ALCARECOPixelLACalibrationTracksRefitMCS = TrackRefitter.clone(src = "ALCARECOPixelLACalibrationTracksMCS",
                                                                TrajectoryInEvent = True,
@@ -65,5 +66,6 @@ seqALCARECOPromptCalibProdSiPixelLorentzAngleMCS = cms.Sequence(
     ALCARECOCalCosmicsFilterForSiPixelLorentzAngleMCS *
     ALCARECOPixelLATrackFilterRefitMCS *
     ALCARECOSiPixelLACalibMCS *
-    MEtoEDMConvertSiPixelLorentzAngleMCS 
+    MEtoEDMConvertSiPixelLorentzAngleMCS,
+    cms.Task(SiPixelTemplateStoreESProducer)
    )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
@@ -62,9 +62,11 @@ MEtoEDMConvertSiPixelLorentzAngle = cms.EDProducer("MEtoEDMConverter",
                                                    )
 
 # The actual sequence
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 seqALCARECOPromptCalibProdSiPixelLorentzAngle = cms.Sequence(
     ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle *
     ALCARECOPixelLATrackFilterRefit *
     ALCARECOSiPixelLACalib *
-    MEtoEDMConvertSiPixelLorentzAngle                                             
+    MEtoEDMConvertSiPixelLorentzAngle,
+    cms.Task(SiPixelTemplateStoreESProducer)
    )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
@@ -63,10 +63,12 @@ ALCARECOCalibrationTracksRefitAAG = TrackRefitter.clone(src = cms.InputTag("ALCA
                                                      )
 
 # refit and BS can be dropped if done together with RECO.
-# track filter can be moved in acalreco if no otehr users
+# track filter can be moved in acalreco if no other users
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOTrackFilterRefitAAG = cms.Sequence(ALCARECOCalibrationTracksAAG +
                                            offlineBeamSpot +
-                                           ALCARECOCalibrationTracksRefitAAG )
+                                           ALCARECOCalibrationTracksRefitAAG,
+                                           cms.Task(SiPixelTemplateStoreESProducer) )
 
 # ------------------------------------------------------------------------------
 # This is the module actually doing the calibration

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -76,8 +76,10 @@ closebyPixelClusters = NearbyPixelClusters.NearbyPixelClustersProducer.clone(clu
 ##################################################################
 # Sequence: track refit + close-by-pixel producer
 ##################################################################
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOSiPixelCalSingleMuonTightOffTrackClusters = cms.Sequence(ALCARECOSiPixelCalSingleMuonTightTracksRefit +
-                                                                 closebyPixelClusters)
+                                                                 closebyPixelClusters ,
+                                                                 cms.Task(SiPixelTemplateStoreESProducer))
 
 ##################################################################
 # Producer of distances value map

--- a/CondFormats/SiPixelTransient/src/T_EventSetup_SiPixelTemplateStore.cc
+++ b/CondFormats/SiPixelTransient/src/T_EventSetup_SiPixelTemplateStore.cc
@@ -1,0 +1,19 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/SiPixelTransient
+// Class  :     T_EventSetup_SiPixelTemplateStore
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 08 Aug 2023 15:33:48 GMT
+//
+
+// system include files
+
+// user include files
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(std::vector<SiPixelTemplateStore>);

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -14,6 +14,7 @@ from DQM.SiPixelPhase1Track.SiPixelPhase1TrackResiduals_cfi import *
 from DQM.SiPixelPhase1Track.SiPixelPhase1ResidualsExtra_cfi import *
 # Clusters ontrack/offtrack (also general tracks)
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 # Hit Efficiencies
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackEfficiency_cfi import *
 # FED/RAW Data
@@ -22,7 +23,6 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
 from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 #Barycenter plots
 from DQM.SiPixelPhase1Summary.SiPixelBarycenter_cfi import *
-
 
 
 from RecoTracker.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
@@ -39,7 +39,8 @@ siPixelPhase1OfflineDQM_source = cms.Sequence(SiPixelPhase1RawDataAnalyzer
                                             + SiPixelPhase1RecHitsAnalyzer
                                             + SiPixelPhase1TrackResidualsAnalyzer
                                             + SiPixelPhase1TrackClustersAnalyzer
-                                            + SiPixelPhase1TrackEfficiencyAnalyzer
+                                            + SiPixelPhase1TrackEfficiencyAnalyzer,
+                                            cms.Task(SiPixelTemplateStoreESProducer)  
                                             )
 
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -97,11 +97,11 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1Digis_cfi import *
 
 # Cluster (track-independent) monitoring
 from DQM.SiPixelPhase1Common.SiPixelPhase1Clusters_cfi import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 # Track cluster 
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackResiduals_cfi import *
-
 
 # Raw data errors
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
@@ -115,7 +115,8 @@ siPixelPhase1OnlineDQM_source = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer
- + SiPixelPhase1TrackResidualsAnalyzer
+ + SiPixelPhase1TrackResidualsAnalyzer,
+ cms.Task(SiPixelTemplateStoreESProducer)   
 )
 
 siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
@@ -149,7 +150,8 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_cosmics
- + SiPixelPhase1TrackResidualsAnalyzer_cosmics
+ + SiPixelPhase1TrackResidualsAnalyzer_cosmics,
+ cms.Task(SiPixelTemplateStoreESProducer)
 )
 
 ## Additional settings for pp_run (Phase 0 test)
@@ -177,6 +179,7 @@ siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_pprun
  + SiPixelPhase1TrackResidualsAnalyzer_pprun
- + SiPixelPhase1TrackEfficiencyAnalyzer_pprun
+ + SiPixelPhase1TrackEfficiencyAnalyzer_pprun,
+ cms.Task(SiPixelTemplateStoreESProducer)
 )
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -70,6 +70,8 @@ from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
 # Track cluster                                                                                                                                                                            
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
+
 SiPixelPhase1TrackClustersOnTrackCorrCharge.enabled=cms.bool(False)
 SiPixelPhase1TrackTemplateCorr.enabled=cms.bool(False)
 SiPixelPhase1TrackClustersOnTrackCorrChargeOuter.enabled=cms.bool(False)
@@ -86,6 +88,7 @@ siPixelPhase1OnlineDQM_source = cms.Sequence(
  + SiPixelPhase1TrackClustersAnalyzer
  + SiPixelPhase1TrackResidualsAnalyzer
 # + SiPixelPhase1GeometryDebugAnalyzer
+ , cms.Task(SiPixelTemplateStoreESProducer)
 )
 
 siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
@@ -119,7 +122,8 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_cosmics
- + SiPixelPhase1TrackResidualsAnalyzer_cosmics
+ + SiPixelPhase1TrackResidualsAnalyzer_cosmics,
+ cms.Task(SiPixelTemplateStoreESProducer)
 )
 
 ## Additional settings for pp_run                                                                                                                                         
@@ -142,7 +146,8 @@ siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_pprun
- + SiPixelPhase1TrackResidualsAnalyzer_pprun
+ + SiPixelPhase1TrackResidualsAnalyzer_pprun,
+ cms.Task(SiPixelTemplateStoreESProducer)
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -4,6 +4,7 @@ from DQMOffline.Trigger.SiPixel_OfflineMonitoring_Cluster_cff import *
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_TrackCluster_cff import *
 from RecoTracker.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
 from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
@@ -12,5 +13,6 @@ sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer
     + hltrefittedForPixelDQM
-    + hltSiPixelPhase1TrackClustersAnalyzer
+    + hltSiPixelPhase1TrackClustersAnalyzer,
+    cms.Task(SiPixelTemplateStoreESProducer)
 )    

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -7,6 +7,7 @@ import FWCore.ParameterSet.Config as cms
 #HLTsiStripClusters.SiStripRefGetter  = cms.InputTag("hltSiStripClusters")
 
 # SiStripCluster monitoring
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
 HLTSiStripMonitorCluster = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone(
     ClusterProducerStrip = "hltSiStripRawToClustersFacility",

--- a/FastSimulation/Configuration/python/Reconstruction_BefMix_cff.py
+++ b/FastSimulation/Configuration/python/Reconstruction_BefMix_cff.py
@@ -41,6 +41,7 @@ from RecoTracker.TkNavigation.NavigationSchoolESProducer_cfi import navigationSc
 
 from FastSimulation.Tracking.iterativeTk_cff import *
 from TrackingTools.TrackFitters.TrackFitters_cff import *
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 reconstruction_befmix = cms.Sequence(
     offlineBeamSpot
@@ -48,5 +49,6 @@ reconstruction_befmix = cms.Sequence(
     * fastMatchedTrackerRecHits
     * fastMatchedTrackerRecHitCombinations
     * MeasurementTrackerEvent
-    * iterTracking
+    * iterTracking,
+    cms.Task(SiPixelTemplateStoreESProducer)
     )

--- a/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/PixelTemplateSmearerBase.h
@@ -49,9 +49,9 @@ protected:
   bool mergeHitsOn = false;  // if true then see if neighboring hits might merge
 
   //--- Template DB Object(s)
-  const SiPixelTemplateDBObject* pixelTemplateDBObject_ = nullptr;     // needed for template<-->DetId map.
-  std::vector<SiPixelTemplateStore> thePixelTemp_;                     // our own template storage
-  std::vector<SiPixelTemplateStore>& thePixelTempRef = thePixelTemp_;  // points to the one we will use.
+  const SiPixelTemplateDBObject* pixelTemplateDBObject_ = nullptr;            // needed for template<-->DetId map.
+  std::vector<SiPixelTemplateStore> thePixelTemp_;                            // our own template storage
+  const std::vector<SiPixelTemplateStore>* thePixelTempRef = &thePixelTemp_;  // points to the one we will use.
   int templateId = -1;
 
   //--- Flag to tell us whether we are in barrel or in forward.
@@ -92,7 +92,7 @@ public:
   void beginRun(edm::Run const& run,
                 const edm::EventSetup& eventSetup,
                 const SiPixelTemplateDBObject* pixelTemplateDBObjectPtr,
-                std::vector<SiPixelTemplateStore>& tempStoreRef) override;
+                const std::vector<SiPixelTemplateStore>& tempStoreRef) override;
   // void endEvent(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   //--- Process all unmerged hits. Calls smearHit() for each.

--- a/FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitAlgorithm.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/TrackingRecHitAlgorithm.h
@@ -51,7 +51,7 @@ public:
   virtual void beginRun(edm::Run const& run,
                         const edm::EventSetup& eventSetup,
                         const SiPixelTemplateDBObject* pixelTemplateDBObjectPtr,
-                        std::vector<SiPixelTemplateStore>& tempStoreRef);
+                        const std::vector<SiPixelTemplateStore>& tempStoreRef);
 
   //this function will only be called once per event
   virtual void beginEvent(edm::Event& event, const edm::EventSetup& eventSetup);

--- a/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
@@ -136,14 +136,14 @@ PixelTemplateSmearerBase::~PixelTemplateSmearerBase() {}
 void PixelTemplateSmearerBase::beginRun(edm::Run const& run,
                                         const edm::EventSetup& eventSetup,
                                         const SiPixelTemplateDBObject* pixelTemplateDBObjectPtr,
-                                        std::vector<SiPixelTemplateStore>& tempStoreRef) {
+                                        const std::vector<SiPixelTemplateStore>& tempStoreRef) {
   //--- Check if we need to use the template from the DB (namely if
   //    id == -1).  Otherwise the template has already been loaded from
   //    the ascii file in constructor, and thePixelTempRef wakes up
   //    pointing to thePixelTemp_, so then we use our own store.
   //
   if (templateId == -1) {
-    thePixelTempRef = tempStoreRef;                     // we use the store from TrackingRecHitProducer
+    thePixelTempRef = &tempStoreRef;                    // we use the store from TrackingRecHitProducer
     pixelTemplateDBObject_ = pixelTemplateDBObjectPtr;  // needed for template<-->DetId map.
   }
 
@@ -392,7 +392,7 @@ FastSingleTrackerRecHit PixelTemplateSmearerBase::smearHit(const PSimHit& simHit
   }
 
   //--- Make the template object
-  SiPixelTemplate templ(thePixelTempRef);
+  SiPixelTemplate templ(*thePixelTempRef);
 
   //--- Produce the template that corresponds to our local angles.
   templ.interpolate(ID, cotalpha, cotbeta);
@@ -778,7 +778,7 @@ FastSingleTrackerRecHit PixelTemplateSmearerBase::smearMergeGroup(MergeGroup* mg
   }
 
   //--- Make the template object
-  SiPixelTemplate templ(thePixelTempRef);
+  SiPixelTemplate templ(*thePixelTempRef);
 
   //--- Produce the template that corresponds to our local angles.
   templ.interpolate(ID, cotalpha, cotbeta);

--- a/FastSimulation/TrackingRecHitProducer/src/TrackingRecHitAlgorithm.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackingRecHitAlgorithm.cc
@@ -66,7 +66,7 @@ void TrackingRecHitAlgorithm::beginStream(const edm::StreamID& id) {
 void TrackingRecHitAlgorithm::beginRun(edm::Run const& run,
                                        const edm::EventSetup& eventSetup,
                                        const SiPixelTemplateDBObject* pixelTemplateDBObjectPtr,
-                                       std::vector<SiPixelTemplateStore>& tempStoreRef) {
+                                       const std::vector<SiPixelTemplateStore>& tempStoreRef) {
   // The default is to do nothing.
 }
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -268,6 +268,13 @@ def customizeHLTfor42410(process):
 
     return process
 
+def customizeHLTfor42514(process):
+    for p in esproducers_by_type(process, 'SiPixelTemplateDBObjectESProducer'):
+        process.load('RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi')
+        break
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -281,5 +288,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customizeHLTfor41815(process)
     process = customizeHLTfor41632(process)
     process = customizeHLTfor42410(process)
+    process = customizeHLTfor42514(process)
 
     return process

--- a/RecoHI/HiTracking/python/HighPtTracking_PbPb_cff.py
+++ b/RecoHI/HiTracking/python/HighPtTracking_PbPb_cff.py
@@ -4,6 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import * #also includes global tracking geometry
 from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff import * #cluster parameter estimator producer
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 from RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi import *
 
 ### pixel primary vertices
@@ -31,4 +32,5 @@ hiBasicTrackingTask = cms.Task(hiPixelVerticesTask
                                 , hiPrimTrackCandidates
                                 , hiGlobalPrimTracks
                                 , hiTracksWithQualityTask
+                                , SiPixelTemplateStoreESProducer
                                 )

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEClusterRepair.h
@@ -56,6 +56,7 @@ public:
                         const TrackerGeometry &,
                         const TrackerTopology &,
                         const SiPixelLorentzAngle *,
+                        const std::vector<SiPixelTemplateStore> *,
                         const SiPixelTemplateDBObject *,
                         const SiPixel2DTemplateDBObject *);
 
@@ -97,7 +98,8 @@ private:
   void fill2DTemplIDs();
 
   // Template storage
-  std::vector<SiPixelTemplateStore> thePixelTemp_;
+  std::vector<SiPixelTemplateStore> const *thePixelTemp_;
+  std::vector<SiPixelTemplateStore> thePixelTempCache_;
   std::vector<SiPixelTemplateStore2D> thePixelTemp2D_;
 
   int speed_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -56,6 +56,7 @@ public:
                        const TrackerGeometry &,
                        const TrackerTopology &,
                        const SiPixelLorentzAngle *,
+                       const std::vector<SiPixelTemplateStore> *,
                        const SiPixelTemplateDBObject *);
 
   ~PixelCPETemplateReco() override;
@@ -74,7 +75,8 @@ private:
   LocalError localError(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
 
   // Template storage
-  std::vector<SiPixelTemplateStore> thePixelTemp_;
+  std::vector<SiPixelTemplateStore> thePixelTempCache_;
+  const std::vector<SiPixelTemplateStore> *thePixelTemp_;
 
   int speed_;
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="RecoLocalTracker/Records"/>
 <use name="RecoLocalTracker/SiPixelRecHits"/>
 <use name="DataFormats/TrackerCommon"/>
+<use name="CondFormats/SiPixelTransient"/>
 <iftool name="cuda-gcc-support">
   <use name="cuda"/>
   <set name="cuda_src" value="*.cu"/>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -30,6 +30,7 @@ private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> hTTToken_;
   edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleRcd> lorentzAngleToken_;
+  edm::ESGetToken<std::vector<SiPixelTemplateStore>, SiPixelTemplateDBObjectESProducerRcd> templateStoreToken_;
   edm::ESGetToken<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd> templateDBobjectToken_;
   edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectESProducerRcd> templateDBobject2DToken_;
 
@@ -51,6 +52,7 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
   magfieldToken_ = c.consumes();
   pDDToken_ = c.consumes();
   hTTToken_ = c.consumes();
+  templateStoreToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
   templateDBobject2DToken_ = c.consumes();
   if (useLAFromDB_ || doLorentzFromAlignment_) {
@@ -91,6 +93,7 @@ std::unique_ptr<PixelClusterParameterEstimator> PixelCPEClusterRepairESProducer:
                                                  iRecord.get(pDDToken_),
                                                  iRecord.get(hTTToken_),
                                                  lorentzAngleProduct,
+                                                 &iRecord.get(templateStoreToken_),
                                                  &iRecord.get(templateDBobjectToken_),
                                                  &iRecord.get(templateDBobject2DToken_));
 }

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -28,6 +28,7 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> hTTToken_;
   edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleRcd> lorentzAngleToken_;
   edm::ESGetToken<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd> templateDBobjectToken_;
+  edm::ESGetToken<std::vector<SiPixelTemplateStore>, SiPixelTemplateDBObjectESProducerRcd> templateStoreToken_;
 
   edm::ParameterSet pset_;
   bool doLorentzFromAlignment_;
@@ -48,6 +49,7 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
   pDDToken_ = c.consumes();
   hTTToken_ = c.consumes();
   templateDBobjectToken_ = c.consumes();
+  templateStoreToken_ = c.consumes();
   if (useLAFromDB_ || doLorentzFromAlignment_) {
     char const* laLabel = doLorentzFromAlignment_ ? "fromAlignment" : "";
     lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
@@ -69,6 +71,7 @@ std::unique_ptr<PixelClusterParameterEstimator> PixelCPETemplateRecoESProducer::
                                                 iRecord.get(pDDToken_),
                                                 iRecord.get(hTTToken_),
                                                 lorentzAngleProduct,
+                                                &iRecord.get(templateStoreToken_),
                                                 &iRecord.get(templateDBobjectToken_));
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelTemplateStoreESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelTemplateStoreESProducer.cc
@@ -1,0 +1,80 @@
+// -*- C++ -*-
+//
+// Package:     RecoLocalTracker/SiPixelRecHits
+// Class  :     SiPixelTemplateStoreESProducer
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 08 Aug 2023 14:21:50 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+
+#include "CalibTracker/Records/interface/SiPixelTemplateDBObjectESProducerRcd.h"
+
+class SiPixelTemplateStoreESProducer : public edm::ESProducer {
+public:
+  SiPixelTemplateStoreESProducer(edm::ParameterSet const&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  std::unique_ptr<std::vector<SiPixelTemplateStore>> produce(const SiPixelTemplateDBObjectESProducerRcd&);
+
+private:
+  edm::ESGetToken<SiPixelTemplateDBObject, SiPixelTemplateDBObjectESProducerRcd> token_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+SiPixelTemplateStoreESProducer::SiPixelTemplateStoreESProducer(edm::ParameterSet const& iPSet) {
+  token_ = setWhatProduced(this).consumes();
+}
+
+//
+// member functions
+//
+std::unique_ptr<std::vector<SiPixelTemplateStore>> SiPixelTemplateStoreESProducer::produce(
+    const SiPixelTemplateDBObjectESProducerRcd& iRecord) {
+  auto returnValue = std::make_unique<std::vector<SiPixelTemplateStore>>();
+
+  if (not SiPixelTemplate::pushfile(iRecord.get(token_), *returnValue)) {
+    throw cms::Exception("SiPixelTemplateDBObjectFailure")
+        << "Templates not filled correctly. Check the DB. Using SiPixelTemplateDBObject version "
+        << iRecord.get(token_).version();
+  }
+
+  return returnValue;
+}
+
+//
+// const member functions
+//
+
+//
+// static member functions
+//
+void SiPixelTemplateStoreESProducer::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+  edm::ParameterSetDescription iPSet;
+  iDesc.addDefault(iPSet);
+  iDesc.add("SiPixelTemplateStoreESProducer", iPSet);
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(SiPixelTemplateStoreESProducer);
+;

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTracker.FinalTrackSelectors.DuplicateTrackMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.DuplicateListMerger_cfi import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 
 from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import Chi2MeasurementEstimator as _Chi2MeasurementEstimator
 duplicateTrackCandidatesChi2Est = _Chi2MeasurementEstimator.clone(
@@ -48,7 +49,8 @@ generalTracksTask = cms.Task(
     duplicateTrackCandidates,
     mergedDuplicateTracks,
     duplicateTrackClassifier,
-    generalTracks
+    generalTracks,
+    SiPixelTemplateStoreESProducer
     )
 generalTracksSequence = cms.Sequence(generalTracksTask)
 

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -52,5 +52,6 @@ cosmicDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWith
 )
 
 # Final Sequence
-cosmicDCTracksSeqTask = cms.Task( cosmicDCSeeds , cosmicDCCkfTrackCandidates , cosmicDCTracks )
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
+cosmicDCTracksSeqTask = cms.Task( cosmicDCSeeds , cosmicDCCkfTrackCandidates , cosmicDCTracks , SiPixelTemplateStoreESProducer )
 cosmicDCTracksSeq = cms.Sequence(cosmicDCTracksSeqTask)

--- a/RecoTracker/TrackProducer/test/refitFromAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromAOD.py
@@ -75,8 +75,11 @@ process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefi
     Fitter = 'FlexibleKFFittingSmoother'
 )
 
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
+
 # Path and EndPath definitions
-process.reconstruction_step = cms.Path(process.trackExtraRekeyer*process.myRefittedTracks)
+process.reconstruction_step = cms.Path(process.trackExtraRekeyer*process.myRefittedTracks, 
+    cms.Task(process.TTRHBuilderAngleAndTemplate, process.templates, process.SiPixelTemplateStoreESProducer))
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
 

--- a/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
+++ b/RecoTracker/TrackProducer/test/refitFromMINIAOD.py
@@ -75,7 +75,8 @@ process.myRefittedTracks = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefi
 )
                                          
 # Path and EndPath definitions
-process.reconstruction_step = cms.Path(process.tracksFromMuons*process.myRefittedTracks)
+process.reconstruction_step = cms.Path(process.tracksFromMuons*process.myRefittedTracks, 
+    cms.Task(process.TTRHBuilderAngleAndTemplate, process.templates, process.SiPixelTemplateStoreESProducer))
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.RECOSIMoutput_step = cms.EndPath(process.RECOSIMoutput)
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilders_cff.py
@@ -14,3 +14,4 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPEClusterRepair_cfi import *
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *
 from RecoTracker.TransientTrackingRecHit.TTRHBuilderWithTemplate_cfi import *
 
+from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *


### PR DESCRIPTION
#### PR description:

All DB construction was switched to using EventSetup. Cases using reading from files were kept local to module.
The new ESProducer was added as a Task to all needed Sequences.

#### PR validation:

Code compiles. All changed python files are readable by python3. No cmsRun jobs were run.