### PR TITLE
`Alignment/OfflineValidation`: follow-up to `SiPixelTemplateStore` from DB to an `ESProducer`

### DIFF
--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -28,6 +28,7 @@
     <use name="Alignment/OfflineValidation"/>
   </bin>
   <test name="DiMuonVertex" command="testingScripts/test_unitDiMuonVertex.sh"/>
+  <test name="DiElectronVertex" command="testingScripts/test_unitDiElectronVertex.sh"/>
   <test name="SubmitPVrbr" command="testingScripts/test_unitSubmitPVrbr.sh"/>
   <test name="SubmitPVsplit" command="testingScripts/test_unitSubmitPVsplit.sh"/>
   <test name="EoP" command="testingScripts/test_unitEoP.sh"/>

--- a/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py
@@ -26,13 +26,13 @@ options.register('maxEvents',
                  VarParsing.VarParsing.varType.int,
                  "number of events to process (\"-1\" for all)")
 options.register ('era',
-                  '2017', # default value
+                  '2022', # default value
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "CMS running era")
 
 options.register ('GlobalTag',
-                  '113X_mc2017_realistic_v4', # default value
+                  'auto:phase1_2022_realistic', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "seed number")
@@ -56,7 +56,7 @@ options.register ('myseed',
                   "seed number")
 
 options.register ('myfile',
-                  'root://cms-xrd-global.cern.ch//store/relval/CMSSW_10_6_1/RelValZEE_13/GEN-SIM-RECO/PU25ns_106X_mc2017_realistic_v6_HS-v1/10000/B3F7544E-F34D-9D42-B897-21820FDE0331.root',
+                  '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4a1ae43b-f4b3-4ad9-b86e-a7d9f6fc5c40.root',
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "file name")
@@ -95,6 +95,15 @@ elif options.era=='2017':
 elif options.era=='2018':
     print("===> running era 2018")
     process = cms.Process('Analysis',eras.Run2_2018)
+elif options.era=='2022':
+    print("===> running era 2022")
+    process = cms.Process('Analysis',eras.Run3)
+elif options.era=='2023':
+    print("===> running era 2023")
+    process = cms.Process('Analysis',eras.Run3_2023)
+else:
+    print("unrecognized era %s" % options.era)
+    sys.exit(1)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -227,11 +236,13 @@ process.GsfTrackRefitter.AlgorithmName = cms.string('gsf')
 ####################################################################
 # Sequence
 ####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                         # in case NavigatioSchool is set !=''
                                         #process.MeasurementTrackerEvent*
                                         process.TrackRefitter*
-                                        process.GsfTrackRefitter)
+                                        process.GsfTrackRefitter,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
 
 ####################################################################
 # Re-do vertices

--- a/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_TEMPL_cfg.py
@@ -193,6 +193,11 @@ process.TrackRefitter.NavigationSchool = ''
 process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 
 ####################################################################
+# Load .SiPixelTemplateStoreESProducer
+####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
+
+####################################################################
 # Output file
 ####################################################################
 process.TFileService = cms.Service("TFileService",
@@ -249,9 +254,15 @@ process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
                                       )
 
 ####################################################################
+# Refitting Sequence
+####################################################################
+process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
+                                        process.TrackRefitter,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
+
+####################################################################
 # Path
 ####################################################################
 process.p = cms.Path(process.goodvertexSkim*
-                     process.offlineBeamSpot*
-                     process.TrackRefitter*
+                     process.seqTrackselRefit*
                      process.PVValidation)

--- a/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
+++ b/Alignment/OfflineValidation/test/PVValidation_T_cfg.py
@@ -255,10 +255,12 @@ elif (theRefitter == RefitType.STANDARD):
      ####################################################################
      # Sequence
      ####################################################################
+     process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
      process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                              # in case NavigatioSchool is set !=''
                                              #process.MeasurementTrackerEvent*
-                                             process.FinalTrackRefitter)
+                                             process.FinalTrackRefitter,
+                                             cms.Task(process.SiPixelTemplateStoreESProducer))
 
 ####################################################################
 # Output file

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_cfg.py
@@ -127,7 +127,17 @@ process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 process.TrackRefitter.src = 'ALCARECOTkAlMinBias'
 process.TrackRefitter.NavigationSchool = ''
 
+####################################################################
+# Refitting Sequence
+####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
+process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
+                                        process.TrackRefitter,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
+
+####################################################################
 ## PV refit
+####################################################################
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices 
@@ -184,11 +194,11 @@ process.TFileService = cms.Service("TFileService",
                                    )
 
 process.p = cms.Path(process.HLTFilter                               +
-                     process.offlineBeamSpot                         +
-                     process.TrackRefitter                           +
+                     #process.offlineBeamSpot                        +
+                     #process.TrackRefitter                          +
+                     process.seqTrackselRefit                        +
                      process.offlinePrimaryVerticesFromRefittedTrks  +
                      process.PrimaryVertexResolution                 +
-                     process.myanalysis
-                     )
+                     process.myanalysis)
 
 

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -129,7 +129,17 @@ process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 process.TrackRefitter.src = 'ALCARECOTkAlMinBias'
 process.TrackRefitter.NavigationSchool = ''
 
