### PR TITLE
Remove pointers to main ParameterSet in L1Trigger subsystems

### DIFF
--- a/L1Trigger/CSCTrackFinder/test/analysis/CSCTFEfficiency.cc
+++ b/L1Trigger/CSCTrackFinder/test/analysis/CSCTFEfficiency.cc
@@ -313,6 +313,9 @@ void CSCTFEfficiency::beginJob() {
   multHistList = new MultiplicityHistogramList();
   statFile = new StatisticsFile(statsFilename);
   rHistogram = new RHistogram("RHistograms");
+
+  // ParameterSet this points to is deleted after beginJob
+  configuration = nullptr;
 }
 // ------------ method called once each job just after ending the event loop  ------------
 void CSCTFEfficiency::endJob() {

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTFConfig.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTFConfig.h
@@ -72,11 +72,9 @@ public:
   int getNbitsPhiPhib() const { return m_NbitsPhiPhib; }
 
 private:
-  void setDefaults();
+  void setDefaults(const edm::ParameterSet&);
 
 private:
-  const edm::ParameterSet* m_ps;
-
   edm::InputTag m_DTDigiInputTag;
   edm::InputTag m_CSCTrSInputTag;
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTFConfig.cc
@@ -39,10 +39,7 @@ using namespace std;
 // Constructors --
 //----------------
 
-L1MuDTTFConfig::L1MuDTTFConfig(const edm::ParameterSet& ps) {
-  m_ps = &ps;
-  setDefaults();
-}
+L1MuDTTFConfig::L1MuDTTFConfig(const edm::ParameterSet& ps) { setDefaults(ps); }
 
 //--------------
 // Destructor --
@@ -53,51 +50,51 @@ L1MuDTTFConfig::~L1MuDTTFConfig() {}
 // Operations --
 //--------------
 
-void L1MuDTTFConfig::setDefaults() {
-  m_DTDigiInputTag = m_ps->getParameter<edm::InputTag>("DTDigi_Source");
-  m_CSCTrSInputTag = m_ps->getParameter<edm::InputTag>("CSCStub_Source");
+void L1MuDTTFConfig::setDefaults(const edm::ParameterSet& ps) {
+  m_DTDigiInputTag = ps.getParameter<edm::InputTag>("DTDigi_Source");
+  m_CSCTrSInputTag = ps.getParameter<edm::InputTag>("CSCStub_Source");
 
   m_debug = true;
-  m_dbgLevel = m_ps->getUntrackedParameter<int>("Debug", 0);
+  m_dbgLevel = ps.getUntrackedParameter<int>("Debug", 0);
 
-  m_overlap = m_ps->getUntrackedParameter<bool>("Overlap", true);
+  m_overlap = ps.getUntrackedParameter<bool>("Overlap", true);
 
   // set min and max bunch crossing
-  m_BxMin = m_ps->getUntrackedParameter<int>("BX_min", -9);
-  m_BxMax = m_ps->getUntrackedParameter<int>("BX_max", 7);
+  m_BxMin = ps.getUntrackedParameter<int>("BX_min", -9);
+  m_BxMax = ps.getUntrackedParameter<int>("BX_max", 7);
   s_BxMin = m_BxMin;
   s_BxMax = m_BxMax;
 
   // set Filter for Extrapolator
-  m_extTSFilter = m_ps->getUntrackedParameter<int>("Extrapolation_Filter", 1);
+  m_extTSFilter = ps.getUntrackedParameter<int>("Extrapolation_Filter", 1);
 
   // set switch for open LUTs usage
-  m_openLUTs = m_ps->getUntrackedParameter<bool>("Open_LUTs", false);
+  m_openLUTs = ps.getUntrackedParameter<bool>("Open_LUTs", false);
 
   // set switch for EX21 usage
-  m_useEX21 = m_ps->getUntrackedParameter<bool>("Extrapolation_21", false);
+  m_useEX21 = ps.getUntrackedParameter<bool>("Extrapolation_21", false);
 
   // set switch for eta track finder usage
-  m_etaTF = m_ps->getUntrackedParameter<bool>("EtaTrackFinder", true);
+  m_etaTF = ps.getUntrackedParameter<bool>("EtaTrackFinder", true);
 
   // set switch for etaFlag cancellation of CSC segments
-  m_etacanc = m_ps->getUntrackedParameter<bool>("CSC_Eta_Cancellation", false);
+  m_etacanc = ps.getUntrackedParameter<bool>("CSC_Eta_Cancellation", false);
 
   // set Filter for Out-of-time Track Segments
-  m_TSOutOfTimeFilter = m_ps->getUntrackedParameter<bool>("OutOfTime_Filter", false);
-  m_TSOutOfTimeWindow = m_ps->getUntrackedParameter<int>("OutOfTime_Filter_Window", 1);
+  m_TSOutOfTimeFilter = ps.getUntrackedParameter<bool>("OutOfTime_Filter", false);
+  m_TSOutOfTimeWindow = ps.getUntrackedParameter<int>("OutOfTime_Filter_Window", 1);
 
   // set precision for extrapolation
-  m_NbitsExtPhi = m_ps->getUntrackedParameter<int>("Extrapolation_nbits_Phi", 8);
-  m_NbitsExtPhib = m_ps->getUntrackedParameter<int>("Extrapolation_nbits_PhiB", 8);
+  m_NbitsExtPhi = ps.getUntrackedParameter<int>("Extrapolation_nbits_Phi", 8);
+  m_NbitsExtPhib = ps.getUntrackedParameter<int>("Extrapolation_nbits_PhiB", 8);
 
   // set precision for pt-assignment
-  m_NbitsPtaPhi = m_ps->getUntrackedParameter<int>("PT_Assignment_nbits_Phi", 12);
-  m_NbitsPtaPhib = m_ps->getUntrackedParameter<int>("PT_Assignment_nbits_PhiB", 10);
+  m_NbitsPtaPhi = ps.getUntrackedParameter<int>("PT_Assignment_nbits_Phi", 12);
+  m_NbitsPtaPhib = ps.getUntrackedParameter<int>("PT_Assignment_nbits_PhiB", 10);
 
   // set precision for phi-assignment look-up tables
-  m_NbitsPhiPhi = m_ps->getUntrackedParameter<int>("PHI_Assignment_nbits_Phi", 10);
-  m_NbitsPhiPhib = m_ps->getUntrackedParameter<int>("PHI_Assignment_nbits_PhiB", 10);
+  m_NbitsPhiPhi = ps.getUntrackedParameter<int>("PHI_Assignment_nbits_Phi", 10);
+  m_NbitsPhiPhib = ps.getUntrackedParameter<int>("PHI_Assignment_nbits_PhiB", 10);
 
   if (Debug(1))
     cout << endl;

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.cc
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.cc
@@ -77,24 +77,22 @@ using namespace std;
 //----------------
 
 L1MuGMTConfig::L1MuGMTConfig(const edm::ParameterSet& ps) {
-  m_ps = &ps;
-
-  m_DTInputTag = m_ps->getParameter<edm::InputTag>("DTCandidates");
-  m_CSCInputTag = m_ps->getParameter<edm::InputTag>("CSCCandidates");
-  m_RPCbInputTag = m_ps->getParameter<edm::InputTag>("RPCbCandidates");
-  m_RPCfInputTag = m_ps->getParameter<edm::InputTag>("RPCfCandidates");
-  m_MipIsoInputTag = m_ps->getParameter<edm::InputTag>("MipIsoData");
+  m_DTInputTag = ps.getParameter<edm::InputTag>("DTCandidates");
+  m_CSCInputTag = ps.getParameter<edm::InputTag>("CSCCandidates");
+  m_RPCbInputTag = ps.getParameter<edm::InputTag>("RPCbCandidates");
+  m_RPCfInputTag = ps.getParameter<edm::InputTag>("RPCfCandidates");
+  m_MipIsoInputTag = ps.getParameter<edm::InputTag>("MipIsoData");
 
   m_debug = true;
-  m_dbgLevel = m_ps->getUntrackedParameter<int>("Debug", 0);
+  m_dbgLevel = ps.getUntrackedParameter<int>("Debug", 0);
 
   // set min and max bunch crossing
-  m_BxMin = m_ps->getParameter<int>("BX_min");
-  m_BxMax = m_ps->getParameter<int>("BX_max");
+  m_BxMin = ps.getParameter<int>("BX_min");
+  m_BxMax = ps.getParameter<int>("BX_max");
 
   // set min and max bunch crossing for the readout
-  m_BxMinRo = m_ps->getParameter<int>("BX_min_readout");
-  m_BxMaxRo = m_ps->getParameter<int>("BX_max_readout");
+  m_BxMinRo = ps.getParameter<int>("BX_min_readout");
+  m_BxMaxRo = ps.getParameter<int>("BX_max_readout");
 }
 
 //--------------
@@ -309,8 +307,6 @@ void L1MuGMTConfig::dumpRegs(std::string dir) {
 }
 
 // static data members
-
-const edm::ParameterSet* L1MuGMTConfig::m_ps = nullptr;
 
 edm::InputTag L1MuGMTConfig::m_DTInputTag = edm::InputTag();
 edm::InputTag L1MuGMTConfig::m_CSCInputTag = edm::InputTag();

--- a/L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.h
+++ b/L1Trigger/GlobalMuonTrigger/src/L1MuGMTConfig.h
@@ -186,8 +186,6 @@ public:
   void setGMTChanMask(const L1MuGMTChannelMask* gmtchanmask) { m_GMTChanMask = gmtchanmask; }
   static const L1MuGMTChannelMask* getGMTChanMask() { return m_GMTChanMask; }
 
-  static const edm::ParameterSet* getParameterSet() { return m_ps; }
-
   void createLUTsRegs();
   void clearLUTsRegs();
   void dumpLUTs(std::string dir);
@@ -196,7 +194,6 @@ public:
   void setDefaults();
 
 private:
-  static const edm::ParameterSet* m_ps;
   static const L1MuGMTParameters* m_GMTParams;
   static const L1MuGMTChannelMask* m_GMTChanMask;
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc
@@ -26,18 +26,18 @@ namespace trklet {
     unique_ptr<ChannelAssignment> produce(const ChannelAssignmentRcd& rcd);
 
   private:
-    const ParameterSet* iConfig_;
+    const ParameterSet iConfig_;
     ESGetToken<Setup, SetupRcd> esGetToken_;
   };
 
-  ProducerChannelAssignment::ProducerChannelAssignment(const ParameterSet& iConfig) : iConfig_(&iConfig) {
+  ProducerChannelAssignment::ProducerChannelAssignment(const ParameterSet& iConfig) : iConfig_(iConfig) {
     auto cc = setWhatProduced(this);
     esGetToken_ = cc.consumes();
   }
 
   unique_ptr<ChannelAssignment> ProducerChannelAssignment::produce(const ChannelAssignmentRcd& rcd) {
     const Setup* setup = &rcd.get(esGetToken_);
-    return make_unique<ChannelAssignment>(*iConfig_, setup);
+    return make_unique<ChannelAssignment>(iConfig_, setup);
   }
 
 }  // namespace trklet

--- a/L1Trigger/TrackerTFP/plugins/ProducerDemonstrator.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerDemonstrator.cc
@@ -24,18 +24,18 @@ namespace trackerTFP {
     unique_ptr<Demonstrator> produce(const DemonstratorRcd& rcd);
 
   private:
-    const ParameterSet* iConfig_;
+    const ParameterSet iConfig_;
     ESGetToken<Setup, SetupRcd> esGetToken_;
   };
 
-  ProducerDemonstrator::ProducerDemonstrator(const ParameterSet& iConfig) : iConfig_(&iConfig) {
+  ProducerDemonstrator::ProducerDemonstrator(const ParameterSet& iConfig) : iConfig_(iConfig) {
     auto cc = setWhatProduced(this);
     esGetToken_ = cc.consumes();
   }
 
   unique_ptr<Demonstrator> ProducerDemonstrator::produce(const DemonstratorRcd& rcd) {
     const Setup* setup = &rcd.get(esGetToken_);
-    return make_unique<Demonstrator>(*iConfig_, setup);
+    return make_unique<Demonstrator>(iConfig_, setup);
   }
 
 }  // namespace trackerTFP

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigBti.h
@@ -189,12 +189,7 @@ public:
   //! Print the setup
   void print() const;
 
-  /*   //! Return pointer to parameter set  */
-  /*   const edm::ParameterSet* getParameterSet() { return m_ps; } */
-
 private:
-  //  const edm::ParameterSet* m_ps;
-
   int8_t m_debug;
   int8_t m_kcut;
   int8_t m_kacctheta;

--- a/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
+++ b/L1TriggerConfig/DTTPGConfig/interface/DTConfigTraco.h
@@ -234,12 +234,7 @@ public:
   //! Print the setup
   void print() const;
 
-  /*   //! Return pointer to parameter set */
-  /*   const edm::ParameterSet* getParameterSet() { return m_ps; } */
-
 private:
-  //  const edm::ParameterSet* m_ps;
-
   int8_t m_debug;
   int8_t m_krad;
   int8_t m_btic;


### PR DESCRIPTION
#### PR description:

In an effort to reduce memory usage we are attempting to remove pointers into the main ParameterSet held by ProcessDesc from module data members. When that effort is complete, the intent is to submit a separate PR deleting that ParameterSet when beginJob is complete.

This PR addresses modules in the L1Trigger subsystems with such a pointer. Below is a summary of the changes.

CSCTFEfficiency. Pointer is only used in beginJob so it should be OK. Modify the module to set the pointer to null at the end of beginJob. Note this module isn't currently compiled (commented out in BuildFile) and fails compilation for several other reasons if you try to compile it.

L1MuDTTFConfig.h. The pointer to ParameterSet data member can be deleted by simply passing a ParameterSet reference as an argument to the one function using it.

L1MuGMTConfig.h No need for the ParameterSet* data member. One can simply use the constructor argument. It is only needed in the constructor. Delete the data member.

ProducerChannelAssignment.cc The easiest fix is to make the data member a ParameterSet instead of a pointer and do a deep copy to it.

ProducerDemonstrator.cc The easiest fix is to make the data member a ParameterSet instead of a pointer and do a deep copy to it.

DTConfigTraco.h and DTConfigBti.h The pointer is already commented out. I deleted the comments.

#### PR validation:

Relies on existing tests.
