### PR TITLE
Remove references to main ParameterSet in Reco* subsystem

### DIFF
--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -140,7 +140,6 @@ public:
 private:
   void checkEventSetup(const edm::EventSetup& iSetup);
 
-  const edm::ParameterSet& m_config;
   edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
   edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> token_trackBuilder;
   edm::ESGetToken<TrackProbabilityCalibration, BTagTrackProbability2DRcd> token_calib2D;
@@ -189,28 +188,28 @@ private:
 //
 template <class Container, class Base, class Helper>
 IPProducer<Container, Base, Helper>::IPProducer(const edm::ParameterSet& iConfig)
-    : m_config(iConfig), m_helper(iConfig, consumesCollector()) {
+    : m_helper(iConfig, consumesCollector()) {
   m_calibrationCacheId3D = 0;
   m_calibrationCacheId2D = 0;
 
-  token_primaryVertex = consumes<reco::VertexCollection>(m_config.getParameter<edm::InputTag>("primaryVertex"));
+  token_primaryVertex = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertex"));
   token_trackBuilder =
       esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
   token_calib2D = esConsumes<TrackProbabilityCalibration, BTagTrackProbability2DRcd>();
   token_calib3D = esConsumes<TrackProbabilityCalibration, BTagTrackProbability3DRcd>();
 
-  m_computeProbabilities = m_config.getParameter<bool>("computeProbabilities");
-  m_computeGhostTrack = m_config.getParameter<bool>("computeGhostTrack");
-  m_ghostTrackPriorDeltaR = m_config.getParameter<double>("ghostTrackPriorDeltaR");
-  m_cutPixelHits = m_config.getParameter<int>("minimumNumberOfPixelHits");
-  m_cutTotalHits = m_config.getParameter<int>("minimumNumberOfHits");
-  m_cutMaxTIP = m_config.getParameter<double>("maximumTransverseImpactParameter");
-  m_cutMinPt = m_config.getParameter<double>("minimumTransverseMomentum");
-  m_cutMaxChiSquared = m_config.getParameter<double>("maximumChiSquared");
-  m_cutMaxLIP = m_config.getParameter<double>("maximumLongitudinalImpactParameter");
-  m_directionWithTracks = m_config.getParameter<bool>("jetDirectionUsingTracks");
-  m_directionWithGhostTrack = m_config.getParameter<bool>("jetDirectionUsingGhostTrack");
-  m_useTrackQuality = m_config.getParameter<bool>("useTrackQuality");
+  m_computeProbabilities = iConfig.getParameter<bool>("computeProbabilities");
+  m_computeGhostTrack = iConfig.getParameter<bool>("computeGhostTrack");
+  m_ghostTrackPriorDeltaR = iConfig.getParameter<double>("ghostTrackPriorDeltaR");
+  m_cutPixelHits = iConfig.getParameter<int>("minimumNumberOfPixelHits");
+  m_cutTotalHits = iConfig.getParameter<int>("minimumNumberOfHits");
+  m_cutMaxTIP = iConfig.getParameter<double>("maximumTransverseImpactParameter");
+  m_cutMinPt = iConfig.getParameter<double>("minimumTransverseMomentum");
+  m_cutMaxChiSquared = iConfig.getParameter<double>("maximumChiSquared");
+  m_cutMaxLIP = iConfig.getParameter<double>("maximumLongitudinalImpactParameter");
+  m_directionWithTracks = iConfig.getParameter<bool>("jetDirectionUsingTracks");
+  m_directionWithGhostTrack = iConfig.getParameter<bool>("jetDirectionUsingGhostTrack");
+  m_useTrackQuality = iConfig.getParameter<bool>("useTrackQuality");
 
   if (m_computeGhostTrack)
     produces<reco::TrackCollection>("ghostTracks");

--- a/RecoPPS/Local/interface/RPixDetClusterizer.h
+++ b/RecoPPS/Local/interface/RPixDetClusterizer.h
@@ -54,7 +54,6 @@ public:
 private:
   std::set<CTPPSPixelDigi> rpix_digi_set_;
   std::map<unsigned int, RPixCalibDigi> calib_rpix_digi_map_;
-  const edm::ParameterSet &params_;
   int verbosity_;
   unsigned short SeedADCThreshold_;
   unsigned short ADCThreshold_;

--- a/RecoPPS/Local/interface/TotemRPClusterProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/TotemRPClusterProducerAlgorithm.h
@@ -32,8 +32,6 @@ private:
 
   TotemRPDigiSet strip_digi_set_;  ///< input digi set, strip by strip
 
-  const edm::ParameterSet &param_;
-
   int verbosity_;
 };
 

--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -13,7 +13,7 @@ namespace {
   constexpr int rocOffset = 13;
 }  // namespace
 
-RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const &conf) : params_(conf), SeedVector_(0) {
+RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const &conf) : SeedVector_(0) {
   verbosity_ = conf.getUntrackedParameter<int>("RPixVerbosity");
   SeedADCThreshold_ = conf.getParameter<int>("SeedADCThreshold");
   ADCThreshold_ = conf.getParameter<int>("ADCThreshold");

--- a/RecoPPS/Local/src/TotemRPClusterProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemRPClusterProducerAlgorithm.cc
@@ -13,8 +13,8 @@
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPClusterProducerAlgorithm::TotemRPClusterProducerAlgorithm(const edm::ParameterSet &param) : param_(param) {
-  verbosity_ = param_.getParameter<int>("verbosity");
+TotemRPClusterProducerAlgorithm::TotemRPClusterProducerAlgorithm(const edm::ParameterSet &param) {
+  verbosity_ = param.getParameter<int>("verbosity");
 }
 
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### PR description:

In an effort to reduce memory usage we are attempting to remove references into the main ParameterSet from modules. When that effort is complete, the intent is to submit a separate PR deleting that ParameterSet when all module construction is complete.

This PR addresses modules in the Reco* subsystems with such a reference.

These references were not needed. I just deleted them. In two of the modules, I had to convert code to use the referenced passed in as an argument instead of its copy.

#### PR validation:

Relies on existing tests.
