### PR TITLE
restrict PCA z-component axis in the tracks matched to PV (dz<0.1)

### DIFF
--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -315,7 +315,11 @@ TrackMon = DQMEDAnalyzer('TrackingMonitor',
     VZBin = cms.int32(100),
     VZMax = cms.double(30.0),                        
     VZMin = cms.double(-30.0),
-    
+
+    # PCA z position (to PV)
+    VZ_PVMax = cms.double(30.0),
+    VZ_PVMin = cms.double(-30.0),
+
     # PCA z position for profile
     VZBinProf = cms.int32(100),
     VZMaxProf = cms.double(0.2),                        

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -362,6 +362,9 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker& ibooker) {
   double VZMin = conf_->getParameter<double>("VZMin");
   double VZMax = conf_->getParameter<double>("VZMax");
 
+  double VZ_PVMin = conf_->getParameter<double>("VZ_PVMin");
+  double VZ_PVMax = conf_->getParameter<double>("VZ_PVMax");
+
   ibooker.setCurrentFolder(TopFolder_);
 
   // book the Hit Property histograms
@@ -682,7 +685,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker& ibooker) {
 
       histname = "zPointOfClosestApproachToPV_";
       zPointOfClosestApproachToPV =
-          ibooker.book1D(histname + CategoryName, histname + CategoryName, VZBin, VZMin, VZMax);
+          ibooker.book1D(histname + CategoryName, histname + CategoryName, VZBin, VZ_PVMin, VZ_PVMax);
       zPointOfClosestApproachToPV->setAxisTitle("z component of Track PCA to pv line (cm)", 1);
       zPointOfClosestApproachToPV->setAxisTitle("Number of Tracks", 2);
     }

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -303,8 +303,8 @@ vertexfolderName['highPurityPV0p1'] = 'Tracking/PrimaryVertices/highPurityTracks
 trackPtN        ['highPurityPV0p1'] = cms.int32(100)
 trackPtMin      ['highPurityPV0p1'] = cms.double(0.)
 trackPtMax      ['highPurityPV0p1'] = cms.double(100.)
-pcaZtoPVMax     ['highPurityPV0p1'] = cms.double(0.2)
-pcaZtoPVMin     ['highPurityPV0p1'] = cms.double(-0.2)
+pcaZtoPVMax     ['highPurityPV0p1'] = cms.double(0.15)
+pcaZtoPVMin     ['highPurityPV0p1'] = cms.double(-0.15)
 doPlotsPCA      ['highPurityPV0p1'] = cms.bool(True)
 numCutString    ['highPurityPV0p1'] = cms.string("quality('highPurity')") # num := den + quality('highPurity')
 denCutString    ['highPurityPV0p1'] = cms.string("") # den := kinematic cuts

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -7,6 +7,8 @@ sequenceName = {}
 trackPtN   = {}
 trackPtMin = {}
 trackPtMax = {}
+pcaZtoPVMax = {}
+pcaZtoPVMin = {}
 doPlotsPCA = {}
 numCutString = {}
 denCutString = {}
@@ -37,6 +39,8 @@ vertexfolderName['generalTracks'] = 'Tracking/PrimaryVertices/generalTracks'
 trackPtN        ['generalTracks'] = cms.int32(100)
 trackPtMin      ['generalTracks'] = cms.double(0.)
 trackPtMax      ['generalTracks'] = cms.double(100.)
+pcaZtoPVMax     ['generalTracks'] = cms.double(30.)
+pcaZtoPVMin     ['generalTracks'] = cms.double(-30.)
 doPlotsPCA      ['generalTracks'] = cms.bool(False)
 numCutString    ['generalTracks'] = cms.string("quality('highPurity')") # num := den + quality('highPurity')
 denCutString    ['generalTracks'] = cms.string("") # den := kinematics cuts
@@ -76,6 +80,8 @@ vertexfolderName['highPurityPtRange0to1'] = 'Tracking/PrimaryVertices/highPurity
 trackPtN        ['highPurityPtRange0to1'] = cms.int32(10)
 trackPtMin      ['highPurityPtRange0to1'] = cms.double(0.)
 trackPtMax      ['highPurityPtRange0to1'] = cms.double(1.)
