### PR TITLE
Update GPU workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2017.py
+++ b/Configuration/PyReleaseValidation/python/relval_2017.py
@@ -10,8 +10,6 @@ workflows = Matrix()
 
 from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgrade_workflows
 
-#just define all of them
-
 #WFs to run in IB:
 #   2017 (ele guns 10, 35, 1000; pho guns 10, 35; mu guns 1, 10, 100, 1000, QCD 3TeV, QCD Flat)
 #        (ZMM, TTbar, ZEE, MinBias, TTbar PU, ZEE PU, TTbar design)
@@ -34,10 +32,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (ZMM, TTbar, ZEE, MinBias, TTbar PU, TTbar PU premix, ZEE PU, TTbar design)
 #        (TTbar trackingOnly, pixelTrackingOnly, trackingMkFit, trackdnn)
 #        (TTbar with JME NanoAOD)
-#        (Patatrack pixel-only: ZMM - on CPU: quadruplets, triplets)
-#        (Patatrack pixel-only: TTbar - on CPU: quadruplets, triplets)
-#        (Patatrack ECAL-only: TTbar - on CPU)
-#        (Patatrack HCAL-only: TTbar - on CPU)
 #        (TTbar 0T, TTbar PU 0T)
 #        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing)
 #        (TTbar PU MLPF ecal_deepsc)
@@ -47,6 +41,10 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #        (TTbar DigiNoHLT)
 #   2023 (TTbar, TTbar PU, TTbar PU premix)
 #        (TTbar trackingMkFit)
+#        (Patatrack pixel-only: TTbar - on CPU: quadruplets, triplets)
+#        (Patatrack ECAL-only: TTbar - on CPU)
+#        (Patatrack HCAL-only: TTbar - on CPU)
+#        (Patatrack pixel-only: ZMM - on CPU: quadruplets, triplets)
 #        (TTbar FastSim, TTbar FastSim PU, MinBiasFS for mixing))
 #   2024 (TTbar, TTbar PU, TTbar PU premix)
 numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009.0,10059.0,10071.0,
@@ -71,10 +69,6 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            #11725.0,11925.0,
            11634.1,11634.5,11634.7,11634.71,11634.72,11634.91,
            11634.15,
-           11650.501,11650.505,
-           11634.501,11634.505,
-           11634.511,
-           11634.521,
            11634.24,11834.24,
            13234.0,13434.0,13240.303,
            11834.13, 11834.19,
@@ -84,8 +78,14 @@ numWFIB = [10001.0,10002.0,10003.0,10004.0,10005.0,10006.0,10007.0,10008.0,10009
            11634.601,
            12434.0,12634.0,12634.99,
            12434.7,
+           12434.501,12434.505,
+           12434.511,
+           12434.521,
+           12450.501,12450.505,
            14034.0,14234.0,14040.303,
            12834.0,13034.0,13034.99,]
+
 for numWF in numWFIB:
-    if not numWF in _upgrade_workflows: continue
+    if not numWF in _upgrade_workflows:
+        continue
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -11,30 +11,29 @@ workflows = Matrix()
 
 from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgrade_workflows
 
-# just define all of them
+# mc WFs to run in IB:
 
-# WFs to run in IB:
-# mc 2022   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+# mc 2022   Patatrack pixel-only quadruplets:                   ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:                      ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets:                   TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:                      TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack ECAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack HCAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation
+#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation
+#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation
+#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation
 