+####################################################################
+# Refitting Sequence
+####################################################################
+process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
+process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
+                                        process.TrackRefitter,
+                                        cms.Task(process.SiPixelTemplateStoreESProducer))
+
+####################################################################
 ## PV refit
+####################################################################
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices 
@@ -164,8 +174,9 @@ process.TFileService = cms.Service("TFileService",
                                    closeFileFast = cms.untracked.bool(False)
                                    )
 
-process.p = cms.Path(process.offlineBeamSpot                        + 
-                     process.TrackRefitter                          + 
+process.p = cms.Path(process.seqTrackselRefit                       +
+                     #process.offlineBeamSpot                       +
+                     #process.TrackRefitter                         +
                      process.offlinePrimaryVerticesFromRefittedTrks +
                      process.PrimaryVertexResolution)
 

--- a/Alignment/OfflineValidation/test/testPVValidation_Relvals_DATA.ini
+++ b/Alignment/OfflineValidation/test/testPVValidation_Relvals_DATA.ini
@@ -13,11 +13,11 @@ maxevents: 10000
 
 [Conditions:OfflineGT]
 jobname: testingOfflineGT
-gt: auto:run2_data
+gt: auto:run3_data
 allFromGT: False
-applyextracond: True
+applyextracond: False
 alignmentdb: frontier://FrontierProd/CMS_CONDITIONS 
-alignmenttag:  TrackerAlignment_v14_offline
+alignmenttag: TrackerAlignment_v30_offline
 apedb: frontier://FrontierProd/CMS_CONDITIONS
 apetag: TrackerAlignmentExtendedErr_2009_v2_express_IOVs
 applybows: True
@@ -30,17 +30,17 @@ tracktype: ALCARECOTkAlMinBias
 
 [Refit]
 refittertype: RefitType.COMMON
-ttrhtype: WithTrackAngle
-#ttrhtype: WithAngleAndTemplate
+#ttrhtype: WithTrackAngle
+ttrhtype: WithAngleAndTemplate
 
 [Selection]
-applyruncontrol: True
+applyruncontrol: False
 ptcut: 3.
 runboundary: 275657 
 # also on afs
 #lumilist: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/DCSOnly/json_DCSONLY.txt
-lumilist: /eos/cms/store/group/comm_dqm/certification/Collisions16/13TeV/DCSOnly/json_DCSONLY.txt
-
+#lumilist: /eos/cms/store/group/comm_dqm/certification/Collisions16/13TeV/DCSOnly/json_DCSONLY.txt
+lumilist:
 [ExtraConditions]   
 SiPixelTemplateDBObjectRcd:frontier://FrontierProd/CMS_CONDITIONS,SiPixelTemplateDBObject_38T_2015_v3_hltvalidation 
 

--- a/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_Phase2_cfg.py
@@ -232,10 +232,12 @@ elif (theRefitter == RefitType.STANDARD):
      ####################################################################
      # Sequence
      ####################################################################
+     process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
      process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                              # in case NavigatioSchool is set !='' 
                                              #process.MeasurementTrackerEvent*
-                                             process.FinalTrackRefitter)     
+                                             process.FinalTrackRefitter,
+                                             cms.Task(process.SiPixelTemplateStoreESProducer))
 
 ####################################################################
 # Output file

--- a/Alignment/OfflineValidation/test/test_all_cfg.py
+++ b/Alignment/OfflineValidation/test/test_all_cfg.py
@@ -230,10 +230,12 @@ elif (theRefitter == RefitType.STANDARD):
      ####################################################################
      # Sequence
      ####################################################################
+     process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
      process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                              # in case NavigatioSchool is set !='' 
                                              #process.MeasurementTrackerEvent*
-                                             process.FinalTrackRefitter)     
+                                             process.FinalTrackRefitter,
+                                             cms.Task(process.SiPixelTemplateStoreESProducer))
 
 ####################################################################
 # Output file

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitDiElectronVertex.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitDiElectronVertex.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Double Electron Vertex validation ..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/DiElectronVertexValidation_cfg.py maxEvents=10 || die "Failure running DiElectronVertexValidation_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVrbr.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVrbr.sh
@@ -8,6 +8,6 @@ conddb --yes --db pro copy TrackerAlignment_Upgrade2017_design_v4 --destdb myfil
 conddb --yes --db pro copy TrackerAlignmentErrorsExtended_Upgrade2017_design_v0 --destdb myfile.db
 
 echo " TESTING Primary Vertex Validation run-by-run submission ..."
-submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO \
+submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2023D-TkAlMinBias-PromptReco-v2/ALCARECO \
   -i ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
 


### PR DESCRIPTION
#### PR description:

This PR is a quick follow-up to https://github.com/cms-sw/cmssw/pull/42514. After integration few untested configuration file are left broken (fixed at 79bd2f8547f898eca9fdd8b3e925e1493f5b9cd3). 
I profit of this PR to introduce a unit test for `DiElectronVertexValidation` in 0314ce3104cd9e178683fb8b99478b9cd9140109, and to refresh the unit test for the run-by-run PVVValidation (0cddd1097c044e6363bc3127f6e15d859a0b7a7f).

#### PR validation:

`scram b runtests` in `Alignment/OfflineValidation` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A (depends if  https://github.com/cms-sw/cmssw/pull/42514 gets to be backported)