### PR TITLE
check for empty collection in SiStripApproximateClusterCollection

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h
@@ -90,7 +90,7 @@ public:
   void reserve(std::size_t dets, std::size_t clusters);
   Filler beginDet(unsigned int detId);
 
-  const_iterator begin() const { return const_iterator(clusters_.empty() ? nullptr : this); }
+  const_iterator begin() const { return clusters_.empty() ? end() : const_iterator(this); }
   const_iterator cbegin() const { return begin(); }
   const_iterator end() const { return const_iterator(); }
   const_iterator cend() const { return end(); }

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h
@@ -90,7 +90,7 @@ public:
   void reserve(std::size_t dets, std::size_t clusters);
   Filler beginDet(unsigned int detId);
 
-  const_iterator begin() const { return const_iterator(this); }
+  const_iterator begin() const { return const_iterator(clusters_.empty() ? nullptr : this); }
   const_iterator cbegin() const { return begin(); }
   const_iterator end() const { return const_iterator(); }
   const_iterator cend() const { return end(); }


### PR DESCRIPTION
#### PR description:

Attempts to resolve #42746.

#### PR validation:

Tested on the failing dataset and segmentation violations related to `SiStripApproximateClusterCollection` no longer occur. (Subsequent exceptions occur because this is a weird run with no tracker, but those are expected.)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport branch for 13_2_X is prepared at https://github.com/kpedro88/cmssw/tree/HandleEmptyColl_132X, but a PR is not submitted yet, pending verification of the implemented solution by the experts.

attn: @jeongeun, @mmusich, @mandrenguyen 
