### PR TITLE
Add 132X data and MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,14 +31,14 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v4',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v4',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20  (UTC)
-    'run3_data'                    : '130X_dataRun3_v2',
+    # GlobalTag for Run3 HLT: identical to the online GT (132X_dataRun3_HLT_v2) but with snapshot at 2023-08-11 17:35:000 (UTC)
+    'run3_hlt'                     : '132X_dataRun3_HLT_frozen_v1',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 132X_dataRun3_Express_v2 but with snapshot at 2023-08-11 17:35:00 (UTC)
+    'run3_data_express'            : '132X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 132X_dataRun3_Prompt_v2 but with snapshot at 2023-08-11 17:35:00 (UTC)
+    'run3_data_prompt'             : '132X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-08-11 17:04:34 (UTC)
+    'run3_data'                    : '132X_dataRun3_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -62,29 +62,29 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '131X_mcRun3_2022_design_v3',
+    'phase1_2022_design'           : '132X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v4',
+    'phase1_2022_realistic'        : '132X_mcRun3_2022_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v4',
+    'phase1_2022_realistic_postEE' : '132X_mcRun3_2022_realistic_postEE_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v4',
+    'phase1_2022_cosmics'          : '132X_mcRun3_2022cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'   : '132X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v8',
+    'phase1_2022_realistic_hi'     : '132X_mcRun3_2022_realistic_HI_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v7',
+    'phase1_2023_design'           : '132X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v9',
+    'phase1_2023_realistic'        : '132X_mcRun3_2023_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v9',
+    'phase1_2023_cosmics'          : '132X_mcRun3_2023cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v7',
+    'phase1_2023_cosmics_design'   : '132X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v12',
+    'phase1_2023_realistic_hi'     : '132X_mcRun3_2023_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '132X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '131X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:
This PR adds to the release the 132X GTs for data and for Run 3 MC.
There are a few conditions updated, namely:
- Added the new LHCInfoPerLS and LHCInfoPerLS tags (see this [CMSTalk post](https://cms-talk.web.cern.ch/t/online-prompt-new-lhcinfoper-tags-for-run3/28208)) required by the PPS reco changes in PR #42515
  - Tags for Prompt:
     - `LHCInfoPerLS_endFill_Run3_v1`
     - `LHCInfoPerFill_endFill_Run3_v1`
   - Tags for MC:
     - `LHCInfoPerLS_endFill_Run3_mc_v1`
     - `LHCInfoPerFill_endFill_Run3_mc_v1`
   - Tags for HLT/Express (single-IOV "null" tags for the moment, in view of future developments):
     - `LHCInfoPerLS_hlt_forPPS`
     - `LHCInfoPerFill_hlt_forPPS`
- Updated the ZDC reco geometry tags requested in this [CMSTalk post](https://cms-talk.web.cern.ch/t/update-zdc-geometry-for-run3-data-and-mc/24637)
   - For 2022 MC: `ZDCRECO_Geometry_132DD4hepV2`
   - For 2023 MC: `ZDCRECO_Geometry_132DD4hepV3`
- Updated SiPixelDynIneff tag to `SiPixelDynamicInefficiency_phase1_2023_v2_fix3` requested:
  - for 2022 MC in this [CMStalk post](https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670)
  - for 2023 MC in this [CMSTalk post](https://cms-talk.web.cern.ch/t/pixel-conditions-for-2023-mc/24971)
- Updated SiPixel BadComponents tags for 2022 MC as requested in this [CMSTalkPost](https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670):
  - pre-EE leak:
    - `SiPixelQuality_phase1_2022_v2b_mc`
    - `SiPixelQuality_forDigitizer_phase1_2022_v2b_mc`
  - post-EE leak:
    - `SiPixelQuality_phase1_2022_v5_mc`
    - `SiPixelQuality_forDigitizer_phase1_2022_v5_mc`

Additionally, the 132X online GTs contain the updates detailed in this [CMSTalk post](https://cms-talk.web.cern.ch/t/queue-132x-data-queues-for-pp-ref-and-hi-data-taking/28067):
- Addition of `HcalPFCuts_v1.0_hlt` tag  for all three HLT/Express/Prompt GTs
- Cleanup of unused MVA tracking tags from Express/Prompt GTs (see https://github.com/cms-AlCaDB/AlCaTools/issues/81)

**GT Differences**
- *run3_hlt*:
  - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_v2/132X_dataRun3_HLT_v2
  - Diff with frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_dataRun3_HLT_v2/132X_dataRun3_HLT_frozen_v1
- *run3_data_express*:
  - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Express_v3/132X_dataRun3_Express_v2
  - Diff with frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_dataRun3_Express_v2/132X_dataRun3_Express_frozen_v1
- *run3_data_prompt*:
  - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_Prompt_v4/132X_dataRun3_Prompt_v2
  - Diff with frozen GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_dataRun3_Prompt_v2/132X_dataRun3_Prompt_frozen_v1
- *run3_data*:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_v2/132X_dataRun3_v1
- *phase1_2022_design*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_design_v3/132X_mcRun3_2022_design_v1
- *phase1_2022_realistic*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_v4/132X_mcRun3_2022_realistic_v1
- *phase1_2022_realistic_postEE*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_postEE_v4/132X_mcRun3_2022_realistic_postEE_v1
- *phase1_2022_cosmics*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_realistic_deco_v4/132X_mcRun3_2022cosmics_realistic_deco_v1
- *phase1_2022_cosmics_design*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_design_deco_v3/132X_mcRun3_2022cosmics_design_deco_v1
- *phase1_2022_realistic_hi*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v8/132X_mcRun3_2022_realistic_HI_v1
- *phase1_2023_design*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v7/132X_mcRun3_2023_design_v1
- *phase1_2023_realistic*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v9/132X_mcRun3_2023_realistic_v1
- *phase1_2023_cosmics*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v9/132X_mcRun3_2023cosmics_realistic_deco_v1
- *phase1_2023_cosmics_design*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v7/132X_mcRun3_2023cosmics_design_deco_v1
- *phase1_2023_realistic_hi*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v12/132X_mcRun3_2023_realistic_HI_v1
- *phase1_2024_realistic*: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2024_realistic_v4/132X_mcRun3_2024_realistic_v1



#### PR validation:
Validated running:
```
runTheMatrix.py -l 159.0,160.0,12034.0,12434.0,12834.0,11601.0,138.4,138.5,139.001 -j 8 --ibeos
```
on top of PR #42515. Workflows crash without the updated GTs, while the finish successfully with the new 132X GTs.

#### Backport:
Not a backport, but a 13_2_X backport will be opened soon