### PR TITLE
fix tracker map filling in `SiStripBadStripFractionTkMap` and rename `TkMap` → `TH2PolyTkMap`

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -209,9 +209,10 @@ namespace {
   /************************************************
     SiStripTkMaps of SiStrip Lorentz Angle
   *************************************************/
-  class SiStripLorentzAngleTkMap : public PlotImage<SiStripLorentzAngle, SINGLE_IOV> {
+  class SiStripLorentzAngleTH2PolyTkMap : public PlotImage<SiStripLorentzAngle, SINGLE_IOV> {
   public:
-    SiStripLorentzAngleTkMap() : PlotImage<SiStripLorentzAngle, SINGLE_IOV>("Tracker Map SiStrip Lorentz Angle") {}
+    SiStripLorentzAngleTH2PolyTkMap()
+        : PlotImage<SiStripLorentzAngle, SINGLE_IOV>("Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
       //SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
@@ -547,7 +548,7 @@ PAYLOAD_INSPECTOR_MODULE(SiStripLorentzAngle) {
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleTest);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleByPartition);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleValue);
-  PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleTkMap);
+  PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleTH2PolyTkMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngle_TrackerMap);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleByRegion);
   PAYLOAD_INSPECTOR_CLASS(SiStripLorentzAngleCompareByRegion);

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -129,11 +129,11 @@ getPayloadData.py \
     --test;
 
 ######################
-# Test SiStripTkMaps
+# Test SiStripBadStripFractionTH2PolyTkMap
 ######################
 getPayloadData.py \
     --plugin pluginSiStripBadStrip_PayloadInspector \
-    --plot plot_SiStripBadStripFractionTkMap \
+    --plot plot_SiStripBadStripFractionTH2PolyTkMap \
     --tag SiStripBadComponents_startupMC_for2017_v1_mc \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
@@ -142,7 +142,7 @@ getPayloadData.py \
 
 getPayloadData.py \
     --plugin pluginSiStripLorentzAngle_PayloadInspector \
-    --plot plot_SiStripLorentzAngleTkMap \
+    --plot plot_SiStripLorentzAngleTH2PolyTkMap \
     --tag  SiStripLorentzAngleDeco_GR10_v1_prompt \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
 
   edm::LogPrint("testSiStripPayloadInspector") << "## Exercising SiStripTkMaps plots " << std::endl;
 
-  SiStripBadStripFractionTkMap histoTkMap;
+  SiStripBadStripFractionTH2PolyTkMap histoTkMap;
   histoTkMap.process(connectionString, PI::mk_input(tag, start, end));
   edm::LogPrint("testSiStripPayloadInspector") << histoTkMap.data() << std::endl;
 

--- a/DQM/TrackerRemapper/src/SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/src/SiStripTkMaps.cc
@@ -77,7 +77,7 @@ void SiStripTkMaps::drawMap(TCanvas& canvas, std::string option) {
 
   // window size
   static constexpr int wH_ = 3000;
-  static constexpr int hH_ = 850;
+  static constexpr int hH_ = 700;
 
   canvas.cd();
   adjustCanvasMargins(canvas.cd(), tmargin_, bmargin_, lmargin_, rmargin_);


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to fix a bug in the filling of the underlying `SiStripTkMap` in the `SiStripBadStripFractionTkMap` payload inspector.
I also profit of this to rename `TkMap` to `TH2PolyTkMap` for the sake of clarity.

#### PR validation:

Run the following command

```bash
getPayloadData.py \
    --plugin pluginSiStripBadStrip_PayloadInspector \
    --plot plot_SiStripBadStripFractionTkMap \
    --tag SiStripBadComponents_startupMC_for2017_v1_mc \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test ;
```

before the PR:

![image](https://github.com/cms-sw/cmssw/assets/5082376/c3a91e51-323f-42e5-9b62-0713b125ed9c)

after the PR:

![image](https://github.com/cms-sw/cmssw/assets/5082376/c8793e75-e179-4a24-9ccc-02289cee4752)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A