### PR TITLE
Fix compilation warning in SensitiveDetectorCatalog.cc

### DIFF
--- a/SimG4Core/Geometry/src/SensitiveDetectorCatalog.cc
+++ b/SimG4Core/Geometry/src/SensitiveDetectorCatalog.cc
@@ -1,8 +1,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimG4Core/Geometry/interface/SensitiveDetectorCatalog.h"
 
-#define EDM_ML_DEBUG
-
 #include <iostream>
 
 void SensitiveDetectorCatalog::insert(const std::string &cN, const std::string &rN, const std::string &lvN) {


### PR DESCRIPTION
#### PR description:

Remove redefinition of `EDM_ML_DEBUG`. @bsunanda feel free to reject these changes if that debug flag is needed for non-debug IBs.

