### PR TITLE
Update autoSkim with 2023 PbPb skims

### DIFF
--- a/Configuration/Skimming/python/PbPb_EMuSkim_cff.py
+++ b/Configuration/Skimming/python/PbPb_EMuSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT dimuon trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltEMuHI = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltEMuHI.HLTPaths = ["HLT_HIEle*Gsf_v*","HLT_HIL3SingleMu*_Open_v*"]
+hltEMuHI.HLTPaths = ["HLT_HIEle*Gsf_v*","HLT_HIL3SingleMu*_v*"]
 hltEMuHI.throw = False
 hltEMuHI.andOr = True
 

--- a/Configuration/Skimming/python/PbPb_ZMMSkim_cff.py
+++ b/Configuration/Skimming/python/PbPb_ZMMSkim_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # HLT dimuon trigger
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 hltZMMPbPb = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
-hltZMMPbPb.HLTPaths = ["HLT_HIL3SingleMu*_Open_v*"]
+hltZMMPbPb.HLTPaths = ["HLT_HIL3SingleMu*_v*"]
 hltZMMPbPb.throw = False
 hltZMMPbPb.andOr = True
 

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -41,6 +41,10 @@ autoSkim = {
  'SingleMuon': 'LogError+LogErrorMonitor',
 }
 
+# For 2023 PbPb skims
+for i_split in range(32):
+    autoSkim[f'HIPhysics{i_split}'] = 'PbPbEMu+PbPbZEE+PbPbZMM+LogError+LogErrorMonitor'
+
 autoSkimRunII = {
  'BTagCSV' : 'LogError+LogErrorMonitor',
  'BTagMu' : 'LogError+LogErrorMonitor',

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -43,7 +43,7 @@ autoSkim = {
 
 # For 2023 PbPb skims
 for i_split in range(32):
-    autoSkim[f'HIPhysics{i_split}'] = 'PbPbEMu+PbPbZEE+PbPbZMM+LogError+LogErrorMonitor'
+    autoSkim[f'HIPhysicsRawPrime{i_split}'] = 'PbPbEMu+PbPbZEE+PbPbZMM+LogError+LogErrorMonitor'
 
 autoSkimRunII = {
  'BTagCSV' : 'LogError+LogErrorMonitor',


### PR DESCRIPTION
#### PR description:

Update the autoSkim file for 2023 PbPb skims by following the [CMSHLT-2882](https://its.cern.ch/jira/browse/CMSHLT-2882) [CMSHLT-2913](https://its.cern.ch/jira/browse/CMSHLT-2913). 


@francescobrivio , could you please confirm the 2023 PbPb PromptReco has scenario ```ppEra_Run3_pp_on_PbPb``` so that the [here](https://github.com/cms-sw/cmssw/blob/master/Configuration/Applications/python/ConfigBuilder.py#L1026) can be included and [here](https://github.com/cms-sw/cmssw/blob/master/Configuration/Applications/python/ConfigBuilder.py#L1799) can catch 'HIPhysics[N]' PD  once T0 config for PbPb skim is updated and later cmssw is deployed? Thanks for help.

@mandrenguyen please follow.

#### PR validation:

```python3 RunPromptReco.py --scenario ppEra_Run3_pp_on_PbPb_2023 --reco --aod --dqmio --global-tag 130X_dataRun3_Prompt_v4 --lfn=./ --PhysicsSkim=@HIPhysicsRawPrime20```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

```13_2_X```
