### PR TITLE
revert DeepMET TensorFlow workaround

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -43,17 +43,8 @@ DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const tensorflow:
       session_(cache->getSession()) {
   produces<pat::METCollection>();
 
-  // Workaround for missing constructor TensorShape::TensorShape(absl::Slice<long>),
-  // the constructor expects Slice<int64> or initializer_list<int64> and is marked explicit
-  tensorflow::TensorShape shape;
-  shape.AddDim(1);
-  shape.AddDim(max_n_pf_);
-  shape.AddDim(8);
-
-  tensorflow::TensorShape cat_shape;
-  cat_shape.AddDim(1);
-  cat_shape.AddDim(max_n_pf_);
-  cat_shape.AddDim(1);
+  const tensorflow::TensorShape shape({1, max_n_pf_, 8});
+  const tensorflow::TensorShape cat_shape({1, max_n_pf_, 1});
 
   input_ = tensorflow::Tensor(tensorflow::DT_FLOAT, shape);
   input_cat0_ = tensorflow::Tensor(tensorflow::DT_FLOAT, cat_shape);


### PR DESCRIPTION
#### PR description:

The need for the workaround in #42228 is obviated by the fix to TensorFlow dependencies in https://github.com/cms-sw/cmsdist/pull/8672.

#### PR validation:

Compiles without error.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

I think the workaround is only in 13_3_X, so no backports should be needed.