### PR TITLE
Replace the access to track reference with a more robust approach

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGSFToTrackLinker.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGSFToTrackLinker.cc
@@ -54,7 +54,7 @@ void LowPtGSFToTrackLinker::produce(edm::StreamID, edm::Event& iEvent, const edm
   //map Track --> GSF and fill GSF --> PackedCandidates and GSF --> Lost associations
   for (unsigned int igsf = 0; igsf < ngsf; ++igsf) {
     reco::GsfTrackRef gref(gsftracks, igsf);
-    reco::TrackRef trk = preid->at(gref->seedRef().castTo<reco::ElectronSeedRef>().index()).trackRef();
+    reco::TrackRef trk = gref->seedRef().castTo<reco::ElectronSeedRef>()->ctfTrack();
 
     if (trk.id() != tracks.id()) {
       throw cms::Exception(


### PR DESCRIPTION
#### PR description:

Replacing access to track reference with a more robust approach, which doesn't rely on indices in a list.

More details in https://github.com/cms-sw/cmssw/issues/42110

Please note, that this change does not introduce any differences into the usual workflows, while allowing correct behaviour for [tau embedding](https://github.com/KIT-CMS/cmssw/tree/embedding_update_for_run3), where parts of the simulated content (simulation of empty detector except of 2 particles) needs to be re-evaluated under data conditions later on. This lead to inconsistencies between the number of GSF tracks considered in the producer, and the number of preid's, such that access by index number was not possible anymore.

More details on the problem on slide 11 of the following presentation:

https://indico.cern.ch/event/1301309/#26-tau-embedding-integration-i

#### PR validation:

As mentioned in https://github.com/cms-sw/cmssw/issues/42110 and if looking at

https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc

it can be concluded, that the change leads to an equivalent behaviour by construction. Please refer for this to the following code snippets from the `produce` method of  `LowPtGsfElectronSeedProducer`:

**CTF track set for the seed**

```cpp
    // Create ElectronSeed
    reco::ElectronSeed seed(*(trackRef->seedRef()));
    if (seed.nHits() == 0) {  //if DeepCore is used in jetCore iteration the seed are hitless, in case skip
      continue;
    }
    seed.setCtfTrack(trackRef);
```

**Setting the same track for preId's**

```cpp
    // Create PreIds
    unsigned int nModels = globalCache()->modelNames().size();
    reco::PreId ecalPreId(nModels);
    reco::PreId hcalPreId(nModels);

    // Add track ref to PreId
    ecalPreId.setTrack(trackRef);
    hcalPreId.setTrack(trackRef);
```

**Storing  outputs**

```cpp
    // Store PreId
    ecalPreIds.push_back(ecalPreId);
    hcalPreIds.push_back(hcalPreId);
    trksToPreIdIndx[trackRef.index()] = ecalPreIds.size() - 1;

    // Store ElectronSeed and corresponding edm::Ref<PreId>.index()
    seeds.push_back(seed);
```


