### PR TITLE
Run3-hcx352A Modify the sensitive detector xmls of HCAL to allow old style HF simhits

### DIFF
--- a/Geometry/HcalCommonData/data/dd4hep/cmsExtendedGeometry2021.xml
+++ b/Geometry/HcalCommonData/data/dd4hep/cmsExtendedGeometry2021.xml
@@ -233,8 +233,8 @@
     <Include ref='Geometry/HcalCommonData/data/hcalouteralgo/v1/hcalouteralgo.xml'/>
     <Include ref='Geometry/HcalCommonData/data/hcalforwardalgo.xml'/>
     <Include ref='Geometry/HcalCommonData/data/average/hcalforwardmaterial.xml'/>
-    <Include ref='Geometry/HcalCommonData/data/hcalSimNumbering/2021/v2/hcalSimNumbering.xml'/>
-    <Include ref='Geometry/HcalCommonData/data/hcalRecNumbering/2021/v1/hcalRecNumbering.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalSimNumbering/2021/v1/hcalSimNumbering.xml'/>
+    <Include ref='Geometry/HcalCommonData/data/hcalRecNumbering/2021/hcalRecNumbering.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mbCommon/2021/v2/mbCommon.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb1/2021/v1/mb1.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mb2/2021/v1/mb2.xml'/>
@@ -354,7 +354,7 @@
     <Include ref='Geometry/VeryForwardData/data/CTPPS_2021/RP_Dist_Beam_Cent/Simu/v1/RP_Dist_Beam_Cent.xml'/>
     <Include ref='Geometry/EcalSimData/data/ecalsens.xml'/>
     <Include ref='Geometry/HcalCommonData/data/hcalsens/2021/v1/hcalsenspmf.xml'/>
-    <Include ref='Geometry/HcalSimData/data/hf/v1/hf.xml'/>
+    <Include ref='Geometry/HcalSimData/data/hf.xml'/>
     <Include ref='Geometry/HcalSimData/data/hfpmt.xml'/>
     <Include ref='Geometry/HcalSimData/data/hffibrebundle.xml'/>
     <Include ref='Geometry/HcalSimData/data/CaloUtil/2021/v1/CaloUtil.xml'/>
@@ -378,6 +378,5 @@
     <Include ref='Geometry/ForwardSimData/data/bhmProdCuts/2021/v1/bhmProdCuts.xml'/>
     <Include ref='Geometry/ForwardSimData/data/zdcProdCuts/2021/v2/zdcProdCuts.xml'/>
     <Include ref='Geometry/CMSCommonData/data/FieldParameters.xml'/>
-    )/>
   </IncludeSection>
 </DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalsens/2021/v2/hcalsenspmf.xml
+++ b/Geometry/HcalCommonData/data/hcalsens/2021/v2/hcalsenspmf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+
+ <SpecParSection label="hcalsenspmf.xml" eval="true">
+  <SpecPar name="hcalSensPar">
+   <PartSelector path="//HBS.*"/>
+   <PartSelector path="//HTS.*"/>
+   <PartSelector path="//.*HES.*"/>
+   <PartSelector path="//HVQF"/>
+   <PartSelector path="//HVQX"/>
+   <PartSelector path="//VcalElecCathode"/>
+   <PartSelector path="//FibreBundle.*"/>
+   <PartSelector path="//VcalFibreBundleL.*"/>
+   <PartSelector path="//VcalFibreBundleR.*"/>
+   <Parameter name="SensitiveDetector" value="HcalSensitiveDetector" eval="false"/>
+   <Parameter name="ReadOutName" value="HcalHits" eval="false"/>
+  </SpecPar>
+ </SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalsens/NoHE/v1/hcalsenspm.xml
+++ b/Geometry/HcalCommonData/data/hcalsens/NoHE/v1/hcalsenspm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<SpecParSection label="hcalsenspm.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HBS.*"/>
+    <PartSelector path="//HTS.*"/>
+    <PartSelector path="//HVQF"/>
+    <PartSelector path="//HVQX"/>
+    <PartSelector path="//VcalElecCathode"/>
+    <Parameter name="SensitiveDetector" value="HcalSensitiveDetector" eval="false"/>
+    <Parameter name="ReadOutName" value="HcalHits" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalsens/NoHE/v1/hcalsenspmf.xml
+++ b/Geometry/HcalCommonData/data/hcalsens/NoHE/v1/hcalsenspmf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<SpecParSection label="hcalsenspmf.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HBS.*"/>
+    <PartSelector path="//HTS.*"/>
+    <PartSelector path="//HVQF"/>
+    <PartSelector path="//HVQX"/>
+    <PartSelector path="//VcalElecCathode"/>
+    <PartSelector path="//FibreBundle.*"/>
+    <PartSelector path="//VcalFibreBundleL.*"/>
+    <PartSelector path="//VcalFibreBundleR.*"/>
+    <Parameter name="SensitiveDetector" value="HcalSensitiveDetector" eval="false"/>
+    <Parameter name="ReadOutName" value="HcalHits" eval="false"/>
+   </SpecPar>
+</SpecParSection>
+
+</DDDefinition>


### PR DESCRIPTION
#### PR description:

Modify the sensitive detector xmls of HCAL to allow old style HF simhits

#### PR validation:

Use some modified scenarios with the added XMLs to verify goodness of HF hits

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special
