### PR TITLE
`ConfigureAlignmentProducer`: add mass constraint for `ALCARECOTkAlJpsiMuMu`

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/alignmentsetup/ConfigureAlignmentProducer.py
@@ -54,7 +54,7 @@ def setConfiguration(process, collection, mode, monitorFile, binaryFile,
     ## Tracktype specific ##
     ########################
 
-    if collection == "ALCARECOTkAlZMuMu" or collection == "ALCARECOTkAlZMuMuHI" or collection == "ALCARECOTkAlZMuMuPA":
+    if collection == "ALCARECOTkAlZMuMu" or collection == "ALCARECOTkAlZMuMuHI" or collection == "ALCARECOTkAlZMuMuPA" or collection == "ALCARECOTkAlDiMuon":
         process.AlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(
              process.TwoBodyDecayTrajectoryFactory
         )
@@ -67,8 +67,17 @@ def setConfiguration(process, collection, mode, monitorFile, binaryFile,
         process.AlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(
              process.TwoBodyDecayTrajectoryFactory
         )
-        process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryMass =  9.4502
+        process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryMass = 9.4502
         process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryWidth = 0.0644
+        process.AlignmentProducer.algoConfig.TrajectoryFactory.MaterialEffects = "LocalGBL"
+        # to account for multiple scattering in these layers
+        process.AlignmentProducer.algoConfig.TrajectoryFactory.UseInvalidHits = True
+    elif collection == "ALCARECOTkAlJpsiMuMu":
+        process.AlignmentProducer.algoConfig.TrajectoryFactory = cms.PSet(
+             process.TwoBodyDecayTrajectoryFactory
+        )
+        process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryMass = 3.0969
+        process.AlignmentProducer.algoConfig.TrajectoryFactory.ParticleProperties.PrimaryWidth = 0.03
         process.AlignmentProducer.algoConfig.TrajectoryFactory.MaterialEffects = "LocalGBL"
         # to account for multiple scattering in these layers
         process.AlignmentProducer.algoConfig.TrajectoryFactory.UseInvalidHits = True


### PR DESCRIPTION
#### PR description:

It was noticed by @henriettepetersen that the general `MillePede` configuration setup doesn't impose automatically a mass constraint when a  J/ψ ALCARECO track collection (`ALCARECOTkAlJpsiMuMu`) is used, whereas it is already the case for Z and ϒ.
The goal of this PR is to supply it too in the case of the J/ψ - based alignment.
I profit to extend the list of track collections supported for the Z case to `ALCARECOTkAlDiMuon` that was included in cmssw in PR https://github.com/cms-sw/cmssw/pull/33770

#### PR validation:

Private validation done by the TkAl group.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
