### PR TITLE
add default for `config` and `ComponentName` in `MkFitIterationConfigESProducer`

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -31,8 +31,9 @@ MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::Parame
 
 void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName")->setComment("Product label");
-  desc.add<edm::FileInPath>("config")->setComment("Path to the JSON file for the mkFit configuration parameters");
+  desc.add<std::string>("ComponentName", "")->setComment("Product label");
+  desc.add<edm::FileInPath>("config", edm::FileInPath())
+      ->setComment("Path to the JSON file for the mkFit configuration parameters");
   desc.add<double>("minPt", 0.0)->setComment("min pT cut applied during track building");
   desc.add<unsigned int>("maxClusterSize", 8)->setComment("Max cluster size of SiStrip hits");
   descriptions.addWithDefaultLabel(desc);


### PR DESCRIPTION
#### PR description:

Title says it all, trivial technical PR in order to help parsing this parameter in confDB (needed to setup the HLT menu for 2023 Heavy Ions data-taking).

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

to be backported to CMSSW_13_2_X for integration of the HLT menu for 2023 Heavy Ion data-taking.

Cc: @vince502 @denerslemos @cms-sw/hlt-l2 