### PR TITLE
Fixed channel decoding for the timeout error in SiPixelRawToClusterGPUKernel

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -209,11 +209,12 @@ namespace pixelgpudetails {
       case (29): {
         if constexpr (debug)
           printf("Timeout on a channel (errorType = 29)\n");
-        if ((errorWord >> sipixelconstants::OMIT_ERR_shift) & sipixelconstants::OMIT_ERR_mask) {
-          if constexpr (debug)
-            printf("...first errorType=29 error, this gets masked out\n");
-        }
         errorFound = true;
+        if (!((errorWord >> sipixelconstants::OMIT_ERR_shift) & sipixelconstants::OMIT_ERR_mask)) {
+          if constexpr (debug)
+            printf("...2nd errorType=29 error, skip\n");
+          errorFound = false;
+        }
         break;
       }
       case (30): {
@@ -253,45 +254,13 @@ namespace pixelgpudetails {
 
     switch (errorType) {
       case 25:
+      case 29:
       case 30:
       case 31:
       case 36:
       case 40: {
         uint32_t roc = 1;
         uint32_t link = sipixelconstants::getLink(errWord);
-        uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
-        if (rID_temp != gpuClustering::invalidModuleId)
-          rID = rID_temp;
-        break;
-      }
-      case 29: {
-        int chanNmbr = 0;
-        const int DB0_shift = 0;
-        const int DB1_shift = DB0_shift + 1;
-        const int DB2_shift = DB1_shift + 1;
-        const int DB3_shift = DB2_shift + 1;
-        const int DB4_shift = DB3_shift + 1;
-        const uint32_t DataBit_mask = ~(~uint32_t(0) << 1);
-
-        int CH1 = (errWord >> DB0_shift) & DataBit_mask;
-        int CH2 = (errWord >> DB1_shift) & DataBit_mask;
-        int CH3 = (errWord >> DB2_shift) & DataBit_mask;
-        int CH4 = (errWord >> DB3_shift) & DataBit_mask;
-        int CH5 = (errWord >> DB4_shift) & DataBit_mask;
-        int BLOCK_bits = 3;
-        int BLOCK_shift = 8;
-        uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
-        int BLOCK = (errWord >> BLOCK_shift) & BLOCK_mask;
-        int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
-        if (BLOCK % 2 == 0)
-          chanNmbr = (BLOCK / 2) * 9 + localCH;
-        else
-          chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
-        if ((chanNmbr < 1) || (chanNmbr > 36))
-          break;  // signifies unexpected result
-
-        uint32_t roc = 1;
-        uint32_t link = chanNmbr;
         uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).rawId;
         if (rID_temp != gpuClustering::invalidModuleId)
           rID = rID_temp;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -209,12 +209,11 @@ namespace pixelgpudetails {
       case (29): {
         if constexpr (debug)
           printf("Timeout on a channel (errorType = 29)\n");
-        errorFound = true;
         if (!((errorWord >> sipixelconstants::OMIT_ERR_shift) & sipixelconstants::OMIT_ERR_mask)) {
           if constexpr (debug)
             printf("...2nd errorType=29 error, skip\n");
-          errorFound = false;
         }
+        errorFound = true;
         break;
       }
       case (30): {


### PR DESCRIPTION
#### PR description:
Follow up of #42010 and addresses #41715 .

#### PR validation:
Done test in 13_0_X release with config and input file mentioned in #41715. Results from running GPU and CPU versions are same.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport. 