### PR TITLE
remove `std::cout` calls in `TriggerMenuParser::parseEnergySumZdc`

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -2410,10 +2410,9 @@ bool l1t::TriggerMenuParser::parseEnergySumZdc(L1TUtmCondition condEnergySumZdc,
   std::string type = l1t2string(condEnergySumZdc.getType());
   std::string name = l1t2string(condEnergySumZdc.getName());
 
-  std::cout << "\n ****************************************** "
-            //LogDebug("TriggerMenuParser") << "\n ****************************************** "
-            << "\n      (in parseEnergySumZdc) "
-            << "\n condition = " << condition << "\n type      = " << type << "\n name      = " << name << std::endl;
+  LogDebug("TriggerMenuParser")
+      << "\n ******************************************\n      (in parseEnergySumZdc)\n condition = " << condition
+      << "\n type      = " << type << "\n name      = " << name;
 
   // determine object type
   GlobalObject energySumObjType;
@@ -2486,12 +2485,9 @@ bool l1t::TriggerMenuParser::parseEnergySumZdc(L1TUtmCondition condEnergySumZdc,
     objParameter[cnt].etHighThreshold = upperThresholdInd;
 
     // Output for debugging
-    std::cout
-        << "\n      EnergySumZdc ET high threshold (hex) for energy sum object "
-        << cnt
-        //LogDebug("TriggerMenuParser") << "\n      EnergySumZdc ET high threshold (hex) for energy sum object " << cnt
-        << " = " << std::hex << objParameter[cnt].etLowThreshold << " - " << objParameter[cnt].etHighThreshold
-        << std::dec << std::endl;
+    LogDebug("TriggerMenuParser") << "\n      EnergySumZdc ET high threshold (hex) for energy sum object " << cnt
+                                  << " = " << std::hex << objParameter[cnt].etLowThreshold << " - "
+                                  << objParameter[cnt].etHighThreshold << std::dec;
 
     cnt++;
   }  //end loop over objects


### PR DESCRIPTION
#### PR description:

This PR removes two `std::cout` calls in the method `TriggerMenuParser::parseEnergySumZdc`, replacing them with `LogDebug` calls. These `std::cout` calls were mistakenly introduced in https://github.com/cms-sw/cmssw/pull/42634, and missed in the review of the latter PR.

The corresponding `std::cout` printouts didn't appear in the PR tests of https://github.com/cms-sw/cmssw/pull/42634, as no PR test yet uses a L1T menu which includes L1T algorithms using ZDC data.

Credits to @Sam-Harper for spotting this.

#### PR validation:

Reproduced extra printouts pre-PR with [*]. They disappear running the same test post-PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_13_2_X`

[*]
```bash
#!/bin/bash

hltGetConfiguration /dev/CMSSW_13_2_0/HIon \
  --globaltag auto:run3_mc_HIon \
  --mc \
  --unprescale \
  --output none \
  --max-events 100 \
  --input /store/mc/Run3Winter23Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/GTv4BTagDigi_126X_mcRun3_2023_forPU65_forBTag_v1_ext2-v2/60000/ae2ab9cc-64d7-40ff-a73f-bae4a7a17cf4.root \
  --eras Run3 --l1-emulator FullMC --l1 L1Menu_CollisionsHeavyIons2023_v1_1_0_xml \
  > hlt.py

cmsRun hlt.py &> hlt.log
```
