### PR TITLE
Follow-up to `pixelgpu` online DQM client and augmented `DQM/Integration` unit tests

### DIFF
--- a/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
+++ b/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
@@ -1,12 +1,23 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import range
-import os
+import os, sys
 import FWCore.ParameterSet.Config as cms
 
 # Parameters for runType
 import FWCore.ParameterSet.VarParsing as VarParsing
 from .dqmPythonTypes import *
+
+'''
+check that the input directory exists and there are files in it
+'''
+def checkInputFolder(streamer_folder):
+  if not (os.path.exists(streamer_folder) and os.path.isdir(os.path.join(streamer_folder))):
+    raise IOError("Input folder '%s' does not exist in CMSSW_SEARCH_PATH" % streamer_folder)
+
+  items = os.listdir(dqm_streamer_folder)
+  if not items:
+    raise IOError("Input folder '%s' does not contain any file" % streamer_folder)
 
 # Dedine and register options
 options = VarParsing.VarParsing("analysis")
@@ -79,7 +90,9 @@ options.parseArguments()
 
 # Read streamer files from https://github.com/cms-data/DQM-Integration
 dqm_integration_data = [os.path.join(dir,'DQM/Integration/data') for dir in os.getenv('CMSSW_SEARCH_PATH','').split(":") if os.path.exists(os.path.join(dir,'DQM/Integration/data'))][0]
-print("Reading streamer files from:\n ", dqm_integration_data)
+dqm_streamer_folder = os.path.join(dqm_integration_data,'run'+str(options.runNumber))
+print("Reading streamer files from:\n ",dqm_streamer_folder)
+checkInputFolder(dqm_streamer_folder)
 
 # Set the process source
 source = cms.Source("DQMStreamerReader",

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -85,28 +85,30 @@ namespace {
     k_FED38 = 38   // 38 indicates the pixels on a ROC weren't read out from lowest to highest row and dcol value
   };
 
-  std::map<SiPixelFEDErrorCodes, std::string> errorCodeToStringMap = {{k_FED25, "FED25 error"},
-                                                                      {k_FED26, "FED26 error"},
-                                                                      {k_FED27, "FED27 error"},
-                                                                      {k_FED28, "FED28 error"},
-                                                                      {k_FED29, "FED29 error"},
-                                                                      {k_FED30, "FED30 error"},
-                                                                      {k_FED31, "FED31 error"}};
+  using MapToCodes = std::map<SiPixelFEDErrorCodes, std::string>;
 
-  std::map<SiPixelFEDErrorCodes, std::string> errorCodeToTypeMap = {{k_FED25, "ROC of 25"},
-                                                                    {k_FED26, "Gap word"},
-                                                                    {k_FED27, "Dummy word"},
-                                                                    {k_FED28, "FIFO full"},
-                                                                    {k_FED29, "Timeout"},
-                                                                    {k_FED30, "TBM error trailer"},
-                                                                    {k_FED31, "Event number"},
-                                                                    {k_FED32, "Slink header"},
-                                                                    {k_FED33, "Slink trailer"},
-                                                                    {k_FED34, "Event size"},
-                                                                    {k_FED35, "Invalid channel#"},
-                                                                    {k_FED36, "ROC value"},
-                                                                    {k_FED37, "Dcol or pixel value"},
-                                                                    {k_FED38, "Readout order"}};
+  const MapToCodes errorCodeToStringMap = {{k_FED25, "FED25 error"},
+                                           {k_FED26, "FED26 error"},
+                                           {k_FED27, "FED27 error"},
+                                           {k_FED28, "FED28 error"},
+                                           {k_FED29, "FED29 error"},
+                                           {k_FED30, "FED30 error"},
+                                           {k_FED31, "FED31 error"}};
+
+  const MapToCodes errorCodeToTypeMap = {{k_FED25, "ROC of 25"},
+                                         {k_FED26, "Gap word"},
+                                         {k_FED27, "Dummy word"},
+                                         {k_FED28, "FIFO full"},
+                                         {k_FED29, "Timeout"},
+                                         {k_FED30, "TBM error trailer"},
+                                         {k_FED31, "Event number"},
+                                         {k_FED32, "Slink header"},
+                                         {k_FED33, "Slink trailer"},
+                                         {k_FED34, "Event size"},
+                                         {k_FED35, "Invalid channel#"},
+                                         {k_FED36, "ROC value"},
+                                         {k_FED37, "Dcol or pixel value"},
+                                         {k_FED38, "Readout order"}};
 }  // namespace
 
 class SiPixelPhase1RawDataErrorComparator : public DQMEDAnalyzer {
@@ -223,13 +225,13 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
     }
   }
 
-  edm::LogPrint(kName) << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU << std::endl;
+  edm::LogPrint(kName) << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU;
 
   h_totFEDErrors_->Fill(errorsOnCPU, errorsOnGPU);
 
   // fill the correlations per error type
   for (unsigned int j = k_FED25; j <= k_FED31; j++) {
-    SiPixelFEDErrorCodes code = static_cast<SiPixelFEDErrorCodes>(j);
+    const SiPixelFEDErrorCodes code = static_cast<SiPixelFEDErrorCodes>(j);
     h_nFEDErrors_[code]->Fill(std::min(1000, countsOnCPU[j]), std::min(1000, countsOnGPU[j]));
   }
 
@@ -239,7 +241,7 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
       if (countsMatrixOnGPU[i][j] != 0 || countsMatrixOnCPU[i][j] != 0) {
         edm::LogVerbatim(kName) << "FED: " << i + FEDNumbering::MINSiPixeluTCAFEDID << " error: " << j + k_FED25
                                 << " | GPU counts: " << countsMatrixOnGPU[i][j]
-                                << " CPU counts:" << countsMatrixOnCPU[i][j] << std::endl;
+                                << " CPU counts:" << countsMatrixOnCPU[i][j];
         h_FEDerrorVsFEDIdUnbalance_->Fill(
             j, i + FEDNumbering::MINSiPixeluTCAFEDID, countsMatrixOnGPU[i][j] - countsMatrixOnCPU[i][j]);
       }
@@ -267,7 +269,7 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                    FEDNumbering::MAXSiPixeluTCAFEDID - 0.5);
   for (int j = 0; j < nErrors; j++) {
     const auto& errorCode = static_cast<SiPixelFEDErrorCodes>(j + k_FED25);
-    h_FEDerrorVsFEDIdUnbalance_->setBinLabel(j + 1, errorCodeToTypeMap[errorCode]);
+    h_FEDerrorVsFEDIdUnbalance_->setBinLabel(j + 1, errorCodeToTypeMap.at(errorCode));
   }
 
   h_totFEDErrors_ = make2DIfLog(iBook,


### PR DESCRIPTION
#### PR description:

This is a quick follow up to the comments received during the integration of https://github.com/cms-sw/cmssw/pull/42583:
   * 3e03be13de51d0fb9921f1f645120efbe1516dfc addresses the static analyzer issue discussed in https://github.com/cms-sw/cmssw/pull/42583#issuecomment-1681704832
   * 777976f5a382cae2feaad086e64dd4384f90ea8b adds a function to `unitteststreamerinputsource_cfi` in order to check if the input streamer files for the unit test exist and otherwise raises an exception, addressing https://github.com/cms-sw/cmssw/pull/42583#issuecomment-1681756967

#### PR validation:

`scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported to 13.2.X