+pcaZtoPVMax     ['highPurityPtRange0to1'] = cms.double(30.)
+pcaZtoPVMin     ['highPurityPtRange0to1'] = cms.double(-30.)
 numCutString    ['highPurityPtRange0to1'] = cms.string(" pt >= 0 & pt < 1 & quality('highPurity')") # num := den + quality('highPurity') [it is the same as the main selection, but just to be sure ...]
 denCutString    ['highPurityPtRange0to1'] = cms.string(" pt >= 0 & pt < 1 ") # den := kinematics cut
 doPlotsPCA      ['highPurityPtRange0to1'] = cms.bool(False)
@@ -109,6 +115,8 @@ vertexfolderName['highPurityPtRange1to10'] = 'Tracking/PrimaryVertices/highPurit
 trackPtN        ['highPurityPtRange1to10'] = cms.int32(10)
 trackPtMin      ['highPurityPtRange1to10'] = cms.double(1.)
 trackPtMax      ['highPurityPtRange1to10'] = cms.double(10.)
+pcaZtoPVMax     ['highPurityPtRange1to10'] = cms.double(30.)
+pcaZtoPVMin     ['highPurityPtRange1to10'] = cms.double(-30.)
 numCutString    ['highPurityPtRange1to10'] = cms.string(" pt >= 1 & pt < 10 & quality('highPurity')") # num := den + quality('highPurity') [it is the same as the main selection, but just to be sure ...]
 denCutString    ['highPurityPtRange1to10'] = cms.string(" pt >= 1 & pt < 10 ") # den := kinematics cuts
 doGoodTracksPlots                   ['highPurityPtRange1to10'] = cms.bool(True)
@@ -141,6 +149,8 @@ vertexfolderName['highPurityPt10'] = 'Tracking/PrimaryVertices/highPurityTracks/
 trackPtN        ['highPurityPt10'] = cms.int32(100)
 trackPtMin      ['highPurityPt10'] = cms.double(10.)
 trackPtMax      ['highPurityPt10'] = cms.double(110.)
+pcaZtoPVMax     ['highPurityPt10'] = cms.double(30.)
+pcaZtoPVMin     ['highPurityPt10'] = cms.double(-30.)
 numCutString    ['highPurityPt10'] = cms.string(" pt >= 10 & quality('highPurity')") # num := den + quality('highPurity') [it is the same as the main selection, but just to be sure ...]
 denCutString    ['highPurityPt10'] = cms.string(" pt >= 10 ") # den := kinematics cuts
 doGoodTracksPlots                   ['highPurityPt10'] = cms.bool(True)
@@ -174,6 +184,8 @@ vertexfolderName['highPurityPt1'] = 'Tracking/PrimaryVertices/highPurityTracks/p
 trackPtN        ['highPurityPt1'] = cms.int32(100)
 trackPtMin      ['highPurityPt1'] = cms.double(0.)
 trackPtMax      ['highPurityPt1'] = cms.double(100.)
+pcaZtoPVMax     ['highPurityPt1'] = cms.double(30.)
+pcaZtoPVMin     ['highPurityPt1'] = cms.double(-30.)
 doPlotsPCA      ['highPurityPt1'] = cms.bool(True)
 numCutString    ['highPurityPt1'] = cms.string(" pt >= 1 & quality('highPurity')") # num := den + quality('highPurity') [it is the same as the main selection, but just to be sure ...]
 denCutString    ['highPurityPt1'] = cms.string(" pt >= 1 ") # den := kinematics cut
@@ -208,6 +220,8 @@ vertexfolderName['highPurityPt1Eta2p5to3p0'] = 'Tracking/PrimaryVertices/highPur
 trackPtN        ['highPurityPt1Eta2p5to3p0'] = cms.int32(100)
 trackPtMin	['highPurityPt1Eta2p5to3p0'] = cms.double(0.)
 trackPtMax	['highPurityPt1Eta2p5to3p0'] = cms.double(100.)
+pcaZtoPVMax     ['highPurityPt1Eta2p5to3p0'] = cms.double(30.)
+pcaZtoPVMin     ['highPurityPt1Eta2p5to3p0'] = cms.double(-30.)
 doPlotsPCA	['highPurityPt1Eta2p5to3p0'] = cms.bool(True)
 numCutString    ['highPurityPt1Eta2p5to3p0'] = cms.string(" pt >= 1 & abs(eta) > 2.5 & quality('highPurity')") # num := den + quality('highPurity') [it is the same as the main selection, but just to be sure ...]
 denCutString    ['highPurityPt1Eta2p5to3p0'] = cms.string(" pt >= 1 & abs(eta) > 2.5") # den := kinematics cut
