### PR TITLE
Move two StopReasonName arrays into source files

### DIFF
--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -715,7 +715,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker& ibooker) {
       oriAlgo->setBinLabel(ibin + 1, reco::TrackBase::algoNames[ibin]);
     }
 
-    size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName) / sizeof(std::string);
+    size_t StopReasonNameSize = static_cast<size_t>(StopReason::SIZE);
     histname = "stoppingSource_";
     stoppingSource = ibooker.book1D(
         histname + CategoryName, histname + CategoryName, StopReasonNameSize, 0., double(StopReasonNameSize));

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -329,7 +329,7 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker& ibooker, const edm::Par
 
   if (doAllTCPlots || doStopSource) {
     // DataFormats/TrackReco/interface/TrajectoryStopReasons.h
-    size_t StopReasonNameSize = sizeof(StopReasonName::StopReasonName) / sizeof(std::string);
+    size_t StopReasonNameSize = static_cast<size_t>(StopReason::SIZE);
 
     histname = "StoppingSource_" + seedProducer.label() + "_";
     stoppingSource = ibooker.book1D(

--- a/DataFormats/TrackCandidate/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackCandidate/interface/TrajectoryStopReasons.h
@@ -22,21 +22,7 @@ enum class StopReason {
 
 // to be kept in synch w/ the above enum ;)
 namespace StopReasonName {
-  static const std::string StopReasonName[] = {
-      "UNINITIALIZED",                 //  0
-      "MAX_HITS",                      //  1
-      "MAX_LOST_HITS",                 //  2
-      "MAX_CONSECUTIVE_LOST_HITS",     //  3
-      "LOST_HIT_FRACTION",             //  4
-      "MIN_PT",                        //  5
-      "CHARGE_SIGNIFICANCE",           //  6
-      "LOOPER",                        //  7
-      "MAX_CCC_LOST_HITS",             //  8
-      "NO_SEGMENTS_FOR_VALID_LAYERS",  //  9
-      "SEED_EXTENSION",                // 10
-      "NOT_STOPPED"                    // 11 (be careful, NOT_STOPPED needs to be the last,
-                                       //     its index differs from the enumeration value)
-  };
+  extern const std::string StopReasonName[];
 };
 
 #endif

--- a/DataFormats/TrackCandidate/src/TrajectoryStopReasons.cc
+++ b/DataFormats/TrackCandidate/src/TrajectoryStopReasons.cc
@@ -1,5 +1,21 @@
 #include "DataFormats/TrackCandidate/interface/TrajectoryStopReasons.h"
 
+const std::string StopReasonName::StopReasonName[] = {
+    "UNINITIALIZED",                 //  0
+    "MAX_HITS",                      //  1
+    "MAX_LOST_HITS",                 //  2
+    "MAX_CONSECUTIVE_LOST_HITS",     //  3
+    "LOST_HIT_FRACTION",             //  4
+    "MIN_PT",                        //  5
+    "CHARGE_SIGNIFICANCE",           //  6
+    "LOOPER",                        //  7
+    "MAX_CCC_LOST_HITS",             //  8
+    "NO_SEGMENTS_FOR_VALID_LAYERS",  //  9
+    "SEED_EXTENSION",                // 10
+    "NOT_STOPPED"                    // 11 (be careful, NOT_STOPPED needs to be the last,
+                                     //     its index differs from the enumeration value)
+};
+
 static_assert(sizeof(StopReasonName::StopReasonName) / sizeof(std::string) ==
                   static_cast<unsigned int>(StopReason::SIZE),
               "StopReason enum and StopReasonName are out of synch");

--- a/DataFormats/TrackReco/interface/SeedStopReason.h
+++ b/DataFormats/TrackReco/interface/SeedStopReason.h
@@ -15,15 +15,7 @@ enum class SeedStopReason {
 };
 
 namespace SeedStopReasonName {
-  static const std::string SeedStopReasonName[] = {
-      "UNINITIALIZED",        // 0
-      "NOT_STOPPED",          // 1
-      "SEED_CLEANING",        // 2
-      "NO_TRAJECTORY",        // 3
-      "SEED_REGION_REBUILD",  // 4
-      "FINAL_CLEAN",          // 5
-      "SMOOTHING_FAILED"      // 6
-  };
+  extern const std::string SeedStopReasonName[];
 }
 
 #endif

--- a/DataFormats/TrackReco/src/SeedStopReason.cc
+++ b/DataFormats/TrackReco/src/SeedStopReason.cc
@@ -1,5 +1,15 @@
 #include "DataFormats/TrackReco/interface/SeedStopReason.h"
 
+const std::string SeedStopReasonName::SeedStopReasonName[] = {
+    "UNINITIALIZED",        // 0
+    "NOT_STOPPED",          // 1
+    "SEED_CLEANING",        // 2
+    "NO_TRAJECTORY",        // 3
+    "SEED_REGION_REBUILD",  // 4
+    "FINAL_CLEAN",          // 5
+    "SMOOTHING_FAILED"      // 6
+};
+
 static_assert(sizeof(SeedStopReasonName::SeedStopReasonName) / sizeof(std::string) ==
                   static_cast<unsigned int>(SeedStopReason::SIZE),
               "SeedStopReason enum and SeedStopReasonName are out of synch");


### PR DESCRIPTION
#### PR description:

This works around https://github.com/root-project/root/issues/13429 by not having `std::string` arrays in headers that are double-freed.

#### PR validation:

Not needed

#### PR backport:

Probably not needed.