### PR TITLE
Add `pixelgpu` online DQM client and augment DQM/Integration unit tests

### DIFF
--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -11,8 +11,8 @@ if 'unitTest=True' in sys.argv:
 ### Load cfis ###
 
 if unitTest:
-    process.load("DQM.Integration.config.unittestinputsource_cfi")
-    from DQM.Integration.config.unittestinputsource_cfi import options
+    process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+    from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 else:
     process.load("DQM.Integration.config.inputsource_cfi")
     from DQM.Integration.config.inputsource_cfi import options

--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -37,8 +37,8 @@ if useOfflineGT:
 else:
 	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
 if unitTest:
-	process.load("DQM.Integration.config.unittestinputsource_cfi")
-	from DQM.Integration.config.unittestinputsource_cfi import options
+        process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+        from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 elif useFileInput:
 	process.load("DQM.Integration.config.fileinputsource_cfi")
 	from DQM.Integration.config.fileinputsource_cfi import options

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,124 @@
+#-------------------------------------
+#	Pixel DQM Application using New DQM Sources/Clients
+#-------------------------------------
+
+#-------------------------------------
+#	Standard Python Imports
+#-------------------------------------
+import os, sys, socket, string
+
+#-------------------------------------
+#	Standard CMSSW Imports/Definitions
+#-------------------------------------
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+process      = cms.Process('PIXELDQMLIVE', Run3)
+subsystem    = 'Pixel'
+cmssw        = os.getenv("CMSSW_VERSION").split("_")
+debugstr     = "### PixelDQM::cfg::DEBUG: "
+warnstr      = "### PixelDQM::cfg::WARN: "
+errorstr     = "### PixelDQM::cfg::ERROR:"
+useOfflineGT = False
+useFileInput = False
+useMap       = False
+
+unitTest = False
+if 'unitTest=True' in sys.argv:
+	unitTest=True
+	useFileInput=False
+
+#-------------------------------------
+#	Central DQM Stuff imports
+#-------------------------------------
+from DQM.Integration.config.online_customizations_cfi import *
+if useOfflineGT:
+        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+        process.GlobalTag.globaltag = autoCond['run3_data_prompt'] 
+else:
+	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+if unitTest:
+	process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+	from DQM.Integration.config.unitteststreamerinputsource_cfi import options
+elif useFileInput:
+	process.load("DQM.Integration.config.fileinputsource_cfi")
+	from DQM.Integration.config.fileinputsource_cfi import options
+else:
+	process.load('DQM.Integration.config.inputsource_cfi')
+	from DQM.Integration.config.inputsource_cfi import options
+process.load('DQM.Integration.config.environment_cfi')
+
+#-------------------------------------
+#	Central DQM Customization
+#-------------------------------------
+process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
+process.dqmEnv.subSystemFolder = subsystem
+process.dqmSaver.tag = 'PixelGPU'
+process.dqmSaver.runNumber = options.runNumber
+process.dqmSaverPB.tag = 'PixelGPU'
+process.dqmSaverPB.runNumber = options.runNumber
+process = customise(process)
+process.DQMStore.verbose = 0
+if not unitTest and not useFileInput :
+  if not options.BeamSplashRun :
+    process.source.minEventsPerLumi = 100
+
+#-------------------------------------
+#	CMSSW/Pixel non-DQM Related Module import
+#-------------------------------------
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+
+#-------------------------------------
+#	CMSSW non-DQM Related Module Settings
+#-------------------------------------
+runType			= process.runType.getRunType()
+runTypeName		= process.runType.getRunTypeName()
+isCosmicRun		= runTypeName=="cosmic_run" or runTypeName=="cosmic_run_stage1"
+isHeavyIon		= runTypeName=="hi_run"
+cmssw			= os.getenv("CMSSW_VERSION").split("_")
+
+#-------------------------------------
+#	Pixel DQM Tasks and Harvesters import
+#-------------------------------------
+process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff')
+
+#-------------------------------------
+#	Some Settings before Finishing up
+#-------------------------------------
+process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = cms.InputTag('hltSiPixelDigisFromSoA')
+process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = cms.InputTag('hltSiPixelDigisLegacy')
+
+#-------------------------------------
+#       Some Debug
+#-------------------------------------
+process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+process.dumpPath = cms.Path(process.dump)
+
+#-------------------------------------
+#	Hcal DQM Tasks/Clients Sequences Definition
+#-------------------------------------
+process.tasksPath = cms.Path(process.siPixelPhase1RawDataErrorComparator)
+
+#-------------------------------------
+#	Paths/Sequences Definitions
+#-------------------------------------
+process.dqmPath = cms.EndPath(process.dqmEnv)
+process.dqmPath1 = cms.EndPath(process.dqmSaver*process.dqmSaverPB)
+process.schedule = cms.Schedule(process.tasksPath,process.dumpPath,process.dqmPath,process.dqmPath1)
+
+#-------------------------------------
+#	Scheduling and Process Customizations
+#-------------------------------------
+process.options = cms.untracked.PSet(
+		Rethrow = cms.untracked.vstring(
+			"ProductNotFound",
+			"TooManyProducts",
+			"TooFewProducts"
+		)
+)
+process.options.wantSummary = True
+
+# tracer
+#process.Tracer = cms.Service("Tracer")
+print("Final Source settings:", process.source)
+process = customise(process)

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -104,7 +104,10 @@ process.tasksPath = cms.Path(process.siPixelPhase1RawDataErrorComparator)
 #-------------------------------------
 process.dqmPath = cms.EndPath(process.dqmEnv)
 process.dqmPath1 = cms.EndPath(process.dqmSaver*process.dqmSaverPB)
