### PR TITLE
Phase2-TB74 Enable Simulation Runs for 6 inch wafers as well

### DIFF
--- a/Geometry/HGCalTBCommonData/python/hgcalParametersInitialization_cfi.py
+++ b/Geometry/HGCalTBCommonData/python/hgcalParametersInitialization_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+hgcalTBEEParametersInitialize = cms.ESProducer('HGCalParametersESModule',
+    name  = cms.string('HGCalEESensitive'),
+    nameW = cms.string('HGCalEEWafer'),
+    nameC = cms.string('HGCalEECell'),
+    nameX = cms.string('HGCalEESensitive'),
+    fromDD4hep = cms.bool(False),
+    appendToDataLabel = cms.string('')
+)
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+
+dd4hep.toModify(hgcalTBEEParametersInitialize,
+                fromDD4hep = True)
+
+hgcalTBHESiParametersInitialize = hgcalTBEEParametersInitialize.clone(
+    name  = "HGCalHESiliconSensitive",
+    nameW = "HGCalHEWafer",
+    nameC = "HGCalHECell",
+    nameX = "HGCalHESiliconSensitive",
+)

--- a/SimG4CMS/Calo/BuildFile.xml
+++ b/SimG4CMS/Calo/BuildFile.xml
@@ -14,6 +14,7 @@
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/EcalCommonData"/>
 <use name="Geometry/HGCalCommonData"/>
+<use name="Geometry/HGCalTBCommonData"/>
 <use name="Geometry/Records"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>

--- a/SimG4CMS/Calo/interface/HGCNumberingScheme.h
+++ b/SimG4CMS/Calo/interface/HGCNumberingScheme.h
@@ -6,7 +6,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
-#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 
 #include "G4ThreeVector.hh"
 
@@ -14,7 +14,7 @@ class HGCNumberingScheme {
 public:
   enum HGCNumberingParameters { HGCCellSize };
 
-  HGCNumberingScheme(const HGCalDDDConstants& hgc, std::string& name);
+  HGCNumberingScheme(const HGCalTBDDDConstants& hgc, std::string& name);
   HGCNumberingScheme() = delete;
 
   ~HGCNumberingScheme();
@@ -35,7 +35,7 @@ public:
   std::pair<float, float> getLocalCoords(int cell, int layer);
 
 private:
-  const HGCalDDDConstants& hgcons_;
+  const HGCalTBDDDConstants& hgcons_;
 };
 
 #endif

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -11,6 +11,7 @@
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4CMS/Calo/interface/HGCNumberingScheme.h"
 #include "SimG4CMS/Calo/interface/HGCMouseBite.h"
+#include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 
 #include <string>
 #include <TTree.h>
