### PR TITLE
Phase2-hgx345 Modify HGCMouseBite such that it can work for both standard HGCal as well as for TB setups with 6 inch wafers

### DIFF
--- a/SimG4CMS/Calo/interface/HGCMouseBite.h
+++ b/SimG4CMS/Calo/interface/HGCMouseBite.h
@@ -2,6 +2,7 @@
 #define SimG4CMS_HGCMouseBite_h
 
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalTBCommonData/interface/HGCalTBDDDConstants.h"
 #include "G4ThreeVector.hh"
 
 #include <vector>
@@ -9,10 +10,15 @@
 class HGCMouseBite {
 public:
   HGCMouseBite(const HGCalDDDConstants& hgc, const std::vector<double>& angle, double maxLength, bool waferRotate);
+  HGCMouseBite(const HGCalTBDDDConstants& hgc, const std::vector<double>& angle, double maxLength, bool waferRotate);
   bool exclude(G4ThreeVector& point, int zside, int layer, int waferU, int waferV);
 
 private:
-  const HGCalDDDConstants& hgcons_;
+  void init(const std::vector<double>& angle);
+
+  const HGCalDDDConstants* hgcons_;
+  const HGCalTBDDDConstants* hgTBcons_;
+  const bool ifTB_;
   double cut_;
   bool rot_;
   bool modeUV_;

--- a/SimG4CMS/Calo/src/HGCMouseBite.cc
+++ b/SimG4CMS/Calo/src/HGCMouseBite.cc
@@ -7,8 +7,18 @@
 //#define EDM_ML_DEBUG
 
 HGCMouseBite::HGCMouseBite(const HGCalDDDConstants& hgc, const std::vector<double>& angle, double maxL, bool rot)
-    : hgcons_(hgc), cut_(maxL), rot_(rot) {
-  modeUV_ = hgcons_.waferHexagon8();
+  : hgcons_(&hgc), hgTBcons_(nullptr), ifTB_(false), cut_(maxL), rot_(rot) {
+  modeUV_ = hgcons_->waferHexagon8();
+  init(angle);
+}
+
+HGCMouseBite::HGCMouseBite(const HGCalTBDDDConstants& hgc, const std::vector<double>& angle, double maxL, bool rot)
+  : hgcons_(nullptr), hgTBcons_(&hgc), ifTB_(true), cut_(maxL), rot_(rot) {
+  modeUV_ = false;
+  init(angle);
+}
+
+void HGCMouseBite::init(const std::vector<double>& angle) {
   for (auto ang : angle) {
     projXY_.push_back(std::pair<double, double>(cos(ang * CLHEP::deg), sin(ang * CLHEP::deg)));
   }
@@ -25,8 +35,11 @@ bool HGCMouseBite::exclude(G4ThreeVector& point, int zside, int lay, int waferU,
   bool check(false);
   double dx(0), dy(0);
   if (point == G4ThreeVector()) {
-    std::pair<double, double> xy =
-        (modeUV_ ? hgcons_.waferPosition(lay, waferU, waferV, false, false) : hgcons_.waferPosition(waferU, false));
+    std::pair<double, double> xy;
+    if (ifTB_) 
+      xy = hgTBcons_->waferPosition(waferU, false);
+    else
+      xy = (modeUV_ ? hgcons_->waferPosition(lay, waferU, waferV, false, false) : hgcons_->waferPosition(waferU, false));
     double xx = (zside > 0) ? xy.first : -xy.first;
     if (rot_) {
       dx = std::abs(point.y() - xy.second);

--- a/SimG4CMS/Calo/src/HGCMouseBite.cc
+++ b/SimG4CMS/Calo/src/HGCMouseBite.cc
@@ -7,13 +7,13 @@
 //#define EDM_ML_DEBUG
 
 HGCMouseBite::HGCMouseBite(const HGCalDDDConstants& hgc, const std::vector<double>& angle, double maxL, bool rot)
-  : hgcons_(&hgc), hgTBcons_(nullptr), ifTB_(false), cut_(maxL), rot_(rot) {
+    : hgcons_(&hgc), hgTBcons_(nullptr), ifTB_(false), cut_(maxL), rot_(rot) {
   modeUV_ = hgcons_->waferHexagon8();
   init(angle);
 }
 
 HGCMouseBite::HGCMouseBite(const HGCalTBDDDConstants& hgc, const std::vector<double>& angle, double maxL, bool rot)
-  : hgcons_(nullptr), hgTBcons_(&hgc), ifTB_(true), cut_(maxL), rot_(rot) {
+    : hgcons_(nullptr), hgTBcons_(&hgc), ifTB_(true), cut_(maxL), rot_(rot) {
   modeUV_ = false;
   init(angle);
 }
@@ -36,10 +36,11 @@ bool HGCMouseBite::exclude(G4ThreeVector& point, int zside, int lay, int waferU,
   double dx(0), dy(0);
   if (point == G4ThreeVector()) {
     std::pair<double, double> xy;
-    if (ifTB_) 
+    if (ifTB_)
       xy = hgTBcons_->waferPosition(waferU, false);
     else
-      xy = (modeUV_ ? hgcons_->waferPosition(lay, waferU, waferV, false, false) : hgcons_->waferPosition(waferU, false));
+      xy =
+          (modeUV_ ? hgcons_->waferPosition(lay, waferU, waferV, false, false) : hgcons_->waferPosition(waferU, false));
     double xx = (zside > 0) ? xy.first : -xy.first;
     if (rot_) {
       dx = std::abs(point.y() - xy.second);


### PR DESCRIPTION
#### PR description:

Modify HGCMouseBite such that it can work for both standard HGCal as well as for TB setups with 6 inch wafers

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special