### PR TITLE
Add Herwig7HadronizerFilter to list of Filters with concurrent lumis disabled

### DIFF
--- a/Configuration/Generator/python/concurrentLumisDisable.py
+++ b/Configuration/Generator/python/concurrentLumisDisable.py
@@ -5,6 +5,7 @@ noConcurrentLumiGenerators = [
     "CosMuoGenProducer",
     "ExhumeGeneratorFilter",
     "Herwig7GeneratorFilter",
+    "Herwig7HadronizerFilter",
     "HydjetGeneratorFilter",
     "Hydjet2GeneratorFilter",
     "PyquenGeneratorFilter",


### PR DESCRIPTION
Fixes the issues observed for Relvals after merging https://github.com/cms-sw/cmssw/pull/42673 by adding Herwig7HadronizerFilter to list of EDModules that do not support concurrentLuminosityBlocks. Not yet tested since I only have a working set of externals for CMSSW_10_6 (where this issue doesn't occur), should be tested with workflows 535, 537 and 538 (ideally also with multiple threads if this can be done before merging).