### PR TITLE
Fix LHCInfoPerLS PopCon incorrectly matching LS between OMS and PPS db

### DIFF
--- a/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
+++ b/CondTools/RunInfo/interface/LHCInfoPopConSourceHandler.h
@@ -30,7 +30,7 @@ private:
   void getDipData(const cond::OMSService& service,
                   const boost::posix_time::ptime& beginFillTime,
                   const boost::posix_time::ptime& endFillTime);
-  bool getCTTPSData(cond::persistency::Session& session,
+  bool getCTPPSData(cond::persistency::Session& session,
                     const boost::posix_time::ptime& beginFillTime,
                     const boost::posix_time::ptime& endFillTime);
   bool getEcalData(cond::persistency::Session& session,

--- a/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
@@ -354,7 +354,7 @@ public:
           boost::posix_time::ptime flumiStop = cond::time::to_boost(m_tmpBuffer.back().first);
           edm::LogInfo(m_name) << "First lumi starts at " << flumiStart << " last lumi starts at " << flumiStop;
           session.transaction().start(true);
-          getCTTPSData(session, startSampleTime, endSampleTime);
+          getCTPPSData(session, startSampleTime, endSampleTime);
           session.transaction().commit();
           session2.transaction().start(true);
           getEcalData(session2, startSampleTime, endSampleTime, updateEcal);
@@ -497,7 +497,7 @@ private:
     }
   }
 
