### PR TITLE
remove useless customization for `siStripClusters` in phase-2 (not used)

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_RealData_cfi.py
@@ -16,13 +16,3 @@ from RecoLocalTracker.SiStripClusterizer.SiStripApprox2Clusters_cfi import SiStr
 SiStripApprox2Clusters.inputApproxClusters = 'SiStripClusters2ApproxClusters'
 approxSiStripClusters.toModify(SiStripApprox2Clusters, inputApproxClusters = 'hltSiStripClusters2ApproxClusters')
 approxSiStripClusters.toReplaceWith(siStripClusters,SiStripApprox2Clusters)
-
-# The SiStripClusters are not used anymore in phase2 tracking
-# This part has to be clean up when they will be officially removed from the entire flow
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(siStripClusters, # FIXME
-  DigiProducersList = [ 'simSiStripDigis:ZeroSuppressed',
-                        'siStripZeroSuppression:VirginRaw',
-                        'siStripZeroSuppression:ProcessedRaw',
-                        'siStripZeroSuppression:ScopeMode']
-)


### PR DESCRIPTION
#### PR description:

While reviewing this code for other reasons I casually noticed this piece of unused customization code. I remove it in this PR.

#### PR validation:

Run successfully `runTheMatrix.py -l 23234.0 -t 4 -j 8 --ibeos`
No regressions expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
