### PR TITLE
[13_0_X] Update 2022,2023,2024 MC GTs 

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,91 +2,93 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '123X_mcRun1_design_v1',
+    'run1_design'                    : '123X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '123X_mcRun1_realistic_v1',
+    'run1_mc'                        : '123X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '123X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'                     : '123X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '123X_mcRun2_startup_v1',
+    'run2_mc_50ns'                   : '123X_mcRun2_startup_v1',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '123X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'               : '123X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '123X_mcRun2_design_v1',
+    'run2_design'                    : '123X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '123X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'                : '123X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '123X_mcRun2_asymptotic_v1',
+    'run2_mc'                        : '123X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '123X_mcRun2cosmics_asymptotic_deco_v1',
+    'run2_mc_cosmics'                : '123X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '123X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'                     : '123X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '123X_mcRun2_pA_v1',
+    'run2_mc_pa'                     : '123X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '124X_dataRun2_v2',
+    'run2_data'                      : '124X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '124X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'               : '124X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'        : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'                : '123X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v4',
+    'run3_hlt'                       : '130X_dataRun3_HLT_frozen_v4',
     # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v4',
+    'run3_data_express'              : '130X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v4',
+    'run3_data_prompt'               : '130X_dataRun3_Prompt_frozen_v4',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20 (UTC)
-    'run3_data'                    : '130X_dataRun3_v2',
+    'run3_data'                      : '130X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '123X_mc2017_design_v2',
+    'phase1_2017_design'             : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '130X_mc2017_realistic_v1',
+    'phase1_2017_realistic'          : '130X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '123X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'            : '123X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '123X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak'       : '123X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '123X_upgrade2018_design_v4',
+    'phase1_2018_design'             : '123X_upgrade2018_design_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '123X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'          : '123X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '123X_upgrade2018_realistic_RD_v3',
+    'phase1_2018_realistic_rd'       : '123X_upgrade2018_realistic_RD_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '123X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi'       : '123X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '123X_upgrade2018_realistic_HEfail_v2',
+    'phase1_2018_realistic_HEfail'   : '123X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '123X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'            : '123X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak'       : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '130X_mcRun3_2022_design_v3',
+    'phase1_2022_design'             : '130X_mcRun3_2022_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '130X_mcRun3_2022_realistic_v4',
+    'phase1_2022_realistic'          : '130X_mcRun3_2022_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '130X_mcRun3_2022_realistic_postEE_v4',
+    'phase1_2022_realistic_postEE'   : '130X_mcRun3_2022_realistic_postEE_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '130X_mcRun3_2022cosmics_realistic_deco_v4',
+    'phase1_2022_cosmics'            : '130X_mcRun3_2022cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '130X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'     : '130X_mcRun3_2022cosmics_design_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '130X_mcRun3_2022_realistic_HI_v7',
+    'phase1_2022_realistic_hi'       : '130X_mcRun3_2022_realistic_HI_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '130X_mcRun3_2023_design_v8',
+    'phase1_2023_design'             : '130X_mcRun3_2023_design_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '130X_mcRun3_2023_realistic_v12',
+    'phase1_2023_realistic'          : '130X_mcRun3_2023_realistic_v13',
+    # GlobalTag for MC production with realistic conditions for Phase1 2023 post-BPIX issue
+    'phase1_2023_realistic_postBPix' : '130X_mcRun3_2023_realistic_postBPix_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '130X_mcRun3_2023cosmics_realistic_deco_v11',
+    'phase1_2023_cosmics'            : '130X_mcRun3_2023cosmics_realistic_deco_v12',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '130X_mcRun3_2023cosmics_design_deco_v8',
+    'phase1_2023_cosmics_design'     : '130X_mcRun3_2023cosmics_design_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '130X_mcRun3_2023_realistic_HI_v15',
+    'phase1_2023_realistic_hi'       : '130X_mcRun3_2023_realistic_HI_v16',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '130X_mcRun3_2024_realistic_v7',
+    'phase1_2024_realistic'          : '130X_mcRun3_2024_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '130X_mcRun4_realistic_v8'
+    'phase2_realistic'               : '130X_mcRun4_realistic_v8'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR is a combined backport of https://github.com/cms-sw/cmssw/pull/42551 and https://github.com/cms-sw/cmssw/pull/42601

