### PR TITLE
Fix elements_with_stride_nd when the index is outside the extent [13.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
@@ -36,6 +36,17 @@ struct VectorAddKernel1D {
   }
 };
 
+struct VectorAddKernel2D {
+  template <typename TAcc, typename T>
+  ALPAKA_FN_ACC void operator()(
+      TAcc const& acc, T const* __restrict__ in1, T const* __restrict__ in2, T* __restrict__ out, Vec2D size) const {
+    for (auto ndindex : cms::alpakatools::elements_with_stride_nd(acc, size)) {
+      auto index = ndindex[0] * size[1] + ndindex[1];
+      out[index] = in1[index] + in2[index];
+    }
+  }
+};
+
 struct VectorAddKernel3D {
   template <typename TAcc, typename T>
   ALPAKA_FN_ACC void operator()(
@@ -119,6 +130,77 @@ TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestKernel), s_tag)
 
       // launch the 1-dimensional kernel with vector size
       alpaka::exec<Acc1D>(queue, div, VectorAddKernel1D{}, in1_d.data(), in2_d.data(), out_d.data(), size);
+
+      // copy the results from the device to the host
+      alpaka::memcpy(queue, out_h, out_d);
+
+      // wait for all the operations to complete
+      alpaka::wait(queue);
+
+      // check the results
+      for (size_t i = 0; i < size; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        REQUIRE(out_h[i] < sum + epsilon);
+        REQUIRE(out_h[i] > sum - epsilon);
+      }
+    }
+  }
+}
+
+TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestKernel2D), s_tag) {
+  SECTION("VectorAddKernel2D") {
+    // get the list of devices on the current platform
+    auto const& devices = cms::alpakatools::devices<Platform>();
+    if (devices.empty()) {
+      std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
+                << ", the test will be skipped.\n";
+      return;
+    }
+
+    // random number generator with a gaussian distribution
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0., 1.};
+
+    // tolerance
+    constexpr float epsilon = 0.000001;
+
+    // 3-dimensional and linearised buffer size
+    constexpr Vec2D ndsize = {16, 16};
+    constexpr size_t size = ndsize.prod();
+
+    // allocate input and output host buffers in pinned memory accessible by the Platform devices
+    auto in1_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto in2_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+    auto out_h = cms::alpakatools::make_host_buffer<float[], Platform>(size);
+
+    // fill the input buffers with random data, and the output buffer with zeros
+    for (size_t i = 0; i < size; ++i) {
+      in1_h[i] = dist(rand);
+      in2_h[i] = dist(rand);
+      out_h[i] = 0.;
+    }
+
+    // run the test on each device
+    for (auto const& device : devices) {
+      std::cout << "Test 2D vector addition on " << alpaka::getName(device) << '\n';
+      auto queue = Queue(device);
+
+      // allocate input and output buffers on the device
+      auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+      auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+      auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+
+      // copy the input data to the device; the size is known from the buffer objects
+      alpaka::memcpy(queue, in1_d, in1_h);
+      alpaka::memcpy(queue, in2_d, in2_h);
+
+      // fill the output buffer with zeros; the size is known from the buffer objects
+      alpaka::memset(queue, out_d, 0.);
+
+      // launch the 3-dimensional kernel
+      auto div = cms::alpakatools::make_workdiv<Acc2D>({4, 4}, {32, 32});
+      alpaka::exec<Acc2D>(queue, div, VectorAddKernel2D{}, in1_d.data(), in2_d.data(), out_d.data(), ndsize);
 
       // copy the results from the device to the host
       alpaka::memcpy(queue, out_h, out_d);


### PR DESCRIPTION
#### PR description:

Extend `testKernel.dev.cc` with a 2D kernel test that uses large block sizes and redundant blocks.

Fix `elements_with_stride_nd` when the initial index is outside the extent; this fixes the issue revealed by the new test.

Also:
  - add support for the `AccCpuThreads` accelerator;
  - rename member variables for consistency;
  - improve comments.


#### PR validation:

The new unit tests completes successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42558.