### PR TITLE
Fix conddb dump functionally when destfile is specified

### DIFF
--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -193,8 +193,8 @@ class CondXmlProcessor(object):
             obj = xmlConverter()
             resultXML = obj.write( data )
             if destFile is None:
-                print(resultXML)    
+                print(resultXML)   
             else:
-                with open(destFile, 'w') as outFile:
+                with open(destFile, 'a') as outFile:
                     outFile.write(resultXML)
-                    outFile.close()
+                    

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -2544,6 +2544,10 @@ def dump(args):
     if args.format == 'xml':
         xmlProcessor = cond2xml.CondXmlProcessor(conddb)
 
+    if args.destfile != None: #The file for XML dump will be cleaned up and automatically closed after this
+        with open(args.destfile, 'w'):
+            pass 
+
     if args.type == 'payload':
         if args.format == 'xml':
             xmlProcessor.payload2xml(session, name, args.destfile)


### PR DESCRIPTION
#### PR description:

Affect creating dump for tag. This pull request fixes the problem wich described in https://github.com/cms-AlCaDB/AlCaTools/issues/89.
Issue: "Dump correctly shows in the terminal, but for XML files write only the last payload."
After fixing XML file shows all info.
Code cleaning:
Removed double close for file
Added file cleaning if file exists before writing. 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
