### PR TITLE
Revert the time category for re-joining threads [13.2.x]

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -1787,7 +1787,8 @@ void FastTimerService::on_scheduler_entry(bool worker) {
     //   - not accounted:       thread().measure()
     //   - considered as idle:  thread().measure_and_accumulate(job_summary_.idle)
     //   - considered as other: thread().measure_and_accumulate(job_summary_.overhead)
-    thread().measure_and_accumulate(job_summary_.overhead);
+    // FIXME "considered as other" has been seen to produce unreliable results; revert to "not accounted" for the time being.
+    thread().measure();
   }
 }
 


### PR DESCRIPTION
#### PR description:

Revert the category to which the time spent by for re-joining TBB threads is assigned.
While "considered as other" was our best guess, it has been seen to produce unreliable results, so revert to "not accounted" for the time being. 

#### PR validation:

The HLT timing measurements confirmed that this change fixes the discrepancy between the throughput and the measured time per event.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42533 to 13.2.x for the online operations.