From the partial backport of https://github.com/cms-sw/cmssw/pull/42551 , this PR:
- Updates the ZDC reco geometry tags in the remaining 2022 and 2023 realistic, design GTs (except HI, which are included in `132X` master GTs via https://github.com/cms-sw/cmssw/pull/42551) requested in [[1]](https://cms-talk.web.cern.ch/t/update-zdc-geometry-for-run3-data-and-mc/24637)
  - For 2022 MC: `ZDCRECO_Geometry_132DD4hepV2` 
  - For 2023 MC: `ZDCRECO_Geometry_132DD4hepV3`
- Updates the 2022 MC GTs with the updated pixel bad components and pixel dynamic inefficiency tags requested in [[2]](https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670) 
- Fixes the pixel dynamic inefficiency tag to `SiPixelDynamicInefficiency_phase1_2023_v2_fix3` in the other GTs introduced via https://github.com/cms-sw/cmssw/pull/41332

From backport of https://github.com/cms-sw/cmssw/pull/42601
- It updates the 2023 realistic MC GTs with the latest requests from pixel and ECAL in [[3]](https://cms-talk.web.cern.ch/t/queues-postbpix-queues-open-for-run3summer23bpix-campaign/27818/4) and [[4]](https://cms-talk.web.cern.ch/t/new-pixel-status-scenarios-and-probabilities-for-2023-mc/28126), and introduces a new key `phase1_2023_realistic_postBPix` for the MC conditions corresponding to the `Run3Summer23BPix` campaign 

For more details, see the master PRs.

[1] https://cms-talk.web.cern.ch/t/update-zdc-geometry-for-run3-data-and-mc/24637
[2] https://cms-talk.web.cern.ch/t/mc-gt-pixel-bad-components-and-dynamic-inefficiency-payloads-for-the-upcoming-2022-mc-campaign/26670
[3] https://cms-talk.web.cern.ch/t/queues-postbpix-queues-open-for-run3summer23bpix-campaign/27818/4
[4] https://cms-talk.web.cern.ch/t/new-pixel-status-scenarios-and-probabilities-for-2023-mc/28126

**GT Differences with the last ones are here**:

- **Phase1 2022 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_design_v3/130X_mcRun3_2022_design_v4

- **Phase1 2022 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_v4/130X_mcRun3_2022_realistic_v5

- **Phase1 2022 realistic postEE**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_postEE_v4/130X_mcRun3_2022_realistic_postEE_v5

- **Phase1 2022 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_realistic_deco_v4/130X_mcRun3_2022cosmics_realistic_deco_v5

- **Phase1 2022 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022cosmics_design_deco_v3/130X_mcRun3_2022cosmics_design_deco_v4

- **Phase1 2022 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2022_realistic_HI_v7/130X_mcRun3_2022_realistic_HI_v8

- **Phase1 2023 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_design_v8/130X_mcRun3_2023_design_v9

- **Phase1 2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v12/130X_mcRun3_2023_realistic_v13

- **Phase1 2023 realistic postBPix**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v12/130X_mcRun3_2023_realistic_postBPix_v1

- **Phase1 2023 cosmics reaslistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_v12/130X_mcRun3_2023_realistic_postBPix_v1

- **Phase1 2023 cosmics design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023cosmics_design_deco_v8/130X_mcRun3_2023cosmics_design_deco_v9

- **Phase1 2023 realistic hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2023_realistic_HI_v15/130X_mcRun3_2023_realistic_HI_v16

- **Phase1 2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_mcRun3_2024_realistic_v7/130X_mcRun3_2024_realistic_v9

#### PR validation:
Tested successfully with 
- `runTheMatrix.py -l 12034.0,12434.0,12834.0,11601.0 -j 8 --ibeos` 
- `runTheMatrix.py -l 12430.0,12440.0 --what upgrade -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
130X backport of https://github.com/cms-sw/cmssw/pull/42601 and https://github.com/cms-sw/cmssw/pull/42551

