### PR TITLE
Do not use a Task with SiPixelTemplateStoreESProducer

### DIFF
--- a/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
+++ b/Alignment/CommonAlignment/python/tools/trackselectionRefitting.py
@@ -391,10 +391,6 @@ def getSequence(process, collection,
         modules.append(getattr(process, src))
 
     moduleSum = process.offlineBeamSpot        # first element of the sequence
-    tasks = []
-    if usePixelQualityFlag:
-        process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
-        tasks =[process.SiPixelTemplateStoreESProducer]
     if g4Refitting:
         # g4Refitter needs measurements
         moduleSum += getattr(process,"MeasurementTrackerEvent")
@@ -425,8 +421,6 @@ def getSequence(process, collection,
 
         moduleSum += module # append the other modules
 
-    if tasks:
-        return cms.Sequence(moduleSum, cms.Task(*tasks))
     return cms.Sequence(moduleSum)
 
 ###############################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -289,19 +289,17 @@ process.TFileService = cms.Service("TFileService",
                                    )
 
 
-process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 if (triggerFilter == "nothing" or triggerFilter == ""):
     process.p = cms.Path(process.offlineBeamSpot                        + 
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
-                         process.jetHTAnalyzer,
-                         cms.Task(process.SiPixelTemplateStoreESProducer))
+                         process.jetHTAnalyzer)
 else:
     process.p = cms.Path(process.HLTFilter                              +
                          process.offlineBeamSpot                        + 
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
-                         process.jetHTAnalyzer,
-                         cms.Task(process.SiPixelTemplateStoreESProducer))
+                         process.jetHTAnalyzer)
+
 
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -197,12 +197,10 @@ process.TFileService = cms.Service("TFileService",
 print("Saving the output at %s" % process.TFileService.fileName.value())
 
 
-process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.theValidSequence = cms.Sequence(process.offlineBeamSpot                        +
                                         process.TrackRefitter                          +
                                         process.offlinePrimaryVerticesFromRefittedTrks +
-                                        process.PrimaryVertexResolution,
-                                        cms.Task(process.SiPixelTemplateStoreESProducer))
+                                        process.PrimaryVertexResolution)
 
 HLTSel = config["validation"].get("HLTselection", False)
 

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -228,12 +228,10 @@ process.TrackRefitter.TTRHBuilder = "WithAngleAndTemplate"
 ####################################################################
 # Sequence
 ####################################################################
-process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.seqTrackselRefit = cms.Sequence(process.offlineBeamSpot*
                                         # in case NavigatioSchool is set !=''
                                         #process.MeasurementTrackerEvent*
-                                        process.TrackRefitter,
-                                        cms.Task(process.SiPixelTemplateStoreESProducer))
+                                        process.TrackRefitter)
 
 ####################################################################
 # Re-do vertices

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -150,10 +150,8 @@ process.TFileService = cms.Service("TFileService",
 ####################################################################
 # Path
 ####################################################################
-process.load("RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi")
 process.p = cms.Path(process.MeasurementTrackerEvent*
                      process.offlineBeamSpot*
                      process.AlignmentTrackSelector*
                      process.TrackRefitter*
-                     process.energyOverMomentumTree,
-                     cms.Task(process.SiPixelTemplateStoreESProducer))
+                     process.energyOverMomentumTree)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngleMCS_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngleMCS_cff.py
@@ -66,6 +66,5 @@ seqALCARECOPromptCalibProdSiPixelLorentzAngleMCS = cms.Sequence(
     ALCARECOCalCosmicsFilterForSiPixelLorentzAngleMCS *
     ALCARECOPixelLATrackFilterRefitMCS *
     ALCARECOSiPixelLACalibMCS *
-    MEtoEDMConvertSiPixelLorentzAngleMCS,
-    cms.Task(SiPixelTemplateStoreESProducer)
+    MEtoEDMConvertSiPixelLorentzAngleMCS
    )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
@@ -67,6 +67,5 @@ seqALCARECOPromptCalibProdSiPixelLorentzAngle = cms.Sequence(
     ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle *
     ALCARECOPixelLATrackFilterRefit *
     ALCARECOSiPixelLACalib *
-    MEtoEDMConvertSiPixelLorentzAngle,
-    cms.Task(SiPixelTemplateStoreESProducer)
+    MEtoEDMConvertSiPixelLorentzAngle
    )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
@@ -67,8 +67,7 @@ ALCARECOCalibrationTracksRefitAAG = TrackRefitter.clone(src = cms.InputTag("ALCA
 from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOTrackFilterRefitAAG = cms.Sequence(ALCARECOCalibrationTracksAAG +
                                            offlineBeamSpot +
-                                           ALCARECOCalibrationTracksRefitAAG,
-                                           cms.Task(SiPixelTemplateStoreESProducer) )
+                                           ALCARECOCalibrationTracksRefitAAG )
 
 # ------------------------------------------------------------------------------
 # This is the module actually doing the calibration

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -78,8 +78,7 @@ closebyPixelClusters = NearbyPixelClusters.NearbyPixelClustersProducer.clone(clu
 ##################################################################
 from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOSiPixelCalSingleMuonTightOffTrackClusters = cms.Sequence(ALCARECOSiPixelCalSingleMuonTightTracksRefit +
-                                                                 closebyPixelClusters ,
-                                                                 cms.Task(SiPixelTemplateStoreESProducer))
+                                                                 closebyPixelClusters)
 
 ##################################################################
 # Producer of distances value map

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -39,8 +39,7 @@ siPixelPhase1OfflineDQM_source = cms.Sequence(SiPixelPhase1RawDataAnalyzer
                                             + SiPixelPhase1RecHitsAnalyzer
                                             + SiPixelPhase1TrackResidualsAnalyzer
                                             + SiPixelPhase1TrackClustersAnalyzer
-                                            + SiPixelPhase1TrackEfficiencyAnalyzer,
-                                            cms.Task(SiPixelTemplateStoreESProducer)  
+                                            + SiPixelPhase1TrackEfficiencyAnalyzer
                                             )
 
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -115,8 +115,7 @@ siPixelPhase1OnlineDQM_source = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer
- + SiPixelPhase1TrackResidualsAnalyzer,
- cms.Task(SiPixelTemplateStoreESProducer)   
+ + SiPixelPhase1TrackResidualsAnalyzer
 )
 
 siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
