### PR TITLE
remove a bunch of useless `SiPixelTemplateStoreESProducer` includes 

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/JetHT_cfg.py
@@ -300,6 +300,3 @@ else:
                          process.TrackRefitter                          + 
                          process.offlinePrimaryVerticesFromRefittedTrks +
                          process.jetHTAnalyzer)
-
-
-

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/SplitV_cfg.py
@@ -196,7 +196,6 @@ process.TFileService = cms.Service("TFileService",
                                    )
 print("Saving the output at %s" % process.TFileService.fileName.value())
 
-
 process.theValidSequence = cms.Sequence(process.offlineBeamSpot                        +
                                         process.TrackRefitter                          +
                                         process.offlinePrimaryVerticesFromRefittedTrks +

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiPixelLorentzAngle_cff.py
@@ -62,7 +62,6 @@ MEtoEDMConvertSiPixelLorentzAngle = cms.EDProducer("MEtoEDMConverter",
                                                    )
 
 # The actual sequence
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 seqALCARECOPromptCalibProdSiPixelLorentzAngle = cms.Sequence(
     ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle *
     ALCARECOPixelLATrackFilterRefit *

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGainsAAG_cff.py
@@ -64,7 +64,6 @@ ALCARECOCalibrationTracksRefitAAG = TrackRefitter.clone(src = cms.InputTag("ALCA
 
 # refit and BS can be dropped if done together with RECO.
 # track filter can be moved in acalreco if no other users
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOTrackFilterRefitAAG = cms.Sequence(ALCARECOCalibrationTracksAAG +
                                            offlineBeamSpot +
                                            ALCARECOCalibrationTracksRefitAAG )

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiPixelCalSingleMuonTight_cff.py
@@ -76,7 +76,6 @@ closebyPixelClusters = NearbyPixelClusters.NearbyPixelClustersProducer.clone(clu
 ##################################################################
 # Sequence: track refit + close-by-pixel producer
 ##################################################################
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import SiPixelTemplateStoreESProducer
 ALCARECOSiPixelCalSingleMuonTightOffTrackClusters = cms.Sequence(ALCARECOSiPixelCalSingleMuonTightTracksRefit +
                                                                  closebyPixelClusters)
 

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OfflineDQM_source_cff.py
@@ -14,7 +14,6 @@ from DQM.SiPixelPhase1Track.SiPixelPhase1TrackResiduals_cfi import *
 from DQM.SiPixelPhase1Track.SiPixelPhase1ResidualsExtra_cfi import *
 # Clusters ontrack/offtrack (also general tracks)
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 # Hit Efficiencies
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackEfficiency_cfi import *
 # FED/RAW Data

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_Timing_cff.py
@@ -97,7 +97,6 @@ from DQM.SiPixelPhase1Common.SiPixelPhase1Digis_cfi import *
 
 # Cluster (track-independent) monitoring
 from DQM.SiPixelPhase1Common.SiPixelPhase1Clusters_cfi import *
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 # Track cluster 
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *

--- a/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
+++ b/DQM/SiPixelPhase1Config/python/SiPixelPhase1OnlineDQM_cff.py
@@ -70,7 +70,6 @@ from DQM.SiPixelPhase1Summary.SiPixelPhase1Summary_cfi import *
 
 # Track cluster                                                                                                                                                                            
 from DQM.SiPixelPhase1Track.SiPixelPhase1TrackClusters_cfi import *
-from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 SiPixelPhase1TrackClustersOnTrackCorrCharge.enabled=cms.bool(False)
 SiPixelPhase1TrackTemplateCorr.enabled=cms.bool(False)


### PR DESCRIPTION
#### PR description:

Clean-up after https://github.com/cms-sw/cmssw/pull/42514.
Addresses https://github.com/cms-sw/cmssw/pull/42644#issuecomment-1692019347

#### PR validation:

```
runTheMatrix.py -l 1001,1001.2,1001.3,1005 -t 4 -j 8 --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A, but to be backported together with https://github.com/cms-sw/cmssw/pull/42644 (and corresponding backports)