### PR TITLE
Remove references to main ParameterSet in DQM subsystems

### DIFF
--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -59,7 +59,6 @@ public:
   typedef std::map<GeometryInterface::Values, AbstractHistogram> Table;
 
 private:
-  const edm::ParameterSet& iConfig;
   GeometryInterface& geometryInterface;
 
   std::vector<SummationSpecification> specs;

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -16,8 +16,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 HistogramManager::HistogramManager(const edm::ParameterSet& iconfig, GeometryInterface& geo)
-    : iConfig(iconfig),
-      geometryInterface(geo),
+    : geometryInterface(geo),
       enabled(iconfig.getParameter<bool>("enabled")),
       perLumiHarvesting(iconfig.getParameter<bool>("perLumiHarvesting")),
       bookUndefined(iconfig.getParameter<bool>("bookUndefined")),

--- a/DQM/TrackerRemapper/plugins/TrackerRemapper.cc
+++ b/DQM/TrackerRemapper/plugins/TrackerRemapper.cc
@@ -104,7 +104,6 @@ private:
   const edm::ESGetToken<TkDetMap, TrackerTopologyRcd> tkDetMapToken_;
 
   edm::Service<TFileService> fs;
-  const edm::ParameterSet& iConfig;
 
   int m_opMode;
   int m_analyzeMode;
@@ -166,7 +165,6 @@ TrackerRemapper::TrackerRemapper(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes()),
       topoToken_(esConsumes()),
       tkDetMapToken_(esConsumes()),
-      iConfig(iConfig),
       m_opMode(iConfig.getParameter<int>("opMode")),
       m_analyzeMode(iConfig.getParameter<int>("analyzeMode")) {
   usesResource("TFileService");

--- a/HLTriggerOffline/Egamma/interface/EmDQM.h
+++ b/HLTriggerOffline/Egamma/interface/EmDQM.h
@@ -92,8 +92,6 @@ private:
 
   // run in automatic configuration generation mode
   bool autoConfMode_;
-  // parameter set from config file
-  const edm::ParameterSet &pset;
   // global parameters
   edm::InputTag triggerObject_;
   unsigned int verbosity_;

--- a/HLTriggerOffline/Egamma/src/EmDQM.cc
+++ b/HLTriggerOffline/Egamma/src/EmDQM.cc
@@ -8,14 +8,14 @@ using namespace ROOT::Math::VectorUtil;
 ////////////////////////////////////////////////////////////////////////////////
 //                             Constructor                                    //
 ////////////////////////////////////////////////////////////////////////////////
-EmDQM::EmDQM(const edm::ParameterSet &pset_) : pset(pset_) {
+EmDQM::EmDQM(const edm::ParameterSet &pset) {
   // are we running in automatic configuration mode with the HLTConfigProvider
   // or with a per path python config file
   autoConfMode_ = pset.getUntrackedParameter<bool>("autoConfMode", false);
 
   // set global parameters
-  triggerObject_ = pset_.getParameter<edm::InputTag>("triggerobject");
-  verbosity_ = pset_.getUntrackedParameter<unsigned int>("verbosity", 0);
+  triggerObject_ = pset.getParameter<edm::InputTag>("triggerobject");
+  verbosity_ = pset.getUntrackedParameter<unsigned int>("verbosity", 0);
   genEtaAcc_ = pset.getParameter<double>("genEtaAcc");
   genEtAcc_ = pset.getParameter<double>("genEtAcc");
   ptMax_ = pset.getUntrackedParameter<double>("PtMax", 1000.);


### PR DESCRIPTION
#### PR description:

In an effort to reduce memory usage we are attempting to remove references into the main ParameterSet from module data members. When that effort is complete, the intent is to submit a separate PR deleting that ParameterSet when all module construction is complete.

This PR addresses modules in the DQM subsystems with such a reference.

These references were not needed. I just deleted them. They were either not used at all or used only in the constructor and not needed because the constructor already has a reference as an argument.

There is more information in Issue #42503.

#### PR validation:

Relies on existing tests.
