### PR TITLE
Fix chaining in rules and unify prefix and rules of protocols

### DIFF
--- a/FWCore/Catalog/interface/FileLocator.h
+++ b/FWCore/Catalog/interface/FileLocator.h
@@ -42,6 +42,7 @@ namespace edm {
     typedef std::map<std::string, Rules> ProtocolRules;
 
     void init_trivialCatalog(std::string const& catUrl, unsigned iCatalog);
+
     void parseRuleTrivialCatalog(tinyxml2::XMLElement* ruleNode, ProtocolRules& rules);
     //using data-access
     void init(edm::CatalogAttributes const& input_dataCatalog,
@@ -68,9 +69,11 @@ namespace edm {
 
     std::string m_fileType;
     std::string m_filename;
+    //TFC allows more than one protocols provided in a catalog, separated by a comma
+    //In new Rucio storage description, only one protocol is provided in a catalog
+    //This variable can be simplified in the future
     std::vector<std::string> m_protocols;
     std::string m_destination;
-    std::string m_prefix;
   };
 }  // namespace edm
 

--- a/FWCore/Catalog/src/FileLocator.cc
+++ b/FWCore/Catalog/src/FileLocator.cc
@@ -70,14 +70,6 @@ namespace edm {
     //check if input is an authentic LFN
     if (input.compare(0, 7, kLFNPrefix) != 0)
       return out;
-    //use prefix in the protocol
-    if (!m_prefix.empty()) {
-      out = m_prefix + "/" + input;
-      if (input[0] == '/')
-        out = m_prefix + input;
-      return out;
-    }
-    //no prefix in the protocol, use rule
     for (size_t pi = 0, pe = m_protocols.size(); pi != pe; ++pi) {
       out = applyRules(rules, m_protocols[pi], m_destination, direct, input);
       if (!out.empty()) {
@@ -118,11 +110,12 @@ namespace edm {
     }
     auto const pathMatchRegexp = storageRule.second.get<std::string>("lfn");
     auto const result = storageRule.second.get<std::string>("pfn");
+    auto const chain = storageRule.second.get("chain", kEmptyString);
     Rule rule;
     rule.pathMatch.assign(pathMatchRegexp);
     rule.destinationMatch.assign(".*");
     rule.result = result;
-    rule.chain = "";
+    rule.chain = chain;
     rules[protocol].emplace_back(std::move(rule));
   }
 
@@ -293,22 +286,27 @@ namespace edm {
 
     std::string protName = found_protocol->second.get("protocol", kEmptyString);
     m_protocols.push_back(protName);
-    m_prefix = found_protocol->second.get("prefix", kEmptyString);
-    if (m_prefix == kEmptyString) {
-      //get rules
-      if (found_protocol->second.find("rules") == found_protocol->second.not_found()) {
-        cms::Exception ex("FileCatalog");
-        ex << "protocol must contain either a prefix or rules, "
-           << "neither found for protocol \"" << aCatalog.protocol << "\" for the storage site \""
-           << aCatalog.storageSite << "\" and volume \"" << aCatalog.volume
-           << "\" in storage.json. Check site-local-config.xml <data-access> and storage.json";
-        ex.addContext("edm::FileLocator:init()");
-        throw ex;
-      }
-      const pt::ptree& rules = found_protocol->second.find("rules")->second;
+
+    //store all prefixes and rules to m_directRules. We need to do this so that "applyRules" can find the rule in case chaining is used
+    //loop over protocols
+    for (pt::ptree::value_type const& protocol : protocols) {
+      std::string protName = protocol.second.get("protocol", kEmptyString);
       //loop over rules
-      for (pt::ptree::value_type const& storageRule : rules) {
-        parseRule(storageRule, protName, m_directRules);
+      std::string prefixTmp = protocol.second.get("prefix", kEmptyString);
+      if (prefixTmp == kEmptyString) {
+        const pt::ptree& rules = protocol.second.find("rules")->second;
+        for (pt::ptree::value_type const& storageRule : rules) {
+          parseRule(storageRule, protName, m_directRules);
+        }
+      }
+      //now convert prefix to a rule and save it
+      else {
+        Rule rule;
+        rule.pathMatch.assign("/?(.*)");
+        rule.destinationMatch.assign(".*");
+        rule.result = prefixTmp + "/$1";
+        rule.chain = kEmptyString;
+        m_directRules[protName].emplace_back(std::move(rule));
       }
     }
   }

--- a/FWCore/Catalog/test/storage.json
+++ b/FWCore/Catalog/test/storage.json
@@ -13,7 +13,39 @@
                   "pfn": "root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/$1"
                }
             ]
-         }
+         },
+         {
+            "protocol": "first",
+            "rules": [
+               { "lfn": "/+store/user/aaa/(.*)",
+                 "pfn": "/store/user/AAA/$1"
+               },
+               { "lfn": "/+(.*)",
+                 "pfn": "$1"
+               }
+            ]
+         },
+         {
+             "protocol": "second",
+             "rules": [
+              { "lfn": "/+store/user/(.*)",
+                "pfn": "/cms/store/user/$1",
+                "chain": "first"
+              },
+              { "lfn": "/+store/(.*)",
+                "pfn": "/cms/store/$1"
+              }
+            ]
+          },
+          {
+            "protocol": "root",
+            "rules": [
+              { "lfn": "/+(.*)",
+                "pfn": "root://host.domain//pnfs/$1",
+                "chain": "second"
+              }
+            ]
+          }
       ],
       "type": "DISK",
       "rse": "T1_US_FNAL_Disk",


### PR DESCRIPTION
The chaining mechanism is still be supported in the new storage description as in the case of Trivial File Catalogue (TFC) before:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/StorageDescription
However, it was effectively turned off (chain="") during development of codes for the new storage description
https://github.com/cms-sw/cmssw/pull/37278
Therefore, some sites will not see the file, for example T2_DE_DESY
https://cms-talk.web.cern.ch/t/errors-of-missing-files-at-t2-de-desy/27838/20
(currently there are three sites use 'chain' T1_DE_KIT, T2_DE_DESY, T2_BE_IIHE.)

This PR puts back the chaining feature. It also unifies the prefix and rules of protocols by converting the prefix to a rule. Therefore, codes handling prefix and rules are the same.
