### PR TITLE
[13.2.X] add information on first hit from HitPattern to LostTracks

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -313,6 +313,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
   cands.back().setLostInnerHits(lostHits);
   if (trk->pt() > minPtToStoreProps_ || trkStatus == TrkStatus::VTX) {
     cands.back().setTrkAlgo(static_cast<uint8_t>(trk->algo()), static_cast<uint8_t>(trk->originalAlgo()));
+    cands.back().setFirstHit(trk->hitPattern().getHitPattern(reco::HitPattern::TRACK_HITS, 0));
     if (useLegacySetup_ || std::abs(id) == 11 || trkStatus == TrkStatus::VTX) {
       cands.back().setTrackProperties(*trk, covariancePackingSchemas_[4], covarianceVersion_);
     } else {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42681

#### PR description:

Title says it all, as per request [here](https://indico.cern.ch/event/1315744/contributions/5541450/attachments/2703932/4693599/trk_20230828.pdf#page=3). 
It will add information about the first hit in the hit pattern for `lostTracks` with pT > 0.95 GeV 

https://github.com/cms-sw/cmssw/blob/8922daa677f3d06719547fcd5bdd57c8c8aaa59e/PhysicsTools/PatAlgos/python/slimming/lostTracks_cfi.py#L21

similarly for what is already done for `packedPfCandidates`

https://github.com/cms-sw/cmssw/blob/8922daa677f3d06719547fcd5bdd57c8c8aaa59e/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc#L293-L294

https://github.com/cms-sw/cmssw/blob/8922daa677f3d06719547fcd5bdd57c8c8aaa59e/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py#L19

#### PR validation:

`cmssw` compiles.
On-file size increase in miniAOD has not been measured, but should be negligible as per reasoning in [reference](https://indico.cern.ch/event/1315744/contributions/5541450/attachments/2703932/4693599/trk_20230828.pdf#page=3).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/42681 to 13.2.X (meant as as intermediate backport to downstream releases)
