### PR TITLE
CMSEmStandardPhysicsEMMT, don't hold ref into main ParameterSet

### DIFF
--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMMT.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsEMMT.h
@@ -6,6 +6,7 @@
 #include "G4MscStepLimitType.hh"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManagerParams.h"
 
 class CMSEmStandardPhysicsEMMT : public G4VPhysicsConstructor {
 public:
@@ -16,7 +17,7 @@ public:
   void ConstructProcess() override;
 
 private:
-  const edm::ParameterSet& fParameterSet;
+  CMSEmStandardPhysicsTrackingManagerParams trackingManagerParams_;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManager.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManager.h
@@ -5,8 +5,6 @@
 #include "globals.hh"
 #include "G4MscStepLimitType.hh"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 class G4eMultipleScattering;
 class G4CoulombScattering;
 class G4eIonisation;
@@ -16,10 +14,11 @@ class G4ElectronNuclearProcess;
 class G4PositronNuclearProcess;
 
 class G4GammaGeneralProcess;
+struct CMSEmStandardPhysicsTrackingManagerParams;
 
 class CMSEmStandardPhysicsTrackingManager : public G4VTrackingManager {
 public:
-  CMSEmStandardPhysicsTrackingManager(const edm::ParameterSet &p);
+  CMSEmStandardPhysicsTrackingManager(const CMSEmStandardPhysicsTrackingManagerParams &);
   ~CMSEmStandardPhysicsTrackingManager() override;
 
   void BuildPhysicsTable(const G4ParticleDefinition &) override;

--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManagerParams.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManagerParams.h
@@ -1,0 +1,13 @@
+#ifndef SimG4Core_PhysicsLists_CMSEmStandardPhysicsTrackingManagerParams_h
+#define SimG4Core_PhysicsLists_CMSEmStandardPhysicsTrackingManagerParams_h
+
+struct CMSEmStandardPhysicsTrackingManagerParams {
+public:
+  double rangeFactor_ = 0.0;
+  double geomFactor_ = 0.0;
+  double safetyFactor_ = 0.0;
+  double lambdaLimit_ = 0.0;
+  std::string stepLimit_;
+};
+
+#endif

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMMT.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsEMMT.cc
@@ -24,8 +24,10 @@
 #include "G4PhysicsListHelper.hh"
 #include "G4BuilderType.hh"
 
+#include <string>
+
 CMSEmStandardPhysicsEMMT::CMSEmStandardPhysicsEMMT(G4int ver, const edm::ParameterSet& p)
-    : G4VPhysicsConstructor("CMSEmStandard_emmt"), fParameterSet(p) {
+    : G4VPhysicsConstructor("CMSEmStandard_emmt") {
   SetVerboseLevel(ver);
   G4EmParameters* param = G4EmParameters::Instance();
   param->SetDefaults();
@@ -39,6 +41,12 @@ CMSEmStandardPhysicsEMMT::CMSEmStandardPhysicsEMMT(G4int ver, const edm::Paramet
   double tcut = p.getParameter<double>("G4TrackingCut") * CLHEP::MeV;
   param->SetLowestElectronEnergy(tcut);
   param->SetLowestMuHadEnergy(tcut);
+
+  trackingManagerParams_.rangeFactor_ = p.getParameter<double>("G4MscRangeFactor");
+  trackingManagerParams_.geomFactor_ = p.getParameter<double>("G4MscGeomFactor");
+  trackingManagerParams_.safetyFactor_ = p.getParameter<double>("G4MscSafetyFactor");
+  trackingManagerParams_.lambdaLimit_ = p.getParameter<double>("G4MscLambdaLimit") * CLHEP::mm;
+  trackingManagerParams_.stepLimit_ = p.getParameter<std::string>("G4MscStepLimit");
 }
 
 CMSEmStandardPhysicsEMMT::~CMSEmStandardPhysicsEMMT() {}
@@ -61,7 +69,7 @@ void CMSEmStandardPhysicsEMMT::ConstructProcess() {
   G4NuclearStopping* pnuc(nullptr);
 
   // register specialized tracking for e-/e+ and gammas
-  auto* trackingManager = new CMSEmStandardPhysicsTrackingManager(fParameterSet);
+  auto* trackingManager = new CMSEmStandardPhysicsTrackingManager(trackingManagerParams_);
   G4Electron::Electron()->SetTrackingManager(trackingManager);
   G4Positron::Positron()->SetTrackingManager(trackingManager);
   G4Gamma::Gamma()->SetTrackingManager(trackingManager);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsTrackingManager.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsTrackingManager.cc
@@ -1,4 +1,5 @@
 #include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManager.h"
+#include "SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsTrackingManagerParams.h"
 #include "TrackingManagerHelper.h"
 
 #include "G4CoulombScattering.hh"
@@ -48,12 +49,14 @@
 
 CMSEmStandardPhysicsTrackingManager *CMSEmStandardPhysicsTrackingManager::masterTrackingManager = nullptr;
 
-CMSEmStandardPhysicsTrackingManager::CMSEmStandardPhysicsTrackingManager(const edm::ParameterSet &p) {
-  fRangeFactor = p.getParameter<double>("G4MscRangeFactor");
-  fGeomFactor = p.getParameter<double>("G4MscGeomFactor");
-  fSafetyFactor = p.getParameter<double>("G4MscSafetyFactor");
-  fLambdaLimit = p.getParameter<double>("G4MscLambdaLimit") * CLHEP::mm;
-  std::string msc = p.getParameter<std::string>("G4MscStepLimit");
+CMSEmStandardPhysicsTrackingManager::CMSEmStandardPhysicsTrackingManager(
+    const CMSEmStandardPhysicsTrackingManagerParams &trackingManagerParams) {
+  fRangeFactor = trackingManagerParams.rangeFactor_;
+  fGeomFactor = trackingManagerParams.geomFactor_;
+  fSafetyFactor = trackingManagerParams.safetyFactor_;
+  fLambdaLimit = trackingManagerParams.lambdaLimit_;
+  std::string msc = trackingManagerParams.stepLimit_;
+
   fStepLimitType = fUseSafety;
   if (msc == "UseSafetyPlus") {
     fStepLimitType = fUseSafetyPlus;


### PR DESCRIPTION
#### PR description:

In an effort to reduce memory usage we are attempting to remove references into the main ParameterSet from modules. When that effort is complete, the intent is to submit a separate PR deleting that ParameterSet when all module construction is complete.

This PR addresses the last module in the Sim* subsystems with such a reference.

This copies the required parameters into a struct and holds that until it is needed instead of holding a reference to the entire ParameterSet.

#### PR validation:

The change is fairly trivial, but I'd like to run a manual test that the values are going through OK. The parameters are set in g4SimHits_cfi.py (only there). I've so far unsuccessfully been looking for an existing test that executes the function CMSEmStandardPhysicsEMMT::ConstructProcess(). This looks like code that might still be actively used. I am still looking. Could someone point me to a test that runs it, maybe a RelVal number?
