### PR TITLE
add necessary changes to run the uploads of `SiStripLorentzAngle` payloads in the PCL

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLHarvester.cc
@@ -225,11 +225,18 @@ void SiStripLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
 
   // prepare the profiles
   for (const auto& ME : iHists_.h2_) {
+    if (!ME.second)
+      continue;
     TProfile* hp = (TProfile*)ME.second->getTH2F()->ProfileX();
     iBooker.setCurrentFolder(folderToHarvest + "/" + getStem(ME.first, /* isFolder = */ true));
     iHists_.p_[hp->GetName()] = iBooker.bookProfile(hp->GetName(), hp);
     iHists_.p_[hp->GetName()]->setAxisTitle(ME.second->getAxisTitle(2), 2);
     delete hp;
+  }
+
+  if (iHists_.p_.empty()) {
+    edm::LogError(moduleDescription().moduleName()) << "None of the input histograms could be retrieved. Aborting";
+    return;
   }
 
   std::map<std::string, std::pair<double, double>> LAMap_;

--- a/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
+++ b/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
@@ -8,7 +8,7 @@ TARGET_LIST_OF_TAGS=['BeamSpotObject_ByLumi',           # beamspot
                      'BeamSpotObjectHP_ByLumi', 
                      'BeamSpotObjectHP_ByRun',
                      'SiPixelLA_pcl',                   # SiPixel
-                     'SiPixelLAMCS_pcl',                   # SiPixel
+                     'SiPixelLAMCS_pcl',
                      'SiPixelQualityFromDbRcd_other', 
                      'SiPixelQualityFromDbRcd_prompt', 
                      'SiPixelQualityFromDbRcd_stuckTBM',
@@ -16,6 +16,7 @@ TARGET_LIST_OF_TAGS=['BeamSpotObject_ByLumi',           # beamspot
                      'SiStripApvGainAAG_pcl', 
                      'SiStripBadStrip_pcl', 
                      'SiStripBadStripRcdHitEff_pcl',
+                     'SiStripLA_pcl',
                      'SiPixelAli_pcl',                  # Alignment
                      'SiPixelAliHG_pcl']                  
 TARGET_DQM_FILES=1

--- a/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
+++ b/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
@@ -85,6 +85,7 @@ process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAli_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAliHG_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelLA_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelLAMCS_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripLA_dbOutput)
 process.PoolDBOutputService.toPut.extend(process.ALCAHARVESTSiPixelQuality_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotByRun_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTBeamSpotByLumi_dbOutput)
@@ -107,6 +108,7 @@ process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAli_meta
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAliHG_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelLA_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelLAMCS_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripLA_metadata)
 process.pclMetadataWriter.recordsToMap.extend(process.ALCAHARVESTSiPixelQuality_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotByRun_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTBeamSpotByLumi_metadata)
@@ -145,7 +147,9 @@ process.SiPixelAliPedeAlignmentProducerHG.algoConfig.mergeBinaryFiles=[]
 
 process.SiPixelLA      = cms.Path(process.ALCAHARVESTSiPixelLorentzAngle)
 process.SiPixelLAMCS   = cms.Path(process.ALCAHARVESTSiPixelLorentzAngleMCS)
-process.SiPixelQuality  = cms.Path(process.ALCAHARVESTSiPixelQuality)
+process.SiPixelQuality = cms.Path(process.ALCAHARVESTSiPixelQuality)
+
+process.SiStripLA      = cms.Path(process.ALCAHARVESTSiStripLorentzAngle)
 
 process.ALCAHARVESTDQMSaveAndMetadataWriter = cms.Path(process.dqmSaver+process.pclMetadataWriter)
 
@@ -162,6 +166,7 @@ process.schedule = cms.Schedule(process.SiStripQuality,
                                 process.SiPixelAliHG,
                                 process.SiPixelLA,
                                 process.SiPixelLAMCS,
+                                process.SiStripLA,
                                 process.SiPixelQuality,
                                 process.BeamSpotByRun,
                                 process.BeamSpotByLumi,

--- a/CondFormats/Common/data/SiStripLorentzAngleRcd_multirun_prep.json
+++ b/CondFormats/Common/data/SiStripLorentzAngleRcd_multirun_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripLorentzAngle_byPCL_multirun_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripLA_pcl", 
+    "since": null, 
+    "userText": "Multirun Upload for SiStripLA (prep)"
+}

