### PR TITLE
remove duplicate plugin `SiPixelRawToClusterCUDA`

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterCUDA.cc
@@ -309,8 +309,6 @@ void SiPixelRawToClusterCUDAT<TrackerTraits>::produce(edm::Event& iEvent, const 
 }
 
 // define as framework plugin
-using SiPixelRawToClusterCUDA = SiPixelRawToClusterCUDAT<pixelTopology::Phase1>;
-DEFINE_FWK_MODULE(SiPixelRawToClusterCUDA);
 using SiPixelRawToClusterCUDAPhase1 = SiPixelRawToClusterCUDAT<pixelTopology::Phase1>;
 DEFINE_FWK_MODULE(SiPixelRawToClusterCUDAPhase1);
 using SiPixelRawToClusterCUDAHIonPhase1 = SiPixelRawToClusterCUDAT<pixelTopology::HIonPhase1>;


### PR DESCRIPTION
#### PR description:

This PR removes a duplicate plugin (i.e. `SiPixelRawToClusterCUDA`, a duplicate of `SiPixelRawToClusterCUDAPhase1`). This plugin was left around by #41632, mainly because it was used in the Run-3 HLT menus in CMSSW at the time. The use of `SiPixelRawToClusterCUDA` was removed from the latest Run-3 HLT menus in #42610.

Merely technical. No changes expected.

#### PR validation:

`addOnTests.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
