### PR TITLE
Fix ODR violation in BaseKeyed serialization

### DIFF
--- a/CondCore/BaseKeyedPlugins/BuildFile.xml
+++ b/CondCore/BaseKeyedPlugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="CondCore/ESSources"/>
+<use name="CondFormats/SerializationHelper"/>
+<use name="CondFormats/Calibration"/>
+<use name="CondFormats/DTObjects"/>
+<flags EDM_PLUGIN="1"/>

--- a/CondCore/BaseKeyedPlugins/src/plugin.cc
+++ b/CondCore/BaseKeyedPlugins/src/plugin.cc
@@ -1,0 +1,51 @@
+/*
+ *  plugin.cc
+ *  CMSSW
+ *
+ *  Created by Chris Jones on 8/16/23.
+ *
+ */
+
+#include "CondFormats/Common/interface/BaseKeyed.h"
+#include "CondFormats/Calibration/interface/Conf.h"
+#include "CondFormats/DataRecord/interface/ExEfficiency.h"
+
+#include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
+#include "CondFormats/DataRecord/interface/DTKeyedConfigContainerRcd.h"
+#include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
+
+#include "CondCore/ESSources/interface/registration_macros.h"
+#include "CondCore/CondDB/interface/KeyListProxy.h"
+
+namespace cond {
+  template <>
+  std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>(const std::string& payloadType,
+                                                    const Binary& payloadData,
+                                                    const Binary& streamerInfoData) {
+    DESERIALIZE_BASE_CASE(BaseKeyed);
+    DESERIALIZE_POLIMORPHIC_CASE(BaseKeyed, condex::ConfI);
+    DESERIALIZE_POLIMORPHIC_CASE(BaseKeyed, DTKeyedConfig);
+
+    // here we come if none of the deserializations above match the payload type:
+    throwException(std::string("Type mismatch, target object is type \"") + payloadType + "\"", "deserialize<>");
+  }
+}  // namespace cond
+
+namespace cond::serialization {
+  template <>
+  struct BaseClassInfo<BaseKeyed> {
+    constexpr static bool kAbstract = false;
+    using inheriting_classes_t = edm::mpl::Vector<condex::ConfI, DTKeyedConfig>;
+  };
+}  // namespace cond::serialization
+
+DEFINE_COND_CLASSNAME(condex::ConfI)
+DEFINE_COND_CLASSNAME(DTKeyedConfig)
+
+DEFINE_COND_SERIAL_REGISTER_PLUGIN(cond::BaseKeyed);
+
+REGISTER_PLUGIN_NO_SERIAL(ExDwarfRcd, cond::BaseKeyed);
+REGISTER_KEYLIST_PLUGIN(ExDwarfListRcd, cond::persistency::KeyList, ExDwarfRcd);
+
+REGISTER_PLUGIN_NO_SERIAL(DTKeyedConfigContainerRcd, cond::BaseKeyed);
+REGISTER_KEYLIST_PLUGIN(DTKeyedConfigListRcd, cond::persistency::KeyList, DTKeyedConfigContainerRcd);

--- a/CondCore/CalibPlugins/src/plugin.cc
+++ b/CondCore/CalibPlugins/src/plugin.cc
@@ -14,8 +14,6 @@
 #include "CondFormats/DataRecord/interface/mySiStripNoisesRcd.h"
 #include "CondFormats/Calibration/interface/Efficiency.h"
 #include "CondFormats/DataRecord/interface/ExEfficiency.h"
-#include "CondFormats/Common/interface/BaseKeyed.h"
-#include "CondCore/CondDB/interface/KeyListProxy.h"
 
 //
 #include "CondCore/CondDB/interface/Serialization.h"