-process.schedule = cms.Schedule(process.tasksPath,process.dumpPath,process.dqmPath,process.dqmPath1)
+process.schedule = cms.Schedule(process.tasksPath,
+                                #process.dumpPath,  # for debug
+                                process.dqmPath,
+                                process.dqmPath1)
 
 #-------------------------------------
 #	Scheduling and Process Customizations

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -23,6 +23,9 @@
 <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 369956"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 369956"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 369956"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->

--- a/DQM/Integration/test/runtest.sh
+++ b/DQM/Integration/test/runtest.sh
@@ -16,4 +16,10 @@ if [[ -z ${CLIENTS_DIR} ]]; then
 fi
 
 mkdir -p $LOCAL_TEST_DIR/upload
-cmsRun $CLIENTS_DIR/$1 unitTest=True
+
+if [[ $# -eq 1 ]]; then
+    cmsRun $CLIENTS_DIR/$1 unitTest=True
+else
+    echo "Will use streamers files for run $2"
+    cmsRun $CLIENTS_DIR/$1 unitTest=True runNumber=$2
+fi

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -7,32 +7,26 @@
 //
 // Author: Marco Musich
 //
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-// DQM Histograming
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-#include "DataFormats/SiPixelRawData/interface/SiPixelErrorsSoA.h"
 #include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
-
-#include "DQMServices/Core/interface/MonitorElement.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 // for string manipulations
 #include <fmt/printf.h>
 
@@ -84,8 +78,7 @@ namespace {
     k_FED31 = 31,  // 31 indicates an event number error (TBM and FED event number mismatch)
     k_FED32 = 32,  // 32 indicates an incorrectly formatted Slink Header
     k_FED33 = 33,  // 33 indicates an incorrectly formatted Slink Trailer
-    k_FED34 =
-        34,  // 34 indicates the event size encoded in the Slink Trailer is different than size found at raw2digi conversion
+    k_FED34 = 34,  // 34 indicates the evt size encoded in Slink Trailer is different than size found at raw2digi
     k_FED35 = 35,  // 35 indicates an invalid FED channel number
     k_FED36 = 36,  // 36 indicates an invalid ROC value
     k_FED37 = 37,  // 37 indicates an invalid dcol or pixel value
@@ -172,14 +165,24 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
     countsOnGPU[j] = 0.;
   }
 
+  // check upfront if the error collection is present
   edm::Handle<edm::DetSetVector<SiPixelRawDataError>> inputFromCPU;
   iEvent.getByToken(tokenErrorsCPU_, inputFromCPU);
   if (!inputFromCPU.isValid()) {
-    edm::LogWarning("SiPixelCompareTrackSoA") << "reference (cpu) SiPixelRawDataErrors not found; \n"
-                                              << "the comparison will not run.";
+    edm::LogError("SiPixelPhase1RawDataErrorComparator") << "reference (cpu) SiPixelRawDataErrors not found; \n"
+                                                         << "the comparison will not run.";
     return;
   }
 
+  edm::Handle<edm::DetSetVector<SiPixelRawDataError>> inputFromGPU;
+  iEvent.getByToken(tokenErrorsGPU_, inputFromGPU);
+  if (!inputFromGPU.isValid()) {
+    edm::LogError("SiPixelPhase1RawDataErrorComparator") << "target (gpu) SiPixelRawDataErrors not found; \n"
+                                                         << "the comparison will not run.";
+    return;
+  }
+
+  // fill the counters on host
   uint errorsOnCPU{0};
   for (auto it = inputFromCPU->begin(); it != inputFromCPU->end(); ++it) {
     for (auto& siPixelRawDataError : *it) {
@@ -191,20 +194,13 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
       countsOnCPU[type] += 1;
       countsMatrixOnCPU[fed - FEDNumbering::MINSiPixeluTCAFEDID][type - k_FED25] += 1;
 
-      edm::LogInfo("SiPixelPhase1RawDataErrorComparator")
-          << __PRETTY_FUNCTION__ << " on cpu: FED: " << fed << " detid: " << id.rawId() << " type:" << type;
+      LogDebug("SiPixelPhase1RawDataErrorComparator")
+          << " (on cpu) FED: " << fed << " detid: " << id.rawId() << " type:" << type;
       errorsOnCPU++;
     }
   }
 
-  edm::Handle<edm::DetSetVector<SiPixelRawDataError>> inputFromGPU;
-  iEvent.getByToken(tokenErrorsGPU_, inputFromGPU);
-  if (!inputFromGPU.isValid()) {
-    edm::LogWarning("SiPixelCompareTrackSoA") << "target (gpu) SiPixelRawDataErrors not found; \n"
-                                              << "the comparison will not run.";
-    return;
-  }
-
+  // fill the counters on device
   uint errorsOnGPU{0};
   for (auto it = inputFromGPU->begin(); it != inputFromGPU->end(); ++it) {
     for (auto& siPixelRawDataError : *it) {
@@ -216,28 +212,28 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
       countsOnGPU[type] += 1;
       countsMatrixOnGPU[fed - FEDNumbering::MINSiPixeluTCAFEDID][type - k_FED25] += 1;
 
-      edm::LogInfo("SiPixelPhase1RawDataErrorComparator")
-          << __PRETTY_FUNCTION__ << " on gpu: FED: " << fed << " detid: " << id.rawId() << " type:" << type;
+      LogDebug("SiPixelPhase1RawDataErrorComparator")
+          << " (on gpu) FED: " << fed << " detid: " << id.rawId() << " type:" << type;
       errorsOnGPU++;
     }
   }
 
-  edm::LogInfo("SiPixelPhase1RawDataErrorComparator")
-      << __PRETTY_FUNCTION__ << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU << std::endl;
+  edm::LogPrint("SiPixelPhase1RawDataErrorComparator")
+      << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU << std::endl;
 
   h_totFEDErrors_->Fill(errorsOnCPU, errorsOnGPU);
 
   // fill the correlations per error type
   for (unsigned int j = k_FED25; j <= k_FED31; j++) {
     SiPixelFEDErrorCodes code = static_cast<SiPixelFEDErrorCodes>(j);
-    h_nFEDErrors_[code]->Fill(countsOnCPU[j], countsOnGPU[j]);
+    h_nFEDErrors_[code]->Fill(std::min(1000, countsOnCPU[j]), std::min(1000, countsOnGPU[j]));
   }
 
   // fill the error unbalance per FEDid per error type
   for (int i = 0; i < nFEDs; i++) {
     for (int j = 0; j < nErrors; j++) {
       if (countsMatrixOnGPU[i][j] != 0 || countsMatrixOnCPU[i][j] != 0) {
-        edm::LogInfo("SiPixelPhase1RawDataErrorComparator")
+        edm::LogVerbatim("SiPixelPhase1RawDataErrorComparator")
             << "FED: " << i + FEDNumbering::MINSiPixeluTCAFEDID << " error: " << j + k_FED25
             << " | GPU counts: " << countsMatrixOnGPU[i][j] << " CPU counts:" << countsMatrixOnCPU[i][j] << std::endl;
         h_FEDerrorVsFEDIdUnbalance_->Fill(
@@ -258,7 +254,7 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
 
   h_FEDerrorVsFEDIdUnbalance_ =
       iBook.book2I("FEErrorVsFEDIdUnbalance",
-                   "difference (GPU-CPE) of FED errors per FEDid per error type;;FED Id number;GPU counts - CPU counts",
+                   "difference (GPU-CPU) of FED errors per FEDid per error type;;FED Id number;GPU counts - CPU counts",
                    nErrors,
                    -0.5,
                    nErrors - 0.5,
@@ -277,26 +273,25 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                                 "n. of total Pixel FEDError per event; CPU; GPU",
                                 500,
                                 log10(0.5),
-                                log10(500.5),
+                                log10(5000.5),
                                 500,
                                 log10(0.5),
-                                log10(500.5));
+                                log10(5000.5));
 
   for (const auto& element : errorCodeToStringMap) {
     h_nFEDErrors_[element.first] = iBook.book2I(fmt::sprintf("nFED%i_Errors", element.first),
                                                 fmt::sprintf("n. of %ss per event; CPU; GPU", element.second),
-                                                501,
+                                                1000,
                                                 -0.5,
-                                                500.5,
-                                                501,
+                                                1000.5,
+                                                1000,
                                                 -0.5,
-                                                500.5);
+                                                1000.5);
   }
 }
 
 void SiPixelPhase1RawDataErrorComparator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  //desc.add<edm::InputTag>("pixelErrorSrcGPU", edm::InputTag("siPixelDigiErrors"));
   desc.add<edm::InputTag>("pixelErrorSrcGPU", edm::InputTag("siPixelDigis@cuda"))
       ->setComment("input GPU SiPixel FED errors");
   desc.add<edm::InputTag>("pixelErrorSrcCPU", edm::InputTag("siPixelDigis@cpu"))


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to my previous PR https://github.com/cms-sw/cmssw/pull/41939 and to the TSG ticket https://its.cern.ch/jira/browse/CMSHLT-2846.
The main goal is to add `DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py`: a new DQM online client designed to monitor the GPU and CPU Pixel collections from within the  `streamDQMGPUvsCPU` stream. 
At the moment only the `SiPixelRawDataError` collections are monitored by `SiPixelPhase1RawDataErrorComparator`, but in future, once more event products could be persisted after the ongoing `alpaka` migration, also other clients that are currently run within the HLT menu itself could be moved here.
I profit of this PR to include the new GPUVsCPU client (and the two existing ECAL and HCAL ones) in the battery of unit tests.
For data a corresponding PR to `cms-data` has been created (https://github.com/cms-data/DQM-Integration/pull/4) in order to supply the necessary input files (albeit - alas - these files lack the proper pixel collections (`SiPixelRawDataErroredmDetSetVector_hltSiPixelDigisFromSoA_*_*` and `SiPixelRawDataErroredmDetSetVector_hltSiPixelDigisLegacy_*_*`) that became available after [CMSHLT-2846](https://its.cern.ch/jira/browse/CMSHLT-2846) was closed).

#### PR validation:

Run successfully:
```
scram b runtests_TestDQMOnlineClient-ecalgpu_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-hcalgpu_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but to be backported for deployment in 2023 data-taking.
