### PR TITLE
Include an additional input to fill standalone muon tracks in MuonIdProducer

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -237,7 +237,8 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       iEvent.getByToken(outerTrackSecondaryCollectionToken_, outerTrackSecondaryCollectionHandle_);
       if (!outerTrackSecondaryCollectionHandle_.isValid())
         throw cms::Exception("FatalError") << "Failed to get input track collection with label: " << inputLabel;
-      LogTrace("MuonIdentification") << "Number of input outer secondary tracks: " << outerTrackSecondaryCollectionHandle_->size();
+      LogTrace("MuonIdentification") << "Number of input outer secondary tracks: "
+                                     << outerTrackSecondaryCollectionHandle_->size();
     } else if (inputType == ICTypes::LINKS) {
       iEvent.getByToken(linkCollectionToken_, linkCollectionHandle_);
       if (!linkCollectionHandle_.isValid())
@@ -638,10 +639,13 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   if (outerTrackCollectionHandle_.isValid()) {
     LogTrace("MuonIdentification") << "Looking for new muons among stand alone muon tracks";
     const unsigned int nouter = outerTrackCollectionHandle_->size();
-    const unsigned int nsecond = (outerTrackSecondaryCollectionHandle_.isValid()) ? outerTrackSecondaryCollectionHandle_->size() : 0;
+    const unsigned int nsecond =
+        (outerTrackSecondaryCollectionHandle_.isValid()) ? outerTrackSecondaryCollectionHandle_->size() : 0;
     for (unsigned int i = 0; i < nouter + nsecond; ++i) {
-      const auto& outerTrack = (i < nouter) ? outerTrackCollectionHandle_->at(i) : outerTrackSecondaryCollectionHandle_->at(i - nouter);
-      reco::TrackRef refToTrack = (i < nouter) ? reco::TrackRef(outerTrackCollectionHandle_, i) : reco::TrackRef(outerTrackSecondaryCollectionHandle_, i - nouter);
+      const auto& outerTrack =
+          (i < nouter) ? outerTrackCollectionHandle_->at(i) : outerTrackSecondaryCollectionHandle_->at(i - nouter);
+      reco::TrackRef refToTrack = (i < nouter) ? reco::TrackRef(outerTrackCollectionHandle_, i)
+                                               : reco::TrackRef(outerTrackSecondaryCollectionHandle_, i - nouter);
 
       // check if this muon is already in the list of global muons
       bool newMuon = true;
@@ -673,8 +677,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       }
       if (newMuon) {
         LogTrace("MuonIdentification") << "No associated stand alone track is found. Making a muon";
-        outputMuons->push_back(
-            makeMuon(iEvent, iSetup, refToTrack, reco::Muon::OuterTrack));
+        outputMuons->push_back(makeMuon(iEvent, iSetup, refToTrack, reco::Muon::OuterTrack));
         outputMuons->back().setType(reco::Muon::StandAloneMuon);
       }
     }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -228,6 +228,7 @@ private:
 
   edm::Handle<reco::TrackCollection> innerTrackCollectionHandle_;
   edm::Handle<reco::TrackCollection> outerTrackCollectionHandle_;
+  edm::Handle<reco::TrackCollection> outerTrackSecondaryCollectionHandle_;
   edm::Handle<reco::MuonCollection> muonCollectionHandle_;
   edm::Handle<reco::MuonTrackLinksCollection> linkCollectionHandle_;
   edm::Handle<reco::TrackToTrackMap> tpfmsCollectionHandle_;
@@ -237,6 +238,7 @@ private:
 
   edm::EDGetTokenT<reco::TrackCollection> innerTrackCollectionToken_;
   edm::EDGetTokenT<reco::TrackCollection> outerTrackCollectionToken_;
+  edm::EDGetTokenT<reco::TrackCollection> outerTrackSecondaryCollectionToken_;
   edm::EDGetTokenT<reco::MuonCollection> muonCollectionToken_;
   edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkCollectionToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> tpfmsCollectionToken_;

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -35,6 +35,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     inputCollectionTypes = cms.vstring('inner tracks', 
                                        'links', 
                                        'outer tracks',
+                                       'outer tracks',
                                        'tev firstHit',
                                        'tev picky',
                                        'tev dyt'),
@@ -44,7 +45,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     # internal
     debugWithTruthMatching = cms.bool(False),
     # input tracks
-    inputCollectionLabels = cms.VInputTag(cms.InputTag("generalTracks"), cms.InputTag("globalMuons"), cms.InputTag("standAloneMuons","UpdatedAtVtx"),
+    inputCollectionLabels = cms.VInputTag(cms.InputTag("generalTracks"), cms.InputTag("globalMuons"), cms.InputTag("standAloneMuons","UpdatedAtVtx"), cms.InputTag("standAloneMuons"),
                                           cms.InputTag("tevMuons","firstHit"),cms.InputTag("tevMuons","picky"),cms.InputTag("tevMuons","dyt")),
     fillCaloCompatibility = cms.bool(True),
     # OR


### PR DESCRIPTION
#### PR description:

This PR modifies the MuonIdProducer to admit one more input intended to serve as an additional source for standalone muon tracks. The motivation behind this implementation would be to feed the collection `muons` with both `standAloneMuons::UpdatedAtVtx` and `standAloneMuons` track collections, while until now only the former has been taken as an unique input.

The main reason to include this collection is summarized as follows:

1. `standAloneMuons::UpdatedAtVtx` are a subset of `standAloneMuons`
2. Both `standAloneMuons::UpdatedAtVtx` and `standAloneMuons` are used to reconstruct the global muons that are saved in the muons collection.
3. If we only feed the muons collection with `standAloneMuons::UpdatedAtVtx`, muons that are only in `standAloneMuons` can enter in the muons collection **if and only if** they become global muons.
4. Using the muons collection to measure the global muon efficiency over standalone muons would risk introducing a bias, because a small fraction of the standalone muons are already preselected to be global muons.

The potential bias has been proved to be small, with an average value of ~1% while being higher at some parts of the detector e.g. the barrel-endcap transition region, where the reconstruction efficiency if lower.

A detailed presentation summarizing the main aspects of the implementation was presented in the[ last Muon POG general meeting](https://indico.cern.ch/event/1273299/#2-improvements-for-standalone).

Since the impact is very small, we are likely to see nothing in the standard tests, but if any:

- **What changes are expected?**
  - A small increase in the number of muons in the `muons` collection labelled as isStandaloneMuon() == True.
  - Small increase in the yield of some distributions, due to the aforementioned included standalone muons.
  - Some variations in variables of already existing muons inside `muons` that before were just tracker muons, but now are also standalone muons.

- **What is not expected?**
  - Global muons must remain invariant in any of the collections.
  - Changes are only expected in reco::Muon `muons` (and collections made from it) but not in other muon collections.

This PR is closely related to an already solved issue because they were caused by the same logic established in the `GlobalMuonProducer.cc`: https://github.com/cms-sw/cmssw/issues/38201

#### PR validation:

This PR has passed the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).

#### Backport:

This PR is not a backport but **should we prepare one?**

