### PR TITLE
Add a 2023 data workflow for all patatrack reconstruction using the `gpuValidation` modifier

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -42,7 +42,6 @@ for numWF in numWFIB:
         continue
     workflows[numWF] = _upgrade_workflows[numWF]
 
-
 # data WFs to run in IB:
 
 # data 2023 Patatrack pixel-only triplets:   RunJetMET2022D on GPU (optional), RunJetMET2022D GPU-vs-CPU validation, RunJetMET2022D profiling
@@ -102,5 +101,11 @@ workflows[141.008524] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU_Profiling',[
                             'RECODR3_reHLT_HCALOnlyGPUProfiling'
                         ]]
 
+workflows[141.008583] = ['Run3-2023_JetMET2023B_GPUValidation',[
+                            'RunJetMET2023B',
+                            'RecoData_Patatrack_AllGPU_Validation_2023',
+                            'HARVESTData_Patatrack_AllGPU_Validation_2023'
+                        ]]
+
 # 2023 HIon MC Patatrack pixel-only quadruplets on HydjetQ_MinBias_5362GeV_2023_ppReco on GPU (optional)
-workflows[160.502] = ['',['HydjetQ_MinBias_5362GeV_2023_ppReco','DIGIHI2023PPRECO','RAWPRIMESIMHI18','RECOHI2023PPRECOMB_PatatrackGPU','MINIHI2023PROD']]
+workflows[160.03502] = ['',['HydjetQ_MinBias_5362GeV_2023_ppReco','DIGIHI2023PPRECO','RAWPRIMESIMHI18','RECOHI2023PPRECOMB_PatatrackGPU','MINIHI2023PROD']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2934,6 +2934,17 @@ steps['RECONANORUN3_ZB_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO
 steps['RECONANORUN3_ZB_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023']])
 steps['RECOCOSMRUN3_reHLT_2023']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L1Reco,RECO,DQM','--datatier':'RECO,DQMIO','--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT_2023']])
 
+# patatrack validation in data
+steps['RecoData_Patatrack_AllGPU_Validation_2023'] = merge([{'-s':'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+                                                             '--conditions':'auto:run3_data_prompt',
+                                                             '--datatier':'RECO,MINIAOD,DQMIO',
+                                                             '-n':'100',
+                                                             '--eventcontent':'RECO,MINIAOD,DQM',
+                                                             '--geometry':'DB:Extended',
+                                                             '--era':'Run3',
+                                                             '--accelerators': 'gpu-nvidia',
+                                                             '--procModifiers':'pixelNtupletFit,gpuValidation'},dataReco])
+
 # Run-3 2022 skim
 for s in autoSkim.keys():
 
@@ -3609,6 +3620,14 @@ steps['HARVESTRUN3_ECALOnly'] = merge([ {'-s':'HARVESTING:@ecal'}, steps['HARVES
 steps['HARVESTRUN3_ECALOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_ECALOnly']])
 steps['HARVESTRUN3_HCALOnly'] = merge([ {'-s':'HARVESTING:@hcalOnly'}, steps['HARVESTRUN3_2023']])
 steps['HARVESTRUN3_HCALOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_HCALOnly']])
+
+steps['HARVESTData_Patatrack_AllGPU_Validation_2023'] = merge([{'--data':'',
+                                                                '-s':'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only',
+                                                                '--conditions':'auto:run3_data_prompt',
+                                                                '--geometry':'DB:Extended',
+                                                                '--scenario': 'pp',
+                                                                '--era': 'Run3',
+                                                                '--procModifiers': 'gpuValidation'},steps['HARVESTDRUN3']])
 
 
 #MC


### PR DESCRIPTION
#### PR description:

As pointed out in https://github.com/cms-sw/cmssw/pull/42631#issuecomment-1695166913 it seems there is no data relval workflow that runs the patatrack reconstruction in CPU and GPU and does the comparison between the two (in short using the `gpuValidation` modifier).
I add a workflow here that does that.

#### PR validation:

Run `runTheMatrix.py --what gpu -l 141.008583` successfully.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Perhaps to be backported to 13.2.X