-# mc 2023   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+# mc 2023   Patatrack pixel-only quadruplets:                   ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:                      ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets:                   TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:                      TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack ECAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack HCAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling (to be implemented)
+#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling (to be implemented)
+#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation
+#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation
 numWFIB = [
            # 2022
            11650.502, 11650.503, 11650.504,
@@ -43,8 +42,8 @@ numWFIB = [
            11634.506, 11634.507, 11634.508,
            11634.512, 11634.513, 11634.514,
            11634.522, 11634.523, 11634.524,
-           11634.582, 11634.583, # 11634.524,
-           11634.586, 11634.587, # 11634.528,
+           11634.582, 11634.583,
+           11634.586, 11634.587,
            11634.592, 11634.593,
            11634.596, 11634.597,
 
@@ -55,14 +54,19 @@ numWFIB = [
            12434.506, 12434.507, 12434.508,
            12434.512, 12434.513, 12434.514,
            12434.522, 12434.523, 12434.524,
-           12434.582, 12434.583,
-           12434.586, 12434.587,
+           12434.582, 12434.583, # 12434.584,
+           12434.586, 12434.587, # 12434.588,
            12434.592, 12434.593,
            12434.596, 12434.597,
         ]
+
 for numWF in numWFIB:
-    if not numWF in _upgrade_workflows: continue
+    if not numWF in _upgrade_workflows:
+        continue
     workflows[numWF] = _upgrade_workflows[numWF]
+
+
+# data WFs to run in IB:
 
 # data 2023 Patatrack pixel-only triplets:   RunJetMET2022D on GPU (optional)
 #           Patatrack ECAL-only:             RunJetMET2022D on GPU (optional)
@@ -70,5 +74,6 @@ for numWF in numWFIB:
 workflows[141.008506] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU','HARVESTRUN3_pixelTrackingOnly']]
 workflows[141.008512] = ['Run3-2023_JetMET2023B_RecoECALOnlyGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_ECALOnlyGPU','HARVESTRUN3_ECALOnly']]
 workflows[141.008522] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_HCALOnlyGPU','HARVESTRUN3_HCALOnly']]
-#2023 HIon MC Patatrack pixel-only quadruplets on HydjetQ_MinBias_5362GeV_2023_ppReco on GPU (optional)
+
+# 2023 HIon MC Patatrack pixel-only quadruplets on HydjetQ_MinBias_5362GeV_2023_ppReco on GPU (optional)
 workflows[160.502] = ['',['HydjetQ_MinBias_5362GeV_2023_ppReco','DIGIHI2023PPRECO','RAWPRIMESIMHI18','RECOHI2023PPRECOMB_PatatrackGPU','MINIHI2023PROD']]

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -45,12 +45,62 @@ for numWF in numWFIB:
 
 # data WFs to run in IB:
 
-# data 2023 Patatrack pixel-only triplets:   RunJetMET2022D on GPU (optional)
-#           Patatrack ECAL-only:             RunJetMET2022D on GPU (optional)
-#           Patatrack HCAL-only:             RunJetMET2022D on GPU (optional)
-workflows[141.008506] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU','HARVESTRUN3_pixelTrackingOnly']]
-workflows[141.008512] = ['Run3-2023_JetMET2023B_RecoECALOnlyGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_ECALOnlyGPU','HARVESTRUN3_ECALOnly']]
-workflows[141.008522] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_HCALOnlyGPU','HARVESTRUN3_HCALOnly']]
+# data 2023 Patatrack pixel-only triplets:   RunJetMET2022D on GPU (optional), RunJetMET2022D GPU-vs-CPU validation, RunJetMET2022D profiling
+#           Patatrack ECAL-only:             RunJetMET2022D on GPU (optional), RunJetMET2022D GPU-vs-CPU validation, RunJetMET2022D profiling
+#           Patatrack HCAL-only:             RunJetMET2022D on GPU (optional), RunJetMET2022D GPU-vs-CPU validation, RunJetMET2022D profiling
+workflows[141.008506] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU',
+                            'HARVESTRUN3_pixelTrackingOnly'
+                        ]]
+workflows[141.008507] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU_Validation',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPUValidation',
+                            'HARVESTRUN3_pixelTrackingOnlyGPUValidation'
+                        ]]
+workflows[141.008508] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU_Profiling',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPUProfiling'
+                        ]]
+
+workflows[141.008512] = ['Run3-2023_JetMET2023B_RecoECALOnlyGPU',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_ECALOnlyGPU',
+                            'HARVESTRUN3_ECALOnly'
+                        ]]
+workflows[141.008513] = ['Run3-2023_JetMET2023B_RecoECALOnlyGPU_Validation',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_ECALOnlyGPUValidation',
+                            'HARVESTRUN3_ECALOnlyGPUValidation'
+                        ]]
+workflows[141.008514] = ['Run3-2023_JetMET2023B_RecoECALOnlyGPU_Profiling',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_ECALOnlyGPUProfiling'
+                        ]]
+
+workflows[141.008522] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_HCALOnlyGPU',
+                            'HARVESTRUN3_HCALOnly'
+                        ]]
+workflows[141.008523] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU_Validation',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_HCALOnlyGPUValidation',
+                            'HARVESTRUN3_HCALOnlyGPUValidation'
+                        ]]
+workflows[141.008524] = ['Run3-2023_JetMET2023B_RecoHCALOnlyGPU_Profiling',[
+                            'RunJetMET2023B',
+                            'HLTDR3_2023',
+                            'RECODR3_reHLT_HCALOnlyGPUProfiling'
+                        ]]
 
 # 2023 HIon MC Patatrack pixel-only quadruplets on HydjetQ_MinBias_5362GeV_2023_ppReco on GPU (optional)
 workflows[160.502] = ['',['HydjetQ_MinBias_5362GeV_2023_ppReco','DIGIHI2023PPRECO','RAWPRIMESIMHI18','RECOHI2023PPRECOMB_PatatrackGPU','MINIHI2023PROD']]

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -13,17 +13,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 
 # mc WFs to run in IB:
 
