### PR TITLE
Remove duplicate entry

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,18 +1,16 @@
 ---
-Language:        Cpp
-BasedOnStyle:  Google
-ColumnLimit:     120
-#didn't we want to change this?
+Language: Cpp
+BasedOnStyle: Google
+ColumnLimit: 120
 NamespaceIndentation: All
-SortIncludes:    false
-IndentWidth:     2
+SortIncludes: false
+IndentWidth: 2
 AccessModifierOffset: -2
 PenaltyBreakComment: 30
 PenaltyExcessCharacter: 100
 AlignAfterOpenBracket: Align
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-BinPackParameters: false
 AlwaysBreakTemplateDeclarations: Yes
 ReflowComments: false
 BinPackArguments: false


### PR DESCRIPTION
#### PR description:

Remove a duplicate entry from `.clang_format`.

`clang-format` 17 and later fail with an error if they encounter a duplicate entry.

#### PR validation:

None.