### PR TITLE
Replace reference to ParameterSet with explicit parameter values in HBHEDarkening

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.cc
@@ -8,9 +8,28 @@
 #include <vector>
 #include <map>
 
-HBHEDarkeningEP::HBHEDarkeningEP(const edm::ParameterSet& pset) : pset_(pset) {
+HBHEDarkeningEP::HBHEDarkeningEP(const edm::ParameterSet& pset)
+    : drdA_(pset.getParameter<double>("drdA")),
+      drdB_(pset.getParameter<double>("drdB")),
+      ieta_shift_(pset.getParameter<int>("ieta_shift")) {
   setWhatProduced(this);
   findingRecord<HBHEDarkeningRecord>();
+
+  const std::vector<edm::ParameterSet>& p_dosemaps = pset.getParameter<std::vector<edm::ParameterSet>>("dosemaps");
+  dosemaps_.reserve(p_dosemaps.size());
+  for (const auto& p_dosemap : p_dosemaps) {
+    dosemaps_.push_back({p_dosemap.getParameter<edm::FileInPath>("file"), p_dosemap.getParameter<int>("energy")});
+  }
+
+  //initialize years
+  const std::vector<edm::ParameterSet>& p_years = pset.getParameter<std::vector<edm::ParameterSet>>("years");
+  years_.reserve(p_years.size());
+  for (const auto& p_year : p_years) {
+    years_.emplace_back(p_year.getParameter<std::string>("year"),
+                        p_year.getParameter<double>("intlumi"),
+                        p_year.getParameter<double>("lumirate"),
+                        p_year.getParameter<int>("energy"));
+  }
 }
 
 HBHEDarkeningEP::~HBHEDarkeningEP() {}
@@ -45,30 +64,12 @@ void HBHEDarkeningEP::fillDescriptions(edm::ConfigurationDescriptions& descripti
 // ------------ method called to produce the data  ------------
 HBHEDarkeningEP::ReturnType HBHEDarkeningEP::produce(const HBHEDarkeningRecord& iRecord) {
   //initialize dose maps
-  std::vector<edm::ParameterSet> p_dosemaps = pset_.getParameter<std::vector<edm::ParameterSet>>("dosemaps");
   std::map<int, std::vector<std::vector<float>>> dosemaps;
-  for (const auto& p_dosemap : p_dosemaps) {
-    edm::FileInPath fp = p_dosemap.getParameter<edm::FileInPath>("file");
-    int file_energy = p_dosemap.getParameter<int>("energy");
-    dosemaps.emplace(file_energy, HBHEDarkening::readDoseMap(fp.fullPath()));
+  for (const auto& p_dosemap : dosemaps_) {
+    dosemaps.emplace(p_dosemap.file_energy, HBHEDarkening::readDoseMap(p_dosemap.fp.fullPath()));
   }
 
-  //initialize years
-  std::vector<edm::ParameterSet> p_years = pset_.getParameter<std::vector<edm::ParameterSet>>("years");
-  std::vector<HBHEDarkening::LumiYear> years;
-  years.reserve(p_years.size());
-  for (const auto& p_year : p_years) {
-    years.emplace_back(p_year.getParameter<std::string>("year"),
-                       p_year.getParameter<double>("intlumi"),
-                       p_year.getParameter<double>("lumirate"),
-                       p_year.getParameter<int>("energy"));
-  }
-
-  return std::make_unique<HBHEDarkening>(pset_.getParameter<int>("ieta_shift"),
-                                         pset_.getParameter<double>("drdA"),
-                                         pset_.getParameter<double>("drdB"),
-                                         std::move(dosemaps),
-                                         std::move(years));
+  return std::make_unique<HBHEDarkening>(ieta_shift_, drdA_, drdB_, std::move(dosemaps), years_);
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(HBHEDarkeningEP);

--- a/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.cc
@@ -67,8 +67,8 @@ HBHEDarkeningEP::ReturnType HBHEDarkeningEP::produce(const HBHEDarkeningRecord& 
   return std::make_unique<HBHEDarkening>(pset_.getParameter<int>("ieta_shift"),
                                          pset_.getParameter<double>("drdA"),
                                          pset_.getParameter<double>("drdB"),
-                                         dosemaps,
-                                         years);
+                                         std::move(dosemaps),
+                                         std::move(years));
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(HBHEDarkeningEP);

--- a/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.h
+++ b/CalibCalorimetry/HcalPlugins/src/HBHEDarkeningEP.h
@@ -32,7 +32,15 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  const edm::ParameterSet& pset_;
+  struct Dosemap {
+    edm::FileInPath fp;
+    int file_energy;
+  };
+  std::vector<Dosemap> dosemaps_;
+  std::vector<HBHEDarkening::LumiYear> years_;
+  const double drdA_;
+  const double drdB_;
+  const int ieta_shift_;
 };
 
 #endif

--- a/CondFormats/HcalObjects/interface/HBHEDarkening.h
+++ b/CondFormats/HcalObjects/interface/HBHEDarkening.h
@@ -40,8 +40,8 @@ public:
   HBHEDarkening(int ieta_shift,
                 float drdA,
                 float drdB,
-                const std::map<int, std::vector<std::vector<float>>>& dosemaps,
-                const std::vector<LumiYear>& years);
+                std::map<int, std::vector<std::vector<float>>> dosemaps,
+                std::vector<LumiYear> years);
   ~HBHEDarkening() {}
 
   //public accessors

--- a/CondFormats/HcalObjects/src/HBHEDarkening.cc
+++ b/CondFormats/HcalObjects/src/HBHEDarkening.cc
@@ -16,9 +16,9 @@
 HBHEDarkening::HBHEDarkening(int ieta_shift,
                              float drdA,
                              float drdB,
-                             const std::map<int, std::vector<std::vector<float>>>& dosemaps,
-                             const std::vector<LumiYear>& years)
-    : ieta_shift_(ieta_shift), drdA_(drdA), drdB_(drdB), dosemaps_(dosemaps), years_(years) {
+                             std::map<int, std::vector<std::vector<float>>> dosemaps,
+                             std::vector<LumiYear> years)
+    : ieta_shift_(ieta_shift), drdA_(drdA), drdB_(drdB), dosemaps_(std::move(dosemaps)), years_(std::move(years)) {
   //finish initializing years
   std::sort(years_.begin(), years_.end());
   //sum up int lumi


### PR DESCRIPTION
#### PR description:

This PR replaces a reference to `edm::ParameterSet` with explicitly parsed data structures for the configuration parameters. This change is needed for https://github.com/cms-sw/cmssw/pull/42503.

Resolves https://github.com/makortel/framework/issues/621

#### PR validation:

Code compiles.