### PR TITLE
make `trigger::TriggerEvent::filterLabel` return `std::string_view`

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
@@ -654,10 +654,10 @@ void AlCaHcalIsotrkProducer::produce(edm::Event& iEvent, edm::EventSetup const& 
             //loop over all trigger filters in event (i.e. filters passed)
             for (unsigned int ifilter = 0; ifilter < triggerEvent.sizeFilters(); ++ifilter) {
               std::vector<int> Keys;
-              std::string label = triggerEvent.filterTag(ifilter).label();
+              auto const label = triggerEvent.filterLabel(ifilter);
               //loop over keys to objects passing this filter
               for (unsigned int imodule = 0; imodule < moduleLabels.size(); imodule++) {
-                if (label.find(moduleLabels[imodule]) != std::string::npos) {
+                if (label.find(moduleLabels[imodule]) != label.npos) {
 #ifdef EDM_ML_DEBUG
                   if (debug_)
                     edm::LogVerbatim("HcalIsoTrack") << "FilterName " << label;

--- a/DataFormats/HLTReco/interface/TriggerEvent.h
+++ b/DataFormats/HLTReco/interface/TriggerEvent.h
@@ -16,6 +16,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/traits.h"
 #include <string>
+#include <string_view>
 #include <vector>
 #include <cassert>
 
@@ -109,10 +110,10 @@ namespace trigger {
       return edm::InputTag(triggerFilters_.at(index).filterTag_);
     }
     const std::string& filterTagEncoded(trigger::size_type index) const { return triggerFilters_.at(index).filterTag_; }
-    std::string filterLabel(trigger::size_type index) const {
-      const std::string& tag = triggerFilters_.at(index).filterTag_;
-      std::string::size_type idx = tag.find(':');
-      return (idx == std::string::npos ? tag : tag.substr(0, idx));
+    std::string_view filterLabel(trigger::size_type index) const {
+      std::string_view tag = triggerFilters_.at(index).filterTag_;
+      auto const idx = tag.find(':');
+      return (idx == tag.npos ? tag : tag.substr(0, idx));
     }
     const Vids& filterIds(trigger::size_type index) const { return triggerFilters_.at(index).filterIds_; }
     const Keys& filterKeys(trigger::size_type index) const { return triggerFilters_.at(index).filterKeys_; }

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -743,7 +743,7 @@ void PATTriggerProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       auto triggerFilters = std::make_unique<TriggerFilterCollection>();
       triggerFilters->reserve(sizeFilters);
       for (size_t iF = 0; iF < sizeFilters; ++iF) {
-        const std::string nameFilter(handleTriggerEvent->filterTag(iF).label());
+        const std::string nameFilter(handleTriggerEvent->filterLabel(iF));
         const trigger::Keys& keys = handleTriggerEvent->filterKeys(iF);  // not cached
         const trigger::Vids& types = handleTriggerEvent->filterIds(iF);  // not cached
         TriggerFilter triggerFilter(nameFilter);


### PR DESCRIPTION
#### PR description:

This PR tries to implement the suggestion in https://github.com/cms-sw/cmssw/issues/42672#issuecomment-1695959141 (and https://github.com/missirol/cmssw/commit/9550c30b26dca6d500a009bc6f08449132c5dd5a#r125745581), in order to avoid unnecessary memory allocations when trying to extract the label of the `edm::InputTag` associated to a certain `trigger::TriggerEvent::TriggerFilterObject` of an instance of `trigger::TriggerEvent`.

 - The return type of the method `trigger::TriggerEvent::filterLabel` is changed to `std::string_view`.
 - In connection to the specific issue mentioned in https://github.com/cms-sw/cmssw/issues/42672#issuecomment-1695959141, the plugin `AlCaHcalIsotrkProducer` is also modified accordingly, in order to reduce extra memory allocations.
 - A small, related, technical change to `PATTriggerProducer` is also included, see https://github.com/cms-sw/cmssw/pull/42675#issuecomment-1697071803.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A