--- a/CondFormats/Common/data/SiStripLorentzAngleRcd_multirun_prod.json
+++ b/CondFormats/Common/data/SiStripLorentzAngleRcd_multirun_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripLorentzAngle_byPCL_multirun_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripLA_pcl", 
+    "since": null, 
+    "userText": "Multirun Upload for SiStripLorentzAngle"
+}

--- a/CondFormats/Common/data/SiStripLorentzAngleRcd_prep.json
+++ b/CondFormats/Common/data/SiStripLorentzAngleRcd_prep.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripLorentzAngle_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripLA_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for SiStripLA (prep)"
+}

--- a/CondFormats/Common/data/SiStripLorentzAngleRcd_prod.json
+++ b/CondFormats/Common/data/SiStripLorentzAngleRcd_prod.json
@@ -1,0 +1,9 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiStripLorentzAngle_byPCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiStripLA_pcl", 
+    "since": null, 
+    "userText": "Tier0 PCL Upload for SiStripLorentzAngle"
+}

--- a/CondFormats/Common/test/DropBoxMetadataReader.py
+++ b/CondFormats/Common/test/DropBoxMetadataReader.py
@@ -48,7 +48,8 @@ process.myReader = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                     "SiPixelLorentzAngleRcdMCS",                                      
                                     "CTPPSRPAlignmentCorrectionsDataRcd",
                                     "PPSTimingCalibrationRcd_HPTDC",
-                                    "PPSTimingCalibrationRcd_SAMPIC"
+                                    "PPSTimingCalibrationRcd_SAMPIC",
+                                    "SiStripLorentzAngleRcd",
                                     ) # same strings as fType
                                   )
 

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -105,6 +105,11 @@ PPSTimingCalibrationRcd_prep_str = encodeJsonInString("PPSTimingCalibrationRcd_p
 PPSTimingCalibrationRcd_Sampic_prod_str = encodeJsonInString("PPSTimingCalibrationRcd_Sampic_prod.json")
 PPSTimingCalibrationRcd_Sampic_prep_str = encodeJsonInString("PPSTimingCalibrationRcd_Sampic_prep.json")
 
+#SiStripLorenzAngle
+SiStripLorentzAngleRcd_prod_str =  encodeJsonInString("SiStripLorentzAngleRcd_prod.json")
+SiStripLorentzAngleRcd_multirun_prod_str =  encodeJsonInString("SiStripLorentzAngleRcd_multirun_prod.json")
+SiStripLorentzAngleRcd_prep_str = encodeJsonInString("SiStripLorentzAngleRcd_prep.json")
+SiStripLorentzAngleRcd_multirun_prep_str = encodeJsonInString("SiStripLorentzAngleRcd_multirun_prep.json")
 
 # given a set of .json files in the current dir, ProduceDropBoxMetadata produces a sqlite containign the payload with the prod/and/prep metadata
 process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
@@ -240,7 +245,15 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                FileClass           = cms.untracked.string("ALCA"),
                                                                prodMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_Sampic_prod_str),
                                                                prepMetaData        = cms.untracked.string(PPSTimingCalibrationRcd_Sampic_prep_str),
-                                                               )
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('SiStripLorentzAngleRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(SiStripLorentzAngleRcd_prod_str),
+                                                               prodMetaDataMultiRun = cms.untracked.string(SiStripLorentzAngleRcd_multirun_prod_str),
+                                                               prepMetaData        = cms.untracked.string(SiStripLorentzAngleRcd_prep_str),
+                                                               prepMetaDataMultiRun = cms.untracked.string(SiStripLorentzAngleRcd_multirun_prep_str),
+                                                               ),
                                                       ),
                                   # this boolean will read the content of whichever payload is available and print its content to stoutput
                                   # set this to false if you write out a sqlite.db translating the json's into a payload


### PR DESCRIPTION
#### PR description:

This is a minimal follow-up to https://github.com/cms-sw/cmssw/pull/42574 in order to be able to support uploads from the Prompt Calibration Loop:
   * updated `DropBoxMetaData` writer and reader configuration files
   * provided steering meta-data for upload to prod / prep and for the multi-run harvesting case
   * added `SiStripLorentzAngle` workflow to `Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py`

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A