### PR TITLE
PPS full simulation with beam spot information deom SimBeamSpotObjects

### DIFF
--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -1,8 +1,8 @@
 #ifndef HECTOR_TRANSPORT
 #define HECTOR_TRANSPORT
 #include "SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h"
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
-#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
 
@@ -57,9 +57,9 @@ private:
   std::unique_ptr<H_BeamLine> m_beamline56;
 
   edm::ESGetToken<CTPPSBeamParameters, CTPPSBeamParametersRcd> beamParametersToken_;
-  edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamspotToken_;
+  edm::ESGetToken<SimBeamSpotObjects, SimBeamSpotObjectsRcd> beamspotToken_;
 
   const CTPPSBeamParameters* beamParameters_{nullptr};
-  const BeamSpotObjects* beamspot_{nullptr};
+  const SimBeamSpotObjects* beamspot_{nullptr};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
@@ -1,7 +1,7 @@
 #ifndef OPTICALFUNCTION_TRANSPORT
 #define OPTICALFUNCTION_TRANSPORT
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
-#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
 #include "CondFormats/DataRecord/interface/CTPPSInterpolatedOpticsRcd.h"
@@ -29,12 +29,12 @@ private:
   edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
   edm::ESGetToken<CTPPSBeamParameters, CTPPSBeamParametersRcd> beamParametersToken_;
   edm::ESGetToken<LHCInterpolatedOpticalFunctionsSetCollection, CTPPSInterpolatedOpticsRcd> opticsToken_;
-  edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamspotToken_;
+  edm::ESGetToken<SimBeamSpotObjects, SimBeamSpotObjectsRcd> beamspotToken_;
 
   const LHCInfo* lhcInfo_{nullptr};
   const CTPPSBeamParameters* beamParameters_{nullptr};
   const LHCInterpolatedOpticalFunctionsSetCollection* opticalFunctions_{nullptr};
-  const BeamSpotObjects* beamspot_{nullptr};
+  const SimBeamSpotObjects* beamspot_{nullptr};
 
   unsigned int optFunctionId45_{0};
   unsigned int optFunctionId56_{0};


### PR DESCRIPTION
#### PR description:

This PR addresses the issue #41894 to avoid using the ```BeamSpotObjects``` from reconstructions and moving to the newly ```SimBeamSpotObjects``` in the PPS full simulation. The simulation of generator protons will be based on the simulated beam spot position in accordance with the simulation workflow in central production. The correspoding tag will be provided by AlCa as given in this AlCaDB PR [#86](https://github.com/cms-AlCaDB/AlCaTools/issues/86).

#### PR validation:

The changes were validated with the current version of the PPS full simulation and replacing the tag for ```BeamSpotObectsRcd``` by the available preliminary tag for ```SimBeamSpotObectsRcd``` in PrepDB [here](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prep/tags/SimBeamSpot_Run3RoundOptics25ns13TeVHighSigmaZVtxSmearingParameters_v0_mc) via:

```
process.GlobalTag.toGet = cms.VPSet(
  cms.PSet(
           record = cms.string("SimBeamSpotObjectsRcd"),
           tag = cms.string("SimBeamSpot_Run3RoundOptics25ns13TeVHighSigmaZVtxSmearingParameters_v0_mc"),
           connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS")
          )
)
```

As shown below the vertex z position is correctly simulated by the PPS full simulation. The coordinates are centered in zero to perform the proton reconstruction within the PPS acceptance w.r.t. the TOTEM coordinates.

![VtxZ](https://github.com/cms-sw/cmssw/assets/5755070/57d88000-a728-4c0c-ba16-efd4e034e6e5)

PR passes all code checks.

FYI @fabferro @mundim @wpcarvalho @mmusich @francescobrivio 