### PR TITLE
Update 2023 MC GTs - 13_2_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -76,17 +76,17 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           : '132X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '132X_mcRun3_2023_realistic_v2',
+    'phase1_2023_realistic'        : '132X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '132X_mcRun3_2023_realistic_postBPix_v1',
+    'phase1_2023_realistic_postBPix'  : '132X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '132X_mcRun3_2023cosmics_realistic_deco_v2',
+    'phase1_2023_cosmics'          : '132X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   : '132X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '132X_mcRun3_2023_realistic_HI_v1',
+    'phase1_2023_realistic_hi'     : '132X_mcRun3_2023_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '132X_mcRun3_2024_realistic_v1',
+    'phase1_2024_realistic'        : '132X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '131X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:

This PR updates in the release the 132X GTs for Run 3 MC.

There are a few conditions updated, namely:

- ECAL time calibration conditions compatible with the new CC timing algorithm
  - Tags for ABC eras, for D era (postBPix), for cosmics, for HI, and for 2024:
    - EcalTimeOffsetConstantRcd: EcalTimeOffsetConstant_cctiming_v01_mc
  - CMS Talk post in https://cms-talk.web.cern.ch/t/full-track-validation-ecal-time-calibration-conditions-for-cc-timing-algorithm/28247/6

- Fix the L1T tag in the 2023 MC production
  - Tags for ABC eras, for D era (postBPix), and for cosmics:
    - L1TMuonGlobalParamsRcd: L1TMuonGlobalParams_Stage2v0_2023_mc_v3
  - CMS Talk post in  https://cms-talk.web.cern.ch/t/mc-call-for-conditions-for-2023-mc/24376/29

GT Differences:

- phase1_2023_realistic:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023_realistic_v2/132X_mcRun3_2023_realistic_v4
- phase1_2023_realistic_postBPix:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023_realistic_postBPix_v1/132X_mcRun3_2023_realistic_postBPix_v3
- phase1_2023_cosmics:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023cosmics_realistic_deco_v2/132X_mcRun3_2023cosmics_realistic_deco_v3
- phase1_2023_realistic_hi:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2023_realistic_HI_v1/132X_mcRun3_2023_realistic_HI_v2
- phase1_2024_realistic:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2024_realistic_v1/132X_mcRun3_2024_realistic_v2


#### PR validation:

Validated running runTheMatrix.py -l 160,12434,12834


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #42701


