### PR TITLE
[13_1_X] Update the ZDC geometry fix and pixel conditions in MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -62,25 +62,25 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '131X_mcRun3_2022_design_v3',
+    'phase1_2022_design'           : '131X_mcRun3_2022_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v4',
+    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v4',
+    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v4',
+    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
     'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v7',
+    'phase1_2023_design'           : '131X_mcRun3_2023_design_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
     'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v9',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v7',
+    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v12',
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

Partial backport of [#42551](https://github.com/cms-sw/cmssw/pull/42551).

- Updated the ZDC reco geometry tags requested in this [CMSTalk post](https://cms-talk.web.cern.ch/t/update-zdc-geometry-for-run3-data-and-mc/24637)

   - For 2022 MC: `ZDCRECO_Geometry_132DD4hepV2`
   - For 2023 MC: `ZDCRECO_Geometry_132DD4hepV3`

- Updated SiPixelDynIneff tag to `SiPixelDynamicInefficiency_phase1_2023_v2_fix3` requested for 2022 realistic MC in this [CMStalk post](https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670)

- Updated SiPixel BadComponents tags for 2022 realistic MC as requested in this [CMSTalkPost](https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670):

   - pre-EE leak:
        `SiPixelQuality_phase1_2022_v2b_mc`
        `SiPixelQuality_forDigitizer_phase1_2022_v2b_mc`
   - post-EE leak:
        `SiPixelQuality_phase1_2022_v5_mc`
        `SiPixelQuality_forDigitizer_phase1_2022_v5_mc`

GT differences:

- _phase1_2022_design:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_design_v3/131X_mcRun3_2022_design_v4

- _phase1_2022_realistic:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_v4/131X_mcRun3_2022_realistic_v6

- _phase1_2022_realistic_postEE:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_postEE_v4/131X_mcRun3_2022_realistic_postEE_v6

- _phase1_2022_cosmics:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_realistic_deco_v4/131X_mcRun3_2022cosmics_realistic_deco_v6

- _phase1_2022_cosmics_design:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_design_deco_v3/131X_mcRun3_2022cosmics_design_deco_v4

- _phase1_2023_design:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v7/131X_mcRun3_2023_design_v8

- _phase1_2023_cosmics_design:_ 

   - Diff wrt last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v7/131X_mcRun3_2023cosmics_design_deco_v8


#### PR validation:

Tested with:

`runTheMatrix -l 12034.0,12434.0,12834.0,11601.0 -j 8 --ibeos`

#### Backport:

Partial backport of [#42551](https://github.com/cms-sw/cmssw/pull/42551)

