### PR TITLE
Fix HGCAL Layer Clusters visualization in Fireworks - Backport CMSSW_13_2_X

### DIFF
--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -55,7 +55,15 @@ void FWCaloClusterProxyBuilder::build(const FWEventItem *iItem, TEveElementList 
     timeUpperBound = std::max(item()->getConfig()->value<double>("TimeLowerBound(ns)"),
                               item()->getConfig()->value<double>("TimeUpperBound(ns)"));
   } else {
-    std::cerr << "Warning: couldn't locate 'timeLayerCluster' ValueMap in root file." << std::endl;
+    iItem->getEvent()->getByLabel(edm::InputTag("hgcalMergeLayerClusters", "timeLayerCluster"), TimeValueMapHandle);
+    std::cerr << __FILE__ << ":" << __LINE__
+              << " couldn't locate 'hgcalLayerClusters:timeLayerCluster' ValueMap in input file. Trying to access "
+                 "'hgcalMergeLayerClusters:timeLayerClusters' ValueMap"
+              << std::endl;
+    if (!TimeValueMapHandle.isValid()) {
+      std::cerr << __FILE__ << ":" << __LINE__
+                << " couldn't locate 'hgcalMergeLayerClusters:timeLayerCluster' ValueMap in input file." << std::endl;
+    }
   }
 
   layer = item()->getConfig()->value<long>("Layer");

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -70,11 +70,28 @@ void FWTracksterHitsProxyBuilder::build(const FWEventItem *iItem, TEveElementLis
           << "lower time bound is larger than upper time bound. Maybe opposite is desired?";
     }
   } else {
-    edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
+    iItem->getEvent()->getByLabel(edm::InputTag("hgcalMergeLayerClusters", "timeLayerCluster"), TimeValueMapHandle_);
+    edm::LogWarning("DataNotFound|InvalidData")
+        << __FILE__ << ":" << __LINE__
+        << " couldn't locate 'hgcalLayerClusters:timeLayerCluster' ValueMap in input file. Trying to access "
+           "'hgcalMergeLayerClusters:timeLayerClusters' ValueMap";
+    if (!TimeValueMapHandle_.isValid()) {
+      edm::LogWarning("DataNotFound|InvalidData")
+          << __FILE__ << ":" << __LINE__
+          << " couldn't locate 'hgcalMergeLayerClusters:timeLayerCluster' ValueMap in input file.";
+    }
   }
 
   if (!layerClustersHandle_.isValid()) {
-    edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
+    iItem->getEvent()->getByLabel(edm::InputTag("hgcalMergeLayerClusters"), layerClustersHandle_);
+    edm::LogWarning("DataNotFound|InvalidData")
+        << __FILE__ << ":" << __LINE__
+        << " couldn't locate 'hgcalLayerClusters' collection "
+           "in input file. Trying to access 'hgcalMergeLayerClusters' collection.";
+    if (!layerClustersHandle_.isValid()) {
+      edm::LogWarning("DataNotFound|InvalidData")
+          << __FILE__ << ":" << __LINE__ << " couldn't locate 'hgcalMergeLayerClusters' collection in input file.";
+    }
   }
 
   layer_ = item()->getConfig()->value<long>("Layer");

--- a/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterLayersProxyBuilder.cc
@@ -76,11 +76,28 @@ void FWTracksterLayersProxyBuilder::build(const FWEventItem *iItem, TEveElementL
           << "lower time bound is larger than upper time bound. Maybe opposite is desired?";
     }
   } else {
-    edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
+    iItem->getEvent()->getByLabel(edm::InputTag("hgcalMergeLayerClusters", "timeLayerCluster"), TimeValueMapHandle_);
+    edm::LogWarning("DataNotFound|InvalidData")
+        << __FILE__ << ":" << __LINE__
+        << " couldn't locate 'hgcalLayerClusters:timeLayerCluster' ValueMap in input file. Trying to access "
+           "'hgcalMergeLayerClusters:timeLayerClusters' ValueMap";
+    if (!TimeValueMapHandle_.isValid()) {
+      edm::LogWarning("DataNotFound|InvalidData")
+          << __FILE__ << ":" << __LINE__
+          << " couldn't locate 'hgcalMergeLayerClusters:timeLayerCluster' ValueMap in input file.";
+    }
   }
 
   if (!layerClustersHandle_.isValid()) {
-    edm::LogWarning("DataNotFound|InvalidData") << "couldn't locate 'timeLayerCluster' ValueMap in root file.";
+    iItem->getEvent()->getByLabel(edm::InputTag("hgcalMergeLayerClusters"), layerClustersHandle_);
+    edm::LogWarning("DataNotFound|InvalidData")
+        << __FILE__ << ":" << __LINE__
+        << " couldn't locate 'hgcalLayerClusters' collection "
+           "in input file. Trying to access 'hgcalMergeLayerClusters' collection.";
+    if (!layerClustersHandle_.isValid()) {
+      edm::LogWarning("DataNotFound|InvalidData")
+          << __FILE__ << ":" << __LINE__ << " couldn't locate 'hgcalMergeLayerClusters' collection in input file.";
+    }
   }
 
   layer_ = item()->getConfig()->value<long>("Layer");


### PR DESCRIPTION
This PR is a backport of  #42519

## Description 
This PR fixes the HGCAL Layer Clusters (CaloClusters) visualization in Fireworks. The Layer Clusters collection changed name in CMSSW_13_2_X in https://github.com/cms-sw/cmssw/pull/41589
With this PR Fireworks will check if the `hgcalLayerClusters` collection is present, if not it will try to read the `hgcalMergeLayerClusters` collection, in this way it is possible to read files produced before CMSSW_13_2_X with new releases.
Validation
## Validation 
   - Tested on WF 20906.0