### PR TITLE
MTD geometry: add test for pixel acceptance in module

### DIFF
--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -220,7 +220,6 @@ void MTDDigiGeometryAnalyzer::checkRotation(const GeomDetUnit& det) {
 }
 
 void MTDDigiGeometryAnalyzer::checkPixelsAcceptance(const GeomDetUnit& det) {
-
   const Bounds& bounds = det.surface().bounds();
   const RectangularPlaneBounds* tb = dynamic_cast<const RectangularPlaneBounds*>(&bounds);
   if (tb == nullptr)
@@ -236,17 +235,16 @@ void MTDDigiGeometryAnalyzer::checkPixelsAcceptance(const GeomDetUnit& det) {
   const size_t maxindex = 100000;
   size_t inpixel(0);
   for (size_t index = 0; index < maxindex; index++) {
-    double ax = CLHEP::RandFlat::shoot(-width*0.5, width*0.5);
-    double ay = CLHEP::RandFlat::shoot(-length*0.5, length*0.5);
+    double ax = CLHEP::RandFlat::shoot(-width * 0.5, width * 0.5);
+    double ay = CLHEP::RandFlat::shoot(-length * 0.5, length * 0.5);
     LocalPoint hit(ax, ay, 0);
     if (topo.isInPixel(hit)) {
       inpixel++;
     }
   }
-  double acc = (double)inpixel/(double)maxindex;
-  double accerr = std::sqrt(acc*(1.-acc)/(double)maxindex);
-  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "Acceptance: "<< acc << " +/- " << accerr;
-
+  double acc = (double)inpixel / (double)maxindex;
+  double accerr = std::sqrt(acc * (1. - acc) / (double)maxindex);
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "Acceptance: " << acc << " +/- " << accerr;
 }
 
 //define this as a plug-in

--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -26,6 +26,8 @@
 
 #include <fstream>
 
+#include "CLHEP/Random/RandFlat.h"
+
 // class declaration
 
 class MTDDigiGeometryAnalyzer : public edm::one::EDAnalyzer<> {
@@ -41,6 +43,7 @@ private:
   void analyseRectangle(const GeomDetUnit& det);
   void checkRotation(const GeomDetUnit& det);
   void checkRectangularMTDTopology(const RectangularMTDTopology&);
+  void checkPixelsAcceptance(const GeomDetUnit& det);
 
   std::stringstream sunitt;
 
@@ -115,6 +118,13 @@ void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
       checkRectangularMTDTopology(topo);
     }
   }
+
+  edm::LogInfo("MTDDigiGeometryAnalyzer") << "Acceptance of BTL module:";
+  auto const& btldet = *(dynamic_cast<const MTDGeomDetUnit*>(pDD->detsBTL().front()));
+  checkPixelsAcceptance(btldet);
+  edm::LogInfo("MTDDigiGeometryAnalyzer") << "Acceptance of ETL module:";
+  auto const& etldet = *(dynamic_cast<const MTDGeomDetUnit*>(pDD->detsETL().front()));
+  checkPixelsAcceptance(etldet);
 
   edm::LogInfo("MTDDigiGeometryAnalyzer") << "Additional MTD geometry content:"
                                           << "\n"
@@ -207,6 +217,36 @@ void MTDDigiGeometryAnalyzer::checkRotation(const GeomDetUnit& det) {
     edm::LogWarning("MTDDigiGeometryAnalyzer") << " Rotation not good by bector mag: " << (a).mag() << ", " << (b).mag()
                                                << ", " << (c).mag() << " for det at pos " << det.surface().position();
   }
+}
+
+void MTDDigiGeometryAnalyzer::checkPixelsAcceptance(const GeomDetUnit& det) {
+
+  const Bounds& bounds = det.surface().bounds();
+  const RectangularPlaneBounds* tb = dynamic_cast<const RectangularPlaneBounds*>(&bounds);
+  if (tb == nullptr)
+    return;  // not trapezoidal
+
+  double length = tb->length();
+  double width = tb->width();
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "X (width) = " << width << " Y (length) = " << length;
+
+  const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(det.topology());
+  const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+  const size_t maxindex = 100000;
+  size_t inpixel(0);
+  for (size_t index = 0; index < maxindex; index++) {
+    double ax = CLHEP::RandFlat::shoot(-width*0.5, width*0.5);
+    double ay = CLHEP::RandFlat::shoot(-length*0.5, length*0.5);
+    LocalPoint hit(ax, ay, 0);
+    if (topo.isInPixel(hit)) {
+      inpixel++;
+    }
+  }
+  double acc = (double)inpixel/(double)maxindex;
+  double accerr = std::sqrt(acc*(1.-acc)/(double)maxindex);
+  edm::LogVerbatim("MTDDigiGeometryAnalyzer") << "Acceptance: "<< acc << " +/- " << accerr;
+
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

A test to evaluate the effective acceptance of logical pixels in MTD modules as provided by the ```RectangularMTDTopology``` class is added. The test is based on a trivial MonteCarlo estimate of the fraction of random points contained into the pixels. This update provides just output on the STDOUT for visual inspection and does nto affect the content of the file used for comparisons in the unit test procedure. 

#### PR validation:

The code has been used in the investigation of the track-hit matching efficiency in ETL, helping to understand issues with the pixel definition.