### PR TITLE
Tk Alignment Payload Inspector: add pixel alignment comparison maps per coordinate

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -11,6 +11,7 @@
 #include "TPaveStats.h"
 #include "TStyle.h"
 #include "TList.h"
+#include "TLatex.h"
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -32,8 +33,27 @@ namespace AlignmentPI {
   // size of the phase-I Tracker APE payload (including both SS + DS modules)
   static const unsigned int phase0size = 19876;
   static const unsigned int phase1size = 20292;
+  static const unsigned int mismatched = 99999;
   static const float cmToUm = 10000.f;
   static const float tomRad = 1000.f;
+
+  /*--------------------------------------------------------------------*/
+  inline void displayNotSupported(TCanvas& canv, const unsigned int size)
+  /*--------------------------------------------------------------------*/
+  {
+    std::string phase = (size < AlignmentPI::phase1size) ? "Phase-0" : "Phase-2";
+    canv.cd();
+    TLatex t2;
+    t2.SetTextAlign(21);
+    t2.SetTextSize(0.1);
+    t2.SetTextAngle(45);
+    t2.SetTextColor(kRed);
+    if (size != AlignmentPI::mismatched) {
+      t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+    } else {
+      t2.DrawLatexNDC(0.6, 0.50, "MISMATCHED PAYLOAD SIZE!");
+    }
+  }
 
   // method to zero all elements whose difference from 2Pi
   // is less than the tolerance (2*10e-7)

--- a/CondCore/AlignmentPlugins/plugins/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/plugins/BuildFile.xml
@@ -13,7 +13,9 @@
   <use name="CondFormats/Alignment"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="Alignment/CommonAlignment"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="DQM/TrackerRemapper"/>
 </library>
 
 <library file="TrackerSurfaceDeformations_PayloadInspector.cc" name="TrackerSurfaceDeformations_PayloadInspector">

--- a/CondCore/AlignmentPlugins/test/BuildFile.xml
+++ b/CondCore/AlignmentPlugins/test/BuildFile.xml
@@ -3,4 +3,6 @@
 <use name="Alignment/CommonAlignment"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <bin file="testTrackerAlignmentPayloadInspector.cpp" name="testTrackerAlignmentPayloadInspector">
+  <use name="DQM/TrackerRemapper"/>   
+  <use name="CalibTracker/SiPixelESProducers"/>
 </bin>

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -71,5 +71,15 @@ int main(int argc, char** argv) {
       PI::mk_input("TrackerAlignment_2017_ultralegacymc_v2", 1, 1, "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1));
   edm::LogPrint("testTrackerAlignmentPayloadInspector") << histo8.data();
 
+  PixelAlignmentCompareMapX histo9;
+  histo9.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testTrackerAlignmentPayloadInspector") << histo9.data();
+
+  PixelAlignmentCompareMapXTwoTags histo10;
+  histo10.process(
+      connectionString,
+      PI::mk_input("TrackerAlignment_2017_ultralegacymc_v2", 1, 1, "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1));
+  edm::LogPrint("testTrackerAlignmentPayloadInspector") << histo10.data();
+
   Py_Finalize();
 }


### PR DESCRIPTION
#### PR description:

In a quest to better understand what kind of movements are applied by the HighGranularity PCL during production (following up to [this presentation](https://indico.cern.ch/event/1271493/contributions/5530671/attachments/2698389/4683271/alignmentPCLlike_2023_08_07.pdf)), I have added a set of templated classes to display maps of pixel alignment coordinate comparisons for two IoVs within the same tag or two tags.

#### PR validation:

Run the following script:

<details>
  <summary>Click me</summary>
  
```bash
#!/bin/bash

# prepare the local comparison file 
conddb_import -c sqlite_file:toCompare.db -f sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp3710/jobData/jobm/alignments_MP.db -i Alignments -t mp3710
conddb_import -c sqlite_file:toCompare.db -f sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp3711/jobData/jobm/alignments_MP.db -i Alignments -t mp3711
conddb_import -c sqlite_file:toCompare.db -f sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp3712/jobData/jobm/alignments_MP.db -i Alignments -t mp3712
conddb_import -c sqlite_file:toCompare.db -f frontier://FrontierProd/CMS_CONDITIONS -i TrackerAlignment_PCL_byRun_v2_express -t StartingGeometry -b 368410 -e 368410

# Save current working dir so img can be outputted there later
W_DIR=$(pwd);

cd $W_DIR;
source /afs/cern.ch/cms/cmsset_default.sh;
eval `scram run -sh`;

#*************************************************************************#
tags=(mp3710 mp3711 mp3712)
elements=(X Y Z Alpha Beta Gamma)

for j in "${tags[@]}"
do
    echo "Processing tag: ${j}"
    mkdir -p $W_DIR/results_alignments_${j}
    for i in "${elements[@]}"
    do
    echo "Processing: $i coordinate"

    getPayloadData.py  \
        --plugin pluginTrackerAlignment_PayloadInspector \
        --plot plot_PixelAlignmentCompareMap${i}TwoTags \
        --tag StartingGeometry \
        --tagtwo ${j} \
        --time_type Run \
        --iovs '{"start_iov": "368410", "end_iov": "368410"}' \
        --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
        --db sqlite_file:toCompare.db \
        --test;

    mv *.png $W_DIR/results_alignments_${j}/TrackerAlignmentCompare${i}.png
    done
done
```
</details>


and obtained the following [results](http://musich.web.cern.ch/musich/display/testPixelAlignmentComparisonMaps/).
As an example I post here one of the maps obtained in the comparisons:

![image](https://github.com/cms-sw/cmssw/assets/5082376/bd6adcc9-7484-467f-be0f-25f53bb15d13)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
