### PR TITLE
add support for L1T `EtSum`s of type `kZDC{P,M}` as trigger objects at HLT [`13_2_X`]

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -74,6 +74,9 @@ namespace trigger {
     TriggerL1Vertex = -124,
     // Phase-1: MuonShower
     TriggerL1MuShower = -125,  // stage2 (introduced in Run 3)
+    // Phase-1: ZDC+ and ZDC-
+    TriggerL1ZDCP = -126,  // stage2 (introduced in 2023 during Run 3)
+    TriggerL1ZDCM = -127,  // stage2 (introduced in 2023 during Run 3)
 
     /// HLT
     TriggerPhoton = +81,

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -56,6 +56,9 @@ HLTL1TSeed::HLTL1TSeed(const edm::ParameterSet& parSet)
       m_l1EtSumCollectionsTag(parSet.getParameter<edm::InputTag>("L1EtSumInputTag")),  // FIX WHEN UNPACKERS ADDED
       m_l1EtSumTag(m_l1EtSumCollectionsTag),
       m_l1EtSumToken(consumes<l1t::EtSumBxCollection>(m_l1EtSumTag)),
+      m_l1EtSumZdcCollectionsTag(parSet.getParameter<edm::InputTag>("L1EtSumZdcInputTag")),  // FIX WHEN UNPACKERS ADDED
+      m_l1EtSumZdcTag(m_l1EtSumZdcCollectionsTag),
+      m_l1EtSumZdcToken(consumes<l1t::EtSumBxCollection>(m_l1EtSumZdcTag)),
       m_l1GlobalDecision(false),
       m_isDebugEnabled(edm::isDebugEnabled()) {
   if (m_l1SeedsLogicalExpression.empty()) {
@@ -104,6 +107,7 @@ void HLTL1TSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<edm::InputTag>("L1JetInputTag", edm::InputTag("hltGtStage2Digis:Jet"));
   desc.add<edm::InputTag>("L1TauInputTag", edm::InputTag("hltGtStage2Digis:Tau"));
   desc.add<edm::InputTag>("L1EtSumInputTag", edm::InputTag("hltGtStage2Digis:EtSum"));
+  desc.add<edm::InputTag>("L1EtSumZdcInputTag", edm::InputTag("hltGtStage2Digis:EtSumZDC"));
   descriptions.add("hltL1TSeed", desc);
 }
 
@@ -131,6 +135,9 @@ bool HLTL1TSeed::hltFilter(edm::Event& iEvent,
 
     // etsum
     filterproduct.addCollectionTag(m_l1EtSumTag);
+
+    // etsum (ZDC)
+    filterproduct.addCollectionTag(m_l1EtSumZdcTag);
   }
 
   // Get all the seeding from iEvent (i.e. L1TriggerObjectMapRecord)
@@ -423,6 +430,36 @@ void HLTL1TSeed::dumpTriggerFilterObjectWithRefs(trigger::TriggerFilterObjectWit
     LogTrace("HLTL1TSeed") << "\tL1EtSum  AsymHtHF: hwPt = " << obj->hwPt();
   }
 
+  vector<l1t::EtSumRef> seedsL1EtSumZDCP;
+  filterproduct.getObjects(trigger::TriggerL1ZDCP, seedsL1EtSumZDCP);
+  const size_t sizeSeedsL1EtSumZDCP = seedsL1EtSumZDCP.size();
+  LogTrace("HLTL1TSeed") << "\n  L1EtSum ZDCP seeds:      " << sizeSeedsL1EtSumZDCP << endl << endl;
+
+  for (size_t i = 0; i != sizeSeedsL1EtSumZDCP; i++) {
+    l1t::EtSumRef obj = l1t::EtSumRef(seedsL1EtSumZDCP[i]);
+
+    LogTrace("HLTL1TSeed") << "\tL1EtSum  ZDCP"
+                           << "\t"
+                           << "pt = " << obj->pt() << "\t"
+                           << "eta =  " << obj->eta() << "\t"
+                           << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
+  }
+
+  vector<l1t::EtSumRef> seedsL1EtSumZDCM;
+  filterproduct.getObjects(trigger::TriggerL1ZDCM, seedsL1EtSumZDCM);
+  const size_t sizeSeedsL1EtSumZDCM = seedsL1EtSumZDCM.size();
+  LogTrace("HLTL1TSeed") << "\n  L1EtSum ZDCM seeds:      " << sizeSeedsL1EtSumZDCM << endl << endl;
+
+  for (size_t i = 0; i != sizeSeedsL1EtSumZDCM; i++) {
+    l1t::EtSumRef obj = l1t::EtSumRef(seedsL1EtSumZDCM[i]);
+
+    LogTrace("HLTL1TSeed") << "\tL1EtSum  ZDCM"
+                           << "\t"
+                           << "pt = " << obj->pt() << "\t"
+                           << "eta =  " << obj->eta() << "\t"
+                           << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
+  }
+
   LogTrace("HLTL1TSeed") << " \n\n" << endl;
 }
 
@@ -463,6 +500,8 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
   std::list<int> listAsymHt;
   std::list<int> listAsymEtHF;
   std::list<int> listAsymHtHF;
+  std::list<int> listZDCP;
+  std::list<int> listZDCM;
 
   // get handle to unpacked GT
   edm::Handle<GlobalAlgBlkBxCollection> uGtAlgoBlocks;
@@ -780,6 +819,12 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
             case l1t::gtAsymmetryHtHF: {
               listAsymHtHF.push_back(*itObject);
             } break;
+            case l1t::gtZDCP: {
+              listZDCP.push_back(*itObject);
+            } break;
+            case l1t::gtZDCM: {
+              listZDCM.push_back(*itObject);
+            } break;
             case l1t::gtCentrality0:
             case l1t::gtCentrality1:
             case l1t::gtCentrality2:
@@ -884,6 +929,12 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
 
   listAsymHtHF.sort();
   listAsymHtHF.unique();
+
+  listZDCP.sort();
+  listZDCP.unique();
+
+  listZDCM.sort();
+  listZDCM.unique();
 
   // record the L1 physics objects in the HLT filterproduct
   // //////////////////////////////////////////////////////
@@ -1068,6 +1119,42 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
         default:
           LogTrace("HLTL1TSeed") << "  L1EtSum seed of currently unsuported HLT TriggerType. l1t::EtSum type:      "
                                  << iter->getType() << "\n";
+
+      }  // end switch
+
+    }  // end for
+
+  }  // end else
+
+  // ZDCP, ZDCM
+  edm::Handle<l1t::EtSumBxCollection> etsumzdcs;
+  iEvent.getByToken(m_l1EtSumZdcToken, etsumzdcs);
+  if (!etsumzdcs.isValid()) {
+    //!! FIXME: replace LogDebug with edm::LogWarning once unpacker of ZDC inputs to L1-uGT becomes available
+    //!!        https://github.com/cms-sw/cmssw/pull/42634#issuecomment-1698132805
+    //!!        https://github.com/cms-sw/cmssw/blob/bece38936ef0ba111f4b5f4502e819595560afa6/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc#L76
+    LogDebug("HLTL1TSeed") << "\nWarning: L1EtSumBxCollection with input tag " << m_l1EtSumZdcTag
+                           << "\nrequested in configuration, but not found in the event."
+                           << "\nNo etsums (ZDC) added to filterproduct.";
+  } else {
+    l1t::EtSumBxCollection::const_iterator iter;
+
+    for (iter = etsumzdcs->begin(0); iter != etsumzdcs->end(0); ++iter) {
+      l1t::EtSumRef myref(etsumzdcs, etsumzdcs->key(iter));
+
+      switch (iter->getType()) {
+        case l1t::EtSum::kZDCP:
+          if (!listZDCP.empty())
+            filterproduct.addObject(trigger::TriggerL1ZDCP, myref);
+          break;
+        case l1t::EtSum::kZDCM:
+          if (!listZDCM.empty())
+            filterproduct.addObject(trigger::TriggerL1ZDCM, myref);
+          break;
+        default:
+          LogTrace("HLTL1TSeed")
+              << "  L1EtSum (ZDC) seed of currently unsuported HLT TriggerType. l1t::EtSum type:      "
+              << iter->getType() << "\n";
 
       }  // end switch
 

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
@@ -120,20 +120,25 @@ private:
   edm::InputTag m_l1EGammaTag;
   edm::EDGetTokenT<l1t::EGammaBxCollection> m_l1EGammaToken;
 
-  /// Meta InputTag for L1 Egamma collection
+  /// Meta InputTag for L1 Jet collection
   edm::InputTag m_l1JetCollectionsTag;
   edm::InputTag m_l1JetTag;
   edm::EDGetTokenT<l1t::JetBxCollection> m_l1JetToken;
 
-  /// Meta InputTag for L1 Egamma collection
+  /// Meta InputTag for L1 Tau collection
   edm::InputTag m_l1TauCollectionsTag;
   edm::InputTag m_l1TauTag;
   edm::EDGetTokenT<l1t::TauBxCollection> m_l1TauToken;
 
-  /// Meta InputTag for L1 Egamma collection
+  /// Meta InputTag for L1 EtSum collection
   edm::InputTag m_l1EtSumCollectionsTag;
   edm::InputTag m_l1EtSumTag;
   edm::EDGetTokenT<l1t::EtSumBxCollection> m_l1EtSumToken;
+
+  /// Meta InputTag for L1 EtSum (ZDC) collection
+  edm::InputTag m_l1EtSumZdcCollectionsTag;
+  edm::InputTag m_l1EtSumZdcTag;
+  edm::EDGetTokenT<l1t::EtSumBxCollection> m_l1EtSumZdcToken;
 
   /// flag to pass if L1TGlobal accept
   bool m_l1GlobalDecision;


### PR DESCRIPTION
backport of #42707

#### PR description:

This PR adds support for L1T `EtSum`s of type `kZDC{P,M}` as trigger objects at HLT. These new types were introduced in #42634 (L1T-ZDC emulation).

Two types, `trigger::TriggerL1ZDC{P,M}`, are added to `TriggerTypeDefs.h`, and support for them is added to the plugin `HLTL1TSeed` (which puts L1T objects into the `edm::Event` as part of the `TriggerFilterObjectWithRefs` data format).

A similar update was done in #36951 to support the L1T data formats for "MuonShowers". One difference in this PR is that the underlying data format, i.e. `l1t::EtSum`, is not a new one (unlike `l1t::MuonShower` was), and this makes the changes on the HLT side less extensive compared to #36951.

Note: the `edm::InputTag` added to `HLTL1TSeed` in this PR will point to a non-existing collection in the current HLT menus until an unpacker for the ZDC inputs to the L1T-uGT is added to CMSSW (see https://github.com/cms-sw/cmssw/pull/42634#issuecomment-1698132805). For this reason, only a `LogDebug` message is issued when this collection is missing, and eventually this should be replaced by a `edm::LogWarning` (once the unpacker is available). 

No changes expected.

Requires https://github.com/cms-sw/cmssw/pull/42706.

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#42707

HLT software for 2023 (and beyond ?).