@@ -22,7 +23,7 @@ class G4Step;
 class HGCSD : public CaloSD, public Observer<const BeginOfJob *> {
 public:
   HGCSD(const std::string &,
-        const HGCalDDDConstants *,
+        const HGCalTBDDDConstants *,
         const SensitiveDetectorCatalog &,
         edm::ParameterSet const &,
         const SimTrackManager *);
@@ -43,7 +44,7 @@ private:
   uint32_t setDetUnitId(ForwardSubdetector &, int, int, int, int, G4ThreeVector &);
   bool isItinFidVolume(const G4ThreeVector &) { return true; }
 
-  const HGCalDDDConstants *hgcons_;
+  const HGCalTBDDDConstants *hgcons_;
   std::string nameX_;
   HGCalGeometryMode::GeometryMode geom_mode_;
   std::unique_ptr<HGCNumberingScheme> numberingScheme_;

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -16,7 +16,7 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 
 #include <string>
-#ifdef plotDebug 
+#ifdef plotDebug
 #include <TTree.h>
 #endif
 class G4LogicalVolume;
@@ -61,7 +61,7 @@ private:
   bool dd4hep_;
   std::vector<double> angles_;
 
-#ifdef plotDebug 
+#ifdef plotDebug
   TTree *tree_;
 #endif
   uint32_t t_EventID_;

--- a/SimG4CMS/Calo/interface/HGCSD.h
+++ b/SimG4CMS/Calo/interface/HGCSD.h
@@ -6,6 +6,8 @@
 //              appropriate container
 ///////////////////////////////////////////////////////////////////////////////
 
+//#define plotDebug
+
 #include "SimG4CMS/Calo/interface/CaloSD.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
@@ -14,8 +16,9 @@
 #include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 
 #include <string>
+#ifdef plotDebug 
 #include <TTree.h>
-
+#endif
 class G4LogicalVolume;
 class G4Material;
 class G4Step;
@@ -58,7 +61,9 @@ private:
   bool dd4hep_;
   std::vector<double> angles_;
 
+#ifdef plotDebug 
   TTree *tree_;
+#endif
   uint32_t t_EventID_;
   std::vector<int> t_Layer_, t_Parcode_;
   std::vector<double> t_dEStep1_, t_dEStep2_, t_TrackE_;

--- a/SimG4CMS/Calo/plugins/BuildFile.xml
+++ b/SimG4CMS/Calo/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="Geometry/HcalCommonData"/>
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
+<use name="Geometry/HGCalTBCommonData"/>
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
 <use name="SimDataFormats/CaloHit"/>

--- a/SimG4CMS/Calo/plugins/HGCSensitiveDetectorBuilder.cc
+++ b/SimG4CMS/Calo/plugins/HGCSensitiveDetectorBuilder.cc
@@ -8,7 +8,7 @@
 #include "SimG4Core/Notification/interface/SimActivityRegistryEnroller.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetectorPluginFactory.h"
 
-#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "SimG4CMS/Calo/interface/HGCSD.h"
 
@@ -40,7 +40,7 @@ public:
                                           const edm::ParameterSet& p,
                                           const SimTrackManager* man,
                                           SimActivityRegistry& reg) const final {
-    const HGCalDDDConstants* hgc = nullptr;
+    const HGCalTBDDDConstants* hgc = nullptr;
     for (int k = 0; k < num_; ++k) {
       if (iname.find(name1_[k]) != std::string::npos) {
         if (hgcons_[k].isValid())
@@ -58,8 +58,8 @@ private:
   const std::string name0_[nameSize_] = {"HGCalEESensitive", "HGCalHESiliconSensitive", "HGCalHEScintillatorSensitive"};
   const std::string name1_[nameSize_] = {"HitsEE", "HitsHEfront", "HitsHEback"};
   int num_;
-  std::vector<edm::ESGetToken<HGCalDDDConstants, IdealGeometryRecord>> hgcToken_;
-  std::vector<edm::ESHandle<HGCalDDDConstants>> hgcons_;
+  std::vector<edm::ESGetToken<HGCalTBDDDConstants, IdealGeometryRecord>> hgcToken_;
+  std::vector<edm::ESHandle<HGCalTBDDDConstants>> hgcons_;
 };
 
 typedef HGCSD HGCSensitiveDetector;

--- a/SimG4CMS/Calo/src/HGCNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCNumberingScheme.cc
@@ -15,7 +15,7 @@
 
 //#define EDM_ML_DEBUG
 
-HGCNumberingScheme::HGCNumberingScheme(const HGCalDDDConstants& hgc, std::string& name) : hgcons_(hgc) {
+HGCNumberingScheme::HGCNumberingScheme(const HGCalTBDDDConstants& hgc, std::string& name) : hgcons_(hgc) {
   edm::LogVerbatim("HGCSim") << "Creating HGCNumberingScheme for " << name;
 }
 

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -27,7 +27,6 @@
 #include <memory>
 
 //#define EDM_ML_DEBUG
-//#define plotDebug
 
 HGCSD::HGCSD(const std::string& name,
              const HGCalTBDDDConstants* hgc,
@@ -42,8 +41,10 @@ HGCSD::HGCSD(const std::string& name,
              p.getParameter<edm::ParameterSet>("HGCSD").getParameter<bool>("IgnoreTrackID")),
       hgcons_(hgc),
       slopeMin_(0),
-      levelT_(99),
-      tree_(nullptr) {
+      levelT_(99) {
+#ifdef plotDebug
+  tree_ = nullptr;
+#endif
   numberingScheme_.reset(nullptr);
   mouseBite_.reset(nullptr);
 

--- a/SimG4CMS/Calo/src/HGCSD.cc
+++ b/SimG4CMS/Calo/src/HGCSD.cc
@@ -11,7 +11,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
 #include "G4LogicalVolumeStore.hh"
 #include "G4LogicalVolume.hh"
@@ -30,7 +30,7 @@
 //#define plotDebug
 
 HGCSD::HGCSD(const std::string& name,
-             const HGCalDDDConstants* hgc,
+             const HGCalTBDDDConstants* hgc,
              const SensitiveDetectorCatalog& clg,
              edm::ParameterSet const& p,
              const SimTrackManager* manager)
@@ -196,8 +196,10 @@ uint32_t HGCSD::setDetUnitId(const G4Step* aStep) {
 #endif
     G4ThreeVector local =
         ((moduleLev >= 0) ? (touch->GetHistory()->GetTransform(moduleLev).TransformPoint(hitPoint)) : G4ThreeVector());
+    /*
     if (mouseBite_->exclude(local, z, layer, wafer, 0))
       id = 0;
+    */
   }
   return id;
 }
@@ -210,11 +212,13 @@ void HGCSD::update(const BeginOfJob* job) {
     if (dd4hep_)
       ++levelT_;
     numberingScheme_ = std::make_unique<HGCNumberingScheme>(*hgcons_, nameX_);
+    /*
     if (rejectMB_)
       mouseBite_ = std::make_unique<HGCMouseBite>(*hgcons_, angles_, mouseBiteCut_, waferRot_);
+    */
   } else {
-    edm::LogError("HGCSim") << "HGCSD : Cannot find HGCalDDDConstants for " << nameX_;
-    throw cms::Exception("Unknown", "HGCSD") << "Cannot find HGCalDDDConstants for " << nameX_ << "\n";
+    edm::LogError("HGCSim") << "HGCSD : Cannot find HGCalTBDDDConstants for " << nameX_;
+    throw cms::Exception("Unknown", "HGCSD") << "Cannot find HGCalTBDDDConstants for " << nameX_ << "\n";
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCSim") << "HGCSD::Initialized with mode " << geom_mode_ << " Slope cut " << slopeMin_

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1_cfg.py
@@ -10,8 +10,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('SimG4CMS.HGCalTestBeam.HGCalTB181Oct1XML_cfi')
-process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
-process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
+process.load('Geometry.HGCalTBCommonData.hgcalTBNumberingInitialization_cfi')
+process.load('Geometry.HGCalTBCommonData.hgcalTBParametersInitialization_cfi')
 process.load('Geometry.HcalTestBeamData.hcalTB06Parameters_cff')
 process.load('Configuration.StandardSequences.MagneticField_0T_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
@@ -95,6 +95,9 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
+process.g4SimHits.G4CheckOverlap.OutputBaseName = "2018"
+process.g4SimHits.G4CheckOverlap.gdmlFlag       = True
+process.g4SimHits.FileNameGDML                  = "TBHGCal181Oct.gdml"
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),
@@ -134,7 +137,7 @@ process.schedule = cms.Schedule(process.generation_step,
 				process.genfiltersummary_step,
 				process.simulation_step,
 				process.gunfilter_step,
-				process.analysis_step,
+#         			process.analysis_step,
 				process.endjob_step,
                                 process.FEVTDEBUGoutput_step
 				)


### PR DESCRIPTION
#### PR description:

Enables Simulation Runs for 6-inch wafers as well. It was not working for the last several CMSSW cycles. This PR does not affect any Phase2 workflows that utilise the entire HGCal detector.

#### PR validation:

Tested using a cfg file in SimG4CMS/HGCalTestBeam/test

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special