### PR TITLE
Print the file open error message when a fallback file will be attempted

### DIFF
--- a/IOPool/Input/test/sitelocalconfig/useFallbackFile/local/storage.json
+++ b/IOPool/Input/test/sitelocalconfig/useFallbackFile/local/storage.json
@@ -11,7 +11,7 @@
       "volume": "DummyVolume2",
       "protocols": [
          {  "protocol": "protocolThatDoesNotExist2",
-            "prefix": "abc"
+            "prefix": "def"
          }
       ]
    }

--- a/IOPool/Input/test/testFileOpenErrorExitCode.sh
+++ b/IOPool/Input/test/testFileOpenErrorExitCode.sh
@@ -24,7 +24,13 @@ fi
 
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/local/storage.json ${SITECONFIG_PATH}/
-cmsRun -j UseFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root && die "$F1 should have failed after file fallback but didn\'t, exit code was 0" 1
+cmsRun -j UseFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root > UseFallbackFile_output.log 2>&1 && die "$F1 should have failed after file fallback but didn't, exit code was 0" 1
+grep -q "Input file abc/store/FileThatDoesNotExist.root could not be opened, and fallback was attempted" UseFallbackFile_output.log
+RET=$?
+if [ "${RET}" != "0" ]; then
+    cat UseFallbackFile_output.log
+    die "UseFallbackFile_output.log did not contain the detailed error message of the first file open failure " $RET
+fi
 
 CMSRUN_EXIT_CODE=$(edmFjrDump --exitCode UseFallbackFile_jobreport.xml)
 echo "Exit code after second run of test_fileOpenErrorExitCode_cfg.py is ${CMSRUN_EXIT_CODE}"


### PR DESCRIPTION
#### PR description:

In a couple of past occasions (e.g. https://github.com/root-project/root/issues/13429#issuecomment-1686079491) seeing details from the file open errors would have been useful.

Resolves https://github.com/makortel/framework/issues/653

#### PR validation:

The unit test succeeds.