-  bool getCTTPSData(cond::persistency::Session& session,
+  bool getCTPPSData(cond::persistency::Session& session,
                     const boost::posix_time::ptime& beginFillTime,
                     const boost::posix_time::ptime& endFillTime) {
     //run the fifth query against the CTPPS schema

--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -240,7 +240,7 @@ void LHCInfoPopConSourceHandler::getDipData(const cond::OMSService& oms,
   }
 }
 
-bool LHCInfoPopConSourceHandler::getCTTPSData(cond::persistency::Session& session,
+bool LHCInfoPopConSourceHandler::getCTPPSData(cond::persistency::Session& session,
                                               const boost::posix_time::ptime& beginFillTime,
                                               const boost::posix_time::ptime& endFillTime) {
   //run the fifth query against the CTPPS schema
@@ -665,7 +665,7 @@ void LHCInfoPopConSourceHandler::getNewObjects() {
     boost::posix_time::ptime flumiStop = cond::time::to_boost(m_tmpBuffer.back().first);
     edm::LogInfo(m_name) << "First lumi starts at " << flumiStart << " last lumi starts at " << flumiStop;
     session.transaction().start(true);
-    getCTTPSData(session, startSampleTime, endSampleTime);
+    getCTPPSData(session, startSampleTime, endSampleTime);
     session.transaction().commit();
     session2.transaction().start(true);
     getEcalData(session2, startSampleTime, endSampleTime, updateEcal);

--- a/CondTools/RunInfo/test/summarizePerLSPopConValidityLogs.sh
+++ b/CondTools/RunInfo/test/summarizePerLSPopConValidityLogs.sh
@@ -1,0 +1,10 @@
+LOG_FILE=$1
+echo "Number of invalid payloads found in the logs"
+for CONDITION in "crossingAngle == 0 for both X and Y" "crossingAngle != 0 for both X and Y" \
+                 "negative crossingAngle: " "negative betaStar" "Number of records from PPS DB with fillNumber different from OMS" \
+                 "Number of stable beam LS in OMS without corresponding record in PPS DB" ; do
+    echo -n "$CONDITION:  max in one fill: "
+    (cat $LOG_FILE | grep -E "$CONDITION" | awk '{print $NF}' ; echo 0) | sort -gr | head -n 1
+    echo -n "$CONDITION:  total: "
+    (cat $LOG_FILE | grep -E "$CONDITION" | awk '{print $NF}'; echo 0) | paste -sd+ | bc
+done

--- a/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
+++ b/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
@@ -36,14 +36,23 @@ assert_equal 7 `cat fill_end_test.log | grep -E '^Since ' | \
     wc -l` "LHCInfoPerFillPopConAnalyzer in EndFill mode written wrong number of payloads"
 assert_found_fills fill_end_test.log "LHCInfoPerFillPopConAnalyzer in EndFill mode" 8307 8309
 
-echo "testing LHCInfoPerLSPopConAnalyzerEndFill in endFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
+echo "testing LHCInfoPerLSPopConAnalyzer in endFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
 cmsRun ${SCRIPTS_DIR}/LHCInfoPerLSPopConAnalyzer.py mode=endFill \
     destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
     startTime="2022-10-24 01:00:00.000" endTime="2022-10-24 20:00:00.000" \
     tag=ls_end_test > ls_end_test.log || die "cmsRun LHCInfoPerLSPopConAnalyzer.py mode=endFill" $?
 assert_equal 169 `cat ls_end_test.log | grep -E '^Since ' | \
-    wc -l` "LHCInfoPerLSPopConAnalyzerEndFill in endFill mode written wrong number of payloads"
-assert_found_fills ls_end_test.log "LHCInfoPerLSPopConAnalyzerEndFill in endFill mode" 8307 8309
+    wc -l` "LHCInfoPerLSPopConAnalyzer in endFill mode written wrong number of payloads"
+assert_found_fills ls_end_test.log "LHCInfoPerLSPopConAnalyzer in endFill mode" 8307 8309
+
+echo "testing LHCInfoPerLSPopConAnalyzer in endFill mode for startTime=\"2022-07-11 22:00:00.000\" endTime=\"2022-07-12 18:10:10.000\"" 
+cmsRun ${SCRIPTS_DIR}/LHCInfoPerLSPopConAnalyzer.py mode=endFill \
+    destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
+    startTime="2022-07-11 22:00:00.000" endTime="2022-07-12 18:10:10.000" \
+    tag=ls_end_test2 > ls_end_test2.log || die "cmsRun LHCInfoPerLSPopConAnalyzer.py mode=endFill" $?
+assert_equal 69 `cat ls_end_test2.log | grep -E '^Since ' | \
+    wc -l` "LHCInfoPerLSPopConAnalyzer in endFill mode written wrong number of payloads"
+assert_found_fills ls_end_test2.log "LHCInfoPerLSPopConAnalyzer in endFill mode" 7967
 
 echo "testing LHCInfoPerFillPopConAnalyzer in DuringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
 cmsRun ${SCRIPTS_DIR}/LHCInfoPerFillPopConAnalyzer.py mode=duringFill \
@@ -54,11 +63,11 @@ assert_equal 1 `cat fill_during_test.log | grep -E '^Since ' | \
     wc -l` "LHCInfoPerFillPopConAnalyzer in DuringFill written wrong number of payloads"
 assert_found_fills fill_during_test.log "LHCInfoPerFillPopConAnalyzer in DuringFill" 8307 8309
 
-echo "testing LHCInfoPerLSPopConAnalyzerEndFill in duringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
+echo "testing LHCInfoPerLSPopConAnalyzer in duringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
 cmsRun ${SCRIPTS_DIR}/LHCInfoPerLSPopConAnalyzer.py mode=duringFill \
     destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
     startTime="2022-10-24 01:00:00.000" endTime="2022-10-24 20:00:00.000" \
     tag=ls_during_test > ls_during_test.log || die "cmsRun LHCInfoPerLSPopConAnalyzer.py mode=duringFill" $?
 assert_equal 1 `cat ls_during_test.log | grep -E '^Since ' | \
-    wc -l` "LHCInfoPerLSPopConAnalyzerEndFill in duringFill mode written wrong number of payloads"
-assert_found_fills ls_during_test.log  "LHCInfoPerLSPopConAnalyzerEndFill in duringFill mode" 8307 8309
+    wc -l` "LHCInfoPerLSPopConAnalyzer in duringFill mode written wrong number of payloads"
+assert_found_fills ls_during_test.log  "LHCInfoPerLSPopConAnalyzer in duringFill mode" 8307 8309


### PR DESCRIPTION
#### PR description:

Fixes a bug in `LHCInfoPerLS` PopCon: before it was writing a payload on a wrong IOV (corresponding to a different lumisection) or skipping a payload in these cases:
* `start_time` of lumisection in OMS greater or equal to `DIP_UPDATE_TIME` in PPS DB
* lumisection missing in OMS

Additionally it introduces logs monitoring payload quality to `LHCInfoPerLS` PopCon. It logs payloads with invalid values of beta star and crossing angle as well as missing records in the PPS DB.

#### PR validation:

Added validation of writing correct number of payloads for fill 7967 to the `CondToolsLHCInfoNewPopConTest` unit test. Before the fix payload on IOV 7119284725528657920 was skipped.

#### Backporting

I suspect it should be backproted back to 13_0_X but please confirm it.