### PR TITLE
Disentangle Phase-2 pixel Digitization and Reconstruction from Phase-1 conditions

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/MeasurementTrackerEvent_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/MeasurementTrackerEvent_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 MeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
     Phase2TrackerCluster1DProducer = cms.string('siPhase2Clusters'),
-    badPixelFEDChannelCollectionLabels = cms.VInputTag("siPixelDigis"),
+    badPixelFEDChannelCollectionLabels = cms.VInputTag(),
     inactivePixelDetectorLabels = cms.VInputTag(),
     inactiveStripDetectorLabels = cms.VInputTag("siStripDigis"),
     measurementTracker = cms.string(''),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/siPixelClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/siPixelClusters_cfi.py
@@ -19,6 +19,6 @@ siPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     VCaltoElectronOffset_L1 = cms.int32(0),
     maxNumberOfClusters = cms.int32(-1),
     mightGet = cms.optional.untracked.vstring,
-    payloadType = cms.string('Offline'),
+    payloadType = cms.string('None'),
     src = cms.InputTag("simSiPixelDigis","Pixel")
 )

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -77,6 +77,8 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc);
 
+  inline bool isCalibrated() { return doMissCalibrate; }
+
 protected:
   template <typename T>
   void clusterizeDetUnitT(const T& input,

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -58,12 +58,15 @@ SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf)
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 
   const auto& payloadType = conf.getParameter<std::string>("payloadType");
+
   if (payloadType == "HLT")
     theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationForHLTService>(conf, consumesCollector());
   else if (payloadType == "Offline")
     theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationOfflineService>(conf, consumesCollector());
   else if (payloadType == "Full")
     theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationService>(conf, consumesCollector());
+  else if (payloadType == "None")
+    theSiPixelGainCalibration_ = nullptr;
 
   //--- Make the algorithm(s) according to what the user specified
   //--- in the ParameterSet.
@@ -80,7 +83,7 @@ void SiPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("ClusterMode", "PixelThresholdClusterizer");
   desc.add<int>("maxNumberOfClusters", -1)->setComment("-1 means no limit");
   desc.add<std::string>("payloadType", "Offline")
-      ->setComment("Options: HLT - column granularity, Offline - gain:col/ped:pix");
+      ->setComment("Options: HLT - column granularity, Offline - gain:col/ped:pix, None: no gain calibrations");
 
   PixelThresholdClusterizer::fillPSetDescription(desc);
   SiPixelGainCalibrationServiceBase::fillPSetDescription(desc);  // no-op, but in principle the structures are there...
@@ -93,7 +96,8 @@ void SiPixelClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& de
 //---------------------------------------------------------------------------
 void SiPixelClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   //Setup gain calibration service
-  theSiPixelGainCalibration_->setESObjects(es);
+  if (theSiPixelGainCalibration_.get())
+    theSiPixelGainCalibration_->setESObjects(es);
 
   // Step A.1: get input data
   edm::Handle<SiPixelClusterCollectionNew> inputClusters;
@@ -141,7 +145,9 @@ void SiPixelClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 void SiPixelClusterProducer::setupClusterizer(const edm::ParameterSet& conf) {
   if (clusterMode_ == "PixelThresholdReclusterizer" || clusterMode_ == "PixelThresholdClusterizer") {
     clusterizer_ = std::make_unique<PixelThresholdClusterizer>(conf);
-    clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_.get());
+    if (theSiPixelGainCalibration_.get()) {
+      clusterizer_->setSiPixelGainCalibrationService(theSiPixelGainCalibration_.get());
+    }
   } else {
     throw cms::Exception("Configuration") << "[SiPixelClusterProducer]:"
                                           << " choice " << clusterMode_ << " is invalid.\n"

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -34,6 +34,7 @@ from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import PixelDigitiz
 phase2_tracker.toModify(siPixelClusters, # FIXME
   src = 'simSiPixelDigis:Pixel',
   DropDuplicates = False, # do not drop duplicates for phase-2 until the digitizer can handle them consistently
+  payloadType = 'None', # do not run gain calibration
   MissCalibrate = False,
   Phase2Calibration = True,
   Phase2ReadoutMode = PixelDigitizerAlgorithmCommon.Phase2ReadoutMode.value(), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -126,7 +126,6 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
   std::tie(pixelQualityFlags_, pixelQualityDebugFlags_) = pixelFlags(p);
   if (pixelQualityFlags_ != 0) {
     pixelQualityToken_ = c.consumes();
-    pixelCablingToken_ = c.consumes();
   }
 
   std::tie(stripQualityFlags_, stripQualityDebugFlags_) = stripFlags(p);
@@ -159,6 +158,9 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
     phase2TrackerCPEToken_ = c.consumes(edm::ESInputTag("", phase2));
   } else {
     stripCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("StripCPE")));
+    if (pixelQualityFlags_ != 0) {
+      pixelCablingToken_ = c.consumes();
+    }
   }
 }
 
@@ -171,7 +173,9 @@ std::unique_ptr<MeasurementTracker> MeasurementTrackerESProducer::produce(const 
 
   if (pixelQualityFlags_ != 0) {
     ptr_pixelQuality = &iRecord.get(pixelQualityToken_);
-    ptr_pixelCabling = &iRecord.get(pixelCablingToken_);
+    if (!usePhase2_) {
+      ptr_pixelCabling = &iRecord.get(pixelCablingToken_);
+    }
   }
 
   // ========= SiStripQuality related tasks =============

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerEventProducer_cfi.py
@@ -16,6 +16,7 @@ approxSiStripClusters.toModify(MeasurementTrackerEvent,
 # Need this line to stop error about missing siPixelDigis
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(MeasurementTrackerEvent, # FIXME
+    badPixelFEDChannelCollectionLabels = [],
     inactivePixelDetectorLabels = [],
     Phase2TrackerCluster1DProducer = 'siPhase2Clusters',
     stripClusterProducer = ''

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -33,7 +33,6 @@ namespace CLHEP {
 class DetId;
 class GaussianTailNoiseGenerator;
 class SiG4UniversalFluctuation;
-class SiPixelFedCablingMap;
 class SiPixelGainCalibrationOfflineSimService;
 class SiPixelLorentzAngle;
 class SiPixelQuality;
@@ -93,7 +92,6 @@ protected:
   const SiPixelQuality* siPixelBadModule_;
 
   // Accessing Map and Geom:
-  const SiPixelFedCablingMap* fedCablingMap_;
   const TrackerGeometry* geom_;
   struct SubdetEfficiencies {
     SubdetEfficiencies(const edm::ParameterSet& conf);

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -3,7 +3,6 @@
 
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
-#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -64,7 +63,6 @@ public:
 
   edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> siPixelBadModuleToken_;
   edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleSimRcd> siPixelLorentzAngleToken_;
-  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> fedCablingMapToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 #endif


### PR DESCRIPTION
#### PR description:

This is a follow-up on https://github.com/cms-AlCaDB/AlCaTools/issues/88. 
In order to remove from Phase-2 Global Tags several (currently) unused Phase-1 pixel conditions, some code changes are necessary in order to avoid calling the `consumes` in the Phase-2 Pixel Digitizer, in the Pixel clusterizer and in the `MeasurementTracker{Event/ESproducer}` in the phase-2 case.
For the pixel digitizer in particular the whole function `module_killing_DB` is removed since it cannot currently generate the expected behavior for lack of an appropriate FED cabling map in `cmssw`. Once that is available it will need to be re-impelemented. 

#### PR validation:

Run successfully `runTheMatrix.py -s` and `addOnTests.py`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

cc: @emiglior 