@@ -150,8 +149,7 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_cosmics
- + SiPixelPhase1TrackResidualsAnalyzer_cosmics,
- cms.Task(SiPixelTemplateStoreESProducer)
+ + SiPixelPhase1TrackResidualsAnalyzer_cosmics
 )
 
 ## Additional settings for pp_run (Phase 0 test)
@@ -179,7 +177,6 @@ siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_pprun
  + SiPixelPhase1TrackResidualsAnalyzer_pprun
- + SiPixelPhase1TrackEfficiencyAnalyzer_pprun,
- cms.Task(SiPixelTemplateStoreESProducer)
+ + SiPixelPhase1TrackEfficiencyAnalyzer_pprun
 )
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -88,7 +88,6 @@ siPixelPhase1OnlineDQM_source = cms.Sequence(
  + SiPixelPhase1TrackClustersAnalyzer
  + SiPixelPhase1TrackResidualsAnalyzer
 # + SiPixelPhase1GeometryDebugAnalyzer
- , cms.Task(SiPixelTemplateStoreESProducer)
 )
 
 siPixelPhase1OnlineDQM_harvesting = cms.Sequence(
@@ -122,8 +121,7 @@ siPixelPhase1OnlineDQM_source_cosmics = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_cosmics
- + SiPixelPhase1TrackResidualsAnalyzer_cosmics,
- cms.Task(SiPixelTemplateStoreESProducer)
+ + SiPixelPhase1TrackResidualsAnalyzer_cosmics
 )
 
 ## Additional settings for pp_run                                                                                                                                         
@@ -146,8 +144,7 @@ siPixelPhase1OnlineDQM_source_pprun = cms.Sequence(
  + SiPixelPhase1ClustersAnalyzer
  + SiPixelPhase1RawDataAnalyzer
  + SiPixelPhase1TrackClustersAnalyzer_pprun
- + SiPixelPhase1TrackResidualsAnalyzer_pprun,
- cms.Task(SiPixelTemplateStoreESProducer)
+ + SiPixelPhase1TrackResidualsAnalyzer_pprun
 )
 
 siPixelPhase1OnlineDQM_timing_harvesting = siPixelPhase1OnlineDQM_harvesting.copyAndExclude([

--- a/FastSimulation/Configuration/python/Reconstruction_BefMix_cff.py
+++ b/FastSimulation/Configuration/python/Reconstruction_BefMix_cff.py
@@ -49,6 +49,5 @@ reconstruction_befmix = cms.Sequence(
     * fastMatchedTrackerRecHits
     * fastMatchedTrackerRecHitCombinations
     * MeasurementTrackerEvent
-    * iterTracking,
-    cms.Task(SiPixelTemplateStoreESProducer)
+    * iterTracking
     )

--- a/RecoHI/HiTracking/python/HighPtTracking_PbPb_cff.py
+++ b/RecoHI/HiTracking/python/HighPtTracking_PbPb_cff.py
@@ -32,5 +32,4 @@ hiBasicTrackingTask = cms.Task(hiPixelVerticesTask
                                 , hiPrimTrackCandidates
                                 , hiGlobalPrimTracks
                                 , hiTracksWithQualityTask
-                                , SiPixelTemplateStoreESProducer
                                 )

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -49,8 +49,7 @@ generalTracksTask = cms.Task(
     duplicateTrackCandidates,
     mergedDuplicateTracks,
     duplicateTrackClassifier,
-    generalTracks,
-    SiPixelTemplateStoreESProducer
+    generalTracks
     )
 generalTracksSequence = cms.Sequence(generalTracksTask)
 

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -52,6 +52,5 @@ cosmicDCTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterialP5_cff.ctfWith
 )
 
 # Final Sequence
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
-cosmicDCTracksSeqTask = cms.Task( cosmicDCSeeds , cosmicDCCkfTrackCandidates , cosmicDCTracks , SiPixelTemplateStoreESProducer )
+cosmicDCTracksSeqTask = cms.Task( cosmicDCSeeds , cosmicDCCkfTrackCandidates , cosmicDCTracks )
 cosmicDCTracksSeq = cms.Sequence(cosmicDCTracksSeqTask)


### PR DESCRIPTION
#### PR description:

The use of a Task at this time causes to much disruption. Moving ES modules to Tasks should wait till a dedicated campaign.

#### PR validation:

Ran unit tests for all packages changed plus all packages which had unit test failures in the IB. All tests now pass.