### PR TITLE
add customization function to remove check on Tracker DCS bits in Strip and Tracker DQM

### DIFF
--- a/DQM/SiStripMonitorClient/python/customizeForNoTrackerDCS.py
+++ b/DQM/SiStripMonitorClient/python/customizeForNoTrackerDCS.py
@@ -1,0 +1,35 @@
+"""
+Module to remove SiStrip DCS checks in Strip and Tracking Monitors
+"""
+
+import FWCore.ParameterSet.Config as cms
+
+def producers_by_type(process, *types):
+    return [module for module in process._Process__producers.values() if module._TypedParameterizable__type in types]
+
+def removeDCSChecks(process, acceptedParts):
+    print('WARNING: removing SiStrip DCS Checks in Strip and Tracking Monitors')
+
+    for producerType in ['SiStripMonitorTrack', 'SiStripMonitorCluster']:
+        for producer in producers_by_type(process, producerType):
+            producer.UseDCSFiltering = cms.bool(False)
+                    
+    for producer in producers_by_type(process, 'SiStripMonitorCluster'):
+        producer.StripDCSfilter.dcsPartitions = cms.vint32(acceptedParts)
+
+    for producer in producers_by_type(process, 'TrackingMonitor'):
+        producer.genericTriggerEventPSet.dcsPartitions = cms.vint32(acceptedParts)
+
+    return process
+
+def removeStripDCSChecks(process):
+    removeDCSChecks(process, [28, 29])  # keep 28-29: pixel
+    return process
+
+def removePixelDCSChecks(process):
+    removeDCSChecks(process, [24, 25, 26, 27])  # keep 24-27: strip
+    return process
+
+def removeTrackerDCSChecks(process):
+    removeDCSChecks(process, []) # do not keep anything
+    return process


### PR DESCRIPTION
#### PR description:

It is sometimes useful for private data certification checks to remove the DCS requirement on the Tracker partitions in the SiStrip and Tracking DQM monitors. This is generally applied in order to discard bad data, but it has been noticed several times in Run 3 (especially during cosmics data-taking) that the DCS information in the FEDRawData (obtained offline via `onlineMetaDataDigis`) is not 100% reliable. 
Moreover there has been at least one occurrence (for run [368343](https://cmsoms.cern.ch/cms/runs/lumisection?cms_run=368343&cms_run_sequence=GLOBAL-RUN)) in which a DCS issue which caused the TEC- DCS bit to be false till LS 990 of run 368343 (~9 am [elog](http://cmsonline.cern.ch/cms-elog/1185134)). As a consequence, the LS in the range [1-990] were discarded by the offline Strip and Tracking DQM (see [this presentation](https://indico.cern.ch/event/1271488/contributions/5445588/attachments/2663515/4614878/debuggingStripClient.pdf)) for more details.
This impedes the correct certification of that run. 

#### PR validation:

I have run a modified `141.032`  workflow using this customization function (as in https://github.com/mmusich/cmssw/commit/80e792e11ce53320b9840ef499f0070a2e129974) in order to use LS=484 of run 368343, starting from the data in `/ExpressPhysics/Run2023C-Express-v4/FEVT` and obtained filled Strip and Tracking Plots (which are otherwise empty).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to 13.0.X to request a re-reco of run 368343 (in order to be able to certify it offline)

Cc: @cardinia @sroychow 