@@ -289,6 +303,8 @@ vertexfolderName['highPurityPV0p1'] = 'Tracking/PrimaryVertices/highPurityTracks
 trackPtN        ['highPurityPV0p1'] = cms.int32(100)
 trackPtMin      ['highPurityPV0p1'] = cms.double(0.)
 trackPtMax      ['highPurityPV0p1'] = cms.double(100.)
+pcaZtoPVMax     ['highPurityPV0p1'] = cms.double(0.2)
+pcaZtoPVMin     ['highPurityPV0p1'] = cms.double(-0.2)
 doPlotsPCA      ['highPurityPV0p1'] = cms.bool(True)
 numCutString    ['highPurityPV0p1'] = cms.string("quality('highPurity')") # num := den + quality('highPurity')
 denCutString    ['highPurityPV0p1'] = cms.string("") # den := kinematic cuts
@@ -324,6 +340,8 @@ vertexfolderName['hiConformalPixelTracksQA'] = 'Tracking/PrimaryVertices/hiConfo
 trackPtN        ['hiConformalPixelTracksQA'] = cms.int32(100)
 trackPtMin      ['hiConformalPixelTracksQA'] = cms.double(0.)
 trackPtMax      ['hiConformalPixelTracksQA'] = cms.double(10.)
+pcaZtoPVMax     ['hiConformalPixelTracksQA'] = cms.double(30.)
+pcaZtoPVMin     ['hiConformalPixelTracksQA'] = cms.double(-30.)
 numCutString    ['hiConformalPixelTracksQA'] = cms.string(" pt >= 0 ") 
 denCutString    ['hiConformalPixelTracksQA'] = cms.string(" pt >= 0 ") 
 doPlotsPCA      ['hiConformalPixelTracksQA'] = cms.bool(False)

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -57,6 +57,8 @@ for tracks in selectedTracks :
     locals()[label].TrackPBin        = trackPtN[tracks]
     locals()[label].TrackPMin        = trackPtMin[tracks]
     locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].VZ_PVMax         = pcaZtoPVMax[tracks]
+    locals()[label].VZ_PVMin         = pcaZtoPVMin[tracks]
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
@@ -98,6 +100,8 @@ for tracks in selectedTracks :
     locals()[label].TrackPBin        = trackPtN[tracks]
     locals()[label].TrackPMin        = trackPtMin[tracks]
     locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].VZ_PVMax         = pcaZtoPVMax[tracks]
+    locals()[label].VZ_PVMin         = pcaZtoPVMin[tracks]
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
@@ -138,6 +142,8 @@ for tracks in selectedTracks :
     locals()[label].TrackPBin        = trackPtN[tracks]
     locals()[label].TrackPMin        = trackPtMin[tracks]
     locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].VZ_PVMax         = pcaZtoPVMax[tracks]
+    locals()[label].VZ_PVMin         = pcaZtoPVMin[tracks]
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
@@ -178,6 +184,8 @@ for tracks in selectedTracks :
     locals()[label].TrackPBin        = trackPtN[tracks]
     locals()[label].TrackPMin        = trackPtMin[tracks]
     locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].VZ_PVMax         = pcaZtoPVMax[tracks]
+    locals()[label].VZ_PVMin         = pcaZtoPVMin[tracks]
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
@@ -219,6 +227,8 @@ for tracks in selectedTracks :
     locals()[label].TrackPBin        = trackPtN[tracks]
     locals()[label].TrackPMin        = trackPtMin[tracks]
     locals()[label].TrackPMax        = trackPtMax[tracks]
+    locals()[label].VZ_PVMax         = pcaZtoPVMax[tracks]
+    locals()[label].VZ_PVMin         = pcaZtoPVMin[tracks]
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
@@ -450,4 +460,3 @@ TrackingDQMSourceTier0MinBias += voWcutMonitoringZBHIPOOTSequence
 TrackingDQMSourceTier0MinBias += primaryVertexResolution
 
 TrackingDQMSourceTier0MinBias += dqmInfoTracking
-


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

Run `runTheMatrix.py -l 141.031 -t 4 -j 8 --ibeos`
Obtained the following plot under `Tracking/Run Summary/TrackParameters/highPurityTracks/dzPV0p1/GeneralProperties`:

![Screenshot from 2023-08-09 16-16-29](https://github.com/cms-sw/cmssw/assets/5082376/b07cd260-8dca-41e4-9bc0-5c894eb2f4be)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A