-# mc 2022   Patatrack pixel-only quadruplets:                   ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:                      ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets:                   TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only triplets:                      TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack ECAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack HCAL-only:                                TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
-#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation
-#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation
-#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation
-#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation
-
 # mc 2023   Patatrack pixel-only quadruplets:                   ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only triplets:                      ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
 #           Patatrack pixel-only quadruplets:                   TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
@@ -35,18 +24,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation
 #           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation
 numWFIB = [
-           # 2022
-           11650.502, 11650.503, 11650.504,
-           11650.506, 11650.507, 11650.508,
-           11634.502, 11634.503, 11634.504,
-           11634.506, 11634.507, 11634.508,
-           11634.512, 11634.513, 11634.514,
-           11634.522, 11634.523, 11634.524,
-           11634.582, 11634.583,
-           11634.586, 11634.587,
-           11634.592, 11634.593,
-           11634.596, 11634.597,
-
            # 2023
            12450.502, 12450.503, 12450.504,
            12450.506, 12450.507, 12450.508,

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2687,8 +2687,17 @@ step3_pixel_ntuplet_cpu = {
 step3_pixel_ntuplet_gpu = {
     '--procModifiers': 'pixelNtupletFit,gpu'
 }
+step3_pixel_ntuplet_gpu_validation = {
+    '--procModifiers': 'pixelNtupletFit,gpuValidation'
+}
 step3_pixel_triplets = {
     '--customise': 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
+}
+step3_pixel_profiling = {
+    '--customise': 'RecoTracker/Configuration/customizePixelOnlyForProfiling.customizePixelOnlyForProfilingGPUOnly'
+}
+step3_pixel_triplets_profiling = {
+    '--customise': 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,RecoTracker/Configuration/customizePixelOnlyForProfiling.customizePixelOnlyForProfilingGPUOnly'
 }
 step3_gpu = {
     '--procModifiers': 'gpu',
@@ -2900,12 +2909,20 @@ steps['RECODR3_reHLT_AlCaTkCosmics_Offline']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,
 steps['RECODR3_reHLT_pixelTrackingOnly']=merge([{'-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,DQM:@pixelTrackingOnlyDQM'},steps['RECODR3_reHLT_2023']])
 steps['RECODR3_reHLT_Patatrack_PixelOnlyCPU']=merge([step3_pixel_ntuplet_cpu, steps['RECODR3_reHLT_pixelTrackingOnly']])
 steps['RECODR3_reHLT_Patatrack_PixelOnlyGPU']=merge([step3_pixel_ntuplet_gpu, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyGPUValidation']=merge([{'--accelerators':'gpu-nvidia'},step3_pixel_ntuplet_gpu_validation,steps['RECODR3_reHLT_Patatrack_PixelOnlyGPU']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyGPUProfiling']=merge([{'-s':'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly','--customise':'RecoTracker/Configuration/customizePixelOnlyForProfiling.customizePixelOnlyForProfilingGPUOnly'},steps['RECODR3_reHLT_Patatrack_PixelOnlyGPU']])
 steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsCPU']=merge([step3_pixel_ntuplet_cpu, step3_pixel_triplets, steps['RECODR3_reHLT_pixelTrackingOnly']])
 steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU']=merge([step3_pixel_ntuplet_gpu, step3_pixel_triplets, steps['RECODR3_reHLT_pixelTrackingOnly']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPUValidation']=merge([{'--accelerators':'gpu-nvidia'},step3_pixel_ntuplet_gpu_validation,steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU']])
+steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPUProfiling']=merge([{'-s':'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly','--customise':'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets,RecoTracker/Configuration/customizePixelOnlyForProfiling.customizePixelOnlyForProfilingGPUOnly'},steps['RECODR3_reHLT_Patatrack_PixelOnlyTripletsGPU']])
 steps['RECODR3_reHLT_ECALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,DQM:@ecalOnly'},steps['RECODR3_reHLT_2023']])
 steps['RECODR3_reHLT_ECALOnlyGPU']=merge([step3_gpu, steps['RECODR3_reHLT_ECALOnlyCPU']])
+steps['RECODR3_reHLT_ECALOnlyGPUValidation']=merge([{'--accelerators':'gpu-nvidia','--procModifiers':'gpuValidation'},steps['RECODR3_reHLT_ECALOnlyGPU']])
+steps['RECODR3_reHLT_ECALOnlyGPUProfiling']=merge([{'-s':'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly', '--customise':'RecoLocalCalo/Configuration/customizeEcalOnlyForProfiling.customizeEcalOnlyForProfilingGPUOnly'},steps['RECODR3_reHLT_ECALOnlyGPU']])
 steps['RECODR3_reHLT_HCALOnlyCPU']=merge([{'-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,DQM:@hcalOnly+@hcal2Only'},steps['RECODR3_reHLT_2023']])
 steps['RECODR3_reHLT_HCALOnlyGPU']=merge([step3_gpu, steps['RECODR3_reHLT_HCALOnlyCPU']])
+steps['RECODR3_reHLT_HCALOnlyGPUValidation']=merge([{'--accelerators':'gpu-nvidia','--procModifiers':'gpuValidation'},steps['RECODR3_reHLT_HCALOnlyGPU']])
+steps['RECODR3_reHLT_HCALOnlyGPUProfiling']=merge([{'-s':'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly','--customise':'RecoLocalCalo/Configuration/customizeHcalOnlyForProfiling.customizeHcalOnlyForProfilingGPUOnly'},steps['RECODR3_reHLT_HCALOnlyGPU']])
 
 steps['RECONANORUN3_reHLT_2022']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQMFakeHLT+@miniAODDQM+@nanoAODDQM','--datatier':'RECO,MINIAOD,NANOAOD,DQMIO','--eventcontent':'RECO,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2022']])
 steps['RECONANORUN3_ZB_reHLT_2022']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBiasFakeHLT+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2022']])
@@ -3586,9 +3603,12 @@ steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM
 steps['HARVESTRUN3_ZB_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_ZB_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_COS_2023']=merge([{'--scenario':'cosmics', '--era':'Run3_2023', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTRUN3_2022']])
-steps['HARVESTRUN3_pixelTrackingOnly'] = merge([ {'-s':'HARVESTING:@pixelTrackingOnlyDQM'}, steps['HARVESTRUN3_2023'] ])
-steps['HARVESTRUN3_ECALOnly'] = merge([ {'-s':'HARVESTING:@ecal'}, steps['HARVESTRUN3_2023'] ])
-steps['HARVESTRUN3_HCALOnly'] = merge([ {'-s':'HARVESTING:@hcalOnly'}, steps['HARVESTRUN3_2023'] ])
+steps['HARVESTRUN3_pixelTrackingOnly'] = merge([ {'-s':'HARVESTING:@pixelTrackingOnlyDQM'}, steps['HARVESTRUN3_2023']])
+steps['HARVESTRUN3_pixelTrackingOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_pixelTrackingOnly']])
+steps['HARVESTRUN3_ECALOnly'] = merge([ {'-s':'HARVESTING:@ecal'}, steps['HARVESTRUN3_2023']])
+steps['HARVESTRUN3_ECALOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_ECALOnly']])
+steps['HARVESTRUN3_HCALOnly'] = merge([ {'-s':'HARVESTING:@hcalOnly'}, steps['HARVESTRUN3_2023']])
+steps['HARVESTRUN3_HCALOnlyGPUValidation'] = merge([ {'--procModifiers':'gpuValidation'}, steps['HARVESTRUN3_HCALOnly']])
 
 
 #MC


### PR DESCRIPTION
#### PR description:

Clean up the definition of the GPU workflows.
Drop 2022 MC GPU workflows.
Move Patatrack data workflows to 2023.
Add workflows for GPU validation and profiling on data.

#### PR validation:

New matrix workflows pass:
```
runTheMatrix.py -w gpu -l 141.008507,141.008508,141.008513,141.008514,141.008523,141.008524
...
141.008507_Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU_Validation Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Sep  5 07:39:36 2023-date Tue Sep  5 07:29:23 2023; exit: 0 0 0 0
141.008508_Run3-2023_JetMET2023B_RecoPixelOnlyTripletsGPU_Profiling Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Sep  5 07:37:50 2023-date Tue Sep  5 07:29:24 2023; exit: 0 0 0
141.008513_Run3-2023_JetMET2023B_RecoECALOnlyGPU_Validation Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Sep  5 07:39:40 2023-date Tue Sep  5 07:29:24 2023; exit: 0 0 0 0
141.008514_Run3-2023_JetMET2023B_RecoECALOnlyGPU_Profiling Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Sep  5 07:37:48 2023-date Tue Sep  5 07:29:25 2023; exit: 0 0 0
141.008523_Run3-2023_JetMET2023B_RecoHCALOnlyGPU_Validation Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Tue Sep  5 07:48:39 2023-date Tue Sep  5 07:37:48 2023; exit: 0 0 0 0
141.008524_Run3-2023_JetMET2023B_RecoHCALOnlyGPU_Profiling Step0-PASSED Step1-PASSED Step2-PASSED  - time date Tue Sep  5 07:41:42 2023-date Tue Sep  5 07:37:50 2023; exit: 0 0 0
6 6 6 3 tests passed, 0 0 0 0 failed
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Can be backported to 13.2.x if requested.