@@ -28,20 +26,6 @@ namespace cond {
     // DESERIALIZE_BASE_CASE( condex::Efficiency ); abstract
     DESERIALIZE_POLIMORPHIC_CASE(condex::Efficiency, condex::ParametricEfficiencyInPt);
     DESERIALIZE_POLIMORPHIC_CASE(condex::Efficiency, condex::ParametricEfficiencyInEta);
-
-    // here we come if none of the deserializations above match the payload type:
-    throwException(std::string("Type mismatch, target object is type \"") + payloadType + "\"", "deserialize<>");
-  }
-}  // namespace cond
-
-namespace cond {
-  template <>
-  std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>(const std::string& payloadType,
-                                                    const Binary& payloadData,
-                                                    const Binary& streamerInfoData) {
-    DESERIALIZE_BASE_CASE(BaseKeyed);
-    DESERIALIZE_POLIMORPHIC_CASE(BaseKeyed, condex::ConfI);
-    DESERIALIZE_POLIMORPHIC_CASE(BaseKeyed, condex::ConfI);
 
     // here we come if none of the deserializations above match the payload type:
     throwException(std::string("Type mismatch, target object is type \"") + payloadType + "\"", "deserialize<>");
@@ -61,21 +45,12 @@ namespace cond::serialization {
     using inheriting_classes_t = edm::mpl::Vector<condex::ParametricEfficiencyInPt, condex::ParametricEfficiencyInEta>;
   };
 
-  template <>
-  struct BaseClassInfo<BaseKeyed> {
-    constexpr static bool kAbstract = false;
-    using inheriting_classes_t = edm::mpl::Vector<condex::ConfI>;
-  };
 }  // namespace cond::serialization
 
 DEFINE_COND_CLASSNAME(condex::ParametricEfficiencyInPt)
 DEFINE_COND_CLASSNAME(condex::ParametricEfficiencyInEta)
-DEFINE_COND_CLASSNAME(condex::ConfI)
 
 REGISTER_PLUGIN(PedestalsRcd, Pedestals);
 REGISTER_PLUGIN_NO_SERIAL(anotherPedestalsRcd, Pedestals);
 REGISTER_PLUGIN(mySiStripNoisesRcd, mySiStripNoises);
 REGISTER_PLUGIN_INIT(ExEfficiencyRcd, condex::Efficiency, InitEfficiency);
-REGISTER_PLUGIN(ExDwarfRcd, cond::BaseKeyed);
-// REGISTER_PLUGIN(ExDwarfListRcd, cond::KeyList);
-REGISTER_KEYLIST_PLUGIN(ExDwarfListRcd, cond::persistency::KeyList, ExDwarfRcd);

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -27,9 +27,6 @@
 #include "CondFormats/DataRecord/interface/DTPerformanceRcd.h"
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DataRecord/interface/DTCCBConfigRcd.h"
-#include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
-#include "CondFormats/DataRecord/interface/DTKeyedConfigContainerRcd.h"
-#include "CondFormats/DataRecord/interface/DTKeyedConfigListRcd.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
 #include "CondFormats/DataRecord/interface/DTTPGParametersRcd.h"
 #include "CondFormats/DTObjects/interface/DTHVStatus.h"
@@ -50,19 +47,6 @@
 #include "CondFormats/External/interface/DetID.h"
 
 #include <memory>
-
-namespace cond {
-  template <>
-  std::unique_ptr<BaseKeyed> deserialize<BaseKeyed>(const std::string& payloadType,
-                                                    const Binary& payloadData,
-                                                    const Binary& streamerInfoData) {
-    DESERIALIZE_BASE_CASE(BaseKeyed);
-    DESERIALIZE_POLIMORPHIC_CASE(BaseKeyed, DTKeyedConfig);
-
-    // here we come if none of the deserializations above match the payload type:
-    throwException(std::string("Type mismatch, target object is type \"") + payloadType + "\"", "deserialize<>");
-  }
-}  // namespace cond
 
 namespace {
   struct InitDTCCBConfig {
@@ -137,8 +121,6 @@ REGISTER_PLUGIN_INIT(DTCCBConfigRcd, DTCCBConfig, InitDTCCBConfig);
 REGISTER_PLUGIN_INIT(DTTPGParametersRcd, DTTPGParameters, InitDTTPGParameters);
 REGISTER_PLUGIN_INIT(DTHVStatusRcd, DTHVStatus, InitDTHVStatus);
 REGISTER_PLUGIN_INIT(DTLVStatusRcd, DTLVStatus, InitDTLVStatus);
-REGISTER_PLUGIN(DTKeyedConfigContainerRcd, cond::BaseKeyed);
-REGISTER_KEYLIST_PLUGIN(DTKeyedConfigListRcd, cond::persistency::KeyList, DTKeyedConfigContainerRcd);
 REGISTER_PLUGIN(DTRecoUncertaintiesRcd, DTRecoUncertainties);
 //New flexyble payloads for ttrig, vdrift, uncertainty
 REGISTER_PLUGIN(DTRecoConditionsTtrigRcd, DTRecoConditions);


### PR DESCRIPTION
#### PR description:

Combined the different implementation of the same tempalte function specialization into one function.
Register the SerializationHelper only once.

#### PR validation:

Code compiles.