### PR TITLE
Phase 2 GTT MET cosLUT overflow fix

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkEtMissEmuAlgo.h
@@ -29,7 +29,7 @@ namespace l1tmetemu {
   const unsigned int kCosLUTSize{10};
   const unsigned int kCosLUTMagSize{1};
   const unsigned int kCosLUTTableSize{10};
-  const unsigned int kCosLUTBins{1 << kCosLUTTableSize};
+  const unsigned int kCosLUTBins{(1 << kCosLUTTableSize) + 1};
   const unsigned int kCosLUTShift{TTTrack_TrackWord::TrackBitWidths::kPhiSize - kCosLUTTableSize};
   const unsigned int kAtanLUTSize{64};
   const unsigned int kAtanLUTMagSize{2};

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackerEtMissEmulatorProducer.cc
@@ -227,9 +227,6 @@ void L1TrackerEtMissEmulatorProducer::produce(edm::Event& iEvent, const edm::Eve
               << " Emu Cos(Phi): " << cosLUT_[(phiQuadrants_[4] - 1 - globalPhi) >> l1tmetemu::kCosLUTShift]
               << " Emu Sin(Phi): -" << cosLUT_[(globalPhi - phiQuadrants_[3]) >> l1tmetemu::kCosLUTShift] << "\n";
         }
-      } else {
-        temppx = 0;
-        temppy = 0;
       }
 
       int link_number = (track->phiSector() * 2) + ((EtaSector) ? 0 : 1);


### PR DESCRIPTION
#### PR description:

This PR addresses a very rare bug, in which a lookuptable (vector) is addressed with out-of-bounds values. The solution is to extend the lookup table by 1 (it's generated in a loop based on the size of the updated constant). Firmware HLS does not currently match this, but HLS behavior with out-of-bounds access is not the same as C++

Parasitically, a review comment is addressed, cleaning up the code somewhat (unnecessary explicit setting of values to 0, which were already initialized as such). See https://github.com/cms-sw/cmssw/pull/42347


#### PR validation:

This PR passes 
scram b
scram b code-checks
scram b code-format

Additionally it's used to generate test vectors for L1T workflows, and all outputs are identical in cases not affected by the bug, and results are as expected in the region that is.

This will need to be backported to cms-l1t-offline Phase 2 integration branch