### PR TITLE
[13.2.X] fix removal of `siStripDigis` from `RawToDigi` task

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_Repacked_cff.py
@@ -35,10 +35,6 @@ RawToDigiTask = cms.Task(
     castorDigis,
     scalersRawToDigi)
 
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-approxSiStripClusters.toModify(RawToDigiTask, 
-                               RawToDigiTask.copyAndExclude(siStripDigis)) # in case of the approximate cluster wf don't run the 
-
 RawToDigi = cms.Sequence(RawToDigiTask)
 
 RawToDigiTask_woGCT = RawToDigiTask.copyAndExclude([gctDigis])

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -91,6 +91,10 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 # No Strips in the Phase-2 tracker
 phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixelDigis,siStripDigis])) # FIXME
 
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toReplaceWith(RawToDigiTask,
+                                    RawToDigiTask.copyAndExclude([siStripDigis])) # in case of the approximate cluster wf don't run the strip unpacker
+
 # add CTPPS 2016 raw-to-digi modules
 from Configuration.Eras.Modifier_ctpps_cff import ctpps
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42655

#### PR description:

Fixes a bug introduced involuntarily at https://github.com/cms-sw/cmssw/commit/6cc72b501cc8e3f44bf0e86529a539aefe729636

#### PR validation:

Run `runTheMatrix.py -l 140.58,140.60 -t 4 -j 8 --ibeos` successfully

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/42655 for 2023 HI data-taking.