### PR TITLE
FKDTree_t: avoid Wmaybe-uninitialized warning in CPP20 builds

### DIFF
--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -45,7 +45,7 @@ void TestFKDTree::test2D() {
 
     for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
-      float y;
+      float y = 1.f;
       if (x <= maxX && x >= minX) {
         y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
         if (y == maxY)

--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -95,7 +95,7 @@ void TestFKDTree::test3D() {
 
     for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
-      float y;
+      float y = 1.f;
       if (x <= maxX && x >= minX) {
         y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
         if (y == maxY)


### PR DESCRIPTION
#### PR description:

The following warning is emitted in CPP20 builds:
```
>> Building binary FKDTree_t
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC tmp/el8_amd64_gcc12/src/CommonTools/RecoAlgos/test/FKDTree_t/FKDTree_t.cpp.o -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/biglib/el8_amd64_gcc12 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/lib/el8_amd64_gcc12 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/external/el8_amd64_gcc12/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/static/el8_amd64_gcc12 -lCommonToolsRecoAlgos -lTrackingToolsIPTools -lRecoVertexVertexTools -lRecoVertexVertexPrimitives -lTrackingToolsTransientTrack -lDataFormatsPatCandidates -lDataFormatsHLTReco -lDataFormatsBTauReco -lDataFormatsJetMatching -lDataFormatsL1TParticleFlow -lDataFormatsMETReco -lDataFormatsTauReco -lDataFormatsJetReco -lTrackingToolsGsfTools -lDataFormatsParticleFlowCandidate -lTrackingToolsPatternTools -lDataFormatsParticleFlowReco -lTrackingToolsTransientTrackingRecHit -lDataFormatsEgammaCandidates -lDataFormatsHcalIsolatedTrack -lDataFormatsL1TCorrelator -lDataFormatsL1TMuonPhase2 -lDataFormatsMuonReco -lTrackingToolsDetLayers -lDataFormatsL1TMuon -lDataFormatsRecoCandidate -lTrackingToolsGeomPropagators -lDataFormatsCSCDigi -lDataFormatsEgammaReco -lDataFormatsGsfTrackReco -lDataFormatsVertexReco -lSimDataFormatsTrackingAnalysis -lTrackingToolsTrajectoryState -lDataFormatsGEMDigi -lDataFormatsTrackReco -lDataFormatsGEMRecHit -lDataFormatsTrackCandidate -lDataFormatsTrackerRecHit2D -lDataFormatsCSCRecHit -lDataFormatsDTRecHit -lDataFormatsFTLRecHit -lDataFormatsTrajectorySeed -lDataFormatsL1Trigger -lDataFormatsTrackingRecHit -lGeometryTrackerGeometryBuilder -lDataFormatsL1TrackTrigger -lDataFormatsTrackerCommon -lGeometryCaloGeometry -lGeometryCommonTopologies -lCondFormatsAlignment -lDataFormatsBeamSpot -lDataFormatsCaloTowers -lDataFormatsEcalRecHit -lDataFormatsGeometryCommonDetAlgo -lDataFormatsHcalRecHit -lDataFormatsHepMCCandidate -lDataFormatsSiStripCluster -lGeometryRecords -lGeometryTrackerNumberingBuilder -lTrackingToolsAnalyticalJacobians -lCondFormatsAlignmentRecord -lDataFormatsCandidate -lDataFormatsDTDigi -lDataFormatsEcalDigi -lDataFormatsGeometrySurface -lDataFormatsHcalDigi -lDataFormatsL1GlobalCaloTrigger -lDataFormatsTrajectoryState -lDetectorDescriptionCore -lDetectorDescriptionDDCMS -lMagneticFieldEngine -lSimGeneralHepPDTRecord -lCondFormatsGeometryObjects -lDataFormatsCLHEP -lDataFormatsCaloRecHit -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lDataFormatsL1CaloTrigger -lDataFormatsL1GlobalTrigger -lDataFormatsMuonDetId -lDataFormatsPhase2TrackerCluster -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lSimDataFormatsTrack -lSimDataFormatsVertex -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lDataFormatsPhase2TrackerDigi -lDataFormatsScouting -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lSimDataFormatsGeneratorProducts -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lTrackingToolsTrajectoryParametrization -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lSimDataFormatsEncodedEventId -lDDAlign -lDDCond -lDDCore -lDDParsers -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lGeom -lThread -lMathCore -lRIO -lSmatrix -lboost_regex -lboost_serialization -lCore -lboost_thread -lboost_date_time -lCLHEP -lHepMCfio -lHepMC -lpcre -lbz2 -lcppunit -lfastjetplugins -lfastjettools -lsiscone -lsiscone_spherical -lfastjet -lgsl -lHepPDT -lHepPID -luuid -ltbb -lxerces-c -llzma -lz -lfmt -lHepMC3 -lHepMC3search -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2 -o tmp/el8_amd64_gcc12/src/CommonTools/RecoAlgos/test/FKDTree_t/FKDTree_t
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/src/CommonTools/RecoAlgos/test/FKDTree_t.cpp: In member function 'test2D':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/src/CommonTools/RecoAlgos/test/FKDTree_t.cpp:48:13: warning: 'y' may be used uninitialized [-Wmaybe-uninitialized]
    48 |       float y;
      |             ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/src/CommonTools/RecoAlgos/test/FKDTree_t.cpp: In member function 'test3D':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/bde6290197b40a7abece5e0ce6f36880/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-08-21-1100/src/CommonTools/RecoAlgos/test/FKDTree_t.cpp:98:13: warning: 'y' may be used uninitialized [-Wmaybe-uninitialized]
    98 |       float y;
      |             ^
```

#### PR validation:

Bot tests.
