### PR TITLE
update input collections of `pixelgpu` online-DQM client for HI mode

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -85,9 +85,12 @@ process.load('DQM.SiPixelHeterogeneous.SiPixelHeterogenousDQM_FirstStep_cff')
 #-------------------------------------
 #	Some Settings before Finishing up
 #-------------------------------------
-process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = cms.InputTag('hltSiPixelDigisFromSoA')
-process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = cms.InputTag('hltSiPixelDigisLegacy')
-
+if process.runType.getRunType() == process.runType.hi_run:
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoAPPOnAA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacyPPOnAA'
+else:
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoA'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacy'
 #-------------------------------------
 #       Some Debug
 #-------------------------------------


### PR DESCRIPTION
#### PR description:

This PR updates the input collections to be consumed by the `pixelgpu` online-DQM client during heavy-ion data-taking.

This follows the update of the HIon HLT menu as detailed in [CMSHLT-2882](https://its.cern.ch/jira/browse/CMSHLT-2882) (see for example the following HLT menu in ConfDB: `/dev/CMSSW_13_2_0/HIon/V33`).

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_2_X`