### PR TITLE
improve `SiPixelBadModuleByHandBuilderFromROCList` in case of by-LS IOVs and introduce unit tests

### DIFF
--- a/CondTools/SiPixel/test/BuildFile.xml
+++ b/CondTools/SiPixel/test/BuildFile.xml
@@ -1,3 +1,3 @@
-<test name="createDBObjecs" command="createTestDBObjects.sh"/>
+<test name="createDBObjects" command="createTestDBObjects.sh"/>
 <test name="SiPixelGainCalibrationTests" command="testSiPixelGainCalibrationHandlers.sh"/>
 <test name="SiPixelCondPlottingTests" command="testPlottingSiPixelObjects.sh"/>

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
@@ -1,5 +1,30 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as opts
 process = cms.Process("ICALIB")
+
+options = opts.VarParsing ('standard')
+
+options.register('byLumi',
+                 False,
+                 opts.VarParsing.multiplicity.singleton,
+                 opts.VarParsing.varType.bool,
+                 'is output LS Based?')
+options.register('outputFileName',
+                 'SiPixelQualityTest',
+                 opts.VarParsing.multiplicity.singleton,
+                 opts.VarParsing.varType.string,
+                 'output file name')
+options.register('outputTagName',
+                 'SiPixelQualityTest',
+                 opts.VarParsing.multiplicity.singleton,
+                 opts.VarParsing.varType.string,
+                 'output tag name')
+options.register('inputROCList',
+                 'ROCList.txt',
+                 opts.VarParsing.multiplicity.singleton,
+                 opts.VarParsing.varType.string,
+                 'input ROC to maks list')
+options.parseArguments()
 
 process.load("Configuration.Geometry.GeometryExtended2017_cff")
 process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
@@ -15,38 +40,45 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
+# print("using EmptySource")
+# process.source = cms.Source("EmptySource",
+#                             numberEventsInRun = cms.untracked.uint32(1),
+#                             firstRun = cms.untracked.uint32(1),
+#                             numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+#                             firstLuminosityBlock = cms.untracked.uint32(1))
+
+print("using EmptyIOVSource")
 process.source = cms.Source("EmptyIOVSource",
-    timetype = cms.string('runnumber'),
-    firstValue = cms.uint64(1),
-    lastValue = cms.uint64(1),
-    interval = cms.uint64(1)
-)
+                            timetype = cms.string('lumiid' if options.byLumi else 'runnumber'),
+                            firstValue = cms.uint64(4294967297 if options.byLumi else 1),
+                            lastValue = cms.uint64(4294967297 if options.byLumi else 1),
+                            interval = cms.uint64(1))
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
+
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-    DBParameters = cms.PSet(
-        authenticationPath = cms.untracked.string('')
-    ),
-    timetype = cms.untracked.string('runnumber'),
-    connect = cms.string('sqlite_file:SiPixelQuality_phase1_2018_permanentlyBad.db'),
-    toPut = cms.VPSet(cms.PSet(
-        record = cms.string('SiPixelQualityFromDbRcd'),
-        tag = cms.string('SiPixelQuality_phase1_2018_permanentlyBad')
-    ))
-)
+                                          BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                          DBParameters = cms.PSet(
+                                              authenticationPath = cms.untracked.string('')
+                                          ),
+                                          timetype = cms.untracked.string('lumiid' if options.byLumi else 'runnumber'),
+                                          connect = cms.string(('sqlite_file:%s.db') % options.outputFileName),
+                                          toPut = cms.VPSet(cms.PSet(
+                                              record = cms.string('SiPixelQualityFromDbRcd'),
+                                              tag = cms.string(options.outputTagName)
+                                          )))
 
 process.prod = cms.EDAnalyzer("SiPixelBadModuleByHandBuilder",
                               BadModuleList = cms.untracked.VPSet(),
                               Record = cms.string('SiPixelQualityFromDbRcd'),
                               SinceAppendMode = cms.bool(True),
-                              IOVMode = cms.string('Run'),
+                              IOVMode = cms.string('LumiBlock' if options.byLumi else 'Run'),
                               printDebug = cms.untracked.bool(True),
                               doStoreOnDB = cms.bool(True),
-                              ROCListFile = cms.untracked.string("forPermanentSiPixelQuality_unlabeled.txt"),
-                              )
+                              TimeFromEndRun = cms.untracked.bool(True),
+                              ROCListFile = cms.untracked.string(options.inputROCList))
 
 #process.print = cms.OutputModule("AsciiOutputModule")
 

--- a/CondTools/SiPixel/test/createTestDBObjects.sh
+++ b/CondTools/SiPixel/test/createTestDBObjects.sh
@@ -59,6 +59,47 @@ cmsRun  ${SCRAM_TEST_PATH}/SiPixelBadModuleByHandBuilder_cfg.py || die "Failure 
 echo -e "TESTING Reading SiPixelQuality DB object ...\n\n"
 cmsRun  ${SCRAM_TEST_PATH}/SiPixelBadModuleReader_cfg.py || die "Failure running SiPixelBadModuleReader_cfg.py" $?
 
+echo -e "TESTING Writing SiPixelQuality DB object from ROC list \n\n"
+
+cat <<@EOF >> inputListOfROCs.txt
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 0
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 1
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 2
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 3
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 4
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 5
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 6
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 7
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 8
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 9
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 10
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 11
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 12
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 13
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 14
+BPix_BmI_SEC7_LYR3_LDR18F_MOD1_ROC 15
+@EOF
+
+echo -e "TESTING Writing SiPixelQuality DB object from input ROC list ...\n\n"
+cmsRun  ${SCRAM_TEST_PATH}/SiPixelBadModuleByHandBuilderFromROCList_cfg.py inputROCList=inputListOfROCs.txt || die "Failure running SiPixelBadModuleByHandBuilderFromROCList_cfg.py" $?
+
+if conddb --db SiPixelQualityTest.db list SiPixelQualityTest | grep -q "Run"; then
+    echo "Found 'Run' in the output. No error."
+else
+    echo "Error: 'Run' not found in the output."
+    exit 1
+fi
+
+echo -e "TESTING Writing SiPixelQuality DB object from input ROC list (by LS IOVs) ...\n\n"
+cmsRun  ${SCRAM_TEST_PATH}/SiPixelBadModuleByHandBuilderFromROCList_cfg.py  inputROCList=inputListOfROCs.txt byLumi=True outputTagName=SiPixelQualityTestByLumi || die "Failure running SiPixelBadModuleByHandBuilderFromROCList_cfg.py byLumi=True" $?
+
+if conddb --db SiPixelQualityTest.db list SiPixelQualityTestByLumi | grep -q "Lumi"; then
+    echo "Found 'Lumi' in the output. No error."
+else
+    echo "Error: 'Lumi' not found in the output."
+    exit 1
+fi
+
 echo -e "TESTING SiPixelQualityProbabilities codes ...\n\n"
 
 echo -e "TESTING Writing SiPixelQualityProbabilities DB object ...\n\n"


### PR DESCRIPTION
#### PR description:

It is sometimes useful to be able to create by hand `SiPixelQuality` payloads by giving a user-input list of ROCs, but with per-LS granularity. The configuration file present in `CondTools/SiPixel` at the moment doesn't allow to do that. The goal of this PR is to improve it in order to allow by LS IOVs (to be configured by means of passing arguments to `cmsRun`). 
I also add a couple of tests cases to the `createDBObjects` unit test.

#### PR validation:

Relies on the (augmented) unit tests (run successfully `scram b runtests_createDBObjects`) 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @tsusa 