### PR TITLE
Update 2023 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -76,9 +76,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '132X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '132X_mcRun3_2023_realistic_v1',
+    'phase1_2023_realistic'        : '132X_mcRun3_2023_realistic_v2',
+    # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
+    'phase1_2023_realistic_postBPix'  : '132X_mcRun3_2023_realistic_postBPix_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '132X_mcRun3_2023cosmics_realistic_deco_v1',
+    'phase1_2023_cosmics'          : '132X_mcRun3_2023cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '132X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:

This PR updates in the release the 132X GTs for Run 3 MC, also adding a new key (`phase1_2023_realistic_postBPix`) for the "postBPix" era.

There are a few conditions updated, namely:

- **Updated ECAL conditions to best represent the collected data**

   - Tags for ABC eras:
      - EcalLaserAPDPNRatiosRcd:  `EcalLaserAPDPNRatios_2023ABC_outliers_cleaned_3sigma_mc`
      - EcalPedestalsRcd:  `EcalPedestals_2023ABC_corrected_mc`
      - EcalTPGLinearizationConstRcd:  `EcalTPGLinearizationConst_2023ABC_mc`
      - EcalTPGPedestalsRcd:	`EcalTPGPedestals_2023ABC_mc`

   - Tags for D era (postBPix) and for cosmics:
      - EcalLaserAPDPNRatiosRcd:  `EcalLaserAPDPNRatios_2023D_outliers_cleaned_3sigma_mc`
      - EcalPedestalsRcd:  `EcalPedestals_2023ABC_corrected_mc`
      - EcalTPGLinearizationConstRcd:  `EcalTPGLinearizationConst_2023D_mc`
      - EcalTPGPedestalsRcd:	`EcalTPGPedestals_2023D_mc`
 
   - CMS Talk post in https://cms-talk.web.cern.ch/t/queues-postbpix-queues-open-for-run3summer23bpix-campaign/27818/4


- **New payloads for status of pixel bad components scenarios and probabilities**

   - Tags for ABC eras:
      - SiPixelStatusScenarioProbabilityRcd:	`SiPixelQualityProbabilities_2023_v2_mc`
      - SiPixelStatusScenariosRcd:  `SiPixelStatusScenarios_StuckTBMandOther_2023_v2_mc`

   - Tags for D era (postBPix) and for cosmics:
      - SiPixelQualityFromDbRcd:  `SiPixelQuality_phase1_2023_v5_mc`
      - SiPixelQualityFromDbRcd,forDigitizer:	`SiPixelQuality_forDigitizer_phase1_2023_v5_mc`
      - SiPixelStatusScenarioProbabilityRcd: `SiPixelQualityProbabilities_2023_v2_BPix_mc`
      - SiPixelStatusScenariosRcd:  `SiPixelStatusScenarios_StuckTBMandOther_2023_v2_mc`

   - CMS Talk post in https://cms-talk.web.cern.ch/t/new-pixel-status-scenarios-and-probabilities-for-2023-mc/28126


**GT Differences**:

- phase1_2023_realistic:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023_realistic_v1/132X_mcRun3_2023_realistic_v2
- phase1_2023_realistic_postBPix (difference wrt previous phase1_2023_realistic):
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023_realistic_v1/132X_mcRun3_2023_realistic_postBPix_v1
- phase1_2023_cosmics:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023cosmics_realistic_deco_v1/132X_mcRun3_2023cosmics_realistic_deco_v2


#### PR validation:

Validated running:

runTheMatrix.py -s


#### Backport:

Corresponding updates for 13_2_X, 13_1_X, 13_0_X will be opened soon

