### PR TITLE
Added option to FastMonitoringService to quiet LogInfos

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -294,6 +294,8 @@ namespace evf {
     std::atomic<bool> has_data_exception_ = false;
     std::vector<unsigned int> exceptionInLS_;
     std::vector<std::string> fastPathList_;
+
+    bool verbose_ = false;
   };
 
 }  // namespace evf

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -133,7 +133,8 @@ namespace evf {
         fastName_("fastmoni"),
         slowName_("slowmoni"),
         filePerFwkStream_(iPS.getUntrackedParameter<bool>("filePerFwkStream", false)),
-        totalEventsProcessed_(0) {
+        totalEventsProcessed_(0),
+        verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
     reg.watchPreallocate(this, &FastMonitoringService::preallocate);  //receiving information on number of threads
     reg.watchJobFailure(this, &FastMonitoringService::jobFailure);    //global
 
@@ -194,6 +195,7 @@ namespace evf {
         ->setComment("Modulo of sleepTime intervals on which fastmon file is written out");
     desc.addUntracked<bool>("filePerFwkStream", false)
         ->setComment("Switches on monitoring output per framework stream");
+    desc.addUntracked<bool>("verbose", false)->setComment("Set to use LogInfo messages from the monitoring thread");
     desc.setAllowAnything();
     descriptions.add("FastMonitoringService", desc);
   }
@@ -817,7 +819,7 @@ namespace evf {
         snapCounter_++;
       }
 
-      {
+      if (verbose_) {
         edm::LogInfo msg("FastMonitoringService");
         auto f = [&](std::vector<unsigned int> const& p) {
           for (unsigned int i = 0; i < nStreams_; i++) {


### PR DESCRIPTION
#### PR description:

The LogInfos can cause the MessageLogger to drop messages as the job summaries are being printed.

#### PR validation:

The missing summary messages were seen while doing testing the an HLT configuration. After the change and turning on the option, 10 runs of the job did not show any losses of summary information. Previously a loss was seen about every 3 runs of the job.