### PR TITLE
Remove references to PSet in SimMuon and SimPPS

### DIFF
--- a/SimMuon/MCTruth/interface/CSCTruthTest.h
+++ b/SimMuon/MCTruth/interface/CSCTruthTest.h
@@ -14,8 +14,8 @@ public:
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  const edm::ParameterSet &conf_;
-  edm::ConsumesCollector consumeCollector_;
+
+  MuonTruth theTruth_;
   const edm::EDGetTokenT<CSCRecHit2DCollection> cscRecHitToken_;
 };
 

--- a/SimMuon/MCTruth/interface/MuonTruth.h
+++ b/SimMuon/MCTruth/interface/MuonTruth.h
@@ -29,7 +29,6 @@ public:
   typedef edm::DetSet<StripDigiSimLink> LayerLinks;
   typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
 
-  MuonTruth(const edm::Event &, const edm::EventSetup &, const edm::ParameterSet &, edm::ConsumesCollector &);
   MuonTruth(const edm::ParameterSet &, edm::ConsumesCollector &&iC);
 
   void initEvent(const edm::Event &, const edm::EventSetup &);

--- a/SimMuon/MCTruth/src/CSCTruthTest.cc
+++ b/SimMuon/MCTruth/src/CSCTruthTest.cc
@@ -4,18 +4,17 @@
 #include "SimMuon/MCTruth/interface/CSCTruthTest.h"
 
 CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig)
-    : conf_(iConfig),
-      consumeCollector_(consumesCollector()),
+    : theTruth_(iConfig, consumesCollector()),
       cscRecHitToken_(consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits"))) {}
 
 void CSCTruthTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   const edm::Handle<CSCRecHit2DCollection> &cscRecHits = iEvent.getHandle(cscRecHitToken_);
 
-  MuonTruth theTruth(iEvent, iSetup, conf_, consumeCollector_);
+  theTruth_.initEvent(iEvent, iSetup);
 
   for (CSCRecHit2DCollection::const_iterator recHitItr = cscRecHits->begin(); recHitItr != cscRecHits->end();
        recHitItr++) {
-    theTruth.analyze(*recHitItr);
-    edm::LogVerbatim("SimMuonCSCTruthTest") << theTruth.muonFraction() << " " << recHitItr->cscDetId();
+    theTruth_.analyze(*recHitItr);
+    edm::LogVerbatim("SimMuonCSCTruthTest") << theTruth_.muonFraction() << " " << recHitItr->cscDetId();
   }
 }

--- a/SimPPS/RPDigiProducer/plugins/RPLinearChargeDivider.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPLinearChargeDivider.cc
@@ -7,7 +7,7 @@
 RPLinearChargeDivider::RPLinearChargeDivider(const edm::ParameterSet& params,
                                              CLHEP::HepRandomEngine& eng,
                                              RPDetId det_id)
-    : params_(params), rndEngine_(eng), det_id_(det_id) {
+    : rndEngine_(eng), det_id_(det_id) {
   verbosity_ = params.getParameter<int>("RPVerbosity");
 
   fluctuate_ = std::make_unique<SiG4UniversalFluctuation>();

--- a/SimPPS/RPDigiProducer/plugins/RPLinearChargeDivider.h
+++ b/SimPPS/RPDigiProducer/plugins/RPLinearChargeDivider.h
@@ -17,7 +17,6 @@ public:
   simromanpot::energy_path_distribution divide(const PSimHit& hit);
 
 private:
-  const edm::ParameterSet& params_;
   CLHEP::HepRandomEngine& rndEngine_;
   RPDetId det_id_;
 

--- a/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.cc
+++ b/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.cc
@@ -4,7 +4,7 @@
 #include <vector>
 #include <iostream>
 
-RPVFATSimulator::RPVFATSimulator(const edm::ParameterSet &params, RPDetId det_id) : params_(params), det_id_(det_id) {
+RPVFATSimulator::RPVFATSimulator(const edm::ParameterSet &params, RPDetId det_id) : det_id_(det_id) {
   threshold_ = params.getParameter<double>("RPVFATThreshold");
   dead_strip_probability_ = params.getParameter<double>("RPDeadStripProbability");
   dead_strips_simulation_on_ = params.getParameter<bool>("RPDeadStripSimulationOn");

--- a/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.h
+++ b/SimPPS/RPDigiProducer/plugins/RPVFATSimulator.h
@@ -18,7 +18,6 @@ public:
 
 private:
   typedef std::set<unsigned short, std::less<unsigned short> > dead_strip_set;
-  const edm::ParameterSet &params_;
   RPDetId det_id_;
   double dead_strip_probability_;
   bool dead_strips_simulation_on_;


### PR DESCRIPTION
#### PR description:

In an effort to reduce memory usage we are attempting to remove references into the main ParameterSet from modules. When that effort is complete delete, the intent is to submit a separate PR deleting that object when all module construction is complete (I'm not sure this will succeed, but the changes in this PR are improvements even if it doesn't).

This PR addresses 3 of the modules with such references.

In RPVFATSimulator and RPLinearChargeDivider, the reference is simply an unused member that is deleted. Trivial cleanup that ought to be done anyway.

CSCTruthTest is a module that has been broken since at least May 2022 because the consumes calls are made during the Event transition. Possibly there are other problems in there. I didn't try to fix everything, but this is a step in the proper direction. The MuonTruth object is now a data member instead of being constructed on each Event. This eliminates the need for the reference and as a side benefit fixes problems with the consumes calls.

Note that nothing in the repository uses CSCTruthTest or MuonTruth. Possibly it would be better to delete them entirely. I will do that instead if requested.

#### PR validation:

Compilation should be good enough to test the member deletions. There is not an existing test for CSCTruthTest. I created a dummy job with no input that gets to expected ProductNotFound exceptions. Before the changes in this PR, it died when the consumes calls were improperly executed.

FYI @makortel 
