### PR TITLE
Include plugin factory name as part duplicate plugin check

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -255,7 +255,7 @@ def searchDuplicatePlugins ():
         if libdir.endswith(biglib): continue
         if os.path.exists(libdir+'/.edmplugincache'): edmpluginFile = edmpluginFile + ' ' + libdir+'/.edmplugincache'
     if edmpluginFile == '': edmpluginFile = os.path.join(os.environ.get('CMSSW_BASE'),'lib',os.environ.get('SCRAM_ARCH'),'.edmplugincache')
-    cmd = "cat %s | awk '{print $2\" \"$1}' | sort | uniq | awk '{print $1}' | sort | uniq -c | grep '2 ' | awk '{print $2}'" % edmpluginFile
+    cmd = "cat %s | awk '{print $2\"?\"$3\" \"$1}' | sort | uniq | awk '{print $1}' | sort | uniq -c | grep '2 ' | tr \"?\" \" \" | awk '{print $2}'" % edmpluginFile
     output = getoutput (cmd).split('\n')
     for line in output:
         if line in ignoreEdmDP: continue


### PR DESCRIPTION
#### PR description:

The duplicate checker was complaining that the plugin `SiPixelLorentzAngle` was found from two packages (see https://github.com/cms-sw/cmssw/pull/42431#issuecomment-1680628827). While this was the case, the name was used in different plugin factories, which is technically allowed. This change uses the plugin factory name (3rd field in `.edmplugincache`) as part of the plugin name for the uniqueness check (by concatenating the two together with `?` as separator), and later strips out the plugin factory name.

Resolves https://github.com/makortel/framework/issues/641

#### PR validation:

Tested the ~~command line~~ script on CMSSW_13_3_X_2023-08-16-1100 that the `SiPixelLorentzAngle` is no longer reported as duplicate, while the `cond::BaseKeyed` still is.
